### PR TITLE
video_core: Various fixes

### DIFF
--- a/src/core/libraries/kernel/libkernel.cpp
+++ b/src/core/libraries/kernel/libkernel.cpp
@@ -360,7 +360,6 @@ int PS4_SYSV_ABI posix_connect() {
 }
 
 int PS4_SYSV_ABI _sigprocmask() {
-    LOG_DEBUG(Lib_Kernel, "STUBBED");
     return ORBIS_OK;
 }
 

--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -162,7 +162,7 @@ T Translator::GetSrc(const InstOperand& operand) {
         }
     } else {
         if (operand.input_modifier.abs) {
-            UNREACHABLE();
+            LOG_WARNING(Render_Vulkan, "Input abs modifier on integer instruction");
         }
         if (operand.input_modifier.neg) {
             UNREACHABLE();

--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -494,6 +494,13 @@ void PatchImageInstruction(IR::Block& block, IR::Inst& inst, Info& info, Descrip
     const auto tsharp = TrackSharp(tsharp_handle);
     const auto image = info.ReadUd<AmdGpu::Image>(tsharp.sgpr_base, tsharp.dword_offset);
     const auto inst_info = inst.Flags<IR::TextureInstInfo>();
+    if (!image.Valid()) {
+        LOG_ERROR(Render_Vulkan, "Shader compiled with unbound image!");
+        IR::IREmitter ir{block, IR::Block::InstructionList::s_iterator_to(inst)};
+        inst.ReplaceUsesWith(ir.CompositeConstruct(ir.Imm32(0.f), ir.Imm32(0.f),
+                                                   ir.Imm32(0.f), ir.Imm32(0.f)));
+        return;
+    }
     ASSERT(image.GetType() != AmdGpu::ImageType::Invalid);
     u32 image_binding = descriptors.Add(ImageResource{
         .sgpr_base = tsharp.sgpr_base,

--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -497,8 +497,8 @@ void PatchImageInstruction(IR::Block& block, IR::Inst& inst, Info& info, Descrip
     if (!image.Valid()) {
         LOG_ERROR(Render_Vulkan, "Shader compiled with unbound image!");
         IR::IREmitter ir{block, IR::Block::InstructionList::s_iterator_to(inst)};
-        inst.ReplaceUsesWith(ir.CompositeConstruct(ir.Imm32(0.f), ir.Imm32(0.f),
-                                                   ir.Imm32(0.f), ir.Imm32(0.f)));
+        inst.ReplaceUsesWith(
+            ir.CompositeConstruct(ir.Imm32(0.f), ir.Imm32(0.f), ir.Imm32(0.f), ir.Imm32(0.f)));
         return;
     }
     ASSERT(image.GetType() != AmdGpu::ImageType::Invalid);

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -408,7 +408,7 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
         }
         case PM4ItOpcode::WaitRegMem: {
             const auto* wait_reg_mem = reinterpret_cast<const PM4CmdWaitRegMem*>(header);
-            ASSERT(wait_reg_mem->engine.Value() == PM4CmdWaitRegMem::Engine::Me);
+            // ASSERT(wait_reg_mem->engine.Value() == PM4CmdWaitRegMem::Engine::Me);
             // Optimization: VO label waits are special because the emulator
             // will write to the label when presentation is finished. So if
             // there are no other submits to yield to we can sleep the thread

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -867,6 +867,33 @@ struct Liverpool {
         }
     };
 
+    union ShaderStageEnable {
+        u32 raw;
+        BitField<0, 2, u32> ls_en;
+        BitField<2, 1, u32> hs_en;
+        BitField<3, 2, u32> es_en;
+        BitField<5, 1, u32> gs_en;
+        BitField<6, 1, u32> vs_en;
+
+        bool IsStageEnabled(u32 stage) {
+            switch (stage) {
+            case 0:
+            case 1:
+                return true;
+            case 2:
+                return gs_en.Value();
+            case 3:
+                return es_en.Value();
+            case 4:
+                return hs_en.Value();
+            case 5:
+                return ls_en.Value();
+            default:
+                UNREACHABLE();
+            }
+        }
+    };
+
     union Regs {
         struct {
             INSERT_PADDING_WORDS(0x2C08);
@@ -945,7 +972,9 @@ struct Liverpool {
             INSERT_PADDING_WORDS(0xA2A8 - 0xA2A1 - 1);
             u32 vgt_instance_step_rate_0;
             u32 vgt_instance_step_rate_1;
-            INSERT_PADDING_WORDS(0xA2DF - 0xA2A9 - 1);
+            INSERT_PADDING_WORDS(0xA2D5 - 0xA2A9 - 1);
+            ShaderStageEnable stage_enable;
+            INSERT_PADDING_WORDS(9);
             PolygonOffset poly_offset;
             INSERT_PADDING_WORDS(0xA2F8 - 0xA2DF - 5);
             AaConfig aa_config;
@@ -1140,6 +1169,7 @@ static_assert(GFX6_3D_REG_INDEX(index_buffer_type) == 0xA29F);
 static_assert(GFX6_3D_REG_INDEX(enable_primitive_id) == 0xA2A1);
 static_assert(GFX6_3D_REG_INDEX(vgt_instance_step_rate_0) == 0xA2A8);
 static_assert(GFX6_3D_REG_INDEX(vgt_instance_step_rate_1) == 0xA2A9);
+static_assert(GFX6_3D_REG_INDEX(stage_enable) == 0xA2D5);
 static_assert(GFX6_3D_REG_INDEX(poly_offset) == 0xA2DF);
 static_assert(GFX6_3D_REG_INDEX(aa_config) == 0xA2F8);
 static_assert(GFX6_3D_REG_INDEX(color_buffers[0].base_address) == 0xA318);

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -81,6 +81,8 @@ vk::PrimitiveTopology PrimitiveType(Liverpool::PrimitiveType type) {
         return vk::PrimitiveTopology::eTriangleListWithAdjacency;
     case Liverpool::PrimitiveType::AdjTriangleStrip:
         return vk::PrimitiveTopology::eTriangleStripWithAdjacency;
+    case Liverpool::PrimitiveType::PatchPrimitive:
+        return vk::PrimitiveTopology::ePatchList;
     case Liverpool::PrimitiveType::QuadList:
         // Needs to generate index buffer on the fly.
         return vk::PrimitiveTopology::eTriangleList;


### PR DESCRIPTION
* Don't log sigprocmask at all, it's spammed quite a bit by games
* Downgrade abs input modifier for integers to warning. It should be ignored I think but needs some investigation in games that trigger it. At least we will know it exists
* Respect shader stage enable register. Some games may leave a hw stage bound even when its not used