### PR TITLE
Initialize patch stack before thread TLS.

### DIFF
--- a/src/core/libraries/kernel/thread_management.cpp
+++ b/src/core/libraries/kernel/thread_management.cpp
@@ -994,8 +994,8 @@ static void* run_thread(void* arg) {
     auto* thread = static_cast<ScePthread>(arg);
     Common::SetCurrentThreadName(thread->name.c_str());
     auto* linker = Common::Singleton<Core::Linker>::Instance();
-    linker->InitTlsForThread(false);
     Core::InitializeThreadPatchStack();
+    linker->InitTlsForThread(false);
     void* ret = nullptr;
     g_pthread_self = thread;
     pthread_cleanup_push(cleanup_thread, thread);

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -86,8 +86,8 @@ void Linker::Execute() {
     // Init primary thread.
     Common::SetCurrentThreadName("GAME_MainThread");
     Libraries::Kernel::pthreadInitSelfMainThread();
-    InitTlsForThread(true);
     InitializeThreadPatchStack();
+    InitTlsForThread(true);
 
     // Start shared library modules
     for (auto& m : m_modules) {


### PR DESCRIPTION
We need to initialize the patch stack first as there may be a custom heap API configured that uses patched instructions, which would crash when trying to allocate TLS memory.

Fixes https://github.com/shadps4-emu/shadPS4/issues/667. I tested one of the affected games and it is now working again.