### PR TITLE
shader_recompiler: Add ConvertF16F32 to FP16 detection.

### DIFF
--- a/src/shader_recompiler/ir/passes/shader_info_collection_pass.cpp
+++ b/src/shader_recompiler/ir/passes/shader_info_collection_pass.cpp
@@ -22,6 +22,7 @@ void Visit(Info& info, IR::Inst& inst) {
     case IR::Opcode::WriteSharedU64:
         info.uses_shared = true;
         break;
+    case IR::Opcode::ConvertF16F32:
     case IR::Opcode::ConvertF32F16:
     case IR::Opcode::BitCastF16U16:
         info.uses_fp16 = true;


### PR DESCRIPTION
Adds ConvertF16F32 to the FP16 detection in the shader info collection pass.

Fixes an issue in CUSA10155 where it would crash compiling a shader on boot due to F16 not being defined. Now it reaches menus where it then stalls loading into the game due to some network functions.