### PR TITLE
Additional VirtualQuery improvements

### DIFF
--- a/src/core/libraries/kernel/memory_management.h
+++ b/src/core/libraries/kernel/memory_management.h
@@ -56,7 +56,7 @@ struct OrbisVirtualQueryInfo {
         BitField<1, 1, u32> is_direct;
         BitField<2, 1, u32> is_stack;
         BitField<3, 1, u32> is_pooled;
-        BitField<4, 1, u32> is_commited;
+        BitField<4, 1, u32> is_committed;
     };
     std::array<char, 32> name;
 };

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -311,6 +311,8 @@ int MemoryManager::VirtualQuery(VAddr addr, int flags,
     info->protection = static_cast<s32>(vma.prot);
     info->is_flexible.Assign(vma.type == VMAType::Flexible);
     info->is_direct.Assign(vma.type == VMAType::Direct);
+    info->is_stack.Assign(vma.type == VMAType::Stack);
+    info->is_pooled.Assign(vma.type == VMAType::Pooled);
     info->is_commited.Assign(vma.type != VMAType::Free && vma.type != VMAType::Reserved);
     vma.name.copy(info->name.data(), std::min(info->name.size(), vma.name.size()));
     if (vma.type == VMAType::Direct) {

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -308,6 +308,7 @@ int MemoryManager::VirtualQuery(VAddr addr, int flags,
     const auto& vma = it->second;
     info->start = vma.base;
     info->end = vma.base + vma.size;
+    info->offset = vma.phys_base;
     info->protection = static_cast<s32>(vma.prot);
     info->is_flexible.Assign(vma.type == VMAType::Flexible);
     info->is_direct.Assign(vma.type == VMAType::Direct);
@@ -318,8 +319,9 @@ int MemoryManager::VirtualQuery(VAddr addr, int flags,
     if (vma.type == VMAType::Direct) {
         const auto dmem_it = FindDmemArea(vma.phys_base);
         ASSERT(dmem_it != dmem_map.end());
-        info->offset = vma.phys_base;
         info->memory_type = dmem_it->second.memory_type;
+    } else {
+        info->memory_type = ::Libraries::Kernel::SCE_KERNEL_WB_ONION;
     }
 
     return ORBIS_OK;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -313,7 +313,7 @@ int MemoryManager::VirtualQuery(VAddr addr, int flags,
     info->is_direct.Assign(vma.type == VMAType::Direct);
     info->is_stack.Assign(vma.type == VMAType::Stack);
     info->is_pooled.Assign(vma.type == VMAType::Pooled);
-    info->is_commited.Assign(vma.type != VMAType::Free && vma.type != VMAType::Reserved);
+    info->is_committed.Assign(vma.type != VMAType::Free && vma.type != VMAType::Reserved);
     vma.name.copy(info->name.data(), std::min(info->name.size(), vma.name.size()));
     if (vma.type == VMAType::Direct) {
         const auto dmem_it = FindDmemArea(vma.phys_base);

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -165,7 +165,7 @@ public:
 
     int VirtualQuery(VAddr addr, int flags, ::Libraries::Kernel::OrbisVirtualQueryInfo* info);
 
-    int DirectMemoryQuery(PAddr addr, bool find_next, 
+    int DirectMemoryQuery(PAddr addr, bool find_next,
                           ::Libraries::Kernel::OrbisQueryInfo* out_info);
 
     int DirectQueryAvailable(PAddr search_start, PAddr search_end, size_t alignment,

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -163,9 +163,9 @@ public:
 
     int QueryProtection(VAddr addr, void** start, void** end, u32* prot);
 
-    int VirtualQuery(VAddr addr, int flags, Libraries::Kernel::OrbisVirtualQueryInfo* info);
+    int VirtualQuery(VAddr addr, int flags, ::Libraries::Kernel::OrbisVirtualQueryInfo* info);
 
-    int DirectMemoryQuery(PAddr addr, bool find_next, Libraries::Kernel::OrbisQueryInfo* out_info);
+    int DirectMemoryQuery(PAddr addr, bool find_next, ::Libraries::Kernel::OrbisQueryInfo* out_info);
 
     int DirectQueryAvailable(PAddr search_start, PAddr search_end, size_t alignment,
                              PAddr* phys_addr_out, size_t* size_out);

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -165,7 +165,8 @@ public:
 
     int VirtualQuery(VAddr addr, int flags, ::Libraries::Kernel::OrbisVirtualQueryInfo* info);
 
-    int DirectMemoryQuery(PAddr addr, bool find_next, ::Libraries::Kernel::OrbisQueryInfo* out_info);
+    int DirectMemoryQuery(PAddr addr, bool find_next, 
+                          ::Libraries::Kernel::OrbisQueryInfo* out_info);
 
     int DirectQueryAvailable(PAddr search_start, PAddr search_end, size_t alignment,
                              PAddr* phys_addr_out, size_t* size_out);


### PR DESCRIPTION
At the suggestion of @georgemoralis, I've adjusted sceKernelVirtualQuery to properly initialize all variables in the OrbisVirtualQueryInfo struct. I also resolved some minor nits I had with the code. 

In my testing, this doesn't appear to improve or regress any games using VirtualQuery. 