### PR TITLE
video_core: various fixes

### DIFF
--- a/src/core/libraries/libc/libc_math.cpp
+++ b/src/core/libraries/libc/libc_math.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <cmath>
+#include "common/assert.h"
 #include "core/libraries/libc/libc_math.h"
 
 namespace Libraries::LibC {
@@ -38,8 +39,13 @@ double PS4_SYSV_ABI ps4__Sin(double x) {
     return sin(x);
 }
 
-float PS4_SYSV_ABI ps4__Fsin(float arg) {
-    return sinf(arg);
+float PS4_SYSV_ABI ps4__Fsin(float arg, unsigned int m, int n) {
+    ASSERT(n == 0);
+    if (m != 0) {
+        return cosf(arg);
+    } else {
+        return sinf(arg);
+    }
 }
 
 double PS4_SYSV_ABI ps4_exp2(double arg) {

--- a/src/core/libraries/libc/libc_math.h
+++ b/src/core/libraries/libc/libc_math.h
@@ -13,7 +13,7 @@ float PS4_SYSV_ABI ps4_tanf(float num);
 float PS4_SYSV_ABI ps4_asinf(float num);
 double PS4_SYSV_ABI ps4_pow(double base, double exponent);
 double PS4_SYSV_ABI ps4__Sin(double x);
-float PS4_SYSV_ABI ps4__Fsin(float arg);
+float PS4_SYSV_ABI ps4__Fsin(float arg, unsigned int,int);
 double PS4_SYSV_ABI ps4_exp2(double arg);
 float PS4_SYSV_ABI ps4_powf(float x, float y);
 float PS4_SYSV_ABI ps4_roundf(float arg);

--- a/src/core/libraries/libc/libc_math.h
+++ b/src/core/libraries/libc/libc_math.h
@@ -13,7 +13,7 @@ float PS4_SYSV_ABI ps4_tanf(float num);
 float PS4_SYSV_ABI ps4_asinf(float num);
 double PS4_SYSV_ABI ps4_pow(double base, double exponent);
 double PS4_SYSV_ABI ps4__Sin(double x);
-float PS4_SYSV_ABI ps4__Fsin(float arg, unsigned int,int);
+float PS4_SYSV_ABI ps4__Fsin(float arg, unsigned int, int);
 double PS4_SYSV_ABI ps4_exp2(double arg);
 float PS4_SYSV_ABI ps4_powf(float x, float y);
 float PS4_SYSV_ABI ps4_roundf(float arg);

--- a/src/core/libraries/videoout/driver.h
+++ b/src/core/libraries/videoout/driver.h
@@ -18,7 +18,7 @@ struct VideoOutPort {
     bool is_open = false;
     SceVideoOutResolutionStatus resolution;
     std::array<VideoOutBuffer, MaxDisplayBuffers> buffer_slots;
-    std::array<uintptr_t, MaxDisplayBuffers> buffer_labels; // should be contiguous in memory
+    std::array<u64, MaxDisplayBuffers> buffer_labels; // should be contiguous in memory
     static_assert(sizeof(buffer_labels[0]) == 8u);
     std::array<BufferAttributeGroup, MaxDisplayBufferGroups> groups;
     FlipStatus flip_status;

--- a/src/core/libraries/videoout/video_out.cpp
+++ b/src/core/libraries/videoout/video_out.cpp
@@ -251,6 +251,7 @@ s32 sceVideoOutSubmitEopFlip(s32 handle, u32 buf_id, u32 mode, u32 arg, void** u
     Platform::IrqC::Instance()->RegisterOnce(
         Platform::InterruptId::GfxFlip, [=](Platform::InterruptId irq) {
             ASSERT_MSG(irq == Platform::InterruptId::GfxFlip, "An unexpected IRQ occured");
+            ASSERT_MSG(port->buffer_labels[buf_id] == 1, "Out of order flip IRQ");
             const auto result = driver->SubmitFlip(port, buf_id, arg, true);
             ASSERT_MSG(result, "EOP flip submission failed");
         });

--- a/src/core/platform.h
+++ b/src/core/platform.h
@@ -66,7 +66,7 @@ struct IrqController {
             h(irq);
         }
 
-        while (!ctx.one_time_subscribers.empty()) {
+        if (!ctx.one_time_subscribers.empty()) {
             const auto& h = ctx.one_time_subscribers.front();
             h(irq);
 

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -19,6 +19,7 @@ Liverpool::Liverpool() {
 Liverpool::~Liverpool() {
     process_thread.request_stop();
     cv_submit.notify_one();
+    process_thread.join();
 }
 
 void Liverpool::Process(std::stop_token stoken) {

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -771,9 +771,6 @@ private:
 
     Vulkan::Rasterizer* rasterizer{};
     std::jthread process_thread{};
-    std::condition_variable_any cv_submit{};
-    std::condition_variable cv_complete{};
-    std::mutex m_submit{};
     std::atomic<u32> num_submits{};
 };
 

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -206,6 +206,7 @@ bool Instance::CreateDevice() {
         },
         vk::PhysicalDeviceVulkan13Features{
             .dynamicRendering = true,
+            .maintenance4 = true,
         },
         vk::PhysicalDeviceCustomBorderColorFeaturesEXT{
             .customBorderColors = true,
@@ -213,9 +214,6 @@ bool Instance::CreateDevice() {
         },
         vk::PhysicalDeviceIndexTypeUint8FeaturesEXT{
             .indexTypeUint8 = true,
-        },
-        vk::PhysicalDeviceMaintenance4Features{
-            .maintenance4 = true,
         },
     };
 

--- a/src/video_core/texture_cache/image.h
+++ b/src/video_core/texture_cache/image.h
@@ -53,9 +53,14 @@ struct UniqueImage {
     UniqueImage(const UniqueImage&) = delete;
     UniqueImage& operator=(const UniqueImage&) = delete;
 
-    UniqueImage(UniqueImage&& other) : image{std::exchange(other.image, VK_NULL_HANDLE)} {}
+    UniqueImage(UniqueImage&& other)
+        : image{std::exchange(other.image, VK_NULL_HANDLE)},
+          allocator{std::exchange(other.allocator, VK_NULL_HANDLE)},
+          allocation{std::exchange(other.allocation, VK_NULL_HANDLE)} {}
     UniqueImage& operator=(UniqueImage&& other) {
         image = std::exchange(other.image, VK_NULL_HANDLE);
+        allocator = std::exchange(other.allocator, VK_NULL_HANDLE);
+        allocation = std::exchange(other.allocation, VK_NULL_HANDLE);
         return *this;
     }
 


### PR DESCRIPTION
This PR addresses the next issues:
- out of order flip IRQ processing;
- incorrect renderer de-initialization;
- possible deadlock in gpu idle waits;
- incorrect `_Fsin` implementation in HLE libc