### PR TITLE
graphics: separate IRQ for GPU driven flips

### DIFF
--- a/src/core/libraries/gnmdriver/gnmdriver.cpp
+++ b/src/core/libraries/gnmdriver/gnmdriver.cpp
@@ -49,12 +49,13 @@ s32 PS4_SYSV_ABI sceGnmAddEqEvent(SceKernelEqueue eq, u64 id, void* udata) {
     kernel_event.event.udata = udata;
     eq->addEvent(kernel_event);
 
-    Platform::IrqC::Instance()->Register([=](Platform::InterruptId irq) {
-        ASSERT_MSG(irq == Platform::InterruptId::GfxEop,
-                   "An unexpected IRQ occured"); // We need to conver IRQ# to event id and do proper
-                                                 // filtering in trigger function
-        eq->triggerEvent(SceKernelEvent::Type::GfxEop, EVFILT_GRAPHICS_CORE, nullptr);
-    });
+    Platform::IrqC::Instance()->Register(
+        Platform::InterruptId::GfxEop, [=](Platform::InterruptId irq) {
+            ASSERT_MSG(irq == Platform::InterruptId::GfxEop,
+                       "An unexpected IRQ occured"); // We need to conver IRQ# to event id and do
+                                                     // proper filtering in trigger function
+            eq->triggerEvent(SceKernelEvent::Type::GfxEop, EVFILT_GRAPHICS_CORE, nullptr);
+        });
     return ORBIS_OK;
 }
 
@@ -164,7 +165,7 @@ s32 PS4_SYSV_ABI sceGnmDeleteEqEvent(SceKernelEqueue eq, u64 id) {
 
     eq->removeEvent(id);
 
-    Platform::IrqC::Instance()->Unregister();
+    Platform::IrqC::Instance()->Unregister(Platform::InterruptId::GfxEop);
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/videoout/video_out.cpp
+++ b/src/core/libraries/videoout/video_out.cpp
@@ -223,11 +223,12 @@ s32 sceVideoOutSubmitEopFlip(s32 handle, u32 buf_id, u32 mode, u32 arg, void** u
         return 0x8029000b;
     }
 
-    Platform::IrqC::Instance()->RegisterOnce([=](Platform::InterruptId irq) {
-        ASSERT_MSG(irq == Platform::InterruptId::GfxEop, "An unexpected IRQ occured");
-        const auto result = driver->SubmitFlip(port, buf_id, arg, true);
-        ASSERT_MSG(result, "EOP flip submission failed");
-    });
+    Platform::IrqC::Instance()->RegisterOnce(
+        Platform::InterruptId::GfxFlip, [=](Platform::InterruptId irq) {
+            ASSERT_MSG(irq == Platform::InterruptId::GfxFlip, "An unexpected IRQ occured");
+            const auto result = driver->SubmitFlip(port, buf_id, arg, true);
+            ASSERT_MSG(result, "EOP flip submission failed");
+        });
 
     return ORBIS_OK;
 }


### PR DESCRIPTION
This PR changes the way how GPU driven flips are handled. Previously, the VO was waiting for an EOP to process a surface. Now the GPU raises another IRQ dedicated for flips only and completely separated from EOP packets.