### PR TITLE
video_core: Add constant buffer support

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -189,6 +189,7 @@ public:
         } else {
             ForEachBackend([&entry](auto& backend) { backend.Write(entry); });
         }
+        std::fflush(stdout);
     }
 
 private:

--- a/src/core/libraries/kernel/libkernel.cpp
+++ b/src/core/libraries/kernel/libkernel.cpp
@@ -204,6 +204,7 @@ void LibKernel_Register(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("rTXw65xmLIA", "libkernel", 1, "libkernel", 1, 1, sceKernelAllocateDirectMemory);
     LIB_FUNCTION("pO96TwzOm5E", "libkernel", 1, "libkernel", 1, 1, sceKernelGetDirectMemorySize);
     LIB_FUNCTION("L-Q3LEjIbgA", "libkernel", 1, "libkernel", 1, 1, sceKernelMapDirectMemory);
+    LIB_FUNCTION("WFcfL2lzido", "libkernel", 1, "libkernel", 1, 1, sceKernelQueryMemoryProtection);
     LIB_FUNCTION("MBuItvba6z8", "libkernel", 1, "libkernel", 1, 1, sceKernelReleaseDirectMemory);
     LIB_FUNCTION("cQke9UuBQOk", "libkernel", 1, "libkernel", 1, 1, sceKernelMunmap);
     LIB_FUNCTION("mL8NDH86iQI", "libkernel", 1, "libkernel", 1, 1, sceKernelMapNamedFlexibleMemory);

--- a/src/core/libraries/kernel/memory_management.cpp
+++ b/src/core/libraries/kernel/memory_management.cpp
@@ -114,4 +114,9 @@ s32 PS4_SYSV_ABI sceKernelMapFlexibleMemory(void** addr_in_out, std::size_t len,
     return sceKernelMapNamedFlexibleMemory(addr_in_out, len, prot, flags, "");
 }
 
+int PS4_SYSV_ABI sceKernelQueryMemoryProtection(void* addr, void** start, void** end, u32* prot) {
+    auto* memory = Core::Memory::Instance();
+    return memory->QueryProtection(std::bit_cast<VAddr>(addr), start, end, prot);
+}
+
 } // namespace Libraries::Kernel

--- a/src/core/libraries/kernel/memory_management.h
+++ b/src/core/libraries/kernel/memory_management.h
@@ -39,5 +39,6 @@ s32 PS4_SYSV_ABI sceKernelMapNamedFlexibleMemory(void** addrInOut, std::size_t l
                                                  int flags, const char* name);
 s32 PS4_SYSV_ABI sceKernelMapFlexibleMemory(void** addr_in_out, std::size_t len, int prot,
                                             int flags);
+int PS4_SYSV_ABI sceKernelQueryMemoryProtection(void* addr, void** start, void** end, u32* prot);
 
 } // namespace Libraries::Kernel

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -107,6 +107,8 @@ public:
 
     void UnmapMemory(VAddr virtual_addr, size_t size);
 
+    int QueryProtection(VAddr addr, void** start, void** end, u32* prot);
+
     std::pair<vk::Buffer, size_t> GetVulkanBuffer(VAddr addr);
 
 private:

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -29,6 +29,10 @@ Id OutputAttrPointer(EmitContext& ctx, IR::Attribute attr, u32 element) {
 }
 } // Anonymous namespace
 
+void EmitGetUserData(EmitContext&) {
+    throw LogicError("Unreachable instruction");
+}
+
 void EmitGetScalarRegister(EmitContext&) {
     throw LogicError("Unreachable instruction");
 }
@@ -93,6 +97,40 @@ Id EmitGetAttributeU32(EmitContext& ctx, IR::Attribute attr, u32 comp) {
 void EmitSetAttribute(EmitContext& ctx, IR::Attribute attr, Id value, u32 element) {
     const Id pointer{OutputAttrPointer(ctx, attr, element)};
     ctx.OpStore(pointer, value);
+}
+
+Id EmitLoadBufferF32(EmitContext& ctx, IR::Inst* inst, const IR::Value& handle,
+                     const IR::Value& address) {
+    UNREACHABLE();
+}
+
+Id EmitLoadBufferF32x2(EmitContext& ctx, IR::Inst* inst, const IR::Value& handle,
+                       const IR::Value& address) {
+    UNREACHABLE();
+}
+
+Id EmitLoadBufferF32x3(EmitContext& ctx, IR::Inst* inst, const IR::Value& handle,
+                       const IR::Value& address) {
+    UNREACHABLE();
+}
+
+Id EmitLoadBufferF32x4(EmitContext& ctx, IR::Inst* inst, const IR::Value& handle,
+                       const IR::Value& address) {
+    const auto info = inst->Flags<IR::BufferInstInfo>();
+    const Id buffer = ctx.buffers[handle.U32()];
+    const Id type = ctx.info.buffers[handle.U32()].is_storage ? ctx.storage_f32 : ctx.uniform_f32;
+    if (info.index_enable && info.offset_enable) {
+        UNREACHABLE();
+    } else if (info.index_enable) {
+        boost::container::static_vector<Id, 4> ids;
+        for (u32 i = 0; i < 4; i++) {
+            const Id index{ctx.OpIAdd(ctx.U32[1], ctx.Def(address), ctx.ConstU32(i))};
+            const Id ptr{ctx.OpAccessChain(type, buffer, ctx.ConstU32(0U), index)};
+            ids.push_back(ctx.OpLoad(ctx.F32[1], ptr));
+        }
+        return ctx.OpCompositeConstruct(ctx.F32[4], ids);
+    }
+    UNREACHABLE();
 }
 
 } // namespace Shader::Backend::SPIRV

--- a/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
@@ -34,6 +34,7 @@ void EmitGetVcc(EmitContext& ctx);
 void EmitSetVcc(EmitContext& ctx);
 void EmitPrologue(EmitContext& ctx);
 void EmitEpilogue(EmitContext& ctx);
+void EmitGetUserData(EmitContext& ctx);
 void EmitGetScalarRegister(EmitContext& ctx);
 void EmitSetScalarRegister(EmitContext& ctx);
 void EmitGetVectorRegister(EmitContext& ctx);
@@ -46,6 +47,14 @@ Id EmitReadConstBuffer(EmitContext& ctx, const IR::Value& handle, const IR::Valu
                        const IR::Value& offset);
 Id EmitReadConstBufferF32(EmitContext& ctx, const IR::Value& handle, const IR::Value& index,
                           const IR::Value& offset);
+Id EmitLoadBufferF32(EmitContext& ctx, IR::Inst* inst, const IR::Value& handle,
+                     const IR::Value& address);
+Id EmitLoadBufferF32x2(EmitContext& ctx, IR::Inst* inst, const IR::Value& handle,
+                       const IR::Value& address);
+Id EmitLoadBufferF32x3(EmitContext& ctx, IR::Inst* inst, const IR::Value& handle,
+                       const IR::Value& address);
+Id EmitLoadBufferF32x4(EmitContext& ctx, IR::Inst* inst, const IR::Value& handle,
+                       const IR::Value& address);
 Id EmitGetAttribute(EmitContext& ctx, IR::Attribute attr, u32 comp);
 Id EmitGetAttributeU32(EmitContext& ctx, IR::Attribute attr, u32 comp);
 void EmitSetAttribute(EmitContext& ctx, IR::Attribute attr, Id value, u32 comp);

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -114,6 +114,7 @@ public:
         return ConstantComposite(type, constituents);
     }
 
+    Info& info;
     const Profile& profile;
     Stage stage{};
 
@@ -141,12 +142,18 @@ public:
     Id output_u32{};
     Id output_f32{};
 
+    Id uniform_f32{};
+    Id storage_f32{};
+
     boost::container::small_vector<Id, 16> interfaces;
 
     Id output_position{};
     Id vertex_index{};
     Id base_vertex{};
     std::array<Id, 8> frag_color{};
+
+    u32 binding{};
+    boost::container::small_vector<Id, 4> buffers;
 
     struct SpirvAttribute {
         Id id;
@@ -160,8 +167,9 @@ public:
 private:
     void DefineArithmeticTypes();
     void DefineInterfaces(const IR::Program& program);
-    void DefineInputs(const IR::Program& program);
-    void DefineOutputs(const IR::Program& program);
+    void DefineInputs(const Info& info);
+    void DefineOutputs(const Info& info);
+    void DefineBuffers(const Info& info);
 
     SpirvAttribute GetAttributeInfo(AmdGpu::NumberFormat fmt, Id id);
 };

--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -36,7 +36,7 @@ Translator::Translator(IR::Block* block_, Info& info_) : block{block_}, ir{*bloc
     // Initialize user data.
     IR::ScalarReg dst_sreg = IR::ScalarReg::S0;
     for (u32 i = 0; i < 16; i++) {
-        ir.SetScalarReg(dst_sreg++, ir.Imm32(0U));
+        ir.SetScalarReg(dst_sreg++, ir.GetUserData(dst_sreg));
     }
 }
 
@@ -170,6 +170,9 @@ void Translate(IR::Block* block, std::span<const GcnInst> inst_list, Info& info)
             break;
         case Opcode::V_CNDMASK_B32:
             translator.V_CNDMASK_B32(inst);
+            break;
+        case Opcode::TBUFFER_LOAD_FORMAT_XYZW:
+            translator.TBUFFER_LOAD_FORMAT_XYZW(inst);
             break;
         case Opcode::S_MOV_B64:
         case Opcode::S_WQM_B64:

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -48,6 +48,9 @@ public:
     void V_CMP_EQ_U32(const GcnInst& inst);
     void V_CNDMASK_B32(const GcnInst& inst);
 
+    // Vector Memory
+    void TBUFFER_LOAD_FORMAT_XYZW(const GcnInst& inst);
+
     // Vector interpolation
     void V_INTERP_P2_F32(const GcnInst& inst);
 

--- a/src/shader_recompiler/frontend/translate/vector_memory.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_memory.cpp
@@ -100,4 +100,35 @@ void Translator::IMAGE_SAMPLE(const GcnInst& inst) {
     }
 }
 
+void Translator::TBUFFER_LOAD_FORMAT_XYZW(const GcnInst& inst) {
+    const auto& mtbuf = inst.control.mtbuf;
+    const IR::VectorReg vaddr{inst.src[0].code};
+    const IR::ScalarReg sharp{inst.src[2].code * 4};
+    const IR::Value address = [&] -> IR::Value {
+        if (mtbuf.idxen && mtbuf.offen) {
+            return ir.CompositeConstruct(ir.GetVectorReg(vaddr), ir.GetVectorReg(vaddr + 1));
+        }
+        if (mtbuf.idxen || mtbuf.offen) {
+            return ir.GetVectorReg(vaddr);
+        }
+        return {};
+    }();
+    const IR::Value soffset{GetSrc(inst.src[3])};
+    ASSERT_MSG(soffset.IsImmediate() && soffset.U32() == 0, "Non immediate offset not supported");
+
+    IR::BufferInstInfo info{};
+    info.index_enable.Assign(mtbuf.idxen);
+    info.offset_enable.Assign(mtbuf.offen);
+    info.inst_offset.Assign(mtbuf.offset);
+    info.dmft.Assign(static_cast<AmdGpu::DataFormat>(mtbuf.dfmt));
+    info.nfmt.Assign(static_cast<AmdGpu::NumberFormat>(mtbuf.nfmt));
+    info.is_typed.Assign(1);
+
+    const IR::Value value = ir.LoadBuffer(4, ir.GetScalarReg(sharp), address, info);
+    const IR::VectorReg dst_reg{inst.src[1].code};
+    for (u32 i = 0; i < 4; i++) {
+        ir.SetVectorReg(dst_reg + i, IR::F32{ir.CompositeExtract(value, i)});
+    }
+}
+
 } // namespace Shader::Gcn

--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -111,6 +111,10 @@ void IREmitter::Epilogue() {
     Inst(Opcode::Epilogue);
 }
 
+U32 IREmitter::GetUserData(IR::ScalarReg reg) {
+    return Inst<U32>(Opcode::GetUserData, reg);
+}
+
 template <>
 U32 IREmitter::GetScalarReg(IR::ScalarReg reg) {
     return Inst<U32>(Opcode::GetScalarRegister, reg);
@@ -231,6 +235,22 @@ U32 IREmitter::ReadConstBuffer(const Value& handle, const U32& index, const U32&
 template <>
 F32 IREmitter::ReadConstBuffer(const Value& handle, const U32& index, const U32& offset) {
     return Inst<F32>(Opcode::ReadConstBufferF32, handle, index, offset);
+}
+
+Value IREmitter::LoadBuffer(int num_dwords, const Value& handle, const Value& address,
+                            BufferInstInfo info) {
+    switch (num_dwords) {
+    case 1:
+        return Inst(Opcode::LoadBufferF32, Flags{info}, handle, address);
+    case 2:
+        return Inst(Opcode::LoadBufferF32x2, Flags{info}, handle, address);
+    case 3:
+        return Inst(Opcode::LoadBufferF32x3, Flags{info}, handle, address);
+    case 4:
+        return Inst(Opcode::LoadBufferF32x4, Flags{info}, handle, address);
+    default:
+        throw InvalidArgument("Invalid number of dwords {}", num_dwords);
+    }
 }
 
 F32F64 IREmitter::FPAdd(const F32F64& a, const F32F64& b) {

--- a/src/shader_recompiler/ir/ir_emitter.h
+++ b/src/shader_recompiler/ir/ir_emitter.h
@@ -42,6 +42,8 @@ public:
     void Prologue();
     void Epilogue();
 
+    U32 GetUserData(IR::ScalarReg reg);
+
     template <typename T = U32>
     [[nodiscard]] T GetScalarReg(IR::ScalarReg reg);
     template <typename T = U32>
@@ -68,6 +70,9 @@ public:
     [[nodiscard]] U32 ReadConst(const U64& address, const U32& offset);
     template <typename T = U32>
     [[nodiscard]] T ReadConstBuffer(const Value& handle, const U32& index, const U32& offset);
+
+    [[nodiscard]] Value LoadBuffer(int num_dwords, const Value& handle, const Value& address,
+                                   BufferInstInfo info);
 
     [[nodiscard]] U1 GetZeroFromOp(const Value& op);
     [[nodiscard]] U1 GetSignFromOp(const Value& op);

--- a/src/shader_recompiler/ir/opcodes.inc
+++ b/src/shader_recompiler/ir/opcodes.inc
@@ -19,6 +19,7 @@ OPCODE(ReadConstBuffer,                                     U32,            Opaq
 OPCODE(ReadConstBufferF32,                                  F32,            Opaque,         U32,            U32                                             )
 
 // Context getters/setters
+OPCODE(GetUserData,                                         U32,            ScalarReg,                                                                      )
 OPCODE(GetScalarRegister,                                   U32,            ScalarReg,                                                                      )
 OPCODE(SetScalarRegister,                                   Void,           ScalarReg,      U32,                                                            )
 OPCODE(GetVectorRegister,                                   U32,            VectorReg,                                                                      )
@@ -41,6 +42,12 @@ OPCODE(UndefU8,                                             U8,                 
 OPCODE(UndefU16,                                            U16,                                                                                            )
 OPCODE(UndefU32,                                            U32,                                                                                            )
 OPCODE(UndefU64,                                            U64,                                                                                            )
+
+// Buffer operations
+OPCODE(LoadBufferF32,                                       F32,            Opaque,         Opaque,                                                         )
+OPCODE(LoadBufferF32x2,                                     F32x2,          Opaque,         Opaque,                                                         )
+OPCODE(LoadBufferF32x3,                                     F32x3,          Opaque,         Opaque,                                                         )
+OPCODE(LoadBufferF32x4,                                     F32x4,          Opaque,         Opaque,                                                         )
 
 // Vector utility
 OPCODE(CompositeConstructU32x2,                             U32x2,          U32,            U32,                                                            )

--- a/src/shader_recompiler/ir/reg.h
+++ b/src/shader_recompiler/ir/reg.h
@@ -6,6 +6,7 @@
 #include "common/bit_field.h"
 #include "common/types.h"
 #include "shader_recompiler/exception.h"
+#include "video_core/amdgpu/pixel_format.h"
 
 namespace Shader::IR {
 
@@ -39,6 +40,16 @@ union TextureInstInfo {
     BitField<22, 1, u32> relaxed_precision;
     BitField<23, 2, u32> gather_component;
     BitField<25, 2, u32> num_derivatives;
+};
+
+union BufferInstInfo {
+    u32 raw;
+    BitField<0, 1, u32> index_enable;
+    BitField<1, 1, u32> offset_enable;
+    BitField<2, 12, u32> inst_offset;
+    BitField<14, 4, AmdGpu::DataFormat> dmft;
+    BitField<18, 3, AmdGpu::NumberFormat> nfmt;
+    BitField<21, 1, u32> is_typed;
 };
 
 enum class ScalarReg : u32 {

--- a/src/shader_recompiler/recompiler.cpp
+++ b/src/shader_recompiler/recompiler.cpp
@@ -62,15 +62,16 @@ IR::Program TranslateProgram(ObjectPool<IR::Inst>& inst_pool, ObjectPool<IR::Blo
 
     // Run optimization passes
     Shader::Optimization::SsaRewritePass(program.post_order_blocks);
+    Shader::Optimization::ResourceTrackingPass(program);
     Shader::Optimization::ConstantPropagationPass(program.post_order_blocks);
     Shader::Optimization::IdentityRemovalPass(program.blocks);
-    Shader::Optimization::ResourceTrackingPass(program);
     Shader::Optimization::DeadCodeEliminationPass(program.blocks);
     Shader::Optimization::CollectShaderInfoPass(program);
 
     for (const auto& block : program.blocks) {
         fmt::print("{}\n", IR::DumpBlock(*block));
     }
+    std::fflush(stdout);
 
     return program;
 }

--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -27,6 +27,7 @@ struct Buffer {
         BitField<15, 4, DataFormat> data_format;
         BitField<19, 2, u32> element_size;
         BitField<21, 2, u32> index_stride;
+        BitField<23, 1, u32> add_tid_enable;
     };
 };
 

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -55,11 +55,15 @@ public:
     }
 
 private:
+    vk::UniqueDescriptorSetLayout BuildSetLayout() const;
+
+private:
     const Instance& instance;
     Scheduler& scheduler;
     vk::UniquePipeline pipeline;
     vk::UniquePipelineLayout pipeline_layout;
-    std::array<Shader::Info, MaxShaderStages> stages;
+    vk::UniqueDescriptorSetLayout desc_layout;
+    std::array<Shader::Info, MaxShaderStages> stages{};
     PipelineKey key;
 };
 

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -150,6 +150,7 @@ bool Instance::CreateDevice() {
     tooling_info = add_extension(VK_EXT_TOOLING_INFO_EXTENSION_NAME);
     custom_border_color = add_extension(VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
     index_type_uint8 = add_extension(VK_KHR_INDEX_TYPE_UINT8_EXTENSION_NAME);
+    add_extension(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
 
     const auto family_properties = physical_device.getQueueFamilyProperties();
     if (family_properties.empty()) {

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -123,7 +123,12 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreatePipeline() {
                                                std::move(info));
 
         // Compile IR to SPIR-V
-        const auto spv_code = Shader::Backend::SPIRV::EmitSPIRV(Shader::Profile{}, programs[i]);
+        const auto profile = Shader::Profile{.supported_spirv = 0x00010600U};
+        const auto spv_code = Shader::Backend::SPIRV::EmitSPIRV(profile, programs[i]);
+        std::ofstream file("shader0.spv", std::ios::out | std::ios::binary);
+        file.write((const char*)spv_code.data(), spv_code.size() * 4);
+        file.close();
+
         stages[i] = CompileSPV(spv_code, instance.GetDevice());
         infos[i] = &programs[i].info;
     }

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -61,7 +61,7 @@ void Rasterizer::Draw(bool is_indexed) {
     if (is_indexed) {
         cmdbuf.drawIndexed(num_indices, regs.num_instances.NumInstances(), 0, 0, 0);
     } else {
-        cmdbuf.draw(regs.num_indices, regs.num_instances.NumInstances(), 0, 0);
+        cmdbuf.draw(num_indices, regs.num_instances.NumInstances(), 0, 0);
     }
     cmdbuf.endRendering();
 }
@@ -85,7 +85,7 @@ u32 Rasterizer::SetupIndexBuffer(bool& is_indexed) {
         return index_size / sizeof(u16);
     }
     if (!is_indexed) {
-        return 0;
+        return regs.num_indices;
     }
 
     const VAddr index_address = regs.index_base_address.Address();


### PR DESCRIPTION
Next step after previous PR was to add constant buffers to shader recompiler. The goal of the design is to hopefully be able to handle more advanced cases like bindless or when sharps are nested behind many constant load operations. So in general, cases where sharp location is difficult to know upfront. When emitting IR we the recompiler is not aware of the sharp location. The emitted instruction will have a handle that is the SGPR of the loaded sharp and some additional arguments that we can derive without needing to read the sharp.

Then once IR has been emitted we run a resource tracking pass whose job is to follow constant loads and figure out where the sharp is located in memory. After it's loaded we patch the buffer instruction, replacing the handle with the binding index in the buffer resource array and compute the full address. Also it will check if the sharp address is aligned to UBO requirement of the host and fallback to SSBO if not. On SPIR-V side for simplicity buffers are arrays of floats (will also be uint in the future), so it can handle any provided address it has been given (not all loads can be expressed as a single composite array load, especially 3 dword loads whose offset is not 3 dword aligned). In the future I would like to experiment with attempting to reconstruct the struct layout of the UBO/SSBO.

For vulkan side, resources use push descriptors for the simplicity. I think some AMD drivers have broken push descriptors though so a fallback back with normal descriptor writes can be implemented as well without too much hassle.

```glsl
#version 450
#extension GL_EXT_scalar_block_layout : require

layout(set = 0, binding = 0, scalar) uniform vs_cbuf_block_f32
{
    float data[16];
} c0;

layout(location = 0) in vec4 vs_in_attr0;
layout(location = 0) out vec4 out_attr0;

void main()
{
    uint _57 = uint(gl_VertexIndex) * 4u;
    vec4 _70 = vec4(c0.data[_57 + 0u], c0.data[_57 + 1u], c0.data[_57 + 2u], c0.data[_57 + 3u]);
    gl_Position.x = vs_in_attr0.x;
    gl_Position.y = vs_in_attr0.y;
    gl_Position.z = vs_in_attr0.z;
    gl_Position.w = vs_in_attr0.w;
    out_attr0.x = _70.x;
    out_attr0.y = _70.y;
    out_attr0.z = _70.z;
    out_attr0.w = _70.w;
}
```