### PR TITLE
Fix gcc compilation error in vk_graphics_pipeline.cpp

### DIFF
--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -173,16 +173,17 @@ GraphicsPipeline::GraphicsPipeline(const Instance& instance_, Scheduler& schedul
         },
         .back{
             .failOp = LiverpoolToVK::StencilOp(key.depth.backface_enable
-                                                   ? key.stencil.stencil_fail_back
-                                                   : key.stencil.stencil_fail_front),
+                                                   ? key.stencil.stencil_fail_back.Value()
+                                                   : key.stencil.stencil_fail_front.Value()),
             .passOp = LiverpoolToVK::StencilOp(key.depth.backface_enable
-                                                   ? key.stencil.stencil_zpass_back
-                                                   : key.stencil.stencil_zpass_front),
+                                                   ? key.stencil.stencil_zpass_back.Value()
+                                                   : key.stencil.stencil_zpass_front.Value()),
             .depthFailOp = LiverpoolToVK::StencilOp(key.depth.backface_enable
-                                                        ? key.stencil.stencil_zfail_back
-                                                        : key.stencil.stencil_zfail_front),
-            .compareOp = LiverpoolToVK::CompareOp(
-                key.depth.backface_enable ? key.depth.stencil_bf_func : key.depth.stencil_ref_func),
+                                                        ? key.stencil.stencil_zfail_back.Value()
+                                                        : key.stencil.stencil_zfail_front.Value()),
+            .compareOp = LiverpoolToVK::CompareOp(key.depth.backface_enable
+                                                      ? key.depth.stencil_bf_func.Value()
+                                                      : key.depth.stencil_ref_func.Value()),
             .compareMask = key.stencil_ref_back.stencil_mask,
             .writeMask = key.stencil_ref_back.stencil_write_mask,
             .reference = key.stencil_ref_back.stencil_test_val,


### PR DESCRIPTION
The main branch currently doesn't compile with GCC.

GCC fails to infer the type of the two parts of a ternary expression whose types are different but both contain an implicit cast operator to the same type.

See example here: https://godbolt.org/z/Y5KdM77EW

Maybe adding a GCC pipeline to the CI could be a good idea for GCC/Clang differences(?)