### PR TITLE
361: Game directory window appears every time

### DIFF
--- a/src/qt_gui/main.cpp
+++ b/src/qt_gui/main.cpp
@@ -21,8 +21,11 @@ int main(int argc, char* argv[]) {
     Config::load(user_dir / "config.toml");
     std::filesystem::create_directory(user_dir / "game_data");
 
+    // Check if elf or eboot.bin path was passed as a command line argument
+    bool has_command_line_argument = argc > 1;
+
     // Check if the game install directory is set
-    if (Config::getGameInstallDir() == "") {
+    if (Config::getGameInstallDir() == "" && !has_command_line_argument) {
         GameInstallDialog dlg;
         dlg.exec();
     }
@@ -35,7 +38,7 @@ int main(int argc, char* argv[]) {
     m_main_window->Init();
 
     // Check for command line arguments
-    if (argc > 1) {
+    if (has_command_line_argument) {
         Core::Emulator emulator;
         emulator.Run(argv[1]);
     }


### PR DESCRIPTION
qt_gui: When a command line argument is passed to the GUI version, it will always prompt to change the game directory. 
This happens because the "user" folder is created on the elf or eboot.bin location. 
This change will ignore the game install directory configuration at startup when an command line argument is passed. 
Since if a game was passed, it should start automatically as this is the expected behaviour.