### PR TITLE
Basic gamepad support through SDL

### DIFF
--- a/src/core/libraries/pad/pad.cpp
+++ b/src/core/libraries/pad/pad.cpp
@@ -419,8 +419,14 @@ int PS4_SYSV_ABI scePadSetForceIntercepted() {
 }
 
 int PS4_SYSV_ABI scePadSetLightBar(s32 handle, const OrbisPadLightBarParam* pParam) {
-    LOG_ERROR(Lib_Pad, "(STUBBED) called");
-    return ORBIS_OK;
+    if (pParam != nullptr) {
+        LOG_INFO(Lib_Pad, "scePadSetLightBar called handle = {} rgb = {} {} {}", handle, pParam->r,
+                 pParam->g, pParam->b);
+        auto* controller = Common::Singleton<Input::GameController>::Instance();
+        controller->SetLightBarRGB(pParam->r, pParam->g, pParam->b);
+        return ORBIS_OK;
+    }
+    return ORBIS_PAD_ERROR_INVALID_ARG;
 }
 
 int PS4_SYSV_ABI scePadSetLightBarBaseBrightness() {
@@ -479,8 +485,14 @@ int PS4_SYSV_ABI scePadSetUserColor() {
 }
 
 int PS4_SYSV_ABI scePadSetVibration(s32 handle, const OrbisPadVibrationParam* pParam) {
-    LOG_DEBUG(Lib_Pad, "(STUBBED) called");
-    return ORBIS_OK;
+    if (pParam != nullptr) {
+        LOG_INFO(Lib_Pad, "scePadSetVibration called handle = {} data = {} , {}", handle,
+                 pParam->smallMotor, pParam->largeMotor);
+        auto* controller = Common::Singleton<Input::GameController>::Instance();
+        controller->SetVibration(pParam->smallMotor, pParam->largeMotor);
+        return ORBIS_OK;
+    }
+    return ORBIS_PAD_ERROR_INVALID_ARG;
 }
 
 int PS4_SYSV_ABI scePadSetVibrationForce() {

--- a/src/input/controller.cpp
+++ b/src/input/controller.cpp
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <SDL3/SDL.h>
 #include "core/libraries/kernel/time_management.h"
 #include "core/libraries/pad/pad.h"
 #include "input/controller.h"
-#include <SDL3/SDL.h>
 
 namespace Input {
 
@@ -126,7 +126,8 @@ void GameController::SetLightBarRGB(u8 r, u8 g, u8 b) {
 
 bool GameController::SetVibration(u8 smallMotor, u8 largeMotor) {
     if (m_sdl_gamepad != nullptr) {
-        return SDL_RumbleGamepad(m_sdl_gamepad, (smallMotor / 255.0f) * 0xFFFF, (largeMotor / 255.0f) * 0xFFFF, -1) == 0;
+        return SDL_RumbleGamepad(m_sdl_gamepad, (smallMotor / 255.0f) * 0xFFFF, 
+                                 (largeMotor / 255.0f) * 0xFFFF, -1) == 0;
     }
     return true;
 }

--- a/src/input/controller.cpp
+++ b/src/input/controller.cpp
@@ -126,7 +126,7 @@ void GameController::SetLightBarRGB(u8 r, u8 g, u8 b) {
 
 bool GameController::SetVibration(u8 smallMotor, u8 largeMotor) {
     if (m_sdl_gamepad != nullptr) {
-        return SDL_RumbleGamepad(m_sdl_gamepad, (smallMotor / 255.0f) * 0xFFFF, 
+        return SDL_RumbleGamepad(m_sdl_gamepad, (smallMotor / 255.0f) * 0xFFFF,
                                  (largeMotor / 255.0f) * 0xFFFF, -1) == 0;
     }
     return true;

--- a/src/input/controller.cpp
+++ b/src/input/controller.cpp
@@ -4,6 +4,7 @@
 #include "core/libraries/kernel/time_management.h"
 #include "core/libraries/pad/pad.h"
 #include "input/controller.h"
+#include <SDL3/SDL.h>
 
 namespace Input {
 
@@ -115,6 +116,30 @@ void GameController::Axis(int id, Input::Axis axis, int value) {
     }
 
     AddState(state);
+}
+
+void GameController::SetLightBarRGB(u8 r, u8 g, u8 b) {
+    if (m_sdl_gamepad != nullptr) {
+        SDL_SetGamepadLED(m_sdl_gamepad, r, g, b);
+    }
+}
+
+bool GameController::SetVibration(u8 smallMotor, u8 largeMotor) {
+    if (m_sdl_gamepad != nullptr) {
+        return SDL_RumbleGamepad(m_sdl_gamepad, (smallMotor / 255.0f) * 0xFFFF, (largeMotor / 255.0f) * 0xFFFF, -1) == 0;
+    }
+    return true;
+}
+
+void GameController::TryOpenSDLController() {
+    if (m_sdl_gamepad == nullptr || !SDL_GamepadConnected(m_sdl_gamepad)) {
+        int gamepad_count;
+        SDL_JoystickID* gamepads = SDL_GetGamepads(&gamepad_count);
+        m_sdl_gamepad = gamepad_count > 0 ? SDL_OpenGamepad(gamepads[0]) : nullptr;
+        SDL_free(gamepads);
+    }
+
+    SetLightBarRGB(0, 0, 255);
 }
 
 } // namespace Input

--- a/src/input/controller.h
+++ b/src/input/controller.h
@@ -6,6 +6,8 @@
 #include <mutex>
 #include "common/types.h"
 
+struct SDL_Gamepad;
+
 namespace Input {
 
 enum class Axis {
@@ -43,6 +45,9 @@ public:
     void CheckButton(int id, u32 button, bool isPressed);
     void AddState(const State& state);
     void Axis(int id, Input::Axis axis, int value);
+    void SetLightBarRGB(u8 r, u8 g, u8 b);
+    bool SetVibration(u8 smallMotor, u8 largeMotor);
+    void TryOpenSDLController();
 
 private:
     struct StateInternal {
@@ -57,6 +62,8 @@ private:
     u32 m_first_state = 0;
     std::array<State, MAX_STATES> m_states;
     std::array<StateInternal, MAX_STATES> m_private;
+
+    SDL_Gamepad* m_sdl_gamepad = nullptr;
 };
 
 } // namespace Input

--- a/src/sdl_window.cpp
+++ b/src/sdl_window.cpp
@@ -289,7 +289,7 @@ void WindowSDL::onGamepadEvent(const SDL_Event* event) {
 
     u32 button = 0;
     Input::Axis axis = Input::Axis::AxisMax;
-    switch (event->type) { 
+    switch (event->type) {
     case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
     case SDL_EVENT_GAMEPAD_BUTTON_UP:
         button = sdlGamepadToOrbisButton(event->gbutton.button);
@@ -316,38 +316,38 @@ int WindowSDL::sdlGamepadToOrbisButton(u8 button) {
     using Libraries::Pad::OrbisPadButtonDataOffset;
 
     switch (button) {
-        case SDL_GAMEPAD_BUTTON_DPAD_DOWN:
-            return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_DOWN;
-        case SDL_GAMEPAD_BUTTON_DPAD_UP:
-            return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_UP;
-        case SDL_GAMEPAD_BUTTON_DPAD_LEFT:
-            return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_LEFT;
-        case SDL_GAMEPAD_BUTTON_DPAD_RIGHT:
-            return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_RIGHT;
-        case SDL_GAMEPAD_BUTTON_SOUTH:
-            return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_CROSS;
-        case SDL_GAMEPAD_BUTTON_NORTH:
-            return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_TRIANGLE;
-        case SDL_GAMEPAD_BUTTON_WEST:
-            return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_SQUARE;
-        case SDL_GAMEPAD_BUTTON_EAST:
-            return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_CIRCLE;
-        case SDL_GAMEPAD_BUTTON_START:
-            return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_OPTIONS;
-        case SDL_GAMEPAD_BUTTON_TOUCHPAD:
-            return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_TOUCH_PAD;
-        case SDL_GAMEPAD_BUTTON_BACK:
-            return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_TOUCH_PAD;
-        case SDL_GAMEPAD_BUTTON_LEFT_SHOULDER:
-            return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_L1;
-        case SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER:
-            return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_R1;
-        case SDL_GAMEPAD_BUTTON_LEFT_STICK:
-            return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_L3;
-        case SDL_GAMEPAD_BUTTON_RIGHT_STICK:
-            return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_R3;
-        default:
-            return 0;
+    case SDL_GAMEPAD_BUTTON_DPAD_DOWN:
+        return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_DOWN;
+    case SDL_GAMEPAD_BUTTON_DPAD_UP:
+        return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_UP;
+    case SDL_GAMEPAD_BUTTON_DPAD_LEFT:
+        return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_LEFT;
+    case SDL_GAMEPAD_BUTTON_DPAD_RIGHT:
+        return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_RIGHT;
+    case SDL_GAMEPAD_BUTTON_SOUTH:
+        return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_CROSS;
+    case SDL_GAMEPAD_BUTTON_NORTH:
+        return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_TRIANGLE;
+    case SDL_GAMEPAD_BUTTON_WEST:
+        return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_SQUARE;
+    case SDL_GAMEPAD_BUTTON_EAST:
+        return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_CIRCLE;
+    case SDL_GAMEPAD_BUTTON_START:
+        return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_OPTIONS;
+    case SDL_GAMEPAD_BUTTON_TOUCHPAD:
+        return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_TOUCH_PAD;
+    case SDL_GAMEPAD_BUTTON_BACK:
+        return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_TOUCH_PAD;
+    case SDL_GAMEPAD_BUTTON_LEFT_SHOULDER:
+        return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_L1;
+    case SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER:
+        return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_R1;
+    case SDL_GAMEPAD_BUTTON_LEFT_STICK:
+        return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_L3;
+    case SDL_GAMEPAD_BUTTON_RIGHT_STICK:
+        return OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_R3;
+    default:
+        return 0;
     }
 }
 

--- a/src/sdl_window.h
+++ b/src/sdl_window.h
@@ -69,6 +69,8 @@ private:
     void onKeyPress(const SDL_Event* event);
     void onGamepadEvent(const SDL_Event* event);
 
+    int sdlGamepadToOrbisButton(u8 button);
+
 private:
     s32 width;
     s32 height;
@@ -77,7 +79,6 @@ private:
     SDL_Window* window{};
     bool is_shown{};
     bool is_open{true};
-    SDL_Gamepad* gamepad{nullptr};
 };
 
 } // namespace Frontend

--- a/src/sdl_window.h
+++ b/src/sdl_window.h
@@ -7,6 +7,7 @@
 #include "common/types.h"
 
 struct SDL_Window;
+struct SDL_Gamepad;
 union SDL_Event;
 
 namespace Input {
@@ -66,6 +67,7 @@ public:
 private:
     void onResize();
     void onKeyPress(const SDL_Event* event);
+    void onGamepadEvent(const SDL_Event* event);
 
 private:
     s32 width;
@@ -75,6 +77,7 @@ private:
     SDL_Window* window{};
     bool is_shown{};
     bool is_open{true};
+    SDL_Gamepad* gamepad{nullptr};
 };
 
 } // namespace Frontend


### PR DESCRIPTION
Ideally we'd have a whole GUI to configure gamepads for every player but that's kind of a long-term goal, so for now I made it just take the first SDL-compatible controller and pass it's buttons and axes to `WindowSDL`'s `controller`, just like the current keyboard handler does. It's not much, but I think it will make early testing less annoying, especially for me with an 80% keyboard with no numpad.