### PR TITLE
Initial support for compiling on ARM64.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,22 @@ endif()
 
 option(ENABLE_QT_GUI "Enable the Qt GUI. If not selected then the emulator uses a minimal SDL-based UI instead" OFF)
 
+# First, determine whether to use CMAKE_OSX_ARCHITECTURES or CMAKE_SYSTEM_PROCESSOR.
+if (APPLE AND CMAKE_OSX_ARCHITECTURES)
+    set(BASE_ARCHITECTURE "${CMAKE_OSX_ARCHITECTURES}")
+else()
+    set(BASE_ARCHITECTURE "${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+
+# Next, match common architecture strings down to a known common value.
+if (BASE_ARCHITECTURE MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
+    set(ARCHITECTURE "x86_64")
+elseif (BASE_ARCHITECTURE MATCHES "(aarch64)|(AARCH64)|(arm64)|(ARM64)")
+    set(ARCHITECTURE "arm64")
+else()
+    message(FATAL_ERROR "Unsupported CPU architecture: ${BASE_ARCHITECTURE}")
+endif()
+
 # This function should be passed a list of all files in a target. It will automatically generate file groups
 # following the directory hierarchy, so that the layout of the files in IDEs matches the one in the filesystem.
 function(create_target_directory_groups target_name)
@@ -308,6 +324,7 @@ set(COMMON src/common/logging/backend.cpp
            src/common/logging/text_formatter.h
            src/common/logging/types.h
            src/common/alignment.h
+           src/common/arch.h
            src/common/assert.cpp
            src/common/assert.h
            src/common/bit_field.h
@@ -356,8 +373,6 @@ set(CORE src/core/aerolib/stubs.cpp
          src/core/aerolib/aerolib.h
          src/core/address_space.cpp
          src/core/address_space.h
-         src/core/cpu_patches.cpp
-         src/core/cpu_patches.h
          src/core/crypto/crypto.cpp
          src/core/crypto/crypto.h
          src/core/crypto/keys.h
@@ -414,6 +429,12 @@ set(CORE src/core/aerolib/stubs.cpp
          src/core/virtual_memory.cpp
          src/core/virtual_memory.h
 )
+
+if (ARCHITECTURE STREQUAL "x86_64")
+    set(CORE ${CORE}
+             src/core/cpu_patches.cpp
+             src/core/cpu_patches.h)
+endif()
 
 set(SHADER_RECOMPILER src/shader_recompiler/exception.h
                       src/shader_recompiler/profile.h
@@ -658,8 +679,10 @@ if (APPLE)
       target_link_libraries(shadps4 PRIVATE ${MOLTENVK})
   endif()
 
-  # Reserve system-managed memory space.
-  target_link_options(shadps4 PRIVATE -Wl,-no_pie,-no_fixup_chains,-no_huge,-pagezero_size,0x4000,-segaddr,TCB_SPACE,0x4000,-segaddr,GUEST_SYSTEM,0x400000,-image_base,0x20000000000)
+  if (ARCHITECTURE STREQUAL "x86_64")
+      # Reserve system-managed memory space.
+      target_link_options(shadps4 PRIVATE -Wl,-no_pie,-no_fixup_chains,-no_huge,-pagezero_size,0x4000,-segaddr,TCB_SPACE,0x4000,-segaddr,GUEST_SYSTEM,0x400000,-image_base,0x20000000000)
+  endif()
 
   # Replacement for std::chrono::time_zone
   target_link_libraries(shadps4 PRIVATE date::date-tz)

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -43,7 +43,6 @@ else()
 endif()
 
 if (NOT TARGET FFmpeg::ffmpeg)
-    set(ARCHITECTURE "x86_64")
     add_subdirectory(ffmpeg-core)
     add_library(FFmpeg::ffmpeg ALIAS ffmpeg)
 endif()

--- a/src/common/arch.h
+++ b/src/common/arch.h
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#if defined(__x86_64__) || defined(_M_X64)
+#define ARCH_X86_64 1
+#elif defined(__aarch64__) || defined(_M_ARM64)
+#define ARCH_ARM64 1
+#endif

--- a/src/common/assert.cpp
+++ b/src/common/assert.cpp
@@ -1,10 +1,17 @@
 // SPDX-FileCopyrightText: Copyright 2021 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/arch.h"
 #include "common/assert.h"
 #include "common/logging/backend.h"
 
+#if defined(ARCH_X86_64)
 #define Crash() __asm__ __volatile__("int $3")
+#elif defined(ARCH_ARM64)
+#define Crash() __asm__ __volatile__("brk 0")
+#else
+#error "Missing Crash() implementation for target CPU architecture."
+#endif
 
 void assert_fail_impl() {
     Common::Log::Stop();

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -3,11 +3,13 @@
 
 #include <boost/icl/separate_interval_set.hpp>
 #include "common/alignment.h"
+#include "common/arch.h"
 #include "common/assert.h"
 #include "common/error.h"
 #include "core/address_space.h"
 #include "core/libraries/kernel/memory_management.h"
 #include "core/memory.h"
+#include "libraries/error_codes.h"
 
 #ifdef _WIN32
 #include <windows.h>
@@ -15,9 +17,8 @@
 #include <fcntl.h>
 #include <sys/mman.h>
 #endif
-#include "libraries/error_codes.h"
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && defined(ARCH_X86_64)
 // Reserve space for the system address space using a zerofill section.
 asm(".zerofill GUEST_SYSTEM,GUEST_SYSTEM,__guest_system,0xFBFC00000");
 #endif
@@ -308,12 +309,12 @@ struct AddressSpace::Impl {
 
         constexpr int protection_flags = PROT_READ | PROT_WRITE;
         constexpr int base_map_flags = MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE;
-#ifdef __APPLE__
-        // On ARM64 Macs, we run into limitations due to the commpage from 0xFC0000000 - 0xFFFFFFFFF
-        // and the GPU carveout region from 0x1000000000 - 0x6FFFFFFFFF. We can allocate the system
-        // managed region, as well as system reserved if reduced in size slightly, but we cannot map
-        // the user region where we want, so we must let the OS put it wherever possible and hope
-        // the game won't rely on its location.
+#if defined(__APPLE__) && defined(ARCH_X86_64)
+        // On ARM64 Macs under Rosetta 2, we run into limitations due to the commpage from
+        // 0xFC0000000 - 0xFFFFFFFFF and the GPU carveout region from 0x1000000000 - 0x6FFFFFFFFF.
+        // We can allocate the system managed region, as well as system reserved if reduced in size
+        // slightly, but we cannot map the user region where we want, so we must let the OS put it
+        // wherever possible and hope the game won't rely on its location.
         system_managed_base = reinterpret_cast<u8*>(
             mmap(reinterpret_cast<void*>(SYSTEM_MANAGED_MIN), system_managed_size, protection_flags,
                  base_map_flags | MAP_FIXED, -1, 0));
@@ -325,12 +326,22 @@ struct AddressSpace::Impl {
                                                protection_flags, base_map_flags, -1, 0));
 #else
         const auto virtual_size = system_managed_size + system_reserved_size + user_size;
+#if defined(ARCH_X86_64)
         const auto virtual_base =
             reinterpret_cast<u8*>(mmap(reinterpret_cast<void*>(SYSTEM_MANAGED_MIN), virtual_size,
                                        protection_flags, base_map_flags | MAP_FIXED, -1, 0));
         system_managed_base = virtual_base;
         system_reserved_base = reinterpret_cast<u8*>(SYSTEM_RESERVED_MIN);
         user_base = reinterpret_cast<u8*>(USER_MIN);
+#else
+        // Map memory wherever possible and instruction translation can handle offsetting to the
+        // base.
+        const auto virtual_base = reinterpret_cast<u8*>(
+            mmap(nullptr, virtual_size, protection_flags, base_map_flags, -1, 0));
+        system_managed_base = virtual_base;
+        system_reserved_base = virtual_base + SYSTEM_RESERVED_MIN - SYSTEM_MANAGED_MIN;
+        user_base = virtual_base + USER_MIN - SYSTEM_MANAGED_MIN;
+#endif
 #endif
         if (system_managed_base == MAP_FAILED || system_reserved_base == MAP_FAILED ||
             user_base == MAP_FAILED) {
@@ -430,9 +441,11 @@ struct AddressSpace::Impl {
         if (write) {
             flags |= PROT_WRITE;
         }
+#ifdef ARCH_X86_64
         if (execute) {
             flags |= PROT_EXEC;
         }
+#endif
         int ret = mprotect(reinterpret_cast<void*>(virtual_addr), size, flags);
         ASSERT_MSG(ret == 0, "mprotect failed: {}", strerror(errno));
     }
@@ -463,8 +476,14 @@ AddressSpace::~AddressSpace() = default;
 
 void* AddressSpace::Map(VAddr virtual_addr, size_t size, u64 alignment, PAddr phys_addr,
                         bool is_exec) {
-    return impl->Map(virtual_addr, phys_addr, size,
-                     is_exec ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE);
+#if ARCH_X86_64
+    const auto prot = is_exec ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE;
+#else
+    // On non-native architectures, we can simplify things by ignoring the execute flag for the
+    // canonical copy of the memory and rely on the JIT to map translated code as executable.
+    constexpr auto prot = PAGE_READWRITE;
+#endif
+    return impl->Map(virtual_addr, phys_addr, size, prot);
 }
 
 void* AddressSpace::MapFile(VAddr virtual_addr, size_t size, size_t offset, u32 prot,

--- a/src/core/address_space.h
+++ b/src/core/address_space.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <memory>
+#include "common/arch.h"
 #include "common/enum.h"
 #include "common/types.h"
 
@@ -23,7 +24,7 @@ constexpr VAddr CODE_BASE_OFFSET = 0x100000000ULL;
 constexpr VAddr SYSTEM_MANAGED_MIN = 0x00000400000ULL;
 constexpr VAddr SYSTEM_MANAGED_MAX = 0x07FFFFBFFFULL;
 constexpr VAddr SYSTEM_RESERVED_MIN = 0x07FFFFC000ULL;
-#ifdef __APPLE__
+#if defined(__APPLE__) && defined(ARCH_X86_64)
 // Can only comfortably reserve the first 0x7C0000000 of system reserved space.
 constexpr VAddr SYSTEM_RESERVED_MAX = 0xFBFFFFFFFULL;
 #else

--- a/src/core/libraries/kernel/thread_management.cpp
+++ b/src/core/libraries/kernel/thread_management.cpp
@@ -6,6 +6,7 @@
 #include <thread>
 
 #include "common/alignment.h"
+#include "common/arch.h"
 #include "common/assert.h"
 #include "common/error.h"
 #include "common/logging/log.h"
@@ -995,7 +996,9 @@ static void cleanup_thread(void* arg) {
 static void* run_thread(void* arg) {
     auto* thread = static_cast<ScePthread>(arg);
     Common::SetCurrentThreadName(thread->name.c_str());
+#ifdef ARCH_X86_64
     Core::InitializeThreadPatchStack();
+#endif
     auto* linker = Common::Singleton<Core::Linker>::Instance();
     linker->InitTlsForThread(false);
     void* ret = nullptr;

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -3,6 +3,7 @@
 
 #include <xbyak/xbyak.h>
 #include "common/alignment.h"
+#include "common/arch.h"
 #include "common/assert.h"
 #include "common/logging/log.h"
 #ifdef ENABLE_QT_GUI
@@ -134,9 +135,11 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
             LOG_INFO(Core_Linker, "segment_mode ..........: {}", segment_mode);
 
             add_segment(elf_pheader[i]);
+#ifdef ARCH_X86_64
             if (elf_pheader[i].p_flags & PF_EXEC) {
                 PatchInstructions(segment_addr, segment_file_size, c);
             }
+#endif
             break;
         }
         case PT_DYNAMIC:


### PR DESCRIPTION
This is a more complete version of https://github.com/shadps4-emu/shadPS4/pull/769, aiming for initial ARM64 compilation support.

This does a few things:
* Adds CMake and code level architecture definitions for architecture-specific code. FFmpeg-specific `ARCHITECTURE` configuration fixed to `x86_64` is removed in favor of the overall properly detected architecture.
* Add ARM64-specific versions of certain x86_64-specific code, such as assert crashes, CPU timers, and signal context reading. These parts are set up to emit a clear compile error message if attempting to compile for an unimplemented system.
* Completely gates off some parts that only apply to x86_64, such as instruction patching and some macOS-specific linker flags. Some other parts like TLS and memory mapping are implemented but in more generic ways that can be accounted for by the eventual instruction translation that would be needed for ARM support.
* Skips mapping main memory pages as executable on non-x86_64 as a JIT would be responsible for taking that memory and creating executable translated code pages.

Tested compiling for ARM64 and was able to run until it tries to jump into the first module's code. With x86_64 everything also still runs as expected.