### PR TITLE
Use create_directories in sceKernelMkdir instead of create_directory

### DIFF
--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -268,7 +268,7 @@ int PS4_SYSV_ABI sceKernelMkdir(const char* path, u16 mode) {
     }
 
     // CUSA02456: path = /aotl after sceSaveDataMount(mode = 1)
-    if (dir_name.empty() || !std::filesystem::create_directory(dir_name)) {
+    if (dir_name.empty() || !std::filesystem::create_directories(dir_name)) {
         return SCE_KERNEL_ERROR_EIO;
     }
 


### PR DESCRIPTION
Fixes an error thrown when launching CUSA00568 because it attempts to make `/app0/temp/stress_cores` without making `/app0/temp` first