### PR TITLE
vulkan: Improve format support info for vertex buffer formats.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -227,8 +227,11 @@ private:
     void CollectDeviceParameters();
     void CollectToolingInfo();
 
-    /// Determines if a format is supported.
-    [[nodiscard]] bool IsFormatSupported(vk::Format format) const;
+    /// Determines if a format is supported for images.
+    [[nodiscard]] bool IsImageFormatSupported(vk::Format format) const;
+
+    /// Determines if a format is supported for vertex buffers.
+    [[nodiscard]] bool IsVertexFormatSupported(vk::Format format) const;
 
     /// Gets a commonly available alternative for an unsupported pixel format.
     vk::Format GetAlternativeFormat(const vk::Format format) const;


### PR DESCRIPTION
Slightly improves printing of format support info by noting if a format is supported for vertex buffers, if not supported for images.

Ideally we would be able to report based on what these formats may actually be used for in practice but that does not seem to be well tracked; currently everything is bucketed into `SurfaceFormat`. This is the next best thing I could come up with to note that, while a format may not be supported for images, it is supported for vertex buffers and thus that may not be an issue.