### PR TITLE
memory: Fixes for direct memory allocation.

### DIFF
--- a/src/core/libraries/kernel/memory_management.cpp
+++ b/src/core/libraries/kernel/memory_management.cpp
@@ -15,7 +15,8 @@ namespace Libraries::Kernel {
 
 u64 PS4_SYSV_ABI sceKernelGetDirectMemorySize() {
     LOG_WARNING(Kernel_Vmm, "called");
-    return SCE_KERNEL_MAIN_DMEM_SIZE;
+    const auto* memory = Core::Memory::Instance();
+    return memory->GetTotalDirectSize();
 }
 
 int PS4_SYSV_ABI sceKernelAllocateDirectMemory(s64 searchStart, s64 searchEnd, u64 len,
@@ -52,8 +53,8 @@ int PS4_SYSV_ABI sceKernelAllocateDirectMemory(s64 searchStart, s64 searchEnd, u
 
 s32 PS4_SYSV_ABI sceKernelAllocateMainDirectMemory(size_t len, size_t alignment, int memoryType,
                                                    s64* physAddrOut) {
-    return sceKernelAllocateDirectMemory(0, SCE_KERNEL_MAIN_DMEM_SIZE, len, alignment, memoryType,
-                                         physAddrOut);
+    const auto searchEnd = static_cast<s64>(sceKernelGetDirectMemorySize());
+    return sceKernelAllocateDirectMemory(0, searchEnd, len, alignment, memoryType, physAddrOut);
 }
 
 s32 PS4_SYSV_ABI sceKernelCheckedReleaseDirectMemory(u64 start, size_t len) {
@@ -78,7 +79,7 @@ s32 PS4_SYSV_ABI sceKernelAvailableDirectMemorySize(u64 searchStart, u64 searchE
     if (physAddrOut == nullptr || sizeOut == nullptr) {
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
-    if (searchEnd > SCE_KERNEL_MAIN_DMEM_SIZE) {
+    if (searchEnd > sceKernelGetDirectMemorySize()) {
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
     if (searchEnd <= searchStart) {

--- a/src/core/libraries/kernel/memory_management.h
+++ b/src/core/libraries/kernel/memory_management.h
@@ -6,7 +6,7 @@
 #include "common/bit_field.h"
 #include "common/types.h"
 
-constexpr u64 SCE_KERNEL_MAIN_DMEM_SIZE = 4608_MB; // ~ 4.5GB
+constexpr u64 SCE_KERNEL_MAIN_DMEM_SIZE = 5056_MB; // ~ 5GB
 
 namespace Libraries::Kernel {
 

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -68,9 +68,17 @@ void Linker::Execute() {
     }
 
     // Configure used flexible memory size.
-    if (auto* mem_param = GetProcParam()->mem_param) {
-        if (u64* flexible_size = mem_param->flexible_memory_size) {
-            memory->SetupMemoryRegions(*flexible_size);
+    if (const auto* proc_param = GetProcParam()) {
+        if (proc_param->size >=
+            offsetof(OrbisProcParam, mem_param) + sizeof(OrbisKernelMemParam*)) {
+            if (const auto* mem_param = proc_param->mem_param) {
+                if (mem_param->size >=
+                    offsetof(OrbisKernelMemParam, flexible_memory_size) + sizeof(u64*)) {
+                    if (const auto* flexible_size = mem_param->flexible_memory_size) {
+                        memory->SetupMemoryRegions(*flexible_size);
+                    }
+                }
+            }
         }
     }
 

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -68,11 +68,11 @@ void Linker::Execute() {
     }
 
     // Configure used flexible memory size.
-    // if (auto* mem_param = GetProcParam()->mem_param) {
-    //      if (u64* flexible_size = mem_param->flexible_memory_size) {
-    //          memory->SetTotalFlexibleSize(*flexible_size);
-    //      }
-    //  }
+    if (auto* mem_param = GetProcParam()->mem_param) {
+        if (u64* flexible_size = mem_param->flexible_memory_size) {
+            memory->SetupMemoryRegions(*flexible_size);
+        }
+    }
 
     // Init primary thread.
     Common::SetCurrentThreadName("GAME_MainThread");

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -130,8 +130,8 @@ public:
         rasterizer = rasterizer_;
     }
 
-    void SetTotalFlexibleSize(u64 size) {
-        total_flexible_size = size;
+    u64 GetTotalDirectSize() const {
+        return total_direct_size;
     }
 
     u64 GetAvailableFlexibleSize() const {
@@ -141,6 +141,8 @@ public:
     VAddr SystemReservedVirtualBase() noexcept {
         return impl.SystemReservedVirtualBase();
     }
+
+    void SetupMemoryRegions(u64 flexible_size);
 
     PAddr Allocate(PAddr search_start, PAddr search_end, size_t size, u64 alignment,
                    int memory_type);
@@ -217,7 +219,8 @@ private:
     DMemMap dmem_map;
     VMAMap vma_map;
     std::recursive_mutex mutex;
-    size_t total_flexible_size = 448_MB;
+    size_t total_direct_size{};
+    size_t total_flexible_size{};
     size_t flexible_usage{};
     Vulkan::Rasterizer* rasterizer{};
 };


### PR DESCRIPTION
Sizes the direct memory area based on the flexible memory size requested by the game.

`SCE_KERNEL_MAIN_DMEM_SIZE` is set to the total of direct memory and flexible memory, and the flexible memory is removed from that total to arrive at the direct memory size. `sceKernelGetDirectMemorySize()` replaces most uses of the constant to make sure the proper calculated size is used.

This PR also fixes some areas where requested alignment was not taken into account for the size of an available direct memory region.

This fixes some games hitting `Unable to find free direct memory area` in https://github.com/shadps4-emu/shadPS4/issues/601