### PR TITLE
stubs: also log return address

### DIFF
--- a/src/Core/PS4/Stubs.cpp
+++ b/src/Core/PS4/Stubs.cpp
@@ -19,12 +19,12 @@
 #define MAX_STUBS 128
 
 u64 UnresolvedStub() {
-    LOG_ERROR("Unresolved Stub: called, returning zero\n");
+    LOG_ERROR("Unresolved Stub: called, returning zero to {}\n", __builtin_return_address(0));
     return 0;
 }
 
 static u64 UnknownStub() {
-    LOG_ERROR("Stub: Unknown (nid: Unknown) called, returning zero\n");
+    LOG_ERROR("Stub: Unknown (nid: Unknown) called, returning zero to {}\n", __builtin_return_address(0));
     return 0;
 }
 
@@ -36,9 +36,9 @@ template <int stub_index>
 static u64 CommonStub() {
     auto entry = stub_nids[stub_index];
     if (entry) {
-        LOG_ERROR("Stub: {} (nid: {}) called, returning zero\n", entry->name, entry->nid);
+        LOG_ERROR("Stub: {} (nid: {}) called, returning zero to {}\n", entry->name, entry->nid, __builtin_return_address(0));
     } else {
-        LOG_ERROR("Stub: Unknown (nid: {}) called, returning zero\n", stub_nids_unknown[stub_index]);
+        LOG_ERROR("Stub: Unknown (nid: {}) called, returning zero to {}\n", stub_nids_unknown[stub_index], __builtin_return_address(0));
     }
     return 0;
 }


### PR DESCRIPTION
Can help with figuring out where the stub is called from
```
|E|: Stub: Unknown (nid: Q2V+iqvjgC0) called, returning zero to 0x900122ee2
|E|: Stub: Unknown (nid: Q2V+iqvjgC0) called, returning zero to 0x900122e91   
```