### PR TITLE
Set game window size based on the config (in windowed mode)

### DIFF
--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -34,9 +34,6 @@ Frontend::WindowSDL* g_window = nullptr;
 
 namespace Core {
 
-static constexpr s32 WindowWidth = 1280;
-static constexpr s32 WindowHeight = 720;
-
 Emulator::Emulator() {
     // Read configuration file.
     const auto config_dir = Common::FS::GetUserPath(Common::FS::PathType::UserDir);
@@ -114,8 +111,9 @@ void Emulator::Run(const std::filesystem::path& file) {
         window_title =
             fmt::format("shadPS4 v{} {} | {}", Common::VERSION, Common::g_scm_desc, game_title);
     }
-    window =
-        std::make_unique<Frontend::WindowSDL>(WindowWidth, WindowHeight, controller, window_title);
+    window = std::make_unique<Frontend::WindowSDL>(
+        Config::getScreenWidth(), Config::getScreenHeight(),
+                                                   controller, window_title);
 
     g_window = window.get();
 

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -111,9 +111,8 @@ void Emulator::Run(const std::filesystem::path& file) {
         window_title =
             fmt::format("shadPS4 v{} {} | {}", Common::VERSION, Common::g_scm_desc, game_title);
     }
-    window = std::make_unique<Frontend::WindowSDL>(Config::getScreenWidth(),
-                                                   Config::getScreenHeight(),
-                                                   controller, window_title);
+    window = std::make_unique<Frontend::WindowSDL>(
+        Config::getScreenWidth(), Config::getScreenHeight(), controller, window_title);
 
     g_window = window.get();
 

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -111,7 +111,9 @@ void Emulator::Run(const std::filesystem::path& file) {
         window_title =
             fmt::format("shadPS4 v{} {} | {}", Common::VERSION, Common::g_scm_desc, game_title);
     }
-    window = std::make_unique<Frontend::WindowSDL>(Config::getScreenWidth(), Config::getScreenHeight(), controller, window_title);
+    window = std::make_unique<Frontend::WindowSDL>(Config::getScreenWidth(),
+                                                   Config::getScreenHeight(),
+                                                   controller, window_title);
 
     g_window = window.get();
 

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -111,9 +111,7 @@ void Emulator::Run(const std::filesystem::path& file) {
         window_title =
             fmt::format("shadPS4 v{} {} | {}", Common::VERSION, Common::g_scm_desc, game_title);
     }
-    window = std::make_unique<Frontend::WindowSDL>(
-        Config::getScreenWidth(), Config::getScreenHeight(),
-                                                   controller, window_title);
+    window = std::make_unique<Frontend::WindowSDL>(Config::getScreenWidth(), Config::getScreenHeight(), controller, window_title);
 
     g_window = window.get();
 


### PR DESCRIPTION
Changing the width and height in the emulator config didn't affect the game window size (in non-fullscreen mode). This little PR changes that. 

I don't actually know what resolution the games render at, so this might be an issue -- please let me know below. (I guess the games have the info on what resolution to render at for both PS4 and Pro?)

A possible next step would be to make the window properly resizeable, and then just do a basic scaling on the framebuffer based on it, while maintaining aspect ratio. 

EDIT: same for fullscreen mode -- for example, I have an ultrawide monitor, and usiong fullscreen mode just stretches the framebuffer.