### PR TITLE
Portablecrypto

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,7 @@
 	path = externals/cryptopp
 	url = https://github.com/shadps4-emu/ext-cryptopp.git
 	branch = master
+[submodule "externals/cryptoppwin"]
+	path = externals/cryptoppwin
+	url = https://github.com/shadps4-emu/ext-cryptoppwin.git
+	branch = main

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,38 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": ""
+    },
+    {
+      "name": "x64-Clang-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "clang_cl_x64_x64" ]
+    },
+    {
+      "name": "x64-Clang-Release",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "clang_cl_x64_x64" ],
+      "variables": []
+    }
+  ]
+}

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,17 +1,6 @@
 ﻿{
   "configurations": [
     {
-      "name": "x64-Debug",
-      "generator": "Ninja",
-      "configurationType": "Debug",
-      "inheritEnvironments": [ "msvc_x64_x64" ],
-      "buildRoot": "${projectDir}\\out\\build\\${name}",
-      "installRoot": "${projectDir}\\out\\install\\${name}",
-      "cmakeCommandArgs": "",
-      "buildCommandArgs": "",
-      "ctestCommandArgs": ""
-    },
-    {
       "name": "x64-Clang-Debug",
       "generator": "Ninja",
       "configurationType": "Debug",
@@ -31,8 +20,7 @@
       "cmakeCommandArgs": "",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
-      "inheritEnvironments": [ "clang_cl_x64_x64" ],
-      "variables": []
+      "inheritEnvironments": [ "clang_cl_x64_x64" ]
     }
   ]
 }

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -1,6 +1,8 @@
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND MSVC)
 #if it is clang and MSVC we will add a static lib
+    add_subdirectory(cryptoppwin EXCLUDE_FROM_ALL)
+    target_include_directories(cryptoppwin INTERFACE cryptoppwin/include)
 else() # all the other cases probably could do build it
 	set(CRYPTOPP_BUILD_TESTING OFF)
 	set(CRYPTOPP_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/cryptopp/)

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -1,3 +1,8 @@
-set(CRYPTOPP_BUILD_TESTING OFF)
-set(CRYPTOPP_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/cryptopp/)
-add_subdirectory(cryptopp-cmake EXCLUDE_FROM_ALL)
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND MSVC)
+#if it is clang and MSVC we will add a static lib
+else() # all the other cases probably could do build it
+	set(CRYPTOPP_BUILD_TESTING OFF)
+	set(CRYPTOPP_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/cryptopp/)
+	add_subdirectory(cryptopp-cmake EXCLUDE_FROM_ALL)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,11 @@ qt_add_executable(shadps4
     main.cpp
 )
 
-target_link_libraries(shadps4 PRIVATE Qt6::Widgets Qt6::Concurrent cryptopp::cryptopp)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND MSVC) #ugly probably make it better :D
+    target_link_libraries(shadps4 PRIVATE Qt6::Widgets Qt6::Concurrent cryptoppwin)
+else()
+    target_link_libraries(shadps4 PRIVATE Qt6::Widgets Qt6::Concurrent cryptopp::cryptopp)
+endif()
 
 set_target_properties(shadps4 PROPERTIES
     WIN32_EXECUTABLE ON

--- a/src/emulator/file_format/pkg.cpp
+++ b/src/emulator/file_format/pkg.cpp
@@ -1,6 +1,6 @@
 #include <direct.h>
 #include "../../common/io_file.h"
-#include "PKG.h"
+#include "pkg.h"
 
 PKG::PKG() {}
 

--- a/src/emulator/file_format/psf.cpp
+++ b/src/emulator/file_format/psf.cpp
@@ -2,7 +2,7 @@
 #include <iostream>
 
 #include "../../common/io_file.h"
-#include "PSF.h"
+#include "psf.h"
 
 PSF::PSF() {}
 

--- a/src/emulator/loader.cpp
+++ b/src/emulator/loader.cpp
@@ -1,6 +1,6 @@
 #include "../common/io_file.h"
 #include "../common/types.h"
-#include "Loader.h"
+#include "loader.h"
 
 FileTypes detectFileType(const std::string& filepath) {
     if (filepath.size() == 0) // no file loaded

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -8,7 +8,7 @@
 #include "ui_main_window.h"
 
 #include "../common/io_file.h"
-#include "../emulator/Loader.h"
+#include "../emulator/loader.h"
 #include "../emulator/file_format/pkg.h"
 
 main_window::main_window(std::shared_ptr<gui_settings> gui_settings, QWidget* parent)


### PR DESCRIPTION
Steps is 

use static lib for clang and msvc

configure to work on the way it is , on other compilers (possible linux as well)