### PR TITLE
core,shader_recompiler: added const ref filesystem::path and removed if type size less 16

### DIFF
--- a/src/core/file_format/pkg.cpp
+++ b/src/core/file_format/pkg.cpp
@@ -350,7 +350,7 @@ bool PKG::Extract(const std::filesystem::path& filepath, const std::filesystem::
     return true;
 }
 
-void PKG::ExtractFiles(const int& index) {
+void PKG::ExtractFiles(const int index) {
     int inode_number = fsTable[index].inode;
     int inode_type = fsTable[index].type;
     std::string inode_name = fsTable[index].name;

--- a/src/core/file_format/pkg.h
+++ b/src/core/file_format/pkg.h
@@ -104,7 +104,7 @@ public:
     ~PKG();
 
     bool Open(const std::filesystem::path& filepath);
-    void ExtractFiles(const int& index);
+    void ExtractFiles(const int index);
     bool Extract(const std::filesystem::path& filepath, const std::filesystem::path& extract,
                  std::string& failreason);
 

--- a/src/core/file_format/trp.cpp
+++ b/src/core/file_format/trp.cpp
@@ -6,7 +6,7 @@
 TRP::TRP() = default;
 TRP::~TRP() = default;
 
-void TRP::GetNPcommID(std::filesystem::path trophyPath, int index) {
+void TRP::GetNPcommID(const std::filesystem::path& trophyPath, int index) {
     std::filesystem::path trpPath = trophyPath / "sce_sys/npbind.dat";
     Common::FS::IOFile npbindFile(trpPath, Common::FS::FileAccessMode::Read);
     if (!npbindFile.IsOpen()) {
@@ -27,7 +27,7 @@ static void removePadding(std::vector<u8>& vec) {
     }
 }
 
-bool TRP::Extract(std::filesystem::path trophyPath) {
+bool TRP::Extract(const std::filesystem::path& trophyPath) {
     std::string title = trophyPath.filename().string();
     std::filesystem::path gameSysDir = trophyPath / "sce_sys/trophy/";
     if (!std::filesystem::exists(gameSysDir)) {

--- a/src/core/file_format/trp.h
+++ b/src/core/file_format/trp.h
@@ -33,8 +33,8 @@ class TRP {
 public:
     TRP();
     ~TRP();
-    bool Extract(std::filesystem::path trophyPath);
-    void GetNPcommID(std::filesystem::path trophyPath, int index);
+    bool Extract(const std::filesystem::path& trophyPath);
+    void GetNPcommID(const std::filesystem::path& trophyPath, int index);
 
 private:
     Crypto crypto;

--- a/src/shader_recompiler/ir/attribute.h
+++ b/src/shader_recompiler/ir/attribute.h
@@ -105,7 +105,7 @@ struct fmt::formatter<Shader::IR::Attribute> {
     constexpr auto parse(format_parse_context& ctx) {
         return ctx.begin();
     }
-    auto format(const Shader::IR::Attribute& attribute, format_context& ctx) const {
+    auto format(const Shader::IR::Attribute attribute, format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", Shader::IR::NameOf(attribute));
     }
 };

--- a/src/shader_recompiler/ir/condition.h
+++ b/src/shader_recompiler/ir/condition.h
@@ -44,7 +44,7 @@ constexpr std::string_view NameOf(Condition condition) {
 
 template <>
 struct fmt::formatter<Shader::IR::Condition> : formatter<std::string_view> {
-    auto format(const Shader::IR::Condition& cond, format_context& ctx) const {
+    auto format(const Shader::IR::Condition cond, format_context& ctx) const {
         return formatter<string_view>::format(NameOf(cond), ctx);
     }
 };

--- a/src/shader_recompiler/ir/passes/ssa_rewrite_pass.cpp
+++ b/src/shader_recompiler/ir/passes/ssa_rewrite_pass.cpp
@@ -129,19 +129,19 @@ IR::Opcode UndefOpcode(IR::VectorReg) noexcept {
     return IR::Opcode::UndefU32;
 }
 
-IR::Opcode UndefOpcode(const VccLoTag&) noexcept {
+IR::Opcode UndefOpcode(const VccLoTag) noexcept {
     return IR::Opcode::UndefU32;
 }
 
-IR::Opcode UndefOpcode(const SccLoTag&) noexcept {
+IR::Opcode UndefOpcode(const SccLoTag) noexcept {
     return IR::Opcode::UndefU32;
 }
 
-IR::Opcode UndefOpcode(const VccHiTag&) noexcept {
+IR::Opcode UndefOpcode(const VccHiTag) noexcept {
     return IR::Opcode::UndefU32;
 }
 
-IR::Opcode UndefOpcode(const FlagTag&) noexcept {
+IR::Opcode UndefOpcode(const FlagTag) noexcept {
     return IR::Opcode::UndefU1;
 }
 

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -228,7 +228,7 @@ struct fmt::formatter<Shader::Stage> {
     constexpr auto parse(format_parse_context& ctx) {
         return ctx.begin();
     }
-    auto format(const Shader::Stage& stage, format_context& ctx) const {
+    auto format(const Shader::Stage stage, format_context& ctx) const {
         constexpr static std::array names = {"fs", "vs", "gs", "es", "hs", "ls", "cs"};
         return fmt::format_to(ctx.out(), "{}", names[static_cast<size_t>(stage)]);
     }


### PR DESCRIPTION
Code generation by compiler may deteriorate if type has a size less than 16.

![изображение](https://github.com/user-attachments/assets/e4b92ec2-6467-401e-9f7e-285dac38d558)
