### PR TITLE
AvPlayer: Handle Initialization errors

### DIFF
--- a/src/core/libraries/avplayer/avplayer_data_streamer.h
+++ b/src/core/libraries/avplayer/avplayer_data_streamer.h
@@ -7,6 +7,8 @@
 
 #include "common/types.h"
 
+#include <string_view>
+
 struct AVIOContext;
 
 namespace Libraries::AvPlayer {
@@ -14,6 +16,7 @@ namespace Libraries::AvPlayer {
 class IDataStreamer {
 public:
     virtual ~IDataStreamer() = default;
+    virtual bool Init(std::string_view path) = 0;
     virtual AVIOContext* GetContext() = 0;
 };
 

--- a/src/core/libraries/avplayer/avplayer_file_streamer.h
+++ b/src/core/libraries/avplayer/avplayer_file_streamer.h
@@ -15,8 +15,10 @@ namespace Libraries::AvPlayer {
 
 class AvPlayerFileStreamer : public IDataStreamer {
 public:
-    AvPlayerFileStreamer(const SceAvPlayerFileReplacement& file_replacement, std::string_view path);
+    AvPlayerFileStreamer(const SceAvPlayerFileReplacement& file_replacement);
     ~AvPlayerFileStreamer();
+
+    bool Init(std::string_view path) override;
 
     AVIOContext* GetContext() override {
         return m_avio_context;

--- a/src/core/libraries/avplayer/avplayer_impl.cpp
+++ b/src/core/libraries/avplayer/avplayer_impl.cpp
@@ -110,7 +110,7 @@ s32 AvPlayer::AddSource(std::string_view path) {
     if (path.empty()) {
         return ORBIS_AVPLAYER_ERROR_INVALID_PARAMS;
     }
-    if (AVPLAYER_IS_ERROR(m_state->AddSource(path, GetSourceType(path)))) {
+    if (!m_state->AddSource(path, GetSourceType(path))) {
         return ORBIS_AVPLAYER_ERROR_OPERATION_FAILED;
     }
     return ORBIS_OK;
@@ -128,7 +128,7 @@ s32 AvPlayer::GetStreamCount() {
 }
 
 s32 AvPlayer::GetStreamInfo(u32 stream_index, SceAvPlayerStreamInfo& info) {
-    if (AVPLAYER_IS_ERROR(m_state->GetStreamInfo(stream_index, info))) {
+    if (!m_state->GetStreamInfo(stream_index, info)) {
         return ORBIS_AVPLAYER_ERROR_OPERATION_FAILED;
     }
     return ORBIS_OK;
@@ -145,7 +145,10 @@ s32 AvPlayer::EnableStream(u32 stream_index) {
 }
 
 s32 AvPlayer::Start() {
-    return m_state->Start();
+    if (!m_state->Start()) {
+        return ORBIS_AVPLAYER_ERROR_OPERATION_FAILED;
+    }
+    return ORBIS_OK;
 }
 
 bool AvPlayer::GetVideoData(SceAvPlayerFrameInfo& video_info) {

--- a/src/core/libraries/avplayer/avplayer_source.h
+++ b/src/core/libraries/avplayer/avplayer_source.h
@@ -120,17 +120,17 @@ private:
 
 class AvPlayerSource {
 public:
-    AvPlayerSource(AvPlayerStateCallback& state, std::string_view path,
-                   const SceAvPlayerInitData& init_data, SceAvPlayerSourceType source_type);
+    AvPlayerSource(AvPlayerStateCallback& state);
     ~AvPlayerSource();
 
+    bool Init(const SceAvPlayerInitData& init_data, std::string_view path);
     bool FindStreamInfo();
     s32 GetStreamCount();
-    s32 GetStreamInfo(u32 stream_index, SceAvPlayerStreamInfo& info);
+    bool GetStreamInfo(u32 stream_index, SceAvPlayerStreamInfo& info);
     bool EnableStream(u32 stream_index);
     void SetLooping(bool is_looping);
     std::optional<bool> HasFrames(u32 num_frames);
-    s32 Start();
+    bool Start();
     bool Stop();
     bool GetAudioData(SceAvPlayerFrameInfo& audio_info);
     bool GetVideoData(SceAvPlayerFrameInfo& video_info);

--- a/src/core/libraries/avplayer/avplayer_state.h
+++ b/src/core/libraries/avplayer/avplayer_state.h
@@ -24,11 +24,11 @@ public:
     AvPlayerState(const SceAvPlayerInitData& init_data);
     ~AvPlayerState();
 
-    s32 AddSource(std::string_view filename, SceAvPlayerSourceType source_type);
+    bool AddSource(std::string_view filename, SceAvPlayerSourceType source_type);
     s32 GetStreamCount();
-    s32 GetStreamInfo(u32 stream_index, SceAvPlayerStreamInfo& info);
+    bool GetStreamInfo(u32 stream_index, SceAvPlayerStreamInfo& info);
     bool EnableStream(u32 stream_index);
-    s32 Start();
+    bool Start();
     bool Stop();
     bool GetAudioData(SceAvPlayerFrameInfo& audio_info);
     bool GetVideoData(SceAvPlayerFrameInfo& video_info);


### PR DESCRIPTION
Replaced asserts during the initialization stage with error propagation. This fixes some non-well-behaving games and games with modified or removed video files.

Also did some refactoring of return values to `bool` as they were binary 0/-1.