### PR TITLE
savedata: Add another missing case to saveDataMount

### DIFF
--- a/src/core/libraries/save_data/savedata.cpp
+++ b/src/core/libraries/save_data/savedata.cpp
@@ -519,7 +519,9 @@ s32 saveDataMount(u32 user_id, char* dir_name, u32 mount_mode,
     case ORBIS_SAVE_DATA_MOUNT_MODE_CREATE2:
     case ORBIS_SAVE_DATA_MOUNT_MODE_CREATE2 | ORBIS_SAVE_DATA_MOUNT_MODE_RDWR:
     case ORBIS_SAVE_DATA_MOUNT_MODE_CREATE2 | ORBIS_SAVE_DATA_MOUNT_MODE_RDWR |
-        ORBIS_SAVE_DATA_MOUNT_MODE_COPY_ICON: {
+        ORBIS_SAVE_DATA_MOUNT_MODE_COPY_ICON:
+    case ORBIS_SAVE_DATA_MOUNT_MODE_CREATE2 | ORBIS_SAVE_DATA_MOUNT_MODE_RDWR |
+        ORBIS_SAVE_DATA_MOUNT_MODE_DESTRUCT_OFF | ORBIS_SAVE_DATA_MOUNT_MODE_COPY_ICON: {
         if (!std::filesystem::exists(mount_dir)) {
             std::filesystem::create_directories(mount_dir);
         }


### PR DESCRIPTION
This helps Five Nights at Freddy's: Sister Location (CUSA17983) boot and is playable. 
Fixes issue #554