### PR TITLE
Remove from_compute check in texture cache invalidation

### DIFF
--- a/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
@@ -195,7 +195,7 @@ bool ComputePipeline::BindResources(VideoCore::BufferCache& buffer_cache,
         }
         const u32 size = vsharp.GetSize();
         if (desc.is_written) {
-            texture_cache.InvalidateMemory(address, size, true);
+            texture_cache.InvalidateMemory(address, size);
         }
         const u32 alignment =
             is_storage ? instance.StorageMinAlignment() : instance.UniformMinAlignment();
@@ -235,7 +235,7 @@ bool ComputePipeline::BindResources(VideoCore::BufferCache& buffer_cache,
                 }
             }
             if (desc.is_written && info->pgm_hash != 0xfefebf9f && info->pgm_hash != 0x3d5ebf4e) {
-                texture_cache.InvalidateMemory(address, size, true);
+                texture_cache.InvalidateMemory(address, size);
             }
             const u32 alignment = instance.TexelBufferMinAlignment();
             const auto [vk_buffer, offset] =

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -34,7 +34,7 @@ TextureCache::TextureCache(const Vulkan::Instance& instance_, Vulkan::Scheduler&
 
 TextureCache::~TextureCache() = default;
 
-void TextureCache::InvalidateMemory(VAddr address, size_t size, bool from_compute) {
+void TextureCache::InvalidateMemory(VAddr address, size_t size) {
     std::unique_lock lock{mutex};
     ForEachImageInRegion(address, size, [&](ImageId image_id, Image& image) {
         if (!image.Overlaps(address, size)) {

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -37,7 +37,7 @@ TextureCache::~TextureCache() = default;
 void TextureCache::InvalidateMemory(VAddr address, size_t size, bool from_compute) {
     std::unique_lock lock{mutex};
     ForEachImageInRegion(address, size, [&](ImageId image_id, Image& image) {
-        if (from_compute && !image.Overlaps(address, size)) {
+        if (!image.Overlaps(address, size)) {
             return;
         }
         // Ensure image is reuploaded when accessed again.

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -38,7 +38,7 @@ public:
     ~TextureCache();
 
     /// Invalidates any image in the logical page range.
-    void InvalidateMemory(VAddr address, size_t size, bool from_compute = false);
+    void InvalidateMemory(VAddr address, size_t size);
 
     /// Evicts any images that overlap the unmapped range.
     void UnmapMemory(VAddr cpu_addr, size_t size);


### PR DESCRIPTION
This is the change that fixes the character rendering in Bloodborne. 

![image](https://github.com/user-attachments/assets/fa8bc491-18fb-4fbb-88b4-06b3025faff1)
