### PR TITLE
Add messages to asserts

### DIFF
--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -98,7 +98,7 @@ struct AddressSpace::Impl {
         backing_handle =
             CreateFileMapping2(INVALID_HANDLE_VALUE, nullptr, FILE_MAP_WRITE | FILE_MAP_READ,
                                PAGE_READWRITE, SEC_COMMIT, BackingSize, nullptr, nullptr, 0);
-        ASSERT(backing_handle);
+        ASSERT_MSG(backing_handle, "{}", Common::GetLastErrorMsg());
         // Allocate a virtual memory for the backing file map as placeholder
         backing_base = static_cast<u8*>(VirtualAlloc2(process, nullptr, BackingSize,
                                                       MEM_RESERVE | MEM_RESERVE_PLACEHOLDER,
@@ -106,7 +106,7 @@ struct AddressSpace::Impl {
         // Map backing placeholder. This will commit the pages
         void* const ret = MapViewOfFile3(backing_handle, process, backing_base, 0, BackingSize,
                                          MEM_REPLACE_PLACEHOLDER, PAGE_READWRITE, nullptr, 0);
-        ASSERT(ret == backing_base);
+        ASSERT_MSG(ret == backing_base, "{}", Common::GetLastErrorMsg());
     }
 
     ~Impl() {


### PR DESCRIPTION
A lot of people were having issues with `CreateFileMapping2`, would be cool to at least see a message in logs