### PR TITLE
video_core: CPU flip relay

### DIFF
--- a/src/core/libraries/videoout/driver.h
+++ b/src/core/libraries/videoout/driver.h
@@ -102,6 +102,7 @@ private:
     };
 
     std::chrono::microseconds Flip(const Request& req);
+    bool SubmitFlipInternal(VideoOutPort* port, s32 index, s64 flip_arg, bool is_eop = false);
     void PresentThread(std::stop_token token);
 
     std::mutex mutex;

--- a/src/core/libraries/videoout/driver.h
+++ b/src/core/libraries/videoout/driver.h
@@ -29,6 +29,7 @@ struct VideoOutPort {
     std::vector<Kernel::SceKernelEqueue> flip_events;
     std::vector<Kernel::SceKernelEqueue> vblank_events;
     std::mutex vo_mutex;
+    std::mutex port_mutex;
     std::condition_variable vo_cv;
     std::condition_variable vblank_cv;
     int flip_rate = 0;
@@ -93,7 +94,6 @@ private:
         VideoOutPort* port;
         s32 index;
         s64 flip_arg;
-        u64 submit_tsc;
         bool eop;
 
         operator bool() const noexcept {

--- a/src/core/libraries/videoout/driver.h
+++ b/src/core/libraries/videoout/driver.h
@@ -102,7 +102,7 @@ private:
     };
 
     std::chrono::microseconds Flip(const Request& req);
-    bool SubmitFlipInternal(VideoOutPort* port, s32 index, s64 flip_arg, bool is_eop = false);
+    void SubmitFlipInternal(VideoOutPort* port, s32 index, s64 flip_arg, bool is_eop = false);
     void PresentThread(std::stop_token token);
 
     std::mutex mutex;

--- a/src/core/libraries/videoout/video_out.cpp
+++ b/src/core/libraries/videoout/video_out.cpp
@@ -113,7 +113,9 @@ s32 PS4_SYSV_ABI sceVideoOutSetFlipRate(s32 handle, s32 rate) {
 
 s32 PS4_SYSV_ABI sceVideoOutIsFlipPending(s32 handle) {
     LOG_INFO(Lib_VideoOut, "called");
-    s32 pending = driver->GetPort(handle)->flip_status.flipPendingNum;
+    auto* port = driver->GetPort(handle);
+    std::unique_lock lock{port->port_mutex};
+    s32 pending = port->flip_status.flipPendingNum;
     return pending;
 }
 
@@ -161,6 +163,7 @@ s32 PS4_SYSV_ABI sceVideoOutGetFlipStatus(s32 handle, FlipStatus* status) {
         return ORBIS_VIDEO_OUT_ERROR_INVALID_HANDLE;
     }
 
+    std::unique_lock lock{port->port_mutex};
     *status = port->flip_status;
 
     LOG_INFO(Lib_VideoOut,

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -11,10 +11,12 @@
 #include <span>
 #include <thread>
 #include <queue>
+
 #include "common/assert.h"
 #include "common/bit_field.h"
 #include "common/polyfill_thread.h"
 #include "common/types.h"
+#include "common/unique_function.h"
 #include "video_core/amdgpu/pixel_format.h"
 #include "video_core/amdgpu/resource.h"
 
@@ -1025,6 +1027,13 @@ public:
         rasterizer = rasterizer_;
     }
 
+    void SendCommand(Common::UniqueFunction<void>&& func) {
+        std::scoped_lock lk{submit_mutex};
+        command_queue.emplace(std::move(func));
+        ++num_commands;
+        submit_cv.notify_one();
+    }
+
 private:
     struct Task {
         struct promise_type {
@@ -1093,9 +1102,11 @@ private:
     Libraries::VideoOut::VideoOutPort* vo_port{};
     std::jthread process_thread{};
     std::atomic<u32> num_submits{};
+    std::atomic<u32> num_commands{};
     std::atomic<bool> submit_done{};
     std::mutex submit_mutex;
     std::condition_variable_any submit_cv;
+    std::queue<Common::UniqueFunction<void>> command_queue{};
 };
 
 static_assert(GFX6_3D_REG_INDEX(ps_program) == 0x2C08);

--- a/src/video_core/renderer_vulkan/renderer_vulkan.h
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.h
@@ -48,13 +48,14 @@ public:
                         VAddr cpu_address, bool is_eop) {
         const auto info = VideoCore::ImageInfo{attribute, cpu_address};
         const auto image_id = texture_cache.FindImage(info);
+        texture_cache.UpdateImage(image_id, is_eop ? nullptr : &flip_scheduler);
         auto& image = texture_cache.GetImage(image_id);
         return PrepareFrameInternal(image, is_eop);
     }
 
-    Frame* PrepareBlankFrame() {
+    Frame* PrepareBlankFrame(bool is_eop) {
         auto& image = texture_cache.GetImage(VideoCore::NULL_IMAGE_ID);
-        return PrepareFrameInternal(image, true);
+        return PrepareFrameInternal(image, is_eop);
     }
 
     VideoCore::Image& RegisterVideoOutSurface(
@@ -74,6 +75,11 @@ public:
     bool ShowSplash(Frame* frame = nullptr);
     void Present(Frame* frame);
     void RecreateFrame(Frame* frame, u32 width, u32 height);
+
+    void FlushDraw() {
+        SubmitInfo info{};
+        draw_scheduler.Flush(info);
+    }
 
 private:
     Frame* PrepareFrameInternal(VideoCore::Image& image, bool is_eop = true);

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -223,7 +223,7 @@ ImageView& TextureCache::FindDepthTarget(const ImageInfo& image_info,
     return RegisterImageView(image_id, view_info);
 }
 
-void TextureCache::RefreshImage(Image& image) {
+void TextureCache::RefreshImage(Image& image, Vulkan::Scheduler* custom_scheduler /*= nullptr*/) {
     // Mark image as validated.
     image.flags &= ~ImageFlagBits::CpuModified;
 
@@ -269,8 +269,10 @@ void TextureCache::RefreshImage(Image& image) {
         return;
     }
 
-    scheduler.EndRendering();
-    const auto cmdbuf = scheduler.CommandBuffer();
+    auto* sched_ptr = custom_scheduler ? custom_scheduler : &scheduler;
+    sched_ptr->EndRendering();
+
+    const auto cmdbuf = sched_ptr->CommandBuffer();
     image.Transit(vk::ImageLayout::eTransferDstOptimal, vk::AccessFlagBits::eTransferWrite, cmdbuf);
 
     const VAddr image_addr = image.info.guest_address;

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -59,17 +59,17 @@ public:
                                              const ImageViewInfo& view_info);
 
     /// Updates image contents if it was modified by CPU.
-    void UpdateImage(ImageId image_id) {
+    void UpdateImage(ImageId image_id, Vulkan::Scheduler* custom_scheduler = nullptr) {
         Image& image = slot_images[image_id];
         if (False(image.flags & ImageFlagBits::CpuModified)) {
             return;
         }
-        RefreshImage(image);
+        RefreshImage(image, custom_scheduler);
         TrackImage(image, image_id);
     }
 
     /// Reuploads image contents.
-    void RefreshImage(Image& image);
+    void RefreshImage(Image& image, Vulkan::Scheduler* custom_scheduler = nullptr);
 
     /// Retrieves the sampler that matches the provided S# descriptor.
     [[nodiscard]] vk::Sampler GetSampler(const AmdGpu::Sampler& sampler);


### PR DESCRIPTION
Cherry-pick from https://github.com/shadps4-emu/shadPS4/pull/370. This PR fixes racing in flip submitted by CPU. 

At the time when the CPU submits a flip request (fence for VO surface access is signaled by the GPU), it may be immediately taken into processing by the presenter thread via `flip_scheduler`. However, all operations made on the surface are recorded in `draw_scheduler`, which needs to be submitted at the time of presentation. This might not be true, as the GPU can have other work to finish before the scheduler flush. With these changes, we postpone CPU flip submission and trigger `draw_scheduler` flush. Then the flip is relayed into the flip queue as it was previously. This ensures the VO surface is presented in the correct state.