### PR TITLE
SampleCountFlagBits::e16 - GetGpuClock64

### DIFF
--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -312,13 +312,6 @@ struct PM4CmdEventWriteEop {
         return data_lo | u64(data_hi) << 32;
     }
 
-    uint64_t GetGpuClock64() const {
-        auto now = std::chrono::high_resolution_clock::now();
-        auto duration = now.time_since_epoch();
-        auto ticks = std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count();
-        return static_cast<uint64_t>(ticks);
-    }
-
     void SignalFence() const {
         switch (data_sel.Value()) {
         case DataSelect::None: {

--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -662,6 +662,10 @@ struct PM4CmdReleaseMem {
             *Address<u64>() = DataQWord();
             break;
         }
+        case DataSelect::GpuClock64: {
+            // TODO
+            break;
+        }
         case DataSelect::PerfCounter: {
             *Address<u64>() = Common::FencedRDTSC();
             break;

--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -312,6 +312,13 @@ struct PM4CmdEventWriteEop {
         return data_lo | u64(data_hi) << 32;
     }
 
+    uint64_t GetGpuClock64() const {
+        auto now = std::chrono::high_resolution_clock::now();
+        auto duration = now.time_since_epoch();
+        auto ticks = std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count();
+        return static_cast<uint64_t>(ticks);
+    }
+
     void SignalFence() const {
         switch (data_sel.Value()) {
         case DataSelect::None: {
@@ -336,7 +343,7 @@ struct PM4CmdEventWriteEop {
 
         switch (int_sel.Value()) {
         case InterruptSelect::None: {
-            // No interrupt
+            *Address<u64>() = GetGpuClock64();
             break;
         }
         case InterruptSelect::IrqOnly:

--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -343,7 +343,7 @@ struct PM4CmdEventWriteEop {
 
         switch (int_sel.Value()) {
         case InterruptSelect::None: {
-            *Address<u64>() = GetGpuClock64();
+            // No interrupt
             break;
         }
         case InterruptSelect::IrqOnly:
@@ -659,6 +659,13 @@ struct PM4CmdReleaseMem {
         return data_lo | u64(data_hi) << 32;
     }
 
+    uint64_t GetGpuClock64() const {
+        auto now = std::chrono::high_resolution_clock::now();
+        auto duration = now.time_since_epoch();
+        auto ticks = std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count();
+        return static_cast<uint64_t>(ticks);
+    }
+
     void SignalFence(Platform::InterruptId irq_id) const {
         switch (data_sel.Value()) {
         case DataSelect::Data32Low: {
@@ -670,7 +677,7 @@ struct PM4CmdReleaseMem {
             break;
         }
         case DataSelect::GpuClock64: {
-            // TODO
+            *Address<u64>() = GetGpuClock64();
             break;
         }
         case DataSelect::PerfCounter: {

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -681,6 +681,8 @@ vk::SampleCountFlagBits NumSamples(u32 num_samples) {
         return vk::SampleCountFlagBits::e4;
     case 8:
         return vk::SampleCountFlagBits::e8;
+    case 16:
+        return vk::SampleCountFlagBits::e16;
     default:
         UNREACHABLE();
     }


### PR DESCRIPTION
Fix: `[Debug] <Critical> liverpool_to_vk.cpp:NumSamples:685: Unreachable code!`

Used in CUSA05795, as mentioned by Stephen on discord.

----

GpuClock64 Used in CUSA01322