### PR TITLE
video_core: Crucial buffer cache fixes + proper GPU clears

### DIFF
--- a/src/core/file_sys/fs.cpp
+++ b/src/core/file_sys/fs.cpp
@@ -54,6 +54,7 @@ std::filesystem::path MntPoints::GetHostPath(const std::string& guest_directory)
 
     // If the path does not exist attempt to verify this.
     // Retrieve parent path until we find one that exists.
+    std::scoped_lock lk{m_mutex};
     path_parts.clear();
     auto current_path = host_path;
     while (!std::filesystem::exists(current_path)) {

--- a/src/core/libraries/kernel/threads/semaphore.cpp
+++ b/src/core/libraries/kernel/threads/semaphore.cpp
@@ -9,7 +9,6 @@
 #include "common/assert.h"
 #include "common/logging/log.h"
 #include "core/libraries/error_codes.h"
-#include "core/libraries/kernel/thread_management.h"
 #include "core/libraries/libs.h"
 
 namespace Libraries::Kernel {
@@ -82,7 +81,6 @@ public:
 
 public:
     struct WaitingThread : public ListBaseHook {
-        std::string name;
         std::condition_variable cv;
         u32 priority;
         s32 need_count;
@@ -90,7 +88,6 @@ public:
         bool was_cancled{};
 
         explicit WaitingThread(s32 need_count, bool is_fifo) : need_count{need_count} {
-            name = scePthreadSelf()->name;
             if (is_fifo) {
                 return;
             }

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -128,11 +128,7 @@ Id EmitReadConst(EmitContext& ctx) {
 
 Id EmitReadConstBuffer(EmitContext& ctx, u32 handle, Id index) {
     auto& buffer = ctx.buffers[handle];
-    if (!Sirit::ValidId(buffer.offset)) {
-        buffer.offset = ctx.GetBufferOffset(buffer.global_binding);
-    }
-    const Id offset_dwords{ctx.OpShiftRightLogical(ctx.U32[1], buffer.offset, ctx.ConstU32(2U))};
-    index = ctx.OpIAdd(ctx.U32[1], index, offset_dwords);
+    index = ctx.OpIAdd(ctx.U32[1], index, buffer.offset_dwords);
     const Id ptr{ctx.OpAccessChain(buffer.pointer_type, buffer.id, ctx.u32_zero_value, index)};
     return ctx.OpLoad(buffer.data_types->Get(1), ptr);
 }
@@ -229,9 +225,6 @@ Id EmitLoadBufferU32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address) {
 template <u32 N>
 static Id EmitLoadBufferF32xN(EmitContext& ctx, u32 handle, Id address) {
     auto& buffer = ctx.buffers[handle];
-    if (!Sirit::ValidId(buffer.offset)) {
-        buffer.offset = ctx.GetBufferOffset(buffer.global_binding);
-    }
     address = ctx.OpIAdd(ctx.U32[1], address, buffer.offset);
     const Id index = ctx.OpShiftRightLogical(ctx.U32[1], address, ctx.ConstU32(2u));
     if constexpr (N == 1) {
@@ -404,9 +397,6 @@ static Id GetBufferFormatValue(EmitContext& ctx, u32 handle, Id address, u32 com
 template <u32 N>
 static Id EmitLoadBufferFormatF32xN(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address) {
     auto& buffer = ctx.buffers[handle];
-    if (!Sirit::ValidId(buffer.offset)) {
-        buffer.offset = ctx.GetBufferOffset(buffer.global_binding);
-    }
     address = ctx.OpIAdd(ctx.U32[1], address, buffer.offset);
     if constexpr (N == 1) {
         return GetBufferFormatValue(ctx, handle, address, 0);
@@ -438,9 +428,6 @@ Id EmitLoadBufferFormatF32x4(EmitContext& ctx, IR::Inst* inst, u32 handle, Id ad
 template <u32 N>
 static void EmitStoreBufferF32xN(EmitContext& ctx, u32 handle, Id address, Id value) {
     auto& buffer = ctx.buffers[handle];
-    if (!Sirit::ValidId(buffer.offset)) {
-        buffer.offset = ctx.GetBufferOffset(buffer.global_binding);
-    }
     address = ctx.OpIAdd(ctx.U32[1], address, buffer.offset);
     const Id index = ctx.OpShiftRightLogical(ctx.U32[1], address, ctx.ConstU32(2u));
     if constexpr (N == 1) {

--- a/src/shader_recompiler/backend/spirv/emit_spirv_special.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_special.cpp
@@ -6,7 +6,9 @@
 
 namespace Shader::Backend::SPIRV {
 
-void EmitPrologue(EmitContext& ctx) {}
+void EmitPrologue(EmitContext& ctx) {
+    ctx.DefineBufferOffsets();
+}
 
 void EmitEpilogue(EmitContext& ctx) {}
 

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -331,8 +331,9 @@ void EmitContext::DefineBuffers() {
     for (u32 i = 0; const auto& buffer : info.buffers) {
         const auto* data_types = True(buffer.used_types & IR::Type::F32) ? &F32 : &U32;
         const Id data_type = (*data_types)[1];
-        const Id record_array_type{buffer.is_storage ? TypeRuntimeArray(data_type) :
-                                                       TypeArray(data_type, ConstU32(buffer.length))};
+        const Id record_array_type{buffer.is_storage
+                                       ? TypeRuntimeArray(data_type)
+                                       : TypeArray(data_type, ConstU32(buffer.length))};
         const Id struct_type{TypeStruct(record_array_type)};
         if (std::ranges::find(type_ids, record_array_type.value, &Id::value) == type_ids.end()) {
             Decorate(record_array_type, spv::Decoration::ArrayStride, 4);

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -331,7 +331,8 @@ void EmitContext::DefineBuffers() {
     for (u32 i = 0; const auto& buffer : info.buffers) {
         const auto* data_types = True(buffer.used_types & IR::Type::F32) ? &F32 : &U32;
         const Id data_type = (*data_types)[1];
-        const Id record_array_type{TypeArray(data_type, ConstU32(buffer.length))};
+        const Id record_array_type{buffer.is_storage ? TypeRuntimeArray(data_type) :
+                                                       TypeArray(data_type, ConstU32(buffer.length))};
         const Id struct_type{TypeStruct(record_array_type)};
         if (std::ranges::find(type_ids, record_array_type.value, &Id::value) == type_ids.end()) {
             Decorate(record_array_type, spv::Decoration::ArrayStride, 4);

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -40,7 +40,7 @@ public:
     ~EmitContext();
 
     Id Def(const IR::Value& value);
-    Id GetBufferOffset(u32 binding);
+    void DefineBufferOffsets();
 
     [[nodiscard]] Id DefineInput(Id type, u32 location) {
         const Id input_id{DefineVar(type, spv::StorageClass::Input)};
@@ -203,7 +203,8 @@ public:
     struct BufferDefinition {
         Id id;
         Id offset;
-        u32 global_binding;
+        Id offset_dwords;
+        u32 binding;
         const VectorIds* data_types;
         Id pointer_type;
         AmdGpu::Buffer buffer;

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -211,10 +211,10 @@ public:
     void IMAGE_ATOMIC(AtomicOp op, const GcnInst& inst);
 
 private:
-    template <typename T = IR::U32F32>
-    [[nodiscard]] T GetSrc(const InstOperand& operand, bool flt_zero = false);
-    template <typename T = IR::U64F64>
-    [[nodiscard]] T GetSrc64(const InstOperand& operand, bool flt_zero = false);
+    template <typename T = IR::U32>
+    [[nodiscard]] T GetSrc(const InstOperand& operand);
+    template <typename T = IR::U64>
+    [[nodiscard]] T GetSrc64(const InstOperand& operand);
     void SetDst(const InstOperand& operand, const IR::U32F32& value);
     void SetDst64(const InstOperand& operand, const IR::U64F64& value_raw);
 

--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -353,22 +353,8 @@ void Translator::V_CNDMASK_B32(const GcnInst& inst) {
     const IR::U1 flag = inst.src[2].field == OperandField::ScalarGPR
                             ? ir.GetThreadBitScalarReg(flag_reg)
                             : ir.GetVcc();
-
-    // We can treat the instruction as integer most of the time, but when a source is
-    // a floating point constant we will force the other as float for better readability
-    // The other operand is also higly likely to be float as well.
-    const auto is_float_const = [](OperandField field) {
-        return field >= OperandField::ConstFloatPos_0_5 && field <= OperandField::ConstFloatNeg_4_0;
-    };
-    const bool has_flt_source =
-        is_float_const(inst.src[0].field) || is_float_const(inst.src[1].field);
-    if (has_flt_source) {
-        const IR::Value result = ir.Select(flag, GetSrc<IR::F32>(inst.src[1]), GetSrc<IR::F32>(inst.src[0]));
-        ir.SetVectorReg(dst_reg, IR::U32F32{result});
-    } else {
-        const IR::Value result = ir.Select(flag, GetSrc(inst.src[1]), GetSrc(inst.src[0]));
-        ir.SetVectorReg(dst_reg, IR::U32F32{result});
-    }
+    const IR::Value result = ir.Select(flag, GetSrc<IR::F32>(inst.src[1]), GetSrc<IR::F32>(inst.src[0]));
+    ir.SetVectorReg(dst_reg, IR::U32F32{result});
 }
 
 void Translator::V_OR_B32(bool is_xor, const GcnInst& inst) {

--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -709,9 +709,17 @@ void Translator::V_SAD_U32(const GcnInst& inst) {
     const IR::U32 src0{GetSrc(inst.src[0])};
     const IR::U32 src1{GetSrc(inst.src[1])};
     const IR::U32 src2{GetSrc(inst.src[2])};
-    const IR::U32 max{ir.IMax(src0, src1, false)};
-    const IR::U32 min{ir.IMin(src0, src1, false)};
-    SetDst(inst.dst[0], ir.IAdd(ir.ISub(max, min), src2));
+    IR::U32 result;
+    if (src0.IsImmediate() && src0.U32() == 0U) {
+        result = src1;
+    } else if (src1.IsImmediate() && src1.U32() == 0U) {
+        result = src0;
+    } else {
+        const IR::U32 max{ir.IMax(src0, src1, false)};
+        const IR::U32 min{ir.IMin(src0, src1, false)};
+        result = ir.ISub(max, min);
+    }
+    SetDst(inst.dst[0], ir.IAdd(result, src2));
 }
 
 void Translator::V_BFE_U32(bool is_signed, const GcnInst& inst) {

--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -353,7 +353,8 @@ void Translator::V_CNDMASK_B32(const GcnInst& inst) {
     const IR::U1 flag = inst.src[2].field == OperandField::ScalarGPR
                             ? ir.GetThreadBitScalarReg(flag_reg)
                             : ir.GetVcc();
-    const IR::Value result = ir.Select(flag, GetSrc<IR::F32>(inst.src[1]), GetSrc<IR::F32>(inst.src[0]));
+    const IR::Value result =
+        ir.Select(flag, GetSrc<IR::F32>(inst.src[1]), GetSrc<IR::F32>(inst.src[0]));
     ir.SetVectorReg(dst_reg, IR::U32F32{result});
 }
 

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -8,7 +8,6 @@
 #include "video_core/amdgpu/liverpool.h"
 #include "video_core/buffer_cache/buffer_cache.h"
 #include "video_core/renderer_vulkan/liverpool_to_vk.h"
-#include "video_core/renderer_vulkan/liverpool_to_vk.h"
 #include "video_core/renderer_vulkan/vk_instance.h"
 #include "video_core/renderer_vulkan/vk_scheduler.h"
 

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -134,7 +134,8 @@ bool BufferCache::BindVertexBuffers(const Shader::Info& vs_info) {
         attributes.push_back({
             .location = input.binding,
             .binding = input.binding,
-            .format = Vulkan::LiverpoolToVK::SurfaceFormat(buffer.GetDataFmt(), buffer.GetNumberFmt()),
+            .format =
+                Vulkan::LiverpoolToVK::SurfaceFormat(buffer.GetDataFmt(), buffer.GetNumberFmt()),
             .offset = 0,
         });
         bindings.push_back({

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -69,11 +69,17 @@ public:
     /// Obtains a buffer for the specified region.
     [[nodiscard]] std::pair<Buffer*, u32> ObtainBuffer(VAddr gpu_addr, u32 size, bool is_written);
 
+    /// Obtains a temporary buffer for usage in texture cache.
+    [[nodiscard]] std::pair<const Buffer*, u32> ObtainTempBuffer(VAddr gpu_addr, u32 size);
+
     /// Return true when a region is registered on the cache
     [[nodiscard]] bool IsRegionRegistered(VAddr addr, size_t size);
 
     /// Return true when a CPU region is modified from the CPU
     [[nodiscard]] bool IsRegionCpuModified(VAddr addr, size_t size);
+
+    /// Return true when a CPU region is modified from the GPU
+    [[nodiscard]] bool IsRegionGpuModified(VAddr addr, size_t size);
 
 private:
     template <typename Func>

--- a/src/video_core/renderer_vulkan/renderer_vulkan.h
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.h
@@ -47,7 +47,7 @@ public:
     Frame* PrepareFrame(const Libraries::VideoOut::BufferAttributeGroup& attribute,
                         VAddr cpu_address, bool is_eop) {
         const auto info = VideoCore::ImageInfo{attribute, cpu_address};
-        const auto image_id = texture_cache.FindImage(info, false);
+        const auto image_id = texture_cache.FindImage(info);
         auto& image = texture_cache.GetImage(image_id);
         return PrepareFrameInternal(image, is_eop);
     }
@@ -61,7 +61,7 @@ public:
         const Libraries::VideoOut::BufferAttributeGroup& attribute, VAddr cpu_address) {
         vo_buffers_addr.emplace_back(cpu_address);
         const auto info = VideoCore::ImageInfo{attribute, cpu_address};
-        const auto image_id = texture_cache.FindImage(info, false);
+        const auto image_id = texture_cache.FindImage(info);
         return texture_cache.GetImage(image_id);
     }
 

--- a/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
@@ -96,7 +96,7 @@ bool ComputePipeline::BindResources(VideoCore::BufferCache& buffer_cache,
     Shader::PushData push_data{};
     u32 binding{};
 
-    for (u32 i = 0; const auto& buffer : info.buffers) {
+    for (const auto& buffer : info.buffers) {
         const auto vsharp = buffer.GetVsharp(info);
         const VAddr address = vsharp.base_address;
         // Most of the time when a metadata is updated with a shader it gets cleared. It means we
@@ -115,7 +115,7 @@ bool ComputePipeline::BindResources(VideoCore::BufferCache& buffer_cache,
         }
         const u32 size = vsharp.GetSize();
         if (buffer.is_written) {
-            texture_cache.InvalidateMemory(address, size);
+            texture_cache.InvalidateMemory(address, size, true);
         }
         const u32 alignment =
             buffer.is_storage ? instance.StorageMinAlignment() : instance.UniformMinAlignment();
@@ -137,7 +137,6 @@ bool ComputePipeline::BindResources(VideoCore::BufferCache& buffer_cache,
                                                 : vk::DescriptorType::eUniformBuffer,
             .pBufferInfo = &buffer_infos.back(),
         });
-        i++;
     }
 
     for (const auto& image_desc : info.images) {

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -145,6 +145,9 @@ GraphicsPipeline::GraphicsPipeline(const Instance& instance_, Scheduler& schedul
         dynamic_states.push_back(vk::DynamicState::eColorWriteEnableEXT);
         dynamic_states.push_back(vk::DynamicState::eColorWriteMaskEXT);
     }
+    if (instance.IsVertexInputDynamicState()) {
+        dynamic_states.push_back(vk::DynamicState::eVertexInputEXT);
+    }
 
     const vk::PipelineDynamicStateCreateInfo dynamic_info = {
         .dynamicStateCount = static_cast<u32>(dynamic_states.size()),

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -202,6 +202,8 @@ bool Instance::CreateDevice() {
     add_extension(VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME);
     workgroup_memory_explicit_layout =
         add_extension(VK_KHR_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_EXTENSION_NAME);
+    vertex_input_dynamic_state = add_extension(VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
+
     // The next two extensions are required to be available together in order to support write masks
     color_write_en = add_extension(VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME);
     color_write_en &= add_extension(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
@@ -319,6 +321,9 @@ bool Instance::CreateDevice() {
         vk::PhysicalDeviceSynchronization2Features{
             .synchronization2 = true,
         },
+        vk::PhysicalDeviceVertexInputDynamicStateFeaturesEXT{
+            .vertexInputDynamicState = true,
+        },
     };
 
     if (!color_write_en) {
@@ -331,8 +336,8 @@ bool Instance::CreateDevice() {
     } else {
         device_chain.unlink<vk::PhysicalDeviceRobustness2FeaturesEXT>();
     }
-    if (!has_sync2) {
-        device_chain.unlink<vk::PhysicalDeviceSynchronization2Features>();
+    if (!vertex_input_dynamic_state) {
+        device_chain.unlink<vk::PhysicalDeviceVertexInputDynamicStateFeaturesEXT>();
     }
 
     try {

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -132,6 +132,11 @@ public:
         return color_write_en;
     }
 
+    /// Returns true when VK_EXT_vertex_input_dynamic_state is supported.
+    bool IsVertexInputDynamicState() const {
+        return vertex_input_dynamic_state;
+    }
+
     /// Returns the vendor ID of the physical device
     u32 GetVendorID() const {
         return properties.vendorID;
@@ -257,6 +262,7 @@ private:
     bool external_memory_host{};
     bool workgroup_memory_explicit_layout{};
     bool color_write_en{};
+    bool vertex_input_dynamic_state{};
     u64 min_imported_host_pointer_alignment{};
     u32 subgroup_size{};
     bool tooling_info{};

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -209,6 +209,10 @@ void PipelineCache::RefreshGraphicsKey() {
             continue;
         }
         const auto* bininfo = Liverpool::GetBinaryInfo(*pgm);
+        if (!bininfo->Valid()) {
+            key.stage_hashes[i] = 0;
+            continue;
+        }
         key.stage_hashes[i] = bininfo->shader_hash;
     }
 }

--- a/src/video_core/texture_cache/image.cpp
+++ b/src/video_core/texture_cache/image.cpp
@@ -117,6 +117,7 @@ Image::Image(const Vulkan::Instance& instance_, Vulkan::Scheduler& scheduler_,
     : instance{&instance_}, scheduler{&scheduler_}, info{info_},
       image{instance->GetDevice(), instance->GetAllocator()}, cpu_addr{info.guest_address},
       cpu_addr_end{cpu_addr + info.guest_size_bytes} {
+    mip_hashes.resize(info.resources.levels);
     ASSERT(info.pixel_format != vk::Format::eUndefined);
     // Here we force `eExtendedUsage` as don't know all image usage cases beforehand. In normal case
     // the texture cache should re-create the resource with the usage requested

--- a/src/video_core/texture_cache/image.h
+++ b/src/video_core/texture_cache/image.h
@@ -111,6 +111,7 @@ struct Image {
     vk::Flags<vk::PipelineStageFlagBits> pl_stage = vk::PipelineStageFlagBits::eAllCommands;
     vk::Flags<vk::AccessFlagBits> access_mask = vk::AccessFlagBits::eNone;
     vk::ImageLayout layout = vk::ImageLayout::eUndefined;
+    boost::container::small_vector<u64, 14> mip_hashes;
 };
 
 } // namespace VideoCore

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -3,8 +3,8 @@
 
 #include <xxhash.h>
 #include "common/assert.h"
-#include "video_core/page_manager.h"
 #include "video_core/buffer_cache/buffer_cache.h"
+#include "video_core/page_manager.h"
 #include "video_core/renderer_vulkan/vk_instance.h"
 #include "video_core/renderer_vulkan/vk_scheduler.h"
 #include "video_core/texture_cache/texture_cache.h"
@@ -255,10 +255,10 @@ void TextureCache::RefreshImage(Image& image) {
             .bufferRowLength = static_cast<u32>(mip_pitch),
             .bufferImageHeight = static_cast<u32>(mip_height),
             .imageSubresource{
-              .aspectMask = vk::ImageAspectFlagBits::eColor,
-              .mipLevel = m,
-              .baseArrayLayer = 0,
-              .layerCount = num_layers,
+                .aspectMask = vk::ImageAspectFlagBits::eColor,
+                .mipLevel = m,
+                .baseArrayLayer = 0,
+                .layerCount = num_layers,
             },
             .imageOffset = {0, 0, 0},
             .imageExtent = {width, height, depth},

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -31,9 +31,12 @@ TextureCache::TextureCache(const Vulkan::Instance& instance_, Vulkan::Scheduler&
 
 TextureCache::~TextureCache() = default;
 
-void TextureCache::InvalidateMemory(VAddr address, size_t size) {
+void TextureCache::InvalidateMemory(VAddr address, size_t size, bool from_compute) {
     std::unique_lock lock{mutex};
     ForEachImageInRegion(address, size, [&](ImageId image_id, Image& image) {
+        if (from_compute && !image.Overlaps(address, size)) {
+            return;
+        }
         // Ensure image is reuploaded when accessed again.
         image.flags |= ImageFlagBits::CpuModified;
         // Untrack image, so the range is unprotected and the guest can write freely.

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -38,7 +38,7 @@ public:
     ~TextureCache();
 
     /// Invalidates any image in the logical page range.
-    void InvalidateMemory(VAddr address, size_t size);
+    void InvalidateMemory(VAddr address, size_t size, bool from_compute = false);
 
     /// Evicts any images that overlap the unmapped range.
     void UnmapMemory(VAddr cpu_addr, size_t size);

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -44,7 +44,7 @@ public:
     void UnmapMemory(VAddr cpu_addr, size_t size);
 
     /// Retrieves the image handle of the image with the provided attributes.
-    [[nodiscard]] ImageId FindImage(const ImageInfo& info, bool refresh_on_create = true);
+    [[nodiscard]] ImageId FindImage(const ImageInfo& info);
 
     /// Retrieves an image view with the properties of the specified image descriptor.
     [[nodiscard]] ImageView& FindTexture(const ImageInfo& image_info,
@@ -57,6 +57,16 @@ public:
     /// Retrieves the depth target with specified properties
     [[nodiscard]] ImageView& FindDepthTarget(const ImageInfo& image_info,
                                              const ImageViewInfo& view_info);
+
+    /// Updates image contents if it was modified by CPU.
+    void UpdateImage(ImageId image_id) {
+        Image& image = slot_images[image_id];
+        if (False(image.flags & ImageFlagBits::CpuModified)) {
+            return;
+        }
+        RefreshImage(image);
+        TrackImage(image, image_id);
+    }
 
     /// Reuploads image contents.
     void RefreshImage(Image& image);
@@ -170,7 +180,6 @@ private:
     Vulkan::Scheduler& scheduler;
     BufferCache& buffer_cache;
     PageManager& tracker;
-    StreamBuffer staging;
     TileManager tile_manager;
     Common::SlotVector<Image> slot_images;
     Common::SlotVector<ImageView> slot_image_views;

--- a/src/video_core/texture_cache/tile_manager.cpp
+++ b/src/video_core/texture_cache/tile_manager.cpp
@@ -5,7 +5,6 @@
 #include "video_core/renderer_vulkan/vk_scheduler.h"
 #include "video_core/renderer_vulkan/vk_shader_util.h"
 #include "video_core/texture_cache/image_view.h"
-#include "video_core/texture_cache/texture_cache.h"
 #include "video_core/texture_cache/tile_manager.h"
 
 #include "video_core/host_shaders/detile_m32x1_comp.h"


### PR DESCRIPTION
Cherry-pick from https://github.com/shadps4-emu/shadPS4/pull/370 mostly.
* Buffer offsets are now defined upfront. We can't define them on demand like previously as a buffer access might be inside a scope. If the same buffer is accessed again under a different scope it is invalid to reuse the Id of offset.
* Use hashes to protect images from accidental re-upload. Guest might write some CPU data to the same page as a render target for example. This also fixes some flickering in simpler 2D games due to that.
* When refreshing an image attempt to use a buffer provided from the buffer cache instead of uploading always from CPU. This particularly affects clears as guest performs them by writing to memory region of render target viewed as SSBO. Now the entire process can happen in the GPU giving more performance, and more correctness; we no longer upload whatever garbage values the CPU had in that region