### PR TITLE
virt: Initial implementation using zydis and xbyak

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -41,3 +41,8 @@
 	path = third-party/xxHash
 	url = https://github.com/Cyan4973/xxHash.git
 	branch = dev
+[submodule "third-party/xbyak"]
+	path = third-party/xbyak
+	url = https://github.com/herumi/xbyak.git
+	shallow = true
+	branch = v6.73

--- a/src/core/PS4/HLE/LibKernel.cpp
+++ b/src/core/PS4/HLE/LibKernel.cpp
@@ -3,6 +3,7 @@
 #include <Util/log.h>
 #include <debug.h>
 #include <windows.h>
+#include <io.h>
 
 #include "Emulator/Util/singleton.h"
 #include "../Loader/Elf.h"
@@ -26,6 +27,51 @@ int32_t PS4_SYSV_ABI sceKernelReleaseDirectMemory(off_t start, size_t len) {
 static PS4_SYSV_ABI void stack_chk_fail() { BREAKPOINT(); }
 
 int PS4_SYSV_ABI sceKernelMunmap(void* addr, size_t len) { BREAKPOINT(); }
+
+static thread_local int libc_error;
+PS4_SYSV_ABI int* __Error() { return &libc_error; }
+
+#define PROT_READ 0x1
+#define PROT_WRITE 0x2
+
+int PS4_SYSV_ABI sceKernelMmap(void* addr, u64 len, int prot, int flags, int fd, off_t offset, void** res) {
+    DWORD flProtect;
+    if (prot & PROT_WRITE) {
+        flProtect = PAGE_READWRITE;
+    }
+    off_t end = len + offset;
+    HANDLE mmap_fd, h;
+    if (fd == -1)
+        mmap_fd = INVALID_HANDLE_VALUE;
+    else
+        mmap_fd = (HANDLE)_get_osfhandle(fd);
+    h = CreateFileMapping(mmap_fd, NULL, flProtect, 0, end, NULL);
+    int k = GetLastError();
+    if (NULL == h) return -1;
+    DWORD dwDesiredAccess;
+    if (prot & PROT_WRITE)
+        dwDesiredAccess = FILE_MAP_WRITE;
+    else
+        dwDesiredAccess = FILE_MAP_READ;
+    void* ret = MapViewOfFile(h, dwDesiredAccess, 0, offset, len);
+    if (ret == NULL) {
+        CloseHandle(h);
+        ret = nullptr;
+    }
+    *res = ret;
+    return 0;
+}
+
+PS4_SYSV_ABI void* mmap(void* addr, u64 len, int prot, int flags, int fd, u64 offset) {
+    void* ptr;
+    // posix call the difference is that there is a different behaviour when it doesn't return 0 or SCE_OK
+    int result = sceKernelMmap(addr, len, prot, flags, fd, offset, &ptr);
+    if (result != 0) {
+        BREAKPOINT();
+    }
+    return ptr;
+}
+
 void LibKernel_Register(SymbolsResolver* sym) {
     // obj
     LIB_OBJ("f7uOxY9mM1U", "libkernel", 1, "libkernel", 1, 1, &HLE::Libs::LibKernel::g_stack_chk_guard);
@@ -41,6 +87,10 @@ void LibKernel_Register(SymbolsResolver* sym) {
     // misc
     LIB_FUNCTION("WslcK1FQcGI", "libkernel", 1, "libkernel", 1, 1, CPUManagement::sceKernelIsNeoMode);
     LIB_FUNCTION("Ou3iL1abvng", "libkernel", 1, "libkernel", 1, 1, stack_chk_fail);
+
+    LIB_FUNCTION("9BcDykPmo1I", "libkernel", 1, "libkernel", 1, 1, __Error);
+
+    LIB_FUNCTION("BPE9s9vQQXo", "libkernel", 1, "libkernel", 1, 1, mmap);
     
     Core::Libraries::LibKernel::fileSystemSymbolsRegister(sym);
     Core::Libraries::LibKernel::timeSymbolsRegister(sym);

--- a/src/core/PS4/Linker.cpp
+++ b/src/core/PS4/Linker.cpp
@@ -815,6 +815,7 @@ auto TranslateCode(u08* runtime_address, u64 context_base) -> PS4_SYSV_ABI u64 (
 		bool UsesFlags = false;
 
 		if (instruction.info.meta.branch_type != ZYDIS_BRANCH_TYPE_NONE) {
+            assert((instruction.info.attributes & (ZYDIS_ATTRIB_HAS_SEGMENT_FS | ZYDIS_ATTRIB_HAS_SEGMENT_GS)) == 0);
             if (instruction.info.mnemonic == ZYDIS_MNEMONIC_CALL || instruction.info.mnemonic == ZYDIS_MNEMONIC_JMP) {
 
                 if (instruction.info.mnemonic == ZYDIS_MNEMONIC_CALL) {
@@ -957,6 +958,8 @@ auto TranslateCode(u08* runtime_address, u64 context_base) -> PS4_SYSV_ABI u64 (
 			}
             break;
         } else {
+            assert((instruction.info.attributes & (ZYDIS_ATTRIB_HAS_SEGMENT_FS | ZYDIS_ATTRIB_HAS_SEGMENT_GS)) == 0);
+
             for (int i = 0; i < instruction.info.operand_count; i++) {
                 auto operand = &instruction.operands[i];
                 if (operand->type == ZYDIS_OPERAND_TYPE_REGISTER) {

--- a/src/core/PS4/Linker.cpp
+++ b/src/core/PS4/Linker.cpp
@@ -1167,8 +1167,10 @@ static void run_main_entry(u64 addr, EntryParams* params, exit_func_t exit_func)
         rsp = rsp & ~16;
         rsp = rsp - 8;
 
-        rsp = rsp - 8;
-        *(void**)rsp = params->argv;
+        for (int i = params->argc; i > 0; i--) {
+            rsp = rsp - 8;
+            *(void**)rsp = &params->argv[i - 1];
+        }
 
         rsp = rsp - 8;
         *(u64*)rsp = params->argc;
@@ -1202,6 +1204,8 @@ static void run_main_entry_native(u64 addr, EntryParams* params, exit_func_t exi
         // Kernel also pushes some more things here during process init
         // at least: environment, auxv, possibly other things
 
+        // TODO: The array should be pushed here, not the pointer to the array
+        //       similar to run_main_entry 
         "pushq 8(%1)\n"  // copy EntryParams to top of stack like the kernel does
         "pushq 0(%1)\n"  // OpenOrbis expects to find it there
 

--- a/src/core/PS4/Stubs.cpp
+++ b/src/core/PS4/Stubs.cpp
@@ -18,12 +18,12 @@
 // Must match STUBS_LIST define
 #define MAX_STUBS 128
 
-u64 UnresolvedStub() {
+PS4_SYSV_ABI u64 UnresolvedStub() {
     LOG_ERROR("Unresolved Stub: called, returning zero to {}\n", __builtin_return_address(0));
     return 0;
 }
 
-static u64 UnknownStub() {
+static PS4_SYSV_ABI u64 UnknownStub() {
     LOG_ERROR("Stub: Unknown (nid: Unknown) called, returning zero to {}\n", __builtin_return_address(0));
     return 0;
 }
@@ -33,7 +33,7 @@ static aerolib::nid_entry* stub_nids[MAX_STUBS];
 static std::string stub_nids_unknown[MAX_STUBS];
 
 template <int stub_index>
-static u64 CommonStub() {
+static PS4_SYSV_ABI u64 CommonStub() {
     auto entry = stub_nids[stub_index];
     if (entry) {
         LOG_ERROR("Stub: {} (nid: {}) called, returning zero to {}\n", entry->name, entry->nid, __builtin_return_address(0));
@@ -60,7 +60,7 @@ static u32 UsedStubEntries;
 
 #define STUBS_LIST XREP_128(0)
 
-static u64 (*stub_handlers[MAX_STUBS])() = {
+static PS4_SYSV_ABI u64 (*stub_handlers[MAX_STUBS])() = {
     STUBS_LIST
 };
 

--- a/src/core/PS4/Stubs.h
+++ b/src/core/PS4/Stubs.h
@@ -1,4 +1,4 @@
 #include "types.h"
 
-u64 UnresolvedStub();
+PS4_SYSV_ABI u64 UnresolvedStub();
 u64 GetStub(const char *nid);


### PR DESCRIPTION
### Overview
This is a cut-down version of #23, meant to provide very basic, simple virtualization at the cost of perfomance.

### Goals
- Simple implementation
- Virtualize all registers
- No register allocation
- Support most (all?) ps4 instructions/regs, though just passthrough
- Basic, per thread code cache
- No SMC support
- No instruction rewriting for most operations

### Todo
- [x] Get basic hack-and-slash demo working
- [ ] Decide on a testing stategy
- [ ] Rework to less horrific code
- [ ] Support multiple threads, TCB overflows, and other corner cases gracefully