### PR TITLE
Stubs: Log nids for unknown ones

### DIFF
--- a/src/Core/PS4/Linker.cpp
+++ b/src/Core/PS4/Linker.cpp
@@ -623,11 +623,11 @@ void Linker::Resolve(const std::string& name, int Symtype, Module* m, SymbolReco
                 if (aeronid) {
                     return_info->name = aeronid->name;
                     return_info->virtual_address = GetStub(aeronid->nid);
-                    LOG_ERROR_IF(debug_loader, "Linker: Stub resolved {} as {} (lib: {}, mod: {}) \n", sr.name, return_info->name, library->name, module->name);
                 } else {
-                    return_info->virtual_address = (u64)&UnresolvedStub;
-                    return_info->name = "Unresolved!!!";
+                    return_info->virtual_address = GetStub(sr.name.c_str());
+                    return_info->name = "Unknown !!!";
 				}
+                LOG_ERROR_IF(debug_loader, "Linker: Stub resolved {} as {} (lib: {}, mod: {}) \n", sr.name, return_info->name, library->name, module->name);
             }
 		}
 		else


### PR DESCRIPTION
## Overview
Adds support to log stubs with only nid info (up to the stub limit)

Ex:
<img width="853" alt="Screenshot 2023-10-14 190907" src="https://github.com/georgemoralis/shadPS4/assets/393266/3fd00447-bae2-4e6b-85d4-b573334dfae3">
