### PR TITLE
core, video_core: Use reserve() before loops where possible

### DIFF
--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -15,7 +15,9 @@ namespace Libraries::Kernel {
 
 std::vector<Core::FileSys::DirEntry> GetDirectoryEntries(const std::filesystem::path& path) {
     std::vector<Core::FileSys::DirEntry> files;
-    for (const auto& entry : std::filesystem::directory_iterator(path)) {
+    const auto dirIt = std::filesystem::directory_iterator{path};
+    files.reserve(std::distance(dirIt, std::filesystem::directory_iterator{}));
+    for (const auto& entry : dirIt) {
         auto& dir_entry = files.emplace_back();
         dir_entry.name = entry.path().filename().string();
         dir_entry.isFile = !std::filesystem::is_directory(entry.path().string());

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -33,6 +33,7 @@ std::vector<std::string> GetSupportedExtensions(vk::PhysicalDevice physical) {
 std::unordered_map<vk::Format, vk::FormatProperties> GetFormatProperties(
     vk::PhysicalDevice physical) {
     std::unordered_map<vk::Format, vk::FormatProperties> format_properties;
+    format_properties.reserve(LiverpoolToVK::GetAllFormats().size());
     for (const auto& format : LiverpoolToVK::GetAllFormats()) {
         format_properties.emplace(format, physical.getFormatProperties(format));
     }

--- a/src/video_core/renderer_vulkan/vk_resource_pool.cpp
+++ b/src/video_core/renderer_vulkan/vk_resource_pool.cpp
@@ -125,6 +125,7 @@ DescriptorHeap::DescriptorHeap(const Instance& instance, MasterSemaphore* master
     for (const auto& binding : bindings) {
         descriptor_type_counts[binding.descriptorType] += binding.descriptorCount;
     }
+    pool_sizes.reserve(descriptor_type_counts.size());
     for (const auto& [type, count] : descriptor_type_counts) {
         auto& pool_size = pool_sizes.emplace_back();
         pool_size.descriptorCount = count * descriptor_heap_count;


### PR DESCRIPTION
Hi @georgemoralis these are the more useful reserves. Im waiting code review.