### PR TITLE
macos: Remove need for TLS patch by storing TCB pointer in FS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -636,7 +636,7 @@ target_link_libraries(shadps4 PRIVATE Boost::headers GPUOpen::VulkanMemoryAlloca
 
 if (APPLE)
   # Reserve system-managed memory space.
-  target_link_options(shadps4 PRIVATE -Wl,-no_pie,-no_fixup_chains,-no_huge,-pagezero_size,0x400000,-segaddr,GUEST_SYSTEM,0x400000,-image_base,0x20000000000)
+  target_link_options(shadps4 PRIVATE -Wl,-no_pie,-no_fixup_chains,-no_huge,-pagezero_size,0x4000,-segaddr,TCB_SPACE,0x4000,-segaddr,GUEST_SYSTEM,0x400000,-image_base,0x20000000000)
 
   # Link MoltenVK for Vulkan support
   find_library(MOLTENVK MoltenVK REQUIRED)

--- a/src/core/libraries/kernel/thread_management.cpp
+++ b/src/core/libraries/kernel/thread_management.cpp
@@ -18,6 +18,7 @@
 #include "core/libraries/kernel/threads/threads.h"
 #include "core/libraries/libs.h"
 #include "core/linker.h"
+#include "core/tls.h"
 #ifdef _WIN64
 #include <windows.h>
 #else
@@ -987,6 +988,7 @@ static void cleanup_thread(void* arg) {
             destructor(value);
         }
     }
+    Core::SetTcbBase(nullptr);
     thread->is_almost_done = true;
 }
 

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -106,6 +106,8 @@ void Linker::Execute() {
             RunMainEntry(m->GetEntryAddress(), &p, ProgramExitFunc);
         }
     }
+
+    SetTcbBase(nullptr);
 }
 
 s32 Linker::LoadModule(const std::filesystem::path& elf_name, bool is_dynamic) {

--- a/src/core/tls.h
+++ b/src/core/tls.h
@@ -22,8 +22,10 @@ struct Tcb {
     void* tcb_thread;
 };
 
+#ifdef _WIN32
 /// Gets the thread local storage key for the TCB block.
 u32 GetTcbKey();
+#endif
 
 /// Sets the data pointer to the TCB block.
 void SetTcbBase(void* image_address);


### PR DESCRIPTION
On macOS we can actually store the TCB pointer at `fs:0x0` as expected by using local descriptor tables.

* First we define a region in 32-bit address space to hold the pages these descriptors will point to (since only 32-bit addresses are supported by the syscall) and define a set to track free LDT entry indices.
* Then whenever a thread initializes its TCB we can store it in a descriptor page: pop a free index from the set, calculate a page address based on that index, store the TCB pointer, and set up the LDT entry using the `i386_set_ldt` syscall.
* Finally, we can store a selector pointing to that LDT entry in the FS register.
* When the thread exits we call `SetTcbBase(nullptr)` which signals the code to clean up by freeing the LDT entry.

This completely eliminates the need to apply TCB access code patches on macOS.