### PR TITLE
Recompiler: sampler patching

### DIFF
--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -196,7 +196,8 @@ std::pair<const IR::Inst*, bool> TryDisableAnisoLod0(const IR::Inst* inst) {
 
     // We're working on the first dword of s#
     const auto* prod2 = inst->Arg(2).InstRecursive();
-    if (prod2->GetOpcode() != IR::Opcode::GetUserData) {
+    if (prod2->GetOpcode() != IR::Opcode::GetUserData &&
+        prod2->GetOpcode() != IR::Opcode::ReadConst) {
         return not_found;
     }
 

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -67,6 +67,8 @@ using ImageResourceList = boost::container::static_vector<ImageResource, 16>;
 struct SamplerResource {
     u32 sgpr_base;
     u32 dword_offset;
+    u32 associated_image : 4;
+    u32 disable_aniso : 1;
 };
 using SamplerResourceList = boost::container::static_vector<SamplerResource, 16>;
 

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -348,9 +348,10 @@ void GraphicsPipeline::BindResources(Core::MemoryManager* memory, StreamBuffer& 
             }
         }
 
+        boost::container::static_vector<AmdGpu::Image, 16> tsharps;
         for (const auto& image_desc : stage.images) {
-            const auto tsharp =
-                stage.ReadUd<AmdGpu::Image>(image_desc.sgpr_base, image_desc.dword_offset);
+            const auto& tsharp = tsharps.emplace_back(
+                stage.ReadUd<AmdGpu::Image>(image_desc.sgpr_base, image_desc.dword_offset));
             const auto& image_view = texture_cache.FindImageView(tsharp, image_desc.is_storage);
             const auto& image = texture_cache.GetImage(image_view.image_id);
             image_infos.emplace_back(VK_NULL_HANDLE, *image_view.image_view, image.layout);
@@ -369,8 +370,13 @@ void GraphicsPipeline::BindResources(Core::MemoryManager* memory, StreamBuffer& 
             }
         }
         for (const auto& sampler : stage.samplers) {
-            const auto ssharp =
-                stage.ReadUd<AmdGpu::Sampler>(sampler.sgpr_base, sampler.dword_offset);
+            auto ssharp = stage.ReadUd<AmdGpu::Sampler>(sampler.sgpr_base, sampler.dword_offset);
+            if (sampler.disable_aniso) {
+                const auto& tsharp = tsharps[sampler.associated_image];
+                if (tsharp.base_level == 0 && tsharp.last_level == 0) {
+                    ssharp.max_aniso.Assign(AmdGpu::AnisoRatio::One);
+                }
+            }
             const auto vk_sampler = texture_cache.GetSampler(ssharp);
             image_infos.emplace_back(vk_sampler, VK_NULL_HANDLE, vk::ImageLayout::eGeneral);
             set_writes.push_back({


### PR DESCRIPTION
In some shaders, a pattern has been observed where the anisotropy setting in S# is reset if a sampled texture lacks mips in its view. To address this issue, this PR introduces a heuristic based on pattern detection. Specifically, if expected sharp fields are accessed, the emitted sampler descriptor will have the `disable_aniso` flag set. This allows the runtime to check it later and modify parameters of the bound sampler as needed.

Also, restored BFS in search of image instruction producer.