### PR TITLE
video_core/renderer_vulkan: Ignore unsupported shader stages

### DIFF
--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -291,8 +291,7 @@ bool PipelineCache::RefreshGraphicsKey() {
         const auto stage = Shader::StageFromIndex(i);
         const auto params = Liverpool::GetParams(*pgm);
 
-        if (stage != Shader::Stage::Vertex && 
-            stage != Shader::Stage::Fragment) {
+        if (stage != Shader::Stage::Vertex && stage != Shader::Stage::Fragment) {
             return false;
         }
 

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -290,6 +290,12 @@ bool PipelineCache::RefreshGraphicsKey() {
         }
         const auto stage = Shader::StageFromIndex(i);
         const auto params = Liverpool::GetParams(*pgm);
+
+        if (stage != Shader::Stage::Vertex && 
+            stage != Shader::Stage::Fragment) {
+            return false;
+        }
+
         std::tie(infos[i], modules[i], key.stage_hashes[i]) = GetProgram(stage, params, binding);
     }
     return true;


### PR DESCRIPTION
Avoids PSPHD games from compiling geometry shaders.