### PR TITLE
kernel/shader_recompiler: Fixes and cleanups to improve stability

### DIFF
--- a/src/common/io_file.h
+++ b/src/common/io_file.h
@@ -181,7 +181,7 @@ public:
     }
 
     template <typename T>
-    size_t WriteRaw(void* data, size_t size) const {
+    size_t WriteRaw(const void* data, size_t size) const {
         return std::fwrite(data, sizeof(T), size, file);
     }
 

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -126,7 +126,7 @@ int PS4_SYSV_ABI posix_close(int d) {
     return ORBIS_OK;
 }
 
-size_t PS4_SYSV_ABI sceKernelWrite(int d, void* buf, size_t nbytes) {
+size_t PS4_SYSV_ABI sceKernelWrite(int d, const void* buf, size_t nbytes) {
     if (d <= 2) { // stdin,stdout,stderr
         char* str = strdup((const char*)buf);
         if (str[nbytes - 1] == '\n')

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -3,8 +3,8 @@
 
 #include "common/assert.h"
 #include "common/logging/log.h"
-#include "common/singleton.h"
 #include "common/scope_exit.h"
+#include "common/singleton.h"
 #include "core/file_sys/fs.h"
 #include "core/libraries/error_codes.h"
 #include "core/libraries/kernel/file_system.h"
@@ -148,7 +148,7 @@ size_t PS4_SYSV_ABI sceKernelWrite(int d, const void* buf, size_t nbytes) {
 size_t PS4_SYSV_ABI _readv(int d, const SceKernelIovec* iov, int iovcnt) {
     auto* h = Common::Singleton<Core::FileSys::HandleTable>::Instance();
     auto* file = h->GetFile(d);
-    size_t total_read = 0;    
+    size_t total_read = 0;
     std::scoped_lock lk{file->m_mutex};
     for (int i = 0; i < iovcnt; i++) {
         total_read += file->f.ReadRaw<u8>(iov[i].iov_base, iov[i].iov_len);
@@ -278,7 +278,9 @@ s64 PS4_SYSV_ABI sceKernelPread(int d, void* buf, size_t nbytes, s64 offset) {
 
     std::scoped_lock lk{file->m_mutex};
     const s64 pos = file->f.Tell();
-    SCOPE_EXIT { file->f.Seek(pos); };
+    SCOPE_EXIT {
+        file->f.Seek(pos);
+    };
     file->f.Seek(offset);
     return file->f.ReadRaw<u8>(buf, nbytes);
 }
@@ -370,7 +372,9 @@ s64 PS4_SYSV_ABI sceKernelPwrite(int d, void* buf, size_t nbytes, s64 offset) {
 
     std::scoped_lock lk{file->m_mutex};
     const s64 pos = file->f.Tell();
-    SCOPE_EXIT { file->f.Seek(pos); };
+    SCOPE_EXIT {
+        file->f.Seek(pos);
+    };
     file->f.Seek(offset);
     return file->f.WriteRaw<u8>(buf, nbytes);
 }

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -277,9 +277,9 @@ s64 PS4_SYSV_ABI sceKernelPread(int d, void* buf, size_t nbytes, s64 offset) {
     }
 
     std::scoped_lock lk{file->m_mutex};
-    if (file->f.Tell() != offset) {
-        file->f.Seek(offset);
-    }
+    const s64 pos = file->f.Tell();
+    SCOPE_EXIT { file->f.Seek(pos); };
+    file->f.Seek(offset);
     return file->f.ReadRaw<u8>(buf, nbytes);
 }
 
@@ -371,7 +371,8 @@ s64 PS4_SYSV_ABI sceKernelPwrite(int d, void* buf, size_t nbytes, s64 offset) {
     std::scoped_lock lk{file->m_mutex};
     const s64 pos = file->f.Tell();
     SCOPE_EXIT { file->f.Seek(pos); };
-    return file->f.Seek(offset) && file->f.WriteRaw<u8>(buf, nbytes);
+    file->f.Seek(offset);
+    return file->f.WriteRaw<u8>(buf, nbytes);
 }
 
 void fileSystemSymbolsRegister(Core::Loader::SymbolsResolver* sym) {

--- a/src/core/libraries/kernel/threads/semaphore.cpp
+++ b/src/core/libraries/kernel/threads/semaphore.cpp
@@ -9,8 +9,8 @@
 #include "common/assert.h"
 #include "common/logging/log.h"
 #include "core/libraries/error_codes.h"
-#include "core/libraries/libs.h"
 #include "core/libraries/kernel/thread_management.h"
+#include "core/libraries/libs.h"
 
 namespace Libraries::Kernel {
 
@@ -20,8 +20,8 @@ using ListBaseHook =
 class Semaphore {
 public:
     Semaphore(s32 init_count, s32 max_count, std::string_view name, bool is_fifo)
-        : name{name}, token_count{init_count}, max_count{max_count},
-          init_count{init_count}, is_fifo{is_fifo} {}
+        : name{name}, token_count{init_count}, max_count{max_count}, init_count{init_count},
+          is_fifo{is_fifo} {}
     ~Semaphore() {
         ASSERT(wait_list.empty());
     }
@@ -187,7 +187,7 @@ s32 PS4_SYSV_ABI sceKernelPollSema(OrbisKernelSema sem, s32 needCount) {
     return sem->Wait(false, needCount, nullptr);
 }
 
-int PS4_SYSV_ABI sceKernelCancelSema(OrbisKernelSema sem, s32 setCount, s32 *pNumWaitThreads) {
+int PS4_SYSV_ABI sceKernelCancelSema(OrbisKernelSema sem, s32 setCount, s32* pNumWaitThreads) {
     return sem->Cancel(setCount, pNumWaitThreads);
 }
 

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -68,8 +68,10 @@ void Linker::Execute() {
     }
 
     // Configure used flexible memory size.
-    if (u64* flexible_size = GetProcParam()->mem_param->flexible_memory_size) {
-        memory->SetTotalFlexibleSize(*flexible_size);
+    if (auto* mem_param = GetProcParam()->mem_param) {
+        if (u64* flexible_size = mem_param->flexible_memory_size) {
+            memory->SetTotalFlexibleSize(*flexible_size);
+        }
     }
 
     // Init primary thread.

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -206,9 +206,15 @@ int MemoryManager::QueryProtection(VAddr addr, void** start, void** end, u32* pr
     const auto& vma = it->second;
     ASSERT_MSG(vma.type != VMAType::Free, "Provided address is not mapped");
 
-    *start = reinterpret_cast<void*>(vma.base);
-    *end = reinterpret_cast<void*>(vma.base + vma.size);
-    *prot = static_cast<u32>(vma.prot);
+    if (start != nullptr) {
+        *start = reinterpret_cast<void*>(vma.base);
+    }
+    if (end != nullptr) {
+        *end = reinterpret_cast<void*>(vma.base + vma.size);
+    }
+    if (prot != nullptr) {
+        *prot = static_cast<u32>(vma.prot);
+    }
     return ORBIS_OK;
 }
 

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -11,7 +11,6 @@
 #include "core/memory.h"
 #include "core/module.h"
 #include "core/tls.h"
-#include "core/virtual_memory.h"
 
 namespace Core {
 

--- a/src/shader_recompiler/frontend/translate/scalar_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_alu.cpp
@@ -196,6 +196,9 @@ void Translator::S_AND_B64(bool negate, const GcnInst& inst) {
     case OperandField::ScalarGPR:
         ir.SetThreadBitScalarReg(IR::ScalarReg(inst.dst[0].code), result);
         break;
+    case OperandField::ExecLo:
+        ir.SetExec(result);
+        break;
     default:
         UNREACHABLE();
     }
@@ -323,6 +326,22 @@ void Translator::S_NOT_B64(const GcnInst& inst) {
 
 void Translator::S_BREV_B32(const GcnInst& inst) {
     SetDst(inst.dst[0], ir.BitReverse(GetSrc(inst.src[0])));
+}
+
+void Translator::S_ADD_U32(const GcnInst& inst) {
+    const IR::U32 src0{GetSrc(inst.src[0])};
+    const IR::U32 src1{GetSrc(inst.src[1])};
+    SetDst(inst.dst[0], ir.IAdd(src0, src1));
+    // TODO: Carry out
+    ir.SetScc(ir.Imm1(false));
+}
+
+void Translator::S_SUB_U32(const GcnInst& inst) {
+    const IR::U32 src0{GetSrc(inst.src[0])};
+    const IR::U32 src1{GetSrc(inst.src[1])};
+    SetDst(inst.dst[0], ir.ISub(src0, src1));
+    // TODO: Carry out
+    ir.SetScc(ir.Imm1(false));
 }
 
 } // namespace Shader::Gcn

--- a/src/shader_recompiler/frontend/translate/scalar_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_alu.cpp
@@ -46,40 +46,6 @@ void Translator::S_CMP(ConditionOp cond, bool is_signed, const GcnInst& inst) {
     ir.SetScc(result);
 }
 
-void Translator::S_ANDN2_B64(const GcnInst& inst) {
-    // TODO: What if this is used for something other than EXEC masking?
-    const auto get_src = [&](const InstOperand& operand) {
-        switch (operand.field) {
-        case OperandField::VccLo:
-            return ir.GetVcc();
-        case OperandField::ExecLo:
-            return ir.GetExec();
-        case OperandField::ScalarGPR:
-            return ir.GetThreadBitScalarReg(IR::ScalarReg(operand.code));
-        default:
-            UNREACHABLE();
-        }
-    };
-
-    const IR::U1 src0{get_src(inst.src[0])};
-    const IR::U1 src1{get_src(inst.src[1])};
-    const IR::U1 result{ir.LogicalAnd(src0, ir.LogicalNot(src1))};
-    ir.SetScc(result);
-    switch (inst.dst[0].field) {
-    case OperandField::VccLo:
-        ir.SetVcc(result);
-        break;
-    case OperandField::ExecLo:
-        ir.SetExec(result);
-        break;
-    case OperandField::ScalarGPR:
-        ir.SetThreadBitScalarReg(IR::ScalarReg(inst.dst[0].code), result);
-        break;
-    default:
-        UNREACHABLE();
-    }
-}
-
 void Translator::S_AND_SAVEEXEC_B64(const GcnInst& inst) {
     // This instruction normally operates on 64-bit data (EXEC, VCC, SGPRs)
     // However here we flatten it to 1-bit EXEC and 1-bit VCC. For the destination
@@ -138,7 +104,7 @@ void Translator::S_MOV_B64(const GcnInst& inst) {
     }
 }
 
-void Translator::S_OR_B64(bool negate, const GcnInst& inst) {
+void Translator::S_OR_B64(NegateMode negate, const GcnInst& inst) {
     const auto get_src = [&](const InstOperand& operand) {
         switch (operand.field) {
         case OperandField::VccLo:
@@ -151,9 +117,12 @@ void Translator::S_OR_B64(bool negate, const GcnInst& inst) {
     };
 
     const IR::U1 src0{get_src(inst.src[0])};
-    const IR::U1 src1{get_src(inst.src[1])};
+    IR::U1 src1{get_src(inst.src[1])};
+    if (negate == NegateMode::Src1) {
+        src1 = ir.LogicalNot(src1);
+    }
     IR::U1 result = ir.LogicalOr(src0, src1);
-    if (negate) {
+    if (negate == NegateMode::Result) {
         result = ir.LogicalNot(result);
     }
     ir.SetScc(result);
@@ -169,7 +138,7 @@ void Translator::S_OR_B64(bool negate, const GcnInst& inst) {
     }
 }
 
-void Translator::S_AND_B64(bool negate, const GcnInst& inst) {
+void Translator::S_AND_B64(NegateMode negate, const GcnInst& inst) {
     const auto get_src = [&](const InstOperand& operand) {
         switch (operand.field) {
         case OperandField::VccLo:
@@ -183,9 +152,12 @@ void Translator::S_AND_B64(bool negate, const GcnInst& inst) {
         }
     };
     const IR::U1 src0{get_src(inst.src[0])};
-    const IR::U1 src1{get_src(inst.src[1])};
+    IR::U1 src1{get_src(inst.src[1])};
+    if (negate == NegateMode::Src1) {
+        src1 = ir.LogicalNot(src1);
+    }
     IR::U1 result = ir.LogicalAnd(src0, src1);
-    if (negate) {
+    if (negate == NegateMode::Result) {
         result = ir.LogicalNot(result);
     }
     ir.SetScc(result);

--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -469,7 +469,10 @@ void Translate(IR::Block* block, std::span<const GcnInst> inst_list, Info& info)
             translator.V_RSQ_F32(inst);
             break;
         case Opcode::S_ANDN2_B64:
-            translator.S_ANDN2_B64(inst);
+            translator.S_AND_B64(NegateMode::Src1, inst);
+            break;
+        case Opcode::S_ORN2_B64:
+            translator.S_OR_B64(NegateMode::Src1, inst);
             break;
         case Opcode::V_SIN_F32:
             translator.V_SIN_F32(inst);
@@ -608,19 +611,19 @@ void Translate(IR::Block* block, std::span<const GcnInst> inst_list, Info& info)
             translator.V_CMP_U32(ConditionOp::TRU, false, true, inst);
             break;
         case Opcode::S_OR_B64:
-            translator.S_OR_B64(false, inst);
+            translator.S_OR_B64(NegateMode::None, inst);
             break;
         case Opcode::S_NOR_B64:
-            translator.S_OR_B64(true, inst);
+            translator.S_OR_B64(NegateMode::Result, inst);
             break;
         case Opcode::S_AND_B64:
-            translator.S_AND_B64(false, inst);
+            translator.S_AND_B64(NegateMode::None, inst);
             break;
         case Opcode::S_NOT_B64:
             translator.S_NOT_B64(inst);
             break;
         case Opcode::S_NAND_B64:
-            translator.S_AND_B64(true, inst);
+            translator.S_AND_B64(NegateMode::Result, inst);
             break;
         case Opcode::V_LSHRREV_B32:
             translator.V_LSHRREV_B32(inst);

--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -331,6 +331,7 @@ void Translate(IR::Block* block, std::span<const GcnInst> inst_list, Info& info)
         case Opcode::IMAGE_SAMPLE_C_LZ:
         case Opcode::IMAGE_SAMPLE_LZ:
         case Opcode::IMAGE_SAMPLE:
+        case Opcode::IMAGE_SAMPLE_L:
             translator.IMAGE_SAMPLE(inst);
             break;
         case Opcode::IMAGE_STORE:

--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -105,7 +105,11 @@ IR::U32F32 Translator::GetSrc(const InstOperand& operand, bool force_flt) {
         }
         break;
     case OperandField::ConstFloatPos_1_0:
-        value = ir.Imm32(1.f);
+        if (force_flt) {
+            value = ir.Imm32(1.f);
+        } else {
+            value = ir.Imm32(std::bit_cast<u32>(1.f));
+        }
         break;
     case OperandField::ConstFloatPos_0_5:
         value = ir.Imm32(0.5f);
@@ -274,6 +278,9 @@ void Translate(IR::Block* block, std::span<const GcnInst> inst_list, Info& info)
         case Opcode::S_LOAD_DWORDX8:
             translator.S_LOAD_DWORD(8, inst);
             break;
+        case Opcode::S_LOAD_DWORDX16:
+            translator.S_LOAD_DWORD(16, inst);
+            break;
         case Opcode::S_BUFFER_LOAD_DWORD:
             translator.S_BUFFER_LOAD_DWORD(1, inst);
             break;
@@ -437,8 +444,17 @@ void Translate(IR::Block* block, std::span<const GcnInst> inst_list, Info& info)
         case Opcode::BUFFER_LOAD_FORMAT_X:
             translator.BUFFER_LOAD_FORMAT(1, false, inst);
             break;
+        case Opcode::BUFFER_LOAD_FORMAT_XYZ:
+            translator.BUFFER_LOAD_FORMAT(3, false, inst);
+            break;
+        case Opcode::BUFFER_LOAD_FORMAT_XYZW:
+            translator.BUFFER_LOAD_FORMAT(4, false, inst);
+            break;
         case Opcode::BUFFER_STORE_FORMAT_X:
             translator.BUFFER_STORE_FORMAT(1, false, inst);
+            break;
+        case Opcode::BUFFER_STORE_FORMAT_XYZW:
+            translator.BUFFER_STORE_FORMAT(4, false, inst);
             break;
         case Opcode::V_MAX_F32:
             translator.V_MAX_F32(inst);
@@ -695,6 +711,29 @@ void Translate(IR::Block* block, std::span<const GcnInst> inst_list, Info& info)
             break;
         case Opcode::S_BREV_B32:
             translator.S_BREV_B32(inst);
+            break;
+        case Opcode::S_ADD_U32:
+            translator.S_ADD_U32(inst);
+            break;
+        case Opcode::S_SUB_U32:
+            translator.S_SUB_U32(inst);
+            break;
+        // TODO: Separate implementation for legacy variants.
+        case Opcode::V_MUL_LEGACY_F32:
+            translator.V_MUL_F32(inst);
+            break;
+        case Opcode::V_MAC_LEGACY_F32:
+            translator.V_MAC_F32(inst);
+            break;
+        case Opcode::V_MAD_LEGACY_F32:
+            translator.V_MAD_F32(inst);
+            break;
+        case Opcode::V_RSQ_LEGACY_F32:
+        case Opcode::V_RSQ_CLAMP_F32:
+            translator.V_RSQ_F32(inst);
+            break;
+        case Opcode::V_RCP_IFLAG_F32:
+            translator.V_RCP_F32(inst);
             break;
         case Opcode::S_TTRACEDATA:
             LOG_WARNING(Render_Vulkan, "S_TTRACEDATA instruction!");

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -26,6 +26,12 @@ enum class ConditionOp : u32 {
     TRU,
 };
 
+enum class NegateMode : u32 {
+    None,
+    Src1,
+    Result,
+};
+
 class Translator {
 public:
     explicit Translator(IR::Block* block_, Info& info);
@@ -38,11 +44,10 @@ public:
     void S_MOV(const GcnInst& inst);
     void S_MUL_I32(const GcnInst& inst);
     void S_CMP(ConditionOp cond, bool is_signed, const GcnInst& inst);
-    void S_ANDN2_B64(const GcnInst& inst);
     void S_AND_SAVEEXEC_B64(const GcnInst& inst);
     void S_MOV_B64(const GcnInst& inst);
-    void S_OR_B64(bool negate, const GcnInst& inst);
-    void S_AND_B64(bool negate, const GcnInst& inst);
+    void S_OR_B64(NegateMode negate, const GcnInst& inst);
+    void S_AND_B64(NegateMode negate, const GcnInst& inst);
     void S_ADD_I32(const GcnInst& inst);
     void S_AND_B32(const GcnInst& inst);
     void S_OR_B32(const GcnInst& inst);

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -54,6 +54,8 @@ public:
     void S_BFM_B32(const GcnInst& inst);
     void S_NOT_B64(const GcnInst& inst);
     void S_BREV_B32(const GcnInst& inst);
+    void S_ADD_U32(const GcnInst& inst);
+    void S_SUB_U32(const GcnInst& inst);
 
     // Scalar Memory
     void S_LOAD_DWORD(int num_dwords, const GcnInst& inst);

--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -315,8 +315,11 @@ void PatchImageInstruction(IR::Block& block, IR::Inst& inst, Info& info, Descrip
         const u32 arg_pos = inst_info.is_depth ? 5 : 4;
         inst.SetArg(arg_pos, arg);
     }
-    if (inst_info.explicit_lod && inst.GetOpcode() == IR::Opcode::ImageFetch) {
-        inst.SetArg(3, arg);
+    if (inst_info.explicit_lod) {
+        ASSERT(inst.GetOpcode() == IR::Opcode::ImageFetch ||
+               inst.GetOpcode() == IR::Opcode::ImageSampleExplicitLod);
+        const u32 pos = inst.GetOpcode() == IR::Opcode::ImageFetch ? 3 : 2;
+        inst.SetArg(pos, arg);
     }
 }
 

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -485,7 +485,7 @@ void Liverpool::SubmitGfx(std::span<const u32> dcb, std::span<const u32> ccb) {
 }
 
 void Liverpool::SubmitAsc(u32 vqid, std::span<const u32> acb) {
-    ASSERT_MSG(vqid > 0 && vqid < NumTotalQueues, "Invalid virtual ASC queue index");
+    ASSERT_MSG(vqid >= 0 && vqid < NumTotalQueues, "Invalid virtual ASC queue index");
     auto& queue = mapped_queues[vqid];
 
     const auto& task = ProcessCompute(acb);

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -354,7 +354,8 @@ vk::Format SurfaceFormat(AmdGpu::DataFormat data_format, AmdGpu::NumberFormat nu
     if (data_format == AmdGpu::DataFormat::FormatBc2 && num_format == AmdGpu::NumberFormat::Unorm) {
         return vk::Format::eBc2UnormBlock;
     }
-    if (data_format == AmdGpu::DataFormat::Format16_16 && num_format == AmdGpu::NumberFormat::Snorm) {
+    if (data_format == AmdGpu::DataFormat::Format16_16 &&
+        num_format == AmdGpu::NumberFormat::Snorm) {
         return vk::Format::eR16G16Snorm;
     }
     UNREACHABLE_MSG("Unknown data_format={} and num_format={}", u32(data_format), u32(num_format));

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -354,6 +354,9 @@ vk::Format SurfaceFormat(AmdGpu::DataFormat data_format, AmdGpu::NumberFormat nu
     if (data_format == AmdGpu::DataFormat::FormatBc2 && num_format == AmdGpu::NumberFormat::Unorm) {
         return vk::Format::eBc2UnormBlock;
     }
+    if (data_format == AmdGpu::DataFormat::Format16_16 && num_format == AmdGpu::NumberFormat::Snorm) {
+        return vk::Format::eR16G16Snorm;
+    }
     UNREACHABLE_MSG("Unknown data_format={} and num_format={}", u32(data_format), u32(num_format));
 }
 


### PR DESCRIPTION
* File system has been cleaned up, mostly by using scoped locks instead of manually (un)locking mutexes everywhere. In addition removed a lot of buffer null checks, as games can pass null buffer with 0 read/write size and get defined results. Also fixed pread/pwrite that wouldn't restore the file position to before the read.

* Added more shader instructions in recompiler and more surface formats. The legacy instructions will need proper implementations one day but for now this will suffice

* Fix multiple crucial issues with semaphore implementation. Waiting threads are now removed by Signal() as there could be many threads in queue waiting to signal a semaphore. Otherwise a thread might consume tokens multiple times and we miss wakeups. Another problem is lock related. The lock during wait was held only during token check and wait list add. This could lead to cases where wait thread wins race again signal thread in token check, but then signal thread assigns the tokens while wait thread is waiting to add the wait object in the list. So unless another signal happens, the program will deadlock. Even with that there is a small window of time where wait thread has unlocked the mutex and is about to enter sleep state with convar, where signal thread could signal the condvar, thus missing a wakeup. To fix these problems, Wait() holds the mutex until wait is about to begin. Before letting it go, it exchanges it with wait object mutex, while Signal() also takes the wait object mutex before signalling. Semaphore deletion and cancelling have also been implemented.