### PR TITLE
CI: include build date and git hash in build artifact name

### DIFF
--- a/.github/workflows/linux-qt.yml
+++ b/.github/workflows/linux-qt.yml
@@ -34,8 +34,12 @@ jobs:
     - name: Run AppImage packaging script
       run:  ./.github/linux-appimage-qt.sh
 
+    - name: Retrieve Git Hash
+      id: git-hash
+      run: echo "hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
     - name: Upload executable
       uses: actions/upload-artifact@v4
       with:
-        name: shadps4-linux-qt
+        name: shadps4-linux-qt-${{ steps.git-hash.outputs.hash }}
         path: Shadps4-qt.AppImage

--- a/.github/workflows/linux-qt.yml
+++ b/.github/workflows/linux-qt.yml
@@ -34,12 +34,14 @@ jobs:
     - name: Run AppImage packaging script
       run:  ./.github/linux-appimage-qt.sh
 
-    - name: Retrieve Git Hash
-      id: git-hash
-      run: echo "hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+    - name: Get date and git hash
+      id: vars
+      run: |
+        echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        echo "shorthash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Upload executable
       uses: actions/upload-artifact@v4
       with:
-        name: shadps4-linux-qt-${{ steps.git-hash.outputs.hash }}
+        name: shadps4-linux-qt-${{ steps.vars.outputs.date }}-${{ steps.vars.outputs.shorthash }}
         path: Shadps4-qt.AppImage

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,10 +31,14 @@ jobs:
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel
 
+    - name: Retrieve Git Hash
+      id: git-hash
+      run: echo "hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
     - name: Upload executable
       uses: actions/upload-artifact@v4
       with:
-        name: shadps4-ubuntu64
+        name: shadps4-ubuntu64-${{ steps.git-hash.outputs.hash }}
         path: |
           ${{github.workspace}}/build/shadps4
 
@@ -44,5 +48,5 @@ jobs:
     - name: Upload executable
       uses: actions/upload-artifact@v4
       with:
-        name: shadps4-sdl-appimage
+        name: shadps4-sdl-appimage-${{ steps.git-hash.outputs.hash }}
         path: Shadps4-sdl.AppImage

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,14 +31,16 @@ jobs:
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel
 
-    - name: Retrieve Git Hash
-      id: git-hash
-      run: echo "hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+    - name: Get date and git hash
+      id: vars
+      run: |
+        echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        echo "shorthash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Upload executable
       uses: actions/upload-artifact@v4
       with:
-        name: shadps4-ubuntu64-${{ steps.git-hash.outputs.hash }}
+        name: shadps4-ubuntu64-${{ steps.vars.outputs.date }}-${{ steps.vars.outputs.shorthash }}
         path: |
           ${{github.workspace}}/build/shadps4
 
@@ -48,5 +50,5 @@ jobs:
     - name: Upload executable
       uses: actions/upload-artifact@v4
       with:
-        name: shadps4-sdl-appimage-${{ steps.git-hash.outputs.hash }}
+        name: shadps4-sdl-appimage-${{ steps.vars.outputs.date }}-${{ steps.vars.outputs.shorthash }}
         path: Shadps4-sdl.AppImage

--- a/.github/workflows/macos-qt.yml
+++ b/.github/workflows/macos-qt.yml
@@ -53,12 +53,15 @@ jobs:
         macdeployqt upload/shadps4.app
         tar cf shadps4-macos-qt.tar.gz -C upload .
 
-    - name: Retrieve Git Hash
-      id: git-hash
-      run: echo "hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+    - name: Get date and git hash
+      id: vars
+      run: |
+        echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        echo "shorthash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
 
     - name: Upload executable
       uses: actions/upload-artifact@v4
       with:
-        name: shadps4-macos-qt-${{ steps.git-hash.outputs.hash }}
+        name: shadps4-macos-qt-${{ steps.vars.outputs.date }}-${{ steps.vars.outputs.shorthash }}
         path: shadps4-macos-qt.tar.gz

--- a/.github/workflows/macos-qt.yml
+++ b/.github/workflows/macos-qt.yml
@@ -53,8 +53,12 @@ jobs:
         macdeployqt upload/shadps4.app
         tar cf shadps4-macos-qt.tar.gz -C upload .
 
+    - name: Retrieve Git Hash
+      id: git-hash
+      run: echo "hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
     - name: Upload executable
       uses: actions/upload-artifact@v4
       with:
-        name: shadps4-macos-qt
+        name: shadps4-macos-qt-${{ steps.git-hash.outputs.hash }}
         path: shadps4-macos-qt.tar.gz

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -45,8 +45,12 @@ jobs:
         install_name_tool -add_rpath "@loader_path" upload/shadps4
         tar cf shadps4-macos-sdl.tar.gz -C upload .
 
+    - name: Retrieve Git Hash
+      id: git-hash
+      run: echo "hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
     - name: Upload executable
       uses: actions/upload-artifact@v4
       with:
-        name: shadps4-macos-sdl
+        name: shadps4-macos-sdl-${{ steps.git-hash.outputs.hash }}
         path: shadps4-macos-sdl.tar.gz

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -45,12 +45,14 @@ jobs:
         install_name_tool -add_rpath "@loader_path" upload/shadps4
         tar cf shadps4-macos-sdl.tar.gz -C upload .
 
-    - name: Retrieve Git Hash
-      id: git-hash
-      run: echo "hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+    - name: Get date and git hash
+      id: vars
+      run: |
+        echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        echo "shorthash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Upload executable
       uses: actions/upload-artifact@v4
       with:
-        name: shadps4-macos-sdl-${{ steps.git-hash.outputs.hash }}
+        name: shadps4-macos-sdl-${{ steps.vars.outputs.date }}-${{ steps.vars.outputs.shorthash }}
         path: shadps4-macos-sdl.tar.gz

--- a/.github/workflows/windows-qt.yml
+++ b/.github/workflows/windows-qt.yml
@@ -41,9 +41,16 @@ jobs:
         mkdir upload
         move build/Release/shadPS4.exe upload
         windeployqt --dir upload upload/shadPS4.exe
+        
+    - name: Retrieve Git Hash
+      id: git-hash
+      shell: cmd
+      run: |
+        FOR /F "tokens=*" %%g IN ('git rev-parse --short HEAD') do (SET HASH=%%g)
+        echo hash=%HASH% >> %GITHUB_OUTPUT%
 
     - name: Upload executable
       uses: actions/upload-artifact@v4
       with:
-        name: shadps4-win64-qt
+        name: shadps4-win64-qt-${{ steps.git-hash.outputs.hash }}
         path: upload

--- a/.github/workflows/windows-qt.yml
+++ b/.github/workflows/windows-qt.yml
@@ -42,15 +42,15 @@ jobs:
         move build/Release/shadPS4.exe upload
         windeployqt --dir upload upload/shadPS4.exe
         
-    - name: Retrieve Git Hash
-      id: git-hash
-      shell: cmd
+    - name: Get date and git hash
+      id: vars
+      shell: pwsh
       run: |
-        FOR /F "tokens=*" %%g IN ('git rev-parse --short HEAD') do (SET HASH=%%g)
-        echo hash=%HASH% >> %GITHUB_OUTPUT%
+        echo "date=$(Get-Date -Format 'yyyy-MM-dd')" >> $env:GITHUB_OUTPUT
+        echo "shorthash=$(git rev-parse --short HEAD)" >> $env:GITHUB_OUTPUT
 
     - name: Upload executable
       uses: actions/upload-artifact@v4
       with:
-        name: shadps4-win64-qt-${{ steps.git-hash.outputs.hash }}
+        name: shadps4-win64-qt-${{ steps.vars.outputs.date }}-${{ steps.vars.outputs.shorthash }}
         path: upload

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,16 +26,16 @@ jobs:
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel
 
-    - name: Retrieve Git Hash
-      id: git-hash
-      shell: cmd
+    - name: Get date and git hash
+      id: vars
+      shell: pwsh
       run: |
-        FOR /F "tokens=*" %%g IN ('git rev-parse --short HEAD') do (SET HASH=%%g)
-        echo hash=%HASH% >> %GITHUB_OUTPUT%
+        echo "date=$(Get-Date -Format 'yyyy-MM-dd')" >> $env:GITHUB_OUTPUT
+        echo "shorthash=$(git rev-parse --short HEAD)" >> $env:GITHUB_OUTPUT
 
     - name: Upload executable
       uses: actions/upload-artifact@v4
       with:
-        name: shadps4-win64-sdl-${{ steps.git-hash.outputs.hash }}
+        name: shadps4-win64-sdl-${{ steps.vars.outputs.date }}-${{ steps.vars.outputs.shorthash }}
         path: |
           ${{github.workspace}}/build/Release/shadPS4.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,9 +26,16 @@ jobs:
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel
 
+    - name: Retrieve Git Hash
+      id: git-hash
+      shell: cmd
+      run: |
+        FOR /F "tokens=*" %%g IN ('git rev-parse --short HEAD') do (SET HASH=%%g)
+        echo hash=%HASH% >> %GITHUB_OUTPUT%
+
     - name: Upload executable
       uses: actions/upload-artifact@v4
       with:
-        name: shadps4-win64-sdl
+        name: shadps4-win64-sdl-${{ steps.git-hash.outputs.hash }}
         path: |
           ${{github.workspace}}/build/Release/shadPS4.exe


### PR DESCRIPTION
Not sure if this is something y'all would want, but I think it's useful to differentiate builds.
 
Include build date and git short hash in build artifact name:
![image](https://github.com/user-attachments/assets/9b923a2b-48ce-4029-9cdb-a3a66354e029)

to avoid this
![image](https://github.com/user-attachments/assets/666907a2-34cb-4696-bf73-0961cefcf3aa)
