### PR TITLE
Set CF correctly on BLSI patch

### DIFF
--- a/src/core/cpu_patches.cpp
+++ b/src/core/cpu_patches.cpp
@@ -308,21 +308,21 @@ static void GenerateBLSI(const ZydisDecodedOperand* operands, Xbyak::CodeGenerat
     SaveRegisters(c, {scratch});
 
     // BLSI sets CF to zero if source is zero, otherwise it sets CF to one.
-    Xbyak::Label carrySet, carryNotSet, end;
+    Xbyak::Label set_carry, clear_carry, end;
 
     c.mov(scratch, *src);
     c.neg(scratch); // NEG, like BLSI, clears CF if the source is zero and sets it otherwise
-    c.jc(carrySet);
-    c.jmp(carryNotSet);
+    c.jc(set_carry);
+    c.jmp(clear_carry);
 
-    c.L(carrySet);
+    c.L(set_carry);
     c.and_(scratch, *src);
     c.stc(); // setting/clearing carry needs to happen after the AND because that clears CF
     c.jmp(end);
 
-    c.L(carryNotSet);
+    c.L(clear_carry);
     c.and_(scratch, *src);
-    c.clc();
+    // We don't need to clear carry here since AND does that for us
 
     c.L(end);
     c.mov(dst, scratch);


### PR DESCRIPTION
BLSI needs to set CF if source is not zero and clear it otherwise:
```
temp := (-SRC) bitwiseAND (SRC);
SF := temp[OperandSize -1];
ZF := (temp = 0);
IF SRC = 0
    CF := 0;
ELSE
    CF := 1;
FI
DEST := temp;
```

Since unfortunately AND clears CF, we need to take the CF from NEG and apply it after the AND.
NEG sets CF like so:
```
IF DEST = 0
    THEN CF := 0;
    ELSE CF := 1;
FI;
DEST := [– (DEST)]
```