### PR TITLE
vulkan: Emulate depth clip control when extension is not available.

### DIFF
--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -63,9 +63,10 @@ using VsOutputMap = std::array<VsOutput, 4>;
 
 struct VertexRuntimeInfo {
     boost::container::static_vector<VsOutputMap, 3> outputs;
+    bool emulate_depth_negative_one_to_one{};
 
     bool operator==(const VertexRuntimeInfo& other) const noexcept {
-        return true;
+        return emulate_depth_negative_one_to_one == other.emulate_depth_negative_one_to_one;
     }
 };
 

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -125,7 +125,7 @@ GraphicsPipeline::GraphicsPipeline(const Instance& instance_, Scheduler& schedul
     };
 
     const vk::PipelineViewportStateCreateInfo viewport_info = {
-        .pNext = &clip_control,
+        .pNext = instance.IsDepthClipControlSupported() ? &clip_control : nullptr,
         .viewportCount = 1,
         .pViewports = &viewport,
         .scissorCount = 1,

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -207,7 +207,7 @@ bool Instance::CreateDevice() {
     external_memory_host = add_extension(VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME);
     custom_border_color = add_extension(VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
     add_extension(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
-    const bool depth_clip_control = add_extension(VK_EXT_DEPTH_CLIP_CONTROL_EXTENSION_NAME);
+    depth_clip_control = add_extension(VK_EXT_DEPTH_CLIP_CONTROL_EXTENSION_NAME);
     add_extension(VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME);
     workgroup_memory_explicit_layout =
         add_extension(VK_KHR_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_EXTENSION_NAME);

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -117,6 +117,11 @@ public:
         return external_memory_host;
     }
 
+    /// Returns true when VK_EXT_depth_clip_control is supported
+    bool IsDepthClipControlSupported() const {
+        return depth_clip_control;
+    }
+
     /// Returns true when VK_EXT_color_write_enable is supported
     bool IsColorWriteEnableSupported() const {
         return color_write_en;
@@ -257,6 +262,7 @@ private:
     bool fragment_shader_barycentric{};
     bool shader_stencil_export{};
     bool external_memory_host{};
+    bool depth_clip_control{};
     bool workgroup_memory_explicit_layout{};
     bool color_write_en{};
     bool vertex_input_dynamic_state{};

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.h
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.h
@@ -60,6 +60,7 @@ private:
                     std::string_view ext);
     vk::ShaderModule CompileModule(Shader::Info& info, const Shader::RuntimeInfo& runtime_info,
                                    std::span<const u32> code, size_t perm_idx, u32& binding);
+    Shader::RuntimeInfo BuildRuntimeInfo(Shader::Stage stage);
 
 private:
     const Instance& instance;


### PR DESCRIPTION
When the depth clip control extension is not available, emulate in the shader by reducing from [-1, 1] to [0, 1].

Fixes likely a number of rendering issues on MoltenVK. For example, Persona Dancing games will now show text and other UI graphics correctly.