### PR TITLE
Fixed video dimensions alignment and image cache

### DIFF
--- a/src/core/libraries/avplayer/avplayer.cpp
+++ b/src/core/libraries/avplayer/avplayer.cpp
@@ -40,9 +40,11 @@ int PS4_SYSV_ABI sceAvPlayerChangeStream() {
 s32 PS4_SYSV_ABI sceAvPlayerClose(SceAvPlayerHandle handle) {
     LOG_TRACE(Lib_AvPlayer, "called");
     if (handle == nullptr) {
+        LOG_TRACE(Lib_AvPlayer, "returning ORBIS_AVPLAYER_ERROR_INVALID_PARAMS");
         return ORBIS_AVPLAYER_ERROR_INVALID_PARAMS;
     }
     delete handle;
+    LOG_TRACE(Lib_AvPlayer, "returning ORBIS_OK");
     return ORBIS_OK;
 }
 
@@ -257,6 +259,7 @@ s32 PS4_SYSV_ABI sceAvPlayerStart(SceAvPlayerHandle handle) {
 s32 PS4_SYSV_ABI sceAvPlayerStop(SceAvPlayerHandle handle) {
     LOG_TRACE(Lib_AvPlayer, "called");
     if (handle == nullptr) {
+        LOG_TRACE(Lib_AvPlayer, "returning ORBIS_AVPLAYER_ERROR_INVALID_PARAMS");
         return ORBIS_AVPLAYER_ERROR_INVALID_PARAMS;
     }
     const auto res = handle->Stop();

--- a/src/core/libraries/avplayer/avplayer_state.cpp
+++ b/src/core/libraries/avplayer/avplayer_state.cpp
@@ -222,8 +222,11 @@ bool AvPlayerState::Stop() {
     if (!SetState(AvState::Stop)) {
         return false;
     }
+    if (!m_up_source->Stop()) {
+        return false;
+    }
     OnPlaybackStateChanged(AvState::Stop);
-    return m_up_source->Stop();
+    return true;
 }
 
 bool AvPlayerState::GetVideoData(SceAvPlayerFrameInfo& video_info) {

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -329,7 +329,6 @@ void TextureCache::UnregisterImage(ImageId image_id) {
         }
         image_ids.erase(vector_it);
     });
-    slot_images.erase(image_id);
 }
 
 void TextureCache::TrackImage(Image& image, ImageId image_id) {


### PR DESCRIPTION
AvPlayer:
The library should provide raw frames and ask user to remove the unused parts with crop offsets.
Since this library supports only AVX (H.264) video we may safely assume that frame buffer dimensions are aligned to 16. Unfortunately, I found no way to get raw frame buffers from ffmpeg, so the data is positioned in the memory manually.

Image cache:
The image should be erased only in `DeleteImage` instead of `UnregisterImage`.