### PR TITLE
A bunch of new functional and small improvements

### DIFF
--- a/src/core/libraries/kernel/event_queues.cpp
+++ b/src/core/libraries/kernel/event_queues.cpp
@@ -34,7 +34,7 @@ int PS4_SYSV_ABI sceKernelCreateEqueue(SceKernelEqueue* eq, const char* name) {
 
 int PS4_SYSV_ABI sceKernelDeleteEqueue(SceKernelEqueue eq) {
     if (eq == nullptr) {
-        return SCE_KERNEL_ERROR_EBADF;
+        return ORBIS_KERNEL_ERROR_EBADF;
     }
 
     delete eq;
@@ -46,7 +46,7 @@ int PS4_SYSV_ABI sceKernelWaitEqueue(SceKernelEqueue eq, SceKernelEvent* ev, int
     LOG_INFO(Kernel_Event, "num = {}", num);
 
     if (eq == nullptr) {
-        return SCE_KERNEL_ERROR_EBADF;
+        return ORBIS_KERNEL_ERROR_EBADF;
     }
 
     if (ev == nullptr) {
@@ -71,7 +71,31 @@ int PS4_SYSV_ABI sceKernelWaitEqueue(SceKernelEqueue eq, SceKernelEvent* ev, int
         }
     }
 
-    return SCE_OK;
+    return ORBIS_OK;
+}
+
+int PS4_SYSV_ABI sceKernelAddUserEvent(SceKernelEqueue eq, int id) {
+    if (eq == nullptr) {
+        return ORBIS_KERNEL_ERROR_EBADF;
+    }
+
+    Kernel::EqueueEvent event{};
+    event.isTriggered = false;
+    event.event.ident = id;
+    event.event.filter = Kernel::EVFILT_USER;
+    event.event.udata = 0;
+    event.event.fflags = 0;
+    event.event.data = 0;
+
+    return eq->addEvent(event);
+}
+
+void* PS4_SYSV_ABI sceKernelGetEventUserData(const SceKernelEvent* ev) {
+    if (!ev) {
+        return nullptr;
+    }
+
+    return ev->udata;
 }
 
 } // namespace Libraries::Kernel

--- a/src/core/libraries/kernel/event_queues.h
+++ b/src/core/libraries/kernel/event_queues.h
@@ -14,5 +14,7 @@ int PS4_SYSV_ABI sceKernelCreateEqueue(SceKernelEqueue* eq, const char* name);
 int PS4_SYSV_ABI sceKernelDeleteEqueue(SceKernelEqueue eq);
 int PS4_SYSV_ABI sceKernelWaitEqueue(SceKernelEqueue eq, SceKernelEvent* ev, int num, int* out,
                                      SceKernelUseconds* timo);
+void* PS4_SYSV_ABI sceKernelGetEventUserData(const SceKernelEvent* ev);
+int PS4_SYSV_ABI sceKernelAddUserEvent(SceKernelEqueue eq, int id);
 
 } // namespace Libraries::Kernel

--- a/src/core/libraries/kernel/libkernel.cpp
+++ b/src/core/libraries/kernel/libkernel.cpp
@@ -196,6 +196,8 @@ void LibKernel_Register(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("D0OdFMjp46I", "libkernel", 1, "libkernel", 1, 1, sceKernelCreateEqueue);
     LIB_FUNCTION("jpFjmgAC5AE", "libkernel", 1, "libkernel", 1, 1, sceKernelDeleteEqueue);
     LIB_FUNCTION("fzyMKs9kim0", "libkernel", 1, "libkernel", 1, 1, sceKernelWaitEqueue);
+    LIB_FUNCTION("vz+pg2zdopI", "libkernel", 1, "libkernel", 1, 1, sceKernelGetEventUserData);
+    LIB_FUNCTION("4R6-OvI2cEA", "libkernel", 1, "libkernel", 1, 1, sceKernelAddUserEvent);
     // misc
     LIB_FUNCTION("WslcK1FQcGI", "libkernel", 1, "libkernel", 1, 1, sceKernelIsNeoMode);
     LIB_FUNCTION("Ou3iL1abvng", "libkernel", 1, "libkernel", 1, 1, stack_chk_fail);

--- a/src/core/libraries/videoout/driver.cpp
+++ b/src/core/libraries/videoout/driver.cpp
@@ -243,6 +243,13 @@ void VideoOutDriver::Vblank() {
     vblank_status.count++;
     vblank_status.processTime = Libraries::Kernel::sceKernelGetProcessTime();
     vblank_status.tsc = Libraries::Kernel::sceKernelReadTsc();
+
+    // Trigger flip events for the port.
+    for (auto& event : main_port.vblank_events) {
+        if (event != nullptr) {
+            event->triggerEvent(SCE_VIDEO_OUT_EVENT_VBLANK, Kernel::EVFILT_VIDEO_OUT, nullptr);
+        }
+    }
 }
 
 } // namespace Libraries::VideoOut

--- a/src/core/libraries/videoout/driver.h
+++ b/src/core/libraries/videoout/driver.h
@@ -25,6 +25,7 @@ struct VideoOutPort {
     FlipStatus flip_status;
     SceVideoOutVblankStatus vblank_status;
     std::vector<Kernel::SceKernelEqueue> flip_events;
+    std::vector<Kernel::SceKernelEqueue> vblank_events;
     int flip_rate = 0;
 
     s32 FindFreeGroup() const {

--- a/src/core/libraries/videoout/video_out.cpp
+++ b/src/core/libraries/videoout/video_out.cpp
@@ -60,6 +60,31 @@ s32 PS4_SYSV_ABI sceVideoOutAddFlipEvent(Kernel::SceKernelEqueue eq, s32 handle,
     return eq->addEvent(event);
 }
 
+s32 PS4_SYSV_ABI sceVideoOutAddVblankEvent(Kernel::SceKernelEqueue eq, s32 handle, void* udata) {
+    LOG_INFO(Lib_VideoOut, "handle = {}", handle);
+
+    auto* port = driver->GetPort(handle);
+    if (port == nullptr) {
+        return ORBIS_VIDEO_OUT_ERROR_INVALID_HANDLE;
+    }
+
+    if (eq == nullptr) {
+        return ORBIS_VIDEO_OUT_ERROR_INVALID_EVENT_QUEUE;
+    }
+
+    Kernel::EqueueEvent event{};
+    event.isTriggered = false;
+    event.event.ident = SCE_VIDEO_OUT_EVENT_VBLANK;
+    event.event.filter = Kernel::EVFILT_VIDEO_OUT;
+    event.event.udata = udata;
+    event.event.fflags = 0;
+    event.event.data = 0;
+    event.filter.data = port;
+
+    port->vblank_events.push_back(eq);
+    return eq->addEvent(event);
+}
+
 s32 PS4_SYSV_ABI sceVideoOutRegisterBuffers(s32 handle, s32 startIndex, void* const* addresses,
                                             s32 bufferNum, const BufferAttribute* attribute) {
     if (!addresses || !attribute) {
@@ -243,6 +268,8 @@ void RegisterLib(Core::Loader::SymbolsResolver* sym) {
                  sceVideoOutRegisterBuffers);
     LIB_FUNCTION("HXzjK9yI30k", "libSceVideoOut", 1, "libSceVideoOut", 0, 0,
                  sceVideoOutAddFlipEvent);
+    LIB_FUNCTION("Xru92wHJRmg", "libSceVideoOut", 1, "libSceVideoOut", 0, 0,
+                 sceVideoOutAddVblankEvent);
     LIB_FUNCTION("CBiu4mCE1DA", "libSceVideoOut", 1, "libSceVideoOut", 0, 0,
                  sceVideoOutSetFlipRate);
     LIB_FUNCTION("i6-sR91Wt-4", "libSceVideoOut", 1, "libSceVideoOut", 0, 0,

--- a/src/core/libraries/videoout/video_out.h
+++ b/src/core/libraries/videoout/video_out.h
@@ -88,6 +88,7 @@ void PS4_SYSV_ABI sceVideoOutSetBufferAttribute(BufferAttribute* attribute, Pixe
                                                 u32 tilingMode, u32 aspectRatio, u32 width,
                                                 u32 height, u32 pitchInPixel);
 s32 PS4_SYSV_ABI sceVideoOutAddFlipEvent(Kernel::SceKernelEqueue eq, s32 handle, void* udata);
+s32 PS4_SYSV_ABI sceVideoOutAddVBlankEvent(Kernel::SceKernelEqueue eq, s32 handle, void* udata);
 s32 PS4_SYSV_ABI sceVideoOutRegisterBuffers(s32 handle, s32 startIndex, void* const* addresses,
                                             s32 bufferNum, const BufferAttribute* attribute);
 s32 PS4_SYSV_ABI sceVideoOutSetFlipRate(s32 handle, s32 rate);


### PR DESCRIPTION
### GnmDriver

- Submission lock moved out from GPU as it needs to be accessed by internal driver functions
- Added `sceGnmAreSubmitsAllowed`

### VideoOut

- Added `sceVideoOutAddVblankEvent`

### Kernel

- Added `sceKernelAddUserEvent` and `sceKernelGetEventUserData`
- Event processing now works with multiple events

### Platform

- Added option to register several listeners to the same IRQ