### PR TITLE
Message Dialog library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,7 @@ set(SYSTEM_LIBS src/core/libraries/system/commondialog.cpp
                 src/core/libraries/system/commondialog.h
                 src/core/libraries/system/msgdialog.cpp
                 src/core/libraries/system/msgdialog.h
+                src/core/libraries/system/msgdialog_ui.cpp
                 src/core/libraries/system/posix.cpp
                 src/core/libraries/system/posix.h
                 src/core/libraries/save_data/error_codes.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,6 +325,7 @@ set(COMMON src/common/logging/backend.cpp
            src/common/error.cpp
            src/common/error.h
            src/common/scope_exit.h
+           src/common/fixed_value.h
            src/common/func_traits.h
            src/common/native_clock.cpp
            src/common/native_clock.h
@@ -563,6 +564,7 @@ set(VIDEO_CORE src/video_core/amdgpu/liverpool.cpp
 
 set(IMGUI src/imgui/imgui_config.h
           src/imgui/imgui_layer.h
+          src/imgui/imgui_std.h
           src/imgui/layer/video_info.cpp
           src/imgui/layer/video_info.h
           src/imgui/renderer/imgui_core.cpp

--- a/src/common/fixed_value.h
+++ b/src/common/fixed_value.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+/**
+ * @brief A template class that encapsulates a fixed, compile-time constant value.
+ *
+ * @tparam T The type of the value.
+ * @tparam Value The fixed value of type T.
+ *
+ * This class provides a way to encapsulate a value that is constant and known at compile-time.
+ * The value is stored as a private member and cannot be changed. Any attempt to assign a new
+ * value to an object of this class will reset it to the fixed value.
+ */
+template <typename T, T Value>
+class FixedValue {
+    T m_value{Value};
+
+public:
+    constexpr FixedValue() = default;
+
+    constexpr explicit(false) operator T() const {
+        return m_value;
+    }
+
+    FixedValue& operator=(const T&) {
+        m_value = Value;
+        return *this;
+    }
+    FixedValue& operator=(T&&) noexcept {
+        m_value = {Value};
+        return *this;
+    }
+};

--- a/src/core/libraries/system/commondialog.cpp
+++ b/src/core/libraries/system/commondialog.cpp
@@ -8,6 +8,9 @@
 
 namespace Libraries::CommonDialog {
 
+bool g_isInitialized = false;
+bool g_isUsed = false;
+
 int PS4_SYSV_ABI _ZN3sce16CommonDialogUtil12getSelfAppIdEv() {
     LOG_ERROR(Lib_CommonDlg, "(STUBBED) called");
     return ORBIS_OK;
@@ -83,14 +86,16 @@ int PS4_SYSV_ABI _ZTVN3sce16CommonDialogUtil6ClientE() {
     return ORBIS_OK;
 }
 
-int PS4_SYSV_ABI sceCommonDialogInitialize() {
-    LOG_ERROR(Lib_CommonDlg, "(DUMMY) called");
-    return ORBIS_OK;
+Error PS4_SYSV_ABI sceCommonDialogInitialize() {
+    if (g_isInitialized) {
+        return Error::ALREADY_SYSTEM_INITIALIZED;
+    }
+    g_isInitialized = true;
+    return Error::OK;
 }
 
-int PS4_SYSV_ABI sceCommonDialogIsUsed() {
-    LOG_ERROR(Lib_CommonDlg, "(STUBBED) called");
-    return ORBIS_OK;
+bool PS4_SYSV_ABI sceCommonDialogIsUsed() {
+    return g_isUsed;
 }
 
 int PS4_SYSV_ABI Func_0FF577E4E8457883() {

--- a/src/core/libraries/system/commondialog.cpp
+++ b/src/core/libraries/system/commondialog.cpp
@@ -88,13 +88,16 @@ int PS4_SYSV_ABI _ZTVN3sce16CommonDialogUtil6ClientE() {
 
 Error PS4_SYSV_ABI sceCommonDialogInitialize() {
     if (g_isInitialized) {
+        LOG_INFO(Lib_CommonDlg, "already initialized");
         return Error::ALREADY_SYSTEM_INITIALIZED;
     }
+    LOG_DEBUG(Lib_CommonDlg, "initialized");
     g_isInitialized = true;
     return Error::OK;
 }
 
 bool PS4_SYSV_ABI sceCommonDialogIsUsed() {
+    LOG_TRACE(Lib_CommonDlg, "called");
     return g_isUsed;
 }
 

--- a/src/core/libraries/system/commondialog.h
+++ b/src/core/libraries/system/commondialog.h
@@ -11,9 +11,44 @@ class SymbolsResolver;
 
 namespace Libraries::CommonDialog {
 
-struct OrbisCommonDialogBaseParam {
+enum class Status : u32 {
+    NONE = 0,
+    INITIALIZED = 1,
+    RUNNING = 2,
+    FINISHED = 3,
+};
+
+enum class Result : u32 {
+    OK = 0,
+    USER_CANCELED = 1,
+};
+
+enum class Error : u32 {
+    OK = 0,
+    NOT_SYSTEM_INITIALIZED = 0x80B80001,
+    ALREADY_SYSTEM_INITIALIZED = 0x80B80002,
+    NOT_INITIALIZED = 0x80B80003,
+    ALREADY_INITIALIZED = 0x80B80004,
+    NOT_FINISHED = 0x80B80005,
+    INVALID_STATE = 0x80B80006,
+    RESULT_NONE = 0x80B80007,
+    BUSY = 0x80B80008,
+    OUT_OF_MEMORY = 0x80B80009,
+    PARAM_INVALID = 0x80B8000A,
+    NOT_RUNNING = 0x80B8000B,
+    ALREADY_CLOSE = 0x80B8000C,
+    ARG_NULL = 0x80B8000D,
+    UNEXPECTED_FATAL = 0x80B8000E,
+    NOT_SUPPORTED = 0x80B8000F,
+    INHIBIT_SHAREPLAY_CLIENT = 0x80B80010,
+};
+
+extern bool g_isInitialized;
+extern bool g_isUsed;
+
+struct BaseParam {
     std::size_t size;
-    u8 reserved[36];
+    std::array<u8, 36> reserved;
     u32 magic;
 };
 
@@ -32,8 +67,8 @@ int PS4_SYSV_ABI _ZNK3sce16CommonDialogUtil6Client8getAppIdEv();
 int PS4_SYSV_ABI _ZNK3sce16CommonDialogUtil6Client8isFinishEv();
 int PS4_SYSV_ABI _ZNK3sce16CommonDialogUtil6Client9getResultEv();
 int PS4_SYSV_ABI _ZTVN3sce16CommonDialogUtil6ClientE();
-int PS4_SYSV_ABI sceCommonDialogInitialize();
-int PS4_SYSV_ABI sceCommonDialogIsUsed();
+Error PS4_SYSV_ABI sceCommonDialogInitialize();
+bool PS4_SYSV_ABI sceCommonDialogIsUsed();
 int PS4_SYSV_ABI Func_0FF577E4E8457883();
 int PS4_SYSV_ABI Func_41716C2CE379416C();
 int PS4_SYSV_ABI Func_483A427D8F6E0748();

--- a/src/core/libraries/system/msgdialog.cpp
+++ b/src/core/libraries/system/msgdialog.cpp
@@ -82,19 +82,48 @@ Error PS4_SYSV_ABI sceMsgDialogOpen(const Param* param) {
     return Error::OK;
 }
 
-int PS4_SYSV_ABI sceMsgDialogProgressBarInc() {
-    LOG_ERROR(Lib_MsgDlg, "(STUBBED) called");
-    return ORBIS_OK;
+Error PS4_SYSV_ABI sceMsgDialogProgressBarInc(OrbisMsgDialogProgressBarTarget target, u32 delta) {
+    if (g_status != Status::RUNNING) {
+        return Error::NOT_RUNNING;
+    }
+    if (g_param.mode != MsgDialogMode::PROGRESS_BAR) {
+        return Error::NOT_SUPPORTED;
+    }
+    if (target != OrbisMsgDialogProgressBarTarget::DEFAULT) {
+        return Error::PARAM_INVALID;
+    }
+    g_msg_dialog_ui.SetProgressBarValue(delta, true);
+    return Error::OK;
 }
 
-int PS4_SYSV_ABI sceMsgDialogProgressBarSetMsg() {
-    LOG_ERROR(Lib_MsgDlg, "(STUBBED) called");
-    return ORBIS_OK;
+Error PS4_SYSV_ABI sceMsgDialogProgressBarSetMsg(OrbisMsgDialogProgressBarTarget target,
+                                                 const char* msg) {
+    if (g_status != Status::RUNNING) {
+        return Error::NOT_RUNNING;
+    }
+    if (g_param.mode != MsgDialogMode::PROGRESS_BAR) {
+        return Error::NOT_SUPPORTED;
+    }
+    if (target != OrbisMsgDialogProgressBarTarget::DEFAULT) {
+        return Error::PARAM_INVALID;
+    }
+    g_param.progBarParam->msg = msg;
+    return Error::OK;
 }
 
-int PS4_SYSV_ABI sceMsgDialogProgressBarSetValue() {
-    LOG_ERROR(Lib_MsgDlg, "(STUBBED) called");
-    return ORBIS_OK;
+Error PS4_SYSV_ABI sceMsgDialogProgressBarSetValue(OrbisMsgDialogProgressBarTarget target,
+                                                   u32 value) {
+    if (g_status != Status::RUNNING) {
+        return Error::NOT_RUNNING;
+    }
+    if (g_param.mode != MsgDialogMode::PROGRESS_BAR) {
+        return Error::NOT_SUPPORTED;
+    }
+    if (target != OrbisMsgDialogProgressBarTarget::DEFAULT) {
+        return Error::PARAM_INVALID;
+    }
+    g_msg_dialog_ui.SetProgressBarValue(value, false);
+    return Error::OK;
 }
 
 Error PS4_SYSV_ABI sceMsgDialogTerminate() {

--- a/src/core/libraries/system/msgdialog.cpp
+++ b/src/core/libraries/system/msgdialog.cpp
@@ -23,6 +23,7 @@ static DialogResult g_result{};
 static MsgDialogUi g_msg_dialog_ui;
 
 Error PS4_SYSV_ABI sceMsgDialogClose() {
+    LOG_DEBUG(Lib_MsgDlg, "called");
     if (g_status != Status::RUNNING) {
         return Error::NOT_RUNNING;
     }
@@ -31,6 +32,7 @@ Error PS4_SYSV_ABI sceMsgDialogClose() {
 }
 
 Error PS4_SYSV_ABI sceMsgDialogGetResult(DialogResult* result) {
+    LOG_DEBUG(Lib_MsgDlg, "called");
     if (g_status != Status::FINISHED) {
         return Error::NOT_FINISHED;
     }
@@ -47,10 +49,12 @@ Error PS4_SYSV_ABI sceMsgDialogGetResult(DialogResult* result) {
 }
 
 Status PS4_SYSV_ABI sceMsgDialogGetStatus() {
+    LOG_TRACE(Lib_MsgDlg, "called status={}", magic_enum::enum_name(g_status));
     return g_status;
 }
 
 Error PS4_SYSV_ABI sceMsgDialogInitialize() {
+    LOG_DEBUG(Lib_MsgDlg, "called");
     if (!CommonDialog::g_isInitialized) {
         return Error::NOT_SYSTEM_INITIALIZED;
     }
@@ -68,11 +72,14 @@ Error PS4_SYSV_ABI sceMsgDialogInitialize() {
 
 Error PS4_SYSV_ABI sceMsgDialogOpen(const OrbisParam* param) {
     if (g_status != Status::INITIALIZED && g_status != Status::FINISHED) {
+        LOG_INFO(Lib_MsgDlg, "called without initialize");
         return Error::INVALID_STATE;
     }
     if (param == nullptr) {
+        LOG_DEBUG(Lib_MsgDlg, "called param:(NULL)");
         return Error::ARG_NULL;
     }
+    LOG_DEBUG(Lib_MsgDlg, "called param->mode: {}", magic_enum::enum_name(param->mode));
     ASSERT(param->size == sizeof(OrbisParam));
     ASSERT(param->baseParam.size == sizeof(CommonDialog::BaseParam));
     g_result = {};
@@ -83,6 +90,7 @@ Error PS4_SYSV_ABI sceMsgDialogOpen(const OrbisParam* param) {
 }
 
 Error PS4_SYSV_ABI sceMsgDialogProgressBarInc(OrbisMsgDialogProgressBarTarget target, u32 delta) {
+    LOG_DEBUG(Lib_MsgDlg, "called");
     if (g_status != Status::RUNNING) {
         return Error::NOT_RUNNING;
     }
@@ -98,6 +106,7 @@ Error PS4_SYSV_ABI sceMsgDialogProgressBarInc(OrbisMsgDialogProgressBarTarget ta
 
 Error PS4_SYSV_ABI sceMsgDialogProgressBarSetMsg(OrbisMsgDialogProgressBarTarget target,
                                                  const char* msg) {
+    LOG_DEBUG(Lib_MsgDlg, "called");
     if (g_status != Status::RUNNING) {
         return Error::NOT_RUNNING;
     }
@@ -113,6 +122,7 @@ Error PS4_SYSV_ABI sceMsgDialogProgressBarSetMsg(OrbisMsgDialogProgressBarTarget
 
 Error PS4_SYSV_ABI sceMsgDialogProgressBarSetValue(OrbisMsgDialogProgressBarTarget target,
                                                    u32 value) {
+    LOG_DEBUG(Lib_MsgDlg, "called");
     if (g_status != Status::RUNNING) {
         return Error::NOT_RUNNING;
     }
@@ -127,6 +137,7 @@ Error PS4_SYSV_ABI sceMsgDialogProgressBarSetValue(OrbisMsgDialogProgressBarTarg
 }
 
 Error PS4_SYSV_ABI sceMsgDialogTerminate() {
+    LOG_DEBUG(Lib_MsgDlg, "called");
     if (g_status == Status::RUNNING) {
         sceMsgDialogClose();
     }
@@ -139,6 +150,7 @@ Error PS4_SYSV_ABI sceMsgDialogTerminate() {
 }
 
 Status PS4_SYSV_ABI sceMsgDialogUpdateStatus() {
+    LOG_TRACE(Lib_MsgDlg, "called status={}", magic_enum::enum_name(g_status));
     return g_status;
 }
 

--- a/src/core/libraries/system/msgdialog.cpp
+++ b/src/core/libraries/system/msgdialog.cpp
@@ -9,8 +9,6 @@
 #include "core/libraries/error_codes.h"
 #include "core/libraries/libs.h"
 #include "core/libraries/system/msgdialog.h"
-#include "imgui/imgui_layer.h"
-#include "imgui/imgui_std.h"
 #include "imgui_internal.h"
 
 namespace Libraries::MsgDialog {
@@ -19,240 +17,16 @@ using CommonDialog::Error;
 using CommonDialog::Result;
 using CommonDialog::Status;
 
-using OrbisUserServiceUserId = s32;
-
-enum class MsgDialogMode : u32 {
-    USER_MSG = 1,
-    PROGRESS_BAR = 2,
-    SYSTEM_MSG = 3,
-};
-
-enum class ButtonId : u32 {
-    INVALID = 0,
-    OK = 1,
-    YES = 1,
-    NO = 2,
-    BUTTON1 = 1,
-    BUTTON2 = 2,
-};
-
-enum class ButtonType : u32 {
-    OK = 0,
-    YESNO = 1,
-    NONE = 2,
-    OK_CANCEL = 3,
-    WAIT = 5,
-    WAIT_CANCEL = 6,
-    YESNO_FOCUS_NO = 7,
-    OK_CANCEL_FOCUS_CANCEL = 8,
-    TWO_BUTTONS = 9,
-};
-
-enum class ProgressBarType : u32 {
-    PERCENTAGE = 0,
-    PERCENTAGE_CANCEL = 1,
-};
-
-enum class SystemMessageType : u32 {
-    TRC_EMPTY_STORE = 0,
-    TRC_PSN_CHAT_RESTRICTION = 1,
-    TRC_PSN_UGC_RESTRICTION = 2,
-    CAMERA_NOT_CONNECTED = 4,
-    WARNING_PROFILE_PICTURE_AND_NAME_NOT_SHARED = 5,
-};
-
-struct ButtonsParam {
-    const char* msg1{};
-    const char* msg2{};
-    std::array<char, 32> reserved{};
-};
-
-struct UserMessageParam {
-    ButtonType buttonType{};
-    s32 : 32;
-    const char* msg{};
-    ButtonsParam* buttonsParam{};
-    std::array<char, 24> reserved{};
-};
-
-struct ProgressBarParam {
-    ProgressBarType barType{};
-    s32 : 32;
-    const char* msg{};
-    std::array<char, 64> reserved{};
-};
-
-struct SystemMessageParam {
-    SystemMessageType sysMsgType{};
-    std::array<char, 32> reserved{};
-};
-
-struct Param {
-    CommonDialog::BaseParam baseParam;
-    std::size_t size;
-    MsgDialogMode mode;
-    s32 : 32;
-    UserMessageParam* userMsgParam;
-    ProgressBarParam* progBarParam;
-    SystemMessageParam* sysMsgParam;
-    OrbisUserServiceUserId userId;
-    std::array<char, 40> reserved;
-    s32 : 32;
-};
-
-struct MsgDialogResult {
-    FixedValue<u32, 0> mode{};
-    Result result{Result::OK};
-    ButtonId buttonId{ButtonId::INVALID};
-    std::array<char, 32> reserved{};
-};
-
 static auto g_status = Status::NONE;
+static Param g_param{};
 static MsgDialogResult g_result{};
-
-struct {
-    int count = 0;
-    const char* text1;
-    const char* text2;
-} static constexpr button_texts[] = {
-    {1, "OK"},             // 0 OK
-    {2, "Yes", "No"},      // 1 YESNO
-    {0},                   // 2 NONE
-    {2, "OK", "Cancel"},   // 3 OK_CANCEL
-    {},                    // 4 !!NOP
-    {1, "Wait"},           // 5 WAIT
-    {2, "Wait", "Cancel"}, // 6 WAIT_CANCEL
-    {2, "Yes", "No"},      // 7 YESNO_FOCUS_NO
-    {2, "OK", "Cancel"},   // 8 OK_CANCEL_FOCUS_CANCEL
-    {0xFF},                // 9 TWO_BUTTONS
-};
-static_assert(std::size(button_texts) == static_cast<int>(ButtonType::TWO_BUTTONS) + 1);
-
-static void Finish(ButtonId buttonId);
-
-namespace {
-using namespace ImGui;
-class MsgDialogGui final : public Layer {
-    const Param* param{};
-    s32 dialog_unique_id{};
-
-    void DrawUser(const UserMessageParam& user_message_param) {
-        constexpr ImVec2 BUTTON_SIZE{100.0f, 30.0f};
-
-        const auto ws = GetWindowSize();
-        SetCursorPosY(ws.y / 2.0f - 50.0f);
-        PushTextWrapPos(ws.x - 30.0f);
-        SetCursorPosX(
-            (ws.x - CalcTextSize(user_message_param.msg, nullptr, false, ws.x - 40.0f).x) / 2.0f);
-        Text("%s", user_message_param.msg);
-        PopTextWrapPos();
-        const auto button_type = user_message_param.buttonType;
-        ASSERT(user_message_param.buttonType <= ButtonType::TWO_BUTTONS);
-        auto [count, text1, text2] = button_texts[static_cast<u32>(button_type)];
-        if (count == 0xFF) { // TWO_BUTTONS -> User defined message
-            count = 2;
-            text1 = user_message_param.buttonsParam->msg1;
-            text2 = user_message_param.buttonsParam->msg2;
-        }
-        const bool focus_first = button_type < ButtonType::YESNO_FOCUS_NO;
-        SetCursorPos({
-            ws.x / 2.0f - BUTTON_SIZE.x / 2.0f * static_cast<float>(count),
-            ws.y - 10.0f - BUTTON_SIZE.y,
-        });
-        BeginGroup();
-        if (count > 0) {
-            // First button at the right, so we render the second button first
-            if (count == 2) {
-                PushID(2);
-                if (Button(text2, BUTTON_SIZE)) {
-                    Finish(ButtonId::BUTTON2);
-                }
-                if (!focus_first) {
-                    SetItemDefaultNav();
-                }
-                PopID();
-                SameLine();
-            }
-            PushID(1);
-            if (Button(text1, BUTTON_SIZE)) {
-                Finish(ButtonId::BUTTON1);
-            }
-            if (focus_first) {
-                SetItemDefaultNav();
-            }
-            PopID();
-            SameLine();
-        }
-        EndGroup();
-    }
-
-    void DrawProgressBar(const ProgressBarParam& progress_bar_param) {}
-
-    void DrawSystemMessage(const SystemMessageParam& system_message_param) {}
-
-public:
-    void Draw() override {
-        if (g_status != Status::RUNNING) {
-            return;
-        }
-        const auto& io = GetIO();
-
-        const ImVec2 window_size{
-            std::min(io.DisplaySize.x, 500.0f),
-            std::min(io.DisplaySize.y, 300.0f),
-        };
-
-        CentralizeWindow();
-        SetNextWindowSize(window_size);
-        SetNextWindowFocus();
-        SetNextWindowCollapsed(false);
-        KeepNavHighlight();
-        // Hack to allow every dialog to have a unique window
-#define TITLE "Message Dialog##MD"
-        char id[sizeof(TITLE) + sizeof(int)] = TITLE "\0\0\0\0";
-        *reinterpret_cast<int*>(&id[sizeof(TITLE) - 1]) =
-            dialog_unique_id |
-            0x80808080; // keep the MSB set to extend the string length (null terminated)
-#undef TITLE
-        if (Begin(id, nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings)) {
-            switch (param->mode) {
-            case MsgDialogMode::USER_MSG:
-                DrawUser(*param->userMsgParam);
-                break;
-            case MsgDialogMode::PROGRESS_BAR:
-                DrawProgressBar(*param->progBarParam);
-                break;
-            case MsgDialogMode::SYSTEM_MSG:
-                DrawSystemMessage(*param->sysMsgParam);
-                break;
-            }
-            End();
-        }
-    }
-
-    bool ShouldGrabGamepad() override {
-        return true;
-    }
-
-    explicit MsgDialogGui(const Param* param = nullptr)
-        : param(param), dialog_unique_id([] {
-              static s32 last_id = 0;
-              return last_id++;
-          }()) {}
-} g_msg_dialog_gui;
-} // namespace
-
-static void Finish(ButtonId buttonId) {
-    g_result.buttonId = buttonId;
-    g_status = Status::FINISHED;
-    Layer::RemoveLayer(&g_msg_dialog_gui);
-}
+static MsgDialogUi g_msg_dialog_ui;
 
 Error PS4_SYSV_ABI sceMsgDialogClose() {
     if (g_status != Status::RUNNING) {
         return Error::NOT_RUNNING;
     }
-    Finish(ButtonId::INVALID);
+    g_msg_dialog_ui.Finish(ButtonId::INVALID);
     return Error::OK;
 }
 
@@ -296,12 +70,15 @@ Error PS4_SYSV_ABI sceMsgDialogOpen(const Param* param) {
     if (g_status != Status::INITIALIZED && g_status != Status::FINISHED) {
         return Error::INVALID_STATE;
     }
+    if (param == nullptr) {
+        return Error::ARG_NULL;
+    }
     ASSERT(param->size == sizeof(Param));
     ASSERT(param->baseParam.size == sizeof(CommonDialog::BaseParam));
     g_status = Status::RUNNING;
+    g_param = *param;
     g_result = {};
-    g_msg_dialog_gui = MsgDialogGui(param);
-    Layer::AddLayer(&g_msg_dialog_gui);
+    g_msg_dialog_ui = MsgDialogUi(&g_param, &g_status, &g_result);
     return Error::OK;
 }
 

--- a/src/core/libraries/system/msgdialog.cpp
+++ b/src/core/libraries/system/msgdialog.cpp
@@ -3,6 +3,7 @@
 
 #include <imgui.h>
 #include <magic_enum.hpp>
+
 #include "common/assert.h"
 #include "common/logging/log.h"
 #include "core/libraries/error_codes.h"
@@ -10,10 +11,9 @@
 #include "core/libraries/system/msgdialog.h"
 #include "imgui/imgui_layer.h"
 #include "imgui/imgui_std.h"
+#include "imgui_internal.h"
 
 namespace Libraries::MsgDialog {
-
-class MsgDialogGui;
 
 using CommonDialog::Error;
 using CommonDialog::Result;
@@ -102,26 +102,88 @@ struct Param {
 
 struct MsgDialogResult {
     FixedValue<u32, 0> mode{};
-    Result result{};
-    ButtonId buttonId{};
+    Result result{Result::OK};
+    ButtonId buttonId{ButtonId::INVALID};
     std::array<char, 32> reserved{};
 };
 
-class MsgDialogGui final : public ImGui::Layer {
+static auto g_status = Status::NONE;
+static MsgDialogResult g_result{};
+
+struct {
+    int count = 0;
+    const char* text1;
+    const char* text2;
+} static constexpr button_texts[] = {
+    {1, "OK"},             // 0 OK
+    {2, "Yes", "No"},      // 1 YESNO
+    {0},                   // 2 NONE
+    {2, "OK", "Cancel"},   // 3 OK_CANCEL
+    {},                    // 4 !!NOP
+    {1, "Wait"},           // 5 WAIT
+    {2, "Wait", "Cancel"}, // 6 WAIT_CANCEL
+    {2, "Yes", "No"},      // 7 YESNO_FOCUS_NO
+    {2, "OK", "Cancel"},   // 8 OK_CANCEL_FOCUS_CANCEL
+    {0xFF},                // 9 TWO_BUTTONS
+};
+static_assert(std::size(button_texts) == static_cast<int>(ButtonType::TWO_BUTTONS) + 1);
+
+static void Finish(ButtonId buttonId);
+
+namespace {
+using namespace ImGui;
+class MsgDialogGui final : public Layer {
     const Param* param{};
+    s32 dialog_unique_id{};
 
     void DrawUser(const UserMessageParam& user_message_param) {
-        const auto ws = ImGui::GetWindowSize();
-        ImGui::SetCursorPosY(ws.y / 2.0f - 30.0f);
-        ImGui::BeginGroup();
-        ImGui::PushTextWrapPos(ws.x - 30.0f);
-        ImGui::SetCursorPosX(
-            (ws.x - ImGui::CalcTextSize(user_message_param.msg, nullptr, false, ws.x - 40.0f).x) /
-            2.0f);
-        ImGui::Text("%s", user_message_param.msg);
-        ImGui::PopTextWrapPos();
-        ImGui::EndGroup();
-        switch (user_message_param.buttonType) {}
+        constexpr ImVec2 BUTTON_SIZE{100.0f, 30.0f};
+
+        const auto ws = GetWindowSize();
+        SetCursorPosY(ws.y / 2.0f - 50.0f);
+        PushTextWrapPos(ws.x - 30.0f);
+        SetCursorPosX(
+            (ws.x - CalcTextSize(user_message_param.msg, nullptr, false, ws.x - 40.0f).x) / 2.0f);
+        Text("%s", user_message_param.msg);
+        PopTextWrapPos();
+        const auto button_type = user_message_param.buttonType;
+        ASSERT(user_message_param.buttonType <= ButtonType::TWO_BUTTONS);
+        auto [count, text1, text2] = button_texts[static_cast<u32>(button_type)];
+        if (count == 0xFF) { // TWO_BUTTONS -> User defined message
+            count = 2;
+            text1 = user_message_param.buttonsParam->msg1;
+            text2 = user_message_param.buttonsParam->msg2;
+        }
+        const bool focus_first = button_type < ButtonType::YESNO_FOCUS_NO;
+        SetCursorPos({
+            ws.x / 2.0f - BUTTON_SIZE.x / 2.0f * static_cast<float>(count),
+            ws.y - 10.0f - BUTTON_SIZE.y,
+        });
+        BeginGroup();
+        if (count > 0) {
+            // First button at the right, so we render the second button first
+            if (count == 2) {
+                PushID(2);
+                if (Button(text2, BUTTON_SIZE)) {
+                    Finish(ButtonId::BUTTON2);
+                }
+                if (!focus_first) {
+                    SetItemDefaultNav();
+                }
+                PopID();
+                SameLine();
+            }
+            PushID(1);
+            if (Button(text1, BUTTON_SIZE)) {
+                Finish(ButtonId::BUTTON1);
+            }
+            if (focus_first) {
+                SetItemDefaultNav();
+            }
+            PopID();
+            SameLine();
+        }
+        EndGroup();
     }
 
     void DrawProgressBar(const ProgressBarParam& progress_bar_param) {}
@@ -130,46 +192,67 @@ class MsgDialogGui final : public ImGui::Layer {
 
 public:
     void Draw() override {
-        const auto& io = ImGui::GetIO();
+        if (g_status != Status::RUNNING) {
+            return;
+        }
+        const auto& io = GetIO();
 
         const ImVec2 window_size{
             std::min(io.DisplaySize.x, 500.0f),
             std::min(io.DisplaySize.y, 300.0f),
         };
 
-        ImGui::CentralizeWindow();
-        ImGui::SetNextWindowSize(window_size);
-        ImGui::Begin("##Message Dialog", nullptr, ImGuiWindowFlags_NoDecoration);
-        switch (param->mode) {
-        case MsgDialogMode::USER_MSG:
-            DrawUser(*param->userMsgParam);
-            break;
-        case MsgDialogMode::PROGRESS_BAR:
-            DrawProgressBar(*param->progBarParam);
-            break;
-        case MsgDialogMode::SYSTEM_MSG:
-            DrawSystemMessage(*param->sysMsgParam);
-            break;
+        CentralizeWindow();
+        SetNextWindowSize(window_size);
+        SetNextWindowFocus();
+        SetNextWindowCollapsed(false);
+        KeepNavHighlight();
+        // Hack to allow every dialog to have a unique window
+#define TITLE "Message Dialog##MD"
+        char id[sizeof(TITLE) + sizeof(int)] = TITLE "\0\0\0\0";
+        *reinterpret_cast<int*>(&id[sizeof(TITLE) - 1]) =
+            dialog_unique_id |
+            0x80808080; // keep the MSB set to extend the string length (null terminated)
+#undef TITLE
+        if (Begin(id, nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings)) {
+            switch (param->mode) {
+            case MsgDialogMode::USER_MSG:
+                DrawUser(*param->userMsgParam);
+                break;
+            case MsgDialogMode::PROGRESS_BAR:
+                DrawProgressBar(*param->progBarParam);
+                break;
+            case MsgDialogMode::SYSTEM_MSG:
+                DrawSystemMessage(*param->sysMsgParam);
+                break;
+            }
+            End();
         }
-        ImGui::End();
     }
 
     bool ShouldGrabGamepad() override {
         return true;
     }
 
-    explicit MsgDialogGui(const Param* param = nullptr) : param(param) {}
-} static g_msg_dialog_gui;
+    explicit MsgDialogGui(const Param* param = nullptr)
+        : param(param), dialog_unique_id([] {
+              static s32 last_id = 0;
+              return last_id++;
+          }()) {}
+} g_msg_dialog_gui;
+} // namespace
 
-static auto g_status = Status::NONE;
-static MsgDialogResult g_result{};
+static void Finish(ButtonId buttonId) {
+    g_result.buttonId = buttonId;
+    g_status = Status::FINISHED;
+    Layer::RemoveLayer(&g_msg_dialog_gui);
+}
 
 Error PS4_SYSV_ABI sceMsgDialogClose() {
     if (g_status != Status::RUNNING) {
         return Error::NOT_RUNNING;
     }
-    g_status = Status::FINISHED;
-    ImGui::Layer::RemoveLayer(&g_msg_dialog_gui);
+    Finish(ButtonId::INVALID);
     return Error::OK;
 }
 
@@ -189,7 +272,7 @@ Error PS4_SYSV_ABI sceMsgDialogGetResult(MsgDialogResult* result) {
     return Error::OK;
 }
 
-CommonDialog::Status PS4_SYSV_ABI sceMsgDialogGetStatus() {
+Status PS4_SYSV_ABI sceMsgDialogGetStatus() {
     return g_status;
 }
 
@@ -216,8 +299,9 @@ Error PS4_SYSV_ABI sceMsgDialogOpen(const Param* param) {
     ASSERT(param->size == sizeof(Param));
     ASSERT(param->baseParam.size == sizeof(CommonDialog::BaseParam));
     g_status = Status::RUNNING;
+    g_result = {};
     g_msg_dialog_gui = MsgDialogGui(param);
-    ImGui::Layer::AddLayer(&g_msg_dialog_gui);
+    Layer::AddLayer(&g_msg_dialog_gui);
     return Error::OK;
 }
 

--- a/src/core/libraries/system/msgdialog.h
+++ b/src/core/libraries/system/msgdialog.h
@@ -3,10 +3,7 @@
 
 #pragma once
 
-#include "common/fixed_value.h"
-#include "common/types.h"
 #include "core/libraries/system/commondialog.h"
-#include "imgui/imgui_layer.h"
 
 namespace Core::Loader {
 class SymbolsResolver;
@@ -14,133 +11,15 @@ class SymbolsResolver;
 
 namespace Libraries::MsgDialog {
 
-using OrbisUserServiceUserId = s32;
-
-enum class MsgDialogMode : u32 {
-    USER_MSG = 1,
-    PROGRESS_BAR = 2,
-    SYSTEM_MSG = 3,
-};
-
-enum class ButtonId : u32 {
-    INVALID = 0,
-    OK = 1,
-    YES = 1,
-    NO = 2,
-    BUTTON1 = 1,
-    BUTTON2 = 2,
-};
-
-enum class ButtonType : u32 {
-    OK = 0,
-    YESNO = 1,
-    NONE = 2,
-    OK_CANCEL = 3,
-    WAIT = 5,
-    WAIT_CANCEL = 6,
-    YESNO_FOCUS_NO = 7,
-    OK_CANCEL_FOCUS_CANCEL = 8,
-    TWO_BUTTONS = 9,
-};
-
-enum class ProgressBarType : u32 {
-    PERCENTAGE = 0,
-    PERCENTAGE_CANCEL = 1,
-};
-
-enum class SystemMessageType : u32 {
-    TRC_EMPTY_STORE = 0,
-    TRC_PSN_CHAT_RESTRICTION = 1,
-    TRC_PSN_UGC_RESTRICTION = 2,
-    CAMERA_NOT_CONNECTED = 4,
-    WARNING_PROFILE_PICTURE_AND_NAME_NOT_SHARED = 5,
-};
-
-enum class OrbisMsgDialogProgressBarTarget : u32 {
-    DEFAULT = 0,
-};
-
-struct ButtonsParam {
-    const char* msg1{};
-    const char* msg2{};
-    std::array<char, 32> reserved{};
-};
-
-struct UserMessageParam {
-    ButtonType buttonType{};
-    s32 : 32;
-    const char* msg{};
-    ButtonsParam* buttonsParam{};
-    std::array<char, 24> reserved{};
-};
-
-struct ProgressBarParam {
-    ProgressBarType barType{};
-    s32 : 32;
-    const char* msg{};
-    std::array<char, 64> reserved{};
-};
-
-struct SystemMessageParam {
-    SystemMessageType sysMsgType{};
-    std::array<char, 32> reserved{};
-};
-
-struct Param {
-    CommonDialog::BaseParam baseParam;
-    std::size_t size;
-    MsgDialogMode mode;
-    s32 : 32;
-    UserMessageParam* userMsgParam;
-    ProgressBarParam* progBarParam;
-    SystemMessageParam* sysMsgParam;
-    OrbisUserServiceUserId userId;
-    std::array<char, 40> reserved;
-    s32 : 32;
-};
-
-struct MsgDialogResult {
-    FixedValue<u32, 0> mode{};
-    CommonDialog::Result result{CommonDialog::Result::OK};
-    ButtonId buttonId{ButtonId::INVALID};
-    std::array<char, 32> reserved{};
-};
-
-class MsgDialogUi final : public ImGui::Layer {
-    s32 dialog_unique_id;
-    const Param* param{};
-    CommonDialog::Status* status{};
-    MsgDialogResult* result{};
-    u32 progress_bar_value{};
-
-    void DrawUser();
-    void DrawProgressBar();
-    void DrawSystemMessage();
-
-public:
-    explicit MsgDialogUi(const Param* param = nullptr, CommonDialog::Status* status = nullptr,
-                         MsgDialogResult* result = nullptr);
-    ~MsgDialogUi() override;
-    MsgDialogUi(const MsgDialogUi& other) = delete;
-    MsgDialogUi(MsgDialogUi&& other) noexcept;
-    MsgDialogUi& operator=(MsgDialogUi other);
-
-    void Finish(ButtonId buttonId, CommonDialog::Result r = CommonDialog::Result::OK);
-
-    void SetProgressBarValue(u32 value, bool increment);
-
-    void Draw() override;
-
-    bool ShouldGrabGamepad() override {
-        return true;
-    }
-};
+struct DialogResult;
+struct OrbisParam;
+enum class OrbisMsgDialogProgressBarTarget : u32;
 
 CommonDialog::Error PS4_SYSV_ABI sceMsgDialogClose();
-CommonDialog::Error PS4_SYSV_ABI sceMsgDialogGetResult(MsgDialogResult* result);
+CommonDialog::Error PS4_SYSV_ABI sceMsgDialogGetResult(DialogResult* result);
 CommonDialog::Status PS4_SYSV_ABI sceMsgDialogGetStatus();
 CommonDialog::Error PS4_SYSV_ABI sceMsgDialogInitialize();
-CommonDialog::Error PS4_SYSV_ABI sceMsgDialogOpen(const Param* param);
+CommonDialog::Error PS4_SYSV_ABI sceMsgDialogOpen(const OrbisParam* param);
 CommonDialog::Error PS4_SYSV_ABI sceMsgDialogProgressBarInc(OrbisMsgDialogProgressBarTarget,
                                                             u32 delta);
 CommonDialog::Error PS4_SYSV_ABI sceMsgDialogProgressBarSetMsg(OrbisMsgDialogProgressBarTarget,

--- a/src/core/libraries/system/msgdialog.h
+++ b/src/core/libraries/system/msgdialog.h
@@ -6,6 +6,7 @@
 #include "common/fixed_value.h"
 #include "common/types.h"
 #include "core/libraries/system/commondialog.h"
+#include "imgui/imgui_layer.h"
 
 namespace Core::Loader {
 class SymbolsResolver;
@@ -13,8 +14,120 @@ class SymbolsResolver;
 
 namespace Libraries::MsgDialog {
 
-struct MsgDialogResult;
-struct Param;
+using OrbisUserServiceUserId = s32;
+
+enum class MsgDialogMode : u32 {
+    USER_MSG = 1,
+    PROGRESS_BAR = 2,
+    SYSTEM_MSG = 3,
+};
+
+enum class ButtonId : u32 {
+    INVALID = 0,
+    OK = 1,
+    YES = 1,
+    NO = 2,
+    BUTTON1 = 1,
+    BUTTON2 = 2,
+};
+
+enum class ButtonType : u32 {
+    OK = 0,
+    YESNO = 1,
+    NONE = 2,
+    OK_CANCEL = 3,
+    WAIT = 5,
+    WAIT_CANCEL = 6,
+    YESNO_FOCUS_NO = 7,
+    OK_CANCEL_FOCUS_CANCEL = 8,
+    TWO_BUTTONS = 9,
+};
+
+enum class ProgressBarType : u32 {
+    PERCENTAGE = 0,
+    PERCENTAGE_CANCEL = 1,
+};
+
+enum class SystemMessageType : u32 {
+    TRC_EMPTY_STORE = 0,
+    TRC_PSN_CHAT_RESTRICTION = 1,
+    TRC_PSN_UGC_RESTRICTION = 2,
+    CAMERA_NOT_CONNECTED = 4,
+    WARNING_PROFILE_PICTURE_AND_NAME_NOT_SHARED = 5,
+};
+
+struct ButtonsParam {
+    const char* msg1{};
+    const char* msg2{};
+    std::array<char, 32> reserved{};
+};
+
+struct UserMessageParam {
+    ButtonType buttonType{};
+    s32 : 32;
+    const char* msg{};
+    ButtonsParam* buttonsParam{};
+    std::array<char, 24> reserved{};
+};
+
+struct ProgressBarParam {
+    ProgressBarType barType{};
+    s32 : 32;
+    const char* msg{};
+    std::array<char, 64> reserved{};
+};
+
+struct SystemMessageParam {
+    SystemMessageType sysMsgType{};
+    std::array<char, 32> reserved{};
+};
+
+struct Param {
+    CommonDialog::BaseParam baseParam;
+    std::size_t size;
+    MsgDialogMode mode;
+    s32 : 32;
+    UserMessageParam* userMsgParam;
+    ProgressBarParam* progBarParam;
+    SystemMessageParam* sysMsgParam;
+    OrbisUserServiceUserId userId;
+    std::array<char, 40> reserved;
+    s32 : 32;
+};
+
+struct MsgDialogResult {
+    FixedValue<u32, 0> mode{};
+    CommonDialog::Result result{CommonDialog::Result::OK};
+    ButtonId buttonId{ButtonId::INVALID};
+    std::array<char, 32> reserved{};
+};
+
+class MsgDialogUi final : public ImGui::Layer {
+    s32 dialog_unique_id;
+    const Param* param{};
+    CommonDialog::Status* status{};
+    MsgDialogResult* result{};
+
+    void DrawUser();
+    void DrawProgressBar();
+    void DrawSystemMessage();
+
+public:
+    explicit MsgDialogUi(const Param* param = nullptr, CommonDialog::Status* status = nullptr,
+                         MsgDialogResult* result = nullptr);
+    ~MsgDialogUi() override;
+    MsgDialogUi(const MsgDialogUi& other) = delete;
+    MsgDialogUi(MsgDialogUi&& other) noexcept;
+    MsgDialogUi& operator=(MsgDialogUi other);
+
+    void Finish(ButtonId buttonId);
+
+    void Draw() override;
+
+    bool ShouldGrabGamepad() override {
+        return true;
+    }
+};
 
 CommonDialog::Error PS4_SYSV_ABI sceMsgDialogClose();
 CommonDialog::Error PS4_SYSV_ABI sceMsgDialogGetResult(MsgDialogResult* result);

--- a/src/core/libraries/system/msgdialog.h
+++ b/src/core/libraries/system/msgdialog.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "common/fixed_value.h"
 #include "common/types.h"
 #include "core/libraries/system/commondialog.h"
 
@@ -12,95 +13,19 @@ class SymbolsResolver;
 
 namespace Libraries::MsgDialog {
 
-using OrbisUserServiceUserId = s32;
+struct MsgDialogResult;
+struct Param;
 
-enum OrbisCommonDialogStatus {
-    ORBIS_COMMON_DIALOG_STATUS_NONE = 0,
-    ORBIS_COMMON_DIALOG_STATUS_INITIALIZED = 1,
-    ORBIS_COMMON_DIALOG_STATUS_RUNNING = 2,
-    ORBIS_COMMON_DIALOG_STATUS_FINISHED = 3
-};
-
-enum OrbisMsgDialogMode {
-    ORBIS_MSG_DIALOG_MODE_USER_MSG = 1,
-    ORBIS_MSG_DIALOG_MODE_PROGRESS_BAR = 2,
-    ORBIS_MSG_DIALOG_MODE_SYSTEM_MSG = 3,
-};
-
-enum OrbisMsgDialogButtonType {
-    ORBIS_MSG_DIALOG_BUTTON_TYPE_OK = 0,
-    ORBIS_MSG_DIALOG_BUTTON_TYPE_YESNO = 1,
-    ORBIS_MSG_DIALOG_BUTTON_TYPE_NONE = 2,
-    ORBIS_MSG_DIALOG_BUTTON_TYPE_OK_CANCEL = 3,
-    ORBIS_MSG_DIALOG_BUTTON_TYPE_WAIT = 5,
-    ORBIS_MSG_DIALOG_BUTTON_TYPE_WAIT_CANCEL = 6,
-    ORBIS_MSG_DIALOG_BUTTON_TYPE_YESNO_FOCUS_NO = 7,
-    ORBIS_MSG_DIALOG_BUTTON_TYPE_OK_CANCEL_FOCUS_CANCEL = 8,
-    ORBIS_MSG_DIALOG_BUTTON_TYPE_2BUTTONS = 9,
-};
-
-enum OrbisMsgDialogProgressBarType {
-    ORBIS_MSG_DIALOG_PROGRESSBAR_TYPE_PERCENTAGE = 0,
-    ORBIS_MSG_DIALOG_PROGRESSBAR_TYPE_PERCENTAGE_CANCEL = 1,
-};
-
-enum OrbisMsgDialogSystemMessageType {
-    ORBIS_MSG_DIALOG_SYSMSG_TYPE_TRC_EMPTY_STORE = 0,
-    ORBIS_MSG_DIALOG_SYSMSG_TYPE_TRC_PSN_CHAT_RESTRICTION = 1,
-    ORBIS_MSG_DIALOG_SYSMSG_TYPE_TRC_PSN_UGC_RESTRICTION = 2,
-    ORBIS_MSG_DIALOG_SYSMSG_TYPE_CAMERA_NOT_CONNECTED = 4,
-    ORBIS_MSG_DIALOG_SYSMSG_TYPE_WARNING_PROFILE_PICTURE_AND_NAME_NOT_SHARED = 5,
-};
-
-struct OrbisMsgDialogButtonsParam {
-    const char* msg1;
-    const char* msg2;
-    char reserved[32];
-};
-
-struct OrbisMsgDialogUserMessageParam {
-    OrbisMsgDialogButtonType buttonType;
-    s32 : 32;
-    const char* msg;
-    OrbisMsgDialogButtonsParam* buttonsParam;
-    char reserved[24];
-};
-
-struct OrbisMsgDialogProgressBarParam {
-    OrbisMsgDialogProgressBarType barType;
-    int32_t : 32;
-    const char* msg;
-    char reserved[64];
-};
-
-struct OrbisMsgDialogSystemMessageParam {
-    OrbisMsgDialogSystemMessageType sysMsgType;
-    char reserved[32];
-};
-
-struct OrbisMsgDialogParam {
-    CommonDialog::OrbisCommonDialogBaseParam baseParam;
-    std::size_t size;
-    OrbisMsgDialogMode mode;
-    s32 : 32;
-    OrbisMsgDialogUserMessageParam* userMsgParam;
-    OrbisMsgDialogProgressBarParam* progBarParam;
-    OrbisMsgDialogSystemMessageParam* sysMsgParam;
-    OrbisUserServiceUserId userId;
-    char reserved[40];
-    s32 : 32;
-};
-
-int PS4_SYSV_ABI sceMsgDialogClose();
-int PS4_SYSV_ABI sceMsgDialogGetResult();
-int PS4_SYSV_ABI sceMsgDialogGetStatus();
-int PS4_SYSV_ABI sceMsgDialogInitialize();
-s32 PS4_SYSV_ABI sceMsgDialogOpen(const OrbisMsgDialogParam* param);
+CommonDialog::Error PS4_SYSV_ABI sceMsgDialogClose();
+CommonDialog::Error PS4_SYSV_ABI sceMsgDialogGetResult(MsgDialogResult* result);
+CommonDialog::Status PS4_SYSV_ABI sceMsgDialogGetStatus();
+CommonDialog::Error PS4_SYSV_ABI sceMsgDialogInitialize();
+CommonDialog::Error PS4_SYSV_ABI sceMsgDialogOpen(const Param* param);
 int PS4_SYSV_ABI sceMsgDialogProgressBarInc();
 int PS4_SYSV_ABI sceMsgDialogProgressBarSetMsg();
 int PS4_SYSV_ABI sceMsgDialogProgressBarSetValue();
-int PS4_SYSV_ABI sceMsgDialogTerminate();
-int PS4_SYSV_ABI sceMsgDialogUpdateStatus();
+CommonDialog::Error PS4_SYSV_ABI sceMsgDialogTerminate();
+CommonDialog::Status PS4_SYSV_ABI sceMsgDialogUpdateStatus();
 
 void RegisterlibSceMsgDialog(Core::Loader::SymbolsResolver* sym);
 } // namespace Libraries::MsgDialog

--- a/src/core/libraries/system/msgdialog.h
+++ b/src/core/libraries/system/msgdialog.h
@@ -56,6 +56,10 @@ enum class SystemMessageType : u32 {
     WARNING_PROFILE_PICTURE_AND_NAME_NOT_SHARED = 5,
 };
 
+enum class OrbisMsgDialogProgressBarTarget : u32 {
+    DEFAULT = 0,
+};
+
 struct ButtonsParam {
     const char* msg1{};
     const char* msg2{};
@@ -107,6 +111,7 @@ class MsgDialogUi final : public ImGui::Layer {
     const Param* param{};
     CommonDialog::Status* status{};
     MsgDialogResult* result{};
+    u32 progress_bar_value{};
 
     void DrawUser();
     void DrawProgressBar();
@@ -120,7 +125,9 @@ public:
     MsgDialogUi(MsgDialogUi&& other) noexcept;
     MsgDialogUi& operator=(MsgDialogUi other);
 
-    void Finish(ButtonId buttonId);
+    void Finish(ButtonId buttonId, CommonDialog::Result r = CommonDialog::Result::OK);
+
+    void SetProgressBarValue(u32 value, bool increment);
 
     void Draw() override;
 
@@ -134,9 +141,12 @@ CommonDialog::Error PS4_SYSV_ABI sceMsgDialogGetResult(MsgDialogResult* result);
 CommonDialog::Status PS4_SYSV_ABI sceMsgDialogGetStatus();
 CommonDialog::Error PS4_SYSV_ABI sceMsgDialogInitialize();
 CommonDialog::Error PS4_SYSV_ABI sceMsgDialogOpen(const Param* param);
-int PS4_SYSV_ABI sceMsgDialogProgressBarInc();
-int PS4_SYSV_ABI sceMsgDialogProgressBarSetMsg();
-int PS4_SYSV_ABI sceMsgDialogProgressBarSetValue();
+CommonDialog::Error PS4_SYSV_ABI sceMsgDialogProgressBarInc(OrbisMsgDialogProgressBarTarget,
+                                                            u32 delta);
+CommonDialog::Error PS4_SYSV_ABI sceMsgDialogProgressBarSetMsg(OrbisMsgDialogProgressBarTarget,
+                                                               const char* msg);
+CommonDialog::Error PS4_SYSV_ABI sceMsgDialogProgressBarSetValue(OrbisMsgDialogProgressBarTarget,
+                                                                 u32 value);
 CommonDialog::Error PS4_SYSV_ABI sceMsgDialogTerminate();
 CommonDialog::Status PS4_SYSV_ABI sceMsgDialogUpdateStatus();
 

--- a/src/core/libraries/system/msgdialog_ui.cpp
+++ b/src/core/libraries/system/msgdialog_ui.cpp
@@ -117,7 +117,34 @@ void MsgDialogUi::DrawProgressBar() {
     EndGroup();
 }
 
-void MsgDialogUi::DrawSystemMessage() {}
+struct {
+    const char* text;
+} static constexpr system_message_texts[] = {
+    "No product available in the store.",            // TRC_EMPTY_STORE
+    "PSN chat restriction.",                         // TRC_PSN_CHAT_RESTRICTION
+    "User-generated Media restriction",              // TRC_PSN_UGC_RESTRICTION
+    nullptr,                                         // !!NOP
+    "Camera not connected.",                         // CAMERA_NOT_CONNECTED
+    "Warning: profile picture and name are not set", // WARNING_PROFILE_PICTURE_AND_NAME_NOT_SHARED
+};
+static_assert(std::size(system_message_texts) ==
+              static_cast<int>(SystemMessageType::WARNING_PROFILE_PICTURE_AND_NAME_NOT_SHARED) + 1);
+
+void MsgDialogUi::DrawSystemMessage() {
+    // TODO: Implement go to settings & user profile
+    const auto& [msg_type, _] = *param->sysMsgParam;
+    ASSERT(msg_type <= SystemMessageType::WARNING_PROFILE_PICTURE_AND_NAME_NOT_SHARED);
+    auto [msg] = system_message_texts[static_cast<u32>(msg_type)];
+    DrawCenteredText(msg);
+    const auto ws = GetWindowSize();
+    SetCursorPos({
+        ws.x / 2.0f - BUTTON_SIZE.x / 2.0f,
+        ws.y - 10.0f - BUTTON_SIZE.y,
+    });
+    if (Button("OK", BUTTON_SIZE)) {
+        Finish(ButtonId::OK);
+    }
+}
 
 MsgDialogUi::MsgDialogUi(const Param* param, Status* status, MsgDialogResult* result)
     : dialog_unique_id([] {

--- a/src/core/libraries/system/msgdialog_ui.cpp
+++ b/src/core/libraries/system/msgdialog_ui.cpp
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <imgui.h>
+#include "imgui/imgui_std.h"
+
+#include "common/assert.h"
+#include "msgdialog.h"
+
+using namespace ImGui;
+using namespace Libraries::CommonDialog;
+using namespace Libraries::MsgDialog;
+
+static constexpr ImVec2 BUTTON_SIZE{100.0f, 30.0f};
+
+struct {
+    int count = 0;
+    const char* text1;
+    const char* text2;
+} static constexpr user_button_texts[] = {
+    {1, "OK"},             // 0 OK
+    {2, "Yes", "No"},      // 1 YESNO
+    {0},                   // 2 NONE
+    {2, "OK", "Cancel"},   // 3 OK_CANCEL
+    {},                    // 4 !!NOP
+    {1, "Wait"},           // 5 WAIT
+    {2, "Wait", "Cancel"}, // 6 WAIT_CANCEL
+    {2, "Yes", "No"},      // 7 YESNO_FOCUS_NO
+    {2, "OK", "Cancel"},   // 8 OK_CANCEL_FOCUS_CANCEL
+    {0xFF},                // 9 TWO_BUTTONS
+};
+static_assert(std::size(user_button_texts) == static_cast<int>(ButtonType::TWO_BUTTONS) + 1);
+
+static void DrawCenteredText(const char* text) {
+    const auto ws = GetWindowSize();
+    SetCursorPosY(ws.y / 2.0f - 50.0f);
+    PushTextWrapPos(ws.x - 30.0f);
+    SetCursorPosX((ws.x - CalcTextSize(text, nullptr, false, ws.x - 40.0f).x) / 2.0f);
+    Text("%s", text);
+    PopTextWrapPos();
+}
+
+void MsgDialogUi::DrawUser() {
+    const auto& [button_type, msg, btn_param, _] = *param->userMsgParam;
+    const auto ws = GetWindowSize();
+    DrawCenteredText(msg);
+    ASSERT(button_type <= ButtonType::TWO_BUTTONS);
+    auto [count, text1, text2] = user_button_texts[static_cast<u32>(button_type)];
+    if (count == 0xFF) { // TWO_BUTTONS -> User defined message
+        count = 2;
+        text1 = btn_param->msg1;
+        text2 = btn_param->msg2;
+    }
+    const bool focus_first = button_type < ButtonType::YESNO_FOCUS_NO;
+    SetCursorPos({
+        ws.x / 2.0f - BUTTON_SIZE.x / 2.0f * static_cast<float>(count),
+        ws.y - 10.0f - BUTTON_SIZE.y,
+    });
+    BeginGroup();
+    if (count > 0) {
+        // First button at the right, so we render the second button first
+        if (count == 2) {
+            PushID(2);
+            if (Button(text2, BUTTON_SIZE)) {
+                Finish(ButtonId::BUTTON2);
+            }
+            if (!focus_first) {
+                SetItemDefaultNav();
+            }
+            PopID();
+            SameLine();
+        }
+        PushID(1);
+        if (Button(text1, BUTTON_SIZE)) {
+            Finish(ButtonId::BUTTON1);
+        }
+        if (focus_first) {
+            SetItemDefaultNav();
+        }
+        PopID();
+        SameLine();
+    }
+    EndGroup();
+}
+
+void MsgDialogUi::DrawProgressBar() {}
+
+void MsgDialogUi::DrawSystemMessage() {}
+
+MsgDialogUi::MsgDialogUi(const Param* param, Status* status, MsgDialogResult* result)
+    : dialog_unique_id([] {
+          static s32 last_id = 0;
+          return ++last_id;
+      }()),
+      param(param), status(status), result(result) {
+    if (status && *status == Status::RUNNING) {
+        AddLayer(this);
+    }
+}
+MsgDialogUi::~MsgDialogUi() {
+    Finish(ButtonId::INVALID);
+}
+MsgDialogUi::MsgDialogUi(MsgDialogUi&& other) noexcept
+    : Layer(other), dialog_unique_id(other.dialog_unique_id), param(other.param),
+      status(other.status), result(other.result) {
+    other.dialog_unique_id = 0;
+    other.param = nullptr;
+    other.status = nullptr;
+    other.result = nullptr;
+}
+MsgDialogUi& MsgDialogUi::operator=(MsgDialogUi other) {
+    using std::swap;
+    swap(dialog_unique_id, other.dialog_unique_id);
+    swap(param, other.param);
+    swap(status, other.status);
+    swap(result, other.result);
+    if (status && *status == Status::RUNNING) {
+        AddLayer(this);
+    }
+    return *this;
+}
+
+void MsgDialogUi::Finish(ButtonId buttonId) {
+    if (result) {
+        result->buttonId = buttonId;
+    }
+    if (status) {
+        *status = Status::FINISHED;
+    }
+    param = nullptr;
+    status = nullptr;
+    result = nullptr;
+    RemoveLayer(this);
+}
+
+void MsgDialogUi::Draw() {
+    if (status == nullptr || *status != Status::RUNNING) {
+        return;
+    }
+    const auto& io = GetIO();
+
+    const ImVec2 window_size{
+        std::min(io.DisplaySize.x, 500.0f),
+        std::min(io.DisplaySize.y, 300.0f),
+    };
+
+    CentralizeWindow();
+    SetNextWindowSize(window_size);
+    SetNextWindowFocus();
+    SetNextWindowCollapsed(false);
+    KeepNavHighlight();
+    // Hack to allow every dialog to have a unique window
+#define TITLE "Message Dialog##MD"
+    char id[sizeof(TITLE) + sizeof(int)] = TITLE "\0\0\0\0";
+    *reinterpret_cast<int*>(&id[sizeof(TITLE) - 1]) =
+        dialog_unique_id |
+        0x80808080; // keep the MSB set to extend the string length (null terminated)
+#undef TITLE
+    if (Begin(id, nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings)) {
+        switch (param->mode) {
+        case MsgDialogMode::USER_MSG:
+            DrawUser();
+            break;
+        case MsgDialogMode::PROGRESS_BAR:
+            DrawProgressBar();
+            break;
+        case MsgDialogMode::SYSTEM_MSG:
+            DrawSystemMessage();
+            break;
+        }
+        End();
+    }
+}

--- a/src/core/libraries/system/msgdialog_ui.cpp
+++ b/src/core/libraries/system/msgdialog_ui.cpp
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <imgui.h>
-#include "imgui/imgui_std.h"
-
 #include "common/assert.h"
-#include "msgdialog.h"
+#include "imgui/imgui_std.h"
+#include "msgdialog_ui.h"
 
 using namespace ImGui;
 using namespace Libraries::CommonDialog;
@@ -34,23 +33,65 @@ static_assert(std::size(user_button_texts) == static_cast<int>(ButtonType::TWO_B
 
 static void DrawCenteredText(const char* text) {
     const auto ws = GetWindowSize();
-    SetCursorPosY(ws.y / 2.0f - 50.0f);
+    const auto text_size = CalcTextSize(text, nullptr, false, ws.x - 40.0f);
     PushTextWrapPos(ws.x - 30.0f);
-    SetCursorPosX((ws.x - CalcTextSize(text, nullptr, false, ws.x - 40.0f).x) / 2.0f);
+    SetCursorPos({
+        (ws.x - text_size.x) / 2.0f,
+        (ws.y - text_size.y) / 2.0f - 50.0f,
+    });
     Text("%s", text);
     PopTextWrapPos();
 }
 
+MsgDialogState::MsgDialogState(const OrbisParam& param) {
+    this->mode = param.mode;
+    switch (mode) {
+    case MsgDialogMode::USER_MSG: {
+        ASSERT(param.userMsgParam);
+        const auto& v = *param.userMsgParam;
+        auto state = UserState{
+            .type = v.buttonType,
+            .msg = std::string(v.msg),
+        };
+        if (v.buttonType == ButtonType::TWO_BUTTONS) {
+            ASSERT(v.buttonsParam);
+            state.btn_param1 = std::string(v.buttonsParam->msg1);
+            state.btn_param2 = std::string(v.buttonsParam->msg2);
+        }
+        this->state = state;
+    } break;
+    case MsgDialogMode::PROGRESS_BAR: {
+        ASSERT(param.progBarParam);
+        const auto& v = *param.progBarParam;
+        this->state = ProgressState{
+            .type = v.barType,
+            .msg = std::string(v.msg),
+            .progress = 0,
+        };
+    } break;
+    case MsgDialogMode::SYSTEM_MSG: {
+        ASSERT(param.sysMsgParam);
+        const auto& v = *param.sysMsgParam;
+        this->state = SystemState{
+            .type = v.sysMsgType,
+        };
+    } break;
+    default:
+        UNREACHABLE_MSG("Unknown dialog mode");
+    }
+}
+
 void MsgDialogUi::DrawUser() {
-    const auto& [button_type, msg, btn_param, _] = *param->userMsgParam;
+    const auto& [button_type, msg, btn_param1, btn_param2] =
+        state->GetState<MsgDialogState::UserState>();
     const auto ws = GetWindowSize();
-    DrawCenteredText(msg);
+    DrawCenteredText(msg.c_str());
     ASSERT(button_type <= ButtonType::TWO_BUTTONS);
     auto [count, text1, text2] = user_button_texts[static_cast<u32>(button_type)];
     if (count == 0xFF) { // TWO_BUTTONS -> User defined message
         count = 2;
-        text1 = btn_param->msg1;
-        text2 = btn_param->msg2;
+        text1 = btn_param1.c_str();
+        text2 = btn_param2.c_str();
     }
     const bool focus_first = button_type < ButtonType::YESNO_FOCUS_NO;
     SetCursorPos({
@@ -74,8 +115,8 @@ void MsgDialogUi::DrawUser() {
                     break;
                 }
             }
-            if (!focus_first) {
-                SetItemDefaultNav();
+            if (first_render && !focus_first) {
+                SetItemCurrentNavFocus();
             }
             PopID();
             SameLine();
@@ -84,8 +125,8 @@ void MsgDialogUi::DrawUser() {
         if (Button(text1, BUTTON_SIZE)) {
             Finish(ButtonId::BUTTON1);
         }
-        if (focus_first) {
-            SetItemDefaultNav();
+        if (first_render && focus_first) {
+            SetItemCurrentNavFocus();
         }
         PopID();
         SameLine();
@@ -94,24 +135,28 @@ void MsgDialogUi::DrawUser() {
 }
 
 void MsgDialogUi::DrawProgressBar() {
-    const auto& [bar_type, msg, _] = *param->progBarParam;
-    DrawCenteredText(msg);
+    const auto& [bar_type, msg, progress_bar_value] =
+        state->GetState<MsgDialogState::ProgressState>();
+    DrawCenteredText(msg.c_str());
     const auto ws = GetWindowSize();
     SetCursorPos({
         ws.x * ((1 - PROGRESS_BAR_WIDTH) / 2.0f),
         ws.y - 10.0f - BUTTON_SIZE.y,
     });
-    bool has_cancel = bar_type == ProgressBarType::PERCENTAGE_CANCEL;
+    const bool has_cancel = bar_type == ProgressBarType::PERCENTAGE_CANCEL;
     float bar_width = PROGRESS_BAR_WIDTH * ws.x;
     if (has_cancel) {
         bar_width -= BUTTON_SIZE.x - 10.0f;
     }
     BeginGroup();
-    ProgressBar((float)progress_bar_value / 100.0f, {bar_width, BUTTON_SIZE.y});
+    ProgressBar(static_cast<float>(progress_bar_value) / 100.0f, {bar_width, BUTTON_SIZE.y});
     if (has_cancel) {
         SameLine();
         if (Button("Cancel", BUTTON_SIZE)) {
             Finish(ButtonId::INVALID, Result::USER_CANCELED);
+        }
+        if (first_render) {
+            SetItemCurrentNavFocus();
         }
     }
     EndGroup();
@@ -132,7 +177,7 @@ static_assert(std::size(system_message_texts) ==
 
 void MsgDialogUi::DrawSystemMessage() {
     // TODO: Implement go to settings & user profile
-    const auto& [msg_type, _] = *param->sysMsgParam;
+    const auto& [msg_type] = state->GetState<MsgDialogState::SystemState>();
     ASSERT(msg_type <= SystemMessageType::WARNING_PROFILE_PICTURE_AND_NAME_NOT_SHARED);
     auto [msg] = system_message_texts[static_cast<u32>(msg_type)];
     DrawCenteredText(msg);
@@ -144,15 +189,15 @@ void MsgDialogUi::DrawSystemMessage() {
     if (Button("OK", BUTTON_SIZE)) {
         Finish(ButtonId::OK);
     }
+    if (first_render) {
+        SetItemCurrentNavFocus();
+    }
 }
 
-MsgDialogUi::MsgDialogUi(const Param* param, Status* status, MsgDialogResult* result)
-    : dialog_unique_id([] {
-          static s32 last_id = 0;
-          return ++last_id;
-      }()),
-      param(param), status(status), result(result) {
+MsgDialogUi::MsgDialogUi(MsgDialogState* state, Status* status, DialogResult* result)
+    : state(state), status(status), result(result) {
     if (status && *status == Status::RUNNING) {
+        first_render = true;
         AddLayer(this);
     }
 }
@@ -160,20 +205,18 @@ MsgDialogUi::~MsgDialogUi() {
     Finish(ButtonId::INVALID);
 }
 MsgDialogUi::MsgDialogUi(MsgDialogUi&& other) noexcept
-    : Layer(other), dialog_unique_id(other.dialog_unique_id), param(other.param),
-      status(other.status), result(other.result) {
-    other.dialog_unique_id = 0;
-    other.param = nullptr;
+    : Layer(other), state(other.state), status(other.status), result(other.result) {
+    other.state = nullptr;
     other.status = nullptr;
     other.result = nullptr;
 }
 MsgDialogUi& MsgDialogUi::operator=(MsgDialogUi other) {
     using std::swap;
-    swap(dialog_unique_id, other.dialog_unique_id);
-    swap(param, other.param);
+    swap(state, other.state);
     swap(status, other.status);
     swap(result, other.result);
     if (status && *status == Status::RUNNING) {
+        first_render = true;
         AddLayer(this);
     }
     return *this;
@@ -187,18 +230,10 @@ void MsgDialogUi::Finish(ButtonId buttonId, Result r) {
     if (status) {
         *status = Status::FINISHED;
     }
-    param = nullptr;
+    state = nullptr;
     status = nullptr;
     result = nullptr;
     RemoveLayer(this);
-}
-
-void MsgDialogUi::SetProgressBarValue(u32 value, bool increment) {
-    if (increment) {
-        progress_bar_value += value;
-    } else {
-        progress_bar_value = value;
-    }
 }
 
 void MsgDialogUi::Draw() {
@@ -218,14 +253,9 @@ void MsgDialogUi::Draw() {
     SetNextWindowCollapsed(false);
     KeepNavHighlight();
     // Hack to allow every dialog to have a unique window
-#define TITLE "Message Dialog##MD"
-    char id[sizeof(TITLE) + sizeof(int)] = TITLE "\0\0\0\0";
-    *reinterpret_cast<int*>(&id[sizeof(TITLE) - 1]) =
-        dialog_unique_id |
-        0x80808080; // keep the MSB set to extend the string length (null terminated)
-#undef TITLE
-    if (Begin(id, nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings)) {
-        switch (param->mode) {
+    if (Begin("Message Dialog##MessageDialog", nullptr,
+              ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings)) {
+        switch (state->GetMode()) {
         case MsgDialogMode::USER_MSG:
             DrawUser();
             break;
@@ -238,4 +268,6 @@ void MsgDialogUi::Draw() {
         }
         End();
     }
+
+    first_render = false;
 }

--- a/src/core/libraries/system/msgdialog_ui.h
+++ b/src/core/libraries/system/msgdialog_ui.h
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <variant>
+
+#include "common/fixed_value.h"
+#include "common/types.h"
+#include "core/libraries/system/commondialog.h"
+#include "imgui/imgui_layer.h"
+
+namespace Libraries::MsgDialog {
+
+using OrbisUserServiceUserId = s32;
+
+enum class MsgDialogMode : u32 {
+    USER_MSG = 1,
+    PROGRESS_BAR = 2,
+    SYSTEM_MSG = 3,
+};
+
+enum class ButtonId : u32 {
+    INVALID = 0,
+    OK = 1,
+    YES = 1,
+    NO = 2,
+    BUTTON1 = 1,
+    BUTTON2 = 2,
+};
+
+enum class ButtonType : u32 {
+    OK = 0,
+    YESNO = 1,
+    NONE = 2,
+    OK_CANCEL = 3,
+    WAIT = 5,
+    WAIT_CANCEL = 6,
+    YESNO_FOCUS_NO = 7,
+    OK_CANCEL_FOCUS_CANCEL = 8,
+    TWO_BUTTONS = 9,
+};
+
+enum class ProgressBarType : u32 {
+    PERCENTAGE = 0,
+    PERCENTAGE_CANCEL = 1,
+};
+
+enum class SystemMessageType : u32 {
+    TRC_EMPTY_STORE = 0,
+    TRC_PSN_CHAT_RESTRICTION = 1,
+    TRC_PSN_UGC_RESTRICTION = 2,
+    CAMERA_NOT_CONNECTED = 4,
+    WARNING_PROFILE_PICTURE_AND_NAME_NOT_SHARED = 5,
+};
+
+enum class OrbisMsgDialogProgressBarTarget : u32 {
+    DEFAULT = 0,
+};
+
+struct ButtonsParam {
+    const char* msg1{};
+    const char* msg2{};
+    std::array<char, 32> reserved{};
+};
+
+struct UserMessageParam {
+    ButtonType buttonType{};
+    s32 : 32;
+    const char* msg{};
+    ButtonsParam* buttonsParam{};
+    std::array<char, 24> reserved{};
+};
+
+struct ProgressBarParam {
+    ProgressBarType barType{};
+    s32 : 32;
+    const char* msg{};
+    std::array<char, 64> reserved{};
+};
+
+struct SystemMessageParam {
+    SystemMessageType sysMsgType{};
+    std::array<char, 32> reserved{};
+};
+
+struct OrbisParam {
+    CommonDialog::BaseParam baseParam;
+    std::size_t size;
+    MsgDialogMode mode;
+    s32 : 32;
+    UserMessageParam* userMsgParam;
+    ProgressBarParam* progBarParam;
+    SystemMessageParam* sysMsgParam;
+    OrbisUserServiceUserId userId;
+    std::array<char, 40> reserved;
+    s32 : 32;
+};
+
+struct DialogResult {
+    FixedValue<u32, 0> mode{};
+    CommonDialog::Result result{CommonDialog::Result::OK};
+    ButtonId buttonId{ButtonId::INVALID};
+    std::array<char, 32> reserved{};
+};
+
+// State is used to copy all the data from the param struct
+class MsgDialogState {
+public:
+    struct UserState {
+        ButtonType type{};
+        std::string msg{};
+        std::string btn_param1{};
+        std::string btn_param2{};
+    };
+    struct ProgressState {
+        ProgressBarType type{};
+        std::string msg{};
+        u32 progress{};
+    };
+    struct SystemState {
+        SystemMessageType type{};
+    };
+
+private:
+    OrbisUserServiceUserId user_id{};
+    MsgDialogMode mode{};
+    std::variant<UserState, ProgressState, SystemState, std::monostate> state{std::monostate{}};
+
+public:
+    explicit MsgDialogState(const OrbisParam& param);
+    MsgDialogState() = default;
+
+    [[nodiscard]] OrbisUserServiceUserId GetUserId() const {
+        return user_id;
+    }
+
+    [[nodiscard]] MsgDialogMode GetMode() const {
+        return mode;
+    }
+
+    template <typename T>
+    [[nodiscard]] T& GetState() {
+        return std::get<T>(state);
+    }
+};
+
+class MsgDialogUi final : public ImGui::Layer {
+    bool first_render{false};
+    MsgDialogState* state{};
+    CommonDialog::Status* status{};
+    DialogResult* result{};
+
+    void DrawUser();
+    void DrawProgressBar();
+    void DrawSystemMessage();
+
+public:
+    explicit MsgDialogUi(MsgDialogState* state = nullptr, CommonDialog::Status* status = nullptr,
+                         DialogResult* result = nullptr);
+    ~MsgDialogUi() override;
+    MsgDialogUi(const MsgDialogUi& other) = delete;
+    MsgDialogUi(MsgDialogUi&& other) noexcept;
+    MsgDialogUi& operator=(MsgDialogUi other);
+
+    void Finish(ButtonId buttonId, CommonDialog::Result r = CommonDialog::Result::OK);
+
+    void SetProgressBarValue(u32 value, bool increment);
+
+    void Draw() override;
+
+    bool ShouldGrabGamepad() override {
+        return true;
+    }
+};
+
+}; // namespace Libraries::MsgDialog

--- a/src/imgui/imgui_std.h
+++ b/src/imgui/imgui_std.h
@@ -5,10 +5,25 @@
 
 #include <imgui.h>
 
+#include "imgui_internal.h"
+
 namespace ImGui {
 
 inline void CentralizeWindow() {
     const auto display_size = GetIO().DisplaySize;
     SetNextWindowPos(display_size / 2.0f, ImGuiCond_Always, {0.5f});
 }
+
+inline void KeepNavHighlight() {
+    GetCurrentContext()->NavDisableHighlight = false;
+}
+
+inline void SetItemDefaultNav() {
+    if (IsWindowAppearing()) {
+        const auto ctx = GetCurrentContext();
+        SetFocusID(ctx->LastItemData.ID, ctx->CurrentWindow);
+        ctx->NavInitResult.Clear();
+    }
+}
+
 } // namespace ImGui

--- a/src/imgui/imgui_std.h
+++ b/src/imgui/imgui_std.h
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <imgui.h>
+
+namespace ImGui {
+
+inline void CentralizeWindow() {
+    const auto display_size = GetIO().DisplaySize;
+    SetNextWindowPos(display_size / 2.0f, ImGuiCond_Always, {0.5f});
+}
+} // namespace ImGui

--- a/src/imgui/imgui_std.h
+++ b/src/imgui/imgui_std.h
@@ -18,12 +18,10 @@ inline void KeepNavHighlight() {
     GetCurrentContext()->NavDisableHighlight = false;
 }
 
-inline void SetItemDefaultNav() {
-    if (IsWindowAppearing()) {
-        const auto ctx = GetCurrentContext();
-        SetFocusID(ctx->LastItemData.ID, ctx->CurrentWindow);
-        ctx->NavInitResult.Clear();
-    }
+inline void SetItemCurrentNavFocus() {
+    const auto ctx = GetCurrentContext();
+    SetFocusID(ctx->LastItemData.ID, ctx->CurrentWindow);
+    ctx->NavInitResult.Clear();
 }
 
 } // namespace ImGui


### PR DESCRIPTION
~- based on the #598 branch, gonna rebase after merge~

> Check discord homebrew-downloads channel for a test binary

Gamepad as first-class

### Msg dialog
- [x] State
- [x] Basic text
- [x] Buttons
- [x] Progress bar
- [x] System error

~### Save Dialog~ I'll split it to another PR

## Demo
![image](https://github.com/user-attachments/assets/50f14cdf-1c85-4da9-9f90-a63eb5238d14)
![image](https://github.com/user-attachments/assets/b0a7ac07-b11b-4778-8229-197ef70d2cca)
![image](https://github.com/user-attachments/assets/71c3f54a-b434-4ddf-b238-cafc22ddf036)
![image](https://github.com/user-attachments/assets/c282f230-f4ca-463a-8088-629d4532c9e4)




