### PR TITLE
shader_recompiler: Address some minor issues

### DIFF
--- a/src/core/libraries/kernel/libkernel.h
+++ b/src/core/libraries/kernel/libkernel.h
@@ -14,8 +14,8 @@ namespace Libraries::Kernel {
 
 struct OrbisTimesec {
     time_t t;
-    u64 west_sec;
-    u64 dst_sec;
+    u32 west_sec;
+    u32 dst_sec;
 };
 
 int32_t PS4_SYSV_ABI sceKernelReleaseDirectMemory(off_t start, size_t len);

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -95,9 +95,14 @@ Id EmitGetAttribute(EmitContext& ctx, IR::Attribute attr, u32 comp) {
         }
     }
     switch (attr) {
-    case IR::Attribute::FragCoord:
-        return ctx.OpLoad(ctx.F32[1],
-                          ctx.OpAccessChain(ctx.input_f32, ctx.frag_coord, ctx.ConstU32(comp)));
+    case IR::Attribute::FragCoord: {
+        const Id coord = ctx.OpLoad(
+            ctx.F32[1], ctx.OpAccessChain(ctx.input_f32, ctx.frag_coord, ctx.ConstU32(comp)));
+        if (comp == 3) {
+            return ctx.OpFDiv(ctx.F32[1], ctx.ConstF32(1.f), coord);
+        }
+        return coord;
+    }
     default:
         throw NotImplementedException("Read attribute {}", attr);
     }

--- a/src/shader_recompiler/frontend/control_flow_graph.h
+++ b/src/shader_recompiler/frontend/control_flow_graph.h
@@ -41,6 +41,7 @@ struct Block : Hook {
     EndClass end_class{};
     Block* branch_true{};
     Block* branch_false{};
+    bool is_dummy{};
 };
 
 class CFG {

--- a/src/shader_recompiler/frontend/structured_control_flow.cpp
+++ b/src/shader_recompiler/frontend/structured_control_flow.cpp
@@ -630,9 +630,11 @@ private:
                 break;
             case StatementType::Code: {
                 ensure_block();
-                const u32 start = stmt.block->begin_index;
-                const u32 size = stmt.block->end_index - start + 1;
-                Translate(current_block, inst_list.subspan(start, size), info);
+                if (!stmt.block->is_dummy) {
+                    const u32 start = stmt.block->begin_index;
+                    const u32 size = stmt.block->end_index - start + 1;
+                    Translate(current_block, inst_list.subspan(start, size), info);
+                }
                 break;
             }
             case StatementType::SetVariable: {
@@ -808,7 +810,7 @@ private:
     ObjectPool<IR::Inst>& inst_pool;
     ObjectPool<IR::Block>& block_pool;
     IR::AbstractSyntaxList& syntax_list;
-    const Block dummy_flow_block{};
+    const Block dummy_flow_block{.is_dummy = true};
     std::span<const GcnInst> inst_list;
     Info& info;
 };

--- a/src/shader_recompiler/frontend/translate/scalar_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_alu.cpp
@@ -55,26 +55,48 @@ void Translator::S_ANDN2_B64(const GcnInst& inst) {
     const IR::U1 src0{get_src(inst.src[0])};
     const IR::U1 src1{get_src(inst.src[1])};
     const IR::U1 result{ir.LogicalAnd(src0, ir.LogicalNot(src1))};
-    SetDst(inst.dst[0], result);
     ir.SetScc(result);
+    switch (inst.dst[0].field) {
+    case OperandField::VccLo:
+        ir.SetVcc(result);
+        break;
+    case OperandField::ExecLo:
+        ir.SetExec(result);
+        break;
+    case OperandField::ScalarGPR:
+        ir.SetThreadBitScalarReg(IR::ScalarReg(inst.dst[0].code), result);
+        break;
+    default:
+        UNREACHABLE();
+    }
 }
 
 void Translator::S_AND_SAVEEXEC_B64(const GcnInst& inst) {
     // This instruction normally operates on 64-bit data (EXEC, VCC, SGPRs)
     // However here we flatten it to 1-bit EXEC and 1-bit VCC. For the destination
     // SGPR we have a special IR opcode for SPGRs that act as thread masks.
+    ASSERT(inst.src[0].field == OperandField::VccLo);
     const IR::U1 exec{ir.GetExec()};
+    const IR::U1 vcc{ir.GetVcc()};
 
     // Mark destination SPGR as an EXEC context. This means we will use 1-bit
     // IR instruction whenever it's loaded.
-    ASSERT(inst.dst[0].field == OperandField::ScalarGPR);
-    const u32 reg = inst.dst[0].code;
-    exec_contexts[reg] = true;
-    ir.SetThreadBitScalarReg(IR::ScalarReg(reg), exec);
+    switch (inst.dst[0].field) {
+    case OperandField::ScalarGPR: {
+        const u32 reg = inst.dst[0].code;
+        exec_contexts[reg] = true;
+        ir.SetThreadBitScalarReg(IR::ScalarReg(reg), exec);
+        break;
+    }
+    case OperandField::VccLo:
+        ir.SetVcc(exec);
+        break;
+    default:
+        UNREACHABLE();
+    }
 
     // Update EXEC.
-    ASSERT(inst.src[0].field == OperandField::VccLo);
-    ir.SetExec(ir.LogicalAnd(exec, ir.GetVcc()));
+    ir.SetExec(ir.LogicalAnd(exec, vcc));
 }
 
 void Translator::S_MOV_B64(const GcnInst& inst) {
@@ -114,9 +136,17 @@ void Translator::S_OR_B64(bool negate, const GcnInst& inst) {
     if (negate) {
         result = ir.LogicalNot(result);
     }
-    ASSERT(inst.dst[0].field == OperandField::VccLo);
-    ir.SetVcc(result);
     ir.SetScc(result);
+    switch (inst.dst[0].field) {
+    case OperandField::VccLo:
+        ir.SetVcc(result);
+        break;
+    case OperandField::ScalarGPR:
+        ir.SetThreadBitScalarReg(IR::ScalarReg(inst.dst[0].code), result);
+        break;
+    default:
+        UNREACHABLE();
+    }
 }
 
 void Translator::S_AND_B64(const GcnInst& inst) {
@@ -135,9 +165,17 @@ void Translator::S_AND_B64(const GcnInst& inst) {
     const IR::U1 src0{get_src(inst.src[0])};
     const IR::U1 src1{get_src(inst.src[1])};
     const IR::U1 result = ir.LogicalAnd(src0, src1);
-    ASSERT(inst.dst[0].field == OperandField::VccLo);
-    ir.SetVcc(result);
     ir.SetScc(result);
+    switch (inst.dst[0].field) {
+    case OperandField::VccLo:
+        ir.SetVcc(result);
+        break;
+    case OperandField::ScalarGPR:
+        ir.SetThreadBitScalarReg(IR::ScalarReg(inst.dst[0].code), result);
+        break;
+    default:
+        UNREACHABLE();
+    }
 }
 
 void Translator::S_ADD_I32(const GcnInst& inst) {
@@ -169,12 +207,50 @@ void Translator::S_CSELECT_B32(const GcnInst& inst) {
     SetDst(inst.dst[0], IR::U32{ir.Select(ir.GetScc(), src0, src1)});
 }
 
+void Translator::S_CSELECT_B64(const GcnInst& inst) {
+    const auto get_src = [&](const InstOperand& operand) {
+        switch (operand.field) {
+        case OperandField::VccLo:
+            return ir.GetVcc();
+        case OperandField::ExecLo:
+            return ir.GetExec();
+        case OperandField::ScalarGPR:
+            return ir.GetThreadBitScalarReg(IR::ScalarReg(operand.code));
+        case OperandField::ConstZero:
+            return ir.Imm1(false);
+        default:
+            UNREACHABLE();
+        }
+    };
+    const IR::U1 src0{get_src(inst.src[0])};
+    const IR::U1 src1{get_src(inst.src[1])};
+    const IR::U1 result{ir.Select(ir.GetScc(), src0, src1)};
+    switch (inst.dst[0].field) {
+    case OperandField::VccLo:
+        ir.SetVcc(result);
+        break;
+    case OperandField::ScalarGPR:
+        ir.SetThreadBitScalarReg(IR::ScalarReg(inst.dst[0].code), result);
+        break;
+    default:
+        UNREACHABLE();
+    }
+}
+
 void Translator::S_BFE_U32(const GcnInst& inst) {
     const IR::U32 src0{GetSrc(inst.src[0])};
     const IR::U32 src1{GetSrc(inst.src[1])};
     const IR::U32 offset{ir.BitwiseAnd(src1, ir.Imm32(0x1F))};
     const IR::U32 count{ir.BitFieldExtract(src1, ir.Imm32(16), ir.Imm32(7))};
     const IR::U32 result{ir.BitFieldExtract(src0, offset, count)};
+    SetDst(inst.dst[0], result);
+    ir.SetScc(ir.INotEqual(result, ir.Imm32(0)));
+}
+
+void Translator::S_LSHL_B32(const GcnInst& inst) {
+    const IR::U32 src0{GetSrc(inst.src[0])};
+    const IR::U32 src1{GetSrc(inst.src[1])};
+    const IR::U32 result = ir.ShiftLeftLogical(src0, ir.BitwiseAnd(src1, ir.Imm32(0x1F)));
     SetDst(inst.dst[0], result);
     ir.SetScc(ir.INotEqual(result, ir.Imm32(0)));
 }

--- a/src/shader_recompiler/frontend/translate/scalar_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_alu.cpp
@@ -104,18 +104,21 @@ void Translator::S_MOV_B64(const GcnInst& inst) {
     if (inst.src[0].field == OperandField::VccLo || inst.dst[0].field == OperandField::VccLo) {
         return;
     }
-    const IR::U1 src0{GetSrc(inst.src[0])};
     if (inst.dst[0].field == OperandField::ScalarGPR && inst.src[0].field == OperandField::ExecLo) {
         // Exec context push
         exec_contexts[inst.dst[0].code] = true;
+        ir.SetThreadBitScalarReg(IR::ScalarReg(inst.dst[0].code), ir.GetExec());
     } else if (inst.dst[0].field == OperandField::ExecLo &&
                inst.src[0].field == OperandField::ScalarGPR) {
         // Exec context pop
         exec_contexts[inst.src[0].code] = false;
-    } else if (inst.src[0].field != OperandField::ConstZero) {
+        ir.SetExec(ir.GetThreadBitScalarReg(IR::ScalarReg(inst.src[0].code)));
+    } else if (inst.dst[0].field == OperandField::ExecLo &&
+               inst.src[0].field == OperandField::ConstZero) {
+        ir.SetExec(ir.Imm1(false));
+    } else {
         UNREACHABLE();
     }
-    SetDst(inst.dst[0], src0);
 }
 
 void Translator::S_OR_B64(bool negate, const GcnInst& inst) {

--- a/src/shader_recompiler/frontend/translate/scalar_memory.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_memory.cpp
@@ -5,30 +5,16 @@
 
 namespace Shader::Gcn {
 
-void Load(IR::IREmitter& ir, int num_dwords, const IR::Value& handle, IR::ScalarReg dst_reg,
-          const IR::U32U64& address) {
-    for (u32 i = 0; i < num_dwords; i++) {
-        if (handle.IsEmpty()) {
-            ir.SetScalarReg(dst_reg++, ir.ReadConst(address, ir.Imm32(i)));
-        } else {
-            const IR::U32 index = ir.IAdd(address, ir.Imm32(i));
-            ir.SetScalarReg(dst_reg++, ir.ReadConstBuffer(handle, index));
-        }
-    }
-}
-
 void Translator::S_LOAD_DWORD(int num_dwords, const GcnInst& inst) {
     const auto& smrd = inst.control.smrd;
+    ASSERT_MSG(smrd.imm, "Bindless texture loads unsupported");
     const IR::ScalarReg sbase{inst.src[0].code * 2};
-    const IR::U32 offset =
-        smrd.imm ? ir.Imm32(smrd.offset * 4)
-                 : IR::U32{ir.ShiftLeftLogical(ir.GetScalarReg(IR::ScalarReg(smrd.offset)),
-                                               ir.Imm32(2))};
-    const IR::U64 base =
-        ir.PackUint2x32(ir.CompositeConstruct(ir.GetScalarReg(sbase), ir.GetScalarReg(sbase + 1)));
-    const IR::U64 address = ir.IAdd(base, offset);
-    const IR::ScalarReg dst_reg{inst.dst[0].code};
-    Load(ir, num_dwords, {}, dst_reg, address);
+    const IR::Value base =
+        ir.CompositeConstruct(ir.GetScalarReg(sbase), ir.GetScalarReg(sbase + 1));
+    IR::ScalarReg dst_reg{inst.dst[0].code};
+    for (u32 i = 0; i < num_dwords; i++) {
+        ir.SetScalarReg(dst_reg++, ir.ReadConst(base, ir.Imm32(smrd.offset + i)));
+    }
 }
 
 void Translator::S_BUFFER_LOAD_DWORD(int num_dwords, const GcnInst& inst) {
@@ -37,8 +23,11 @@ void Translator::S_BUFFER_LOAD_DWORD(int num_dwords, const GcnInst& inst) {
     const IR::U32 dword_offset =
         smrd.imm ? ir.Imm32(smrd.offset) : ir.GetScalarReg(IR::ScalarReg(smrd.offset));
     const IR::Value vsharp = ir.GetScalarReg(sbase);
-    const IR::ScalarReg dst_reg{inst.dst[0].code};
-    Load(ir, num_dwords, vsharp, dst_reg, dword_offset);
+    IR::ScalarReg dst_reg{inst.dst[0].code};
+    for (u32 i = 0; i < num_dwords; i++) {
+        const IR::U32 index = ir.IAdd(dword_offset, ir.Imm32(i));
+        ir.SetScalarReg(dst_reg++, ir.ReadConstBuffer(vsharp, index));
+    }
 }
 
 } // namespace Shader::Gcn

--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -128,7 +128,11 @@ IR::U1U32F32 Translator::GetSrc(const InstOperand& operand, bool force_flt) {
         value = ir.GetExec();
         break;
     case OperandField::VccLo:
-        value = ir.GetVccLo();
+        if (force_flt) {
+            value = ir.BitCast<IR::F32>(ir.GetVccLo());
+        } else {
+            value = ir.GetVccLo();
+        }
         break;
     case OperandField::VccHi:
         value = ir.GetVccHi();
@@ -252,6 +256,12 @@ void Translate(IR::Block* block, std::span<const GcnInst> inst_list, Info& info)
             break;
         case Opcode::S_WAITCNT:
             break;
+        case Opcode::S_LOAD_DWORDX4:
+            translator.S_LOAD_DWORD(4, inst);
+            break;
+        case Opcode::S_LOAD_DWORDX8:
+            translator.S_LOAD_DWORD(8, inst);
+            break;
         case Opcode::S_BUFFER_LOAD_DWORD:
             translator.S_BUFFER_LOAD_DWORD(1, inst);
             break;
@@ -352,8 +362,17 @@ void Translate(IR::Block* block, std::span<const GcnInst> inst_list, Info& info)
         case Opcode::S_CMP_LG_U32:
             translator.S_CMP(ConditionOp::LG, false, inst);
             break;
+        case Opcode::S_CMP_LG_I32:
+            translator.S_CMP(ConditionOp::LG, true, inst);
+            break;
         case Opcode::S_CMP_EQ_I32:
             translator.S_CMP(ConditionOp::EQ, true, inst);
+            break;
+        case Opcode::S_CMP_EQ_U32:
+            translator.S_CMP(ConditionOp::EQ, false, inst);
+            break;
+        case Opcode::S_LSHL_B32:
+            translator.S_LSHL_B32(inst);
             break;
         case Opcode::V_CNDMASK_B32:
             translator.V_CNDMASK_B32(inst);
@@ -505,13 +524,21 @@ void Translate(IR::Block* block, std::span<const GcnInst> inst_list, Info& info)
         case Opcode::S_CSELECT_B32:
             translator.S_CSELECT_B32(inst);
             break;
+        case Opcode::S_CSELECT_B64:
+            translator.S_CSELECT_B64(inst);
+            break;
         case Opcode::S_BFE_U32:
             translator.S_BFE_U32(inst);
+            break;
+        case Opcode::V_RNDNE_F32:
+            translator.V_RNDNE_F32(inst);
             break;
         case Opcode::S_NOP:
         case Opcode::S_CBRANCH_EXECZ:
         case Opcode::S_CBRANCH_SCC0:
         case Opcode::S_CBRANCH_SCC1:
+        case Opcode::S_CBRANCH_VCCNZ:
+        case Opcode::S_CBRANCH_VCCZ:
         case Opcode::S_BRANCH:
         case Opcode::S_WQM_B64:
         case Opcode::V_INTERP_P1_F32:

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -46,7 +46,9 @@ public:
     void S_AND_B32(const GcnInst& inst);
     void S_LSHR_B32(const GcnInst& inst);
     void S_CSELECT_B32(const GcnInst& inst);
+    void S_CSELECT_B64(const GcnInst& inst);
     void S_BFE_U32(const GcnInst& inst);
+    void S_LSHL_B32(const GcnInst& inst);
 
     // Scalar Memory
     void S_LOAD_DWORD(int num_dwords, const GcnInst& inst);
@@ -101,6 +103,7 @@ public:
     void V_LSHR_B32(const GcnInst& inst);
     void V_ASHRREV_I32(const GcnInst& inst);
     void V_MAD_U32_U24(const GcnInst& inst);
+    void V_RNDNE_F32(const GcnInst& inst);
 
     // Vector Memory
     void BUFFER_LOAD_FORMAT(u32 num_dwords, bool is_typed, const GcnInst& inst);

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -124,8 +124,8 @@ public:
     void EXP(const GcnInst& inst);
 
 private:
-    IR::U1U32F32 GetSrc(const InstOperand& operand, bool flt_zero = false);
-    void SetDst(const InstOperand& operand, const IR::U1U32F32& value);
+    IR::U32F32 GetSrc(const InstOperand& operand, bool flt_zero = false);
+    void SetDst(const InstOperand& operand, const IR::U32F32& value);
 
 private:
     IR::IREmitter ir;

--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -273,8 +273,8 @@ void IREmitter::WriteShared(int bit_size, const Value& value, const U32& offset)
     }*/
 }
 
-U32 IREmitter::ReadConst(const U64& address, const U32& offset) {
-    return Inst<U32>(Opcode::ReadConst, address, offset);
+U32 IREmitter::ReadConst(const Value& base, const U32& offset) {
+    return Inst<U32>(Opcode::ReadConst, base, offset);
 }
 
 F32 IREmitter::ReadConstBuffer(const Value& handle, const U32& index) {

--- a/src/shader_recompiler/ir/ir_emitter.h
+++ b/src/shader_recompiler/ir/ir_emitter.h
@@ -77,7 +77,7 @@ public:
     [[nodiscard]] U32U64 ReadShared(int bit_size, bool is_signed, const U32& offset);
     void WriteShared(int bit_size, const Value& value, const U32& offset);
 
-    [[nodiscard]] U32 ReadConst(const U64& address, const U32& offset);
+    [[nodiscard]] U32 ReadConst(const Value& base, const U32& offset);
     [[nodiscard]] F32 ReadConstBuffer(const Value& handle, const U32& index);
 
     [[nodiscard]] Value LoadBuffer(int num_dwords, const Value& handle, const Value& address,

--- a/src/shader_recompiler/ir/opcodes.inc
+++ b/src/shader_recompiler/ir/opcodes.inc
@@ -15,7 +15,7 @@ OPCODE(Epilogue,                                            Void,               
 OPCODE(Discard,                                             Void,                                                                                           )
 
 // Constant memory operations
-OPCODE(ReadConst,                                           U32,            U64,            U32,                                                            )
+OPCODE(ReadConst,                                           U32,            U32x2,          U32,                                                            )
 OPCODE(ReadConstBuffer,                                     F32,            Opaque,         U32,                                                            )
 OPCODE(ReadConstBufferU32,                                  U32,            Opaque,         U32,                                                            )
 

--- a/src/shader_recompiler/ir/passes/dead_code_elimination_pass.cpp
+++ b/src/shader_recompiler/ir/passes/dead_code_elimination_pass.cpp
@@ -5,10 +5,10 @@
 
 namespace Shader::Optimization {
 
-void DeadCodeEliminationPass(IR::BlockList& program) {
+void DeadCodeEliminationPass(IR::Program& program) {
     // We iterate over the instructions in reverse order.
     // This is because removing an instruction reduces the number of uses for earlier instructions.
-    for (IR::Block* const block : program) {
+    for (IR::Block* const block : program.post_order_blocks) {
         auto it{block->end()};
         while (it != block->begin()) {
             --it;

--- a/src/shader_recompiler/ir/passes/ir_passes.h
+++ b/src/shader_recompiler/ir/passes/ir_passes.h
@@ -10,7 +10,7 @@ namespace Shader::Optimization {
 
 void SsaRewritePass(IR::BlockList& program);
 void IdentityRemovalPass(IR::BlockList& program);
-void DeadCodeEliminationPass(IR::BlockList& program);
+void DeadCodeEliminationPass(IR::Program& program);
 void ConstantPropagationPass(IR::BlockList& program);
 void ResourceTrackingPass(IR::Program& program);
 void CollectShaderInfoPass(IR::Program& program);

--- a/src/shader_recompiler/ir/value.h
+++ b/src/shader_recompiler/ir/value.h
@@ -219,7 +219,6 @@ using U64 = TypedValue<Type::U64>;
 using F16 = TypedValue<Type::F16>;
 using F32 = TypedValue<Type::F32>;
 using F64 = TypedValue<Type::F64>;
-using U1U32F32 = TypedValue<Type::U1 | Type::U32 | Type::F32>;
 using U32F32 = TypedValue<Type::U32 | Type::F32>;
 using U32U64 = TypedValue<Type::U32 | Type::U64>;
 using F32F64 = TypedValue<Type::F32 | Type::F64>;

--- a/src/shader_recompiler/recompiler.cpp
+++ b/src/shader_recompiler/recompiler.cpp
@@ -58,7 +58,7 @@ IR::Program TranslateProgram(ObjectPool<IR::Inst>& inst_pool, ObjectPool<IR::Blo
     Shader::Optimization::ResourceTrackingPass(program);
     Shader::Optimization::ConstantPropagationPass(program.post_order_blocks);
     Shader::Optimization::IdentityRemovalPass(program.blocks);
-    Shader::Optimization::DeadCodeEliminationPass(program.blocks);
+    Shader::Optimization::DeadCodeEliminationPass(program);
     Shader::Optimization::CollectShaderInfoPass(program);
 
     fmt::print("Post passes\n\n{}\n", Shader::IR::DumpProgram(program));

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -252,6 +252,16 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
             }
             break;
         }
+        case PM4ItOpcode::DrawIndexOffset2: {
+            const auto* draw_index_off = reinterpret_cast<const PM4CmdDrawIndexOffset2*>(header);
+            regs.max_index_size = draw_index_off->max_size;
+            regs.num_indices = draw_index_off->index_count;
+            regs.draw_initiator = draw_index_off->draw_initiator;
+            if (rasterizer) {
+                rasterizer->Draw(true, draw_index_off->index_offset);
+            }
+            break;
+        }
         case PM4ItOpcode::DrawIndexAuto: {
             const auto* draw_index = reinterpret_cast<const PM4CmdDrawIndexAuto*>(header);
             regs.num_indices = draw_index->index_count;
@@ -270,6 +280,17 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
             if (rasterizer && (regs.cs_program.dispatch_initiator & 1)) {
                 rasterizer->DispatchDirect();
             }
+            break;
+        }
+        case PM4ItOpcode::NumInstances: {
+            const auto* num_instances = reinterpret_cast<const PM4CmdDrawNumInstances*>(header);
+            regs.num_instances.num_instances = num_instances->num_instances;
+            break;
+        }
+        case PM4ItOpcode::IndexBase: {
+            const auto* index_base = reinterpret_cast<const PM4CmdDrawIndexBase*>(header);
+            regs.index_base_address.base_addr_lo = index_base->addr_lo;
+            regs.index_base_address.base_addr_hi.Assign(index_base->addr_hi);
             break;
         }
         case PM4ItOpcode::EventWrite: {

--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -548,4 +548,15 @@ struct PM4CmdDispatchDirect {
     u32 dispatch_initiator; ///< Dispatch Initiator Register
 };
 
+struct PM4CmdDrawNumInstances {
+    PM4Type3Header header;
+    u32 num_instances;
+};
+
+struct PM4CmdDrawIndexBase {
+    PM4Type3Header header;
+    u32 addr_lo;
+    u32 addr_hi;
+};
+
 } // namespace AmdGpu

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -14,6 +14,8 @@ vk::StencilOp StencilOp(Liverpool::StencilFunc op) {
         return vk::StencilOp::eKeep;
     case Liverpool::StencilFunc::Zero:
         return vk::StencilOp::eZero;
+    case Liverpool::StencilFunc::ReplaceTest:
+        return vk::StencilOp::eReplace;
     case Liverpool::StencilFunc::AddClamp:
         return vk::StencilOp::eIncrementAndClamp;
     case Liverpool::StencilFunc::SubClamp:
@@ -306,6 +308,13 @@ vk::Format SurfaceFormat(AmdGpu::DataFormat data_format, AmdGpu::NumberFormat nu
     }
     if (data_format == AmdGpu::DataFormat::FormatBc3 && num_format == AmdGpu::NumberFormat::Srgb) {
         return vk::Format::eBc3SrgbBlock;
+    }
+    if (data_format == AmdGpu::DataFormat::Format16_16_16_16 &&
+        num_format == AmdGpu::NumberFormat::Sint) {
+        return vk::Format::eR16G16B16A16Sint;
+    }
+    if (data_format == AmdGpu::DataFormat::FormatBc7 && num_format == AmdGpu::NumberFormat::Srgb) {
+        return vk::Format::eBc7SrgbBlock;
     }
     UNREACHABLE();
 }

--- a/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
@@ -81,8 +81,17 @@ ComputePipeline::ComputePipeline(const Instance& instance_, Scheduler& scheduler
 
 ComputePipeline::~ComputePipeline() = default;
 
-void ComputePipeline::BindResources(Core::MemoryManager* memory,
+void ComputePipeline::BindResources(Core::MemoryManager* memory, StreamBuffer& staging,
                                     VideoCore::TextureCache& texture_cache) const {
+    static constexpr u64 MinUniformAlignment = 64;
+
+    const auto map_staging = [&](auto src, size_t size) {
+        const auto [data, offset, _] = staging.Map(size, MinUniformAlignment);
+        std::memcpy(data, reinterpret_cast<const void*>(src), size);
+        staging.Commit(size);
+        return offset;
+    };
+
     // Bind resource buffers and textures.
     boost::container::static_vector<vk::DescriptorBufferInfo, 4> buffer_infos;
     boost::container::static_vector<vk::DescriptorImageInfo, 8> image_infos;
@@ -94,8 +103,9 @@ void ComputePipeline::BindResources(Core::MemoryManager* memory,
         const u32 size = vsharp.GetSize();
         const VAddr addr = vsharp.base_address.Value();
         texture_cache.OnCpuWrite(addr);
-        const auto [vk_buffer, offset] = memory->GetVulkanBuffer(addr);
-        buffer_infos.emplace_back(vk_buffer, offset, size);
+        const u32 offset = map_staging(addr, size);
+        // const auto [vk_buffer, offset] = memory->GetVulkanBuffer(addr);
+        buffer_infos.emplace_back(staging.Handle(), offset, size);
         set_writes.push_back({
             .dstSet = VK_NULL_HANDLE,
             .dstBinding = binding++,

--- a/src/video_core/renderer_vulkan/vk_compute_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_compute_pipeline.h
@@ -31,7 +31,8 @@ public:
         return *pipeline;
     }
 
-    void BindResources(Core::MemoryManager* memory, VideoCore::TextureCache& texture_cache) const;
+    void BindResources(Core::MemoryManager* memory, StreamBuffer& staging,
+                       VideoCore::TextureCache& texture_cache) const;
 
 private:
     const Instance& instance;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -29,12 +29,12 @@ public:
                         VideoCore::TextureCache& texture_cache, AmdGpu::Liverpool* liverpool);
     ~Rasterizer();
 
-    void Draw(bool is_indexed);
+    void Draw(bool is_indexed, u32 index_offset = 0);
 
     void DispatchDirect();
 
 private:
-    u32 SetupIndexBuffer(bool& is_indexed);
+    u32 SetupIndexBuffer(bool& is_indexed, u32 index_offset);
     void MapMemory(VAddr addr, size_t size);
 
     void UpdateDynamicState(const GraphicsPipeline& pipeline);

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -116,7 +116,7 @@ Image& TextureCache::FindImage(const ImageInfo& info, VAddr cpu_address) {
     std::unique_lock lock{m_page_table};
     boost::container::small_vector<ImageId, 2> image_ids;
     ForEachImageInRegion(cpu_address, info.guest_size_bytes, [&](ImageId image_id, Image& image) {
-        if (image.cpu_addr == cpu_address) {
+        if (image.cpu_addr == cpu_address && image.info.size.width == info.size.width) {
             image_ids.push_back(image_id);
         }
     });

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -216,54 +216,45 @@ void TextureCache::RefreshImage(Image& image) {
         return;
     }
 
-    const vk::ImageSubresourceRange range = {
-        .aspectMask = vk::ImageAspectFlagBits::eColor,
-        .baseMipLevel = 0,
-        .levelCount = 1,
-        .baseArrayLayer = 0,
-        .layerCount = VK_REMAINING_ARRAY_LAYERS,
-    };
-
     const u8* image_data = reinterpret_cast<const u8*>(image.cpu_addr);
-    for (u32 l = 0; l < image.info.resources.layers; l++) {
+    for (u32 m = 0; m < image.info.resources.levels; m++) {
+        const u32 width = image.info.size.width >> m;
+        const u32 height = image.info.size.height >> m;
+        const u32 map_size = width * height * image.info.resources.layers;
+
         // Upload data to the staging buffer.
-        for (u32 m = 0; m < image.info.resources.levels; m++) {
-            const u32 width = image.info.size.width >> m;
-            const u32 height = image.info.size.height >> m;
-            const u32 map_size = width * height;
-            const auto [data, offset, _] = staging.Map(map_size, 16);
-            if (image.info.is_tiled) {
-                ConvertTileToLinear(data, image_data, width, height, Config::isNeoMode());
-            } else {
-                std::memcpy(data, image_data, map_size);
-            }
-            staging.Commit(map_size);
-            image_data += map_size;
-
-            // Copy to the image.
-            const vk::BufferImageCopy image_copy = {
-                .bufferOffset = offset,
-                .bufferRowLength = 0,
-                .bufferImageHeight = 0,
-                .imageSubresource{
-                    .aspectMask = vk::ImageAspectFlagBits::eColor,
-                    .mipLevel = m,
-                    .baseArrayLayer = l,
-                    .layerCount = 1,
-                },
-                .imageOffset = {0, 0, 0},
-                .imageExtent = {width, height, 1},
-            };
-
-            const auto cmdbuf = scheduler.CommandBuffer();
-            image.Transit(vk::ImageLayout::eTransferDstOptimal, vk::AccessFlagBits::eTransferWrite);
-
-            cmdbuf.copyBufferToImage(staging.Handle(), image.image,
-                                     vk::ImageLayout::eTransferDstOptimal, image_copy);
-
-            image.Transit(vk::ImageLayout::eGeneral,
-                          vk::AccessFlagBits::eShaderRead | vk::AccessFlagBits::eTransferRead);
+        const auto [data, offset, _] = staging.Map(map_size, 16);
+        if (image.info.is_tiled) {
+            ConvertTileToLinear(data, image_data, width, height, Config::isNeoMode());
+        } else {
+            std::memcpy(data, image_data, map_size);
         }
+        staging.Commit(map_size);
+        image_data += map_size;
+
+        // Copy to the image.
+        const vk::BufferImageCopy image_copy = {
+            .bufferOffset = offset,
+            .bufferRowLength = 0,
+            .bufferImageHeight = 0,
+            .imageSubresource{
+                .aspectMask = vk::ImageAspectFlagBits::eColor,
+                .mipLevel = m,
+                .baseArrayLayer = 0,
+                .layerCount = u32(image.info.resources.layers),
+            },
+            .imageOffset = {0, 0, 0},
+            .imageExtent = {width, height, 1},
+        };
+
+        const auto cmdbuf = scheduler.CommandBuffer();
+        image.Transit(vk::ImageLayout::eTransferDstOptimal, vk::AccessFlagBits::eTransferWrite);
+
+        cmdbuf.copyBufferToImage(staging.Handle(), image.image,
+                                 vk::ImageLayout::eTransferDstOptimal, image_copy);
+
+        image.Transit(vk::ImageLayout::eGeneral,
+                      vk::AccessFlagBits::eShaderRead | vk::AccessFlagBits::eTransferRead);
     }
 }
 


### PR DESCRIPTION
* Add more instructions as usual
* Fix a minor bug in structurizer that made it emit code for dummy merge blocks. Mark the block as dummy to avoid that.
* Fix block search order in dead code elimination pass. Sometimes it would miss some unused phi's before and those phis might be misformed too
* Fix stack guard corruption caused by a kernel function. Should allow games that called it to continue and not crash on stack guard