### PR TITLE
qt_gui: Refreshing game list after install directory change

### DIFF
--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -583,6 +583,7 @@ void MainWindow::InstallDragDropPkg(std::filesystem::path file, int pkgNum, int 
 void MainWindow::InstallDirectory() {
     GameInstallDialog dlg;
     dlg.exec();
+    RefreshGameTable();
 }
 
 void MainWindow::SetLastUsedTheme() {


### PR DESCRIPTION
The game list wasn't being refreshed automaticly after a manual directory change on the QT GUI,  now the RefreshGameTable will be called after the GameInstallDialog is executed.