### PR TITLE
Allow graphics/compute shader list for skipping

### DIFF
--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -64,9 +64,8 @@ const ComputePipeline* PipelineCache::GetComputePipeline() {
 }
 
 bool ShouldSkipShader(u64 shader_hash, const char* shader_type) {
-    static constexpr u64 skip_hashes[] = {0xdeadbeefULL};
-    if (std::ranges::find(std::begin(skip_hashes), std::end(skip_hashes), shader_hash) !=
-        std::end(skip_hashes)) {
+    static constexpr std::array<u64, 0> skip_hashes = {};
+    if (std::ranges::find(skip_hashes.begin(), skip_hashes.end(), shader_hash) != skip_hashes.end()) {
         LOG_WARNING(Render_Vulkan, "Skipped {} shader hash {:#x}.", shader_type, shader_hash);
         return true;
     }

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -38,7 +38,9 @@ const GraphicsPipeline* PipelineCache::GetGraphicsPipeline() {
         LOG_TRACE(Render_Vulkan, "FMask decompression pass skipped");
         return nullptr;
     }
-    RefreshGraphicsKey();
+    if (!RefreshGraphicsKey()) {
+        return nullptr;
+    }
     const auto [it, is_new] = graphics_pipelines.try_emplace(graphics_key);
     if (is_new) {
         it.value() = std::make_unique<GraphicsPipeline>(instance, scheduler, graphics_key,
@@ -49,7 +51,9 @@ const GraphicsPipeline* PipelineCache::GetGraphicsPipeline() {
 }
 
 const ComputePipeline* PipelineCache::GetComputePipeline() {
-    RefreshComputeKey();
+    if (!RefreshComputeKey()) {
+      return nullptr;
+    }
     const auto [it, is_new] = compute_pipelines.try_emplace(compute_key);
     if (is_new) {
         it.value() = std::make_unique<ComputePipeline>(instance, scheduler, *pipeline_cache,
@@ -59,7 +63,18 @@ const ComputePipeline* PipelineCache::GetComputePipeline() {
     return pipeline;
 }
 
-void PipelineCache::RefreshGraphicsKey() {
+bool ShouldSkipShader(u32 shader_hash, const char* shader_type) {
+    static constexpr u32 skip_hashes[] = {
+        0xdeadbeefULL
+    };
+    if (std::ranges::find(std::begin(skip_hashes), std::end(skip_hashes), shader_hash) != std::end(skip_hashes)) {
+        LOG_WARNING(Render_Vulkan, "Skipped {} shader hash {:#x}.", shader_type, shader_hash);
+        return true;
+    }
+    return false;
+}
+
+bool PipelineCache::RefreshGraphicsKey() {
     auto& regs = liverpool->regs;
     auto& key = graphics_key;
 
@@ -160,18 +175,26 @@ void PipelineCache::RefreshGraphicsKey() {
             infos[i] = nullptr;
             continue;
         }
+        if (ShouldSkipShader(bininfo->shader_hash, "graphics")) {
+            return false;
+        }
         const auto stage = Shader::Stage{i};
         const GuestProgram guest_pgm{pgm, stage};
         std::tie(infos[i], modules[i], key.stage_hashes[i]) =
             shader_cache->GetProgram(guest_pgm, binding);
     }
+    return true;
 }
 
-void PipelineCache::RefreshComputeKey() {
+bool PipelineCache::RefreshComputeKey() {
     u32 binding{};
     const auto* cs_pgm = &liverpool->regs.cs_program;
     const GuestProgram guest_pgm{cs_pgm, Shader::Stage::Compute};
+    if (ShouldSkipShader(guest_pgm.hash, "compute")) {
+        return false;
+    }
     std::tie(infos[0], modules[0], compute_key) = shader_cache->GetProgram(guest_pgm, binding);
+    return true;
 }
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -65,7 +65,7 @@ const ComputePipeline* PipelineCache::GetComputePipeline() {
 
 bool ShouldSkipShader(u64 shader_hash, const char* shader_type) {
     static constexpr std::array<u64, 0> skip_hashes = {};
-    if (std::ranges::find(skip_hashes.begin(), skip_hashes.end(), shader_hash) != skip_hashes.end()) {
+    if (std::ranges::contains(skip_hashes, shader_hash)) {
         LOG_WARNING(Render_Vulkan, "Skipped {} shader hash {:#x}.", shader_type, shader_hash);
         return true;
     }

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -52,7 +52,7 @@ const GraphicsPipeline* PipelineCache::GetGraphicsPipeline() {
 
 const ComputePipeline* PipelineCache::GetComputePipeline() {
     if (!RefreshComputeKey()) {
-      return nullptr;
+        return nullptr;
     }
     const auto [it, is_new] = compute_pipelines.try_emplace(compute_key);
     if (is_new) {
@@ -175,7 +175,7 @@ bool PipelineCache::RefreshGraphicsKey() {
             continue;
         }
         if (ShouldSkipShader(bininfo->shader_hash, "graphics")) {
-           return false;
+            return false;
         }
         const auto stage = Shader::Stage{i};
         const GuestProgram guest_pgm{pgm, stage};
@@ -190,7 +190,7 @@ bool PipelineCache::RefreshComputeKey() {
     const auto* cs_pgm = &liverpool->regs.cs_program;
     const GuestProgram guest_pgm{cs_pgm, Shader::Stage::Compute};
     if (ShouldSkipShader(guest_pgm.hash, "compute")) {
-       return false;
+        return false;
     }
     std::tie(infos[0], modules[0], compute_key) = shader_cache->GetProgram(guest_pgm, binding);
     return true;

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -63,11 +63,10 @@ const ComputePipeline* PipelineCache::GetComputePipeline() {
     return pipeline;
 }
 
-bool ShouldSkipShader(u32 shader_hash, const char* shader_type) {
-    static constexpr u32 skip_hashes[] = {
-        0xdeadbeefULL
-    };
-    if (std::ranges::find(std::begin(skip_hashes), std::end(skip_hashes), shader_hash) != std::end(skip_hashes)) {
+bool ShouldSkipShader(u64 shader_hash, const char* shader_type) {
+    static constexpr u64 skip_hashes[] = {0xdeadbeefULL};
+    if (std::ranges::find(std::begin(skip_hashes), std::end(skip_hashes), shader_hash) !=
+        std::end(skip_hashes)) {
         LOG_WARNING(Render_Vulkan, "Skipped {} shader hash {:#x}.", shader_type, shader_hash);
         return true;
     }
@@ -176,7 +175,7 @@ bool PipelineCache::RefreshGraphicsKey() {
             continue;
         }
         if (ShouldSkipShader(bininfo->shader_hash, "graphics")) {
-            return false;
+           return false;
         }
         const auto stage = Shader::Stage{i};
         const GuestProgram guest_pgm{pgm, stage};
@@ -191,7 +190,7 @@ bool PipelineCache::RefreshComputeKey() {
     const auto* cs_pgm = &liverpool->regs.cs_program;
     const GuestProgram guest_pgm{cs_pgm, Shader::Stage::Compute};
     if (ShouldSkipShader(guest_pgm.hash, "compute")) {
-        return false;
+       return false;
     }
     std::tie(infos[0], modules[0], compute_key) = shader_cache->GetProgram(guest_pgm, binding);
     return true;

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.h
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.h
@@ -30,8 +30,8 @@ public:
     const ComputePipeline* GetComputePipeline();
 
 private:
-    void RefreshGraphicsKey();
-    void RefreshComputeKey();
+    bool RefreshGraphicsKey();
+    bool RefreshComputeKey();
 
 private:
     const Instance& instance;


### PR DESCRIPTION
This makes it easier for local builders to skip shaders for debugging and testing.
This is helpful for debugging troublesome shaders on forks/branches while merging upstream changes as it provides a specific place to put them to remain constant.

RefreshComputeKey and RefreshGraphicsKey now return bools to check for skips or not.
Logged a warning when skipped for clarity in the log when shaders are skipped and of type
![image](https://github.com/user-attachments/assets/d69edda2-b354-40cd-afbf-23692ea8a6cb)
