### PR TITLE
Set CF correctly on BLSR/BLSMSK patch

### DIFF
--- a/src/core/cpu_patches.cpp
+++ b/src/core/cpu_patches.cpp
@@ -323,9 +323,26 @@ static void GenerateBLSMSK(const ZydisDecodedOperand* operands, Xbyak::CodeGener
 
     SaveRegisters(c, {scratch});
 
+    Xbyak::Label set_carry, clear_carry, end;
+
+    // BLSMSK sets CF to zero if source is NOT zero, otherwise it sets CF to one.
     c.mov(scratch, *src);
+    c.test(scratch, scratch);
+    c.jz(set_carry);
+    c.jmp(clear_carry);
+
+    c.L(set_carry);
     c.dec(scratch);
     c.xor_(scratch, *src);
+    c.stc();
+    c.jmp(end);
+
+    c.L(clear_carry);
+    c.dec(scratch);
+    c.xor_(scratch, *src);
+    // We don't need to clear carry here since XOR does that for us
+
+    c.L(end);
     c.mov(dst, scratch);
 
     RestoreRegisters(c, {scratch});

--- a/src/core/cpu_patches.cpp
+++ b/src/core/cpu_patches.cpp
@@ -339,9 +339,26 @@ static void GenerateBLSR(const ZydisDecodedOperand* operands, Xbyak::CodeGenerat
 
     SaveRegisters(c, {scratch});
 
+    Xbyak::Label set_carry, clear_carry, end;
+
+    // BLSR sets CF to zero if source is NOT zero, otherwise it sets CF to one.
     c.mov(scratch, *src);
+    c.test(scratch, scratch);
+    c.jz(set_carry);
+    c.jmp(clear_carry);
+
+    c.L(set_carry);
     c.dec(scratch);
     c.and_(scratch, *src);
+    c.stc();
+    c.jmp(end);
+
+    c.L(clear_carry);
+    c.dec(scratch);
+    c.and_(scratch, *src);
+    // We don't need to clear carry here since AND does that for us
+
+    c.L(end);
     c.mov(dst, scratch);
 
     RestoreRegisters(c, {scratch});


### PR DESCRIPTION
Similarly to BLSI, BLSR needs to modify CF.
If source is zero CF is set, otherwise it's cleared:

```
temp := (SRC-1) bitwiseAND ( SRC );
SF := temp[OperandSize -1];
ZF := (temp = 0);
IF SRC = 0
    CF := 1;
ELSE
    CF := 0;
FI
DEST := temp;
```
Also doing the same on BLSMSK