### PR TITLE
Fix Linux builds

### DIFF
--- a/src/common/ntapi.cpp
+++ b/src/common/ntapi.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#ifdef _WIN32
+
 #include "ntapi.h"
 
 NtDelayExecution_t NtDelayExecution = nullptr;
@@ -18,3 +20,5 @@ void Initialize() {
 }
 
 } // namespace Common::NtApi
+
+#endif

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -40,7 +40,9 @@ Emulator::Emulator()
     Config::load(config_dir / "config.toml");
 
     // Initialize NT API functions
+#ifdef _WIN32
     Common::NtApi::Initialize();
+#endif
 
     // Start logger.
     Common::Log::Initialize();


### PR DESCRIPTION
I forgot to make `common/ntapi.cpp` compile only on Windows and didn't take Linux into account when making my previous PR (#250)