### PR TITLE
Fix VirtualQuery

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -305,9 +305,10 @@ int MemoryManager::VirtualQuery(VAddr addr, int flags,
     const auto& vma = it->second;
     info->start = vma.base;
     info->end = vma.base + vma.size;
+    info->protection = static_cast<s32>(vma.prot);
     info->is_flexible.Assign(vma.type == VMAType::Flexible);
     info->is_direct.Assign(vma.type == VMAType::Direct);
-    info->is_commited.Assign(vma.type != VMAType::Free);
+    info->is_commited.Assign(vma.type != VMAType::Free && vma.type != VMAType::Reserved);
     vma.name.copy(info->name.data(), std::min(info->name.size(), vma.name.size()));
     if (vma.type == VMAType::Direct) {
         const auto dmem_it = FindDmemArea(vma.phys_base);


### PR DESCRIPTION
Found this issue while looking at code from fpPS4. shadPS4's VirtualQuery implementation was setting info->is_commited to true (to be specific, the u32 equivalent) when the queried region was reserved. As far as I know, reserved regions are not committed, so incorrectly setting this causes issues. 

Also sets the protection value in the VirtualQueryInfo, as I'd assume not storing that could cause issues in games (especially when functions that protect memory are implemented).

This fixes Unity games currently hanging on the sceKernelMprotect stub. 