### PR TITLE
sceSaveDataDirNameSearch: Removed early failure exit

### DIFF
--- a/src/core/libraries/save_data/savedata.cpp
+++ b/src/core/libraries/save_data/savedata.cpp
@@ -177,12 +177,11 @@ int PS4_SYSV_ABI sceSaveDataDeleteUser() {
 
 int PS4_SYSV_ABI sceSaveDataDirNameSearch(const OrbisSaveDataDirNameSearchCond* cond,
                                           OrbisSaveDataDirNameSearchResult* result) {
-    if (cond == nullptr || cond->dirName == nullptr)
-        return ORBIS_SAVE_DATA_ERROR_PARAMETER;
-    LOG_ERROR(Lib_SaveData,
-              "TODO sceSaveDataDirNameSearch: search_dir_name = {}, key = {}, result = {}",
-              cond->dirName->data, (int)cond->key, (result->infos == nullptr));
-
+    if (cond != nullptr && cond->dirName != nullptr) {
+        LOG_ERROR(Lib_SaveData,
+                  "TODO sceSaveDataDirNameSearch: search_dir_name = {}, key = {}, result = {}",
+                  cond->dirName->data, (int)cond->key, (result->infos == nullptr));
+    }
     return ORBIS_OK;
 }
 


### PR DESCRIPTION
Geometry wars will throw a save corrupt error with this early exit, however, if functions perfectly if we let this flow through.
I am not sure why the early exit was implemented originally, was it just to make sure the log didn't throw an nullptr exception?