### PR TITLE
qt_gui: Added double-click game icon to start game

### DIFF
--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -179,32 +179,11 @@ void MainWindow::CreateConnects() {
         }
     });
 
-    connect(ui->playButton, &QPushButton::clicked, this, [this]() {
-        QString gamePath = "";
-        int table_mode = Config::getTableMode();
-        if (table_mode == 0) {
-            if (m_game_list_frame->currentItem()) {
-                int itemID = m_game_list_frame->currentItem()->row();
-                gamePath = QString::fromStdString(m_game_info->m_games[itemID].path + "/eboot.bin");
-            }
-        } else if (table_mode == 1) {
-            if (m_game_grid_frame->cellClicked) {
-                int itemID = (m_game_grid_frame->crtRow * m_game_grid_frame->columnCnt) +
-                             m_game_grid_frame->crtColumn;
-                gamePath = QString::fromStdString(m_game_info->m_games[itemID].path + "/eboot.bin");
-            }
-        } else {
-            if (m_elf_viewer->currentItem()) {
-                int itemID = m_elf_viewer->currentItem()->row();
-                gamePath = QString::fromStdString(m_elf_viewer->m_elf_list[itemID].toStdString());
-            }
-        }
-        if (gamePath != "") {
-            AddRecentFiles(gamePath);
-            Core::Emulator emulator;
-            emulator.Run(gamePath.toUtf8().constData());
-        }
-    });
+    connect(ui->playButton, &QPushButton::clicked, this, &MainWindow::StartGame);
+    connect(m_game_grid_frame.get(), &QTableWidget::cellDoubleClicked, this,
+            &MainWindow::StartGame);
+    connect(m_game_list_frame.get(), &QTableWidget::cellDoubleClicked, this,
+            &MainWindow::StartGame);
 
     connect(ui->setIconSizeTinyAct, &QAction::triggered, this, [this]() {
         if (isTableList) {
@@ -384,6 +363,33 @@ void MainWindow::CreateConnects() {
             isIconBlack = false;
         }
     });
+}
+
+void MainWindow::StartGame() {
+    QString gamePath = "";
+    int table_mode = Config::getTableMode();
+    if (table_mode == 0) {
+        if (m_game_list_frame->currentItem()) {
+            int itemID = m_game_list_frame->currentItem()->row();
+            gamePath = QString::fromStdString(m_game_info->m_games[itemID].path + "/eboot.bin");
+        }
+    } else if (table_mode == 1) {
+        if (m_game_grid_frame->cellClicked) {
+            int itemID = (m_game_grid_frame->crtRow * m_game_grid_frame->columnCnt) +
+                         m_game_grid_frame->crtColumn;
+            gamePath = QString::fromStdString(m_game_info->m_games[itemID].path + "/eboot.bin");
+        }
+    } else {
+        if (m_elf_viewer->currentItem()) {
+            int itemID = m_elf_viewer->currentItem()->row();
+            gamePath = QString::fromStdString(m_elf_viewer->m_elf_list[itemID].toStdString());
+        }
+    }
+    if (gamePath != "") {
+        AddRecentFiles(gamePath);
+        Core::Emulator emulator;
+        emulator.Run(gamePath.toUtf8().constData());
+    }
 }
 
 void MainWindow::SearchGameTable(const QString& text) {

--- a/src/qt_gui/main_window.h
+++ b/src/qt_gui/main_window.h
@@ -39,6 +39,7 @@ public:
     bool Init();
     void InstallDragDropPkg(std::filesystem::path file, int pkgNum, int nPkg);
     void InstallDirectory();
+    void StartGame();
 
 private Q_SLOTS:
     void ConfigureGuiFromSettings();


### PR DESCRIPTION
This should make it so that double-clicking the game icon starts the selected game. This is similar to emulators like RPCS3, Dolphin, Cemu and the like. I have had to redo the entire fork so I hope this works this time.