### PR TITLE
Add patches for F16C instructions under Rosetta 2.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -82,3 +82,6 @@
 	path = externals/ffmpeg-core
 	url = https://github.com/shadps4-emu/ext-ffmpeg-core.git
 	shallow = true
+[submodule "externals/half"]
+	path = externals/half
+	url = https://github.com/ROCm/half.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -638,6 +638,9 @@ if (APPLE)
 
   # Replacement for std::chrono::time_zone
   target_link_libraries(shadps4 PRIVATE date::date-tz)
+
+  # Half float conversions for F16C patches
+  target_link_libraries(shadps4 PRIVATE half)
 endif()
 
 if (NOT ENABLE_QT_GUI)

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -142,11 +142,17 @@ if (WIN32)
     target_compile_options(sirit PUBLIC "-Wno-error=unused-command-line-argument")
 endif()
 
-# date
-if (APPLE AND NOT TARGET date::date-tz)
-    option(BUILD_TZ_LIB "" ON)
-    option(USE_SYSTEM_TZ_DB "" ON)
-    add_subdirectory(date)
+if (APPLE)
+    # half
+    add_library(half INTERFACE)
+    target_include_directories(half INTERFACE half/include)
+
+    # date
+    if (NOT TARGET date::date-tz)
+        option(BUILD_TZ_LIB "" ON)
+        option(USE_SYSTEM_TZ_DB "" ON)
+        add_subdirectory(date)
+    endif()
 endif()
 
 # Tracy

--- a/src/core/cpu_patches.h
+++ b/src/core/cpu_patches.h
@@ -9,6 +9,12 @@ class CodeGenerator;
 
 namespace Core {
 
+/// Initializes a stack for the current thread for use by patch implementations.
+void InitializeThreadPatchStack();
+
+/// Cleans up the patch stack for the current thread.
+void CleanupThreadPatchStack();
+
 /// Patches CPU instructions that cannot run as-is on the host.
 void PatchInstructions(u64 segment_addr, u64 segment_size, Xbyak::CodeGenerator& c);
 

--- a/src/core/libraries/kernel/thread_management.cpp
+++ b/src/core/libraries/kernel/thread_management.cpp
@@ -10,6 +10,7 @@
 #include "common/logging/log.h"
 #include "common/singleton.h"
 #include "common/thread.h"
+#include "core/cpu_patches.h"
 #include "core/libraries/error_codes.h"
 #include "core/libraries/kernel/libkernel.h"
 #include "core/libraries/kernel/thread_management.h"
@@ -985,6 +986,7 @@ static void cleanup_thread(void* arg) {
             destructor(value);
         }
     }
+    Core::CleanupThreadPatchStack();
     thread->is_almost_done = true;
 }
 
@@ -993,6 +995,7 @@ static void* run_thread(void* arg) {
     Common::SetCurrentThreadName(thread->name.c_str());
     auto* linker = Common::Singleton<Core::Linker>::Instance();
     linker->InitTlsForThread(false);
+    Core::InitializeThreadPatchStack();
     void* ret = nullptr;
     g_pthread_self = thread;
     pthread_cleanup_push(cleanup_thread, thread);

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -10,6 +10,7 @@
 #include "common/thread.h"
 #include "core/aerolib/aerolib.h"
 #include "core/aerolib/stubs.h"
+#include "core/cpu_patches.h"
 #include "core/libraries/kernel/memory_management.h"
 #include "core/libraries/kernel/thread_management.h"
 #include "core/linker.h"
@@ -86,6 +87,7 @@ void Linker::Execute() {
     Common::SetCurrentThreadName("GAME_MainThread");
     Libraries::Kernel::pthreadInitSelfMainThread();
     InitTlsForThread(true);
+    InitializeThreadPatchStack();
 
     // Start shared library modules
     for (auto& m : m_modules) {
@@ -104,6 +106,8 @@ void Linker::Execute() {
             RunMainEntry(m->GetEntryAddress(), &p, ProgramExitFunc);
         }
     }
+
+    CleanupThreadPatchStack();
 }
 
 s32 Linker::LoadModule(const std::filesystem::path& elf_name, bool is_dynamic) {


### PR DESCRIPTION
Adds patches for F16C instructions which are currently missing under Rosetta 2 on macOS.

This also enhances the stack saving capabilities in the patcher to allow saving entire contexts with fewer TLS slots. Before the patcher would allocate a TLS slot for each register it needed to save. Now, it only needs two slots for an arbitrary amount of context: one slot for a thread-specific patch stack and the other for the original function stack. When a patch needs to save context it can switch out the stacks and save registers, then do the reverse when done.

Additionally some code is added for using vector and immediate operands in patches.

I tested this with CUSA16429 which is the only game I have that uses these instructions. From basic debugging examining the inputs and outputs it seems to work as expected although the game still does not progress past a black screen on launch so I can't validate it in-depth. It gets a lot further a long though until it hits a missing primitive type.