### PR TITLE
Use cstdint in types.h

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -1,14 +1,15 @@
 #pragma once
+#include <cstdint>
 
-using s08 = char;
-using s16 = short;
-using s32 = int;
-using s64 = long long;
+using s08 = std::int8_t;
+using s16 = std::int16_t;
+using s32 = std::int32_t;
+using s64 = std::int64_t;
 
-using u08 = unsigned char;
-using u16 = unsigned short;
-using u32 = unsigned int;
-using u64 = unsigned long long;
+using u08 = std::uint8_t;
+using u16 = std::uint16_t;
+using u32 = std::uint32_t;
+using u64 = std::uint64_t;
 
 using f32 = float;
 using f64 = double;


### PR DESCRIPTION
- Fixes a bug where s08 is unsigned on some platforms
- Makes the fixed-width integer types fully portable