### PR TITLE
sceSaveDataDirNameSearch: Removed early failure exit

### DIFF
--- a/src/core/libraries/save_data/savedata.cpp
+++ b/src/core/libraries/save_data/savedata.cpp
@@ -177,11 +177,11 @@ int PS4_SYSV_ABI sceSaveDataDeleteUser() {
 
 int PS4_SYSV_ABI sceSaveDataDirNameSearch(const OrbisSaveDataDirNameSearchCond* cond,
                                           OrbisSaveDataDirNameSearchResult* result) {
-    if (cond == nullptr || cond->dirName == nullptr)
-        return ORBIS_SAVE_DATA_ERROR_PARAMETER;
-    LOG_ERROR(Lib_SaveData,
-              "TODO sceSaveDataDirNameSearch: search_dir_name = {}, key = {}, result = {}",
-              cond->dirName->data, (int)cond->key, (result->infos == nullptr));
+    if (cond != nullptr && cond->dirName != nullptr) {
+        LOG_ERROR(Lib_SaveData,
+                  "TODO sceSaveDataDirNameSearch: search_dir_name = {}, key = {}, result = {}",
+                  cond->dirName->data, (int)cond->key, (result->infos == nullptr));
+    }
 
     return ORBIS_OK;
 }

--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -875,6 +875,9 @@ void Translate(IR::Block* block, u32 block_base, std::span<const GcnInst> inst_l
         case Opcode::V_MAD_LEGACY_F32:
             translator.V_MAD_F32(inst);
             break;
+        case Opcode::V_MAX_LEGACY_F32:
+            translator.V_MAX3_F32(inst);
+            break;
         case Opcode::V_RSQ_LEGACY_F32:
         case Opcode::V_RSQ_CLAMP_F32:
             translator.V_RSQ_F32(inst);

--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -876,7 +876,7 @@ void Translate(IR::Block* block, u32 block_base, std::span<const GcnInst> inst_l
             translator.V_MAD_F32(inst);
             break;
         case Opcode::V_MAX_LEGACY_F32:
-            translator.V_MAX3_F32(inst);
+            translator.V_MAX_F32(inst);
             break;
         case Opcode::V_RSQ_LEGACY_F32:
         case Opcode::V_RSQ_CLAMP_F32:


### PR DESCRIPTION
Geometry wars will throw a save corrupt error with this early exit, however, if functions perfectly if we let this flow through.
I am not sure why the early exit was implemented originally, was it just to make sure the log didn't throw an nullptr exception?