### PR TITLE
video_core: implement PM4 disassembler

### DIFF
--- a/src/core/libraries/gnmdriver/gnmdriver.cpp
+++ b/src/core/libraries/gnmdriver/gnmdriver.cpp
@@ -348,8 +348,8 @@ static std::string DisassemblePM4(std::span<const u32> cmds) {
                                header->type0.count.Value()));
             for (size_t i = 0; i < header->type0.count.Value(); i++)
                 append(fmt::format("- 0x{:08X}\n", cmds.data()[1 + i]));
-            break;
             cmds = cmds.subspan(header->type0.NumWords() + 1);
+            break;
         case 1:
             UNREACHABLE();
         case 2:

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -229,16 +229,14 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
             case PM4ItOpcode::SetConfigReg: {
                 const auto* set_data = reinterpret_cast<const PM4CmdSetData*>(header);
                 const auto reg_addr = ConfigRegWordOffset + set_data->reg_offset;
-                const auto* payload = reinterpret_cast<const u32*>(header + 2);
-                std::memcpy(&regs.reg_array[reg_addr], payload, (count - 1) * sizeof(u32));
+                std::memcpy(&regs.reg_array[reg_addr], set_data->data, set_data->Size());
                 break;
             }
             case PM4ItOpcode::SetContextReg: {
                 const auto* set_data = reinterpret_cast<const PM4CmdSetData*>(header);
                 const auto reg_addr = ContextRegWordOffset + set_data->reg_offset;
-                const auto* payload = reinterpret_cast<const u32*>(header + 2);
-
-                std::memcpy(&regs.reg_array[reg_addr], payload, (count - 1) * sizeof(u32));
+                const auto* payload = set_data->data;
+                std::memcpy(&regs.reg_array[reg_addr], payload, set_data->Size());
 
                 // In the case of HW, render target memory has alignment as color block operates on
                 // tiles. There is no information of actual resource extents stored in CB context
@@ -308,14 +306,14 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
             }
             case PM4ItOpcode::SetShReg: {
                 const auto* set_data = reinterpret_cast<const PM4CmdSetData*>(header);
-                std::memcpy(&regs.reg_array[ShRegWordOffset + set_data->reg_offset], header + 2,
-                            (count - 1) * sizeof(u32));
+                const auto reg_addr = ShRegWordOffset + set_data->reg_offset;
+                std::memcpy(&regs.reg_array[reg_addr], set_data->data, set_data->Size());
                 break;
             }
             case PM4ItOpcode::SetUconfigReg: {
                 const auto* set_data = reinterpret_cast<const PM4CmdSetData*>(header);
-                std::memcpy(&regs.reg_array[UconfigRegWordOffset + set_data->reg_offset],
-                            header + 2, (count - 1) * sizeof(u32));
+                const auto reg_addr = UconfigRegWordOffset + set_data->reg_offset;
+                std::memcpy(&regs.reg_array[reg_addr], set_data->data, set_data->Size());
                 break;
             }
             case PM4ItOpcode::IndexType: {
@@ -522,8 +520,8 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, int vqid) {
         }
         case PM4ItOpcode::SetShReg: {
             const auto* set_data = reinterpret_cast<const PM4CmdSetData*>(header);
-            std::memcpy(&regs.reg_array[ShRegWordOffset + set_data->reg_offset], header + 2,
-                        (count - 1) * sizeof(u32));
+            const auto reg_addr = ShRegWordOffset + set_data->reg_offset;
+            std::memcpy(&regs.reg_array[reg_addr], set_data->data, set_data->Size());
             break;
         }
         case PM4ItOpcode::DispatchDirect: {

--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -313,7 +313,7 @@ struct PM4CmdEventWriteEop {
 
     template <typename T>
     T* Address() const {
-        return reinterpret_cast<T*>(address_lo | u64(address_hi) << 32);
+        return reinterpret_cast<T*>((uintptr_t(address_hi) << 32) | address_lo);
     }
 
     u32 DataDWord() const {
@@ -527,7 +527,7 @@ struct PM4CmdEventWriteEos {
 
     template <typename T = u32*>
     T Address() const {
-        return reinterpret_cast<T>(address_lo | u64(address_hi) << 32);
+        return reinterpret_cast<T>((uintptr_t(address_hi) << 32) | address_lo);
     }
 
     u32 DataDWord() const {
@@ -582,7 +582,7 @@ struct PM4DumpConstRam {
 
     template <typename T>
     T Address() const {
-        return reinterpret_cast<T>((u64(addr_hi) << 32u) | addr_lo);
+        return reinterpret_cast<T>((uintptr_t(addr_hi) << 32u) | addr_lo);
     }
 
     [[nodiscard]] u32 Offset() const {
@@ -634,7 +634,7 @@ struct PM4CmdIndirectBuffer {
 
     template <typename T>
     T* Address() const {
-        return reinterpret_cast<T*>((u64(ibase_hi) << 32u) | ibase_lo);
+        return reinterpret_cast<T*>((uintptr_t(ibase_hi) << 32u) | ibase_lo);
     }
 };
 
@@ -671,7 +671,7 @@ struct PM4CmdReleaseMem {
 
     template <typename T>
     T* Address() const {
-        return reinterpret_cast<T*>(address_lo | u64(address_hi) << 32);
+        return reinterpret_cast<T*>((uintptr_t(address_hi) << 32) | address_lo);
     }
 
     u32 DataDWord() const {

--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -187,6 +187,11 @@ struct PM4CmdSetData {
         BitField<28, 4, u32> index;      ///< Index for UCONFIG/CONTEXT on CI+
                                          ///< Program to zero for other opcodes and on SI
     };
+    u32 data[0];
+
+    [[nodiscard]] u32 Size() const {
+        return header.count << 2u;
+    }
 
     template <PM4ShaderType type = PM4ShaderType::ShaderGraphics, typename... Args>
     static constexpr u32* SetContextReg(u32* cmdbuf, Args... data) {
@@ -364,6 +369,16 @@ struct PM4CmdEventWriteEop {
     }
 };
 
+struct PM4CmdAcquireMem {
+    PM4Type3Header header;
+    u32 cp_coher_cntl;
+    u32 cp_coher_size_lo;
+    u32 cp_coher_size_hi;
+    u32 cp_coher_base_lo;
+    u32 cp_coher_base_hi;
+    u32 poll_interval;
+};
+
 struct PM4DmaData {
     PM4Type3Header header;
     union {
@@ -473,6 +488,10 @@ struct PM4CmdWriteData {
     template <typename T>
     void Address(T addr) {
         addr64 = static_cast<u64>(addr);
+    }
+
+    u32 Size() const {
+        return (header.count.Value() - 2) * 4;
     }
 
     template <typename T>


### PR DESCRIPTION
This PR adds a simple PM4 disassembler for debugging purpose.

The disassembled PM4 display lists are saved to disk next to their binary version when `Config::dumpPM4()` is true.

Not all PM4 commands are supported yet but the ones supported by the emulator should disassemble fine.