### PR TITLE
video_core: First batch of fixes for Persona5

### DIFF
--- a/src/core/libraries/gnmdriver/gnmdriver.cpp
+++ b/src/core/libraries/gnmdriver/gnmdriver.cpp
@@ -2462,6 +2462,7 @@ int PS4_SYSV_ABI Func_F916890425496553() {
 }
 
 void RegisterlibSceGnmDriver(Core::Loader::SymbolsResolver* sym) {
+    LOG_INFO(Lib_GnmDriver, "Initializing renderer");
     liverpool = std::make_unique<AmdGpu::Liverpool>();
     renderer = std::make_unique<Vulkan::RendererVulkan>(*g_window, liverpool.get());
 

--- a/src/core/libraries/kernel/thread_management.cpp
+++ b/src/core/libraries/kernel/thread_management.cpp
@@ -1260,6 +1260,10 @@ int PS4_SYSV_ABI posix_sem_post(sem_t* sem) {
     return sem_post(sem);
 }
 
+int PS4_SYSV_ABI posix_sem_getvalue(sem_t* sem, int* sval) {
+    return sem_getvalue(sem, sval);
+}
+
 int PS4_SYSV_ABI scePthreadGetschedparam(ScePthread thread, int* policy,
                                          SceKernelSchedParam* param) {
     return pthread_getschedparam(thread->pth, policy, param);
@@ -1379,6 +1383,7 @@ void pthreadSymbolsRegister(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("pDuPEf3m4fI", "libScePosix", 1, "libkernel", 1, 1, posix_sem_init);
     LIB_FUNCTION("YCV5dGGBcCo", "libScePosix", 1, "libkernel", 1, 1, posix_sem_wait);
     LIB_FUNCTION("IKP8typ0QUk", "libScePosix", 1, "libkernel", 1, 1, posix_sem_post);
+    LIB_FUNCTION("Bq+LRV-N6Hk", "libScePosix", 1, "libkernel", 1, 1, posix_sem_getvalue);
     // libs
     RwlockSymbolsRegister(sym);
     SemaphoreSymbolsRegister(sym);

--- a/src/core/libraries/libs.cpp
+++ b/src/core/libraries/libs.cpp
@@ -38,6 +38,7 @@
 namespace Libraries {
 
 void InitHLELibs(Core::Loader::SymbolsResolver* sym) {
+    LOG_INFO(Lib_Kernel, "Initializing HLE libraries");
     Libraries::Kernel::LibKernel_Register(sym);
     Libraries::VideoOut::RegisterLib(sym);
     Libraries::GnmDriver::RegisterlibSceGnmDriver(sym);

--- a/src/core/libraries/videoout/driver.cpp
+++ b/src/core/libraries/videoout/driver.cpp
@@ -209,6 +209,8 @@ void VideoOutDriver::Flip(std::chrono::microseconds timeout) {
 
 bool VideoOutDriver::SubmitFlip(VideoOutPort* port, s32 index, s64 flip_arg,
                                 bool is_eop /*= false*/) {
+    std::scoped_lock lock{mutex};
+
     Vulkan::Frame* frame;
     if (index == -1) {
         frame = renderer->PrepareBlankFrame();
@@ -217,8 +219,6 @@ bool VideoOutDriver::SubmitFlip(VideoOutPort* port, s32 index, s64 flip_arg,
         const auto& group = port->groups[buffer.group_index];
         frame = renderer->PrepareFrame(group, buffer.address_left);
     }
-
-    std::scoped_lock lock{mutex};
 
     if (index != -1 && requests.size() >= port->NumRegisteredBuffers()) {
         LOG_ERROR(Lib_VideoOut, "Flip queue is full");

--- a/src/core/libraries/videoout/video_out.cpp
+++ b/src/core/libraries/videoout/video_out.cpp
@@ -242,7 +242,7 @@ void sceVideoOutGetBufferLabelAddress(s32 handle, uintptr_t* label_addr) {
 s32 sceVideoOutSubmitEopFlip(s32 handle, u32 buf_id, u32 mode, u32 arg, void** unk) {
     auto* port = driver->GetPort(handle);
     if (!port) {
-        return 0x8029000b;
+        return ORBIS_VIDEO_OUT_ERROR_INVALID_HANDLE;
     }
 
     Platform::IrqC::Instance()->RegisterOnce(

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -20,6 +20,9 @@ MemoryManager::MemoryManager() {
     const VAddr virtual_base = impl.VirtualBase();
     const size_t virtual_size = impl.VirtualSize();
     vma_map.emplace(virtual_base, VirtualMemoryArea{virtual_base, virtual_size});
+
+    // Log initialization.
+    LOG_INFO(Kernel_Vmm, "Usable memory address space {}_GB", virtual_size >> 30);
 }
 
 MemoryManager::~MemoryManager() = default;

--- a/src/core/tls.cpp
+++ b/src/core/tls.cpp
@@ -156,12 +156,12 @@ void PatchTLS(u64 segment_addr, u64 segment_size, Xbyak::CodeGenerator& c) {
             u64 offset = 0;
             if (tls_pattern.imm_size == 4) {
                 std::memcpy(&offset, code + tls_pattern.pattern_size, sizeof(u32));
-                LOG_INFO(Core_Linker, "PATTERN32 FOUND at {}, reg: {} offset: {:#x}",
-                         fmt::ptr(code), tls_pattern.target_reg, offset);
+                LOG_TRACE(Core_Linker, "PATTERN32 FOUND at {}, reg: {} offset: {:#x}",
+                          fmt::ptr(code), tls_pattern.target_reg, offset);
             } else {
                 std::memcpy(&offset, code + tls_pattern.pattern_size, sizeof(u64));
-                LOG_INFO(Core_Linker, "PATTERN64 FOUND at {}, reg: {} offset: {:#x}",
-                         fmt::ptr(code), tls_pattern.target_reg, offset);
+                LOG_ERROR(Core_Linker, "PATTERN64 FOUND at {}, reg: {} offset: {:#x}",
+                          fmt::ptr(code), tls_pattern.target_reg, offset);
                 continue;
             }
             ASSERT(offset == 0);

--- a/src/core/tls.cpp
+++ b/src/core/tls.cpp
@@ -124,9 +124,9 @@ static void PatchFsAccess(u8* code, const TLSPattern& tls_pattern, Xbyak::CodeGe
     const u32 idx1st = slot / PthreadKeySecondLevelSize;
     const u32 idx2nd = slot % PthreadKeySecondLevelSize;
     const auto target_reg = Xbyak::Reg64(tls_pattern.target_reg);
+    c.mov(target_reg, PthreadSpecificOffset);
     c.putSeg(fs);
-    c.mov(target_reg,
-          qword[PthreadSpecificOffset + idx1st * 8]); // Load first level specific array.
+    c.mov(target_reg, qword[target_reg + idx1st * 8]); // Load first level specific array.
     c.mov(target_reg, qword[target_reg + idx2nd * 16 +
                             8]); // Load data member of pthread_key_data our slot specifies.
     c.jmp(code + total_size);    // Return to the instruction right after the mov.

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -139,7 +139,6 @@ void Emulator::Run(const std::filesystem::path& file) {
 }
 
 void Emulator::LoadSystemModules(const std::filesystem::path& file) {
-
     constexpr std::array<SysModules, 6> ModulesToLoad{
         {{"libSceNgs2.sprx", nullptr},
          {"libSceLibcInternal.sprx", &Libraries::LibcInternal::RegisterlibSceLibcInternal},

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -29,8 +29,8 @@ namespace Core {
 static constexpr s32 WindowWidth = 1280;
 static constexpr s32 WindowHeight = 720;
 
-Emulator::Emulator() : memory{Core::Memory::Instance()},
-      window{WindowWidth, WindowHeight, controller} {
+Emulator::Emulator()
+    : memory{Core::Memory::Instance()}, window{WindowWidth, WindowHeight, controller} {
     g_window = &window;
 
     // Read configuration file.

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -126,7 +126,7 @@ void Emulator::Run(const std::filesystem::path& file) {
         std::jthread([this](std::stop_token stop_token) { linker->Execute(); });
 
     // Begin main window loop until the application exits
-    static constexpr std::chrono::microseconds FlipPeriod{10};
+    static constexpr std::chrono::milliseconds FlipPeriod{16};
 
     while (window.isOpen()) {
         window.waitEvent();

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -29,11 +29,9 @@ namespace Core {
 static constexpr s32 WindowWidth = 1280;
 static constexpr s32 WindowHeight = 720;
 
-Emulator::Emulator() : window{WindowWidth, WindowHeight, controller} {
+Emulator::Emulator() : memory{Core::Memory::Instance()},
+      window{WindowWidth, WindowHeight, controller} {
     g_window = &window;
-
-    // Initialize memory system as early as possible to reserve mappings.
-    [[maybe_unused]] const auto* memory = Core::Memory::Instance();
 
     // Read configuration file.
     const auto config_dir = Common::FS::GetUserPath(Common::FS::PathType::UserDir);

--- a/src/emulator.h
+++ b/src/emulator.h
@@ -29,6 +29,8 @@ public:
 
 private:
     void LoadSystemModules(const std::filesystem::path& file);
+
+    Core::MemoryManager* memory;
     Input::GameController* controller = Common::Singleton<Input::GameController>::Instance();
     Core::Linker* linker = Common::Singleton<Core::Linker>::Instance();
     Frontend::WindowSDL window;

--- a/src/shader_recompiler/backend/spirv/emit_spirv.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv.cpp
@@ -200,6 +200,8 @@ void DefineEntryPoint(const IR::Program& program, EmitContext& ctx, Id main) {
             ctx.AddCapability(spv::Capability::GroupNonUniformQuad);
         }
         ctx.AddCapability(spv::Capability::DemoteToHelperInvocationEXT);
+        ctx.AddCapability(spv::Capability::ImageGatherExtended);
+        ctx.AddCapability(spv::Capability::ImageQuery);
         // if (program.info.stores_frag_depth) {
         //     ctx.AddExecutionMode(main, spv::ExecutionMode::DepthReplacing);
         // }

--- a/src/shader_recompiler/backend/spirv/emit_spirv.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv.cpp
@@ -31,6 +31,8 @@ ArgType Arg(EmitContext& ctx, const IR::Value& arg) {
         return arg.U32();
     } else if constexpr (std::is_same_v<ArgType, u64>) {
         return arg.U64();
+    } else if constexpr (std::is_same_v<ArgType, bool>) {
+        return arg.U1();
     } else if constexpr (std::is_same_v<ArgType, IR::Attribute>) {
         return arg.Attribute();
     } else if constexpr (std::is_same_v<ArgType, IR::ScalarReg>) {

--- a/src/shader_recompiler/backend/spirv/emit_spirv_bitwise_conversion.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_bitwise_conversion.cpp
@@ -7,7 +7,7 @@
 namespace Shader::Backend::SPIRV {
 
 void EmitBitCastU16F16(EmitContext&) {
-    throw NotImplementedException("SPIR-V Instruction");
+    UNREACHABLE_MSG("SPIR-V Instruction");
 }
 
 Id EmitBitCastU32F32(EmitContext& ctx, Id value) {
@@ -15,11 +15,11 @@ Id EmitBitCastU32F32(EmitContext& ctx, Id value) {
 }
 
 void EmitBitCastU64F64(EmitContext&) {
-    throw NotImplementedException("SPIR-V Instruction");
+    UNREACHABLE_MSG("SPIR-V Instruction");
 }
 
 void EmitBitCastF16U16(EmitContext&) {
-    throw NotImplementedException("SPIR-V Instruction");
+    UNREACHABLE_MSG("SPIR-V Instruction");
 }
 
 Id EmitBitCastF32U32(EmitContext& ctx, Id value) {
@@ -27,7 +27,7 @@ Id EmitBitCastF32U32(EmitContext& ctx, Id value) {
 }
 
 void EmitBitCastF64U64(EmitContext&) {
-    throw NotImplementedException("SPIR-V Instruction");
+    UNREACHABLE_MSG("SPIR-V Instruction");
 }
 
 Id EmitPackUint2x32(EmitContext& ctx, Id value) {

--- a/src/shader_recompiler/backend/spirv/emit_spirv_composite.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_composite.cpp
@@ -115,27 +115,27 @@ Id EmitCompositeInsertF32x4(EmitContext& ctx, Id composite, Id object, u32 index
 }
 
 void EmitCompositeConstructF64x2(EmitContext&) {
-    throw NotImplementedException("SPIR-V Instruction");
+    UNREACHABLE_MSG("SPIR-V Instruction");
 }
 
 void EmitCompositeConstructF64x3(EmitContext&) {
-    throw NotImplementedException("SPIR-V Instruction");
+    UNREACHABLE_MSG("SPIR-V Instruction");
 }
 
 void EmitCompositeConstructF64x4(EmitContext&) {
-    throw NotImplementedException("SPIR-V Instruction");
+    UNREACHABLE_MSG("SPIR-V Instruction");
 }
 
 void EmitCompositeExtractF64x2(EmitContext&) {
-    throw NotImplementedException("SPIR-V Instruction");
+    UNREACHABLE_MSG("SPIR-V Instruction");
 }
 
 void EmitCompositeExtractF64x3(EmitContext&) {
-    throw NotImplementedException("SPIR-V Instruction");
+    UNREACHABLE_MSG("SPIR-V Instruction");
 }
 
 void EmitCompositeExtractF64x4(EmitContext&) {
-    throw NotImplementedException("SPIR-V Instruction");
+    UNREACHABLE_MSG("SPIR-V Instruction");
 }
 
 Id EmitCompositeInsertF64x2(EmitContext& ctx, Id composite, Id object, u32 index) {

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -31,6 +31,8 @@ Id OutputAttrPointer(EmitContext& ctx, IR::Attribute attr, u32 element) {
             return ctx.frag_color[index];
         }
     }
+    case IR::Attribute::Depth:
+        return ctx.frag_depth;
     default:
         throw NotImplementedException("Read attribute {}", attr);
     }

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -203,7 +203,7 @@ void EmitStoreBufferF32x3(EmitContext& ctx, IR::Inst* inst, u32 handle, Id addre
         for (u32 i = 0; i < 3; i++) {
             const Id index{ctx.OpIAdd(ctx.U32[1], address, ctx.ConstU32(i))};
             const Id ptr{
-                         ctx.OpAccessChain(buffer.pointer_type, buffer.id, ctx.u32_zero_value, index)};
+                ctx.OpAccessChain(buffer.pointer_type, buffer.id, ctx.u32_zero_value, index)};
             ctx.OpStore(ptr, ctx.OpCompositeExtract(ctx.F32[1], value, i));
         }
         return;
@@ -220,7 +220,7 @@ void EmitStoreBufferF32x4(EmitContext& ctx, IR::Inst* inst, u32 handle, Id addre
         for (u32 i = 0; i < 4; i++) {
             const Id index{ctx.OpIAdd(ctx.U32[1], address, ctx.ConstU32(i))};
             const Id ptr{
-                         ctx.OpAccessChain(buffer.pointer_type, buffer.id, ctx.u32_zero_value, index)};
+                ctx.OpAccessChain(buffer.pointer_type, buffer.id, ctx.u32_zero_value, index)};
             ctx.OpStore(ptr, ctx.OpCompositeExtract(ctx.F32[1], value, i));
         }
         return;

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -195,10 +195,36 @@ void EmitStoreBufferF32x2(EmitContext& ctx, IR::Inst* inst, u32 handle, Id addre
 }
 
 void EmitStoreBufferF32x3(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address, Id value) {
+    const auto info = inst->Flags<IR::BufferInstInfo>();
+    const auto& buffer = ctx.buffers[handle];
+    if (info.index_enable && info.offset_enable) {
+        UNREACHABLE();
+    } else if (info.index_enable) {
+        for (u32 i = 0; i < 3; i++) {
+            const Id index{ctx.OpIAdd(ctx.U32[1], address, ctx.ConstU32(i))};
+            const Id ptr{
+                         ctx.OpAccessChain(buffer.pointer_type, buffer.id, ctx.u32_zero_value, index)};
+            ctx.OpStore(ptr, ctx.OpCompositeExtract(ctx.F32[1], value, i));
+        }
+        return;
+    }
     UNREACHABLE();
 }
 
 void EmitStoreBufferF32x4(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address, Id value) {
+    const auto info = inst->Flags<IR::BufferInstInfo>();
+    const auto& buffer = ctx.buffers[handle];
+    if (info.index_enable && info.offset_enable) {
+        UNREACHABLE();
+    } else if (info.index_enable) {
+        for (u32 i = 0; i < 4; i++) {
+            const Id index{ctx.OpIAdd(ctx.U32[1], address, ctx.ConstU32(i))};
+            const Id ptr{
+                         ctx.OpAccessChain(buffer.pointer_type, buffer.id, ctx.u32_zero_value, index)};
+            ctx.OpStore(ptr, ctx.OpCompositeExtract(ctx.F32[1], value, i));
+        }
+        return;
+    }
     UNREACHABLE();
 }
 

--- a/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
@@ -26,7 +26,7 @@ Id EmitImageSampleImplicitLod(EmitContext& ctx, IR::Inst* inst, u32 handle, Id c
     const Id sampled_image = ctx.OpSampledImage(texture.sampled_type, image, sampler);
     ImageOperands operands;
     if (Sirit::ValidId(offset)) {
-        operands.Add(spv::ImageOperandsMask::Offset, offset);
+        operands.Add(spv::ImageOperandsMask::ConstOffset, offset);
     }
     return ctx.OpImageSampleImplicitLod(ctx.F32[4], sampled_image, coords, operands.mask, operands.operands);
 }

--- a/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
@@ -28,7 +28,8 @@ Id EmitImageSampleImplicitLod(EmitContext& ctx, IR::Inst* inst, u32 handle, Id c
     if (Sirit::ValidId(offset)) {
         operands.Add(spv::ImageOperandsMask::ConstOffset, offset);
     }
-    return ctx.OpImageSampleImplicitLod(ctx.F32[4], sampled_image, coords, operands.mask, operands.operands);
+    return ctx.OpImageSampleImplicitLod(ctx.F32[4], sampled_image, coords, operands.mask,
+                                        operands.operands);
 }
 
 Id EmitImageSampleExplicitLod(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id bias_lc,
@@ -41,8 +42,8 @@ Id EmitImageSampleExplicitLod(EmitContext& ctx, IR::Inst* inst, u32 handle, Id c
                                         spv::ImageOperandsMask::Lod, ctx.ConstF32(0.f));
 }
 
-Id EmitImageSampleDrefImplicitLod(EmitContext& ctx, IR::Inst* inst, u32 handle,
-                                  Id coords, Id dref, Id bias_lc, const IR::Value& offset) {
+Id EmitImageSampleDrefImplicitLod(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id dref,
+                                  Id bias_lc, const IR::Value& offset) {
     const auto& texture = ctx.images[handle & 0xFFFF];
     const Id image = ctx.OpLoad(texture.image_type, texture.id);
     const Id sampler = ctx.OpLoad(ctx.sampler_type, ctx.samplers[handle >> 16]);
@@ -91,7 +92,8 @@ Id EmitImageQueryDimensions(EmitContext& ctx, IR::Inst* inst, u32 handle, Id lod
     const auto type = ctx.info.images[handle & 0xFFFF].type;
     const Id zero = ctx.u32_zero_value;
     const auto mips{[&] { return skip_mips ? zero : ctx.OpImageQueryLevels(ctx.U32[1], image); }};
-    const bool uses_lod{type != AmdGpu::ImageType::Color2DMsaa && type != AmdGpu::ImageType::Buffer};
+    const bool uses_lod{type != AmdGpu::ImageType::Color2DMsaa &&
+                        type != AmdGpu::ImageType::Buffer};
     const auto query{[&](Id type) {
         return uses_lod ? ctx.OpImageQuerySizeLod(type, image, lod)
                         : ctx.OpImageQuerySize(type, image);

--- a/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
@@ -1,10 +1,22 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <boost/container/static_vector.hpp>
 #include "shader_recompiler/backend/spirv/emit_spirv_instructions.h"
 #include "shader_recompiler/backend/spirv/spirv_emit_context.h"
 
 namespace Shader::Backend::SPIRV {
+
+struct ImageOperands {
+    void Add(spv::ImageOperandsMask new_mask, Id value) {
+        mask = static_cast<spv::ImageOperandsMask>(static_cast<u32>(mask) |
+                                                   static_cast<u32>(new_mask));
+        operands.push_back(value);
+    }
+
+    spv::ImageOperandsMask mask{};
+    boost::container::static_vector<Id, 4> operands;
+};
 
 Id EmitImageSampleImplicitLod(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id bias_lc,
                               Id offset) {
@@ -12,7 +24,11 @@ Id EmitImageSampleImplicitLod(EmitContext& ctx, IR::Inst* inst, u32 handle, Id c
     const Id image = ctx.OpLoad(texture.image_type, texture.id);
     const Id sampler = ctx.OpLoad(ctx.sampler_type, ctx.samplers[handle >> 16]);
     const Id sampled_image = ctx.OpSampledImage(texture.sampled_type, image, sampler);
-    return ctx.OpImageSampleImplicitLod(ctx.F32[4], sampled_image, coords);
+    ImageOperands operands;
+    if (Sirit::ValidId(offset)) {
+        operands.Add(spv::ImageOperandsMask::Offset, offset);
+    }
+    return ctx.OpImageSampleImplicitLod(ctx.F32[4], sampled_image, coords, operands.mask, operands.operands);
 }
 
 Id EmitImageSampleExplicitLod(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id bias_lc,
@@ -25,9 +41,13 @@ Id EmitImageSampleExplicitLod(EmitContext& ctx, IR::Inst* inst, u32 handle, Id c
                                         spv::ImageOperandsMask::Lod, ctx.ConstF32(0.f));
 }
 
-Id EmitImageSampleDrefImplicitLod(EmitContext& ctx, IR::Inst* inst, const IR::Value& index,
+Id EmitImageSampleDrefImplicitLod(EmitContext& ctx, IR::Inst* inst, u32 handle,
                                   Id coords, Id dref, Id bias_lc, const IR::Value& offset) {
-    throw NotImplementedException("SPIR-V Instruction");
+    const auto& texture = ctx.images[handle & 0xFFFF];
+    const Id image = ctx.OpLoad(texture.image_type, texture.id);
+    const Id sampler = ctx.OpLoad(ctx.sampler_type, ctx.samplers[handle >> 16]);
+    const Id sampled_image = ctx.OpSampledImage(texture.sampled_type, image, sampler);
+    return ctx.OpImageSampleDrefImplicitLod(ctx.F32[1], sampled_image, coords, dref);
 }
 
 Id EmitImageSampleDrefExplicitLod(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id dref,
@@ -42,12 +62,16 @@ Id EmitImageSampleDrefExplicitLod(EmitContext& ctx, IR::Inst* inst, u32 handle, 
 
 Id EmitImageGather(EmitContext& ctx, IR::Inst* inst, const IR::Value& index, Id coords,
                    const IR::Value& offset, const IR::Value& offset2) {
-    throw NotImplementedException("SPIR-V Instruction");
+    UNREACHABLE_MSG("SPIR-V Instruction");
 }
 
-Id EmitImageGatherDref(EmitContext& ctx, IR::Inst* inst, const IR::Value& index, Id coords,
+Id EmitImageGatherDref(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords,
                        const IR::Value& offset, const IR::Value& offset2, Id dref) {
-    throw NotImplementedException("SPIR-V Instruction");
+    const auto& texture = ctx.images[handle & 0xFFFF];
+    const Id image = ctx.OpLoad(texture.image_type, texture.id);
+    const Id sampler = ctx.OpLoad(ctx.sampler_type, ctx.samplers[handle >> 16]);
+    const Id sampled_image = ctx.OpSampledImage(texture.sampled_type, image, sampler);
+    return ctx.OpImageDrefGather(ctx.F32[4], sampled_image, coords, dref);
 }
 
 Id EmitImageFetch(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id offset, Id lod,
@@ -83,21 +107,21 @@ Id EmitImageQueryDimensions(EmitContext& ctx, IR::Inst* inst, u32 handle, Id lod
     case AmdGpu::ImageType::Color3D:
         return ctx.OpCompositeConstruct(ctx.U32[4], query(ctx.U32[3]), mips());
     default:
-        throw NotImplementedException("SPIR-V Instruction");
+        UNREACHABLE_MSG("SPIR-V Instruction");
     }
 }
 
 Id EmitImageQueryLod(EmitContext& ctx, IR::Inst* inst, const IR::Value& index, Id coords) {
-    throw NotImplementedException("SPIR-V Instruction");
+    UNREACHABLE_MSG("SPIR-V Instruction");
 }
 
 Id EmitImageGradient(EmitContext& ctx, IR::Inst* inst, const IR::Value& index, Id coords,
                      Id derivatives, const IR::Value& offset, Id lod_clamp) {
-    throw NotImplementedException("SPIR-V Instruction");
+    UNREACHABLE_MSG("SPIR-V Instruction");
 }
 
 Id EmitImageRead(EmitContext& ctx, IR::Inst* inst, const IR::Value& index, Id coords) {
-    throw NotImplementedException("SPIR-V Instruction");
+    UNREACHABLE_MSG("SPIR-V Instruction");
 }
 
 void EmitImageWrite(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id color) {

--- a/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
@@ -338,13 +338,13 @@ Id EmitImageSampleImplicitLod(EmitContext& ctx, IR::Inst* inst, u32 handle, Id c
                               Id offset);
 Id EmitImageSampleExplicitLod(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id bias_lc,
                               Id offset);
-Id EmitImageSampleDrefImplicitLod(EmitContext& ctx, IR::Inst* inst, const IR::Value& index,
+Id EmitImageSampleDrefImplicitLod(EmitContext& ctx, IR::Inst* inst, u32 handle,
                                   Id coords, Id dref, Id bias_lc, const IR::Value& offset);
 Id EmitImageSampleDrefExplicitLod(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id dref,
                                   Id bias_lc, Id offset);
 Id EmitImageGather(EmitContext& ctx, IR::Inst* inst, const IR::Value& index, Id coords,
                    const IR::Value& offset, const IR::Value& offset2);
-Id EmitImageGatherDref(EmitContext& ctx, IR::Inst* inst, const IR::Value& index, Id coords,
+Id EmitImageGatherDref(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords,
                        const IR::Value& offset, const IR::Value& offset2, Id dref);
 Id EmitImageFetch(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id offset, Id lod,
                   Id ms);

--- a/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
@@ -348,8 +348,7 @@ Id EmitImageGatherDref(EmitContext& ctx, IR::Inst* inst, const IR::Value& index,
                        const IR::Value& offset, const IR::Value& offset2, Id dref);
 Id EmitImageFetch(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id offset, Id lod,
                   Id ms);
-Id EmitImageQueryDimensions(EmitContext& ctx, IR::Inst* inst, const IR::Value& index, Id lod,
-                            const IR::Value& skip_mips);
+Id EmitImageQueryDimensions(EmitContext& ctx, IR::Inst* inst, u32 handle, Id lod, bool skip_mips);
 Id EmitImageQueryLod(EmitContext& ctx, IR::Inst* inst, const IR::Value& index, Id coords);
 Id EmitImageGradient(EmitContext& ctx, IR::Inst* inst, const IR::Value& index, Id coords,
                      Id derivatives, const IR::Value& offset, Id lod_clamp);

--- a/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
@@ -338,8 +338,8 @@ Id EmitImageSampleImplicitLod(EmitContext& ctx, IR::Inst* inst, u32 handle, Id c
                               Id offset);
 Id EmitImageSampleExplicitLod(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id bias_lc,
                               Id offset);
-Id EmitImageSampleDrefImplicitLod(EmitContext& ctx, IR::Inst* inst, u32 handle,
-                                  Id coords, Id dref, Id bias_lc, const IR::Value& offset);
+Id EmitImageSampleDrefImplicitLod(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id dref,
+                                  Id bias_lc, const IR::Value& offset);
 Id EmitImageSampleDrefExplicitLod(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id dref,
                                   Id bias_lc, Id offset);
 Id EmitImageGather(EmitContext& ctx, IR::Inst* inst, const IR::Value& index, Id coords,

--- a/src/shader_recompiler/backend/spirv/emit_spirv_select.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_select.cpp
@@ -11,7 +11,7 @@ Id EmitSelectU1(EmitContext& ctx, Id cond, Id true_value, Id false_value) {
 }
 
 Id EmitSelectU8(EmitContext&, Id, Id, Id) {
-    throw NotImplementedException("SPIR-V Instruction");
+    UNREACHABLE_MSG("SPIR-V Instruction");
 }
 
 Id EmitSelectU16(EmitContext& ctx, Id cond, Id true_value, Id false_value) {

--- a/src/shader_recompiler/backend/spirv/emit_spirv_undefined.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_undefined.cpp
@@ -11,11 +11,11 @@ Id EmitUndefU1(EmitContext& ctx) {
 }
 
 Id EmitUndefU8(EmitContext&) {
-    throw NotImplementedException("SPIR-V Instruction");
+    UNREACHABLE_MSG("SPIR-V Instruction");
 }
 
 Id EmitUndefU16(EmitContext&) {
-    throw NotImplementedException("SPIR-V Instruction");
+    UNREACHABLE_MSG("SPIR-V Instruction");
 }
 
 Id EmitUndefU32(EmitContext& ctx) {
@@ -23,7 +23,7 @@ Id EmitUndefU32(EmitContext& ctx) {
 }
 
 Id EmitUndefU64(EmitContext&) {
-    throw NotImplementedException("SPIR-V Instruction");
+    UNREACHABLE_MSG("SPIR-V Instruction");
 }
 
 } // namespace Shader::Backend::SPIRV

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -187,6 +187,7 @@ void EmitContext::DefineInputs(const Info& info) {
             Decorate(subgroup_local_invocation_id, spv::Decoration::Flat);
         }
         frag_coord = DefineVariable(F32[4], spv::BuiltIn::FragCoord, spv::StorageClass::Input);
+        frag_depth = DefineVariable(F32[1], spv::BuiltIn::FragDepth, spv::StorageClass::Output);
         front_facing = DefineVariable(U1[1], spv::BuiltIn::FrontFacing, spv::StorageClass::Input);
         for (const auto& input : info.ps_inputs) {
             const u32 semantic = input.param_index;

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -265,7 +265,8 @@ void EmitContext::DefineBuffers(const Info& info) {
         const Id struct_type{TypeStruct(record_array_type)};
         if (std::ranges::find(type_ids, record_array_type.value, &Id::value) == type_ids.end()) {
             Decorate(record_array_type, spv::Decoration::ArrayStride, 4);
-            const auto name = fmt::format("{}_cbuf_block_{}{}", stage, 'f', sizeof(float) * CHAR_BIT);
+            const auto name =
+                fmt::format("{}_cbuf_block_{}{}", stage, 'f', sizeof(float) * CHAR_BIT);
             Name(struct_type, name);
             Decorate(struct_type, spv::Decoration::Block);
             MemberName(struct_type, 0, "data");

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -160,6 +160,7 @@ public:
     Id base_vertex{};
     Id frag_coord{};
     Id front_facing{};
+    Id frag_depth{};
     std::array<Id, 8> frag_color{};
     std::array<u32, 8> frag_num_comp{};
 

--- a/src/shader_recompiler/frontend/translate/scalar_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_alu.cpp
@@ -104,7 +104,7 @@ void Translator::S_MOV_B64(const GcnInst& inst) {
     }
 }
 
-void Translator::S_OR_B64(NegateMode negate, const GcnInst& inst) {
+void Translator::S_OR_B64(NegateMode negate, bool is_xor, const GcnInst& inst) {
     const auto get_src = [&](const InstOperand& operand) {
         switch (operand.field) {
         case OperandField::ExecLo:
@@ -123,7 +123,7 @@ void Translator::S_OR_B64(NegateMode negate, const GcnInst& inst) {
     if (negate == NegateMode::Src1) {
         src1 = ir.LogicalNot(src1);
     }
-    IR::U1 result = ir.LogicalOr(src0, src1);
+    IR::U1 result = is_xor ? ir.LogicalXor(src0, src1) : ir.LogicalOr(src0, src1);
     if (negate == NegateMode::Result) {
         result = ir.LogicalNot(result);
     }

--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -328,6 +328,7 @@ void Translate(IR::Block* block, std::span<const GcnInst> inst_list, Info& info)
             translator.V_FMA_F32(inst);
             break;
         case Opcode::IMAGE_SAMPLE_LZ_O:
+        case Opcode::IMAGE_SAMPLE_O:
         case Opcode::IMAGE_SAMPLE_C_LZ:
         case Opcode::IMAGE_SAMPLE_LZ:
         case Opcode::IMAGE_SAMPLE:
@@ -455,6 +456,7 @@ void Translate(IR::Block* block, std::span<const GcnInst> inst_list, Info& info)
             translator.BUFFER_LOAD_FORMAT(4, false, inst);
             break;
         case Opcode::BUFFER_STORE_FORMAT_X:
+        case Opcode::BUFFER_STORE_DWORD:
             translator.BUFFER_STORE_FORMAT(1, false, inst);
             break;
         case Opcode::BUFFER_STORE_FORMAT_XYZW:
@@ -468,6 +470,9 @@ void Translate(IR::Block* block, std::span<const GcnInst> inst_list, Info& info)
             break;
         case Opcode::V_MAX_U32:
             translator.V_MAX_U32(false, inst);
+            break;
+        case Opcode::V_NOT_B32:
+            translator.V_NOT_B32(inst);
             break;
         case Opcode::V_RSQ_F32:
             translator.V_RSQ_F32(inst);

--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -329,11 +329,15 @@ void Translate(IR::Block* block, std::span<const GcnInst> inst_list, Info& info)
             break;
         case Opcode::IMAGE_SAMPLE_LZ_O:
         case Opcode::IMAGE_SAMPLE_O:
+        case Opcode::IMAGE_SAMPLE_C:
         case Opcode::IMAGE_SAMPLE_C_LZ:
         case Opcode::IMAGE_SAMPLE_LZ:
         case Opcode::IMAGE_SAMPLE:
         case Opcode::IMAGE_SAMPLE_L:
             translator.IMAGE_SAMPLE(inst);
+            break;
+        case Opcode::IMAGE_GATHER4_C:
+            translator.IMAGE_GATHER(inst);
             break;
         case Opcode::IMAGE_STORE:
             translator.IMAGE_STORE(inst);
@@ -450,16 +454,22 @@ void Translate(IR::Block* block, std::span<const GcnInst> inst_list, Info& info)
             translator.BUFFER_LOAD_FORMAT(1, false, inst);
             break;
         case Opcode::BUFFER_LOAD_FORMAT_XYZ:
+        case Opcode::BUFFER_LOAD_DWORDX3:
             translator.BUFFER_LOAD_FORMAT(3, false, inst);
             break;
         case Opcode::BUFFER_LOAD_FORMAT_XYZW:
+        case Opcode::BUFFER_LOAD_DWORDX4:
             translator.BUFFER_LOAD_FORMAT(4, false, inst);
             break;
         case Opcode::BUFFER_STORE_FORMAT_X:
         case Opcode::BUFFER_STORE_DWORD:
             translator.BUFFER_STORE_FORMAT(1, false, inst);
             break;
+        case Opcode::BUFFER_STORE_DWORDX3:
+            translator.BUFFER_STORE_FORMAT(3, false, inst);
+            break;
         case Opcode::BUFFER_STORE_FORMAT_XYZW:
+        case Opcode::BUFFER_STORE_DWORDX4:
             translator.BUFFER_STORE_FORMAT(4, false, inst);
             break;
         case Opcode::V_MAX_F32:

--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -406,6 +406,9 @@ void Translate(IR::Block* block, std::span<const GcnInst> inst_list, Info& info)
         case Opcode::V_CMP_NLT_F32:
             translator.V_CMP_F32(ConditionOp::GE, false, inst);
             break;
+        case Opcode::V_CMP_NGT_F32:
+            translator.V_CMP_F32(ConditionOp::LE, false, inst);
+            break;
         case Opcode::S_CMP_LT_U32:
             translator.S_CMP(ConditionOp::LT, false, inst);
             break;
@@ -473,7 +476,7 @@ void Translate(IR::Block* block, std::span<const GcnInst> inst_list, Info& info)
             translator.S_AND_B64(NegateMode::Src1, inst);
             break;
         case Opcode::S_ORN2_B64:
-            translator.S_OR_B64(NegateMode::Src1, inst);
+            translator.S_OR_B64(NegateMode::Src1, false, inst);
             break;
         case Opcode::V_SIN_F32:
             translator.V_SIN_F32(inst);
@@ -612,10 +615,13 @@ void Translate(IR::Block* block, std::span<const GcnInst> inst_list, Info& info)
             translator.V_CMP_U32(ConditionOp::TRU, false, true, inst);
             break;
         case Opcode::S_OR_B64:
-            translator.S_OR_B64(NegateMode::None, inst);
+            translator.S_OR_B64(NegateMode::None, false, inst);
             break;
         case Opcode::S_NOR_B64:
-            translator.S_OR_B64(NegateMode::Result, inst);
+            translator.S_OR_B64(NegateMode::Result, false, inst);
+            break;
+        case Opcode::S_XOR_B64:
+            translator.S_OR_B64(NegateMode::None, true, inst);
             break;
         case Opcode::S_AND_B64:
             translator.S_AND_B64(NegateMode::None, inst);
@@ -738,6 +744,9 @@ void Translate(IR::Block* block, std::span<const GcnInst> inst_list, Info& info)
             break;
         case Opcode::V_RCP_IFLAG_F32:
             translator.V_RCP_F32(inst);
+            break;
+        case Opcode::IMAGE_GET_RESINFO:
+            translator.IMAGE_GET_RESINFO(inst);
             break;
         case Opcode::S_TTRACEDATA:
             LOG_WARNING(Render_Vulkan, "S_TTRACEDATA instruction!");

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -129,6 +129,7 @@ public:
     void V_MIN_U32(const GcnInst& inst);
     void V_CMP_NE_U64(const GcnInst& inst);
     void V_BFI_B32(const GcnInst& inst);
+    void V_NOT_B32(const GcnInst& inst);
 
     // Vector Memory
     void BUFFER_LOAD_FORMAT(u32 num_dwords, bool is_typed, const GcnInst& inst);

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -46,7 +46,7 @@ public:
     void S_CMP(ConditionOp cond, bool is_signed, const GcnInst& inst);
     void S_AND_SAVEEXEC_B64(const GcnInst& inst);
     void S_MOV_B64(const GcnInst& inst);
-    void S_OR_B64(NegateMode negate, const GcnInst& inst);
+    void S_OR_B64(NegateMode negate, bool is_xor, const GcnInst& inst);
     void S_AND_B64(NegateMode negate, const GcnInst& inst);
     void S_ADD_I32(const GcnInst& inst);
     void S_AND_B32(const GcnInst& inst);

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -146,6 +146,7 @@ public:
     // MIMG
     void IMAGE_GET_RESINFO(const GcnInst& inst);
     void IMAGE_SAMPLE(const GcnInst& inst);
+    void IMAGE_GATHER(const GcnInst& inst);
     void IMAGE_STORE(const GcnInst& inst);
     void IMAGE_LOAD(bool has_mip, const GcnInst& inst);
 

--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -46,7 +46,10 @@ void Translator::V_CNDMASK_B32(const GcnInst& inst) {
     const bool has_flt_source =
         is_float_const(inst.src[0].field) || is_float_const(inst.src[1].field);
     const IR::U32F32 src0 = GetSrc(inst.src[0], has_flt_source);
-    const IR::U32F32 src1 = GetSrc(inst.src[1], has_flt_source);
+    IR::U32F32 src1 = GetSrc(inst.src[1], has_flt_source);
+    if (src0.Type() == IR::Type::F32 && src1.Type() == IR::Type::U32) {
+        src1 = ir.BitCast<IR::F32, IR::U32>(src1);
+    }
     const IR::Value result = ir.Select(flag, src1, src0);
     ir.SetVectorReg(dst_reg, IR::U32F32{result});
 }
@@ -476,6 +479,11 @@ void Translator::V_BFI_B32(const GcnInst& inst) {
     const IR::U32 src2{GetSrc(inst.src[2])};
     SetDst(inst.dst[0],
            ir.BitwiseOr(ir.BitwiseAnd(src0, src1), ir.BitwiseAnd(ir.BitwiseNot(src0), src2)));
+}
+
+void Translator::V_NOT_B32(const GcnInst& inst) {
+    const IR::U32 src0{GetSrc(inst.src[0])};
+    SetDst(inst.dst[0], ir.BitwiseNot(src0));
 }
 
 } // namespace Shader::Gcn

--- a/src/shader_recompiler/frontend/translate/vector_memory.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_memory.cpp
@@ -76,6 +76,7 @@ void Translator::IMAGE_SAMPLE(const GcnInst& inst) {
     info.has_bias.Assign(flags.test(MimgModifier::LodBias));
     info.has_lod_clamp.Assign(flags.test(MimgModifier::LodClamp));
     info.force_level0.Assign(flags.test(MimgModifier::Level0));
+    info.has_offset.Assign(flags.test(MimgModifier::Offset));
     info.explicit_lod.Assign(explicit_lod);
 
     // Issue IR instruction, leaving unknown fields blank to patch later.
@@ -104,6 +105,74 @@ void Translator::IMAGE_SAMPLE(const GcnInst& inst) {
         } else {
             value = IR::F32{ir.CompositeExtract(texel, i)};
         }
+        ir.SetVectorReg(dest_reg++, value);
+    }
+}
+
+void Translator::IMAGE_GATHER(const GcnInst& inst) {
+    const auto& mimg = inst.control.mimg;
+    if (mimg.da) {
+        LOG_WARNING(Render_Vulkan, "Image instruction declares an array");
+    }
+
+    IR::VectorReg addr_reg{inst.src[0].code};
+    IR::VectorReg dest_reg{inst.dst[0].code};
+    const IR::ScalarReg tsharp_reg{inst.src[2].code * 4};
+    const IR::ScalarReg sampler_reg{inst.src[3].code * 4};
+    const auto flags = MimgModifierFlags(mimg.mod);
+
+    // Load first dword of T# and S#. We will use them as the handle that will guide resource
+    // tracking pass where to read the sharps. This will later also get patched to the SPIRV texture
+    // binding index.
+    const IR::Value handle =
+        ir.CompositeConstruct(ir.GetScalarReg(tsharp_reg), ir.GetScalarReg(sampler_reg));
+
+    // Load first address components as denoted in 8.2.4 VGPR Usage Sea Islands Series Instruction
+    // Set Architecture
+    const IR::Value offset =
+        flags.test(MimgModifier::Offset) ? ir.GetVectorReg(addr_reg++) : IR::Value{};
+    const IR::F32 bias =
+        flags.test(MimgModifier::LodBias) ? ir.GetVectorReg<IR::F32>(addr_reg++) : IR::F32{};
+    const IR::F32 dref =
+        flags.test(MimgModifier::Pcf) ? ir.GetVectorReg<IR::F32>(addr_reg++) : IR::F32{};
+
+    // Derivatives are tricky because their number depends on the texture type which is located in
+    // T#. We don't have access to T# though until resource tracking pass. For now assume no
+    // derivatives are present, otherwise we don't know where coordinates are placed in the address
+    // stream.
+    ASSERT_MSG(!flags.test(MimgModifier::Derivative), "Derivative image instruction");
+
+    // Now we can load body components as noted in Table 8.9 Image Opcodes with Sampler
+    // Since these are at most 4 dwords, we load them into a single uvec4 and place them
+    // in coords field of the instruction. Then the resource tracking pass will patch the
+    // IR instruction to fill in lod_clamp field.
+    const IR::Value body = ir.CompositeConstruct(
+        ir.GetVectorReg<IR::F32>(addr_reg), ir.GetVectorReg<IR::F32>(addr_reg + 1),
+        ir.GetVectorReg<IR::F32>(addr_reg + 2), ir.GetVectorReg<IR::F32>(addr_reg + 3));
+
+    const bool explicit_lod = flags.any(MimgModifier::Level0, MimgModifier::Lod);
+
+    IR::TextureInstInfo info{};
+    info.is_depth.Assign(flags.test(MimgModifier::Pcf));
+    info.has_bias.Assign(flags.test(MimgModifier::LodBias));
+    info.has_lod_clamp.Assign(flags.test(MimgModifier::LodClamp));
+    info.force_level0.Assign(flags.test(MimgModifier::Level0));
+    info.explicit_lod.Assign(explicit_lod);
+
+    // Issue IR instruction, leaving unknown fields blank to patch later.
+    const IR::Value texel = [&]() -> IR::Value {
+        const IR::F32 lod = flags.test(MimgModifier::Level0) ? ir.Imm32(0.f) : IR::F32{};
+        if (!flags.test(MimgModifier::Pcf)) {
+            return ir.ImageGather(handle, body, offset, {}, info);
+        }
+        return ir.ImageGatherDref(handle, body, offset, {}, dref, info);
+    }();
+
+    for (u32 i = 0; i < 4; i++) {
+        if (((mimg.dmask >> i) & 1) == 0) {
+            continue;
+        }
+        const IR::F32 value = IR::F32{ir.CompositeExtract(texel, i)};
         ir.SetVectorReg(dest_reg++, value);
     }
 }

--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -9,7 +9,7 @@
 namespace Shader::IR {
 namespace {
 [[noreturn]] void ThrowInvalidType(Type type) {
-    throw InvalidArgument("Invalid type {}", u32(type));
+    UNREACHABLE_MSG("Invalid type {}", u32(type));
 }
 
 Value MakeLodClampPair(IREmitter& ir, const F32& bias_lod, const F32& lod_clamp) {
@@ -251,7 +251,7 @@ U32U64 IREmitter::ReadShared(int bit_size, bool is_signed, const U32& offset) {
     case 64:
         return Inst<U64>(Opcode::ReadSharedU64, offset);
     }
-    throw InvalidArgument("Invalid bit size {}", bit_size);*/
+    UNREACHABLE_MSG("Invalid bit size {}", bit_size);*/
 }
 
 void IREmitter::WriteShared(int bit_size, const Value& value, const U32& offset) {
@@ -269,7 +269,7 @@ void IREmitter::WriteShared(int bit_size, const Value& value, const U32& offset)
         Inst(Opcode::WriteSharedU64, offset, value);
         break;
     default:
-        throw InvalidArgument("Invalid bit size {}", bit_size);
+        UNREACHABLE_MSG("Invalid bit size {}", bit_size);
     }*/
 }
 
@@ -293,7 +293,7 @@ Value IREmitter::LoadBuffer(int num_dwords, const Value& handle, const Value& ad
     case 4:
         return Inst(Opcode::LoadBufferF32x4, Flags{info}, handle, address);
     default:
-        throw InvalidArgument("Invalid number of dwords {}", num_dwords);
+        UNREACHABLE_MSG("Invalid number of dwords {}", num_dwords);
     }
 }
 
@@ -314,7 +314,7 @@ void IREmitter::StoreBuffer(int num_dwords, const Value& handle, const Value& ad
         Inst(Opcode::StoreBufferF32x4, Flags{info}, handle, address, data);
         break;
     default:
-        throw InvalidArgument("Invalid number of dwords {}", num_dwords);
+        UNREACHABLE_MSG("Invalid number of dwords {}", num_dwords);
     }
 }
 
@@ -328,7 +328,7 @@ U32 IREmitter::QuadShuffle(const U32& value, const U32& index) {
 
 F32F64 IREmitter::FPAdd(const F32F64& a, const F32F64& b) {
     if (a.Type() != b.Type()) {
-        throw InvalidArgument("Mismatching types {} and {}", a.Type(), b.Type());
+        UNREACHABLE_MSG("Mismatching types {} and {}", a.Type(), b.Type());
     }
     switch (a.Type()) {
     case Type::F32:
@@ -342,7 +342,7 @@ F32F64 IREmitter::FPAdd(const F32F64& a, const F32F64& b) {
 
 F32F64 IREmitter::FPSub(const F32F64& a, const F32F64& b) {
     if (a.Type() != b.Type()) {
-        throw InvalidArgument("Mismatching types {} and {}", a.Type(), b.Type());
+        UNREACHABLE_MSG("Mismatching types {} and {}", a.Type(), b.Type());
     }
     switch (a.Type()) {
     case Type::F32:
@@ -354,7 +354,7 @@ F32F64 IREmitter::FPSub(const F32F64& a, const F32F64& b) {
 
 Value IREmitter::CompositeConstruct(const Value& e1, const Value& e2) {
     if (e1.Type() != e2.Type()) {
-        throw InvalidArgument("Mismatching types {} and {}", e1.Type(), e2.Type());
+        UNREACHABLE_MSG("Mismatching types {} and {}", e1.Type(), e2.Type());
     }
     switch (e1.Type()) {
     case Type::U32:
@@ -372,7 +372,7 @@ Value IREmitter::CompositeConstruct(const Value& e1, const Value& e2) {
 
 Value IREmitter::CompositeConstruct(const Value& e1, const Value& e2, const Value& e3) {
     if (e1.Type() != e2.Type() || e1.Type() != e3.Type()) {
-        throw InvalidArgument("Mismatching types {}, {}, and {}", e1.Type(), e2.Type(), e3.Type());
+        UNREACHABLE_MSG("Mismatching types {}, {}, and {}", e1.Type(), e2.Type(), e3.Type());
     }
     switch (e1.Type()) {
     case Type::U32:
@@ -391,7 +391,7 @@ Value IREmitter::CompositeConstruct(const Value& e1, const Value& e2, const Valu
 Value IREmitter::CompositeConstruct(const Value& e1, const Value& e2, const Value& e3,
                                     const Value& e4) {
     if (e1.Type() != e2.Type() || e1.Type() != e3.Type() || e1.Type() != e4.Type()) {
-        throw InvalidArgument("Mismatching types {}, {}, {}, and {}", e1.Type(), e2.Type(),
+        UNREACHABLE_MSG("Mismatching types {}, {}, {}, and {}", e1.Type(), e2.Type(),
                               e3.Type(), e4.Type());
     }
     switch (e1.Type()) {
@@ -411,7 +411,7 @@ Value IREmitter::CompositeConstruct(const Value& e1, const Value& e2, const Valu
 Value IREmitter::CompositeExtract(const Value& vector, size_t element) {
     const auto read{[&](Opcode opcode, size_t limit) -> Value {
         if (element >= limit) {
-            throw InvalidArgument("Out of bounds element {}", element);
+            UNREACHABLE_MSG("Out of bounds element {}", element);
         }
         return Inst(opcode, vector, Value{static_cast<u32>(element)});
     }};
@@ -448,7 +448,7 @@ Value IREmitter::CompositeExtract(const Value& vector, size_t element) {
 Value IREmitter::CompositeInsert(const Value& vector, const Value& object, size_t element) {
     const auto insert{[&](Opcode opcode, size_t limit) {
         if (element >= limit) {
-            throw InvalidArgument("Out of bounds element {}", element);
+            UNREACHABLE_MSG("Out of bounds element {}", element);
         }
         return Inst(opcode, vector, object, Value{static_cast<u32>(element)});
     }};
@@ -484,7 +484,7 @@ Value IREmitter::CompositeInsert(const Value& vector, const Value& object, size_
 
 Value IREmitter::Select(const U1& condition, const Value& true_value, const Value& false_value) {
     if (true_value.Type() != false_value.Type()) {
-        throw InvalidArgument("Mismatching types {} and {}", true_value.Type(), false_value.Type());
+        UNREACHABLE_MSG("Mismatching types {} and {}", true_value.Type(), false_value.Type());
     }
     switch (true_value.Type()) {
     case Type::U1:
@@ -502,7 +502,7 @@ Value IREmitter::Select(const U1& condition, const Value& true_value, const Valu
     case Type::F64:
         return Inst(Opcode::SelectF64, condition, true_value, false_value);
     default:
-        throw InvalidArgument("Invalid type {}", true_value.Type());
+        UNREACHABLE_MSG("Invalid type {}", true_value.Type());
     }
 }
 
@@ -532,7 +532,7 @@ Value IREmitter::UnpackHalf2x16(const U32& value) {
 
 F32F64 IREmitter::FPMul(const F32F64& a, const F32F64& b) {
     if (a.Type() != b.Type()) {
-        throw InvalidArgument("Mismatching types {} and {}", a.Type(), b.Type());
+        UNREACHABLE_MSG("Mismatching types {} and {}", a.Type(), b.Type());
     }
     switch (a.Type()) {
     case Type::F32:
@@ -546,7 +546,7 @@ F32F64 IREmitter::FPMul(const F32F64& a, const F32F64& b) {
 
 F32F64 IREmitter::FPFma(const F32F64& a, const F32F64& b, const F32F64& c) {
     if (a.Type() != b.Type() || a.Type() != c.Type()) {
-        throw InvalidArgument("Mismatching types {}, {}, and {}", a.Type(), b.Type(), c.Type());
+        UNREACHABLE_MSG("Mismatching types {}, {}, and {}", a.Type(), b.Type(), c.Type());
     }
     switch (a.Type()) {
     case Type::F32:
@@ -646,7 +646,7 @@ F32F64 IREmitter::FPSaturate(const F32F64& value) {
 
 F32F64 IREmitter::FPClamp(const F32F64& value, const F32F64& min_value, const F32F64& max_value) {
     if (value.Type() != min_value.Type() || value.Type() != max_value.Type()) {
-        throw InvalidArgument("Mismatching types {}, {}, and {}", value.Type(), min_value.Type(),
+        UNREACHABLE_MSG("Mismatching types {}, {}, and {}", value.Type(), min_value.Type(),
                               max_value.Type());
     }
     switch (value.Type()) {
@@ -709,7 +709,7 @@ F32 IREmitter::Fract(const F32& value) {
 
 U1 IREmitter::FPEqual(const F32F64& lhs, const F32F64& rhs, bool ordered) {
     if (lhs.Type() != rhs.Type()) {
-        throw InvalidArgument("Mismatching types {} and {}", lhs.Type(), rhs.Type());
+        UNREACHABLE_MSG("Mismatching types {} and {}", lhs.Type(), rhs.Type());
     }
     switch (lhs.Type()) {
     case Type::F32:
@@ -723,7 +723,7 @@ U1 IREmitter::FPEqual(const F32F64& lhs, const F32F64& rhs, bool ordered) {
 
 U1 IREmitter::FPNotEqual(const F32F64& lhs, const F32F64& rhs, bool ordered) {
     if (lhs.Type() != rhs.Type()) {
-        throw InvalidArgument("Mismatching types {} and {}", lhs.Type(), rhs.Type());
+        UNREACHABLE_MSG("Mismatching types {} and {}", lhs.Type(), rhs.Type());
     }
     switch (lhs.Type()) {
     case Type::F32:
@@ -737,7 +737,7 @@ U1 IREmitter::FPNotEqual(const F32F64& lhs, const F32F64& rhs, bool ordered) {
 
 U1 IREmitter::FPLessThan(const F32F64& lhs, const F32F64& rhs, bool ordered) {
     if (lhs.Type() != rhs.Type()) {
-        throw InvalidArgument("Mismatching types {} and {}", lhs.Type(), rhs.Type());
+        UNREACHABLE_MSG("Mismatching types {} and {}", lhs.Type(), rhs.Type());
     }
     switch (lhs.Type()) {
     case Type::F32:
@@ -751,7 +751,7 @@ U1 IREmitter::FPLessThan(const F32F64& lhs, const F32F64& rhs, bool ordered) {
 
 U1 IREmitter::FPGreaterThan(const F32F64& lhs, const F32F64& rhs, bool ordered) {
     if (lhs.Type() != rhs.Type()) {
-        throw InvalidArgument("Mismatching types {} and {}", lhs.Type(), rhs.Type());
+        UNREACHABLE_MSG("Mismatching types {} and {}", lhs.Type(), rhs.Type());
     }
     switch (lhs.Type()) {
     case Type::F32:
@@ -767,7 +767,7 @@ U1 IREmitter::FPGreaterThan(const F32F64& lhs, const F32F64& rhs, bool ordered) 
 
 U1 IREmitter::FPLessThanEqual(const F32F64& lhs, const F32F64& rhs, bool ordered) {
     if (lhs.Type() != rhs.Type()) {
-        throw InvalidArgument("Mismatching types {} and {}", lhs.Type(), rhs.Type());
+        UNREACHABLE_MSG("Mismatching types {} and {}", lhs.Type(), rhs.Type());
     }
     switch (lhs.Type()) {
     case Type::F32:
@@ -783,7 +783,7 @@ U1 IREmitter::FPLessThanEqual(const F32F64& lhs, const F32F64& rhs, bool ordered
 
 U1 IREmitter::FPGreaterThanEqual(const F32F64& lhs, const F32F64& rhs, bool ordered) {
     if (lhs.Type() != rhs.Type()) {
-        throw InvalidArgument("Mismatching types {} and {}", lhs.Type(), rhs.Type());
+        UNREACHABLE_MSG("Mismatching types {} and {}", lhs.Type(), rhs.Type());
     }
     switch (lhs.Type()) {
     case Type::F32:
@@ -812,21 +812,21 @@ U1 IREmitter::FPIsNan(const F32F64& value) {
 
 U1 IREmitter::FPOrdered(const F32F64& lhs, const F32F64& rhs) {
     if (lhs.Type() != rhs.Type()) {
-        throw InvalidArgument("Mismatching types {} and {}", lhs.Type(), rhs.Type());
+        UNREACHABLE_MSG("Mismatching types {} and {}", lhs.Type(), rhs.Type());
     }
     return LogicalAnd(LogicalNot(FPIsNan(lhs)), LogicalNot(FPIsNan(rhs)));
 }
 
 U1 IREmitter::FPUnordered(const F32F64& lhs, const F32F64& rhs) {
     if (lhs.Type() != rhs.Type()) {
-        throw InvalidArgument("Mismatching types {} and {}", lhs.Type(), rhs.Type());
+        UNREACHABLE_MSG("Mismatching types {} and {}", lhs.Type(), rhs.Type());
     }
     return LogicalOr(FPIsNan(lhs), FPIsNan(rhs));
 }
 
 F32F64 IREmitter::FPMax(const F32F64& lhs, const F32F64& rhs) {
     if (lhs.Type() != rhs.Type()) {
-        throw InvalidArgument("Mismatching types {} and {}", lhs.Type(), rhs.Type());
+        UNREACHABLE_MSG("Mismatching types {} and {}", lhs.Type(), rhs.Type());
     }
     switch (lhs.Type()) {
     case Type::F32:
@@ -840,7 +840,7 @@ F32F64 IREmitter::FPMax(const F32F64& lhs, const F32F64& rhs) {
 
 F32F64 IREmitter::FPMin(const F32F64& lhs, const F32F64& rhs) {
     if (lhs.Type() != rhs.Type()) {
-        throw InvalidArgument("Mismatching types {} and {}", lhs.Type(), rhs.Type());
+        UNREACHABLE_MSG("Mismatching types {} and {}", lhs.Type(), rhs.Type());
     }
     switch (lhs.Type()) {
     case Type::F32:
@@ -854,7 +854,7 @@ F32F64 IREmitter::FPMin(const F32F64& lhs, const F32F64& rhs) {
 
 U32U64 IREmitter::IAdd(const U32U64& a, const U32U64& b) {
     if (a.Type() != b.Type()) {
-        throw InvalidArgument("Mismatching types {} and {}", a.Type(), b.Type());
+        UNREACHABLE_MSG("Mismatching types {} and {}", a.Type(), b.Type());
     }
     switch (a.Type()) {
     case Type::U32:
@@ -868,7 +868,7 @@ U32U64 IREmitter::IAdd(const U32U64& a, const U32U64& b) {
 
 U32U64 IREmitter::ISub(const U32U64& a, const U32U64& b) {
     if (a.Type() != b.Type()) {
-        throw InvalidArgument("Mismatching types {} and {}", a.Type(), b.Type());
+        UNREACHABLE_MSG("Mismatching types {} and {}", a.Type(), b.Type());
     }
     switch (a.Type()) {
     case Type::U32:
@@ -1021,7 +1021,7 @@ U1 IREmitter::ILessThan(const U32& lhs, const U32& rhs, bool is_signed) {
 
 U1 IREmitter::IEqual(const U32U64& lhs, const U32U64& rhs) {
     if (lhs.Type() != rhs.Type()) {
-        throw InvalidArgument("Mismatching types {} and {}", lhs.Type(), rhs.Type());
+        UNREACHABLE_MSG("Mismatching types {} and {}", lhs.Type(), rhs.Type());
     }
     switch (lhs.Type()) {
     case Type::U32:
@@ -1075,7 +1075,7 @@ U32U64 IREmitter::ConvertFToS(size_t bitsize, const F32F64& value) {
             ThrowInvalidType(value.Type());
         }
     default:
-        throw InvalidArgument("Invalid destination bitsize {}", bitsize);
+        UNREACHABLE_MSG("Invalid destination bitsize {}", bitsize);
     }
 }
 
@@ -1089,7 +1089,7 @@ U32U64 IREmitter::ConvertFToU(size_t bitsize, const F32F64& value) {
             ThrowInvalidType(value.Type());
         }
     default:
-        throw InvalidArgument("Invalid destination bitsize {}", bitsize);
+        UNREACHABLE_MSG("Invalid destination bitsize {}", bitsize);
     }
 }
 
@@ -1112,7 +1112,7 @@ F32F64 IREmitter::ConvertSToF(size_t dest_bitsize, size_t src_bitsize, const Val
         }
         break;
     }
-    throw InvalidArgument("Invalid bit size combination dst={} src={}", dest_bitsize, src_bitsize);
+    UNREACHABLE_MSG("Invalid bit size combination dst={} src={}", dest_bitsize, src_bitsize);
 }
 
 F32F64 IREmitter::ConvertUToF(size_t dest_bitsize, size_t src_bitsize, const Value& value) {
@@ -1130,7 +1130,7 @@ F32F64 IREmitter::ConvertUToF(size_t dest_bitsize, size_t src_bitsize, const Val
         }
         break;
     }
-    throw InvalidArgument("Invalid bit size combination dst={} src={}", dest_bitsize, src_bitsize);
+    UNREACHABLE_MSG("Invalid bit size combination dst={} src={}", dest_bitsize, src_bitsize);
 }
 
 F32F64 IREmitter::ConvertIToF(size_t dest_bitsize, size_t src_bitsize, bool is_signed,

--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -391,8 +391,8 @@ Value IREmitter::CompositeConstruct(const Value& e1, const Value& e2, const Valu
 Value IREmitter::CompositeConstruct(const Value& e1, const Value& e2, const Value& e3,
                                     const Value& e4) {
     if (e1.Type() != e2.Type() || e1.Type() != e3.Type() || e1.Type() != e4.Type()) {
-        UNREACHABLE_MSG("Mismatching types {}, {}, {}, and {}", e1.Type(), e2.Type(),
-                              e3.Type(), e4.Type());
+        UNREACHABLE_MSG("Mismatching types {}, {}, {}, and {}", e1.Type(), e2.Type(), e3.Type(),
+                        e4.Type());
     }
     switch (e1.Type()) {
     case Type::U32:
@@ -647,7 +647,7 @@ F32F64 IREmitter::FPSaturate(const F32F64& value) {
 F32F64 IREmitter::FPClamp(const F32F64& value, const F32F64& min_value, const F32F64& max_value) {
     if (value.Type() != min_value.Type() || value.Type() != max_value.Type()) {
         UNREACHABLE_MSG("Mismatching types {}, {}, and {}", value.Type(), min_value.Type(),
-                              max_value.Type());
+                        max_value.Type());
     }
     switch (value.Type()) {
     case Type::F32:

--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -306,8 +306,13 @@ void PatchImageInstruction(IR::Block& block, IR::Inst& inst, Info& info, Descrip
     IR::IREmitter ir{block, IR::Block::InstructionList::s_iterator_to(inst)};
     inst.SetArg(0, ir.Imm32(image_binding));
 
+    // No need to patch coordinates if we are just querying.
+    if (inst.GetOpcode() == IR::Opcode::ImageQueryDimensions) {
+        return;
+    }
+
     // Now that we know the image type, adjust texture coordinate vector.
-    const IR::Inst* body = inst.Arg(1).InstRecursive();
+    IR::Inst* body = inst.Arg(1).InstRecursive();
     const auto [coords, arg] = [&] -> std::pair<IR::Value, IR::Value> {
         switch (image.GetType()) {
         case AmdGpu::ImageType::Color1D: // x

--- a/src/shader_recompiler/ir/reg.h
+++ b/src/shader_recompiler/ir/reg.h
@@ -38,6 +38,7 @@ union TextureInstInfo {
     BitField<2, 1, u32> has_lod_clamp;
     BitField<3, 1, u32> force_level0;
     BitField<4, 1, u32> explicit_lod;
+    BitField<5, 1, u32> has_offset;
 };
 
 union BufferInstInfo {

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -52,7 +52,7 @@ struct BufferResource {
 
     auto operator<=>(const BufferResource&) const = default;
 };
-using BufferResourceList = boost::container::static_vector<BufferResource, 8>;
+using BufferResourceList = boost::container::static_vector<BufferResource, 16>;
 
 struct ImageResource {
     u32 sgpr_base;
@@ -62,13 +62,13 @@ struct ImageResource {
     bool is_storage;
     bool is_depth;
 };
-using ImageResourceList = boost::container::static_vector<ImageResource, 8>;
+using ImageResourceList = boost::container::static_vector<ImageResource, 16>;
 
 struct SamplerResource {
     u32 sgpr_base;
     u32 dword_offset;
 };
-using SamplerResourceList = boost::container::static_vector<SamplerResource, 8>;
+using SamplerResourceList = boost::container::static_vector<SamplerResource, 16>;
 
 struct Info {
     struct VsInput {

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -187,6 +187,13 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
         case PM4ItOpcode::ClearState: {
             break;
         }
+        case PM4ItOpcode::SetConfigReg: {
+            const auto* set_data = reinterpret_cast<const PM4CmdSetData*>(header);
+            const auto reg_addr = ConfigRegWordOffset + set_data->reg_offset;
+            const auto* payload = reinterpret_cast<const u32*>(header + 2);
+            std::memcpy(&regs.reg_array[reg_addr], payload, (count - 1) * sizeof(u32));
+            break;
+        }
         case PM4ItOpcode::SetContextReg: {
             const auto* set_data = reinterpret_cast<const PM4CmdSetData*>(header);
             const auto reg_addr = ContextRegWordOffset + set_data->reg_offset;

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -43,6 +43,7 @@ struct Liverpool {
     static constexpr u32 NumShaderUserData = 16;
     static constexpr u32 UconfigRegWordOffset = 0xC000;
     static constexpr u32 ContextRegWordOffset = 0xA000;
+    static constexpr u32 ConfigRegWordOffset = 0x2000;
     static constexpr u32 ShRegWordOffset = 0x2C00;
     static constexpr u32 NumRegs = 0xD000;
 
@@ -789,6 +790,7 @@ struct Liverpool {
         u32 raw;
         BitField<0, 1, u32> depth_clear_enable;
         BitField<1, 1, u32> stencil_clear_enable;
+        BitField<6, 1, u32> depth_compress_disable;
     };
 
     union AaConfig {

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -528,6 +528,14 @@ struct Liverpool {
             BitField<0, 15, s32> bottom_right_x;
             BitField<15, 15, s32> bottom_right_y;
         };
+
+        u32 GetWidth() const {
+            return bottom_right_x - top_left_x;
+        }
+
+        u32 GetHeight() const {
+            return bottom_right_y - top_left_y;
+        }
     };
 
     struct ViewportDepth {

--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -10,6 +10,15 @@
 
 namespace AmdGpu {
 
+enum class CompSwizzle : u32 {
+    Zero = 0,
+    One = 1,
+    Red = 4,
+    Green = 5,
+    Blue = 6,
+    Alpha = 7,
+};
+
 // Table 8.5 Buffer Resource Descriptor [Sea Islands Series Instruction Set Architecture]
 struct Buffer {
     union {
@@ -24,12 +33,17 @@ struct Buffer {
         BitField<3, 3, u32> dst_sel_y;
         BitField<6, 3, u32> dst_sel_z;
         BitField<9, 3, u32> dst_sel_w;
+        BitField<0, 12, u32> dst_sel;
         BitField<12, 3, NumberFormat> num_format;
         BitField<15, 4, DataFormat> data_format;
         BitField<19, 2, u32> element_size;
         BitField<21, 2, u32> index_stride;
         BitField<23, 1, u32> add_tid_enable;
     };
+
+    CompSwizzle GetSwizzle(u32 comp) const noexcept {
+        return static_cast<CompSwizzle>((dst_sel.Value() >> (comp * 3)) & 0x7);
+    }
 
     u32 GetStride() const noexcept {
         return stride == 0 ? 1U : stride.Value();

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -366,6 +366,9 @@ vk::Format SurfaceFormat(AmdGpu::DataFormat data_format, AmdGpu::NumberFormat nu
     if (data_format == AmdGpu::DataFormat::Format8_8 && num_format == AmdGpu::NumberFormat::Unorm) {
         return vk::Format::eR8G8Unorm;
     }
+    if (data_format == AmdGpu::DataFormat::FormatBc7 && num_format == AmdGpu::NumberFormat::Unorm) {
+        return vk::Format::eBc7UnormBlock;
+    }
     if (data_format == AmdGpu::DataFormat::FormatBc2 && num_format == AmdGpu::NumberFormat::Unorm) {
         return vk::Format::eBc2UnormBlock;
     }
@@ -376,8 +379,14 @@ vk::Format SurfaceFormat(AmdGpu::DataFormat data_format, AmdGpu::NumberFormat nu
     if (data_format == AmdGpu::DataFormat::Format2_10_10_10 && num_format == AmdGpu::NumberFormat::Unorm) {
         return vk::Format::eA2R10G10B10UnormPack32;
     }
+    if (data_format == AmdGpu::DataFormat::Format2_10_10_10 && num_format == AmdGpu::NumberFormat::Snorm) {
+        return vk::Format::eA2R10G10B10SnormPack32;
+    }
     if (data_format == AmdGpu::DataFormat::Format10_11_11 && num_format == AmdGpu::NumberFormat::Float) {
         return vk::Format::eB10G11R11UfloatPack32;
+    }
+    if (data_format == AmdGpu::DataFormat::Format16_16 && num_format == AmdGpu::NumberFormat::Float) {
+        return vk::Format::eR16G16Sfloat;
     }
     UNREACHABLE_MSG("Unknown data_format={} and num_format={}", u32(data_format), u32(num_format));
 }

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -376,16 +376,20 @@ vk::Format SurfaceFormat(AmdGpu::DataFormat data_format, AmdGpu::NumberFormat nu
         num_format == AmdGpu::NumberFormat::Snorm) {
         return vk::Format::eR16G16Snorm;
     }
-    if (data_format == AmdGpu::DataFormat::Format2_10_10_10 && num_format == AmdGpu::NumberFormat::Unorm) {
+    if (data_format == AmdGpu::DataFormat::Format2_10_10_10 &&
+        num_format == AmdGpu::NumberFormat::Unorm) {
         return vk::Format::eA2R10G10B10UnormPack32;
     }
-    if (data_format == AmdGpu::DataFormat::Format2_10_10_10 && num_format == AmdGpu::NumberFormat::Snorm) {
+    if (data_format == AmdGpu::DataFormat::Format2_10_10_10 &&
+        num_format == AmdGpu::NumberFormat::Snorm) {
         return vk::Format::eA2R10G10B10SnormPack32;
     }
-    if (data_format == AmdGpu::DataFormat::Format10_11_11 && num_format == AmdGpu::NumberFormat::Float) {
+    if (data_format == AmdGpu::DataFormat::Format10_11_11 &&
+        num_format == AmdGpu::NumberFormat::Float) {
         return vk::Format::eB10G11R11UfloatPack32;
     }
-    if (data_format == AmdGpu::DataFormat::Format16_16 && num_format == AmdGpu::NumberFormat::Float) {
+    if (data_format == AmdGpu::DataFormat::Format16_16 &&
+        num_format == AmdGpu::NumberFormat::Float) {
         return vk::Format::eR16G16Sfloat;
     }
     UNREACHABLE_MSG("Unknown data_format={} and num_format={}", u32(data_format), u32(num_format));

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -373,6 +373,12 @@ vk::Format SurfaceFormat(AmdGpu::DataFormat data_format, AmdGpu::NumberFormat nu
         num_format == AmdGpu::NumberFormat::Snorm) {
         return vk::Format::eR16G16Snorm;
     }
+    if (data_format == AmdGpu::DataFormat::Format2_10_10_10 && num_format == AmdGpu::NumberFormat::Unorm) {
+        return vk::Format::eA2R10G10B10UnormPack32;
+    }
+    if (data_format == AmdGpu::DataFormat::Format10_11_11 && num_format == AmdGpu::NumberFormat::Float) {
+        return vk::Format::eB10G11R11UfloatPack32;
+    }
     UNREACHABLE_MSG("Unknown data_format={} and num_format={}", u32(data_format), u32(num_format));
 }
 

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -381,6 +381,7 @@ Frame* RendererVulkan::GetRenderFrame() {
     {
         std::unique_lock lock{free_mutex};
         free_cv.wait(lock, [this] { return !free_queue.empty(); });
+        LOG_INFO(Render_Vulkan, "Got render frame, remaining {}", free_queue.size() - 1);
 
         // Take the frame from the queue
         frame = free_queue.front();

--- a/src/video_core/renderer_vulkan/renderer_vulkan.h
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.h
@@ -41,7 +41,8 @@ public:
     Frame* PrepareFrame(const Libraries::VideoOut::BufferAttributeGroup& attribute,
                         VAddr cpu_address) {
         const auto info = VideoCore::ImageInfo{attribute};
-        auto& image = texture_cache.FindImage(info, cpu_address);
+        const auto image_id = texture_cache.FindImage(info, cpu_address);
+        auto& image = texture_cache.GetImage(image_id);
         return PrepareFrameInternal(image);
     }
 
@@ -54,7 +55,8 @@ public:
         const Libraries::VideoOut::BufferAttributeGroup& attribute, VAddr cpu_address) {
         vo_buffers_addr.emplace_back(cpu_address);
         const auto info = VideoCore::ImageInfo{attribute};
-        return texture_cache.FindImage(info, cpu_address);
+        const auto image_id = texture_cache.FindImage(info, cpu_address);
+        return texture_cache.GetImage(image_id);
     }
 
     bool IsVideoOutSurface(const AmdGpu::Liverpool::ColorBuffer& color_buffer) {

--- a/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
@@ -126,7 +126,8 @@ bool ComputePipeline::BindResources(Core::MemoryManager* memory, StreamBuffer& s
     }
 
     for (const auto& image_desc : info.images) {
-        const auto tsharp = info.ReadUd<AmdGpu::Image>(image_desc.sgpr_base, image_desc.dword_offset);
+        const auto tsharp =
+            info.ReadUd<AmdGpu::Image>(image_desc.sgpr_base, image_desc.dword_offset);
         const auto& image_view = texture_cache.FindImageView(tsharp, image_desc.is_storage);
         const auto& image = texture_cache.GetImage(image_view.image_id);
         image_infos.emplace_back(VK_NULL_HANDLE, *image_view.image_view, image.layout);

--- a/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
@@ -85,7 +85,7 @@ ComputePipeline::~ComputePipeline() = default;
 bool ComputePipeline::BindResources(Core::MemoryManager* memory, StreamBuffer& staging,
                                     VideoCore::TextureCache& texture_cache) const {
     // Bind resource buffers and textures.
-    boost::container::static_vector<vk::DescriptorBufferInfo, 4> buffer_infos;
+    boost::container::static_vector<vk::DescriptorBufferInfo, 8> buffer_infos;
     boost::container::static_vector<vk::DescriptorImageInfo, 8> image_infos;
     boost::container::small_vector<vk::WriteDescriptorSet, 16> set_writes;
     u32 binding{};
@@ -115,7 +115,7 @@ bool ComputePipeline::BindResources(Core::MemoryManager* memory, StreamBuffer& s
         // need its full emulation anyways. For cases of metadata read a warning will be logged.
         if (buffer.is_storage) {
             if (texture_cache.TouchMeta(address, true)) {
-                LOG_TRACE(Render_Vulkan, "Metadata update skipped");
+                LOG_WARNING(Render_Vulkan, "Metadata update skipped");
                 return false;
             }
         } else {
@@ -127,7 +127,7 @@ bool ComputePipeline::BindResources(Core::MemoryManager* memory, StreamBuffer& s
 
     for (const auto& image : info.images) {
         const auto tsharp = info.ReadUd<AmdGpu::Image>(image.sgpr_base, image.dword_offset);
-        const auto& image_view = texture_cache.FindImageView(tsharp, image.is_storage);
+        const auto& image_view = texture_cache.FindImageView(tsharp, image.is_storage, image.is_depth);
         image_infos.emplace_back(VK_NULL_HANDLE, *image_view.image_view, vk::ImageLayout::eGeneral);
         set_writes.push_back({
             .dstSet = VK_NULL_HANDLE,

--- a/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
@@ -125,17 +125,18 @@ bool ComputePipeline::BindResources(Core::MemoryManager* memory, StreamBuffer& s
         }
     }
 
-    for (const auto& image : info.images) {
-        const auto tsharp = info.ReadUd<AmdGpu::Image>(image.sgpr_base, image.dword_offset);
-        const auto& image_view = texture_cache.FindImageView(tsharp, image.is_storage, image.is_depth);
-        image_infos.emplace_back(VK_NULL_HANDLE, *image_view.image_view, vk::ImageLayout::eGeneral);
+    for (const auto& image_desc : info.images) {
+        const auto tsharp = info.ReadUd<AmdGpu::Image>(image_desc.sgpr_base, image_desc.dword_offset);
+        const auto& image_view = texture_cache.FindImageView(tsharp, image_desc.is_storage);
+        const auto& image = texture_cache.GetImage(image_view.image_id);
+        image_infos.emplace_back(VK_NULL_HANDLE, *image_view.image_view, image.layout);
         set_writes.push_back({
             .dstSet = VK_NULL_HANDLE,
             .dstBinding = binding++,
             .dstArrayElement = 0,
             .descriptorCount = 1,
-            .descriptorType = image.is_storage ? vk::DescriptorType::eStorageImage
-                                               : vk::DescriptorType::eSampledImage,
+            .descriptorType = image_desc.is_storage ? vk::DescriptorType::eStorageImage
+                                                    : vk::DescriptorType::eSampledImage,
             .pImageInfo = &image_infos.back(),
         });
 

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -348,19 +348,18 @@ void GraphicsPipeline::BindResources(Core::MemoryManager* memory, StreamBuffer& 
             }
         }
 
-        for (const auto& image : stage.images) {
-            const auto tsharp = stage.ReadUd<AmdGpu::Image>(image.sgpr_base, image.dword_offset);
-            const auto& image_view = texture_cache.FindImageView(tsharp, image.is_storage, image.is_depth);
-            image_infos.emplace_back(VK_NULL_HANDLE, *image_view.image_view,
-                                     (image.is_storage || image.is_depth) ? vk::ImageLayout::eGeneral
-                                                      : vk::ImageLayout::eShaderReadOnlyOptimal);
+        for (const auto& image_desc : stage.images) {
+            const auto tsharp = stage.ReadUd<AmdGpu::Image>(image_desc.sgpr_base, image_desc.dword_offset);
+            const auto& image_view = texture_cache.FindImageView(tsharp, image_desc.is_storage);
+            const auto& image = texture_cache.GetImage(image_view.image_id);
+            image_infos.emplace_back(VK_NULL_HANDLE, *image_view.image_view, image.layout);
             set_writes.push_back({
                 .dstSet = VK_NULL_HANDLE,
                 .dstBinding = binding++,
                 .dstArrayElement = 0,
                 .descriptorCount = 1,
-                .descriptorType = image.is_storage ? vk::DescriptorType::eStorageImage
-                                                   : vk::DescriptorType::eSampledImage,
+                .descriptorType = image_desc.is_storage ? vk::DescriptorType::eStorageImage
+                                                        : vk::DescriptorType::eSampledImage,
                 .pImageInfo = &image_infos.back(),
             });
 

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -349,7 +349,8 @@ void GraphicsPipeline::BindResources(Core::MemoryManager* memory, StreamBuffer& 
         }
 
         for (const auto& image_desc : stage.images) {
-            const auto tsharp = stage.ReadUd<AmdGpu::Image>(image_desc.sgpr_base, image_desc.dword_offset);
+            const auto tsharp =
+                stage.ReadUd<AmdGpu::Image>(image_desc.sgpr_base, image_desc.dword_offset);
             const auto& image_view = texture_cache.FindImageView(tsharp, image_desc.is_storage);
             const auto& image = texture_cache.GetImage(image_view.image_id);
             image_infos.emplace_back(VK_NULL_HANDLE, *image_view.image_view, image.layout);

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -49,6 +49,7 @@ Instance::Instance(Frontend::WindowSDL& window, s32 physical_device_index,
     }
     const std::size_t num_physical_devices = static_cast<u16>(physical_devices.size());
     ASSERT_MSG(num_physical_devices > 0, "No physical devices found");
+    LOG_INFO(Render_Vulkan, "Found {} physical devices", num_physical_devices);
 
     if (physical_device_index < 0) {
         std::vector<std::pair<size_t, vk::PhysicalDeviceProperties2>> properties2{};
@@ -73,12 +74,10 @@ Instance::Instance(Frontend::WindowSDL& window, s32 physical_device_index,
 
     available_extensions = GetSupportedExtensions(physical_device);
     properties = physical_device.getProperties();
-    if (properties.apiVersion < TargetVulkanApiVersion) {
-        throw std::runtime_error(fmt::format(
-            "Vulkan {}.{} is required, but only {}.{} is supported by device!",
-            VK_VERSION_MAJOR(TargetVulkanApiVersion), VK_VERSION_MINOR(TargetVulkanApiVersion),
-            VK_VERSION_MAJOR(properties.apiVersion), VK_VERSION_MINOR(properties.apiVersion)));
-    }
+    ASSERT_MSG(properties.apiVersion >= TargetVulkanApiVersion,
+               "Vulkan {}.{} is required, but only {}.{} is supported by device!",
+               VK_VERSION_MAJOR(TargetVulkanApiVersion), VK_VERSION_MINOR(TargetVulkanApiVersion),
+               VK_VERSION_MAJOR(properties.apiVersion), VK_VERSION_MINOR(properties.apiVersion));
 
     CollectDeviceParameters();
     CreateDevice();

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -203,6 +203,7 @@ bool Instance::CreateDevice() {
                 .independentBlend = true,
                 .geometryShader = features.geometryShader,
                 .logicOp = features.logicOp,
+                .multiViewport = true,
                 .samplerAnisotropy = features.samplerAnisotropy,
                 .fragmentStoresAndAtomics = features.fragmentStoresAndAtomics,
                 .shaderImageGatherExtended = true,

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -205,6 +205,7 @@ bool Instance::CreateDevice() {
                 .logicOp = features.logicOp,
                 .samplerAnisotropy = features.samplerAnisotropy,
                 .fragmentStoresAndAtomics = features.fragmentStoresAndAtomics,
+                .shaderImageGatherExtended = true,
                 .shaderStorageImageMultisample = true,
                 .shaderClipDistance = features.shaderClipDistance,
             },

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -206,10 +206,6 @@ std::unique_ptr<GraphicsPipeline> PipelineCache::CreateGraphicsPipeline() {
         block_pool.ReleaseContents();
         inst_pool.ReleaseContents();
 
-        if (hash == 0xa34c48f8) {
-            printf("bad\n");
-        }
-
         // Recompile shader to IR.
         try {
             LOG_INFO(Render_Vulkan, "Compiling {} shader {:#x}", stage, hash);

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -258,8 +258,8 @@ std::unique_ptr<ComputePipeline> PipelineCache::CreateComputePipeline() {
             DumpShader(spv_code, compute_key, Shader::Stage::Compute, "spv");
         }
         const auto module = CompileSPV(spv_code, instance.GetDevice());
-        return std::make_unique<ComputePipeline>(instance, scheduler, *pipeline_cache, &program.info,
-                                                 module);
+        return std::make_unique<ComputePipeline>(instance, scheduler, *pipeline_cache,
+                                                 &program.info, module);
     } catch (const Shader::Exception& e) {
         UNREACHABLE_MSG("{}", e.what());
         return nullptr;

--- a/src/video_core/renderer_vulkan/vk_platform.cpp
+++ b/src/video_core/renderer_vulkan/vk_platform.cpp
@@ -168,6 +168,8 @@ std::vector<const char*> GetInstanceExtensions(Frontend::WindowSystemType window
 
 vk::UniqueInstance CreateInstance(vk::DynamicLoader& dl, Frontend::WindowSystemType window_type,
                                   bool enable_validation, bool dump_command_buffers) {
+    LOG_INFO(Render_Vulkan, "Creating vulkan instance");
+
     auto vkGetInstanceProcAddr =
         dl.getProcAddress<PFN_vkGetInstanceProcAddr>("vkGetInstanceProcAddr");
     VULKAN_HPP_DEFAULT_DISPATCHER.init(vkGetInstanceProcAddr);
@@ -176,12 +178,10 @@ vk::UniqueInstance CreateInstance(vk::DynamicLoader& dl, Frontend::WindowSystemT
                                       ? vk::enumerateInstanceVersion()
                                       : VK_API_VERSION_1_0;
 
-    if (available_version < TargetVulkanApiVersion) {
-        throw std::runtime_error(fmt::format(
-            "Vulkan {}.{} is required, but only {}.{} is supported by instance!",
-            VK_VERSION_MAJOR(TargetVulkanApiVersion), VK_VERSION_MINOR(TargetVulkanApiVersion),
-            VK_VERSION_MAJOR(available_version), VK_VERSION_MINOR(available_version)));
-    }
+    ASSERT_MSG(available_version >= TargetVulkanApiVersion,
+               "Vulkan {}.{} is required, but only {}.{} is supported by instance!",
+               VK_VERSION_MAJOR(TargetVulkanApiVersion), VK_VERSION_MINOR(TargetVulkanApiVersion),
+               VK_VERSION_MAJOR(available_version), VK_VERSION_MINOR(available_version));
 
     const auto extensions = GetInstanceExtensions(window_type, true);
 

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -91,7 +91,7 @@ void Rasterizer::Draw(bool is_indexed, u32 index_offset) {
 
     // TODO: Don't restart renderpass every draw
     const auto& scissor = regs.screen_scissor;
-    const vk::RenderingInfo rendering_info = {
+    vk::RenderingInfo rendering_info = {
         .renderArea =
             {
                 .offset = {scissor.top_left_x, scissor.top_left_y},
@@ -102,6 +102,11 @@ void Rasterizer::Draw(bool is_indexed, u32 index_offset) {
         .pColorAttachments = color_attachments.data(),
         .pDepthAttachment = num_depth_attachments ? &depth_attachment : nullptr,
     };
+    auto& area = rendering_info.renderArea.extent;
+    if (area.width == 2048) {
+        area.width = 1920;
+        area.height = 1080;
+    }
 
     UpdateDynamicState(*pipeline);
 

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -103,7 +103,7 @@ void Rasterizer::BeginRendering() {
             .loadOp = is_clear ? vk::AttachmentLoadOp::eClear : vk::AttachmentLoadOp::eLoad,
             .storeOp = vk::AttachmentStoreOp::eStore,
             .clearValue =
-            is_clear ? LiverpoolToVK::ColorBufferClearValue(col_buf) : vk::ClearValue{},
+                is_clear ? LiverpoolToVK::ColorBufferClearValue(col_buf) : vk::ClearValue{},
         };
         texture_cache.TouchMeta(col_buf.CmaskAddress(), false);
     }
@@ -137,7 +137,7 @@ u32 Rasterizer::SetupIndexBuffer(bool& is_indexed, u32 index_offset) {
     // Emulate QuadList primitive type with CPU made index buffer.
     const auto& regs = liverpool->regs;
     if (liverpool->regs.primitive_type == Liverpool::PrimitiveType::QuadList) {
-        //ASSERT_MSG(!is_indexed, "Using QuadList primitive with indexed draw");
+        // ASSERT_MSG(!is_indexed, "Using QuadList primitive with indexed draw");
         is_indexed = true;
 
         // Emit indices.

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -37,6 +37,8 @@ private:
     u32 SetupIndexBuffer(bool& is_indexed, u32 index_offset);
     void MapMemory(VAddr addr, size_t size);
 
+    void BeginRendering();
+
     void UpdateDynamicState(const GraphicsPipeline& pipeline);
     void UpdateViewportScissorState();
     void UpdateDepthStencilState();

--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -32,7 +32,7 @@ void Scheduler::BeginRendering(const RenderState& new_state) {
             .extent = {render_state.width, render_state.height},
         },
         .layerCount = 1,
-        .colorAttachmentCount = static_cast<u32>(render_state.color_attachments.size()),
+        .colorAttachmentCount = render_state.num_color_attachments,
         .pColorAttachments = render_state.color_attachments.data(),
         .pDepthAttachment = render_state.num_depth_attachments ?
                                 &render_state.depth_attachment : nullptr,

--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -27,15 +27,16 @@ void Scheduler::BeginRendering(const RenderState& new_state) {
     render_state = new_state;
 
     const vk::RenderingInfo rendering_info = {
-        .renderArea = {
-            .offset = {0, 0},
-            .extent = {render_state.width, render_state.height},
-        },
+        .renderArea =
+            {
+                .offset = {0, 0},
+                .extent = {render_state.width, render_state.height},
+            },
         .layerCount = 1,
         .colorAttachmentCount = render_state.num_color_attachments,
         .pColorAttachments = render_state.color_attachments.data(),
-        .pDepthAttachment = render_state.num_depth_attachments ?
-                                &render_state.depth_attachment : nullptr,
+        .pDepthAttachment =
+            render_state.num_depth_attachments ? &render_state.depth_attachment : nullptr,
     };
 
     current_cmdbuf.beginRendering(rendering_info);

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -23,7 +23,7 @@ struct RenderState {
 
     bool operator==(const RenderState& other) const noexcept {
         return std::memcmp(this, &other, sizeof(RenderState)) == 0;
-    }    
+    }
 };
 
 class Scheduler {

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -23,7 +23,7 @@ struct RenderState {
 
     bool operator==(const RenderState& other) const noexcept {
         return std::memcmp(this, &other, sizeof(RenderState)) == 0;
-    }
+    }    
 };
 
 class Scheduler {
@@ -45,6 +45,11 @@ public:
 
     /// Ends current rendering scope.
     void EndRendering();
+
+    /// Returns the current render state.
+    const RenderState& GetRenderState() const {
+        return render_state;
+    }
 
     /// Returns the current command buffer.
     vk::CommandBuffer CommandBuffer() const {

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <condition_variable>
+#include <boost/container/static_vector.hpp>
 #include "common/types.h"
 #include "video_core/renderer_vulkan/vk_master_semaphore.h"
 #include "video_core/renderer_vulkan/vk_resource_pool.h"
@@ -11,6 +12,19 @@
 namespace Vulkan {
 
 class Instance;
+
+struct RenderState {
+    std::array<vk::RenderingAttachmentInfo, 8> color_attachments{};
+    vk::RenderingAttachmentInfo depth_attachment{};
+    u32 num_color_attachments{};
+    u32 num_depth_attachments{};
+    u32 width = std::numeric_limits<u32>::max();
+    u32 height = std::numeric_limits<u32>::max();
+
+    bool operator==(const RenderState& other) const noexcept {
+        return std::memcmp(this, &other, sizeof(RenderState)) == 0;
+    }
+};
 
 class Scheduler {
 public:
@@ -25,6 +39,12 @@ public:
 
     /// Waits for the given tick to trigger on the GPU.
     void Wait(u64 tick);
+
+    /// Starts a new rendering scope with provided state.
+    void BeginRendering(const RenderState& new_state);
+
+    /// Ends current rendering scope.
+    void EndRendering();
 
     /// Returns the current command buffer.
     vk::CommandBuffer CommandBuffer() const {
@@ -59,6 +79,8 @@ private:
     CommandPool command_pool;
     vk::CommandBuffer current_cmdbuf;
     std::condition_variable_any event_cv;
+    RenderState render_state;
+    bool is_rendering = false;
     tracy::VkCtxScope* profiler_scope{};
 };
 

--- a/src/video_core/renderer_vulkan/vk_stream_buffer.cpp
+++ b/src/video_core/renderer_vulkan/vk_stream_buffer.cpp
@@ -226,7 +226,7 @@ void StreamBuffer::WaitPendingOperations(u64 requested_upper_bound) {
     while (requested_upper_bound > wait_bound && wait_cursor < *invalidation_mark) {
         auto& watch = previous_watches[wait_cursor];
         wait_bound = watch.upper_bound;
-        scheduler.Wait(watch.tick);
+        //scheduler.Wait(watch.tick);
         ++wait_cursor;
     }
 }

--- a/src/video_core/renderer_vulkan/vk_stream_buffer.cpp
+++ b/src/video_core/renderer_vulkan/vk_stream_buffer.cpp
@@ -226,7 +226,7 @@ void StreamBuffer::WaitPendingOperations(u64 requested_upper_bound) {
     while (requested_upper_bound > wait_bound && wait_cursor < *invalidation_mark) {
         auto& watch = previous_watches[wait_cursor];
         wait_bound = watch.upper_bound;
-        //scheduler.Wait(watch.tick);
+        // scheduler.Wait(watch.tick);
         ++wait_cursor;
     }
 }

--- a/src/video_core/texture_cache/image.cpp
+++ b/src/video_core/texture_cache/image.cpp
@@ -267,7 +267,7 @@ Image::Image(const Vulkan::Instance& instance_, Vulkan::Scheduler& scheduler_,
     if (info.is_tiled) {
         ImageViewInfo view_info;
         view_info.format = DemoteImageFormatForDetiling(info.pixel_format);
-        view_for_detiler.emplace(*instance, view_info, *this);
+        view_for_detiler.emplace(*instance, view_info, *this, ImageId{});
     }
 
     Transit(vk::ImageLayout::eGeneral, vk::AccessFlagBits::eNone);

--- a/src/video_core/texture_cache/image.cpp
+++ b/src/video_core/texture_cache/image.cpp
@@ -104,9 +104,9 @@ static vk::ImageUsageFlags ImageUsageFlags(const ImageInfo& info) {
 static vk::ImageType ConvertImageType(AmdGpu::ImageType type) noexcept {
     switch (type) {
     case AmdGpu::ImageType::Color1D:
+    case AmdGpu::ImageType::Color1DArray:
         return vk::ImageType::e1D;
     case AmdGpu::ImageType::Color2D:
-    case AmdGpu::ImageType::Color1DArray:
     case AmdGpu::ImageType::Cube:
     case AmdGpu::ImageType::Color2DArray:
         return vk::ImageType::e2D;

--- a/src/video_core/texture_cache/image.h
+++ b/src/video_core/texture_cache/image.h
@@ -132,7 +132,8 @@ struct Image {
         return image_view_ids[std::distance(image_view_infos.begin(), it)];
     }
 
-    void Transit(vk::ImageLayout dst_layout, vk::Flags<vk::AccessFlagBits> dst_mask);
+    void Transit(vk::ImageLayout dst_layout, vk::Flags<vk::AccessFlagBits> dst_mask,
+                 vk::CommandBuffer cmdbuf = {});
     void Upload(vk::Buffer buffer, u64 offset);
 
     const Vulkan::Instance* instance;

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -80,8 +80,10 @@ ImageView::ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info
 
     // When sampling D32 texture from shader, the T# specifies R32 Float format so adjust it.
     vk::Format format = info.format;
+    vk::ImageAspectFlags aspect = image.aspect_mask;
     if (image.aspect_mask & vk::ImageAspectFlagBits::eDepth && format == vk::Format::eR32Sfloat) {
-        format = vk::Format::eD32Sfloat;
+        format = image.info.pixel_format;
+        aspect = vk::ImageAspectFlagBits::eDepth;
     }
 
     const vk::ImageViewCreateInfo image_view_ci = {
@@ -91,7 +93,7 @@ ImageView::ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info
         .format = format,
         .components = info.mapping,
         .subresourceRange{
-            .aspectMask = image.aspect_mask,
+            .aspectMask = aspect,
             .baseMipLevel = 0U,
             .levelCount = 1,
             .baseArrayLayer = 0,

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -71,8 +71,9 @@ ImageViewInfo::ImageViewInfo(const AmdGpu::Liverpool::ColorBuffer& col_buffer,
 }
 
 ImageView::ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info_, Image& image,
+                     ImageId image_id_,
                      std::optional<vk::ImageUsageFlags> usage_override /*= {}*/)
-    : info{info_} {
+    : info{info_}, image_id{image_id_} {
     vk::ImageViewUsageCreateInfo usage_ci{};
     if (usage_override) {
         usage_ci.usage = usage_override.value();

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -71,8 +71,7 @@ ImageViewInfo::ImageViewInfo(const AmdGpu::Liverpool::ColorBuffer& col_buffer,
 }
 
 ImageView::ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info_, Image& image,
-                     ImageId image_id_,
-                     std::optional<vk::ImageUsageFlags> usage_override /*= {}*/)
+                     ImageId image_id_, std::optional<vk::ImageUsageFlags> usage_override /*= {}*/)
     : info{info_}, image_id{image_id_} {
     vk::ImageViewUsageCreateInfo usage_ci{};
     if (usage_override) {

--- a/src/video_core/texture_cache/image_view.h
+++ b/src/video_core/texture_cache/image_view.h
@@ -36,8 +36,7 @@ struct Image;
 
 struct ImageView {
     explicit ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info, Image& image,
-                       ImageId image_id,
-                       std::optional<vk::ImageUsageFlags> usage_override = {});
+                       ImageId image_id, std::optional<vk::ImageUsageFlags> usage_override = {});
     ~ImageView();
 
     ImageView(const ImageView&) = delete;

--- a/src/video_core/texture_cache/image_view.h
+++ b/src/video_core/texture_cache/image_view.h
@@ -36,6 +36,7 @@ struct Image;
 
 struct ImageView {
     explicit ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info, Image& image,
+                       ImageId image_id,
                        std::optional<vk::ImageUsageFlags> usage_override = {});
     ~ImageView();
 

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -116,7 +116,8 @@ Image& TextureCache::FindImage(const ImageInfo& info, VAddr cpu_address, bool re
     std::unique_lock lock{m_page_table};
     boost::container::small_vector<ImageId, 2> image_ids;
     ForEachImageInRegion(cpu_address, info.guest_size_bytes, [&](ImageId image_id, Image& image) {
-        if (image.cpu_addr == cpu_address && image.info.size.width == info.size.width) {
+        if (image.cpu_addr == cpu_address && image.info.size.width == info.size.width &&
+            image.info.IsDepthStencil() == info.IsDepthStencil()) {
             image_ids.push_back(image_id);
         }
     });

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -162,7 +162,8 @@ ImageView& TextureCache::RegisterImageView(ImageId image_id, const ImageViewInfo
         usage_override = image.usage & ~vk::ImageUsageFlagBits::eStorage;
     }
 
-    const ImageViewId view_id = slot_image_views.insert(instance, view_info, image, image_id, usage_override);
+    const ImageViewId view_id =
+        slot_image_views.insert(instance, view_info, image, image_id, usage_override);
     image.image_view_infos.emplace_back(view_info);
     image.image_view_ids.emplace_back(view_id);
     return slot_image_views[view_id];
@@ -178,8 +179,9 @@ ImageView& TextureCache::FindImageView(const AmdGpu::Image& desc, bool is_storag
         image.Transit(vk::ImageLayout::eGeneral, vk::AccessFlagBits::eShaderWrite);
         usage.storage = true;
     } else {
-        const auto new_layout = image.info.IsDepthStencil() ? vk::ImageLayout::eDepthStencilReadOnlyOptimal
-                                                            : vk::ImageLayout::eShaderReadOnlyOptimal;
+        const auto new_layout = image.info.IsDepthStencil()
+                                    ? vk::ImageLayout::eDepthStencilReadOnlyOptimal
+                                    : vk::ImageLayout::eShaderReadOnlyOptimal;
         image.Transit(new_layout, vk::AccessFlagBits::eShaderRead);
         usage.texture = true;
     }
@@ -206,8 +208,7 @@ ImageView& TextureCache::RenderTarget(const AmdGpu::Liverpool::ColorBuffer& buff
 }
 
 ImageView& TextureCache::DepthTarget(const AmdGpu::Liverpool::DepthBuffer& buffer,
-                                     VAddr htile_address,
-                                     const AmdGpu::Liverpool::CbDbExtent& hint,
+                                     VAddr htile_address, const AmdGpu::Liverpool::CbDbExtent& hint,
                                      bool write_enabled) {
     const ImageInfo info{buffer, htile_address, hint};
     const ImageId image_id = FindImage(info, buffer.Address(), false);
@@ -216,9 +217,8 @@ ImageView& TextureCache::DepthTarget(const AmdGpu::Liverpool::DepthBuffer& buffe
 
     const auto new_layout = write_enabled ? vk::ImageLayout::eDepthStencilAttachmentOptimal
                                           : vk::ImageLayout::eDepthStencilReadOnlyOptimal;
-    image.Transit(new_layout,
-                  vk::AccessFlagBits::eDepthStencilAttachmentWrite |
-                      vk::AccessFlagBits::eDepthStencilAttachmentRead);
+    image.Transit(new_layout, vk::AccessFlagBits::eDepthStencilAttachmentWrite |
+                                  vk::AccessFlagBits::eDepthStencilAttachmentRead);
 
     image.info.usage.depth_target = true;
 

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -48,19 +48,19 @@ public:
     void OnCpuWrite(VAddr address);
 
     /// Retrieves the image handle of the image with the provided attributes and address.
-    [[nodiscard]] Image& FindImage(const ImageInfo& info, VAddr cpu_address,
-                                   bool refresh_on_create = true);
+    [[nodiscard]] ImageId FindImage(const ImageInfo& info, VAddr cpu_address,
+                                    bool refresh_on_create = true);
 
     /// Retrieves an image view with the properties of the specified image descriptor.
-    [[nodiscard]] ImageView& FindImageView(const AmdGpu::Image& image, bool is_storage,
-                                           bool is_depth);
+    [[nodiscard]] ImageView& FindImageView(const AmdGpu::Image& image, bool is_storage);
 
     /// Retrieves the render target with specified properties
     [[nodiscard]] ImageView& RenderTarget(const AmdGpu::Liverpool::ColorBuffer& buffer,
                                           const AmdGpu::Liverpool::CbDbExtent& hint);
     [[nodiscard]] ImageView& DepthTarget(const AmdGpu::Liverpool::DepthBuffer& buffer,
                                          VAddr htile_address,
-                                         const AmdGpu::Liverpool::CbDbExtent& hint);
+                                         const AmdGpu::Liverpool::CbDbExtent& hint,
+                                         bool write_enabled);
 
     /// Reuploads image contents.
     void RefreshImage(Image& image);
@@ -95,7 +95,7 @@ public:
     }
 
 private:
-    ImageView& RegisterImageView(Image& image, const ImageViewInfo& view_info);
+    ImageView& RegisterImageView(ImageId image_id, const ImageViewInfo& view_info);
 
     /// Iterate over all page indices in a range
     template <typename Func>

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -52,7 +52,8 @@ public:
                                    bool refresh_on_create = true);
 
     /// Retrieves an image view with the properties of the specified image descriptor.
-    [[nodiscard]] ImageView& FindImageView(const AmdGpu::Image& image, bool is_storage);
+    [[nodiscard]] ImageView& FindImageView(const AmdGpu::Image& image, bool is_storage,
+                                           bool is_depth);
 
     /// Retrieves the render target with specified properties
     [[nodiscard]] ImageView& RenderTarget(const AmdGpu::Liverpool::ColorBuffer& buffer,

--- a/src/video_core/texture_cache/tile_manager.cpp
+++ b/src/video_core/texture_cache/tile_manager.cpp
@@ -231,7 +231,7 @@ static constexpr vk::BufferUsageFlags StagingFlags = vk::BufferUsageFlagBits::eT
 
 TileManager::TileManager(const Vulkan::Instance& instance, Vulkan::Scheduler& scheduler)
     : instance{instance}, scheduler{scheduler},
-      staging{instance, scheduler, StagingFlags, 64_MB, Vulkan::BufferType::Upload} {
+      staging{instance, scheduler, StagingFlags, 128_MB, Vulkan::BufferType::Upload} {
 
     static const std::array detiler_shaders{
         HostShaders::DETILE_M8X1_COMP,  HostShaders::DETILE_M8X2_COMP,


### PR DESCRIPTION
* ~~Load libSceFiber LLE if present in sys_modules. We have no HLE for this yet (soon) but it is required for game to boot~~ (removed for now, we need to properly test on windows)
* Switch IREmitter exceptions to assertions as these should fail compilation entirely and help debugging a lot more.
* Fix image type of 1DArray. Add more shaders instructions like textureGather(), textureOffset and textureSize() used by the game.
* Apply buffer swizzles on fetch shader parsing
* Not related to game specifically, but this PR also includes renderpass state tracking so the renderdoc captures are less noisy and we have better performance with validation layers enabled.
* Fixed depth feedback loop of sorts that spammed validation errors. For depth images we try to prefer VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL when possible. So if image is depth we transit to that when bound as texture, and if depth write is disabled we also transit to that when used as attachment. The game can't both write and read to depth, so this will always work and the layout allows depth image to be both attachment and sampled at same time.