### PR TITLE
shader_recompiler: basic implementation of `BUFFER_STORE_FORMAT_`

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -467,4 +467,97 @@ void EmitStoreBufferU32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address
     EmitStoreBufferF32xN<1>(ctx, handle, address, value);
 }
 
+static Id ConvertF32ToFormat(EmitContext& ctx, Id value, AmdGpu::NumberFormat format,
+                             u32 bit_width) {
+    switch (format) {
+    case AmdGpu::NumberFormat::Unorm:
+        return ctx.OpConvertFToU(
+            ctx.U32[1], ctx.OpFMul(ctx.F32[1], value, ctx.ConstF32(float(UXBitsMax(bit_width)))));
+    case AmdGpu::NumberFormat::Uint:
+        return ctx.OpBitcast(ctx.U32[1], value);
+    case AmdGpu::NumberFormat::Float:
+        return value;
+    default:
+        UNREACHABLE_MSG("Unsupported number fromat for conversion: {}",
+                        magic_enum::enum_name(format));
+    }
+}
+
+template <u32 N>
+static void EmitStoreBufferFormatF32xN(EmitContext& ctx, u32 handle, Id address, Id value) {
+    auto& buffer = ctx.buffers[handle];
+    const auto format = buffer.buffer.GetDataFmt();
+    const auto num_format = buffer.buffer.GetNumberFmt();
+
+    switch (format) {
+    case AmdGpu::DataFormat::FormatInvalid:
+        return;
+    case AmdGpu::DataFormat::Format8_8_8_8:
+    case AmdGpu::DataFormat::Format32:
+    case AmdGpu::DataFormat::Format32_32_32_32: {
+        ASSERT(N == AmdGpu::NumComponents(format));
+
+        address = ctx.OpIAdd(ctx.U32[1], address, buffer.offset);
+        const Id index = ctx.OpShiftRightLogical(ctx.U32[1], address, ctx.ConstU32(2u));
+        const Id ptr = ctx.OpAccessChain(buffer.pointer_type, buffer.id, ctx.u32_zero_value, index);
+
+        Id packed_value{};
+        for (u32 i = 0; i < N; i++) {
+            const u32 bit_width = AmdGpu::ComponentBits(format, i);
+            const u32 bit_offset = AmdGpu::ComponentOffset(format, i) % 32;
+
+            const Id comp{ConvertF32ToFormat(
+                ctx, N == 1 ? value : ctx.OpCompositeExtract(ctx.F32[1], value, i), num_format,
+                bit_width)};
+
+            if (bit_width == 32) {
+                if constexpr (N == 1) {
+                    ctx.OpStore(ptr, comp);
+                } else {
+                    const Id index_i = ctx.OpIAdd(ctx.U32[1], index, ctx.ConstU32(i));
+                    const Id ptr = ctx.OpAccessChain(buffer.pointer_type, buffer.id,
+                                                     ctx.u32_zero_value, index_i);
+                    ctx.OpStore(ptr, comp);
+                }
+            } else {
+                ASSERT(bit_width == 8);
+
+                if (i == 0) {
+                    packed_value = comp;
+                } else {
+                    packed_value =
+                        ctx.OpBitFieldInsert(ctx.U32[1], packed_value, comp,
+                                             ctx.ConstU32(bit_offset), ctx.ConstU32(bit_width));
+                }
+
+                if (i == N - 1) {
+                    ctx.OpStore(ptr, packed_value);
+                }
+            }
+        }
+    } break;
+    default:
+        UNREACHABLE_MSG("Invalid format for conversion: {}", magic_enum::enum_name(format));
+    }
+}
+
+void EmitStoreBufferFormatF32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address, Id value) {
+    EmitStoreBufferFormatF32xN<1>(ctx, handle, address, value);
+}
+
+void EmitStoreBufferFormatF32x2(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address,
+                                Id value) {
+    EmitStoreBufferFormatF32xN<2>(ctx, handle, address, value);
+}
+
+void EmitStoreBufferFormatF32x3(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address,
+                                Id value) {
+    EmitStoreBufferFormatF32xN<3>(ctx, handle, address, value);
+}
+
+void EmitStoreBufferFormatF32x4(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address,
+                                Id value) {
+    EmitStoreBufferFormatF32xN<4>(ctx, handle, address, value);
+}
+
 } // namespace Shader::Backend::SPIRV

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -493,6 +493,7 @@ static void EmitStoreBufferFormatF32xN(EmitContext& ctx, u32 handle, Id address,
     case AmdGpu::DataFormat::FormatInvalid:
         return;
     case AmdGpu::DataFormat::Format8_8_8_8:
+    case AmdGpu::DataFormat::Format16:
     case AmdGpu::DataFormat::Format32:
     case AmdGpu::DataFormat::Format32_32_32_32: {
         ASSERT(N == AmdGpu::NumComponents(format));
@@ -520,8 +521,6 @@ static void EmitStoreBufferFormatF32xN(EmitContext& ctx, u32 handle, Id address,
                     ctx.OpStore(ptr, comp);
                 }
             } else {
-                ASSERT(bit_width == 8);
-
                 if (i == 0) {
                     packed_value = comp;
                 } else {

--- a/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
@@ -76,6 +76,10 @@ void EmitStoreBufferF32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address
 void EmitStoreBufferF32x2(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address, Id value);
 void EmitStoreBufferF32x3(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address, Id value);
 void EmitStoreBufferF32x4(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address, Id value);
+void EmitStoreBufferFormatF32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address, Id value);
+void EmitStoreBufferFormatF32x2(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address, Id value);
+void EmitStoreBufferFormatF32x3(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address, Id value);
+void EmitStoreBufferFormatF32x4(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address, Id value);
 void EmitStoreBufferU32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address, Id value);
 Id EmitGetAttribute(EmitContext& ctx, IR::Attribute attr, u32 comp);
 Id EmitGetAttributeU32(EmitContext& ctx, IR::Attribute attr, u32 comp);

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -186,7 +186,7 @@ public:
 
     // Vector Memory
     void BUFFER_LOAD_FORMAT(u32 num_dwords, bool is_typed, bool is_format, const GcnInst& inst);
-    void BUFFER_STORE_FORMAT(u32 num_dwords, bool is_typed, const GcnInst& inst);
+    void BUFFER_STORE_FORMAT(u32 num_dwords, bool is_typed, bool is_format, const GcnInst& inst);
 
     // Vector interpolation
     void V_INTERP_P2_F32(const GcnInst& inst);

--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -347,6 +347,26 @@ void IREmitter::StoreBuffer(int num_dwords, const Value& handle, const Value& ad
     }
 }
 
+void IREmitter::StoreBufferFormat(int num_dwords, const Value& handle, const Value& address,
+                                  const Value& data, BufferInstInfo info) {
+    switch (num_dwords) {
+    case 1:
+        Inst(Opcode::StoreBufferFormatF32, Flags{info}, handle, address, data);
+        break;
+    case 2:
+        Inst(Opcode::StoreBufferFormatF32x2, Flags{info}, handle, address, data);
+        break;
+    case 3:
+        Inst(Opcode::StoreBufferFormatF32x3, Flags{info}, handle, address, data);
+        break;
+    case 4:
+        Inst(Opcode::StoreBufferFormatF32x4, Flags{info}, handle, address, data);
+        break;
+    default:
+        UNREACHABLE_MSG("Invalid number of dwords {}", num_dwords);
+    }
+}
+
 U32 IREmitter::LaneId() {
     return Inst<U32>(Opcode::LaneId);
 }

--- a/src/shader_recompiler/ir/ir_emitter.h
+++ b/src/shader_recompiler/ir/ir_emitter.h
@@ -93,6 +93,8 @@ public:
                                          BufferInstInfo info);
     void StoreBuffer(int num_dwords, const Value& handle, const Value& address, const Value& data,
                      BufferInstInfo info);
+    void StoreBufferFormat(int num_dwords, const Value& handle, const Value& address,
+                           const Value& data, BufferInstInfo info);
 
     [[nodiscard]] U32 LaneId();
     [[nodiscard]] U32 WarpId();

--- a/src/shader_recompiler/ir/microinstruction.cpp
+++ b/src/shader_recompiler/ir/microinstruction.cpp
@@ -55,6 +55,10 @@ bool Inst::MayHaveSideEffects() const noexcept {
     case Opcode::StoreBufferF32x2:
     case Opcode::StoreBufferF32x3:
     case Opcode::StoreBufferF32x4:
+    case Opcode::StoreBufferFormatF32:
+    case Opcode::StoreBufferFormatF32x2:
+    case Opcode::StoreBufferFormatF32x3:
+    case Opcode::StoreBufferFormatF32x4:
     case Opcode::StoreBufferU32:
     case Opcode::WriteSharedU128:
     case Opcode::WriteSharedU64:

--- a/src/shader_recompiler/ir/opcodes.inc
+++ b/src/shader_recompiler/ir/opcodes.inc
@@ -82,6 +82,10 @@ OPCODE(StoreBufferF32,                                      Void,           Opaq
 OPCODE(StoreBufferF32x2,                                    Void,           Opaque,         Opaque,         F32x2,                                          )
 OPCODE(StoreBufferF32x3,                                    Void,           Opaque,         Opaque,         F32x3,                                          )
 OPCODE(StoreBufferF32x4,                                    Void,           Opaque,         Opaque,         F32x4,                                          )
+OPCODE(StoreBufferFormatF32,                                Void,           Opaque,         Opaque,         F32,                                            )
+OPCODE(StoreBufferFormatF32x2,                              Void,           Opaque,         Opaque,         F32x2,                                          )
+OPCODE(StoreBufferFormatF32x3,                              Void,           Opaque,         Opaque,         F32x3,                                          )
+OPCODE(StoreBufferFormatF32x4,                              Void,           Opaque,         Opaque,         F32x4,                                          )
 OPCODE(StoreBufferU32,                                      Void,           Opaque,         Opaque,         U32,                                            )
 
 // Vector utility

--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -37,6 +37,10 @@ bool IsBufferInstruction(const IR::Inst& inst) {
     case IR::Opcode::StoreBufferF32x2:
     case IR::Opcode::StoreBufferF32x3:
     case IR::Opcode::StoreBufferF32x4:
+    case IR::Opcode::StoreBufferFormatF32:
+    case IR::Opcode::StoreBufferFormatF32x2:
+    case IR::Opcode::StoreBufferFormatF32x3:
+    case IR::Opcode::StoreBufferFormatF32x4:
     case IR::Opcode::StoreBufferU32:
         return true;
     default:
@@ -73,6 +77,10 @@ IR::Type BufferDataType(const IR::Inst& inst, AmdGpu::NumberFormat num_format) {
     case IR::Opcode::LoadBufferFormatF32x2:
     case IR::Opcode::LoadBufferFormatF32x3:
     case IR::Opcode::LoadBufferFormatF32x4:
+    case IR::Opcode::StoreBufferFormatF32:
+    case IR::Opcode::StoreBufferFormatF32x2:
+    case IR::Opcode::StoreBufferFormatF32x3:
+    case IR::Opcode::StoreBufferFormatF32x4:
         switch (num_format) {
         case AmdGpu::NumberFormat::Unorm:
         case AmdGpu::NumberFormat::Snorm:
@@ -112,6 +120,10 @@ bool IsBufferStore(const IR::Inst& inst) {
     case IR::Opcode::StoreBufferF32x2:
     case IR::Opcode::StoreBufferF32x3:
     case IR::Opcode::StoreBufferF32x4:
+    case IR::Opcode::StoreBufferFormatF32:
+    case IR::Opcode::StoreBufferFormatF32x2:
+    case IR::Opcode::StoreBufferFormatF32x3:
+    case IR::Opcode::StoreBufferFormatF32x4:
     case IR::Opcode::StoreBufferU32:
         return true;
     default:


### PR DESCRIPTION
This PR adds support for data format conversion in instructions `BUFFER_STORE_FORMAT_X` and `BUFFER_STORE_FORMAT_XYZW` mainly used in surface clear shaders. 