### PR TITLE
Fix creation files.json in 'Download All Patches'

### DIFF
--- a/src/qt_gui/cheats_patches.h
+++ b/src/qt_gui/cheats_patches.h
@@ -36,6 +36,7 @@ public:
     void downloadCheats(const QString& source, const QString& m_gameSerial,
                         const QString& m_gameVersion, bool showMessageBox);
     void downloadPatches(const QString repository, const bool showMessageBox);
+    void createFilesJson(const QString& repository);
 
 signals:
     void downloadFinished();
@@ -58,7 +59,6 @@ private:
     void applyCheat(const QString& modName, bool enabled);
     void applyPatch(const QString& patchName, bool enabled);
 
-    void createFilesJson(const QString& repository);
     void uncheckAllCheatCheckBoxes();
     void updateNoteTextEdit(const QString& patchName);
 

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -391,6 +391,8 @@ void MainWindow::CreateConnects() {
                 nullptr, tr("Download Complete"),
                 QString(tr("Patches Downloaded Successfully!") + "\n" +
                         tr("All Patches available for all games have been downloaded.")));
+            cheatsPatches->createFilesJson("GoldHEN");
+            cheatsPatches->createFilesJson("shadPS4");
             panelDialog->accept();
         });
         panelDialog->exec();


### PR DESCRIPTION
When downloading from the repositories individually, the identification files.json are normally created for the Patches' XML. However, when downloading from all repositories at the same time, it is so fast because there is no message on the screen that it ends up creating an empty json. This fixes the problem.