### PR TITLE
[macOS] Place `shadPS4/user` folder in `Application Support`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -409,3 +409,6 @@ FodyWeavers.xsd
 /out/*
 /third-party/out/*
 /src/common/scm_rev.cpp
+
+# for macOS
+**/.DS_Store

--- a/src/common/path_util.cpp
+++ b/src/common/path_util.cpp
@@ -82,11 +82,20 @@ static std::filesystem::path GetBundleParentDirectory() {
 
 static auto UserPaths = [] {
 #ifdef __APPLE__
-    std::filesystem::current_path(GetBundleParentDirectory());
+    // Start by assuming the base directory is the bundle's parent directory.
+    std::filesystem::path base_dir = GetBundleParentDirectory();
+    std::filesystem::path user_dir = base_dir / PORTABLE_DIR;
+    // Check if the "user" directory exists in the current path:
+    if (!std::filesystem::exists(user_dir)) {
+        // If it doesn't exist, use the new hardcoded path:
+        user_dir =
+            std::filesystem::path(getenv("HOME")) / "Library" / "Application Support" / "shadPS4";
+    }
+#else
+    const auto user_dir = std::filesystem::current_path() / PORTABLE_DIR;
 #endif
 
     std::unordered_map<PathType, fs::path> paths;
-    const auto user_dir = std::filesystem::current_path() / PORTABLE_DIR;
 
     const auto create_path = [&](PathType shad_path, const fs::path& new_path) {
         std::filesystem::create_directory(new_path);


### PR DESCRIPTION
## Details:

Attempts to resolve #509
![CleanShot 2024-09-01 at 12 00 18@2x](https://github.com/user-attachments/assets/cef5d7b5-78f2-45d8-9653-54f973812548)


+ Would say **50% work is done**, as I have no clue what to do with compiled translation files.
+ added `.DS_Store` for `.gitignore`

## How it works?

If it's fresh install, **it will use new requested path**.
If user folder is present near executable, it will continue using **old path**.
To use new path, you can backup user folder, create new one and replace the files.

## TODO:
- [] translations