### PR TITLE
Fixed invalid set public exponent Crypto::DebugRifKeyset_init()

### DIFF
--- a/src/core/crypto/crypto.cpp
+++ b/src/core/crypto/crypto.cpp
@@ -51,8 +51,8 @@ CryptoPP::RSA::PrivateKey Crypto::DebugRifKeyset_init() {
     params.SetPrime2(
         CryptoPP::Integer(DebugRifKeyset_keyset.Prime2, sizeof(DebugRifKeyset_keyset.Prime2)));
 
-    params.SetPublicExponent(CryptoPP::Integer(DebugRifKeyset_keyset.PrivateExponent,
-                                               sizeof(DebugRifKeyset_keyset.PrivateExponent)));
+    params.SetPublicExponent(CryptoPP::Integer(DebugRifKeyset_keyset.PublicExponent,
+                                               sizeof(DebugRifKeyset_keyset.PublicExponent)));
     params.SetPrivateExponent(CryptoPP::Integer(DebugRifKeyset_keyset.PrivateExponent,
                                                 sizeof(DebugRifKeyset_keyset.PrivateExponent)));
 


### PR DESCRIPTION
@georgemoralis, not excluding that function was simply not completed. Decide if this fix is necessary.