### PR TITLE
ci: enable cmake cache on all platforms (SDL/Qt)

### DIFF
--- a/.github/workflows/linux-qt.yml
+++ b/.github/workflows/linux-qt.yml
@@ -25,8 +25,27 @@ jobs:
       run: >
        sudo apt-get update && sudo apt install libx11-dev libxext-dev libwayland-dev libfuse2 clang build-essential qt6-base-dev qt6-tools-dev
 
+    - name: Cache CMake dependency source code
+      uses: actions/cache@v4
+      env:
+          cache-name: ${{ runner.os }}-qt-cache-cmake-dependency-sources
+      with:
+          path: | 
+            ${{github.workspace}}/build
+          key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          restore-keys: |
+            ${{ env.cache-name }}-
+
+    - name: Cache CMake dependency build objects
+      uses: hendrikmuhs/ccache-action@v1.2.14
+      env:
+          cache-name: ${{ runner.os }}-qt-cache-cmake-dependency-builds
+      with:
+        append-timestamp: false
+        key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DENABLE_QT_GUI=ON
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DENABLE_QT_GUI=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,8 +25,27 @@ jobs:
       run: >
        sudo apt-get update && sudo apt install libx11-dev libxext-dev libwayland-dev libfuse2 clang build-essential
 
+    - name: Cache CMake dependency source code
+      uses: actions/cache@v4
+      env:
+          cache-name: ${{ runner.os }}-sdl-cache-cmake-dependency-sources
+      with:
+          path: | 
+            ${{github.workspace}}/build
+          key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          restore-keys: |
+            ${{ env.cache-name }}-
+
+    - name: Cache CMake dependency build objects
+      uses: hendrikmuhs/ccache-action@v1.2.14
+      env:
+          cache-name: ${{ runner.os }}-sdl-cache-cmake-dependency-builds
+      with:
+        append-timestamp: false
+        key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel

--- a/.github/workflows/macos-qt.yml
+++ b/.github/workflows/macos-qt.yml
@@ -40,8 +40,29 @@ jobs:
         arch: clang_64
         archives: qtbase qttools
 
+    - name: Cache CMake dependency source code
+      uses: actions/cache@v4
+      env:
+          cache-name: ${{ runner.os }}-qt-cache-cmake-dependency-sources
+      with:
+          path: | 
+            ${{github.workspace}}/build
+          key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          restore-keys: |
+            ${{ env.cache-name }}-
+
+    - name: Cache CMake dependency build objects
+      uses: hendrikmuhs/ccache-action@v1.2.14
+      env:
+          cache-name: ${{runner.os}}-qt-cache-cmake-dependency-builds
+      with:
+        append-timestamp: false
+        create-symlink: true
+        key: ${{env.cache-name}}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+        variant: sccache
+
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_OSX_ARCHITECTURES=x86_64 -DENABLE_QT_GUI=ON
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_OSX_ARCHITECTURES=x86_64 -DENABLE_QT_GUI=ON -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel $(sysctl -n hw.ncpu)

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -31,8 +31,29 @@ jobs:
         arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
         arch -x86_64 /usr/local/bin/brew install molten-vk
 
+    - name: Cache CMake dependency source code
+      uses: actions/cache@v4
+      env:
+          cache-name: ${{ runner.os }}-sdl-cache-cmake-dependency-sources
+      with:
+          path: | 
+            ${{github.workspace}}/build
+          key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          restore-keys: |
+            ${{ env.cache-name }}-
+
+    - name: Cache CMake dependency build objects
+      uses: hendrikmuhs/ccache-action@v1.2.14
+      env:
+          cache-name: ${{runner.os}}-sdl-cache-cmake-dependency-builds
+      with:
+        append-timestamp: false
+        create-symlink: true
+        key: ${{env.cache-name}}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+        variant: sccache
+
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_OSX_ARCHITECTURES=x86_64
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel $(sysctl -n hw.ncpu)

--- a/.github/workflows/windows-qt.yml
+++ b/.github/workflows/windows-qt.yml
@@ -30,6 +30,17 @@ jobs:
         arch: win64_msvc2019_64
         archives: qtbase qttools
 
+    - name: Cache CMake dependency source code
+      uses: actions/cache@v4
+      env:
+          cache-name: ${{ runner.os }}-qt-cache-cmake-dependency-sources
+      with:
+          path: | 
+            ${{github.workspace}}/build
+          key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          restore-keys: |
+            ${{ env.cache-name }}-
+
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -T ClangCL -DENABLE_QT_GUI=ON
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,6 +20,17 @@ jobs:
       with:
           submodules: recursive
 
+    - name: Cache CMake dependency source code
+      uses: actions/cache@v4
+      env:
+          cache-name: ${{ runner.os }}-sdl-cache-cmake-dependency-sources
+      with:
+          path: | 
+            ${{github.workspace}}/build
+          key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          restore-keys: |
+            ${{ env.cache-name }}-
+
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -T ClangCL
 


### PR DESCRIPTION
This PR aims to improve build times in CI, Linux and macOS building steps have improved by a LOT!
Unfortunately, Windows still can't cache, even using sccache with MSVC.
- Partially solves (#542)

## Changes:
- [x] uses [actions/cache@v4](https://github.com/actions/cache) and [hendrikmuhs/ccache-action@v1.2.14](https://github.com/hendrikmuhs/ccache-action)
- [x] Keeps the cache from CMake Cache configuration (Windows, Linux, macOS).
- [x] Keeps the cache from CMake build objects (Linux/macOS).
- [x] Linux is using **ccache** from hendrikmuhs/ccache-action@v1.2.14.
- [x] macOS is using **sccache** from hendrikmuhs/ccache-action@v1.2.14.
- [x] Windows is caching the **CMake Configuration** step only, I've tried most stuff to force the use of caching, but without success, if anyone is willing to try, I've written some instructions below. ~I'm done with it~.

## Known Issues:
- ~Using same cache name/hash for each OS will create new bugs like macOS-sdl trying to build with Qt.~ (Fixed)
- The first CI run is not cached, the first time is when the cache is stored in [here](https://github.com/shadps4-emu/shadPS4/actions/caches).
- There is a limit for how many cache GitHub actions can store, see [here](https://github.com/actions/cache?tab=readme-ov-file#cache-limits).
- Using CCache with Windows didn't work as expected, but did not broke the actions.
  - The only way that _may_ work (needs testing and time) is by using MSYS2 MINGW64 and installing the packages:
  - `mingw-w64-x86_64-ccache` or `mingw-w64-x86_64-sccache`
  - It's worth noticing that MSYS2-compiled versions will only work under the MSYS2 shell, on native Windows will crash, even if you've copied the DLLs. (see action [here](https://github.com/LeDragoX/shadPS4/actions?query=branch%3Amsys2-ci))
- ~Using CCache with macOS will break the actions.~ Fixed by using sccache instead.

~There are some regression for some tests, but the most results are beneficial to CI building time.~
**Update:** the regressions for Windows and macOS were fixed, and brings about a minute less of compile time.

Comparisons:

|                       | Before Caching | After Caching |
| :--------------: | :--------------: | :--------------: |
|  Linux            |  ![firefox_2NvYAWlE2N](https://github.com/user-attachments/assets/44d440d9-829f-414b-90ef-3d3e722f00c6) 10m 13s | ![firefox_M6CKQAD16m](https://github.com/user-attachments/assets/8c8d94ae-0408-4e09-a746-f5cbaf2793c9) 2m 10s |
|  Linux-Qt       | ![firefox_QmHnVkSlaQ](https://github.com/user-attachments/assets/42f62af6-cd80-452e-815b-ca3cc999cba6) 11m 27s | ![firefox_4HC8x1XkWl](https://github.com/user-attachments/assets/3fe97b04-74dd-489d-920d-25f9b2e1da67) 3m 5s |
|  macOS          | ![firefox_0Zl7SOm1Uu](https://github.com/user-attachments/assets/0a0ea353-3a2d-4e44-aa4c-23be93c03420) 5m 39s | ![Captura de tela 2024-09-01 175335](https://github.com/user-attachments/assets/1708a26b-117c-48ec-976e-fd85befac2ec) 2m 58s |
|  macOS-Qt     | ![firefox_v43iL0Odi9](https://github.com/user-attachments/assets/e3bbcda1-fe98-4a75-a9bf-bcc3d2423fd6) 6m 54s | ![Captura de tela 2024-09-01 175403](https://github.com/user-attachments/assets/7f5522cc-826c-44ea-bf1e-9dc3d26472a4) 4m 8s |
|  Windows       | ![firefox_b615qmUwBJ](https://github.com/user-attachments/assets/6139b6e4-992c-482d-b54c-07fea9ad42cd) 17m 50s | ![firefox_7Zdfq2vBa0](https://github.com/user-attachments/assets/20ff2045-074f-4f3b-b4d0-8bfb64fa8d10) 14m 39s |
|  Windows-Qt | ![firefox_DRsdumDujr](https://github.com/user-attachments/assets/643766df-dabe-432a-abd9-a10ced074773) 18m 15s | ![firefox_ugdmtlIfuw](https://github.com/user-attachments/assets/c30c1814-4ef4-464b-bb22-6c4fa52cc18e) 20m 11s (Fixed) |