### PR TITLE
One more sceBatchMap2 fix

### DIFF
--- a/src/core/libraries/kernel/memory_management.cpp
+++ b/src/core/libraries/kernel/memory_management.cpp
@@ -272,7 +272,7 @@ s32 PS4_SYSV_ABI sceKernelBatchMap2(OrbisKernelBatchMapEntry* entries, int numEn
                                     int* numEntriesOut, int flags) {
     int result = ORBIS_OK;
     int processed = 0;
-    for (int i = 0; i < numEntries; i++) {
+    for (int i = 0; i < numEntries; i++, processed++) {
         if (entries == nullptr || entries[i].length == 0 || entries[i].operation > 4) {
             result = ORBIS_KERNEL_ERROR_EINVAL;
             break; // break and assign a value to numEntriesOut.


### PR DESCRIPTION
https://github.com/shadps4-emu/shadPS4/pull/387 also removed the processed variable from the sceBatchMap2 for loop, a rather important part of the https://github.com/shadps4-emu/shadPS4/pull/602 changes. Without this fix, any game using the BatchMap functions is probably broken.

Apologies for the extra pr, I completely missed this since my first batch of fixes got merged so quick.