### PR TITLE
vk_instance.cpp: Prefer device with most recent ApiVersion

### DIFF
--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -73,7 +73,7 @@ Instance::Instance(Frontend::WindowSDL& window, s32 physical_device_index,
             const vk::PhysicalDeviceProperties& left_prop = std::get<1>(left).properties;
             const vk::PhysicalDeviceProperties& right_prop = std::get<1>(right).properties;
             if (left_prop.apiVersion >= TargetVulkanApiVersion &&
-                right_prop.apiVersion < TargetVulkanApiVersion) {
+                right_prop.apiVersion < left_prop.apiVersion) {
                 return true;
             }
             if (left_prop.deviceType != right_prop.deviceType) {


### PR DESCRIPTION
Changed to prefer the GPU with support for the most recent VulkanApiVersion to avoid selecting the onboard GPU. If both GPUs have support for the same version it will consider the memory heap size while sorting physical devices.

This should solve the issues people are having on https://github.com/shadps4-emu/shadPS4/issues/232.
The problem is that in some cases the GPU selected was the onboard GPU. Another solution would be to change the TargetVulkanApiVersion from VK_API_VERSION_1_2 to VK_API_VERSION_1_3.
https://github.com/shadps4-emu/shadPS4/blob/ab56665d4b75e13e99e824dc531b8642d0377632/src/video_core/renderer_vulkan/vk_platform.h#L20
But since I don't know what problems this might cause this pull request should be the safest fix.