### PR TITLE
Misc fixes 

### DIFF
--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -462,8 +462,8 @@ vk::Format SurfaceFormat(AmdGpu::DataFormat data_format, AmdGpu::NumberFormat nu
     if (data_format == AmdGpu::DataFormat::FormatBc7 && num_format == AmdGpu::NumberFormat::Unorm) {
         return vk::Format::eBc7UnormBlock;
     }
-     if (data_format == AmdGpu::DataFormat::FormatBc2 && num_format == AmdGpu::NumberFormat::Srgb) {
-         return vk::Format::eBc2SrgbBlock;
+    if (data_format == AmdGpu::DataFormat::FormatBc2 && num_format == AmdGpu::NumberFormat::Srgb) {
+        return vk::Format::eBc2SrgbBlock;
     }
     if (data_format == AmdGpu::DataFormat::FormatBc2 && num_format == AmdGpu::NumberFormat::Unorm) {
         return vk::Format::eBc2UnormBlock;

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -296,6 +296,7 @@ std::span<const vk::Format> GetAllFormats() {
         vk::Format::eB10G11R11UfloatPack32,
         vk::Format::eBc1RgbaSrgbBlock,
         vk::Format::eBc1RgbaUnormBlock,
+        vk::Format::eBc2SrgbBlock,
         vk::Format::eBc2UnormBlock,
         vk::Format::eBc3SrgbBlock,
         vk::Format::eBc3UnormBlock,
@@ -457,6 +458,9 @@ vk::Format SurfaceFormat(AmdGpu::DataFormat data_format, AmdGpu::NumberFormat nu
     }
     if (data_format == AmdGpu::DataFormat::FormatBc7 && num_format == AmdGpu::NumberFormat::Unorm) {
         return vk::Format::eBc7UnormBlock;
+    }
+     if (data_format == AmdGpu::DataFormat::FormatBc2 && num_format == AmdGpu::NumberFormat::Srgb) {
+         return vk::Format::eBc2SrgbBlock;
     }
     if (data_format == AmdGpu::DataFormat::FormatBc2 && num_format == AmdGpu::NumberFormat::Unorm) {
         return vk::Format::eBc2UnormBlock;

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -453,6 +453,9 @@ vk::Format SurfaceFormat(AmdGpu::DataFormat data_format, AmdGpu::NumberFormat nu
     if (data_format == AmdGpu::DataFormat::Format8_8 && num_format == AmdGpu::NumberFormat::Unorm) {
         return vk::Format::eR8G8Unorm;
     }
+    if (data_format == AmdGpu::DataFormat::Format8_8 && num_format == AmdGpu::NumberFormat::Uint) {
+        return vk::Format::eR8G8Uint;
+    }
     if (data_format == AmdGpu::DataFormat::Format8_8 && num_format == AmdGpu::NumberFormat::Snorm) {
         return vk::Format::eR8G8Snorm;
     }


### PR DESCRIPTION
Adding missing data format used by Runner2
- data_format=36 and num_format=9
- data_format=3 and num_format=4

![Bit2](https://github.com/user-attachments/assets/c3155e68-cb14-4b74-a292-d698a65f65c7)

The game requires Log Type set to sync
