### PR TITLE
core/kernel: Miscellaneous memory fixes

### DIFF
--- a/src/core/libraries/kernel/memory_management.cpp
+++ b/src/core/libraries/kernel/memory_management.cpp
@@ -75,28 +75,26 @@ s32 PS4_SYSV_ABI sceKernelAvailableDirectMemorySize(u64 searchStart, u64 searchE
     LOG_WARNING(Kernel_Vmm, "called searchStart = {:#x}, searchEnd = {:#x}, alignment = {:#x}",
                 searchStart, searchEnd, alignment);
 
-    if (searchEnd <= searchStart) {
+    if (physAddrOut == nullptr || sizeOut == nullptr) {
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
     if (searchEnd > SCE_KERNEL_MAIN_DMEM_SIZE) {
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
-
-    if (physAddrOut == nullptr || sizeOut == nullptr) {
-        return ORBIS_KERNEL_ERROR_EINVAL;
+    if (searchEnd <= searchStart) {
+        return ORBIS_KERNEL_ERROR_ENOMEM;
     }
 
     auto* memory = Core::Memory::Instance();
 
-    PAddr physAddr;
-    size_t size;
-    s32 result =
-        memory->DirectQueryAvailable(searchStart, searchEnd, alignment, &physAddr, &size);
+    PAddr physAddr{};
+    size_t size{};
+    s32 result = memory->DirectQueryAvailable(searchStart, searchEnd, alignment, &physAddr, &size);
 
     if (size == 0) {
         return ORBIS_KERNEL_ERROR_ENOMEM;
     }
-    
+
     *physAddrOut = static_cast<u64>(physAddr);
     *sizeOut = size;
 

--- a/src/core/libraries/kernel/memory_management.cpp
+++ b/src/core/libraries/kernel/memory_management.cpp
@@ -82,12 +82,23 @@ s32 PS4_SYSV_ABI sceKernelAvailableDirectMemorySize(u64 searchStart, u64 searchE
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
 
+    if (physAddrOut == nullptr || sizeOut == nullptr) {
+        return ORBIS_KERNEL_ERROR_EINVAL;
+    }
+
     auto* memory = Core::Memory::Instance();
 
     PAddr physAddr;
+    size_t size;
     s32 result =
-        memory->DirectQueryAvailable(searchStart, searchEnd, alignment, &physAddr, sizeOut);
+        memory->DirectQueryAvailable(searchStart, searchEnd, alignment, &physAddr, &size);
+
+    if (size == 0) {
+        return ORBIS_KERNEL_ERROR_ENOMEM;
+    }
+    
     *physAddrOut = static_cast<u64>(physAddr);
+    *sizeOut = size;
 
     return result;
 }

--- a/src/core/libraries/kernel/memory_management.h
+++ b/src/core/libraries/kernel/memory_management.h
@@ -6,7 +6,7 @@
 #include "common/bit_field.h"
 #include "common/types.h"
 
-constexpr u64 SCE_KERNEL_MAIN_DMEM_SIZE = 6_GB; // ~ 6GB
+constexpr u64 SCE_KERNEL_MAIN_DMEM_SIZE = 4608_MB; // ~ 4.5GB
 
 namespace Libraries::Kernel {
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -53,6 +53,9 @@ PAddr MemoryManager::Allocate(PAddr search_start, PAddr search_end, size_t size,
     PAddr free_addr = dmem_area->second.base;
     free_addr = alignment > 0 ? Common::AlignUp(free_addr, alignment) : free_addr;
 
+    // Align size
+    size = alignment > 0 ? Common::AlignUp(size, alignment) : size;
+
     // Add the allocated region to the list and commit its pages.
     auto& area = CarveDmemArea(free_addr, size)->second;
     area.memory_type = memory_type;
@@ -328,6 +331,11 @@ int MemoryManager::DirectQueryAvailable(PAddr search_start, PAddr search_end, si
     PAddr paddr{};
     size_t max_size{};
     while (dmem_area != dmem_map.end() && dmem_area->second.GetEnd() <= search_end) {
+        if (!dmem_area->second.is_free) {
+            dmem_area++;
+            continue;
+        }
+
         if (dmem_area->second.size > max_size) {
             paddr = dmem_area->second.base;
             max_size = dmem_area->second.size;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -53,9 +53,6 @@ PAddr MemoryManager::Allocate(PAddr search_start, PAddr search_end, size_t size,
     PAddr free_addr = dmem_area->second.base;
     free_addr = alignment > 0 ? Common::AlignUp(free_addr, alignment) : free_addr;
 
-    // Align size
-    size = alignment > 0 ? Common::AlignUp(size, alignment) : size;
-
     // Add the allocated region to the list and commit its pages.
     auto& area = CarveDmemArea(free_addr, size)->second;
     area.memory_type = memory_type;


### PR DESCRIPTION
This PR:
- Changes the direct memory size to be accurate (SCE_KERNEL_MAIN_DMEM_SIZE aka `sceKernelGetDirectMemorySize`).
- Fixes an inaccuracy where `sceKernelAvailableDirectMemorySize` also accounted for non-free direct memory areas.
- Fixed an inaccuracy where `sceKernelAvailableDirectMemorySize` did not return `ENOMEM`.

Fixes Rock Band 4 ([CUSA02084](https://github.com/shadps4-emu/shadps4-game-compatibility/issues/144)) not booting on version 2.21.
Fixes DRAGON BALL FighterZ ([CUSA09072](https://github.com/shadps4-emu/shadps4-game-compatibility/issues/43)) memory allocations (at @StevenMiller123).
Fixes JoJo's Bizarre Adventure: Eyes of Heaven ([CUSA04909](https://github.com/shadps4-emu/shadps4-game-compatibility/issues/291)) not booting.