### PR TITLE
Fix warnings

### DIFF
--- a/src/qt_gui/cheats_patches.cpp
+++ b/src/qt_gui/cheats_patches.cpp
@@ -147,13 +147,13 @@ void CheatsPatches::setupUI() {
     controlLayout->addWidget(downloadComboBox);
 
     QPushButton* downloadButton = new QPushButton(tr("Download Cheats"));
-    connect(downloadButton, &QPushButton::clicked, [=]() {
+    connect(downloadButton, &QPushButton::clicked, [this, downloadComboBox]() {
         QString source = downloadComboBox->currentData().toString();
         downloadCheats(source, m_gameSerial, m_gameVersion, true);
     });
 
     QPushButton* deleteCheatButton = new QPushButton(tr("Delete File"));
-    connect(deleteCheatButton, &QPushButton::clicked, [=]() {
+    connect(deleteCheatButton, &QPushButton::clicked, [this, CHEATS_DIR_QString]() {
         QStringListModel* model = qobject_cast<QStringListModel*>(listView_selectFile->model());
         if (!model) {
             return;
@@ -232,7 +232,7 @@ void CheatsPatches::setupUI() {
     patchesControlLayout->addWidget(patchesComboBox);
 
     QPushButton* patchesButton = new QPushButton(tr("Download Patches"));
-    connect(patchesButton, &QPushButton::clicked, [=]() {
+    connect(patchesButton, &QPushButton::clicked, [this]() {
         QString selectedOption = patchesComboBox->currentData().toString();
         downloadPatches(selectedOption, true);
     });
@@ -444,8 +444,8 @@ QCheckBox* CheatsPatches::findCheckBoxByName(const QString& name) {
     return nullptr;
 }
 
-void CheatsPatches::downloadCheats(const QString& source, const QString& m_gameSerial,
-                                   const QString& m_gameVersion, const bool showMessageBox) {
+void CheatsPatches::downloadCheats(const QString& source, const QString& gameSerial,
+                                   const QString& gameVersion, const bool showMessageBox) {
     QDir dir(Common::FS::GetUserPath(Common::FS::PathType::CheatsDir));
     if (!dir.exists()) {
         dir.mkpath(".");
@@ -455,7 +455,7 @@ void CheatsPatches::downloadCheats(const QString& source, const QString& m_gameS
     if (source == "GoldHEN") {
         url = "https://raw.githubusercontent.com/GoldHEN/GoldHEN_Cheat_Repository/main/json.txt";
     } else if (source == "wolf2022") {
-        url = "https://wolf2022.ir/trainer/" + m_gameSerial + "_" + m_gameVersion + ".json";
+        url = "https://wolf2022.ir/trainer/" + gameSerial + "_" + gameVersion + ".json";
     } else if (source == "shadPS4") {
         url = "https://raw.githubusercontent.com/shadps4-emu/ps4_cheats/main/"
               "CHEATS_JSON.txt";
@@ -468,7 +468,7 @@ void CheatsPatches::downloadCheats(const QString& source, const QString& m_gameS
     QNetworkRequest request(url);
     QNetworkReply* reply = manager->get(request);
 
-    connect(reply, &QNetworkReply::finished, [=]() {
+    connect(reply, &QNetworkReply::finished, [=, this]() {
         if (reply->error() == QNetworkReply::NoError) {
             QByteArray jsonData = reply->readAll();
             bool foundFiles = false;
@@ -476,7 +476,7 @@ void CheatsPatches::downloadCheats(const QString& source, const QString& m_gameS
             if (source == "GoldHEN" || source == "shadPS4") {
                 QString textContent(jsonData);
                 QRegularExpression regex(
-                    QString("%1_%2[^=]*\.json").arg(m_gameSerial).arg(m_gameVersion));
+                    QString("%1_%2[^=]*\\.json").arg(gameSerial).arg(gameVersion));
                 QRegularExpressionMatchIterator matches = regex.globalMatch(textContent);
                 QString baseUrl;
 
@@ -519,7 +519,7 @@ void CheatsPatches::downloadCheats(const QString& source, const QString& m_gameS
                         QNetworkRequest fileRequest(fileUrl);
                         QNetworkReply* fileReply = manager->get(fileRequest);
 
-                        connect(fileReply, &QNetworkReply::finished, [=]() {
+                        connect(fileReply, &QNetworkReply::finished, [=, this]() {
                             if (fileReply->error() == QNetworkReply::NoError) {
                                 QByteArray fileData = fileReply->readAll();
                                 QFile localFile(localFilePath);
@@ -680,7 +680,7 @@ void CheatsPatches::downloadPatches(const QString repository, const bool showMes
     QNetworkRequest request(url);
     QNetworkReply* reply = manager->get(request);
 
-    connect(reply, &QNetworkReply::finished, [=]() {
+    connect(reply, &QNetworkReply::finished, [=, this]() {
         if (reply->error() == QNetworkReply::NoError) {
             QByteArray htmlData = reply->readAll();
             reply->deleteLater();
@@ -725,7 +725,7 @@ void CheatsPatches::downloadPatches(const QString repository, const bool showMes
                         QNetworkRequest fileRequest(fileUrl);
                         QNetworkReply* fileReply = manager->get(fileRequest);
 
-                        connect(fileReply, &QNetworkReply::finished, [=]() {
+                        connect(fileReply, &QNetworkReply::finished, [=, this]() {
                             if (fileReply->error() == QNetworkReply::NoError) {
                                 QByteArray fileData = fileReply->readAll();
                                 QFile localFile(dir.filePath(fileName));
@@ -864,7 +864,7 @@ void CheatsPatches::addCheatsToLayout(const QJsonArray& modsArray, const QJsonAr
             rightLayout->addWidget(cheatCheckBox);
             m_cheatCheckBoxes.append(cheatCheckBox);
             connect(cheatCheckBox, &QCheckBox::toggled,
-                    [=](bool checked) { applyCheat(modName, checked); });
+                    [this, modName](bool checked) { applyCheat(modName, checked); });
         } else if (modType == "button") {
             QPushButton* cheatButton = new QPushButton(modName);
             cheatButton->adjustSize();
@@ -880,7 +880,8 @@ void CheatsPatches::addCheatsToLayout(const QJsonArray& modsArray, const QJsonAr
             buttonLayout->addStretch();
 
             rightLayout->addLayout(buttonLayout);
-            connect(cheatButton, &QPushButton::clicked, [=]() { applyCheat(modName, true); });
+            connect(cheatButton, &QPushButton::clicked,
+                    [this, modName]() { applyCheat(modName, true); });
         }
     }
 
@@ -1093,7 +1094,7 @@ void CheatsPatches::addPatchesToLayout(const QString& filePath) {
                     patchCheckBox->installEventFilter(this);
 
                     connect(patchCheckBox, &QCheckBox::toggled,
-                            [=](bool checked) { applyPatch(patchName, checked); });
+                            [this, patchName](bool checked) { applyPatch(patchName, checked); });
 
                     patchName.clear();
                     patchAuthor.clear();

--- a/src/video_core/buffer_cache/buffer.cpp
+++ b/src/video_core/buffer_cache/buffer.cpp
@@ -9,7 +9,10 @@
 #include "video_core/renderer_vulkan/vk_platform.h"
 #include "video_core/renderer_vulkan/vk_scheduler.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnullability-completeness"
 #include <vk_mem_alloc.h>
+#pragma GCC diagnostic pop
 
 namespace VideoCore {
 

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -11,7 +11,10 @@
 #include "video_core/renderer_vulkan/vk_rasterizer.h"
 #include "video_core/texture_cache/image.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnullability-completeness"
 #include <vk_mem_alloc.h>
+#pragma GCC diagnostic pop
 
 namespace Vulkan {
 

--- a/src/video_core/renderer_vulkan/vk_common.cpp
+++ b/src/video_core/renderer_vulkan/vk_common.cpp
@@ -5,7 +5,10 @@
 
 // Implement vma functions
 #define VMA_IMPLEMENTATION
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnullability-completeness"
 #include <vk_mem_alloc.h>
+#pragma GCC diagnostic pop
 
 // Store the dispatch loader here
 VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -14,7 +14,10 @@
 #include "video_core/renderer_vulkan/vk_instance.h"
 #include "video_core/renderer_vulkan/vk_platform.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnullability-completeness"
 #include <vk_mem_alloc.h>
+#pragma GCC diagnostic pop
 
 namespace Vulkan {
 

--- a/src/video_core/texture_cache/image.cpp
+++ b/src/video_core/texture_cache/image.cpp
@@ -9,7 +9,10 @@
 #include "video_core/texture_cache/image.h"
 #include "video_core/texture_cache/tile_manager.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnullability-completeness"
 #include <vk_mem_alloc.h>
+#pragma GCC diagnostic pop
 
 namespace VideoCore {
 

--- a/src/video_core/texture_cache/tile_manager.cpp
+++ b/src/video_core/texture_cache/tile_manager.cpp
@@ -15,7 +15,10 @@
 
 #include <boost/container/static_vector.hpp>
 #include <magic_enum.hpp>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnullability-completeness"
 #include <vk_mem_alloc.h>
+#pragma GCC diagnostic pop
 
 namespace VideoCore {
 


### PR DESCRIPTION
fixes warnings like this
```
C:/src/shadPS4/externals/vma/include/vk_mem_alloc.h:16141:22: warning: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified) [-Wnullability-completeness]
 16141 |     VmaAllocationInfo* pAllocationInfo)
       |                      ^
C:/src/shadPS4/externals/vma/include/vk_mem_alloc.h:16141:22: note: insert '_Nullable' if the pointer may be null
 16141 |     VmaAllocationInfo* pAllocationInfo)
       |                      ^
       |                        _Nullable
C:/src/shadPS4/externals/vma/include/vk_mem_alloc.h:16141:22: note: insert '_Nonnull' if the pointer should never be null
 16141 |     VmaAllocationInfo* pAllocationInfo)
       |                      ^
       |                        _Nonnull
```

```
C:/src/shadPS4/src/qt_gui/cheats_patches.cpp:1096:49: warning: implicit capture of 'this' with a capture default of '=' is deprecated [-Wdeprecated-this-capture]
 1096 |                             [=](bool checked) { applyPatch(patchName, checked); });
      |                                                 ^
C:/src/shadPS4/src/qt_gui/cheats_patches.cpp:1096:30: note: add an explicit capture of 'this' to capture '*this' by reference
 1096 |                             [=](bool checked) { applyPatch(patchName, checked); });
      |                              ^
      |                               , this
```