### PR TITLE
Force PIE usage on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,6 @@ cmake_minimum_required(VERSION 3.16.3)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-# Forcing PIE makes sure that the base address is high enough so that it doesn't clash with the PS4 memory.
-if(UNIX AND NOT APPLE)
-    set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
-endif()
-
 if(APPLE)
     enable_language(OBJC)
     set(CMAKE_OSX_DEPLOYMENT_TARGET 11)
@@ -21,6 +16,18 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 project(shadPS4)
+
+# Forcing PIE makes sure that the base address is high enough so that it doesn't clash with the PS4 memory.
+if(UNIX AND NOT APPLE)
+    set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+
+    # check PIE support at link time
+    include(CheckPIESupported)
+    check_pie_supported(OUTPUT_VARIABLE pie_check LANGUAGES C CXX)
+    if(NOT CMAKE_C_LINK_PIE_SUPPORTED OR NOT CMAKE_CXX_LINK_PIE_SUPPORTED)
+        message(WARNING "PIE is not supported at link time: ${pie_check}")
+    endif()
+endif()
 
 option(ENABLE_QT_GUI "Enable the Qt GUI. If not selected then the emulator uses a minimal SDL-based UI instead" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,11 @@ cmake_minimum_required(VERSION 3.16.3)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+# Forcing PIE makes sure that the base address is high enough so that it doesn't clash with the PS4 memory.
+if (UNIX)
+    set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+endif()
+
 if(APPLE)
     enable_language(OBJC)
     set(CMAKE_OSX_DEPLOYMENT_TARGET 11)
@@ -155,7 +160,7 @@ set(GNM_LIB src/core/libraries/gnmdriver/gnmdriver.cpp
             src/core/libraries/gnmdriver/gnm_error.h
 )
 
-set(KERNEL_LIB 
+set(KERNEL_LIB
                src/core/libraries/kernel/event_flag/event_flag.cpp
                src/core/libraries/kernel/event_flag/event_flag.h
                src/core/libraries/kernel/event_flag/event_flag_obj.cpp
@@ -351,7 +356,7 @@ set(CORE src/core/aerolib/stubs.cpp
          src/core/cpu_patches.cpp
          src/core/cpu_patches.h
          src/core/crypto/crypto.cpp
-         src/core/crypto/crypto.h 
+         src/core/crypto/crypto.h
          src/core/crypto/keys.h
          src/core/file_format/pfs.h
          src/core/file_format/pkg.cpp
@@ -376,7 +381,7 @@ set(CORE src/core/aerolib/stubs.cpp
          src/core/loader/elf.h
          src/core/loader/symbols_resolver.h
          src/core/loader/symbols_resolver.cpp
-         src/core/libraries/error_codes.h  
+         src/core/libraries/error_codes.h
          src/core/libraries/libs.h
          src/core/libraries/libs.cpp
          ${AUDIO_LIB}
@@ -628,6 +633,11 @@ else()
 endif()
 
 create_target_directory_groups(shadps4)
+
+# Forcing PIE makes sure that the base address is high enough so that it doesn't clash with the PS4 memory.
+if (UNIX)
+    target_link_options(shadps4 PRIVATE -pie)
+endif()
 
 target_link_libraries(shadps4 PRIVATE magic_enum::magic_enum fmt::fmt toml11::toml11 tsl::robin_map xbyak::xbyak Tracy::TracyClient RenderDoc::API FFmpeg::ffmpeg)
 target_link_libraries(shadps4 PRIVATE Boost::headers GPUOpen::VulkanMemoryAllocator sirit Vulkan::Headers xxHash::xxhash Zydis::Zydis glslang::SPIRV glslang::glslang SDL3::SDL3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 # Forcing PIE makes sure that the base address is high enough so that it doesn't clash with the PS4 memory.
-if (UNIX)
+if(UNIX AND NOT APPLE)
     set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -634,11 +634,6 @@ endif()
 
 create_target_directory_groups(shadps4)
 
-# Forcing PIE makes sure that the base address is high enough so that it doesn't clash with the PS4 memory.
-if (UNIX)
-    target_link_options(shadps4 PRIVATE -pie)
-endif()
-
 target_link_libraries(shadps4 PRIVATE magic_enum::magic_enum fmt::fmt toml11::toml11 tsl::robin_map xbyak::xbyak Tracy::TracyClient RenderDoc::API FFmpeg::ffmpeg)
 target_link_libraries(shadps4 PRIVATE Boost::headers GPUOpen::VulkanMemoryAllocator sirit Vulkan::Headers xxHash::xxhash Zydis::Zydis glslang::SPIRV glslang::glslang SDL3::SDL3)
 


### PR DESCRIPTION
It seems the project currently has an implicit requirement that emulator code be located at an address > 40 bits. Otherwise the code gets overwritten when the PS4 memory is allocated, resulting in memory corruptions.

Some linux distributions (e.g. NixOS and fedora(?)) come with a GCC binary built without the `--enable-default-pie` configuration enabled, which means binaries produces by such systems do not have ASLR support by default.

This causes the compiler to emit relocations which aren't compatible with a high base address (e.g. `R_X86_64_32`) and the linker to map the base address at a fixed address, which happens to be `0x400000` according to GNU's default linker script.

To address this issue, this PR forces GCC to produce a PIE executable via the `CMAKE_POSITION_INDEPENDENT_CODE` cmake variable and adds the `-pie` linker flag to `UNIX` targets.

Note that I am not 100% sure that enabling PIE guarantees that the base address is going to be > 40 bits. I only looked at the linux source tree briefly and it seems to be very configuration-dependant. However in practice the 40 bit assumption seems to hold so far, so I guess worst case scenario it only happens once and relaunching the emulator will do just fine. And if it happens too frequently, a proper linker script can be added to force the base address.