### PR TITLE
Filesystem errors and Base Array Layers

### DIFF
--- a/src/common/io_file.cpp
+++ b/src/common/io_file.cpp
@@ -167,7 +167,7 @@ IOFile& IOFile::operator=(IOFile&& other) noexcept {
     return *this;
 }
 
-errno_t IOFile::Open(const fs::path& path, FileAccessMode mode, FileType type, FileShareFlag flag) {
+int IOFile::Open(const fs::path& path, FileAccessMode mode, FileType type, FileShareFlag flag) {
     Close();
 
     file_path = path;
@@ -175,7 +175,7 @@ errno_t IOFile::Open(const fs::path& path, FileAccessMode mode, FileType type, F
     file_type = type;
 
     errno = 0;
-    errno_t result = 0;
+    int result = 0;
 
 #ifdef _WIN32
     if (flag != FileShareFlag::ShareNone) {

--- a/src/common/io_file.cpp
+++ b/src/common/io_file.cpp
@@ -167,7 +167,7 @@ IOFile& IOFile::operator=(IOFile&& other) noexcept {
     return *this;
 }
 
-void IOFile::Open(const fs::path& path, FileAccessMode mode, FileType type, FileShareFlag flag) {
+errno_t IOFile::Open(const fs::path& path, FileAccessMode mode, FileType type, FileShareFlag flag) {
     Close();
 
     file_path = path;
@@ -175,21 +175,26 @@ void IOFile::Open(const fs::path& path, FileAccessMode mode, FileType type, File
     file_type = type;
 
     errno = 0;
+    errno_t result = 0;
 
 #ifdef _WIN32
     if (flag != FileShareFlag::ShareNone) {
         file = _wfsopen(path.c_str(), AccessModeToWStr(mode, type), ToWindowsFileShareFlag(flag));
+        result = errno;
     } else {
-        _wfopen_s(&file, path.c_str(), AccessModeToWStr(mode, type));
+        result = _wfopen_s(&file, path.c_str(), AccessModeToWStr(mode, type));
     }
 #else
     file = std::fopen(path.c_str(), AccessModeToStr(mode, type));
+    result = errno;
 #endif
 
     if (!IsOpen()) {
         LOG_ERROR(Common_Filesystem, "Failed to open the file at path={}",
                   PathToUTF8String(file_path));
     }
+
+    return result;
 }
 
 void IOFile::Close() {

--- a/src/common/io_file.h
+++ b/src/common/io_file.h
@@ -102,9 +102,9 @@ public:
 
     uintptr_t GetFileMapping();
 
-    errno_t Open(const std::filesystem::path& path, FileAccessMode mode,
-                 FileType type = FileType::BinaryFile,
-                 FileShareFlag flag = FileShareFlag::ShareReadOnly);
+    int Open(const std::filesystem::path& path, FileAccessMode mode,
+             FileType type = FileType::BinaryFile,
+             FileShareFlag flag = FileShareFlag::ShareReadOnly);
     void Close();
 
     bool Flush() const;

--- a/src/common/io_file.h
+++ b/src/common/io_file.h
@@ -102,9 +102,9 @@ public:
 
     uintptr_t GetFileMapping();
 
-    void Open(const std::filesystem::path& path, FileAccessMode mode,
-              FileType type = FileType::BinaryFile,
-              FileShareFlag flag = FileShareFlag::ShareReadOnly);
+    errno_t Open(const std::filesystem::path& path, FileAccessMode mode,
+                 FileType type = FileType::BinaryFile,
+                 FileShareFlag flag = FileShareFlag::ShareReadOnly);
     void Close();
 
     bool Flush() const;

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -73,7 +73,7 @@ int PS4_SYSV_ABI sceKernelOpen(const char* path, int flags, u16 mode) {
     } else {
         file->m_guest_name = path;
         file->m_host_name = mnt->GetHostFile(file->m_guest_name);
-        errno_t e = 0;
+        int e = 0;
         if (read) {
             e = file->f.Open(file->m_host_name, Common::FS::FileAccessMode::Read);
         } else if (write && (create || truncate)) {

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -73,28 +73,25 @@ int PS4_SYSV_ABI sceKernelOpen(const char* path, int flags, u16 mode) {
     } else {
         file->m_guest_name = path;
         file->m_host_name = mnt->GetHostFile(file->m_guest_name);
+        errno_t e = 0;
         if (read) {
-            file->f.Open(file->m_host_name, Common::FS::FileAccessMode::Read);
-        } else if (write && create) {
-            file->f.Open(file->m_host_name, Common::FS::FileAccessMode::Write);
+            e = file->f.Open(file->m_host_name, Common::FS::FileAccessMode::Read);
+        } else if (write && (create || truncate)) {
+            e = file->f.Open(file->m_host_name, Common::FS::FileAccessMode::Write);
         } else if (write && create && append) { // CUSA04729 (appends app0/shaderlist.txt)
-            file->f.Open(file->m_host_name, Common::FS::FileAccessMode::Append);
+            e = file->f.Open(file->m_host_name, Common::FS::FileAccessMode::Append);
         } else if (rdwr) {
             if (create) { // Create an empty file first.
                 Common::FS::IOFile out(file->m_host_name, Common::FS::FileAccessMode::Write);
             }
             // RW, then scekernelWrite is called and savedata is written just fine now.
-            file->f.Open(file->m_host_name, Common::FS::FileAccessMode::ReadWrite);
+            e = file->f.Open(file->m_host_name, Common::FS::FileAccessMode::ReadWrite);
         } else {
             UNREACHABLE();
         }
-        if (!file->f.IsOpen()) {
+        if (e != 0) {
             h->DeleteHandle(handle);
-            if (create) {
-                return ORBIS_KERNEL_ERROR_EACCES;
-            } else {
-                return ORBIS_KERNEL_ERROR_ENOENT;
-            }
+            return ErrnoToSceKernelError(e);
         }
     }
     file->is_opened = true;

--- a/src/core/libraries/kernel/libkernel.cpp
+++ b/src/core/libraries/kernel/libkernel.cpp
@@ -75,7 +75,7 @@ void ErrSceToPosix(int result) {
     g_posix_errno = rt;
 }
 
-int ErrnoToSceKernelError(errno_t e) {
+int ErrnoToSceKernelError(int e) {
     const auto res = SCE_KERNEL_ERROR_UNKNOWN + e;
     return res > SCE_KERNEL_ERROR_ESTOP ? SCE_KERNEL_ERROR_UNKNOWN : res;
 }

--- a/src/core/libraries/kernel/libkernel.cpp
+++ b/src/core/libraries/kernel/libkernel.cpp
@@ -69,10 +69,15 @@ int* PS4_SYSV_ABI __Error() {
 }
 
 void ErrSceToPosix(int result) {
-    int rt = result > SCE_KERNEL_ERROR_UNKNOWN && result <= SCE_KERNEL_ERROR_ESTOP
-                 ? result + -SCE_KERNEL_ERROR_UNKNOWN
-                 : POSIX_EOTHER;
+    const int rt = result > SCE_KERNEL_ERROR_UNKNOWN && result <= SCE_KERNEL_ERROR_ESTOP
+                       ? result + -SCE_KERNEL_ERROR_UNKNOWN
+                       : POSIX_EOTHER;
     g_posix_errno = rt;
+}
+
+int ErrnoToSceKernelError(errno_t e) {
+    const auto res = SCE_KERNEL_ERROR_UNKNOWN + e;
+    return res > SCE_KERNEL_ERROR_ESTOP ? SCE_KERNEL_ERROR_UNKNOWN : res;
 }
 
 int PS4_SYSV_ABI sceKernelMmap(void* addr, u64 len, int prot, int flags, int fd, size_t offset,

--- a/src/core/libraries/kernel/libkernel.h
+++ b/src/core/libraries/kernel/libkernel.h
@@ -13,6 +13,7 @@ class SymbolsResolver;
 namespace Libraries::Kernel {
 
 void ErrSceToPosix(int result);
+int ErrnoToSceKernelError(errno_t e);
 
 struct OrbisTimesec {
     time_t t;

--- a/src/core/libraries/kernel/libkernel.h
+++ b/src/core/libraries/kernel/libkernel.h
@@ -13,7 +13,7 @@ class SymbolsResolver;
 namespace Libraries::Kernel {
 
 void ErrSceToPosix(int result);
-int ErrnoToSceKernelError(errno_t e);
+int ErrnoToSceKernelError(int e);
 
 struct OrbisTimesec {
     time_t t;

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -50,8 +50,8 @@ ImageViewInfo::ImageViewInfo(const AmdGpu::Image& image, bool is_storage) noexce
     : is_storage{is_storage} {
     type = ConvertImageViewType(image.GetType());
     format = Vulkan::LiverpoolToVK::SurfaceFormat(image.GetDataFmt(), image.GetNumberFmt());
-    range.base.level = 0;
-    range.base.layer = 0;
+    range.base.level = static_cast<u32>(image.base_level);
+    range.base.layer = static_cast<u32>(image.base_array);
     range.extent.levels = image.NumLevels();
     range.extent.layers = image.NumLayers();
     if (!is_storage) {
@@ -95,7 +95,7 @@ ImageView::ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info
             .aspectMask = aspect,
             .baseMipLevel = 0U,
             .levelCount = 1,
-            .baseArrayLayer = 0,
+            .baseArrayLayer = info_.range.base.layer,
             .layerCount = image.info.IsBlockCoded() ? 1 : VK_REMAINING_ARRAY_LAYERS,
         },
     };

--- a/src/video_core/texture_cache/types.h
+++ b/src/video_core/texture_cache/types.h
@@ -45,15 +45,15 @@ struct SubresourceLayers {
 };
 
 struct SubresourceBase {
-    s32 level = 0;
-    s32 layer = 0;
+    u32 level = 0;
+    u32 layer = 0;
 
     auto operator<=>(const SubresourceBase&) const = default;
 };
 
 struct SubresourceExtent {
-    s32 levels = 1;
-    s32 layers = 1;
+    u32 levels = 1;
+    u32 layers = 1;
 
     auto operator<=>(const SubresourceExtent&) const = default;
 };


### PR DESCRIPTION
* Added error reporting from `sceKernelOpen`
* Added base array layer to the bound image view