### PR TITLE
core/memory: Fix error on virtual queries of reserved regions

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -273,10 +273,10 @@ int MemoryManager::VirtualQuery(VAddr addr, int flags,
     std::scoped_lock lk{mutex};
 
     auto it = FindVMA(addr);
-    if (!it->second.IsMapped() && flags == 1) {
+    if (it->second.type == VMAType::Free && flags == 1) {
         it++;
     }
-    if (!it->second.IsMapped()) {
+    if (it->second.type == VMAType::Free) {
         LOG_WARNING(Kernel_Vmm, "VirtualQuery on free memory region");
         return ORBIS_KERNEL_ERROR_EACCES;
     }


### PR DESCRIPTION
Commit a2cd166 broke virtual queries of reserved regions of memory (VMAs "mapped" by `sceKernelReserveVirtualRange`), so now it returned an error.

Seen on *Shin Megami Tensei III Nocturne HD Remaster (CUSA24919)*.