### PR TITLE
shader_recompiler: fix BranchTarget sign flip for sopp.simm

### DIFF
--- a/src/shader_recompiler/frontend/instruction.cpp
+++ b/src/shader_recompiler/frontend/instruction.cpp
@@ -7,7 +7,7 @@
 namespace Shader::Gcn {
 
 u32 GcnInst::BranchTarget(u32 pc) const {
-    const s16 simm = static_cast<s16>(control.sopp.simm * 4);
+    const s32 simm = static_cast<s32>(control.sopp.simm) * 4;
     const u32 target = pc + simm + 4;
     return target;
 }


### PR DESCRIPTION
This used to cause a crash that would prevent Amplitude [CUSA02480] from booting beyond initialization.

A conditional true label would get an address starting with `0xffff....`, which wasn't realistic with the given shader.  
With some addresses, the multiplication by 4 causes the value to have its MSB wrongly set due to the small `s16` type - updated it to `s32`.