### PR TITLE
Qt: Update Game List

### DIFF
--- a/src/qt_gui/game_info.h
+++ b/src/qt_gui/game_info.h
@@ -41,7 +41,6 @@ public:
                                           : fw.left(3).insert(1, '.');
             game.fw = (fw_int == 0) ? "0.00" : fw_.toStdString();
             game.version = psf.GetString("APP_VER");
-            game.category = psf.GetString("CATEGORY");
         }
         return game;
     }

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -23,14 +23,13 @@ GameListFrame::GameListFrame(std::shared_ptr<GameInfoClass> game_info_get, QWidg
     this->horizontalHeader()->setSortIndicatorShown(true);
     this->horizontalHeader()->setStretchLastSection(true);
     this->setContextMenuPolicy(Qt::CustomContextMenu);
-    this->setColumnCount(9);
-    this->setColumnWidth(1, 250);
-    this->setColumnWidth(2, 110);
-    this->setColumnWidth(3, 80);
-    this->setColumnWidth(4, 90);
-    this->setColumnWidth(5, 80);
-    this->setColumnWidth(6, 80);
-    this->setColumnWidth(7, 80);
+    this->setColumnCount(8);
+    this->setColumnWidth(1, 300); // Name
+    this->setColumnWidth(2, 120); // Serial
+    this->setColumnWidth(3, 90);  // Region
+    this->setColumnWidth(4, 90);  // Firmware
+    this->setColumnWidth(5, 90);  // Size
+    this->setColumnWidth(6, 90);  // Version
     QStringList headers;
     headers << "Icon"
             << "Name"
@@ -39,7 +38,6 @@ GameListFrame::GameListFrame(std::shared_ptr<GameInfoClass> game_info_get, QWidg
             << "Firmware"
             << "Size"
             << "Version"
-            << "Category"
             << "Path";
     this->setHorizontalHeaderLabels(headers);
     this->horizontalHeader()->setSortIndicatorShown(true);
@@ -87,8 +85,7 @@ void GameListFrame::PopulateGameList() {
         SetTableItem(i, 4, QString::fromStdString(m_game_info->m_games[i].fw));
         SetTableItem(i, 5, QString::fromStdString(m_game_info->m_games[i].size));
         SetTableItem(i, 6, QString::fromStdString(m_game_info->m_games[i].version));
-        SetTableItem(i, 7, QString::fromStdString(m_game_info->m_games[i].category));
-        SetTableItem(i, 8, QString::fromStdString(m_game_info->m_games[i].path));
+        SetTableItem(i, 7, QString::fromStdString(m_game_info->m_games[i].path));
     }
 }
 
@@ -168,7 +165,7 @@ void GameListFrame::SetTableItem(int row, int column, QString itemStr) {
     QVBoxLayout* layout = new QVBoxLayout(widget);
     QLabel* label = new QLabel(itemStr, widget);
 
-    label->setStyleSheet("color: white; font-size: 15px; font-weight: bold;");
+    label->setStyleSheet("color: white; font-size: 16px; font-weight: bold;");
 
     // Create shadow effect
     QGraphicsDropShadowEffect* shadowEffect = new QGraphicsDropShadowEffect();

--- a/src/qt_gui/game_list_utils.h
+++ b/src/qt_gui/game_list_utils.h
@@ -14,7 +14,6 @@ struct GameInfo {
     std::string serial = "Unknown";
     std::string version = "Unknown";
     std::string region = "Unknown";
-    std::string category = "Unknown";
     std::string fw = "Unknown";
 };
 

--- a/src/qt_gui/main_window_ui.h
+++ b/src/qt_gui/main_window_ui.h
@@ -7,8 +7,6 @@
 #include <QPushButton>
 #include <QToolBar>
 
-QT_BEGIN_NAMESPACE
-
 class Ui_MainWindow {
 public:
     QAction* bootInstallPkgAct;
@@ -355,5 +353,3 @@ public:
 namespace Ui {
 class MainWindow : public Ui_MainWindow {};
 } // namespace Ui
-
-QT_END_NAMESPACE


### PR DESCRIPTION
I removed the "Category" tab because it is not very useful to see it.
It is still possible to see it in "SFO Viewer".
I enlarged the font and the "Name" tab because some long titles do not display completely like: Cursed Castilla (Maldita Castilla EX)

Before:
![With category](https://github.com/user-attachments/assets/1a6721e0-4a89-4a04-b7eb-14c03c038d5d)

After:
![Without category](https://github.com/user-attachments/assets/0179f092-ff5e-4855-ab17-c378f7c49a17)