### PR TITLE
gnm_driver: Gnm eventq and GPU flips

### DIFF
--- a/src/core/libraries/gnmdriver/gnmdriver.cpp
+++ b/src/core/libraries/gnmdriver/gnmdriver.cpp
@@ -231,7 +231,7 @@ u32 PS4_SYSV_ABI sceGnmDispatchInitDefaultHardwareState(u32* cmdbuf, u32 size) {
                                              0xffffffffu); // COMPUTE_STATIC_THREAD_MGMT_SE1
             cmdbuf = PM4CmdSetData::SetShReg(cmdbuf, 0x215u, 0x170u); // COMPUTE_RESOURCE_LIMITS
 
-            cmdbuf = WriteHeader<PM4ItOpcode::Unknown58>(
+            cmdbuf = WriteHeader<PM4ItOpcode::AcquireMem>(
                 cmdbuf, 6); // for some reason the packet indicates larger size
             cmdbuf = WriteBody(cmdbuf, 0x28000000u, 0u, 0u, 0u, 0u);
 

--- a/src/core/libraries/gnmdriver/gnmdriver.cpp
+++ b/src/core/libraries/gnmdriver/gnmdriver.cpp
@@ -867,8 +867,48 @@ int PS4_SYSV_ABI sceGnmSetEmbeddedPsShader() {
     return ORBIS_OK;
 }
 
-int PS4_SYSV_ABI sceGnmSetEmbeddedVsShader() {
-    LOG_ERROR(Lib_GnmDriver, "(STUBBED) called");
+s32 PS4_SYSV_ABI sceGnmSetEmbeddedVsShader(u32* cmdbuf, u32 size, u32 shader_id, u32 modifier) {
+    LOG_TRACE(Lib_GnmDriver, "called");
+
+    // A fullscreen triangle with one uv set
+    const static u32 shader_code[] = {
+        0xbeeb03ffu, 00000007u,   // s_mov_b32     vcc_hi, $0x00000007
+        0x36020081u,              // v_and_b32     v1, 1, v0
+        0x34020281u,              // v_lshlrev_b32 v1, 1, v1
+        0x360000c2u,              // v_and_b32     v0, -2, v0
+        0x4a0202c1u,              // v_add_i32     v1, vcc, -1, v1
+        0x4a0000c1u,              // v_add_i32     v0, vcc, -1, v0
+        0x7e020b01u,              // v_cvt_f32_i32 v1, v1
+        0x7e040280u,              // v_cvt_f32_i32 v0, v0
+        0x7e0602f2u,              // v_mov_b32     v3, 1.0
+        0xf80008cfu, 0x03020001u, // exp           pos0, v1, v0, v2, v3 done
+        0xf800020fu, 0x03030303u, // exp           param0, v3, v3, v3, v3
+        0xbf810000u,              // s_endpgm
+
+        // OrbShdr header
+        0x5362724fu, 0x07726468u, 0x00004047u, 0u, 0x47f8c29fu, 0x9b2da5cfu, 0xff7c5b7du,
+        0x00000017u, 0x0fe000f1u, 0u, 0x000c0000u, 4u, 0u, 4u, 0u, 7u};
+
+    const auto shader_addr = uintptr_t(&shader_code); // Original address is 0xfe000f10
+    const static u32 vs_regs[] = {
+        u32(shader_addr >> 8), u32(shader_addr >> 40), 0xc0000u, 4, 0, 4, 0, 7};
+
+    if (shader_id != 0) {
+        return 0x8eee00ff;
+    }
+
+    // Normally the driver will do a call to `sceGnmSetVsShader()`, but this function has
+    // a check for zero in the upper part of shader address. In our case, the address is a
+    // pointer to a stack memory, so the check will likely fail. To workaround it we will
+    // repeat set shader functionality here as it is trivial.
+    cmdbuf = PM4CmdSetData::SetShReg(cmdbuf, 0x48u, vs_regs[0], 0u); // SPI_SHADER_PGM_LO_VS
+    cmdbuf =
+        PM4CmdSetData::SetShReg(cmdbuf, 0x4au, vs_regs[2], vs_regs[3]); // SPI_SHADER_PGM_RSRC1_VS
+    cmdbuf = PM4CmdSetData::SetContextReg(cmdbuf, 0x207u, vs_regs[6]);  // PA_CL_VS_OUT_CNTL
+    cmdbuf = PM4CmdSetData::SetContextReg(cmdbuf, 0x1b1u, vs_regs[4]);  // SPI_VS_OUT_CONFIG
+    cmdbuf = PM4CmdSetData::SetContextReg(cmdbuf, 0x1c3u, vs_regs[5]);  // SPI_SHADER_POS_FORMAT
+
+    WriteTrailingNop<11>(cmdbuf);
     return ORBIS_OK;
 }
 
@@ -1003,6 +1043,8 @@ int PS4_SYSV_ABI sceGnmSetVgtControl() {
 }
 
 s32 PS4_SYSV_ABI sceGnmSetVsShader(u32* cmdbuf, u32 size, const u32* vs_regs, u32 shader_modifier) {
+    LOG_TRACE(Lib_GnmDriver, "called");
+
     if (!cmdbuf || size <= 0x1c) {
         return -1;
     }
@@ -1030,7 +1072,6 @@ s32 PS4_SYSV_ABI sceGnmSetVsShader(u32* cmdbuf, u32 size, const u32* vs_regs, u3
     cmdbuf = PM4CmdSetData::SetContextReg(cmdbuf, 0x1c3u, vs_regs[5]); // SPI_SHADER_POS_FORMAT
 
     WriteTrailingNop<11>(cmdbuf);
-
     return ORBIS_OK;
 }
 
@@ -1229,7 +1270,10 @@ int PS4_SYSV_ABI sceGnmSqttWaitForEvent() {
     return ORBIS_OK;
 }
 
-int PS4_SYSV_ABI sceGnmSubmitAndFlipCommandBuffers() {
+s32 PS4_SYSV_ABI sceGnmSubmitAndFlipCommandBuffers(u32 count, void* dcb_gpu_addrs[],
+                                                   u32* dcb_sizes_in_bytes, void* ccb_gpu_addrs[],
+                                                   u32* ccb_sizes_in_bytes, u32 vo_handle,
+                                                   u32 buf_idx, u32 flip_mode, u32 flip_arg) {
     LOG_ERROR(Lib_GnmDriver, "(STUBBED) called");
     return ORBIS_OK;
 }
@@ -1239,34 +1283,35 @@ int PS4_SYSV_ABI sceGnmSubmitAndFlipCommandBuffersForWorkload() {
     return ORBIS_OK;
 }
 
-int PS4_SYSV_ABI sceGnmSubmitCommandBuffers(u32 count, void* dcbGpuAddrs[], u32* dcbSizesInBytes,
-                                            void* ccbGpuAddrs[], u32* ccbSizesInBytes) {
+s32 PS4_SYSV_ABI sceGnmSubmitCommandBuffers(u32 count, void* dcb_gpu_addrs[],
+                                            u32* dcb_sizes_in_bytes, void* ccb_gpu_addrs[],
+                                            u32* ccb_sizes_in_bytes) {
     LOG_INFO(Lib_GnmDriver, "called");
     ASSERT_MSG(count == 1, "Multiple command buffer submission is unsupported!");
 
-    if (!dcbGpuAddrs || !dcbSizesInBytes) {
+    if (!dcb_gpu_addrs || !dcb_sizes_in_bytes) {
         LOG_ERROR(Lib_GnmDriver, "dcbGpuAddrs and dcbSizesInBytes must not be NULL");
         return 0x80d11000;
     }
 
     for (u32 i = 0; i < count; i++) {
-        if (dcbSizesInBytes[i] == 0) {
+        if (dcb_sizes_in_bytes[i] == 0) {
             LOG_ERROR(Lib_GnmDriver, "Submitting a null DCB {}", i);
             return 0x80d11000;
         }
-        if (dcbSizesInBytes[i] > 0x3ffffc) {
+        if (dcb_sizes_in_bytes[i] > 0x3ffffc) {
             LOG_ERROR(Lib_GnmDriver, "dcbSizesInBytes[{}] ({}) is limited to (2*20)-1 DWORDS", i,
-                      dcbSizesInBytes[i]);
+                      dcb_sizes_in_bytes[i]);
             return 0x80d11000;
         }
-        if (ccbSizesInBytes && ccbSizesInBytes[i] > 0x3ffffc) {
+        if (ccb_sizes_in_bytes && ccb_sizes_in_bytes[i] > 0x3ffffc) {
             LOG_ERROR(Lib_GnmDriver, "ccbSizesInBytes[{}] ({}) is limited to (2*20)-1 DWORDS", i,
-                      ccbSizesInBytes[i]);
+                      ccb_sizes_in_bytes[i]);
             return 0x80d11000;
         }
     }
 
-    liverpool->ProcessCmdList(reinterpret_cast<u32*>(dcbGpuAddrs[0]), dcbSizesInBytes[0]);
+    liverpool->ProcessCmdList(reinterpret_cast<u32*>(dcb_sizes_in_bytes[0]), dcb_sizes_in_bytes[0]);
 
     return ORBIS_OK;
 }

--- a/src/core/libraries/gnmdriver/gnmdriver.cpp
+++ b/src/core/libraries/gnmdriver/gnmdriver.cpp
@@ -1307,8 +1307,8 @@ static inline s32 PatchFlipRequest(u32* cmdbuf, u32 size, u32 vo_handle, u32 buf
     auto* write_lock = reinterpret_cast<PM4CmdWriteData*>(cmdbuf);
     write_lock->header = PM4Type3Header{PM4ItOpcode::WriteData, 3};
     write_lock->raw = 0x500u;
-    *reinterpret_cast<uintptr_t*>(&write_lock->dst_addr_lo) =
-        (label_addr + buf_idx * sizeof(uintptr_t)) & ~0x3ull;
+    const auto addr = (label_addr + buf_idx * sizeof(label_addr)) & ~0x3ull;
+    write_lock->Address<uintptr_t>(addr);
     write_lock->data[0] = 1;
 
     auto* nop = reinterpret_cast<PM4CmdNop*>(cmdbuf + 5);

--- a/src/core/libraries/gnmdriver/gnmdriver.h
+++ b/src/core/libraries/gnmdriver/gnmdriver.h
@@ -107,7 +107,7 @@ s32 PS4_SYSV_ABI sceGnmInsertPushMarker(u32* cmdbuf, u32 size, const char* marke
 int PS4_SYSV_ABI sceGnmInsertSetColorMarker();
 int PS4_SYSV_ABI sceGnmInsertSetMarker();
 int PS4_SYSV_ABI sceGnmInsertThreadTraceMarker();
-int PS4_SYSV_ABI sceGnmInsertWaitFlipDone();
+s32 PS4_SYSV_ABI sceGnmInsertWaitFlipDone(u32* cmdbuf, u32 size, s32 vo_handle, u32 buf_idx);
 int PS4_SYSV_ABI sceGnmIsCoredumpValid();
 int PS4_SYSV_ABI sceGnmIsUserPaEnabled();
 int PS4_SYSV_ABI sceGnmLogicalCuIndexToPhysicalCuIndex();

--- a/src/core/libraries/gnmdriver/gnmdriver.h
+++ b/src/core/libraries/gnmdriver/gnmdriver.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "common/types.h"
+#include "core/libraries/kernel/event_queues.h"
 
 namespace Core::Loader {
 class SymbolsResolver;
@@ -11,7 +12,9 @@ class SymbolsResolver;
 
 namespace Libraries::GnmDriver {
 
-int PS4_SYSV_ABI sceGnmAddEqEvent();
+using namespace Kernel;
+
+s32 PS4_SYSV_ABI sceGnmAddEqEvent(SceKernelEqueue eq, u64 id, void* udata);
 int PS4_SYSV_ABI sceGnmAreSubmitsAllowed();
 int PS4_SYSV_ABI sceGnmBeginWorkload();
 s32 PS4_SYSV_ABI sceGnmComputeWaitOnAddress(u32* cmdbuf, u32 size, uintptr_t addr, u32 mask,
@@ -28,7 +31,7 @@ int PS4_SYSV_ABI sceGnmDebuggerSetAddressWatch();
 int PS4_SYSV_ABI sceGnmDebuggerWriteGds();
 int PS4_SYSV_ABI sceGnmDebuggerWriteSqIndirectRegister();
 int PS4_SYSV_ABI sceGnmDebugHardwareStatus();
-int PS4_SYSV_ABI sceGnmDeleteEqEvent();
+s32 PS4_SYSV_ABI sceGnmDeleteEqEvent(SceKernelEqueue eq, u64 id);
 int PS4_SYSV_ABI sceGnmDestroyWorkloadStream();
 int PS4_SYSV_ABI sceGnmDingDong();
 int PS4_SYSV_ABI sceGnmDingDongForWorkload();

--- a/src/core/libraries/gnmdriver/gnmdriver.h
+++ b/src/core/libraries/gnmdriver/gnmdriver.h
@@ -140,7 +140,7 @@ s32 PS4_SYSV_ABI sceGnmSetCsShader(u32* cmdbuf, u32 size, const u32* cs_regs);
 s32 PS4_SYSV_ABI sceGnmSetCsShaderWithModifier(u32* cmdbuf, u32 size, const u32* cs_regs,
                                                u32 modifier);
 int PS4_SYSV_ABI sceGnmSetEmbeddedPsShader();
-int PS4_SYSV_ABI sceGnmSetEmbeddedVsShader();
+s32 PS4_SYSV_ABI sceGnmSetEmbeddedVsShader(u32* cmdbuf, u32 size, u32 shader_id, u32 modifier);
 int PS4_SYSV_ABI sceGnmSetEsShader();
 int PS4_SYSV_ABI sceGnmSetGsRingSizes();
 int PS4_SYSV_ABI sceGnmSetGsShader();
@@ -194,9 +194,12 @@ int PS4_SYSV_ABI sceGnmSqttStopTrace();
 int PS4_SYSV_ABI sceGnmSqttSwitchTraceBuffer();
 int PS4_SYSV_ABI sceGnmSqttSwitchTraceBuffer2();
 int PS4_SYSV_ABI sceGnmSqttWaitForEvent();
-int PS4_SYSV_ABI sceGnmSubmitAndFlipCommandBuffers();
+s32 PS4_SYSV_ABI sceGnmSubmitAndFlipCommandBuffers(u32 count, void* dcb_gpu_addrs[],
+                                                   u32* dcb_sizes_in_bytes, void* ccb_gpu_addrs[],
+                                                   u32* ccb_sizes_in_bytes, u32 vo_handle,
+                                                   u32 buf_idx, u32 flip_mode, u32 flip_arg);
 int PS4_SYSV_ABI sceGnmSubmitAndFlipCommandBuffersForWorkload();
-int PS4_SYSV_ABI sceGnmSubmitCommandBuffers(u32 count, void* dcb_gpu_addrs[],
+s32 PS4_SYSV_ABI sceGnmSubmitCommandBuffers(u32 count, void* dcb_gpu_addrs[],
                                             u32* dcb_sizes_in_bytes, void* ccb_gpu_addrs[],
                                             u32* ccb_sizes_in_bytes);
 int PS4_SYSV_ABI sceGnmSubmitCommandBuffersForWorkload();

--- a/src/core/libraries/kernel/event_queue.cpp
+++ b/src/core/libraries/kernel/event_queue.cpp
@@ -22,7 +22,7 @@ int EqueueInternal::addEvent(const EqueueEvent& event) {
 
 int EqueueInternal::removeEvent(u64 id) {
     const auto& event_q = std::find_if(m_events.cbegin(), m_events.cend(),
-                                    [id](auto& ev) { return ev.event.ident == id; });
+                                       [id](auto& ev) { return ev.event.ident == id; });
     ASSERT(event_q != m_events.cend());
     m_events.erase(event_q);
     return 0;

--- a/src/core/libraries/kernel/event_queue.cpp
+++ b/src/core/libraries/kernel/event_queue.cpp
@@ -20,6 +20,14 @@ int EqueueInternal::addEvent(const EqueueEvent& event) {
     return 0;
 }
 
+int EqueueInternal::removeEvent(u64 id) {
+    const auto& event_q = std::find_if(m_events.cbegin(), m_events.cend(),
+                                    [id](auto& ev) { return ev.event.ident == id; });
+    ASSERT(event_q != m_events.cend());
+    m_events.erase(event_q);
+    return 0;
+}
+
 int EqueueInternal::waitForEvents(SceKernelEvent* ev, int num, u32 micros) {
     std::unique_lock lock{m_mutex};
     int ret = 0;

--- a/src/core/libraries/kernel/event_queue.cpp
+++ b/src/core/libraries/kernel/event_queue.cpp
@@ -21,8 +21,8 @@ int EqueueInternal::addEvent(const EqueueEvent& event) {
 }
 
 int EqueueInternal::removeEvent(u64 id) {
-    const auto& event_q = std::find_if(m_events.cbegin(), m_events.cend(),
-                                       [id](auto& ev) { return ev.event.ident == id; });
+    const auto& event_q =
+        std::ranges::find_if(m_events, [id](auto& ev) { return ev.event.ident == id; });
     ASSERT(event_q != m_events.cend());
     m_events.erase(event_q);
     return 0;

--- a/src/core/libraries/kernel/event_queue.h
+++ b/src/core/libraries/kernel/event_queue.h
@@ -42,11 +42,22 @@ using ResetFunc = void (*)(EqueueEvent* event);
 using DeleteFunc = void (*)(EqueueInternal* eq, EqueueEvent* event);
 
 struct SceKernelEvent {
+    enum Type : u64 {
+        Compute0RelMem = 0x00,
+        Compute1RelMem = 0x01,
+        Compute2RelMem = 0x02,
+        Compute3RelMem = 0x03,
+        Compute4RelMem = 0x04,
+        Compute5RelMem = 0x05,
+        Compute6RelMem = 0x06,
+        GfxEop = 0x40
+    };
+
     u64 ident = 0;  /* identifier for this event */
     s16 filter = 0; /* filter for event */
     u16 flags = 0;
     u32 fflags = 0;
-    s64 data = 0;
+    u64 data = 0;
     void* udata = nullptr; /* opaque user data identifier */
 };
 
@@ -80,6 +91,7 @@ public:
         this->m_name = m_name;
     }
     int addEvent(const EqueueEvent& event);
+    int removeEvent(u64 id);
     int waitForEvents(SceKernelEvent* ev, int num, u32 micros);
     bool triggerEvent(u64 ident, s16 filter, void* trigger_data);
     int getTriggeredEvents(SceKernelEvent* ev, int num);

--- a/src/core/libraries/kernel/event_queues.cpp
+++ b/src/core/libraries/kernel/event_queues.cpp
@@ -11,29 +11,34 @@ namespace Libraries::Kernel {
 int PS4_SYSV_ABI sceKernelCreateEqueue(SceKernelEqueue* eq, const char* name) {
     if (eq == nullptr) {
         LOG_ERROR(Kernel_Event, "Event queue is null!");
-        return SCE_KERNEL_ERROR_EINVAL;
+        return ORBIS_KERNEL_ERROR_EINVAL;
     }
     if (name == nullptr) {
-        LOG_ERROR(Kernel_Event, "Event queue name is invalid!");
-        return SCE_KERNEL_ERROR_EFAULT;
-    }
-    if (name == NULL) {
         LOG_ERROR(Kernel_Event, "Event queue name is null!");
-        return SCE_KERNEL_ERROR_EINVAL;
+        return ORBIS_KERNEL_ERROR_EINVAL;
     }
 
     // Maximum is 32 including null terminator
     static constexpr size_t MaxEventQueueNameSize = 32;
     if (std::strlen(name) > MaxEventQueueNameSize) {
         LOG_ERROR(Kernel_Event, "Event queue name exceeds 32 bytes!");
-        return SCE_KERNEL_ERROR_ENAMETOOLONG;
+        return ORBIS_KERNEL_ERROR_ENAMETOOLONG;
     }
 
     LOG_INFO(Kernel_Event, "name = {}", name);
 
     *eq = new EqueueInternal;
     (*eq)->setName(std::string(name));
-    return SCE_OK;
+    return ORBIS_OK;
+}
+
+int PS4_SYSV_ABI sceKernelDeleteEqueue(SceKernelEqueue eq) {
+    if (eq == nullptr) {
+        return SCE_KERNEL_ERROR_EBADF;
+    }
+
+    delete eq;
+    return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceKernelWaitEqueue(SceKernelEqueue eq, SceKernelEvent* ev, int num, int* out,

--- a/src/core/libraries/kernel/event_queues.h
+++ b/src/core/libraries/kernel/event_queues.h
@@ -11,6 +11,7 @@ using SceKernelUseconds = u32;
 using SceKernelEqueue = EqueueInternal*;
 
 int PS4_SYSV_ABI sceKernelCreateEqueue(SceKernelEqueue* eq, const char* name);
+int PS4_SYSV_ABI sceKernelDeleteEqueue(SceKernelEqueue eq);
 int PS4_SYSV_ABI sceKernelWaitEqueue(SceKernelEqueue eq, SceKernelEvent* ev, int num, int* out,
                                      SceKernelUseconds* timo);
 

--- a/src/core/libraries/kernel/libkernel.cpp
+++ b/src/core/libraries/kernel/libkernel.cpp
@@ -169,6 +169,7 @@ void LibKernel_Register(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("cQke9UuBQOk", "libkernel", 1, "libkernel", 1, 1, sceKernelMunmap);
     // equeue
     LIB_FUNCTION("D0OdFMjp46I", "libkernel", 1, "libkernel", 1, 1, sceKernelCreateEqueue);
+    LIB_FUNCTION("jpFjmgAC5AE", "libkernel", 1, "libkernel", 1, 1, sceKernelDeleteEqueue);
     LIB_FUNCTION("fzyMKs9kim0", "libkernel", 1, "libkernel", 1, 1, sceKernelWaitEqueue);
     // misc
     LIB_FUNCTION("WslcK1FQcGI", "libkernel", 1, "libkernel", 1, 1, sceKernelIsNeoMode);

--- a/src/core/libraries/videoout/driver.cpp
+++ b/src/core/libraries/videoout/driver.cpp
@@ -196,6 +196,9 @@ void VideoOutDriver::Flip(std::chrono::microseconds timeout) {
                                 reinterpret_cast<void*>(req.flip_arg));
         }
     }
+
+    // Reset flip label
+    req.port->buffer_labels[req.index] = 0;
 }
 
 bool VideoOutDriver::SubmitFlip(VideoOutPort* port, s32 index, s64 flip_arg) {

--- a/src/core/libraries/videoout/driver.h
+++ b/src/core/libraries/videoout/driver.h
@@ -34,6 +34,11 @@ struct VideoOutPort {
         }
         return index;
     }
+
+    [[nodiscard]] int NumRegisteredBuffers() const {
+        return std::count_if(buffer_slots.cbegin(), buffer_slots.cend(),
+                             [](auto& buffer) { return buffer.group_index != -1; });
+    }
 };
 
 struct ServiceThreadParams {
@@ -59,7 +64,7 @@ public:
     int UnregisterBuffers(VideoOutPort* port, s32 attributeIndex);
 
     void Flip(std::chrono::microseconds timeout);
-    bool SubmitFlip(VideoOutPort* port, s32 index, s64 flip_arg);
+    bool SubmitFlip(VideoOutPort* port, s32 index, s64 flip_arg, bool is_eop = false);
 
     void Vblank();
 
@@ -70,6 +75,7 @@ private:
         s32 index;
         s64 flip_arg;
         u64 submit_tsc;
+        bool eop;
     };
 
     std::mutex mutex;

--- a/src/core/libraries/videoout/driver.h
+++ b/src/core/libraries/videoout/driver.h
@@ -19,6 +19,8 @@ struct VideoOutPort {
     bool is_open = false;
     SceVideoOutResolutionStatus resolution;
     std::array<VideoOutBuffer, MaxDisplayBuffers> buffer_slots;
+    std::array<uintptr_t, MaxDisplayBuffers> buffer_labels; // should be contiguous in memory
+    static_assert(sizeof(buffer_labels[0]) == 8u);
     std::array<BufferAttributeGroup, MaxDisplayBufferGroups> groups;
     FlipStatus flip_status;
     SceVideoOutVblankStatus vblank_status;

--- a/src/core/libraries/videoout/video_out.cpp
+++ b/src/core/libraries/videoout/video_out.cpp
@@ -216,6 +216,17 @@ void sceVideoOutGetBufferLabelAddress(s32 handle, uintptr_t* label_addr) {
     *label_addr = reinterpret_cast<uintptr_t>(port->buffer_labels.data());
 }
 
+s32 sceVideoOutSubmitEopFlip(s32 handle, u32 buf_id, u32 mode, u32 arg, void* unk) {
+    auto* port = driver->GetPort(handle);
+    if (!port) {
+        return 0x8029000b;
+    }
+
+    // TODO
+
+    return ORBIS_OK;
+}
+
 void RegisterLib(Core::Loader::SymbolsResolver* sym) {
     driver = std::make_unique<VideoOutDriver>(Config::getScreenWidth(), Config::getScreenHeight());
 

--- a/src/core/libraries/videoout/video_out.cpp
+++ b/src/core/libraries/videoout/video_out.cpp
@@ -210,6 +210,12 @@ void Vblank() {
     return driver->Vblank();
 }
 
+void sceVideoOutGetBufferLabelAddress(s32 handle, uintptr_t* label_addr) {
+    auto* port = driver->GetPort(handle);
+    ASSERT(port);
+    *label_addr = reinterpret_cast<uintptr_t>(port->buffer_labels.data());
+}
+
 void RegisterLib(Core::Loader::SymbolsResolver* sym) {
     driver = std::make_unique<VideoOutDriver>(Config::getScreenWidth(), Config::getScreenHeight());
 

--- a/src/core/libraries/videoout/video_out.cpp
+++ b/src/core/libraries/videoout/video_out.cpp
@@ -10,6 +10,7 @@
 #include "core/libraries/videoout/driver.h"
 #include "core/libraries/videoout/video_out.h"
 #include "core/loader/symbols_resolver.h"
+#include "core/platform.h"
 
 namespace Libraries::VideoOut {
 
@@ -216,13 +217,17 @@ void sceVideoOutGetBufferLabelAddress(s32 handle, uintptr_t* label_addr) {
     *label_addr = reinterpret_cast<uintptr_t>(port->buffer_labels.data());
 }
 
-s32 sceVideoOutSubmitEopFlip(s32 handle, u32 buf_id, u32 mode, u32 arg, void* unk) {
+s32 sceVideoOutSubmitEopFlip(s32 handle, u32 buf_id, u32 mode, u32 arg, void** unk) {
     auto* port = driver->GetPort(handle);
     if (!port) {
         return 0x8029000b;
     }
 
-    // TODO
+    Platform::IrqC::Instance()->RegisterOnce([=](Platform::InterruptId irq) {
+        ASSERT_MSG(irq == Platform::InterruptId::GfxEop, "An unexpected IRQ occured");
+        const auto result = driver->SubmitFlip(port, buf_id, arg, true);
+        ASSERT_MSG(result, "EOP flip submission failed");
+    });
 
     return ORBIS_OK;
 }

--- a/src/core/libraries/videoout/video_out.h
+++ b/src/core/libraries/videoout/video_out.h
@@ -102,7 +102,9 @@ s32 PS4_SYSV_ABI sceVideoOutClose(s32 handle);
 void Flip(std::chrono::microseconds micros);
 void Vblank();
 
+// Internal system functions
 void sceVideoOutGetBufferLabelAddress(s32 handle, uintptr_t* label_addr);
+s32 sceVideoOutSubmitEopFlip(s32 handle, u32 buf_id, u32 mode, u32 arg, void* unk);
 
 void RegisterLib(Core::Loader::SymbolsResolver* sym);
 

--- a/src/core/libraries/videoout/video_out.h
+++ b/src/core/libraries/videoout/video_out.h
@@ -104,7 +104,7 @@ void Vblank();
 
 // Internal system functions
 void sceVideoOutGetBufferLabelAddress(s32 handle, uintptr_t* label_addr);
-s32 sceVideoOutSubmitEopFlip(s32 handle, u32 buf_id, u32 mode, u32 arg, void* unk);
+s32 sceVideoOutSubmitEopFlip(s32 handle, u32 buf_id, u32 mode, u32 arg, void** unk);
 
 void RegisterLib(Core::Loader::SymbolsResolver* sym);
 

--- a/src/core/libraries/videoout/video_out.h
+++ b/src/core/libraries/videoout/video_out.h
@@ -102,6 +102,8 @@ s32 PS4_SYSV_ABI sceVideoOutClose(s32 handle);
 void Flip(std::chrono::microseconds micros);
 void Vblank();
 
+void sceVideoOutGetBufferLabelAddress(s32 handle, uintptr_t* label_addr);
+
 void RegisterLib(Core::Loader::SymbolsResolver* sym);
 
 } // namespace Libraries::VideoOut

--- a/src/core/platform.h
+++ b/src/core/platform.h
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "common/assert.h"
+#include "common/logging/log.h"
+#include "common/singleton.h"
+#include "common/types.h"
+#include "magic_enum.hpp"
+
+#include <functional>
+#include <mutex>
+#include <optional>
+#include <queue>
+
+namespace Platform {
+
+enum class InterruptId : u32 {
+    Compute0RelMem = 0u,
+    Compute1RelMem = 1u,
+    Compute2RelMem = 2u,
+    Compute3RelMem = 3u,
+    Compute4RelMem = 4u,
+    Compute5RelMem = 5u,
+    Compute6RelMem = 6u,
+    GfxEop = 0x40u
+};
+
+using IrqHandler = std::function<void(InterruptId)>;
+
+struct IrqController {
+    void RegisterOnce(IrqHandler handler) {
+        std::unique_lock lock{m_lock};
+        one_time_subscribers.emplace(handler);
+    }
+
+    void Register(IrqHandler handler) {
+        ASSERT_MSG(!persistent_handler.has_value(),
+                   "Too many persistent handlers"); // Add a slot map if so
+        {
+            std::unique_lock lock{m_lock};
+            persistent_handler.emplace(handler);
+        }
+    }
+
+    void Unregister() {
+        std::unique_lock lock{m_lock};
+        persistent_handler.reset();
+    }
+
+    void Signal(InterruptId irq) {
+        LOG_TRACE(Core, "IRQ signaled: {}", magic_enum::enum_name(irq));
+        {
+            std::unique_lock lock{m_lock};
+
+            if (persistent_handler) {
+                persistent_handler.value()(irq);
+            }
+
+            while (!one_time_subscribers.empty()) {
+                const auto& h = one_time_subscribers.front();
+                h(irq);
+
+                one_time_subscribers.pop();
+            }
+        }
+    }
+
+private:
+    std::optional<IrqHandler> persistent_handler{};
+    std::queue<IrqHandler> one_time_subscribers{};
+    std::mutex m_lock{};
+};
+
+using IrqC = Common::Singleton<IrqController>;
+
+} // namespace Platform

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -69,7 +69,16 @@ void Liverpool::ProcessCmdList(u32* cmdbuf, u32 size_in_bytes) {
                 break;
             }
             case PM4ItOpcode::EventWriteEos: {
-                // const auto* event_eos = reinterpret_cast<PM4CmdEventWriteEos*>(header);
+                const auto* event_eos = reinterpret_cast<PM4CmdEventWriteEos*>(header);
+                switch (event_eos->command.Value()) {
+                case PM4CmdEventWriteEos::Command::SingalFence: {
+                    event_eos->SignalFence();
+                    break;
+                }
+                default: {
+                    UNREACHABLE();
+                }
+                }
                 break;
             }
             case PM4ItOpcode::EventWriteEop: {

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -90,8 +90,7 @@ void Liverpool::ProcessCmdList(u32* cmdbuf, u32 size_in_bytes) {
                 ASSERT(write_data->dst_sel.Value() == 2 || write_data->dst_sel.Value() == 5);
                 const u32 data_size = (header->type3.count.Value() - 2) * 4;
                 if (!write_data->wr_one_addr.Value()) {
-                    std::memcpy(reinterpret_cast<void*>(write_data->Address()), write_data->data,
-                                data_size);
+                    std::memcpy(write_data->Address<void*>(), write_data->data, data_size);
                 } else {
                     UNREACHABLE();
                 }

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -3,9 +3,11 @@
 
 #pragma once
 
-#include <array>
 #include "common/bit_field.h"
 #include "common/types.h"
+
+#include <array>
+#include <functional>
 
 namespace AmdGpu {
 
@@ -611,6 +613,8 @@ public:
     Liverpool();
 
     void ProcessCmdList(u32* cmdbuf, u32 size_in_bytes);
+
+    std::function<void(void)> eop_callback{};
 };
 
 static_assert(GFX6_3D_REG_INDEX(ps_program) == 0x2C08);

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -624,17 +624,11 @@ public:
         // reworked with mutiple queues introduction
         cp.get();
     }
-    void SetEopCallback(auto const& cb) {
-        eop_callback = cb;
-    }
 
 private:
     void ProcessCmdList(u32* cmdbuf, u32 size_in_bytes);
 
-    std::function<void(void)> eop_callback{};
     std::future<void> cp{};
-    std::condition_variable cv_reg_mem{};
-    std::mutex m_reg_mem{};
 };
 
 static_assert(GFX6_3D_REG_INDEX(ps_program) == 0x2C08);

--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -286,6 +286,10 @@ struct PM4CmdEventWriteEop {
         return reinterpret_cast<u64*>(address_lo | u64(address_hi) << 32);
     }
 
+    u32 DataDWord() const {
+        return data_lo;
+    }
+
     u64 DataQWord() const {
         return data_lo | u64(data_hi) << 32;
     }

--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -428,12 +428,23 @@ struct PM4CmdWriteData {
         BitField<30, 1, u32> engine_sel;
         u32 raw;
     };
-    u32 dst_addr_lo;
-    u32 dst_addr_hi;
+    union {
+        struct {
+            u32 dst_addr_lo;
+            u32 dst_addr_hi;
+        };
+        u64 addr64;
+    };
     u32 data[0];
 
-    uintptr_t Address() const {
-        return (uintptr_t(dst_addr_hi) << 32) | dst_addr_lo;
+    template <typename T>
+    void Address(T addr) {
+        addr64 = reinterpret_cast<u64>(addr);
+    }
+
+    template <typename T>
+    T* Address() const {
+        return reinterpret_cast<T*>(addr64);
     }
 };
 

--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -330,4 +330,18 @@ struct PM4CmdWaitRegMem {
     u32 poll_interval;
 };
 
+struct PM4CmdWriteData {
+    PM4Type3Header header;
+    union {
+        BitField<8, 11, u32> dst_sel;
+        BitField<16, 1, u32> wr_one_addr;
+        BitField<20, 1, u32> wr_confirm;
+        BitField<30, 1, u32> engine_sel;
+        u32 raw;
+    };
+    u32 dst_addr_lo;
+    u32 dst_addr_hi;
+    u32 data[0];
+};
+
 } // namespace AmdGpu

--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -201,13 +201,18 @@ struct PM4CmdNop {
     PM4Type3Header header;
     u32 data_block[0];
 
-    enum class PayloadType : u32 {
-        DebugMarkerPush = 0x68750001,      ///< Begin of GPU event scope
-        DebugMarkerPop = 0x68750002,       ///< End of GPU event scope
-        SetVsharpInUdata = 0x68750004,     ///< Indicates that V# will be set in the next packet
-        SetTsharpInUdata = 0x68750005,     ///< Indicates that T# will be set in the next packet
-        SetSsharpInUdata = 0x68750006,     ///< Indicates that S# will be set in the next packet
-        DebugColorMarkerPush = 0x6875000e, ///< Begin of GPU event scope with color
+    enum PayloadType : u32 {
+        DebugMarkerPush = 0x68750001u,      ///< Begin of GPU event scope
+        DebugMarkerPop = 0x68750002u,       ///< End of GPU event scope
+        SetVsharpInUdata = 0x68750004u,     ///< Indicates that V# will be set in the next packet
+        SetTsharpInUdata = 0x68750005u,     ///< Indicates that T# will be set in the next packet
+        SetSsharpInUdata = 0x68750006u,     ///< Indicates that S# will be set in the next packet
+        DebugColorMarkerPush = 0x6875000eu, ///< Begin of GPU event scope with color
+        PatchedFlip = 0x68750776u,          ///< Patched flip marker
+        PrepareFlip = 0x68750777u,          ///< Flip marker
+        PrepareFlipLabel = 0x68750778u,     ///< Flip marker with label address
+        PrepareFlipInterrupt = 0x68750780u, ///< Flip marker with interrupt
+        PrepareFlipInterruptLabel = 0x68750781u, ///< Flip marker with interrupt and label
     };
 };
 

--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -5,6 +5,7 @@
 
 #include <cstring>
 #include "common/bit_field.h"
+#include "common/rdtsc.h"
 #include "common/types.h"
 #include "core/platform.h"
 #include "video_core/amdgpu/pm4_opcodes.h"
@@ -304,6 +305,10 @@ struct PM4CmdEventWriteEop {
         }
         case DataSelect::Data64: {
             *Address<u64>() = DataQWord();
+            break;
+        }
+        case DataSelect::PerfCounter: {
+            *Address<u64>() = Common::FencedRDTSC();
             break;
         }
         default: {

--- a/src/video_core/amdgpu/pm4_opcodes.h
+++ b/src/video_core/amdgpu/pm4_opcodes.h
@@ -49,7 +49,7 @@ enum class PM4ItOpcode : u32 {
     PremableCntl = 0x4A,
     DmaData = 0x50,
     ContextRegRmw = 0x51,
-    Unknown58 = 0x58,
+    AcquireMem = 0x58,
     LoadShReg = 0x5F,
     LoadConfigReg = 0x60,
     LoadContextReg = 0x61,


### PR DESCRIPTION
This PR implements Gnm EOP event handling and support for GPU submitted flips.
The next functions were added

GnmDriver: 
* `sceGnmAddEqEvent`
* `sceGnmDeleteEqEvent`
* `sceGnmInsertWaitFlipDone`
* `sceGnmSetEmbeddedVsShader`
* `sceGnmSubmitAndFlipCommandBuffers`

VideoOut:
* `sceVideoOutGetBufferLabelAddress`
* `sceVideoOutSubmitEopFlip`

To maintain proper sync between GPU and presenter, a new entity `Platform::IrqController` was introduced.
