### PR TITLE
libraries: kernel: fix for inaccurate `sceKernelGetProcessTime`

### DIFF
--- a/src/common/native_clock.cpp
+++ b/src/common/native_clock.cpp
@@ -18,16 +18,16 @@ NativeClock::NativeClock()
       us_rdtsc_factor{GetFixedPoint64Factor(std::micro::den, rdtsc_frequency)},
       ms_rdtsc_factor{GetFixedPoint64Factor(std::milli::den, rdtsc_frequency)} {}
 
-u64 NativeClock::GetTimeNS() const {
-    return MultiplyHigh(GetUptime(), ns_rdtsc_factor);
+u64 NativeClock::GetTimeNS(u64 base_ptc /*= 0*/) const {
+    return MultiplyHigh(GetUptime() - base_ptc, ns_rdtsc_factor);
 }
 
-u64 NativeClock::GetTimeUS() const {
-    return MultiplyHigh(GetUptime(), us_rdtsc_factor);
+u64 NativeClock::GetTimeUS(u64 base_ptc /*= 0*/) const {
+    return MultiplyHigh(GetUptime() - base_ptc, us_rdtsc_factor);
 }
 
-u64 NativeClock::GetTimeMS() const {
-    return MultiplyHigh(GetUptime(), ms_rdtsc_factor);
+u64 NativeClock::GetTimeMS(u64 base_ptc /*= 0*/) const {
+    return MultiplyHigh(GetUptime() - base_ptc, ms_rdtsc_factor);
 }
 
 u64 NativeClock::GetUptime() const {

--- a/src/common/native_clock.h
+++ b/src/common/native_clock.h
@@ -16,9 +16,9 @@ public:
         return rdtsc_frequency;
     }
 
-    u64 GetTimeNS() const;
-    u64 GetTimeUS() const;
-    u64 GetTimeMS() const;
+    u64 GetTimeNS(u64 base_ptc = 0) const;
+    u64 GetTimeUS(u64 base_ptc = 0) const;
+    u64 GetTimeMS(u64 base_ptc = 0) const;
     u64 GetUptime() const;
     u64 GetProcessTimeUS() const;
 

--- a/src/core/libraries/kernel/time_management.cpp
+++ b/src/core/libraries/kernel/time_management.cpp
@@ -3,6 +3,7 @@
 
 #include <thread>
 #include "common/assert.h"
+#include "common/debug.h"
 #include "common/native_clock.h"
 #include "core/libraries/error_codes.h"
 #include "core/libraries/kernel/time_management.h"
@@ -30,7 +31,8 @@ u64 PS4_SYSV_ABI sceKernelGetTscFrequency() {
 }
 
 u64 PS4_SYSV_ABI sceKernelGetProcessTime() {
-    return clock->GetProcessTimeUS();
+    // TODO: this timer should support suspends, so initial ptc needs to be updated on wake up
+    return clock->GetTimeUS(initial_ptc);
 }
 
 u64 PS4_SYSV_ABI sceKernelGetProcessTimeCounter() {


### PR DESCRIPTION
Previous implementation of `sceKernelGetProcessTime` used `GetProcessTime` which was inaccurate as profiling and test showed (thanks, Niko). Replaced by standard steady timer