### PR TITLE
Add /hostapp support

### DIFF
--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -84,6 +84,8 @@ void Emulator::Run(const std::filesystem::path& file) {
     // Applications expect to be run from /app0 so mount the file's parent path as app0.
     auto* mnt = Common::Singleton<Core::FileSys::MntPoints>::Instance();
     mnt->Mount(file.parent_path(), "/app0");
+    // Certain games may use /hostapp as well such as CUSA001100
+    mnt->Mount(file.parent_path(), "/hostapp");
 
     // Loading param.sfo file if exists
     std::string id;


### PR DESCRIPTION
In the case of certain games, such as Battlefield 4 (CUSA00110), the local pathing will resolve to /hostapp instead of /app0, which works fine on PS4, but was failing to resolve to any meaningful mount in shadPS4, this corrects this issue when running from eboot.bin directly.