### PR TITLE
Fix missing SDL3.dll error message for Windows-Qt

### DIFF
--- a/.github/workflows/windows-qt.yml
+++ b/.github/workflows/windows-qt.yml
@@ -45,6 +45,7 @@ jobs:
         mkdir upload
         move build/Release/shadPS4.exe upload
         move build/Release/zlib-ng2.dll upload
+        move build/Release/SDL3.dll upload
         windeployqt --dir upload upload/shadPS4.exe
 
     - name: Upload executable

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Check the build instructions for [**Windows**](https://github.com/shadps4-emu/sh
 
 ## Linux
 
-Check the build instructions for [**Linux**](https://github.com/shadps4-emu/shadPS4/blob/main/documents/linux_building.md).
+Check the build instructions for [**Linux**](https://github.com/shadps4-emu/shadPS4/blob/main/documents/building-linux.md).
 
 ## Build status
 


### PR DESCRIPTION
This commit fixes an error when using the Windows-Qt build, the SDL3.dll file is missing. It also fixes a broken link to the Linux build.

Error message:
![Capture d'écran 2024-06-12 170622](https://github.com/shadps4-emu/shadPS4/assets/164882787/e9b8d4c0-ece3-4906-be7a-3f9858a4b661)