### PR TITLE
strdup for Windows

### DIFF
--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <cstdlib>
+#include <cstring>
 #include "common/assert.h"
 #include "common/logging/log.h"
 #include "common/scope_exit.h"
@@ -10,8 +12,7 @@
 #include "core/libraries/kernel/file_system.h"
 #include "core/libraries/libs.h"
 #include "libkernel.h"
-#include <cstdlib>
-#include <cstring>
+
 
 namespace Libraries::Kernel {
 

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -10,6 +10,8 @@
 #include "core/libraries/kernel/file_system.h"
 #include "core/libraries/libs.h"
 #include "libkernel.h"
+#include <cstdlib>
+#include <cstring>
 
 namespace Libraries::Kernel {
 
@@ -451,5 +453,17 @@ void fileSystemSymbolsRegister(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("6c3rCVE-fTU", "libkernel", 1, "libkernel", 1, 1,
                  posix_open); // _open shoudld be equal to open function
 }
+
+#ifdef _WIN32
+// Implementation of strdup for Windows, as it is not standard
+char* strdup(const char* str) {
+    size_t len = strlen(str) + 1; // +1 for the final '\0'
+    char* dup = (char*)malloc(len);
+    if (dup) {
+        strcpy_s(dup, len, str); // Using strcpy_s for safety
+    }
+    return dup;
+}
+#endif
 
 } // namespace Libraries::Kernel

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -13,7 +13,6 @@
 #include "core/libraries/libs.h"
 #include "libkernel.h"
 
-
 namespace Libraries::Kernel {
 
 std::vector<Core::FileSys::DirEntry> GetDirectoryEntries(const std::string& path) {


### PR DESCRIPTION
Adds an implementation of the strdup function for the Windows environment, where it is not standard. This implementation uses strcpy_s to ensure safe string copying. The code is guarded with #ifdef _WIN32 to ensure it compiles only on Windows platforms.
