### PR TITLE
cmake: prefer system libraries

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,7 +39,6 @@ jobs:
         name: shadps4-ubuntu64
         path: |
           ${{github.workspace}}/build/shadps4
-          ${{github.workspace}}/build/libSDL3.so.0.0.0
 
     - name: Run AppImage packaging script
       run:  ./.github/linux-appimage-sdl.sh

--- a/.github/workflows/windows-qt.yml
+++ b/.github/workflows/windows-qt.yml
@@ -44,8 +44,6 @@ jobs:
       run: |
         mkdir upload
         move build/Release/shadPS4.exe upload
-        move build/Release/zlib-ng2.dll upload
-        move build/Release/SDL3.dll upload
         windeployqt --dir upload upload/shadPS4.exe
 
     - name: Upload executable

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,4 +38,3 @@ jobs:
         # A file, directory or wildcard pattern that describes what to upload
         path: |
           ${{github.workspace}}/build/Release/shadPS4.exe
-          ${{github.workspace}}/build/Release/SDL3.dll

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,23 @@ if (CLANG_FORMAT)
     unset(CCOMMENT)
 endif()
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+find_package(Boost 1.83.0 CONFIG)
+find_package(cryptopp 8.9.0 MODULE)
+find_package(fmt 10.2.0 CONFIG)
+find_package(glslang 14.2.0 CONFIG)
+find_package(magic_enum 0.9.5 CONFIG)
+find_package(SDL3 3.1.2 CONFIG)
+find_package(toml11 3.8.1 CONFIG)
+find_package(tsl-robin-map 1.3.0 CONFIG)
+find_package(VulkanHeaders 1.3.288 CONFIG)
+find_package(VulkanMemoryAllocator 3.1.0 CONFIG)
+find_package(xbyak 7.07 CONFIG)
+find_package(xxHash 0.8.2 MODULE)
+find_package(zlib-ng 2.1.6 MODULE)
+find_package(Zydis 4.1.0 CONFIG)
+
 add_subdirectory(externals)
 include_directories(src)
 
@@ -522,17 +539,17 @@ endif()
 
 create_target_directory_groups(shadps4)
 
-target_link_libraries(shadps4 PRIVATE magic_enum::magic_enum fmt::fmt toml11::toml11 tsl::robin_map xbyak Tracy::TracyClient)
-target_link_libraries(shadps4 PRIVATE boost vma sirit vulkan-headers xxhash Zydis SPIRV glslang SDL3-shared)
+target_link_libraries(shadps4 PRIVATE magic_enum::magic_enum fmt::fmt toml11::toml11 tsl::robin_map xbyak::xbyak Tracy::TracyClient)
+target_link_libraries(shadps4 PRIVATE Boost::headers GPUOpen::VulkanMemoryAllocator sirit Vulkan::Headers xxHash::xxhash Zydis::Zydis glslang::SPIRV glslang::glslang SDL3::SDL3)
 
 if (NOT ENABLE_QT_GUI)
-  target_link_libraries(shadps4 PRIVATE SDL3-shared)
+  target_link_libraries(shadps4 PRIVATE SDL3::SDL3)
 endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND MSVC)
-    target_link_libraries(shadps4 PRIVATE cryptoppwin zlib)
+    target_link_libraries(shadps4 PRIVATE cryptoppwin zlib-ng::zlib)
 else()
-    target_link_libraries(shadps4 PRIVATE cryptopp::cryptopp zlib)
+    target_link_libraries(shadps4 PRIVATE cryptopp::cryptopp zlib-ng::zlib)
 endif()
 
 if (ENABLE_QT_GUI)
@@ -577,13 +594,3 @@ if (ENABLE_QT_GUI)
 #        WIN32_EXECUTABLE ON
         MACOSX_BUNDLE ON)
 endif()
-
-add_custom_command(TARGET shadps4 POST_BUILD
-   COMMAND ${CMAKE_COMMAND} -E copy_if_different
-     $<TARGET_FILE:zlib>
-     $<TARGET_FILE_DIR:shadps4>)
-
-add_custom_command(TARGET shadps4 POST_BUILD
-   COMMAND ${CMAKE_COMMAND} -E copy_if_different
-     $<TARGET_FILE:SDL3-shared>
-     $<TARGET_FILE_DIR:shadps4>)

--- a/cmake/Findcryptopp.cmake
+++ b/cmake/Findcryptopp.cmake
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+find_package(PkgConfig QUIET)
+pkg_search_module(CRYPTOPP QUIET IMPORTED_TARGET libcryptopp)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(cryptopp
+    REQUIRED_VARS CRYPTOPP_LINK_LIBRARIES
+    VERSION_VAR CRYPTOPP_VERSION
+)
+
+if (cryptopp_FOUND AND NOT TARGET cryptopp::cryptopp)
+    add_library(cryptopp::cryptopp ALIAS PkgConfig::CRYPTOPP)
+endif()

--- a/cmake/FindxxHash.cmake
+++ b/cmake/FindxxHash.cmake
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+find_package(PkgConfig QUIET)
+pkg_search_module(XXHASH QUIET IMPORTED_TARGET libxxhash)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(xxHash
+    REQUIRED_VARS XXHASH_LINK_LIBRARIES
+    VERSION_VAR XXHASH_VERSION
+)
+
+if (xxHash_FOUND AND NOT TARGET xxHash::xxhash)
+    add_library(xxHash::xxhash ALIAS PkgConfig::XXHASH)
+endif()

--- a/cmake/Findzlib-ng.cmake
+++ b/cmake/Findzlib-ng.cmake
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+find_package(PkgConfig QUIET)
+pkg_search_module(ZLIB_NG QUIET IMPORTED_TARGET zlib-ng)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(zlib-ng
+    REQUIRED_VARS ZLIB_NG_LINK_LIBRARIES
+    VERSION_VAR ZLIB_NG_VERSION
+)
+
+if (zlib-ng_FOUND AND NOT TARGET zlib-ng::zlib)
+    add_library(zlib-ng::zlib ALIAS PkgConfig::ZLIB_NG)
+endif()

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -1,100 +1,134 @@
 # SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+set(BUILD_SHARED_LIBS OFF)
+set(BUILD_TESTING OFF)
+set_property(DIRECTORY PROPERTY EXCLUDE_FROM_ALL ON)
+
 if (MSVC)
     # Silence "deprecation" warnings
     add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS)
 endif()
 
 # Boost
-set(BOOST_ROOT "${CMAKE_SOURCE_DIR}/externals/boost" CACHE STRING "")
-set(Boost_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/externals/boost" CACHE STRING "")
-set(Boost_NO_SYSTEM_PATHS ON CACHE BOOL "")
-add_library(boost INTERFACE)
-target_include_directories(boost SYSTEM INTERFACE ${Boost_INCLUDE_DIR})
+if (NOT TARGET Boost::headers)
+    set(BOOST_ROOT "${CMAKE_SOURCE_DIR}/externals/boost" CACHE STRING "")
+    set(Boost_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/externals/boost" CACHE STRING "")
+    set(Boost_NO_SYSTEM_PATHS ON CACHE BOOL "")
+    add_library(boost INTERFACE)
+    target_include_directories(boost SYSTEM INTERFACE ${Boost_INCLUDE_DIR})
+    add_library(Boost::headers ALIAS boost)
+endif()
 
 # fmtlib
-add_subdirectory(fmt EXCLUDE_FROM_ALL)
+if (NOT TARGET fmt::fmt)
+    add_subdirectory(fmt)
+endif()
 
 # Discord-RPC
 set(BUILD_EXAMPLES OFF CACHE BOOL "")
-add_subdirectory(discord-rpc EXCLUDE_FROM_ALL)
+add_subdirectory(discord-rpc)
 target_include_directories(discord-rpc INTERFACE ./discord-rpc/include)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND MSVC)
     # If it is clang and MSVC we will add a static lib
     # CryptoPP
-    add_subdirectory(cryptoppwin EXCLUDE_FROM_ALL)
+    add_subdirectory(cryptoppwin)
     target_include_directories(cryptoppwin INTERFACE cryptoppwin/include)
 else()
     # CryptoPP
-    set(CRYPTOPP_INSTALL OFF)
-    set(CRYPTOPP_BUILD_TESTING OFF)
-    set(CRYPTOPP_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/cryptopp/)
-    add_subdirectory(cryptopp-cmake EXCLUDE_FROM_ALL)
-    file(COPY cryptopp DESTINATION cryptopp FILES_MATCHING PATTERN "*.h")
-    target_include_directories(cryptopp INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/cryptopp")
+    if (NOT TARGET cryptopp::cryptopp)
+        set(CRYPTOPP_INSTALL OFF)
+        set(CRYPTOPP_BUILD_TESTING OFF)
+        set(CRYPTOPP_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/cryptopp/)
+        add_subdirectory(cryptopp-cmake)
+        file(COPY cryptopp DESTINATION cryptopp FILES_MATCHING PATTERN "*.h")
+        target_include_directories(cryptopp INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/cryptopp")
+    endif()
 endif()
 
 # Zlib-Ng
-set(ZLIB_ENABLE_TESTS OFF)
-set(WITH_GTEST OFF)
-set(WITH_NEW_STRATEGIES ON)
-set(WITH_NATIVE_INSTRUCTIONS ON)
-add_subdirectory(zlib-ng)
+if (NOT TARGET zlib-ng::zlib)
+    set(ZLIB_ENABLE_TESTS OFF)
+    set(WITH_GTEST OFF)
+    set(WITH_NEW_STRATEGIES ON)
+    set(WITH_NATIVE_INSTRUCTIONS ON)
+    add_subdirectory(zlib-ng)
+    add_library(zlib-ng::zlib ALIAS zlib)
+endif()
 
 # SDL3
-add_subdirectory(sdl3 EXCLUDE_FROM_ALL)
+if (NOT TARGET SDL3::SDL3)
+    add_subdirectory(sdl3)
+endif()
 
 # vulkan-headers
-add_library(vulkan-headers INTERFACE)
-target_include_directories(vulkan-headers SYSTEM INTERFACE ./vulkan-headers/include)
+if (NOT TARGET Vulkan::Headers)
+    set(VULKAN_HEADERS_ENABLE_MODULE OFF)
+    add_subdirectory(vulkan-headers)
+endif()
 
 # VMA
-add_library(vma INTERFACE)
-target_include_directories(vma SYSTEM INTERFACE ./vma/include)
+if (NOT TARGET GPUOpen::VulkanMemoryAllocator)
+    add_subdirectory(vma)
+endif()
 
 # glslang
-set(SKIP_GLSLANG_INSTALL ON CACHE BOOL "")
-set(ENABLE_GLSLANG_BINARIES OFF CACHE BOOL "")
-set(ENABLE_SPVREMAPPER OFF CACHE BOOL "")
-set(ENABLE_CTEST OFF CACHE BOOL "")
-set(ENABLE_HLSL OFF CACHE BOOL "")
-set(BUILD_EXTERNAL OFF CACHE BOOL "")
-set(ENABLE_OPT OFF CACHE BOOL "")
-add_subdirectory(glslang)
-file(COPY glslang/SPIRV DESTINATION glslang/glslang FILES_MATCHING PATTERN "*.h")
-target_include_directories(SPIRV INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/glslang")
+if (NOT TARGET glslang::glslang)
+    set(SKIP_GLSLANG_INSTALL ON CACHE BOOL "")
+    set(ENABLE_GLSLANG_BINARIES OFF CACHE BOOL "")
+    set(ENABLE_SPVREMAPPER OFF CACHE BOOL "")
+    set(ENABLE_CTEST OFF CACHE BOOL "")
+    set(ENABLE_HLSL OFF CACHE BOOL "")
+    set(BUILD_EXTERNAL OFF CACHE BOOL "")
+    set(ENABLE_OPT OFF CACHE BOOL "")
+    add_subdirectory(glslang)
+    file(COPY glslang/SPIRV DESTINATION glslang/glslang FILES_MATCHING PATTERN "*.h")
+    target_include_directories(SPIRV INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/glslang")
+endif()
 
 # Robin-map
-add_subdirectory(robin-map EXCLUDE_FROM_ALL)
+if (NOT TARGET tsl::robin_map)
+    add_subdirectory(robin-map)
+endif()
 
 # Xbyak
-add_subdirectory(xbyak EXCLUDE_FROM_ALL)
+if (NOT TARGET xbyak::xbyak)
+    add_subdirectory(xbyak)
+endif()
 
 # MagicEnum
-add_subdirectory(magic_enum EXCLUDE_FROM_ALL)
+if (NOT TARGET magic_enum::magic_enum)
+    add_subdirectory(magic_enum)
+endif()
 
 # Toml11
-add_subdirectory(toml11 EXCLUDE_FROM_ALL)
+if (NOT TARGET toml11::toml11)
+    add_subdirectory(toml11)
+endif()
 
 # xxHash
-add_library(xxhash xxhash/xxhash.h xxhash/xxhash.c)
-target_include_directories(xxhash PUBLIC xxhash)
+if (NOT TARGET xxHash::xxhash)
+    add_library(xxhash xxhash/xxhash.h xxhash/xxhash.c)
+    target_include_directories(xxhash PUBLIC xxhash)
+    add_library(xxHash::xxhash ALIAS xxhash)
+endif()
 
 # Zydis
-option(ZYDIS_BUILD_TOOLS "" OFF)
-option(ZYDIS_BUILD_EXAMPLES "" OFF)
-add_subdirectory(zydis EXCLUDE_FROM_ALL)
+if (NOT TARGET Zydis::Zydis)
+    option(ZYDIS_BUILD_TOOLS "" OFF)
+    option(ZYDIS_BUILD_EXAMPLES "" OFF)
+    add_subdirectory(zydis)
+endif()
 
 # Winpthreads
 if (WIN32)
-    add_subdirectory(winpthreads EXCLUDE_FROM_ALL)
+    add_subdirectory(winpthreads)
     target_include_directories(winpthreads INTERFACE winpthreads/include)
 endif()
 
 # sirit
-add_subdirectory(sirit EXCLUDE_FROM_ALL)
+add_subdirectory(sirit)
 if (WIN32)
     target_compile_options(sirit PUBLIC "-Wno-error=unused-command-line-argument")
 endif()
@@ -105,4 +139,4 @@ option(TRACY_NO_CRASH_HANDLER "" ON) # Otherwise texture cache exceptions will b
 option(TRACY_ON_DEMAND "" ON)
 option(TRACY_NO_FRAME_IMAGE "" ON)
 option(TRACY_FIBERS "" ON) # For AmdGpu frontend profiling
-add_subdirectory(tracy EXCLUDE_FROM_ALL)
+add_subdirectory(tracy)


### PR DESCRIPTION
Is there a reason why `sdl3` and `zlib-ng` were compiled as shared libraries?