### PR TITLE
qt_gui: Added stopping games by esc or stop button

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,6 +578,8 @@ else()
         src/emulator.h
         src/sdl_window.h
         src/sdl_window.cpp
+        src/sdl_window_manager.cpp
+        src/sdl_window_manager.h
     )
 endif()
 

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -15,6 +15,7 @@
 #include "core/loader.h"
 #include "game_install_dialog.h"
 #include "main_window.h"
+#include "sdl_window_manager.h"
 
 MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWindow) {
     ui->setupUi(this);
@@ -184,6 +185,8 @@ void MainWindow::CreateConnects() {
             &MainWindow::StartGame);
     connect(m_game_list_frame.get(), &QTableWidget::cellDoubleClicked, this,
             &MainWindow::StartGame);
+
+    connect(ui->stopButton, &QPushButton::clicked, this, &MainWindow::StopGame);
 
     connect(ui->setIconSizeTinyAct, &QAction::triggered, this, [this]() {
         if (isTableList) {
@@ -390,6 +393,10 @@ void MainWindow::StartGame() {
         Core::Emulator emulator;
         emulator.Run(gamePath.toUtf8().constData());
     }
+}
+
+void MainWindow::StopGame() {
+    Frontend::QuitAllSDLWindows();
 }
 
 void MainWindow::SearchGameTable(const QString& text) {

--- a/src/qt_gui/main_window.h
+++ b/src/qt_gui/main_window.h
@@ -40,6 +40,7 @@ public:
     void InstallDragDropPkg(std::filesystem::path file, int pkgNum, int nPkg);
     void InstallDirectory();
     void StartGame();
+    void StopGame();
 
 private Q_SLOTS:
     void ConfigureGuiFromSettings();

--- a/src/sdl_window.cpp
+++ b/src/sdl_window.cpp
@@ -12,6 +12,7 @@
 #include "input/controller.h"
 #include "sdl_window.h"
 #include "video_core/renderdoc.h"
+#include "sdl_window_manager.h"
 
 #ifdef __APPLE__
 #include <SDL3/SDL_metal.h>
@@ -264,6 +265,11 @@ void WindowSDL::onKeyPress(const SDL_Event* event) {
         break;
     case SDLK_SPACE:
         button = OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_TOUCH_PAD;
+        break;
+    case SDLK_ESCAPE:
+        if (event->type == SDL_EVENT_KEY_UP) {
+            Frontend::QuitAllSDLWindows();
+        }
         break;
     default:
         break;

--- a/src/sdl_window_manager.cpp
+++ b/src/sdl_window_manager.cpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <SDL3/SDL_events.h>
+
+namespace Frontend {
+
+void QuitAllSDLWindows() {
+    // In the future, windows would have to be stored accessibly outside functions to close just a
+    // specific window
+    SDL_Event quitEvent;
+    quitEvent.type = SDL_EVENT_QUIT;
+    SDL_PushEvent(&quitEvent);
+}
+
+} // namespace Frontend

--- a/src/sdl_window_manager.h
+++ b/src/sdl_window_manager.h
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+namespace Frontend {
+
+void QuitAllSDLWindows();
+
+} // namespace Frontend


### PR DESCRIPTION
This PR should theoretically add stopping games by either pressing escape or the stop button in the main window. This is implemented by creating a SDL window manager that's only current use is to hold a function that simply sends a quit event in order to close the window (less invasive than adding SDL headers into QT classes, also can be expanded in the future).