### PR TITLE
Fix a few issues with the intel anv vulkan driver from mesa

### DIFF
--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -304,6 +304,7 @@ std::span<const vk::Format> GetAllFormats() {
         vk::Format::eBc7UnormBlock,
         vk::Format::eD16Unorm,
         vk::Format::eD16UnormS8Uint,
+        vk::Format::eD24UnormS8Uint,
         vk::Format::eD32Sfloat,
         vk::Format::eD32SfloatS8Uint,
         vk::Format::eR4G4B4A4UnormPack16,

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -481,6 +481,8 @@ bool Instance::IsFormatSupported(const vk::Format format) const {
 vk::Format Instance::GetAlternativeFormat(const vk::Format format) const {
     if (format == vk::Format::eB5G6R5UnormPack16) {
         return vk::Format::eR5G6B5UnormPack16;
+    } else if (format == vk::Format::eD16UnormS8Uint) {
+        return vk::Format::eD24UnormS8Uint;
     }
     return format;
 }

--- a/src/video_core/texture_cache/image.cpp
+++ b/src/video_core/texture_cache/image.cpp
@@ -73,14 +73,15 @@ static vk::ImageUsageFlags ImageUsageFlags(const ImageInfo& info) {
         if (!info.IsBlockCoded() && !info.IsPacked()) {
             usage |= vk::ImageUsageFlagBits::eColorAttachment;
         }
+
+        // In cases where an image is created as a render/depth target and cleared with compute,
+        // we cannot predict whether it will be used as a storage image. A proper solution would
+        // involve re-creating the resource with a new configuration and copying previous content
+        // into it. However, for now, we will set storage usage for all images (if the format
+        // allows), sacrificing a bit of performance. Note use of ExtendedUsage flag set by default.
+        usage |= vk::ImageUsageFlagBits::eStorage;
     }
 
-    // In cases where an image is created as a render/depth target and cleared with compute,
-    // we cannot predict whether it will be used as a storage image. A proper solution would
-    // involve re-creating the resource with a new configuration and copying previous content into
-    // it. However, for now, we will set storage usage for all images (if the format allows),
-    // sacrificing a bit of performance. Note use of ExtendedUsage flag set by default.
-    usage |= vk::ImageUsageFlagBits::eStorage;
     return usage;
 }
 

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -200,6 +200,7 @@ ImageView& TextureCache::FindDepthTarget(const ImageInfo& image_info,
     Image& image = slot_images[image_id];
     image.flags |= ImageFlagBits::GpuModified;
     image.flags &= ~ImageFlagBits::CpuModified;
+    image.aspect_mask = vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil;
 
     const auto new_layout = view_info.is_storage ? vk::ImageLayout::eDepthStencilAttachmentOptimal
                                                  : vk::ImageLayout::eDepthStencilReadOnlyOptimal;


### PR DESCRIPTION
- intel doesn't support `VK_FORMAT_D16_UNORM_S8_UINT`, so use `VK_FORMAT_D24_UNORM_S8_UINT` instead.
- the drivers panics when a texture has `usage & VK_IMAGE_USAGE_STORAGE_BIT && aspect == VK_IMAGE_ASPECT_DEPTH_BIT` (https://gitlab.freedesktop.org/mesa/mesa/-/blob/main/src/intel/vulkan/anv_image.c#L760)
- `TextureCache::FindDepthTarget` wasn't setting the `image.aspect_mask` of the depth image properly so it still had its default value `VK_IMAGE_ASPECT_COLOR_BIT` which causes this assert to trigger: https://gitlab.freedesktop.org/mesa/mesa/-/blob/main/src/vulkan/runtime/vk_image.c#L279