### PR TITLE
Fix some Vulkan validation errors on macOS.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_platform.cpp
+++ b/src/video_core/renderer_vulkan/vk_platform.cpp
@@ -157,6 +157,10 @@ std::vector<const char*> GetInstanceExtensions(Frontend::WindowSystemType window
         break;
     }
 
+#ifdef __APPLE__
+    extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+#endif
+
     if (window_type != Frontend::WindowSystemType::Headless) {
         extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
     }
@@ -285,6 +289,9 @@ vk::UniqueInstance CreateInstance(vk::DynamicLoader& dl, Frontend::WindowSystemT
             .ppEnabledLayerNames = layers.data(),
             .enabledExtensionCount = static_cast<u32>(extensions.size()),
             .ppEnabledExtensionNames = extensions.data(),
+#ifdef __APPLE__
+            .flags = vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR,
+#endif
         },
         vk::LayerSettingsCreateInfoEXT{
             .settingCount = layer_setings.size(),

--- a/src/video_core/renderer_vulkan/vk_swapchain.cpp
+++ b/src/video_core/renderer_vulkan/vk_swapchain.cpp
@@ -37,6 +37,16 @@ void Swapchain::Create(u32 width_, u32 height_, vk::SurfaceKHR surface_) {
         instance.GetPresentQueueFamilyIndex(),
     };
 
+    const auto modes = instance.GetPhysicalDevice().getSurfacePresentModesKHR(surface);
+    const auto find_mode = [&modes](vk::PresentModeKHR requested) {
+        const auto it =
+            std::find_if(modes.begin(), modes.end(),
+                         [&requested](vk::PresentModeKHR mode) { return mode == requested; });
+
+        return it != modes.end();
+    };
+    const bool has_mailbox = find_mode(vk::PresentModeKHR::eMailbox);
+
     const bool exclusive = queue_family_indices[0] == queue_family_indices[1];
     const u32 queue_family_indices_count = exclusive ? 1u : 2u;
     const vk::SharingMode sharing_mode =
@@ -55,7 +65,7 @@ void Swapchain::Create(u32 width_, u32 height_, vk::SurfaceKHR surface_) {
         .pQueueFamilyIndices = queue_family_indices.data(),
         .preTransform = transform,
         .compositeAlpha = composite_alpha,
-        .presentMode = vk::PresentModeKHR::eMailbox,
+        .presentMode = has_mailbox ? vk::PresentModeKHR::eMailbox : vk::PresentModeKHR::eImmediate,
         .clipped = true,
         .oldSwapchain = nullptr,
     };


### PR DESCRIPTION
* Set up portability extension requirements to allow using the standard Vulkan loader on macOS, which in turn allows loading validation layers.
* Fix some validation errors for unsupported extensions in the device structure chain.
* Fix using mailbox present mode when unsupported, which was also causing frame pacing issues on macOS.