### PR TITLE
Note macOS and Xcode version requirements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Check the build instructions for [**Linux**](https://github.com/shadps4-emu/shad
 
 Check the build instructions for [**macOS**](https://github.com/shadps4-emu/shadPS4/blob/main/documents/building-macos.md).
 
+Note that macOS users need at least macOS 15 on an Apple Silicon Mac, or at least macOS 11 on an Intel Mac.
+
 ## Building status
 
 <details>

--- a/documents/building-macos.md
+++ b/documents/building-macos.md
@@ -7,7 +7,9 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 ### Install the necessary tools to build shadPS4:
 
-For installing tools and library dependencies we will be using [Homebrew](https://brew.sh/).
+First, make sure you have **Xcode 16.0 or newer** installed.
+
+For installing other tools and library dependencies we will be using [Homebrew](https://brew.sh/).
 
 On an ARM system, we will need the native ARM Homebrew to install tools and x86_64 Homebrew to install libraries.
 


### PR DESCRIPTION
* Add note that macOS 15 or above is needed for Apple Silicon, 11 or above for Intel.
* Add note to build guide that Xcode 16.0 or above is required.