### PR TITLE
avplayer: Fix data returned by sceAvPlayerGetAudioData

### DIFF
--- a/src/core/libraries/avplayer/avplayer_source.cpp
+++ b/src/core/libraries/avplayer/avplayer_source.cpp
@@ -359,6 +359,7 @@ bool AvPlayerSource::GetAudioData(SceAvPlayerFrameInfo& audio_info) {
     audio_info = {};
     audio_info.timestamp = frame->info.timestamp;
     audio_info.pData = reinterpret_cast<u8*>(frame->info.pData);
+    audio_info.details.audio.sample_rate = frame->info.details.audio.sample_rate;
     audio_info.details.audio.size = frame->info.details.audio.size;
     audio_info.details.audio.channel_count = frame->info.details.audio.channel_count;
     return true;
@@ -655,6 +656,7 @@ Frame AvPlayerSource::PrepareAudioFrame(FrameBuffer buffer, const AVFrame& frame
                         .audio =
                             {
                                 .channel_count = u16(frame.ch_layout.nb_channels),
+                                .sample_rate = u32(frame.sample_rate),
                                 .size = u32(size),
                             },
                     },


### PR DESCRIPTION
Gravity Rush uses `sceAvPlayerGetAudioData` to get `sample_rate` which then will be used in `sceAudioOutOpen`.
Without this the game crashes because `sceAudioOutOpen` returns `ORBIS_AUDIO_OUT_ERROR_INVALID_SAMPLE_FREQ` when `sample_rate` is not 48000