### PR TITLE
sceNetAccept sleep and SDLAudio::AudioOutOutput latency and cpu improvements

### DIFF
--- a/src/audio_core/sdl_audio.cpp
+++ b/src/audio_core/sdl_audio.cpp
@@ -84,7 +84,7 @@ int SDLAudio::AudioOutOpen(int type, u32 samples_num, u32 freq,
             port.stream =
                 SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &fmt, NULL, NULL);
             SDL_ResumeAudioDevice(SDL_GetAudioStreamDevice(port.stream));
-            return id + 1;
+            return id + 1; // Handle range 1..n keeps 0 reserved
         }
     }
 
@@ -93,22 +93,35 @@ int SDLAudio::AudioOutOpen(int type, u32 samples_num, u32 freq,
 
 s32 SDLAudio::AudioOutOutput(s32 handle, const void* ptr) {
     std::shared_lock lock{m_mutex};
+    if (handle < 1 || handle > portsOut.size()) {
+        // Handle is outside range 1..n
+        return ORBIS_AUDIO_OUT_ERROR_INVALID_PORT;
+    }
     auto& port = portsOut[handle - 1];
     if (!port.isOpen) {
         return ORBIS_AUDIO_OUT_ERROR_INVALID_PORT;
     }
-    if (ptr == nullptr) {
-        return 0;
-    }
-    // TODO mixing channels
-    int result = SDL_PutAudioStreamData(port.stream, ptr,
-                                        port.samples_num * port.sample_size * port.channels_num);
-    // TODO find a correct value 8192 is estimated
-    while (SDL_GetAudioStreamAvailable(port.stream) > 65536) {
-        SDL_Delay(0);
+
+    // Allow call with null - this acts as "wait for buffer ready"
+    if (ptr != nullptr) {
+        // TODO mixing channels
+        int result = SDL_PutAudioStreamData(
+            port.stream, ptr, port.samples_num * port.sample_size * port.channels_num);
+        if (result != 0) {
+            // There's various possible failures, just assume some buffer is full
+            return ORBIS_AUDIO_OUT_ERROR_PORT_FULL;
+        }
     }
 
-    return result;
+    auto bytesPerSecond = 48000 * port.sample_size * port.channels_num;
+    const int TARGET_LATENCY_MS = 20; // Arbitrary, but slightly more than one 60fps frame
+    auto sizeTarget = (bytesPerSecond * TARGET_LATENCY_MS) / 1000;
+    
+    while (SDL_GetAudioStreamAvailable(port.stream) > sizeTarget) {
+        SDL_Delay(1); // Sleep behaviour is platform-dependent; 1ms may be up to 17ms
+    }
+
+    return ORBIS_OK;
 }
 
 bool SDLAudio::AudioOutSetVolume(s32 handle, s32 bitflag, s32* volume) {

--- a/src/audio_core/sdl_audio.cpp
+++ b/src/audio_core/sdl_audio.cpp
@@ -116,7 +116,7 @@ s32 SDLAudio::AudioOutOutput(s32 handle, const void* ptr) {
     auto bytesPerSecond = 48000 * port.sample_size * port.channels_num;
     const int TARGET_LATENCY_MS = 20; // Arbitrary, but slightly more than one 60fps frame
     auto sizeTarget = (bytesPerSecond * TARGET_LATENCY_MS) / 1000;
-    
+
     while (SDL_GetAudioStreamAvailable(port.stream) > sizeTarget) {
         SDL_Delay(1); // Sleep behaviour is platform-dependent; 1ms may be up to 17ms
     }

--- a/src/core/libraries/network/net.cpp
+++ b/src/core/libraries/network/net.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <thread>
+
 #ifdef WIN32
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
 #include <Ws2tcpip.h>
@@ -59,7 +61,8 @@ int PS4_SYSV_ABI sce_net_in6addr_nodelocal_allnodes() {
 }
 
 OrbisNetId PS4_SYSV_ABI sceNetAccept(OrbisNetId s, OrbisNetSockaddr* addr, u32* paddrlen) {
-    LOG_ERROR(Lib_Net, "(STUBBED) called");
+    LOG_ERROR(Lib_Net, "(STUBBED) called [sleeping]");
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     return ORBIS_OK;
 }
 


### PR DESCRIPTION
The sceNetAccept sleep reduces CPU usage, possibly memory usage depending on game behaviour, and log spam if the game calls it in a loop. BB at least is known to do this. This is still far from ideal but I expect this is beneficial for most games.

The SDLAudio::AudioOutOutput changes will target a particular latency rather than a fixed number of bytes which should make behaviour consistent across games. Handle is validated further. A NULL buffer is supported (I saw this in some OpenOrbis samples). The sleep is changed from 0ms to 1ms. In testing an audio-only homebrew sample, CPU usage is lowered. It's hard to measure exactly (on Windows at least) but a sleep-0 theoretically constantly yields and re-schedules the thread possibly using up a whole core. Sleep-1 is not guaranteed to be 1ms but it should be lower than the (arbitrary) 20ms latency target on all platforms.

20ms is meant to provide ~1-frame latency in 60fps games but may be too low in some cases so this may need tuning. This should be obvious as audio will become crunchy in games where it is currently smooth.

Feedback welcome. This is my first PR.