### PR TITLE
vulkan: Few fixes for MoltenVK

### DIFF
--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -287,8 +287,8 @@ vk::BorderColor BorderColor(AmdGpu::BorderColor color) {
 
 std::span<const vk::Format> GetAllFormats() {
     static constexpr std::array formats{
+        vk::Format::eA2B10G10R10SnormPack32,
         vk::Format::eA2B10G10R10UnormPack32,
-        vk::Format::eA2R10G10B10SnormPack32,
         vk::Format::eA2R10G10B10UnormPack32,
         vk::Format::eB5G6R5UnormPack16,
         vk::Format::eB8G8R8A8Srgb,
@@ -424,6 +424,10 @@ vk::Format SurfaceFormat(AmdGpu::DataFormat data_format, AmdGpu::NumberFormat nu
         num_format == AmdGpu::NumberFormat::Unorm) {
         return vk::Format::eA2B10G10R10UnormPack32;
     }
+    if (data_format == AmdGpu::DataFormat::Format2_10_10_10 &&
+        num_format == AmdGpu::NumberFormat::Snorm) {
+        return vk::Format::eA2B10G10R10SnormPack32;
+    }
     if (data_format == AmdGpu::DataFormat::FormatBc7 && num_format == AmdGpu::NumberFormat::Srgb) {
         return vk::Format::eBc7SrgbBlock;
     }
@@ -471,14 +475,6 @@ vk::Format SurfaceFormat(AmdGpu::DataFormat data_format, AmdGpu::NumberFormat nu
     if (data_format == AmdGpu::DataFormat::Format16_16 &&
         num_format == AmdGpu::NumberFormat::Snorm) {
         return vk::Format::eR16G16Snorm;
-    }
-    if (data_format == AmdGpu::DataFormat::Format2_10_10_10 &&
-        num_format == AmdGpu::NumberFormat::Unorm) {
-        return vk::Format::eA2R10G10B10UnormPack32;
-    }
-    if (data_format == AmdGpu::DataFormat::Format2_10_10_10 &&
-        num_format == AmdGpu::NumberFormat::Snorm) {
-        return vk::Format::eA2R10G10B10SnormPack32;
     }
     if (data_format == AmdGpu::DataFormat::Format10_11_11 &&
         num_format == AmdGpu::NumberFormat::Float) {

--- a/src/video_core/renderer_vulkan/vk_shader_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_shader_cache.cpp
@@ -107,7 +107,7 @@ Shader::Info MakeShaderInfo(const GuestProgram& pgm, const AmdGpu::Liverpool::Re
 ShaderCache::ShaderCache(const Instance& instance_, AmdGpu::Liverpool* liverpool_)
     : instance{instance_}, liverpool{liverpool_}, inst_pool{8192}, block_pool{512} {
     profile = Shader::Profile{
-        .supported_spirv = 0x00010600U,
+        .supported_spirv = instance.ApiVersion() >= VK_API_VERSION_1_3 ? 0x00010600U : 0x00010500U,
         .subgroup_size = instance.SubgroupSize(),
         .support_explicit_workgroup_layout = true,
     };


### PR DESCRIPTION
* Fix an apparent mis-map of Format2_10_10_10. The Unorm version would map to `A2B10G10R10UnormPack32` with an unused duplicate mapping to `A2R10G10B10UnormPack32`, and the Snorm version would map to `A2R10G10B10SnormPack32`. Now both only map to their respective A2B10G10R10 formats. This helps for games that use these formats under MoltenVK since it does not support the A2R10G10B10 versions for vertex buffers.
* Set SPIR-V version to 1.5 if not using Vulkan 1.3 to silence a validation error about supported versions.