### PR TITLE
Amplitude (CUSA02480) former fixes and workarounds

### DIFF
--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -426,6 +426,14 @@ spv::ImageFormat GetFormat(const AmdGpu::Image& image) {
         return spv::ImageFormat::Rgba8;
     }
     if (image.GetDataFmt() == AmdGpu::DataFormat::Format8_8_8_8 &&
+        image.GetNumberFmt() == AmdGpu::NumberFormat::Srgb) {
+        // TEMP: for Amplitude 2016
+        // The game requests a Format8_8_8_8 SRGB image format.
+        // Interpreting it as R16Snorm makes the game draw with no major color deviations.
+        // What should the SRGB format be?
+        return spv::ImageFormat::R16Snorm;
+    }
+    if (image.GetDataFmt() == AmdGpu::DataFormat::Format8_8_8_8 &&
         image.GetNumberFmt() == AmdGpu::NumberFormat::Uint) {
         return spv::ImageFormat::Rgba8ui;
     }

--- a/src/shader_recompiler/frontend/instruction.cpp
+++ b/src/shader_recompiler/frontend/instruction.cpp
@@ -7,7 +7,7 @@
 namespace Shader::Gcn {
 
 u32 GcnInst::BranchTarget(u32 pc) const {
-    const s16 simm = static_cast<s16>(control.sopp.simm * 4);
+    const s32 simm = static_cast<s32>(control.sopp.simm) * 4;
     const u32 target = pc + simm + 4;
     return target;
 }

--- a/src/shader_recompiler/frontend/translate/data_share.cpp
+++ b/src/shader_recompiler/frontend/translate/data_share.cpp
@@ -162,18 +162,22 @@ void Translator::S_BARRIER() {
     ir.Barrier();
 }
 
+// TEMP: for Amplitude 2016
+// These are "warp instructions" and are stubbed to work outside of compute shaders.
+// The game makes use of them and works fine when the assertions are removed.
+
 void Translator::V_READFIRSTLANE_B32(const GcnInst& inst) {
-    ASSERT(info.stage != Stage::Compute);
+    //ASSERT(info.stage != Stage::Compute);
     SetDst(inst.dst[0], GetSrc(inst.src[0]));
 }
 
 void Translator::V_READLANE_B32(const GcnInst& inst) {
-    ASSERT(info.stage != Stage::Compute);
+    //ASSERT(info.stage != Stage::Compute);
     SetDst(inst.dst[0], GetSrc(inst.src[0]));
 }
 
 void Translator::V_WRITELANE_B32(const GcnInst& inst) {
-    ASSERT(info.stage != Stage::Compute);
+    //ASSERT(info.stage != Stage::Compute);
     SetDst(inst.dst[0], GetSrc(inst.src[0]));
 }
 

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -327,6 +327,13 @@ std::unique_ptr<ComputePipeline> PipelineCache::CreateComputePipeline() {
             MakeShaderInfo(Shader::Stage::Compute, cs_pgm.user_data, liverpool->regs);
         info.pgm_base = cs_pgm.Address<uintptr_t>();
         info.pgm_hash = compute_key;
+
+        // TEMP: for Amplitude 2016:
+        // Skip broken shader with V_MOVREL... instructions:
+        if (compute_key == 0xc7f34c4f) {
+            return nullptr;
+        }
+
         auto program =
             Shader::TranslateProgram(inst_pool, block_pool, code, std::move(info), profile);
 


### PR DESCRIPTION
**Previous** fixes and temporary workarounds for Amplitude (2016) that were necessary to boot in-game.  
**NOTE:** these workarounds no longer apply with the latest upstream code!

Upstream now boots the game into the main menu with no workarounds. Using as temporary progress tracker, until below list is completed.

Unchecked items are workarounds that need investigation:
- [x] CFG fix (https://github.com/shadps4-emu/shadPS4/pull/497)
- [x] Handle SRGB images
- [x] Assertions for warp instructions during compute stage
- [x] **[crash]** `V_MOVREL`... shader instructions (missing implementation, pending: https://github.com/shadps4-emu/shadPS4/pull/745)
- [ ] Handle detiling `Display_MacroTiled` `SRGB` textures

![image](https://github.com/user-attachments/assets/0665afa7-bf0b-4ab2-8d6d-4595e45e69c4)