### PR TITLE
L2/R2 input threshold adjustment

### DIFF
--- a/src/input/controller.cpp
+++ b/src/input/controller.cpp
@@ -5,6 +5,7 @@
 #include "core/libraries/kernel/time_management.h"
 #include "core/libraries/pad/pad.h"
 #include "input/controller.h"
+#include "common/logging/log.h"
 
 namespace Input {
 
@@ -99,18 +100,32 @@ void GameController::Axis(int id, Input::Axis axis, int value) {
 
     state.axes[axis_id] = value;
 
+    // Scaled value is 0 .. 255
+    // Rest point for L2/R2 is usually ~127 but may drift
+    // It may also differ across controllers
+    // Use some hysteresis to avoid glitches. 0->255 will also work just slightly later
+
+    const int ON_THRESHOLD = 150;
+    const int OFF_THRESHOLD = 135;
+
     if (axis == Input::Axis::TriggerLeft) {
-        if (value > 0) {
+        LOG_TRACE(Input, "TriggerLeft {}", value);
+        if (value > ON_THRESHOLD) {
+            LOG_TRACE(Input, "L2 ON");
             state.buttonsState |= Libraries::Pad::OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_L2;
-        } else {
+        } else if (value < OFF_THRESHOLD) {
+            LOG_TRACE(Input, "L2 OFF");
             state.buttonsState &= ~Libraries::Pad::OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_L2;
         }
     }
 
     if (axis == Input::Axis::TriggerRight) {
-        if (value > 0) {
+        LOG_TRACE(Input, "TriggerRight {}", value);
+        if (value > ON_THRESHOLD) {
+            LOG_TRACE(Input, "R2 ON");
             state.buttonsState |= Libraries::Pad::OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_R2;
-        } else {
+        } else if (value < OFF_THRESHOLD) {
+            LOG_TRACE(Input, "R2 OFF");
             state.buttonsState &= ~Libraries::Pad::OrbisPadButtonDataOffset::ORBIS_PAD_BUTTON_R2;
         }
     }

--- a/src/input/controller.cpp
+++ b/src/input/controller.cpp
@@ -100,13 +100,13 @@ void GameController::Axis(int id, Input::Axis axis, int value) {
 
     state.axes[axis_id] = value;
 
+    // Derive digital buttons from the analog trigger
     // Scaled value is 0 .. 255
-    // Rest point for L2/R2 is usually ~127 but may drift
-    // It may also differ across controllers
-    // Use some hysteresis to avoid glitches. 0->255 will also work just slightly later
+    // Rest point for L2/R2 is ideally 0 but may drift
+    // Use some hysteresis to avoid glitches
 
-    const int ON_THRESHOLD = 150;
-    const int OFF_THRESHOLD = 135;
+    const int ON_THRESHOLD = 31; // 255 / 8
+    const int OFF_THRESHOLD = 16; // 255 / 16 + 1
 
     if (axis == Input::Axis::TriggerLeft) {
         LOG_TRACE(Input, "TriggerLeft {}", value);

--- a/src/input/controller.cpp
+++ b/src/input/controller.cpp
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <SDL3/SDL.h>
+#include "common/logging/log.h"
 #include "core/libraries/kernel/time_management.h"
 #include "core/libraries/pad/pad.h"
 #include "input/controller.h"
-#include "common/logging/log.h"
 
 namespace Input {
 
@@ -105,7 +105,7 @@ void GameController::Axis(int id, Input::Axis axis, int value) {
     // Rest point for L2/R2 is ideally 0 but may drift
     // Use some hysteresis to avoid glitches
 
-    const int ON_THRESHOLD = 31; // 255 / 8
+    const int ON_THRESHOLD = 31;  // 255 / 8
     const int OFF_THRESHOLD = 16; // 255 / 16 + 1
 
     if (axis == Input::Axis::TriggerLeft) {


### PR DESCRIPTION
- Input threshold changed to ~~150 (pressed) 135 (released)~~ >31 <16
- Fixes L2/R2 sticking where the rest point is ~~127~~ slightly above 0
- Avoids glitches when only partially pressed or drifting
- Still compatible with 0/255 inputs from keyboard (and now controller obviously)
- Tested with xbox controller and keyboard
- TRACE logging to help with threshold tuning; shouldn't compile in on release builds