### PR TITLE
thread_management.cpp: Various Mandatory Threading Fixes | Resolve #398

### DIFF
--- a/src/core/libraries/kernel/memory_management.cpp
+++ b/src/core/libraries/kernel/memory_management.cpp
@@ -212,9 +212,9 @@ s32 PS4_SYSV_ABI sceKernelAvailableFlexibleMemorySize(size_t* out_size) {
     return ORBIS_OK;
 }
 
-void PS4_SYSV_ABI _sceKernelRtldSetApplicationHeapAPI(void* func) {
+void PS4_SYSV_ABI _sceKernelRtldSetApplicationHeapAPI(void* func[]) {
     auto* linker = Common::Singleton<Core::Linker>::Instance();
-    linker->SetHeapApiFunc(func);
+    linker->SetHeapAPI(func);
 }
 
 int PS4_SYSV_ABI sceKernelGetDirectMemoryType(u64 addr, int* directMemoryTypeOut,

--- a/src/core/libraries/kernel/memory_management.h
+++ b/src/core/libraries/kernel/memory_management.h
@@ -98,7 +98,7 @@ int PS4_SYSV_ABI sceKernelQueryMemoryProtection(void* addr, void** start, void**
 int PS4_SYSV_ABI sceKernelDirectMemoryQuery(u64 offset, int flags, OrbisQueryInfo* query_info,
                                             size_t infoSize);
 s32 PS4_SYSV_ABI sceKernelAvailableFlexibleMemorySize(size_t* sizeOut);
-void PS4_SYSV_ABI _sceKernelRtldSetApplicationHeapAPI(void* func);
+void PS4_SYSV_ABI _sceKernelRtldSetApplicationHeapAPI(void* func[]);
 int PS4_SYSV_ABI sceKernelGetDirectMemoryType(u64 addr, int* directMemoryTypeOut,
                                               void** directMemoryStartOut,
                                               void** directMemoryEndOut);

--- a/src/core/libraries/kernel/thread_management.cpp
+++ b/src/core/libraries/kernel/thread_management.cpp
@@ -421,13 +421,17 @@ ScePthreadMutex* createMutex(ScePthreadMutex* addr) {
     return addr;
 }
 
-int PS4_SYSV_ABI scePthreadMutexInit(ScePthreadMutex* mutex, const ScePthreadMutexattr* attr,
+int PS4_SYSV_ABI scePthreadMutexInit(ScePthreadMutex* mutex, const ScePthreadMutexattr* mutex_attr,
                                      const char* name) {
+    const ScePthreadMutexattr* attr;
+
     if (mutex == nullptr) {
         return SCE_KERNEL_ERROR_EINVAL;
     }
-    if (attr == nullptr) {
+    if (mutex_attr == nullptr || *mutex_attr == nullptr) {
         attr = g_pthread_cxt->getDefaultMutexattr();
+    } else {
+        attr = mutex_attr;
     }
 
     *mutex = new PthreadMutexInternal{};

--- a/src/core/libraries/kernel/thread_management.cpp
+++ b/src/core/libraries/kernel/thread_management.cpp
@@ -434,7 +434,7 @@ int PS4_SYSV_ABI scePthreadMutexInit(ScePthreadMutex* mutex, const ScePthreadMut
         if (*mutex_attr == nullptr) {
             attr = g_pthread_cxt->getDefaultMutexattr();
         } else {
-            attr = *mutex_attr;
+            attr = mutex_attr;
         }
     }
 

--- a/src/core/libraries/kernel/thread_management.cpp
+++ b/src/core/libraries/kernel/thread_management.cpp
@@ -428,10 +428,14 @@ int PS4_SYSV_ABI scePthreadMutexInit(ScePthreadMutex* mutex, const ScePthreadMut
     if (mutex == nullptr) {
         return SCE_KERNEL_ERROR_EINVAL;
     }
-    if (mutex_attr == nullptr || *mutex_attr == nullptr) {
+    if (mutex_attr == nullptr) {
         attr = g_pthread_cxt->getDefaultMutexattr();
     } else {
-        attr = mutex_attr;
+        if (*mutex_attr == nullptr) {
+            attr = g_pthread_cxt->getDefaultMutexattr();
+        } else {
+            attr = *mutex_attr;
+        }
     }
 
     *mutex = new PthreadMutexInternal{};

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -305,7 +305,7 @@ void* Linker::TlsGetAddr(u64 module_index, u64 offset) {
         // Module was just loaded by above code. Allocate TLS block for it.
         Module* module = m_modules[module_index - 1].get();
         const u32 init_image_size = module->tls.init_image_size;
-        u8* dest = reinterpret_cast<u8*>(heap_api_func(module->tls.image_size));
+        u8* dest = reinterpret_cast<u8*>(heap_api->heap_malloc(module->tls.image_size));
         const u8* src = reinterpret_cast<const u8*>(module->tls.image_virtual_addr);
         std::memcpy(dest, src, init_image_size);
         std::memset(dest + init_image_size, 0, module->tls.image_size - init_image_size);
@@ -335,8 +335,8 @@ void Linker::InitTlsForThread(bool is_primary) {
             &addr_out, tls_aligned, 3, 0, "SceKernelPrimaryTcbTls");
         ASSERT_MSG(ret == 0, "Unable to allocate TLS+TCB for the primary thread");
     } else {
-        if (heap_api_func) {
-            addr_out = heap_api_func(total_tls_size);
+        if (heap_api) {
+            addr_out = heap_api->heap_malloc(total_tls_size);
         } else {
             addr_out = std::malloc(total_tls_size);
         }

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -336,9 +336,17 @@ void Linker::InitTlsForThread(bool is_primary) {
         ASSERT_MSG(ret == 0, "Unable to allocate TLS+TCB for the primary thread");
     } else {
         if (heap_api) {
-            addr_out = heap_api->heap_malloc(total_tls_size);
-        } else {
+            LOG_ERROR(Core_Linker, "TLS user malloc called, using std::malloc");
+            // TODO: ref rtld_tls_block_malloc, tls malloc replacement
+            //addr_out = heap_api->heap_malloc(total_tls_size);
             addr_out = std::malloc(total_tls_size);
+            if (!addr_out) {
+                auto pth_id = pthread_self();
+                auto handle = pthread_gethandle(pth_id);
+                ASSERT_MSG(addr_out,
+                           "Cannot allocate TLS block defined for handle=%x, index=%d size=%d",
+                           handle, pth_id, total_tls_size);
+            }
         }
     }
 

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -338,7 +338,7 @@ void Linker::InitTlsForThread(bool is_primary) {
         if (heap_api) {
             LOG_ERROR(Core_Linker, "TLS user malloc called, using std::malloc");
             // TODO: ref rtld_tls_block_malloc, tls malloc replacement
-            //addr_out = heap_api->heap_malloc(total_tls_size);
+            // addr_out = heap_api->heap_malloc(total_tls_size);
             addr_out = std::malloc(total_tls_size);
             if (!addr_out) {
                 auto pth_id = pthread_self();

--- a/src/core/linker.h
+++ b/src/core/linker.h
@@ -49,8 +49,15 @@ struct EntryParams {
 struct HeapAPI {
     PS4_SYSV_ABI void* (*heap_malloc)(size_t);
     PS4_SYSV_ABI void (*heap_free)(void*);
-    PS4_SYSV_ABI void* unkn[4];
-    PS4_SYSV_ABI int (*posix_memalign)(size_t, void**, size_t);
+    PS4_SYSV_ABI void* (*heap_calloc)(size_t, size_t);
+    PS4_SYSV_ABI void* (*heap_realloc)(void*, size_t);
+    PS4_SYSV_ABI void* (*heap_memalign)(size_t, size_t);
+    PS4_SYSV_ABI int (*heap_posix_memalign)(void**, size_t, size_t);
+    // NOTE: Fields below may be inaccurate
+    PS4_SYSV_ABI int (*heap_reallocalign)(void);
+    PS4_SYSV_ABI void (*heap_malloc_stats)(void);
+    PS4_SYSV_ABI int (*heap_malloc_stats_fast)(void);
+    PS4_SYSV_ABI size_t (*heap_malloc_usable_size)(void*);
 };
 
 typedef HeapAPI* AppHeapAPI;

--- a/src/core/linker.h
+++ b/src/core/linker.h
@@ -46,7 +46,14 @@ struct EntryParams {
     const char* argv[3];
 };
 
-using HeapApiFunc = PS4_SYSV_ABI void* (*)(size_t);
+struct HeapAPI {
+    PS4_SYSV_ABI void* (*heap_malloc)(size_t);
+    PS4_SYSV_ABI void (*heap_free)(void*);
+    PS4_SYSV_ABI void* unkn[4];
+    PS4_SYSV_ABI int (*posix_memalign)(size_t, void**, size_t);
+};
+
+typedef HeapAPI* AppHeapAPI;
 
 class Linker {
 public:
@@ -75,8 +82,8 @@ public:
         }
     }
 
-    void SetHeapApiFunc(void* func) {
-        heap_api_func = *reinterpret_cast<HeapApiFunc*>(func);
+    void SetHeapAPI(void* func[]) {
+        heap_api = reinterpret_cast<AppHeapAPI>(func);
     }
 
     void AdvanceGenerationCounter() noexcept {
@@ -104,7 +111,7 @@ private:
     size_t static_tls_size{};
     u32 max_tls_index{};
     u32 num_static_modules{};
-    HeapApiFunc heap_api_func{};
+    AppHeapAPI heap_api{};
     std::vector<std::unique_ptr<Module>> m_modules;
     Loader::SymbolsResolver m_hle_symbols{};
 };

--- a/src/core/linker.h
+++ b/src/core/linker.h
@@ -60,7 +60,7 @@ struct HeapAPI {
     PS4_SYSV_ABI size_t (*heap_malloc_usable_size)(void*);
 };
 
-typedef HeapAPI* AppHeapAPI;
+using AppHeapAPI = HeapAPI*;
 
 class Linker {
 public:


### PR DESCRIPTION
- scePthreadMutexInit did not return default when the mutex attributes were empty, resulting in invalid accesses.
Now, we return default as expected.
- Current HeapAPI was incomplete.
Now it has a full struct with all 10 preset function replacement fields.
Additionally, we now account for the full size 10 array parameter passed to _sceKernelRtldSetApplicationHeapAPI.
- HeapAPI malloc replacement unaccounted for
Now, we at least have a fallback to `std::malloc`, such that allocation completes without early crash within user thread.

Resolves #398 