### PR TITLE
shader_recompiler/frontend: Implement opcodes

### DIFF
--- a/src/shader_recompiler/frontend/translate/scalar_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_alu.cpp
@@ -193,6 +193,14 @@ void Translator::S_AND_B32(const GcnInst& inst) {
     ir.SetScc(ir.INotEqual(result, ir.Imm32(0)));
 }
 
+void Translator::S_ASHR_I32(const GcnInst& inst) {
+    const IR::U32 src0{GetSrc(inst.src[0])};
+    const IR::U32 src1{GetSrc(inst.src[1])};
+    const IR::U32 result{ir.ShiftRightArithmetic(src0, src1)};
+    SetDst(inst.dst[0], result);
+    ir.SetScc(ir.INotEqual(result, ir.Imm32(0)));
+}
+
 void Translator::S_OR_B32(const GcnInst& inst) {
     const IR::U32 src0{GetSrc(inst.src[0])};
     const IR::U32 src1{GetSrc(inst.src[1])};

--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -573,6 +573,7 @@ void Translate(IR::Block* block, u32 block_base, std::span<const GcnInst> inst_l
             translator.BUFFER_LOAD_FORMAT(4, true, inst);
             break;
         case Opcode::BUFFER_LOAD_FORMAT_X:
+        case Opcode::BUFFER_LOAD_DWORD:
             translator.BUFFER_LOAD_FORMAT(1, false, inst);
             break;
         case Opcode::BUFFER_LOAD_FORMAT_XYZ:
@@ -817,6 +818,9 @@ void Translate(IR::Block* block, u32 block_base, std::span<const GcnInst> inst_l
             break;
         case Opcode::S_AND_B32:
             translator.S_AND_B32(inst);
+            break;
+        case Opcode::S_ASHR_I32:
+            translator.S_ASHR_I32(inst);
             break;
         case Opcode::S_OR_B32:
             translator.S_OR_B32(inst);

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -69,6 +69,7 @@ public:
     void S_AND_B64(NegateMode negate, const GcnInst& inst);
     void S_ADD_I32(const GcnInst& inst);
     void S_AND_B32(const GcnInst& inst);
+    void S_ASHR_I32(const GcnInst& inst);
     void S_OR_B32(const GcnInst& inst);
     void S_LSHR_B32(const GcnInst& inst);
     void S_CSELECT_B32(const GcnInst& inst);


### PR DESCRIPTION
Implemented the `S_ASHR_I32` and `BUFFER_LOAD_DWORD` opcodes.
Seen on PSPHD.