### PR TITLE
ci: Remove translations folder from Windows/macOS upload.

### DIFF
--- a/.github/workflows/macos-qt.yml
+++ b/.github/workflows/macos-qt.yml
@@ -50,7 +50,6 @@ jobs:
       run: |
         mkdir upload
         mv ${{github.workspace}}/build/shadps4.app upload
-        mv ${{github.workspace}}/build/translations upload
         macdeployqt upload/shadps4.app
         tar cf shadps4-macos-qt.tar.gz -C upload .
 

--- a/.github/workflows/windows-qt.yml
+++ b/.github/workflows/windows-qt.yml
@@ -40,7 +40,6 @@ jobs:
       run: |
         mkdir upload
         move build/Release/shadPS4.exe upload
-        move build/translations upload
         windeployqt --dir upload upload/shadPS4.exe
 
     - name: Upload executable


### PR DESCRIPTION
Removes the translations folder from the Windows and macOS Qt distribution as it is not needed; the translations resources are baked into the app.