### PR TITLE
Enable -fexperimental-library when using clang libc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,15 @@ if(HAVE_SEM_TIMEDWAIT OR WIN32)
     add_compile_options(-DHAVE_SEM_TIMEDWAIT)
 endif()
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    # libc++ requires -fexperimental-library to enable std::jthread and std::stop_token support.
+    include(CheckCXXSymbolExists)
+    check_cxx_symbol_exists(_LIBCPP_VERSION version LIBCPP)
+    if(LIBCPP)
+        add_compile_options(-fexperimental-library)
+    endif()
+endif()
+
 add_subdirectory(externals)
 include_directories(src)
 


### PR DESCRIPTION
This enables support for `std::jthread` and `std::stop_token` in the latest libc++ versions. Useful for better macOS standard library support since it uses clang libc++. Other systems like Ubuntu typically use libstdc++ by default so this hasn't been an issue.