### PR TITLE
URL migration for Build

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ The project started as a fun project. Due to short free time, it will probably t
 
 ## Windows
 
-Check building instructions in [windows build](https://github.com/georgemoralis/shadPS4/blob/main/documents/building-windows.md)
+Check building instructions in [windows build](https://github.com/shadps4-emu/shadPS4/blob/main/documents/building-windows.md)
 
 ## Linux
 
-Check building instructions in [linux build](https://github.com/georgemoralis/shadPS4/blob/main/documents/linux_building.md)
+Check building instructions in [linux build](https://github.com/shadps4-emu/shadPS4/blob/main/documents/linux_building.md)
 
 ## Build status
 

--- a/documents/building-windows.md
+++ b/documents/building-windows.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 # How to build shadps4 in windows 
 
-## Download VStudio Community 2022 17.7.4
+## Download VStudio Community 2022 17.9.5
 
 [VStudio 2022](https://visualstudio.microsoft.com/vs/)
 
@@ -17,7 +17,7 @@ Install the following
 
 ### From Individual components tab install
 
-- C++ Clang Compiler for Windows (16.0.5)
+- C++ Clang Compiler for Windows (17.0.3)
 - MSBuild support for LLVM (clang-cl) toolset
 
 - ## Compiling


### PR DESCRIPTION
I forwarded the URL for Build ShadPS4 from georgemoralis to shadps4-emu. As the old link was archived, this will allow the document to be modified. I also updated the versions for Windows.