### PR TITLE
Support SCHED_FIFO and SCHED_RR Policy

### DIFF
--- a/src/core/libraries/kernel/thread_management.cpp
+++ b/src/core/libraries/kernel/thread_management.cpp
@@ -275,9 +275,16 @@ int PS4_SYSV_ABI scePthreadAttrSetschedpolicy(ScePthreadAttr* attr, int policy) 
         return SCE_KERNEL_ERROR_EINVAL;
     }
 
-    int ppolicy = SCHED_OTHER; // winpthreads only supports SCHED_OTHER
-    if (policy != SCHED_OTHER) {
+    int ppolicy;
+    switch (policy) {
+    case SCHED_OTHER:
+    case SCHED_FIFO:
+    case SCHED_RR:
+        ppolicy = policy;
+        break;
+    default:
         LOG_ERROR(Kernel_Pthread, "policy={} not supported by winpthreads", policy);
+        return SCE_KERNEL_ERROR_EINVAL;
     }
 
     (*attr)->policy = policy;


### PR DESCRIPTION
Expanded support to include POSIX scheduling policies beyond SCHED_OTHER. Added convert_posix_to_windows_priority function for mapping POSIX priorities to Windows. Ensures full compatibility and functionality with POSIX scheduling policies, offering increased thread management flexibility.

need this: https://github.com/shadps4-emu/winpthreads/pull/1