### PR TITLE
Auto reconnect controllers + touchpad functionality

### DIFF
--- a/src/core/libraries/pad/pad.cpp
+++ b/src/core/libraries/pad/pad.cpp
@@ -309,8 +309,8 @@ int PS4_SYSV_ABI scePadRead(s32 handle, OrbisPadData* pData, s32 num) {
         pData[i].angularVelocity.x = 0.0f;
         pData[i].angularVelocity.y = 0.0f;
         pData[i].angularVelocity.z = 0.0f;
-        pData[i].touchData.touchNum = (states[i].touchpad[0].state ? 1 : 0) 
-                                      + (states[i].touchpad[1].state ? 1 : 0);
+        pData[i].touchData.touchNum = 
+            (states[i].touchpad[0].state ? 1 : 0) + (states[i].touchpad[1].state ? 1 : 0);
         pData[i].touchData.touch[0].x = states[i].touchpad[0].x;
         pData[i].touchData.touch[0].y = states[i].touchpad[0].y;
         pData[i].touchData.touch[0].id = 1;

--- a/src/core/libraries/pad/pad.cpp
+++ b/src/core/libraries/pad/pad.cpp
@@ -309,7 +309,7 @@ int PS4_SYSV_ABI scePadRead(s32 handle, OrbisPadData* pData, s32 num) {
         pData[i].angularVelocity.x = 0.0f;
         pData[i].angularVelocity.y = 0.0f;
         pData[i].angularVelocity.z = 0.0f;
-        pData[i].touchData.touchNum = 
+        pData[i].touchData.touchNum =
             (states[i].touchpad[0].state ? 1 : 0) + (states[i].touchpad[1].state ? 1 : 0);
         pData[i].touchData.touch[0].x = states[i].touchpad[0].x;
         pData[i].touchData.touch[0].y = states[i].touchpad[0].y;

--- a/src/core/libraries/pad/pad.cpp
+++ b/src/core/libraries/pad/pad.cpp
@@ -309,12 +309,13 @@ int PS4_SYSV_ABI scePadRead(s32 handle, OrbisPadData* pData, s32 num) {
         pData[i].angularVelocity.x = 0.0f;
         pData[i].angularVelocity.y = 0.0f;
         pData[i].angularVelocity.z = 0.0f;
-        pData[i].touchData.touchNum = 0;
-        pData[i].touchData.touch[0].x = 0;
-        pData[i].touchData.touch[0].y = 0;
+        pData[i].touchData.touchNum = (states[i].touchpad[0].state ? 1 : 0) 
+                                      + (states[i].touchpad[1].state ? 1 : 0);
+        pData[i].touchData.touch[0].x = states[i].touchpad[0].x;
+        pData[i].touchData.touch[0].y = states[i].touchpad[0].y;
         pData[i].touchData.touch[0].id = 1;
-        pData[i].touchData.touch[1].x = 0;
-        pData[i].touchData.touch[1].y = 0;
+        pData[i].touchData.touch[1].x = states[i].touchpad[1].x;
+        pData[i].touchData.touch[1].y = states[i].touchpad[1].y;
         pData[i].touchData.touch[1].id = 2;
         pData[i].connected = connected;
         pData[i].timestamp = states[i].time;

--- a/src/input/controller.cpp
+++ b/src/input/controller.cpp
@@ -134,12 +134,14 @@ bool GameController::SetVibration(u8 smallMotor, u8 largeMotor) {
 
 void GameController::SetTouchpadState(int touchIndex, bool touchDown, float x, float y) {
     if (touchIndex < 2) {   // DS4 has 2-point multitouch
+        std::scoped_lock lock{m_mutex};
         auto state = GetLastState();
-
         state.time = Libraries::Kernel::sceKernelGetProcessTime();
+
         state.touchpad[touchIndex].state = touchDown;
         state.touchpad[touchIndex].x = static_cast<u16>(x * 1920);
         state.touchpad[touchIndex].y = static_cast<u16>(y * 1080);
+
         AddState(state);
     }
 }

--- a/src/input/controller.cpp
+++ b/src/input/controller.cpp
@@ -140,7 +140,7 @@ void GameController::SetTouchpadState(int touchIndex, bool touchDown, float x, f
 
         state.touchpad[touchIndex].state = touchDown;
         state.touchpad[touchIndex].x = static_cast<u16>(x * 1920);
-        state.touchpad[touchIndex].y = static_cast<u16>(y * 1080);
+        state.touchpad[touchIndex].y = static_cast<u16>(y * 941);
 
         AddState(state);
     }

--- a/src/input/controller.cpp
+++ b/src/input/controller.cpp
@@ -132,15 +132,27 @@ bool GameController::SetVibration(u8 smallMotor, u8 largeMotor) {
     return true;
 }
 
+void GameController::SetTouchpadState(int touchIndex, bool touchDown, float x, float y) {
+    if (touchIndex < 2) {   // DS4 has 2-point multitouch
+        auto state = GetLastState();
+
+        state.time = Libraries::Kernel::sceKernelGetProcessTime();
+        state.touchpad[touchIndex].state = touchDown;
+        state.touchpad[touchIndex].x = static_cast<u16>(x * 1920);
+        state.touchpad[touchIndex].y = static_cast<u16>(y * 1080);
+        AddState(state);
+    }
+}
+
 void GameController::TryOpenSDLController() {
     if (m_sdl_gamepad == nullptr || !SDL_GamepadConnected(m_sdl_gamepad)) {
         int gamepad_count;
         SDL_JoystickID* gamepads = SDL_GetGamepads(&gamepad_count);
         m_sdl_gamepad = gamepad_count > 0 ? SDL_OpenGamepad(gamepads[0]) : nullptr;
         SDL_free(gamepads);
-    }
 
-    SetLightBarRGB(0, 0, 255);
+        SetLightBarRGB(0, 0, 255);
+    }
 }
 
 } // namespace Input

--- a/src/input/controller.cpp
+++ b/src/input/controller.cpp
@@ -133,7 +133,7 @@ bool GameController::SetVibration(u8 smallMotor, u8 largeMotor) {
 }
 
 void GameController::SetTouchpadState(int touchIndex, bool touchDown, float x, float y) {
-    if (touchIndex < 2) {   // DS4 has 2-point multitouch
+    if (touchIndex < 2) {
         std::scoped_lock lock{m_mutex};
         auto state = GetLastState();
         state.time = Libraries::Kernel::sceKernelGetProcessTime();

--- a/src/input/controller.h
+++ b/src/input/controller.h
@@ -21,10 +21,17 @@ enum class Axis {
     AxisMax
 };
 
+struct TouchpadEntry {
+    bool state;
+    u16 x;
+    u16 y;
+};
+
 struct State {
     u32 buttonsState = 0;
     u64 time = 0;
     int axes[static_cast<int>(Axis::AxisMax)] = {128, 128, 128, 128, 0, 0};
+    TouchpadEntry touchpad[2] = {{false, 0, 0}, {false, 0, 0}};
 };
 
 inline int GetAxis(int min, int max, int value) {
@@ -47,6 +54,7 @@ public:
     void Axis(int id, Input::Axis axis, int value);
     void SetLightBarRGB(u8 r, u8 g, u8 b);
     bool SetVibration(u8 smallMotor, u8 largeMotor);
+    void SetTouchpadState(int touchIndex, bool touchDown, float x, float y);
     void TryOpenSDLController();
 
 private:

--- a/src/input/controller.h
+++ b/src/input/controller.h
@@ -22,9 +22,9 @@ enum class Axis {
 };
 
 struct TouchpadEntry {
-    bool state;
-    u16 x;
-    u16 y;
+    bool state{};
+    u16 x{};
+    u16 y{};
 };
 
 struct State {

--- a/src/sdl_window.cpp
+++ b/src/sdl_window.cpp
@@ -98,6 +98,11 @@ void WindowSDL::waitEvent() {
     case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
     case SDL_EVENT_GAMEPAD_BUTTON_UP:
     case SDL_EVENT_GAMEPAD_AXIS_MOTION:
+    case SDL_EVENT_GAMEPAD_ADDED:
+    case SDL_EVENT_GAMEPAD_REMOVED:
+    case SDL_EVENT_GAMEPAD_TOUCHPAD_DOWN:
+    case SDL_EVENT_GAMEPAD_TOUCHPAD_UP:
+    case SDL_EVENT_GAMEPAD_TOUCHPAD_MOTION:
         onGamepadEvent(&event);
         break;
     case SDL_EVENT_QUIT:
@@ -299,6 +304,17 @@ void WindowSDL::onGamepadEvent(const SDL_Event* event) {
     u32 button = 0;
     Input::Axis axis = Input::Axis::AxisMax;
     switch (event->type) {
+    case SDL_EVENT_GAMEPAD_ADDED:
+    case SDL_EVENT_GAMEPAD_REMOVED:
+        controller->TryOpenSDLController();
+        break;
+    case SDL_EVENT_GAMEPAD_TOUCHPAD_DOWN:
+    case SDL_EVENT_GAMEPAD_TOUCHPAD_UP:
+    case SDL_EVENT_GAMEPAD_TOUCHPAD_MOTION:
+        controller->SetTouchpadState(event->gtouchpad.finger,
+                                     event->type != SDL_EVENT_GAMEPAD_TOUCHPAD_UP,
+                                     event->gtouchpad.x, event->gtouchpad.y);
+        break;
     case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
     case SDL_EVENT_GAMEPAD_BUTTON_UP:
         button = sdlGamepadToOrbisButton(event->gbutton.button);


### PR DESCRIPTION
This PR makes it so that the controller gets reconnected on SDL `SDL_EVENT_GAMEPAD_ADDED` and `SDL_EVENT_GAMEPAD_REMOVED` events, 
I also implemented touchpad functionality for controllers that have one, I only tested it in Project Diva Future Tone (with a hack to get past the save loading screen) with a DS4 and a Dualsense and it works fine.
*I could not find any documentation as to what range of values the touchpad should output, the HID reports of a real DS4 give 1920 x 941 and that seems to work fine.