### PR TITLE
Add "support" for ORBIS_PAD_PORT_TYPE_REMOTE_CONTROL

### DIFF
--- a/src/core/libraries/pad/pad.cpp
+++ b/src/core/libraries/pad/pad.cpp
@@ -250,7 +250,7 @@ int PS4_SYSV_ABI scePadOpen(s32 userId, s32 type, s32 index, const OrbisPadOpenP
         if (type != ORBIS_PAD_PORT_TYPE_SPECIAL)
             return ORBIS_PAD_ERROR_DEVICE_NOT_CONNECTED;
     } else {
-        if (type != ORBIS_PAD_PORT_TYPE_STANDARD)
+        if (type != ORBIS_PAD_PORT_TYPE_STANDARD && type != ORBIS_PAD_PORT_TYPE_REMOTE_CONTROL)
             return ORBIS_PAD_ERROR_DEVICE_NOT_CONNECTED;
     }
     return 1; // dummy
@@ -263,7 +263,7 @@ int PS4_SYSV_ABI scePadOpenExt(s32 userId, s32 type, s32 index,
         if (type != ORBIS_PAD_PORT_TYPE_SPECIAL)
             return ORBIS_PAD_ERROR_DEVICE_NOT_CONNECTED;
     } else {
-        if (type != ORBIS_PAD_PORT_TYPE_STANDARD)
+        if (type != ORBIS_PAD_PORT_TYPE_STANDARD && type != ORBIS_PAD_PORT_TYPE_REMOTE_CONTROL)
             return ORBIS_PAD_ERROR_DEVICE_NOT_CONNECTED;
     }
     return 1; // dummy

--- a/src/core/libraries/pad/pad.h
+++ b/src/core/libraries/pad/pad.h
@@ -16,6 +16,7 @@ constexpr int ORBIS_PAD_MAX_DEVICE_UNIQUE_DATA_SIZE = 12;
 
 constexpr int ORBIS_PAD_PORT_TYPE_STANDARD = 0;
 constexpr int ORBIS_PAD_PORT_TYPE_SPECIAL = 2;
+constexpr int ORBIS_PAD_PORT_TYPE_REMOTE_CONTROL = 16;
 
 enum OrbisPadDeviceClass {
     ORBIS_PAD_DEVICE_CLASS_INVALID = -1,


### PR DESCRIPTION
Should fix any games regressed by https://github.com/shadps4-emu/shadPS4/pull/626. Only case I know of so far is https://github.com/shadps4-emu/shadPS4/issues/683. I can't test the  Xenoverse games further due to other regressions they've encountered, so I don't know if there are any other issues relating to this port type.