### PR TITLE
video core: null GPU

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -18,6 +18,7 @@ std::string logType = "sync";
 bool isDebugDump = false;
 bool isLibc = true;
 bool isShowSplash = false;
+bool isNullGpu = false;
 
 bool isLleLibc() {
     return isLibc;
@@ -52,6 +53,10 @@ bool debugDump() {
 
 bool showSplash() {
     return isShowSplash;
+}
+
+bool nullGpu() {
+    return isNullGpu;
 }
 
 void load(const std::filesystem::path& path) {
@@ -90,6 +95,7 @@ void load(const std::filesystem::path& path) {
             screenWidth = toml::find_or<toml::integer>(gpu, "screenWidth", screenWidth);
             screenHeight = toml::find_or<toml::integer>(gpu, "screenHeight", screenHeight);
             gpuId = toml::find_or<toml::integer>(gpu, "gpuId", 0);
+            isNullGpu = toml::find_or<toml::boolean>(gpu, "nullGpu", false);
         }
     }
     if (data.contains("Debug")) {
@@ -135,6 +141,7 @@ void save(const std::filesystem::path& path) {
     data["GPU"]["gpuId"] = gpuId;
     data["GPU"]["screenWidth"] = screenWidth;
     data["GPU"]["screenHeight"] = screenHeight;
+    data["GPU"]["nullGpu"] = isNullGpu;
     data["Debug"]["DebugDump"] = isDebugDump;
     data["LLE"]["libc"] = isLibc;
 

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -21,5 +21,6 @@ s32 getGpuId();
 bool debugDump();
 bool isLleLibc();
 bool showSplash();
+bool nullGpu();
 
 }; // namespace Config

--- a/src/core/libraries/gnmdriver/gnmdriver.cpp
+++ b/src/core/libraries/gnmdriver/gnmdriver.cpp
@@ -1429,9 +1429,12 @@ s32 PS4_SYSV_ABI sceGnmSubmitCommandBuffers(u32 count, const u32* dcb_gpu_addrs[
 
     for (auto cbpair = 0u; cbpair < count; ++cbpair) {
         const auto* ccb = ccb_gpu_addrs ? ccb_gpu_addrs[cbpair] : nullptr;
-        const auto ccb_size = ccb_sizes_in_bytes ? ccb_sizes_in_bytes[cbpair] : 0;
+        const auto ccb_size_in_bytes = ccb_sizes_in_bytes ? ccb_sizes_in_bytes[cbpair] : 0;
 
-        liverpool->SubmitGfx({dcb_gpu_addrs[cbpair], dcb_sizes_in_bytes[cbpair]}, {ccb, ccb_size});
+        const auto dcb_size_dw = dcb_sizes_in_bytes[cbpair] >> 2;
+        const auto ccb_size_dw = ccb_size_in_bytes >> 2;
+
+        liverpool->SubmitGfx({dcb_gpu_addrs[cbpair], dcb_size_dw}, {ccb, ccb_size_dw});
     }
 
     return ORBIS_OK;

--- a/src/core/platform.h
+++ b/src/core/platform.h
@@ -26,7 +26,6 @@ enum class InterruptId : u32 {
     Compute6RelMem = 6u,
     GfxEop = 7u,
     GfxFlip = 8u,
-    MaxValue
 };
 
 using IrqHandler = std::function<void(InterruptId)>;
@@ -81,7 +80,7 @@ private:
         std::queue<IrqHandler> one_time_subscribers{};
         std::mutex m_lock{};
     };
-    std::array<IrqContext, (int)InterruptId::MaxValue> irq_contexts{};
+    std::array<IrqContext, magic_enum::enum_count<InterruptId>()> irq_contexts{};
 };
 
 using IrqC = Common::Singleton<IrqController>;

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -34,10 +34,15 @@ void Liverpool::Process(std::stop_token stoken) {
             gfx_ring.pop();
         }
 
-        ASSERT_MSG(dcb.size() != 0, "Empty command list received");
-        ProcessCmdList(dcb.data(), dcb.size());
+        ASSERT_MSG(!dcb.empty(), "Empty command list received");
+        ProcessCmdList(dcb.data(), dcb.size_bytes());
 
-        cv_complete.notify_all();
+        {
+            std::unique_lock lock{m_ring_access};
+            if (gfx_ring.empty()) {
+                cv_complete.notify_all();
+            }
+        }
     }
 }
 

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -108,7 +108,9 @@ void Liverpool::ProcessCmdList(const u32* cmdbuf, u32 size_in_bytes) {
                 regs.index_base_address.base_addr_hi.Assign(draw_index->index_base_hi);
                 regs.num_indices = draw_index->index_count;
                 regs.draw_initiator = draw_index->draw_initiator;
-                rasterizer->DrawIndex();
+                if (rasterizer) {
+                    rasterizer->DrawIndex();
+                }
                 break;
             }
             case PM4ItOpcode::DrawIndexAuto: {

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -644,7 +644,7 @@ private:
     void ProcessCmdList(const u32* cmdbuf, u32 size_in_bytes);
     void Process(std::stop_token stoken);
 
-    Vulkan::Rasterizer* rasterizer;
+    Vulkan::Rasterizer* rasterizer{};
     std::jthread process_thread{};
     std::queue<std::span<const u32>> gfx_ring{};
     std::condition_variable_any cv_submit{};

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/config.h"
 #include "video_core/amdgpu/liverpool.h"
 #include "video_core/renderer_vulkan/vk_instance.h"
 #include "video_core/renderer_vulkan/vk_rasterizer.h"
@@ -19,7 +20,9 @@ Rasterizer::Rasterizer(const Instance& instance_, Scheduler& scheduler_,
     : instance{instance_}, scheduler{scheduler_}, texture_cache{texture_cache_},
       liverpool{liverpool_}, pipeline_cache{instance, scheduler, liverpool},
       vertex_index_buffer{instance, scheduler, VertexIndexFlags, 64_MB} {
-    liverpool->BindRasterizer(this);
+    if (!Config::nullGpu()) {
+        liverpool->BindRasterizer(this);
+    }
 }
 
 Rasterizer::~Rasterizer() = default;


### PR DESCRIPTION
These changes add a config file option to skip Vulkan backend binding. It allows us to bypass draw calls and dispatches processing, so missing functionality in shader recompiler andd state tracker won't crash the emulator.
The option is disabled by default. To enable, use:
```
nullGpu = true
```
in `[GPU]` section of user config file. 