### PR TITLE
Replace remaining uses of `QDir::currentPath() / "user"` with `GetUserPath(UserDir)`.

### DIFF
--- a/src/qt_gui/game_grid_frame.cpp
+++ b/src/qt_gui/game_grid_frame.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/path_util.h"
 #include "game_grid_frame.h"
 
 GameGridFrame::GameGridFrame(std::shared_ptr<GameInfoClass> game_info_get, QWidget* parent)
@@ -113,12 +114,15 @@ void GameGridFrame::SetGridBackgroundImage(int row, int column) {
     QWidget* item = this->cellWidget(row, column);
     if (item) {
         QString pic1Path = QString::fromStdString((*m_games_shared)[itemID].pic_path);
-        QString blurredPic1Path =
-            QDir::currentPath() +
-            QString::fromStdString("/user/game_data/" + (*m_games_shared)[itemID].serial +
-                                   "/pic1.png");
+        const auto blurredPic1Path = Common::FS::GetUserPath(Common::FS::PathType::UserDir) /
+                                     "game_data" / (*m_games_shared)[itemID].serial / "pic1.png";
+#ifdef _WIN32
+        const auto blurredPic1PathQt = QString::fromStdWString(blurredPic1Path.wstring());
+#else
+        const auto blurredPic1PathQt = QString::fromStdString(blurredPic1Path.string());
+#endif
 
-        backgroundImage = QImage(blurredPic1Path);
+        backgroundImage = QImage(blurredPic1PathQt);
         if (backgroundImage.isNull()) {
             QImage image(pic1Path);
             backgroundImage = m_game_list_utils.BlurImage(image, image.rect(), 16);
@@ -126,7 +130,7 @@ void GameGridFrame::SetGridBackgroundImage(int row, int column) {
             std::filesystem::path img_path =
                 std::filesystem::path("user/game_data/") / (*m_games_shared)[itemID].serial;
             std::filesystem::create_directories(img_path);
-            if (!backgroundImage.save(blurredPic1Path, "PNG")) {
+            if (!backgroundImage.save(blurredPic1PathQt, "PNG")) {
                 // qDebug() << "Error: Unable to save image.";
             }
         }

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/path_util.h"
 #include "game_list_frame.h"
 
 GameListFrame::GameListFrame(std::shared_ptr<GameInfoClass> game_info_get, QWidget* parent)
@@ -98,12 +99,16 @@ void GameListFrame::SetListBackgroundImage(QTableWidgetItem* item) {
     }
 
     QString pic1Path = QString::fromStdString(m_game_info->m_games[item->row()].pic_path);
-    QString blurredPic1Path =
-        QDir::currentPath() +
-        QString::fromStdString("/user/game_data/" + m_game_info->m_games[item->row()].serial +
-                               "/pic1.png");
+    const auto blurredPic1Path = Common::FS::GetUserPath(Common::FS::PathType::UserDir) /
+                                 "game_data" / m_game_info->m_games[item->row()].serial /
+                                 "pic1.png";
+#ifdef _WIN32
+    const auto blurredPic1PathQt = QString::fromStdWString(blurredPic1Path.wstring());
+#else
+    const auto blurredPic1PathQt = QString::fromStdString(blurredPic1Path.string());
+#endif
 
-    backgroundImage = QImage(blurredPic1Path);
+    backgroundImage = QImage(blurredPic1PathQt);
     if (backgroundImage.isNull()) {
         QImage image(pic1Path);
         backgroundImage = m_game_list_utils.BlurImage(image, image.rect(), 16);
@@ -111,7 +116,7 @@ void GameListFrame::SetListBackgroundImage(QTableWidgetItem* item) {
         std::filesystem::path img_path =
             std::filesystem::path("user/game_data/") / m_game_info->m_games[item->row()].serial;
         std::filesystem::create_directories(img_path);
-        if (!backgroundImage.save(blurredPic1Path, "PNG")) {
+        if (!backgroundImage.save(blurredPic1PathQt, "PNG")) {
             // qDebug() << "Error: Unable to save image.";
         }
     }

--- a/src/qt_gui/trophy_viewer.cpp
+++ b/src/qt_gui/trophy_viewer.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/path_util.h"
 #include "trophy_viewer.h"
 
 TrophyViewer::TrophyViewer(QString trophyPath, QString gameTrpPath) : QMainWindow() {
@@ -19,8 +20,17 @@ TrophyViewer::TrophyViewer(QString trophyPath, QString gameTrpPath) : QMainWindo
 }
 
 void TrophyViewer::PopulateTrophyWidget(QString title) {
-    QString trophyDir = QDir::currentPath() + "/user/game_data/" + title + "/TrophyFiles";
-    QDir dir(trophyDir);
+#ifdef _WIN32
+    const auto trophyDir = Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "game_data" /
+                           title.toStdWString() / "TrophyFiles";
+    const auto trophyDirQt = QString::fromStdWString(trophyDir.wstring());
+#else
+    const auto trophyDir = Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "game_data" /
+                           title.toStdString() / "TrophyFiles";
+    const auto trophyDirQt = QString::fromStdString(trophyDir.string());
+#endif
+
+    QDir dir(trophyDirQt);
     if (!dir.exists()) {
         std::filesystem::path path(gameTrpPath_.toStdString());
 #ifdef _WIN64
@@ -35,7 +45,7 @@ void TrophyViewer::PopulateTrophyWidget(QString title) {
 
     for (const QFileInfo& dirInfo : dirList) {
         QString tabName = dirInfo.fileName();
-        QString trpDir = trophyDir + "/" + tabName;
+        QString trpDir = trophyDirQt + "/" + tabName;
 
         QString iconsPath = trpDir + "/Icons";
         QDir iconsDir(iconsPath);


### PR DESCRIPTION
Instead of relying on `QDir::currentPath() + "/user"` to be correct, use `GetUserPath(UserDir)` as the single source of truth on the user directory like the rest of the codebase.

I think I handled the cases where `wstring` is needed for Windows correctly, let me know if there's anything wrong there.