### PR TITLE
Synchronization between Qt build title and version.h

### DIFF
--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -9,6 +9,7 @@
 #include <QStatusBar>
 #include <QtConcurrent>
 #include "common/io_file.h"
+#include "common/version.h"
 #include "core/file_format/pkg.h"
 #include "core/loader.h"
 #include "game_install_dialog.h"
@@ -37,7 +38,7 @@ bool MainWindow::Init() {
     LoadGameLists();
 
     setMinimumSize(350, minimumSizeHint().height());
-    setWindowTitle(QString::fromStdString("ShadPS4 v0.0.3"));
+    setWindowTitle(QString::fromStdString("shadPS4 v" + std::string(Common::VERSION)));
     show();
 
     auto end = std::chrono::steady_clock::now();


### PR DESCRIPTION
This will ensure that when the version number is updated, SDL builds and Qt builds are synchronized

Before:
![image](https://github.com/shadps4-emu/shadPS4/assets/164882787/6b885834-eb5a-41b5-97ba-f6ec8ca88457)

After:
![image](https://github.com/shadps4-emu/shadPS4/assets/164882787/8564bb60-795f-4e42-a040-cc3efd011031)