### PR TITLE
shader_recompiler: Add more opcodes

### DIFF
--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -220,7 +220,7 @@ public:
     void IMAGE_GET_RESINFO(const GcnInst& inst);
     void IMAGE_SAMPLE(const GcnInst& inst);
     void IMAGE_GATHER(const GcnInst& inst);
-    void IMAGE_STORE(const GcnInst& inst);
+    void IMAGE_STORE(bool has_mip, const GcnInst& inst);
     void IMAGE_LOAD(bool has_mip, const GcnInst& inst);
     void IMAGE_GET_LOD(const GcnInst& inst);
     void IMAGE_ATOMIC(AtomicOp op, const GcnInst& inst);

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -220,7 +220,7 @@ public:
     void IMAGE_GET_RESINFO(const GcnInst& inst);
     void IMAGE_SAMPLE(const GcnInst& inst);
     void IMAGE_GATHER(const GcnInst& inst);
-    void IMAGE_STORE(bool has_mip, const GcnInst& inst);
+    void IMAGE_STORE(const GcnInst& inst);
     void IMAGE_LOAD(bool has_mip, const GcnInst& inst);
     void IMAGE_GET_LOD(const GcnInst& inst);
     void IMAGE_ATOMIC(AtomicOp op, const GcnInst& inst);

--- a/src/shader_recompiler/frontend/translate/vector_memory.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_memory.cpp
@@ -18,9 +18,11 @@ void Translator::EmitVectorMemory(const GcnInst& inst) {
     case Opcode::IMAGE_SAMPLE_B:
     case Opcode::IMAGE_SAMPLE_C_LZ_O:
     case Opcode::IMAGE_SAMPLE_D:
+    case Opcode::IMAGE_SAMPLE_CD:
         return IMAGE_SAMPLE(inst);
-    case Opcode::IMAGE_GATHER4_C:
     case Opcode::IMAGE_GATHER4_LZ:
+    case Opcode::IMAGE_GATHER4_C:
+    case Opcode::IMAGE_GATHER4_C_LZ:
     case Opcode::IMAGE_GATHER4_LZ_O:
         return IMAGE_GATHER(inst);
     case Opcode::IMAGE_ATOMIC_ADD:
@@ -98,6 +100,8 @@ void Translator::EmitVectorMemory(const GcnInst& inst) {
         return BUFFER_STORE(2, true, inst);
     case Opcode::TBUFFER_STORE_FORMAT_XYZ:
         return BUFFER_STORE(3, true, inst);
+    case Opcode::TBUFFER_STORE_FORMAT_XYZW:
+        return BUFFER_STORE(4, true, inst);
 
     case Opcode::BUFFER_STORE_DWORD:
         return BUFFER_STORE(1, false, inst);

--- a/src/shader_recompiler/frontend/translate/vector_memory.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_memory.cpp
@@ -47,10 +47,8 @@ void Translator::EmitVectorMemory(const GcnInst& inst) {
         return IMAGE_ATOMIC(AtomicOp::Dec, inst);
     case Opcode::IMAGE_GET_LOD:
         return IMAGE_GET_LOD(inst);
-    case Opcode::IMAGE_STORE_MIP:
-        return IMAGE_STORE(true, inst);
     case Opcode::IMAGE_STORE:
-        return IMAGE_STORE(false, inst);
+        return IMAGE_STORE(inst);
     case Opcode::IMAGE_LOAD_MIP:
         return IMAGE_LOAD(true, inst);
     case Opcode::IMAGE_LOAD:
@@ -332,7 +330,7 @@ void Translator::IMAGE_LOAD(bool has_mip, const GcnInst& inst) {
     }
 }
 
-void Translator::IMAGE_STORE(bool has_mip, const GcnInst& inst) {
+void Translator::IMAGE_STORE(const GcnInst& inst) {
     const auto& mimg = inst.control.mimg;
     IR::VectorReg addr_reg{inst.src[0].code};
     IR::VectorReg data_reg{inst.dst[0].code};
@@ -343,9 +341,6 @@ void Translator::IMAGE_STORE(bool has_mip, const GcnInst& inst) {
         ir.CompositeConstruct(ir.GetVectorReg(addr_reg), ir.GetVectorReg(addr_reg + 1),
                               ir.GetVectorReg(addr_reg + 2), ir.GetVectorReg(addr_reg + 3));
 
-    IR::TextureInstInfo info{};
-    info.explicit_lod.Assign(has_mip);
-
     boost::container::static_vector<IR::F32, 4> comps;
     for (u32 i = 0; i < 4; i++) {
         if (((mimg.dmask >> i) & 1) == 0) {
@@ -355,7 +350,7 @@ void Translator::IMAGE_STORE(bool has_mip, const GcnInst& inst) {
         comps.push_back(ir.GetVectorReg<IR::F32>(data_reg++));
     }
     const IR::Value value = ir.CompositeConstruct(comps[0], comps[1], comps[2], comps[3]);
-    ir.ImageWrite(handle, body, value, info);
+    ir.ImageWrite(handle, body, value, {});
 }
 
 void Translator::BUFFER_LOAD(u32 num_dwords, bool is_typed, const GcnInst& inst) {


### PR DESCRIPTION
I've implemented some of the easier looking opcodes from https://github.com/shadps4-emu/shadPS4/issues/496. 

This PR implements:
- TBUFFER_STORE_FORMAT_XYZW
- IMAGE_SAMPLE_CD
- IMAGE_GATHER4_C_LZ

Let me know if there are any changes I need to make or revert.