### PR TITLE
Move "game_data" to RW directory inside user folder for linux

### DIFF
--- a/src/core/file_format/trp.cpp
+++ b/src/core/file_format/trp.cpp
@@ -48,7 +48,7 @@ bool TRP::Extract(std::filesystem::path trophyPath) {
                 return false;
 
             s64 seekPos = sizeof(TrpHeader);
-            std::filesystem::path trpFilesPath(std::filesystem::current_path() / "game_data" /
+            std::filesystem::path trpFilesPath(std::filesystem::current_path() / "user/game_data" /
                                                title / "TrophyFiles" / it.path().stem());
             std::filesystem::create_directories(trpFilesPath / "Icons");
             std::filesystem::create_directory(trpFilesPath / "Xml");

--- a/src/qt_gui/game_grid_frame.cpp
+++ b/src/qt_gui/game_grid_frame.cpp
@@ -114,8 +114,9 @@ void GameGridFrame::SetGridBackgroundImage(int row, int column) {
     if (item) {
         QString pic1Path = QString::fromStdString((*m_games_shared)[itemID].pic_path);
         QString blurredPic1Path =
-            qApp->applicationDirPath() +
-            QString::fromStdString("/game_data/" + (*m_games_shared)[itemID].serial + "/pic1.png");
+            QDir::currentPath() +
+            QString::fromStdString("/user/game_data/" + (*m_games_shared)[itemID].serial +
+                                   "/pic1.png");
 
         backgroundImage = QImage(blurredPic1Path);
         if (backgroundImage.isNull()) {
@@ -123,7 +124,7 @@ void GameGridFrame::SetGridBackgroundImage(int row, int column) {
             backgroundImage = m_game_list_utils.BlurImage(image, image.rect(), 16);
 
             std::filesystem::path img_path =
-                std::filesystem::path("game_data/") / (*m_games_shared)[itemID].serial;
+                std::filesystem::path("user/game_data/") / (*m_games_shared)[itemID].serial;
             std::filesystem::create_directories(img_path);
             if (!backgroundImage.save(blurredPic1Path, "PNG")) {
                 // qDebug() << "Error: Unable to save image.";

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -99,8 +99,8 @@ void GameListFrame::SetListBackgroundImage(QTableWidgetItem* item) {
 
     QString pic1Path = QString::fromStdString(m_game_info->m_games[item->row()].pic_path);
     QString blurredPic1Path =
-        qApp->applicationDirPath() +
-        QString::fromStdString("/game_data/" + m_game_info->m_games[item->row()].serial +
+        QDir::currentPath() +
+        QString::fromStdString("/user/game_data/" + m_game_info->m_games[item->row()].serial +
                                "/pic1.png");
 
     backgroundImage = QImage(blurredPic1Path);
@@ -109,7 +109,7 @@ void GameListFrame::SetListBackgroundImage(QTableWidgetItem* item) {
         backgroundImage = m_game_list_utils.BlurImage(image, image.rect(), 16);
 
         std::filesystem::path img_path =
-            std::filesystem::path("game_data/") / m_game_info->m_games[item->row()].serial;
+            std::filesystem::path("user/game_data/") / m_game_info->m_games[item->row()].serial;
         std::filesystem::create_directories(img_path);
         if (!backgroundImage.save(blurredPic1Path, "PNG")) {
             // qDebug() << "Error: Unable to save image.";

--- a/src/qt_gui/main.cpp
+++ b/src/qt_gui/main.cpp
@@ -20,7 +20,7 @@ int main(int argc, char* argv[]) {
     // Load configurations and initialize Qt application
     const auto config_dir = Common::FS::GetUserPath(Common::FS::PathType::UserDir);
     Config::load(config_dir / "config.toml");
-    QString gameDataPath = qApp->applicationDirPath() + "/game_data/";
+    QString gameDataPath = QDir::currentPath() + "/user/game_data/";
     std::string stdStr = gameDataPath.toStdString();
     std::filesystem::path path(stdStr);
 #ifdef _WIN64

--- a/src/qt_gui/trophy_viewer.cpp
+++ b/src/qt_gui/trophy_viewer.cpp
@@ -19,7 +19,7 @@ TrophyViewer::TrophyViewer(QString trophyPath, QString gameTrpPath) : QMainWindo
 }
 
 void TrophyViewer::PopulateTrophyWidget(QString title) {
-    QString trophyDir = qApp->applicationDirPath() + "/game_data/" + title + "/TrophyFiles";
+    QString trophyDir = QDir::currentPath() + "/user/game_data/" + title + "/TrophyFiles";
     QDir dir(trophyDir);
     if (!dir.exists()) {
         std::filesystem::path path(gameTrpPath_.toStdString());


### PR DESCRIPTION
Moves "game_data" folder inside of user folder created on boot.
Prevents emulator failing to open when attempting to write to read-only section of appimage.

Master:
![image](https://github.com/shadps4-emu/shadPS4/assets/62252937/89a388c3-abea-4422-b13a-77f333a806ed)

PR:
![image](https://github.com/shadps4-emu/shadPS4/assets/62252937/fa371057-af72-47e7-830d-de486a4a1268)
