### PR TITLE
docs: Syntax highlighting for the example code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Follow the indentation/whitespace style shown below. Do not use tabs, use 4-spac
 * For doc-comments (Doxygen comments), use /// if it's a single line, else use the /** */ style featured in the example. Start the text on the second line, not the first containing /**.
 * For items that are both defined and declared in two separate files, put the doc-comment only next to the associated declaration. (In a header file, usually.) Otherwise, put it next to the implementation. Never duplicate doc-comments in both places.
 
-```
+```c++
 // Includes should be sorted lexicographically
 // STD includes first
 #include <array>


### PR DESCRIPTION
Just a small addition to make the example code more readable with syntax highlighting.