### PR TITLE
fix shortcut name with unaccepted characters

### DIFF
--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -141,13 +141,17 @@ public:
             QString exePath;
 #ifdef Q_OS_WIN
             linkPath = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation) + "/" +
-                       QString::fromStdString(m_games[itemID].name) + ".lnk";
+                       QString::fromStdString(m_games[itemID].name)
+                           .remove(QRegularExpression("[\\\\/:*?\"<>|]")) +
+                       ".lnk";
 
             exePath = QCoreApplication::applicationFilePath().replace("\\", "/");
 
 #else
             linkPath = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation) + "/" +
-                       QString::fromStdString(m_games[itemID].name) + ".desktop";
+                       QString::fromStdString(m_games[itemID].name)
+                           .remove(QRegularExpression("[\\\\/:*?\"<>|]")) +
+                       ".desktop";
 #endif
 
             // Convert the icon to .ico if necessary


### PR DESCRIPTION
Fix the name of the shortcut with characters not accepted by windows, for example:
 "`DARK SOULS™ III: The Fire Fades™ Edition`" the shortcut could not be created because of the "`:`"
Now these characters have been removed