### PR TITLE
vulkan: Better support for directly linking a Vulkan support library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -647,12 +647,17 @@ target_link_libraries(shadps4 PRIVATE magic_enum::magic_enum fmt::fmt toml11::to
 target_link_libraries(shadps4 PRIVATE Boost::headers GPUOpen::VulkanMemoryAllocator sirit Vulkan::Headers xxHash::xxhash Zydis::Zydis glslang::SPIRV glslang::glslang SDL3::SDL3)
 
 if (APPLE)
+  option(USE_SYSTEM_VULKAN_LOADER "Enables using the system Vulkan loader instead of directly linking with MoltenVK. Useful for loading validation layers." OFF)
+  if (USE_SYSTEM_VULKAN_LOADER)
+      target_compile_definitions(shadps4 PRIVATE USE_SYSTEM_VULKAN_LOADER=1)
+  else()
+      # Link MoltenVK for Vulkan support
+      find_library(MOLTENVK MoltenVK REQUIRED)
+      target_link_libraries(shadps4 PRIVATE ${MOLTENVK})
+  endif()
+
   # Reserve system-managed memory space.
   target_link_options(shadps4 PRIVATE -Wl,-no_pie,-no_fixup_chains,-no_huge,-pagezero_size,0x4000,-segaddr,TCB_SPACE,0x4000,-segaddr,GUEST_SYSTEM,0x400000,-image_base,0x20000000000)
-
-  # Link MoltenVK for Vulkan support
-  find_library(MOLTENVK MoltenVK REQUIRED)
-  target_link_libraries(shadps4 PRIVATE ${MOLTENVK})
 
   # Replacement for std::chrono::time_zone
   target_link_libraries(shadps4 PRIVATE date::date-tz)

--- a/src/video_core/renderer_vulkan/vk_common.h
+++ b/src/video_core/renderer_vulkan/vk_common.h
@@ -3,6 +3,10 @@
 
 #pragma once
 
+#if defined(__APPLE__) && !USE_SYSTEM_VULKAN_LOADER
+#define VULKAN_HPP_ENABLE_DYNAMIC_LOADER_TOOL 0
+#endif
+
 // Include vulkan-hpp header
 #define VK_ENABLE_BETA_EXTENSIONS
 #define VK_NO_PROTOTYPES

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -47,13 +47,13 @@ std::string GetReadableVersion(u32 version) {
 } // Anonymous namespace
 
 Instance::Instance(bool enable_validation, bool dump_command_buffers)
-    : instance{CreateInstance(dl, Frontend::WindowSystemType::Headless, enable_validation,
+    : instance{CreateInstance(Frontend::WindowSystemType::Headless, enable_validation,
                               dump_command_buffers)},
       physical_devices{instance->enumeratePhysicalDevices()} {}
 
 Instance::Instance(Frontend::WindowSDL& window, s32 physical_device_index,
                    bool enable_validation /*= false*/)
-    : instance{CreateInstance(dl, window.getWindowInfo().type, enable_validation, false)},
+    : instance{CreateInstance(window.getWindowInfo().type, enable_validation, false)},
       physical_devices{instance->enumeratePhysicalDevices()} {
     if (enable_validation) {
         debug_callback = CreateDebugCallback(*instance);

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -17,12 +17,6 @@ class WindowSDL;
 
 VK_DEFINE_HANDLE(VmaAllocator)
 
-#ifdef __APPLE__
-#define VULKAN_LIBRARY_NAME "libMoltenVK.dylib"
-#else
-#define VULKAN_LIBRARY_NAME
-#endif
-
 namespace Vulkan {
 
 class Instance {
@@ -240,7 +234,6 @@ private:
     vk::Format GetAlternativeFormat(const vk::Format format) const;
 
 private:
-    vk::DynamicLoader dl{VULKAN_LIBRARY_NAME};
     vk::UniqueInstance instance;
     vk::PhysicalDevice physical_device;
     vk::UniqueDevice device;

--- a/src/video_core/renderer_vulkan/vk_platform.h
+++ b/src/video_core/renderer_vulkan/vk_platform.h
@@ -21,8 +21,8 @@ constexpr u32 TargetVulkanApiVersion = VK_API_VERSION_1_2;
 
 vk::SurfaceKHR CreateSurface(vk::Instance instance, const Frontend::WindowSDL& emu_window);
 
-vk::UniqueInstance CreateInstance(vk::DynamicLoader& dl, Frontend::WindowSystemType window_type,
-                                  bool enable_validation, bool dump_command_buffers);
+vk::UniqueInstance CreateInstance(Frontend::WindowSystemType window_type, bool enable_validation,
+                                  bool dump_command_buffers);
 
 vk::UniqueDebugUtilsMessengerEXT CreateDebugCallback(vk::Instance instance);
 


### PR DESCRIPTION
Some enhancements for cases like MoltenVK where a Vulkan support library is directly linked. Allows for disabling the part of vulkan-hpp that loads the library from a file with `dlopen`, instead using the `vkGetInstanceProcAddr` that is already linked in.

This helps with development builds as you no longer need to make sure that the MoltenVK path is in the dynamic link library path at runtime, plus it just cuts some waste from loading a library that's already linked.

I've also added an override `USE_SYSTEM_VULKAN_LOADER` for Mac as if you have the full SDK installed it's useful to be able to load validation layers for debugging.