### PR TITLE
Workflows: Use by default the latest CMake

### DIFF
--- a/.github/workflows/linux-qt.yml
+++ b/.github/workflows/linux-qt.yml
@@ -22,6 +22,11 @@ jobs:
     - name: Fetch submodules
       run: git submodule update --init --recursive
 
+    - name: "Setup cmake"
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: ''
+
     - name: Install misc packages
       run: >
        sudo apt-get update && sudo apt install libx11-dev libxext-dev libwayland-dev libfuse2 clang build-essential qt6-base-dev

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,6 +23,11 @@ jobs:
       with:
         submodules: recursive
 
+    - name: "Setup cmake"
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: ''
+
     - name: Install misc packages
       run: >
        sudo apt-get update && sudo apt install libx11-dev libxext-dev libwayland-dev libfuse2 clang build-essential

--- a/.github/workflows/windows-qt.yml
+++ b/.github/workflows/windows-qt.yml
@@ -25,6 +25,11 @@ jobs:
       with:
           submodules: recursive
 
+    - name: "Setup cmake"
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: ''
+
     - name: Setup Qt
       uses: jurplel/install-qt-action@v4
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,6 +23,12 @@ jobs:
     - uses: actions/checkout@v4
       with:
           submodules: recursive
+
+    - name: "Setup cmake"
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: ''
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type


### PR DESCRIPTION
The cmake-version is empty because this allows you to use the latest version by default.
I tested it on my fork and it works