### PR TITLE
Op arg float as default

### DIFF
--- a/src/shader_recompiler/frontend/translate/data_share.cpp
+++ b/src/shader_recompiler/frontend/translate/data_share.cpp
@@ -110,17 +110,17 @@ void Translator::S_BARRIER() {
 
 void Translator::V_READFIRSTLANE_B32(const GcnInst& inst) {
     ASSERT(info.stage != Stage::Compute);
-    SetDst(inst.dst[0], GetSrc(inst.src[0]));
+    SetDst(inst.dst[0], GetSrc<IR::U32>(inst.src[0]));
 }
 
 void Translator::V_READLANE_B32(const GcnInst& inst) {
     ASSERT(info.stage != Stage::Compute);
-    SetDst(inst.dst[0], GetSrc(inst.src[0]));
+    SetDst(inst.dst[0], GetSrc<IR::U32>(inst.src[0]));
 }
 
 void Translator::V_WRITELANE_B32(const GcnInst& inst) {
     ASSERT(info.stage != Stage::Compute);
-    SetDst(inst.dst[0], GetSrc(inst.src[0]));
+    SetDst(inst.dst[0], GetSrc<IR::U32>(inst.src[0]));
 }
 
 } // namespace Shader::Gcn

--- a/src/shader_recompiler/frontend/translate/scalar_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_alu.cpp
@@ -110,12 +110,12 @@ void Translator::S_MOVK(const GcnInst& inst) {
 
 void Translator::S_ADDK_I32(const GcnInst& inst) {
     const s32 simm16 = inst.control.sopk.simm;
-    SetDst(inst.dst[0], ir.IAdd(GetSrc(inst.dst[0]), ir.Imm32(simm16)));
+    SetDst(inst.dst[0], ir.IAdd(GetSrc(inst.dst[0], true), ir.Imm32(simm16)));
 }
 
 void Translator::S_MULK_I32(const GcnInst& inst) {
     const s32 simm16 = inst.control.sopk.simm;
-    SetDst(inst.dst[0], ir.IMul(GetSrc(inst.dst[0]), ir.Imm32(simm16)));
+    SetDst(inst.dst[0], ir.IMul(GetSrc(inst.dst[0], true), ir.Imm32(simm16)));
 }
 
 void Translator::S_MOV(const GcnInst& inst) {
@@ -123,12 +123,12 @@ void Translator::S_MOV(const GcnInst& inst) {
 }
 
 void Translator::S_MUL_I32(const GcnInst& inst) {
-    SetDst(inst.dst[0], ir.IMul(GetSrc(inst.src[0]), GetSrc(inst.src[1])));
+    SetDst(inst.dst[0], ir.IMul(GetSrc(inst.src[0], true), GetSrc(inst.src[1], true)));
 }
 
 void Translator::S_CMP(ConditionOp cond, bool is_signed, const GcnInst& inst) {
-    const IR::U32 lhs = GetSrc(inst.src[0]);
-    const IR::U32 rhs = GetSrc(inst.src[1]);
+    const IR::U32 lhs = GetSrc(inst.src[0], true);
+    const IR::U32 rhs = GetSrc(inst.src[1], true);
     const IR::U1 result = [&] {
         switch (cond) {
         case ConditionOp::EQ:
@@ -288,47 +288,47 @@ void Translator::S_AND_B64(NegateMode negate, const GcnInst& inst) {
 }
 
 void Translator::S_ADD_I32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0])};
-    const IR::U32 src1{GetSrc(inst.src[1])};
+    const IR::U32 src0{GetSrc(inst.src[0], true)};
+    const IR::U32 src1{GetSrc(inst.src[1], true)};
     SetDst(inst.dst[0], ir.IAdd(src0, src1));
     // TODO: Overflow flag
 }
 
 void Translator::S_AND_B32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0])};
-    const IR::U32 src1{GetSrc(inst.src[1])};
+    const IR::U32 src0{GetSrc(inst.src[0], true)};
+    const IR::U32 src1{GetSrc(inst.src[1], true)};
     const IR::U32 result{ir.BitwiseAnd(src0, src1)};
     SetDst(inst.dst[0], result);
     ir.SetScc(ir.INotEqual(result, ir.Imm32(0)));
 }
 
 void Translator::S_ASHR_I32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0])};
-    const IR::U32 src1{GetSrc(inst.src[1])};
+    const IR::U32 src0{GetSrc(inst.src[0], true)};
+    const IR::U32 src1{GetSrc(inst.src[1], true)};
     const IR::U32 result{ir.ShiftRightArithmetic(src0, src1)};
     SetDst(inst.dst[0], result);
     ir.SetScc(ir.INotEqual(result, ir.Imm32(0)));
 }
 
 void Translator::S_OR_B32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0])};
-    const IR::U32 src1{GetSrc(inst.src[1])};
+    const IR::U32 src0{GetSrc(inst.src[0], true)};
+    const IR::U32 src1{GetSrc(inst.src[1], true)};
     const IR::U32 result{ir.BitwiseOr(src0, src1)};
     SetDst(inst.dst[0], result);
     ir.SetScc(ir.INotEqual(result, ir.Imm32(0)));
 }
 
 void Translator::S_LSHR_B32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0])};
-    const IR::U32 src1{GetSrc(inst.src[1])};
+    const IR::U32 src0{GetSrc(inst.src[0], true)};
+    const IR::U32 src1{GetSrc(inst.src[1], true)};
     const IR::U32 result{ir.ShiftRightLogical(src0, src1)};
     SetDst(inst.dst[0], result);
     ir.SetScc(ir.INotEqual(result, ir.Imm32(0)));
 }
 
 void Translator::S_CSELECT_B32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0])};
-    const IR::U32 src1{GetSrc(inst.src[1])};
+    const IR::U32 src0{GetSrc(inst.src[0], true)};
+    const IR::U32 src1{GetSrc(inst.src[1], true)};
     SetDst(inst.dst[0], IR::U32{ir.Select(ir.GetScc(), src0, src1)});
 }
 
@@ -363,8 +363,8 @@ void Translator::S_CSELECT_B64(const GcnInst& inst) {
 }
 
 void Translator::S_BFE_U32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0])};
-    const IR::U32 src1{GetSrc(inst.src[1])};
+    const IR::U32 src0{GetSrc(inst.src[0], true)};
+    const IR::U32 src1{GetSrc(inst.src[1], true)};
     const IR::U32 offset{ir.BitwiseAnd(src1, ir.Imm32(0x1F))};
     const IR::U32 count{ir.BitFieldExtract(src1, ir.Imm32(16), ir.Imm32(7))};
     const IR::U32 result{ir.BitFieldExtract(src0, offset, count)};
@@ -373,16 +373,16 @@ void Translator::S_BFE_U32(const GcnInst& inst) {
 }
 
 void Translator::S_LSHL_B32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0])};
-    const IR::U32 src1{GetSrc(inst.src[1])};
+    const IR::U32 src0{GetSrc(inst.src[0], true)};
+    const IR::U32 src1{GetSrc(inst.src[1], true)};
     const IR::U32 result = ir.ShiftLeftLogical(src0, ir.BitwiseAnd(src1, ir.Imm32(0x1F)));
     SetDst(inst.dst[0], result);
     ir.SetScc(ir.INotEqual(result, ir.Imm32(0)));
 }
 
 void Translator::S_BFM_B32(const GcnInst& inst) {
-    const IR::U32 src0{ir.BitwiseAnd(GetSrc(inst.src[0]), ir.Imm32(0x1F))};
-    const IR::U32 src1{ir.BitwiseAnd(GetSrc(inst.src[1]), ir.Imm32(0x1F))};
+    const IR::U32 src0{ir.BitwiseAnd(GetSrc(inst.src[0], true), ir.Imm32(0x1F))};
+    const IR::U32 src1{ir.BitwiseAnd(GetSrc(inst.src[1], true), ir.Imm32(0x1F))};
     const IR::U32 mask{ir.ISub(ir.ShiftLeftLogical(ir.Imm32(1u), src0), ir.Imm32(1))};
     SetDst(inst.dst[0], ir.ShiftLeftLogical(mask, src1));
 }
@@ -420,16 +420,16 @@ void Translator::S_BREV_B32(const GcnInst& inst) {
 }
 
 void Translator::S_ADD_U32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0])};
-    const IR::U32 src1{GetSrc(inst.src[1])};
+    const IR::U32 src0{GetSrc(inst.src[0], true)};
+    const IR::U32 src1{GetSrc(inst.src[1], true)};
     SetDst(inst.dst[0], ir.IAdd(src0, src1));
     // TODO: Carry out
     ir.SetScc(ir.Imm1(false));
 }
 
 void Translator::S_SUB_U32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0])};
-    const IR::U32 src1{GetSrc(inst.src[1])};
+    const IR::U32 src0{GetSrc(inst.src[0], true)};
+    const IR::U32 src1{GetSrc(inst.src[1], true)};
     SetDst(inst.dst[0], ir.ISub(src0, src1));
     // TODO: Carry out
     ir.SetScc(ir.Imm1(false));
@@ -442,22 +442,22 @@ void Translator::S_GETPC_B64(u32 pc, const GcnInst& inst) {
 }
 
 void Translator::S_ADDC_U32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0])};
-    const IR::U32 src1{GetSrc(inst.src[1])};
+    const IR::U32 src0{GetSrc(inst.src[0], true)};
+    const IR::U32 src1{GetSrc(inst.src[1], true)};
     SetDst(inst.dst[0], ir.IAdd(ir.IAdd(src0, src1), ir.GetSccLo()));
 }
 
 void Translator::S_MAX_U32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0])};
-    const IR::U32 src1{GetSrc(inst.src[1])};
+    const IR::U32 src0{GetSrc(inst.src[0], true)};
+    const IR::U32 src1{GetSrc(inst.src[1], true)};
     const IR::U32 result = ir.UMax(src0, src1);
     SetDst(inst.dst[0], result);
     ir.SetScc(ir.IEqual(result, src0));
 }
 
 void Translator::S_MIN_U32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0])};
-    const IR::U32 src1{GetSrc(inst.src[1])};
+    const IR::U32 src0{GetSrc(inst.src[0], true)};
+    const IR::U32 src1{GetSrc(inst.src[1], true)};
     const IR::U32 result = ir.UMin(src0, src1);
     SetDst(inst.dst[0], result);
     ir.SetScc(ir.IEqual(result, src0));

--- a/src/shader_recompiler/frontend/translate/scalar_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_alu.cpp
@@ -110,25 +110,25 @@ void Translator::S_MOVK(const GcnInst& inst) {
 
 void Translator::S_ADDK_I32(const GcnInst& inst) {
     const s32 simm16 = inst.control.sopk.simm;
-    SetDst(inst.dst[0], ir.IAdd(GetSrc(inst.dst[0], true), ir.Imm32(simm16)));
+    SetDst(inst.dst[0], ir.IAdd(GetSrc<IR::U32>(inst.dst[0]), ir.Imm32(simm16)));
 }
 
 void Translator::S_MULK_I32(const GcnInst& inst) {
     const s32 simm16 = inst.control.sopk.simm;
-    SetDst(inst.dst[0], ir.IMul(GetSrc(inst.dst[0], true), ir.Imm32(simm16)));
+    SetDst(inst.dst[0], ir.IMul(GetSrc<IR::U32>(inst.dst[0]), ir.Imm32(simm16)));
 }
 
 void Translator::S_MOV(const GcnInst& inst) {
-    SetDst(inst.dst[0], GetSrc(inst.src[0]));
+    SetDst(inst.dst[0], GetSrc<IR::U32>(inst.src[0]));
 }
 
 void Translator::S_MUL_I32(const GcnInst& inst) {
-    SetDst(inst.dst[0], ir.IMul(GetSrc(inst.src[0], true), GetSrc(inst.src[1], true)));
+    SetDst(inst.dst[0], ir.IMul(GetSrc<IR::U32>(inst.src[0]), GetSrc<IR::U32>(inst.src[1])));
 }
 
 void Translator::S_CMP(ConditionOp cond, bool is_signed, const GcnInst& inst) {
-    const IR::U32 lhs = GetSrc(inst.src[0], true);
-    const IR::U32 rhs = GetSrc(inst.src[1], true);
+    const IR::U32 lhs = GetSrc(inst.src[0]);
+    const IR::U32 rhs = GetSrc(inst.src[1]);
     const IR::U1 result = [&] {
         switch (cond) {
         case ConditionOp::EQ:
@@ -288,47 +288,47 @@ void Translator::S_AND_B64(NegateMode negate, const GcnInst& inst) {
 }
 
 void Translator::S_ADD_I32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0], true)};
-    const IR::U32 src1{GetSrc(inst.src[1], true)};
+    const IR::U32 src0{GetSrc(inst.src[0])};
+    const IR::U32 src1{GetSrc(inst.src[1])};
     SetDst(inst.dst[0], ir.IAdd(src0, src1));
     // TODO: Overflow flag
 }
 
 void Translator::S_AND_B32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0], true)};
-    const IR::U32 src1{GetSrc(inst.src[1], true)};
+    const IR::U32 src0{GetSrc(inst.src[0])};
+    const IR::U32 src1{GetSrc(inst.src[1])};
     const IR::U32 result{ir.BitwiseAnd(src0, src1)};
     SetDst(inst.dst[0], result);
     ir.SetScc(ir.INotEqual(result, ir.Imm32(0)));
 }
 
 void Translator::S_ASHR_I32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0], true)};
-    const IR::U32 src1{GetSrc(inst.src[1], true)};
+    const IR::U32 src0{GetSrc(inst.src[0])};
+    const IR::U32 src1{GetSrc(inst.src[1])};
     const IR::U32 result{ir.ShiftRightArithmetic(src0, src1)};
     SetDst(inst.dst[0], result);
     ir.SetScc(ir.INotEqual(result, ir.Imm32(0)));
 }
 
 void Translator::S_OR_B32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0], true)};
-    const IR::U32 src1{GetSrc(inst.src[1], true)};
+    const IR::U32 src0{GetSrc(inst.src[0])};
+    const IR::U32 src1{GetSrc(inst.src[1])};
     const IR::U32 result{ir.BitwiseOr(src0, src1)};
     SetDst(inst.dst[0], result);
     ir.SetScc(ir.INotEqual(result, ir.Imm32(0)));
 }
 
 void Translator::S_LSHR_B32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0], true)};
-    const IR::U32 src1{GetSrc(inst.src[1], true)};
+    const IR::U32 src0{GetSrc(inst.src[0])};
+    const IR::U32 src1{GetSrc(inst.src[1])};
     const IR::U32 result{ir.ShiftRightLogical(src0, src1)};
     SetDst(inst.dst[0], result);
     ir.SetScc(ir.INotEqual(result, ir.Imm32(0)));
 }
 
 void Translator::S_CSELECT_B32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0], true)};
-    const IR::U32 src1{GetSrc(inst.src[1], true)};
+    const IR::U32 src0{GetSrc(inst.src[0])};
+    const IR::U32 src1{GetSrc(inst.src[1])};
     SetDst(inst.dst[0], IR::U32{ir.Select(ir.GetScc(), src0, src1)});
 }
 
@@ -363,8 +363,8 @@ void Translator::S_CSELECT_B64(const GcnInst& inst) {
 }
 
 void Translator::S_BFE_U32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0], true)};
-    const IR::U32 src1{GetSrc(inst.src[1], true)};
+    const IR::U32 src0{GetSrc(inst.src[0])};
+    const IR::U32 src1{GetSrc(inst.src[1])};
     const IR::U32 offset{ir.BitwiseAnd(src1, ir.Imm32(0x1F))};
     const IR::U32 count{ir.BitFieldExtract(src1, ir.Imm32(16), ir.Imm32(7))};
     const IR::U32 result{ir.BitFieldExtract(src0, offset, count)};
@@ -373,16 +373,16 @@ void Translator::S_BFE_U32(const GcnInst& inst) {
 }
 
 void Translator::S_LSHL_B32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0], true)};
-    const IR::U32 src1{GetSrc(inst.src[1], true)};
+    const IR::U32 src0{GetSrc(inst.src[0])};
+    const IR::U32 src1{GetSrc(inst.src[1])};
     const IR::U32 result = ir.ShiftLeftLogical(src0, ir.BitwiseAnd(src1, ir.Imm32(0x1F)));
     SetDst(inst.dst[0], result);
     ir.SetScc(ir.INotEqual(result, ir.Imm32(0)));
 }
 
 void Translator::S_BFM_B32(const GcnInst& inst) {
-    const IR::U32 src0{ir.BitwiseAnd(GetSrc(inst.src[0], true), ir.Imm32(0x1F))};
-    const IR::U32 src1{ir.BitwiseAnd(GetSrc(inst.src[1], true), ir.Imm32(0x1F))};
+    const IR::U32 src0{ir.BitwiseAnd(GetSrc(inst.src[0]), ir.Imm32(0x1F))};
+    const IR::U32 src1{ir.BitwiseAnd(GetSrc(inst.src[1]), ir.Imm32(0x1F))};
     const IR::U32 mask{ir.ISub(ir.ShiftLeftLogical(ir.Imm32(1u), src0), ir.Imm32(1))};
     SetDst(inst.dst[0], ir.ShiftLeftLogical(mask, src1));
 }
@@ -420,16 +420,16 @@ void Translator::S_BREV_B32(const GcnInst& inst) {
 }
 
 void Translator::S_ADD_U32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0], true)};
-    const IR::U32 src1{GetSrc(inst.src[1], true)};
+    const IR::U32 src0{GetSrc(inst.src[0])};
+    const IR::U32 src1{GetSrc(inst.src[1])};
     SetDst(inst.dst[0], ir.IAdd(src0, src1));
     // TODO: Carry out
     ir.SetScc(ir.Imm1(false));
 }
 
 void Translator::S_SUB_U32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0], true)};
-    const IR::U32 src1{GetSrc(inst.src[1], true)};
+    const IR::U32 src0{GetSrc(inst.src[0])};
+    const IR::U32 src1{GetSrc(inst.src[1])};
     SetDst(inst.dst[0], ir.ISub(src0, src1));
     // TODO: Carry out
     ir.SetScc(ir.Imm1(false));
@@ -442,22 +442,22 @@ void Translator::S_GETPC_B64(u32 pc, const GcnInst& inst) {
 }
 
 void Translator::S_ADDC_U32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0], true)};
-    const IR::U32 src1{GetSrc(inst.src[1], true)};
+    const IR::U32 src0{GetSrc(inst.src[0])};
+    const IR::U32 src1{GetSrc(inst.src[1])};
     SetDst(inst.dst[0], ir.IAdd(ir.IAdd(src0, src1), ir.GetSccLo()));
 }
 
 void Translator::S_MAX_U32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0], true)};
-    const IR::U32 src1{GetSrc(inst.src[1], true)};
+    const IR::U32 src0{GetSrc(inst.src[0])};
+    const IR::U32 src1{GetSrc(inst.src[1])};
     const IR::U32 result = ir.UMax(src0, src1);
     SetDst(inst.dst[0], result);
     ir.SetScc(ir.IEqual(result, src0));
 }
 
 void Translator::S_MIN_U32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0], true)};
-    const IR::U32 src1{GetSrc(inst.src[1], true)};
+    const IR::U32 src0{GetSrc(inst.src[0])};
+    const IR::U32 src1{GetSrc(inst.src[1])};
     const IR::U32 result = ir.UMin(src0, src1);
     SetDst(inst.dst[0], result);
     ir.SetScc(ir.IEqual(result, src0));

--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -309,11 +309,8 @@ IR::U64F64 Translator::GetSrcRaw64(const InstOperand& operand, bool integer) {
 }
 
 template <>
-Translator::SrcAuto Translator::GetSrc<Translator::SrcAuto>(const InstOperand& operand) {
-    return SrcAuto{
-        *this,
-        operand,
-    };
+Translator::SrcValue Translator::GetSrc<Translator::SrcValue>(const InstOperand& operand) {
+    return SrcValue{*this, operand};
 }
 
 template <>
@@ -346,31 +343,31 @@ IR::F64 Translator::GetSrc(const InstOperand& operand) {
     return GetSrcRaw64(operand, false);
 }
 
-Translator::SrcAuto::operator IR::U32F32() const {
+Translator::SrcValue::operator IR::U32F32() const {
     return translator.GetSrc<IR::U32F32>(operand);
 }
 
-Translator::SrcAuto::operator IR::Value() const {
+Translator::SrcValue::operator IR::Value() const {
     return IR::Value{translator.GetSrc<IR::U32F32>(operand)};
 }
 
-Translator::SrcAuto::operator IR::U32() const {
+Translator::SrcValue::operator IR::U32() const {
     return translator.GetSrc<IR::U32>(operand);
 }
 
-Translator::SrcAuto::operator IR::F32() const {
+Translator::SrcValue::operator IR::F32() const {
     return translator.GetSrc<IR::F32>(operand);
 }
 
-Translator::SrcAuto::operator IR::U64F64() const {
+Translator::SrcValue::operator IR::U64F64() const {
     return translator.GetSrc<IR::U64F64>(operand);
 }
 
-Translator::SrcAuto::operator IR::U64() const {
+Translator::SrcValue::operator IR::U64() const {
     return translator.GetSrc<IR::U64>(operand);
 }
 
-Translator::SrcAuto::operator IR::F64() const {
+Translator::SrcValue::operator IR::F64() const {
     return translator.GetSrc<IR::F64>(operand);
 }
 

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -209,11 +209,11 @@ public:
     void IMAGE_ATOMIC(AtomicOp op, const GcnInst& inst);
 
 private:
-    struct SrcAuto;
+    struct SrcValue;
     [[nodiscard]] IR::U32F32 GetSrcRaw(const InstOperand& operand, bool integer);
     [[nodiscard]] IR::U64F64 GetSrcRaw64(const InstOperand& operand, bool integer);
 
-    template <typename T = SrcAuto>
+    template <typename T = SrcValue>
     [[nodiscard]] T GetSrc(const InstOperand& operand);
 
     void SetDst(const InstOperand& operand, const IR::U32F32& value);
@@ -228,23 +228,27 @@ private:
     IR::U32 m0_value;
     bool opcode_missing = false;
 
-    class SrcAuto {
+    /**
+     * This is a wrapper for IR::Value returned by GetSrc to lazy
+     * evaluate the correct type and auto-cast to integer if needed.
+     */
+    class SrcValue {
         Translator& translator;
         const InstOperand& operand;
 
     public:
-        SrcAuto(Translator& translator, const InstOperand& operand)
+        SrcValue(Translator& translator, const InstOperand& operand)
             : translator(translator), operand(operand) {}
 
-        operator IR::Value() const;
+        explicit(false) operator IR::Value() const;
 
-        operator IR::U32F32() const;
-        operator IR::U32() const;
-        operator IR::F32() const;
+        explicit(false) operator IR::U32F32() const;
+        explicit(false) operator IR::U32() const;
+        explicit(false) operator IR::F32() const;
 
-        operator IR::U64F64() const;
-        operator IR::U64() const;
-        operator IR::F64() const;
+        explicit(false) operator IR::U64F64() const;
+        explicit(false) operator IR::U64() const;
+        explicit(false) operator IR::F64() const;
     };
 };
 

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -210,7 +210,7 @@ public:
 
 private:
     template <typename T = IR::U32F32>
-    [[nodiscard]] T GetSrc(const InstOperand& operand, bool flt_zero = false);
+    [[nodiscard]] T GetSrc(const InstOperand& operand, bool integer = false);
     template <typename T = IR::U64F64>
     [[nodiscard]] T GetSrc64(const InstOperand& operand, bool flt_zero = false);
     void SetDst(const InstOperand& operand, const IR::U32F32& value);

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -209,10 +209,13 @@ public:
     void IMAGE_ATOMIC(AtomicOp op, const GcnInst& inst);
 
 private:
-    template <typename T = IR::U32F32>
-    [[nodiscard]] T GetSrc(const InstOperand& operand, bool integer = false);
-    template <typename T = IR::U64F64>
-    [[nodiscard]] T GetSrc64(const InstOperand& operand, bool flt_zero = false);
+    struct SrcAuto;
+    [[nodiscard]] IR::U32F32 GetSrcRaw(const InstOperand& operand, bool integer);
+    [[nodiscard]] IR::U64F64 GetSrcRaw64(const InstOperand& operand, bool integer);
+
+    template <typename T = SrcAuto>
+    [[nodiscard]] T GetSrc(const InstOperand& operand);
+
     void SetDst(const InstOperand& operand, const IR::U32F32& value);
     void SetDst64(const InstOperand& operand, const IR::U64F64& value_raw);
 
@@ -224,6 +227,25 @@ private:
     const Profile& profile;
     IR::U32 m0_value;
     bool opcode_missing = false;
+
+    class SrcAuto {
+        Translator& translator;
+        const InstOperand& operand;
+
+    public:
+        SrcAuto(Translator& translator, const InstOperand& operand)
+            : translator(translator), operand(operand) {}
+
+        operator IR::Value() const;
+
+        operator IR::U32F32() const;
+        operator IR::U32() const;
+        operator IR::F32() const;
+
+        operator IR::U64F64() const;
+        operator IR::U64() const;
+        operator IR::F64() const;
+    };
 };
 
 void Translate(IR::Block* block, u32 block_base, std::span<const GcnInst> inst_list, Info& info,

--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -933,18 +933,14 @@ F32F64 IREmitter::FPMin(const F32F64& lhs, const F32F64& rhs, bool is_legacy) {
     }
 }
 
-U32U64 IREmitter::IAdd(const U32U64& a, const U32U64& b) {
-    if (a.Type() != b.Type()) {
-        UNREACHABLE_MSG("Mismatching types {} and {}", a.Type(), b.Type());
-    }
-    switch (a.Type()) {
-    case Type::U32:
-        return Inst<U32>(Opcode::IAdd32, a, b);
-    case Type::U64:
-        return Inst<U64>(Opcode::IAdd64, a, b);
-    default:
-        ThrowInvalidType(a.Type());
-    }
+template <>
+U32 IREmitter::IAdd(const U32& a, const U32& b) {
+    return Inst<U32>(Opcode::IAdd32, a, b);
+}
+
+template <>
+U64 IREmitter::IAdd(const U64& a, const U64& b) {
+    return Inst<U64>(Opcode::IAdd64, a, b);
 }
 
 Value IREmitter::IAddCary(const U32& a, const U32& b) {
@@ -959,36 +955,28 @@ Value IREmitter::IAddCary(const U32& a, const U32& b) {
     }
 }
 
-U32U64 IREmitter::ISub(const U32U64& a, const U32U64& b) {
-    if (a.Type() != b.Type()) {
-        UNREACHABLE_MSG("Mismatching types {} and {}", a.Type(), b.Type());
-    }
-    switch (a.Type()) {
-    case Type::U32:
-        return Inst<U32>(Opcode::ISub32, a, b);
-    case Type::U64:
-        return Inst<U64>(Opcode::ISub64, a, b);
-    default:
-        ThrowInvalidType(a.Type());
-    }
+template <>
+U32 IREmitter::ISub(const U32& a, const U32& b) {
+    return Inst<U32>(Opcode::ISub32, a, b);
+}
+
+template <>
+U64 IREmitter::ISub(const U64& a, const U64& b) {
+    return Inst<U64>(Opcode::ISub64, a, b);
 }
 
 IR::Value IREmitter::IMulExt(const U32& a, const U32& b, bool is_signed) {
     return Inst(is_signed ? Opcode::SMulExt : Opcode::UMulExt, a, b);
 }
 
-U32U64 IREmitter::IMul(const U32U64& a, const U32U64& b) {
-    if (a.Type() != b.Type()) {
-        UNREACHABLE_MSG("Mismatching types {} and {}", a.Type(), b.Type());
-    }
-    switch (a.Type()) {
-    case Type::U32:
-        return Inst<U32>(Opcode::IMul32, a, b);
-    case Type::U64:
-        return Inst<U64>(Opcode::IMul64, a, b);
-    default:
-        ThrowInvalidType(a.Type());
-    }
+template <>
+U32 IREmitter::IMul(const U32& a, const U32& b) {
+    return Inst<U32>(Opcode::IMul32, a, b);
+}
+
+template <>
+U64 IREmitter::IMul(const U64& a, const U64& b) {
+    return Inst<U64>(Opcode::IMul64, a, b);
 }
 
 U32 IREmitter::IDiv(const U32& a, const U32& b, bool is_signed) {
@@ -1010,55 +998,45 @@ U32 IREmitter::IAbs(const U32& value) {
     return Inst<U32>(Opcode::IAbs32, value);
 }
 
-U32U64 IREmitter::ShiftLeftLogical(const U32U64& base, const U32& shift) {
-    switch (base.Type()) {
-    case Type::U32:
-        return Inst<U32>(Opcode::ShiftLeftLogical32, base, shift);
-    case Type::U64:
-        return Inst<U64>(Opcode::ShiftLeftLogical64, base, shift);
-    default:
-        ThrowInvalidType(base.Type());
-    }
+template <>
+U32 IREmitter::ShiftLeftLogical(const U32& base, const U32& shift) {
+    return Inst<U32>(Opcode::ShiftLeftLogical32, base, shift);
+}
+template <>
+U64 IREmitter::ShiftLeftLogical(const U64& base, const U32& shift) {
+    return Inst<U64>(Opcode::ShiftLeftLogical64, base, shift);
 }
 
-U32U64 IREmitter::ShiftRightLogical(const U32U64& base, const U32& shift) {
-    switch (base.Type()) {
-    case Type::U32:
-        return Inst<U32>(Opcode::ShiftRightLogical32, base, shift);
-    case Type::U64:
-        return Inst<U64>(Opcode::ShiftRightLogical64, base, shift);
-    default:
-        ThrowInvalidType(base.Type());
-    }
+template <>
+U32 IREmitter::ShiftRightLogical(const U32& base, const U32& shift) {
+    return Inst<U32>(Opcode::ShiftRightLogical32, base, shift);
+}
+template <>
+U64 IREmitter::ShiftRightLogical(const U64& base, const U32& shift) {
+    return Inst<U64>(Opcode::ShiftRightLogical64, base, shift);
 }
 
-U32U64 IREmitter::ShiftRightArithmetic(const U32U64& base, const U32& shift) {
-    switch (base.Type()) {
-    case Type::U32:
-        return Inst<U32>(Opcode::ShiftRightArithmetic32, base, shift);
-    case Type::U64:
-        return Inst<U64>(Opcode::ShiftRightArithmetic64, base, shift);
-    default:
-        ThrowInvalidType(base.Type());
-    }
+template <>
+U32 IREmitter::ShiftRightArithmetic(const U32& base, const U32& shift) {
+    return Inst<U32>(Opcode::ShiftRightArithmetic32, base, shift);
+}
+template <>
+U64 IREmitter::ShiftRightArithmetic(const U64& base, const U32& shift) {
+    return Inst<U64>(Opcode::ShiftRightArithmetic64, base, shift);
 }
 
 U32 IREmitter::BitwiseAnd(const U32& a, const U32& b) {
     return Inst<U32>(Opcode::BitwiseAnd32, a, b);
 }
 
-U32U64 IREmitter::BitwiseOr(const U32U64& a, const U32U64& b) {
-    if (a.Type() != b.Type()) {
-        UNREACHABLE_MSG("Mismatching types {} and {}", a.Type(), b.Type());
-    }
-    switch (a.Type()) {
-    case Type::U32:
-        return Inst<U32>(Opcode::BitwiseOr32, a, b);
-    case Type::U64:
-        return Inst<U64>(Opcode::BitwiseOr64, a, b);
-    default:
-        ThrowInvalidType(a.Type());
-    }
+template <>
+U32 IREmitter::BitwiseOr(const U32& a, const U32& b) {
+    return Inst<U32>(Opcode::BitwiseOr32, a, b);
+}
+
+template <>
+U64 IREmitter::BitwiseOr(const U64& a, const U64& b) {
+    return Inst<U64>(Opcode::BitwiseOr64, a, b);
 }
 
 U32 IREmitter::BitwiseXor(const U32& a, const U32& b) {

--- a/src/shader_recompiler/ir/ir_emitter.h
+++ b/src/shader_recompiler/ir/ir_emitter.h
@@ -157,19 +157,26 @@ public:
     [[nodiscard]] F32F64 FPMax(const F32F64& lhs, const F32F64& rhs, bool is_legacy = false);
     [[nodiscard]] F32F64 FPMin(const F32F64& lhs, const F32F64& rhs, bool is_legacy = false);
 
-    [[nodiscard]] U32U64 IAdd(const U32U64& a, const U32U64& b);
+    template <typename T = U32>
+    [[nodiscard]] T IAdd(const T& a, const T& b);
     [[nodiscard]] Value IAddCary(const U32& a, const U32& b);
-    [[nodiscard]] U32U64 ISub(const U32U64& a, const U32U64& b);
+    template <typename T = U32>
+    [[nodiscard]] T ISub(const T& a, const T& b);
     [[nodiscard]] Value IMulExt(const U32& a, const U32& b, bool is_signed = false);
-    [[nodiscard]] U32U64 IMul(const U32U64& a, const U32U64& b);
+    template <typename T = U32>
+    [[nodiscard]] T IMul(const T& a, const T& b);
     [[nodiscard]] U32 IDiv(const U32& a, const U32& b, bool is_signed = false);
     [[nodiscard]] U32U64 INeg(const U32U64& value);
     [[nodiscard]] U32 IAbs(const U32& value);
-    [[nodiscard]] U32U64 ShiftLeftLogical(const U32U64& base, const U32& shift);
-    [[nodiscard]] U32U64 ShiftRightLogical(const U32U64& base, const U32& shift);
-    [[nodiscard]] U32U64 ShiftRightArithmetic(const U32U64& base, const U32& shift);
+    template <typename T = U32>
+    [[nodiscard]] T ShiftLeftLogical(const T& base, const U32& shift);
+    template <typename T = U32>
+    [[nodiscard]] T ShiftRightLogical(const T& base, const U32& shift);
+    template <typename T = U32>
+    [[nodiscard]] T ShiftRightArithmetic(const T& base, const U32& shift);
     [[nodiscard]] U32 BitwiseAnd(const U32& a, const U32& b);
-    [[nodiscard]] U32U64 BitwiseOr(const U32U64& a, const U32U64& b);
+    template <typename T = U32>
+    [[nodiscard]] T BitwiseOr(const T& a, const T& b);
     [[nodiscard]] U32 BitwiseXor(const U32& a, const U32& b);
     [[nodiscard]] U32 BitFieldInsert(const U32& base, const U32& insert, const U32& offset,
                                      const U32& count);


### PR DESCRIPTION
After removing the 'force_flt' assumption based on input modifications, some games stopped running due to an early MOV operation that restricted the parser from inferring the value as a float, so I thought we should keep all values as float by default and force to integer only when needed by I32 OPs.

However I started getting a lot of errors from invalid types and had to run, wait to crash, and fix. So I changed the GetSrc implementation to infer the correct value based on return type, not only cleaning the code but making it easier for new OP to be implemented without needing to handle type conversion from GetSrc, including 64-bit types.
