### PR TITLE
Psf info + stack allocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,6 +394,8 @@ if (WIN32)
     endif()
     # Target Windows 10 RS5
     add_definitions(-DNTDDI_VERSION=0x0A000006 -D_WIN32_WINNT=0x0A00 -DWINVER=0x0A00)
+    # Increase stack,commit
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:0x200000,0x200000")
 endif()
 
 if (WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,7 +395,7 @@ if (WIN32)
     # Target Windows 10 RS5
     add_definitions(-DNTDDI_VERSION=0x0A000006 -D_WIN32_WINNT=0x0A00 -DWINVER=0x0A00)
     # Increase stack,commit
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:0x200000,0x200000")
+    target_link_options(shadps4 PRIVATE /STACK:0x200000,0x200000)
 endif()
 
 if (WIN32)


### PR DESCRIPTION
This pr resolves the following issues.

Fix stack allocation : Currently we have a lot of crashes with the default stack allocation , the /stack flag increase the stack and commit area so let's hope it will solve all relative crash issues

Print param.sfo at startup : We can print game id , title , fw version required , app version at the startup of the log file. We also will need the following info for savedata and sceAppContent module at future ( savedata pr is on it's way)
