### PR TITLE
BUFFER_STORE_DWORDX2

### DIFF
--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -612,6 +612,9 @@ void Translate(IR::Block* block, u32 block_base, std::span<const GcnInst> inst_l
         case Opcode::BUFFER_STORE_DWORD:
             translator.BUFFER_STORE_FORMAT(1, false, inst);
             break;
+        case Opcode::BUFFER_STORE_DWORDX2:
+            translator.BUFFER_STORE_FORMAT(2, false, inst);
+            break;
         case Opcode::BUFFER_STORE_DWORDX3:
             translator.BUFFER_STORE_FORMAT(3, false, inst);
             break;


### PR DESCRIPTION
This 'pull' should fix this error:
`[Render.Recompiler] <Error> translate.cpp:Translate:974: Unknown opcode BUFFER_STORE_DWORDX2 (1309)`
However, now it presents another error:
`[Debug] <Critical> resource_tracking_pass.cpp:operator():430: Assertion Failed!`
`non-formatting load_buffer_* is not implemented for stride 1`
