### PR TITLE
Standardize game_data directory for game metadata.

### DIFF
--- a/src/common/path_util.cpp
+++ b/src/common/path_util.cpp
@@ -116,6 +116,7 @@ static auto UserPaths = [] {
     create_path(PathType::CheatsDir, user_dir / CHEATS_DIR);
     create_path(PathType::PatchesDir, user_dir / PATCHES_DIR);
     create_path(PathType::AddonsDir, user_dir / ADDONS_DIR);
+    create_path(PathType::MetaDataDir, user_dir / METADATA_DIR);
 
     return paths;
 }();

--- a/src/common/path_util.h
+++ b/src/common/path_util.h
@@ -23,6 +23,7 @@ enum class PathType {
     CheatsDir,      // Where cheats are stored.
     PatchesDir,     // Where patches are stored.
     AddonsDir,      // Where additional content is stored.
+    MetaDataDir,    // Where game metadata (e.g. trophies and menu backgrounds) is stored.
 };
 
 constexpr auto PORTABLE_DIR = "user";
@@ -41,6 +42,7 @@ constexpr auto CAPTURES_DIR = "captures";
 constexpr auto CHEATS_DIR = "cheats";
 constexpr auto PATCHES_DIR = "patches";
 constexpr auto ADDONS_DIR = "addcont";
+constexpr auto METADATA_DIR = "game_data";
 
 // Filenames
 constexpr auto LOG_FILE = "shad_log.txt";

--- a/src/core/file_format/trp.cpp
+++ b/src/core/file_format/trp.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/path_util.h"
 #include "trp.h"
 
 TRP::TRP() = default;
@@ -48,8 +49,9 @@ bool TRP::Extract(const std::filesystem::path& trophyPath) {
                 return false;
 
             s64 seekPos = sizeof(TrpHeader);
-            std::filesystem::path trpFilesPath(std::filesystem::current_path() / "user/game_data" /
-                                               title / "TrophyFiles" / it.path().stem());
+            std::filesystem::path trpFilesPath(
+                Common::FS::GetUserPath(Common::FS::PathType::MetaDataDir) / title / "TrophyFiles" /
+                it.path().stem());
             std::filesystem::create_directories(trpFilesPath / "Icons");
             std::filesystem::create_directory(trpFilesPath / "Xml");
 

--- a/src/qt_gui/game_grid_frame.cpp
+++ b/src/qt_gui/game_grid_frame.cpp
@@ -114,8 +114,8 @@ void GameGridFrame::SetGridBackgroundImage(int row, int column) {
     QWidget* item = this->cellWidget(row, column);
     if (item) {
         QString pic1Path = QString::fromStdString((*m_games_shared)[itemID].pic_path);
-        const auto blurredPic1Path = Common::FS::GetUserPath(Common::FS::PathType::UserDir) /
-                                     "game_data" / (*m_games_shared)[itemID].serial / "pic1.png";
+        const auto blurredPic1Path = Common::FS::GetUserPath(Common::FS::PathType::MetaDataDir) /
+                                     (*m_games_shared)[itemID].serial / "pic1.png";
 #ifdef _WIN32
         const auto blurredPic1PathQt = QString::fromStdWString(blurredPic1Path.wstring());
 #else
@@ -128,7 +128,8 @@ void GameGridFrame::SetGridBackgroundImage(int row, int column) {
             backgroundImage = m_game_list_utils.BlurImage(image, image.rect(), 16);
 
             std::filesystem::path img_path =
-                std::filesystem::path("user/game_data/") / (*m_games_shared)[itemID].serial;
+                Common::FS::GetUserPath(Common::FS::PathType::MetaDataDir) /
+                (*m_games_shared)[itemID].serial;
             std::filesystem::create_directories(img_path);
             if (!backgroundImage.save(blurredPic1PathQt, "PNG")) {
                 // qDebug() << "Error: Unable to save image.";

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -90,9 +90,8 @@ void GameListFrame::SetListBackgroundImage(QTableWidgetItem* item) {
     }
 
     QString pic1Path = QString::fromStdString(m_game_info->m_games[item->row()].pic_path);
-    const auto blurredPic1Path = Common::FS::GetUserPath(Common::FS::PathType::UserDir) /
-                                 "game_data" / m_game_info->m_games[item->row()].serial /
-                                 "pic1.png";
+    const auto blurredPic1Path = Common::FS::GetUserPath(Common::FS::PathType::MetaDataDir) /
+                                 m_game_info->m_games[item->row()].serial / "pic1.png";
 #ifdef _WIN32
     const auto blurredPic1PathQt = QString::fromStdWString(blurredPic1Path.wstring());
 #else
@@ -105,7 +104,8 @@ void GameListFrame::SetListBackgroundImage(QTableWidgetItem* item) {
         backgroundImage = m_game_list_utils.BlurImage(image, image.rect(), 16);
 
         std::filesystem::path img_path =
-            std::filesystem::path("user/game_data/") / m_game_info->m_games[item->row()].serial;
+            Common::FS::GetUserPath(Common::FS::PathType::MetaDataDir) /
+            m_game_info->m_games[item->row()].serial;
         std::filesystem::create_directories(img_path);
         if (!backgroundImage.save(blurredPic1PathQt, "PNG")) {
             // qDebug() << "Error: Unable to save image.";

--- a/src/qt_gui/main.cpp
+++ b/src/qt_gui/main.cpp
@@ -16,7 +16,6 @@ int main(int argc, char* argv[]) {
     // Load configurations and initialize Qt application
     const auto user_dir = Common::FS::GetUserPath(Common::FS::PathType::UserDir);
     Config::load(user_dir / "config.toml");
-    std::filesystem::create_directory(user_dir / "game_data");
 
     // Check if elf or eboot.bin path was passed as a command line argument
     bool has_command_line_argument = argc > 1;

--- a/src/qt_gui/trophy_viewer.cpp
+++ b/src/qt_gui/trophy_viewer.cpp
@@ -21,11 +21,11 @@ TrophyViewer::TrophyViewer(QString trophyPath, QString gameTrpPath) : QMainWindo
 
 void TrophyViewer::PopulateTrophyWidget(QString title) {
 #ifdef _WIN32
-    const auto trophyDir = Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "game_data" /
+    const auto trophyDir = Common::FS::GetUserPath(Common::FS::PathType::MetaDataDir) /
                            title.toStdWString() / "TrophyFiles";
     const auto trophyDirQt = QString::fromStdWString(trophyDir.wstring());
 #else
-    const auto trophyDir = Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "game_data" /
+    const auto trophyDir = Common::FS::GetUserPath(Common::FS::PathType::MetaDataDir) /
                            title.toStdString() / "TrophyFiles";
     const auto trophyDirQt = QString::fromStdString(trophyDir.string());
 #endif


### PR DESCRIPTION
Various references to the `game_data` folder are currently hardcoded throughout the GUI code for trophies and background images. As a result if that does not match the determined user directory in `path_util`, files will be placed in the wrong place.

This PR makes sure they are all going through `GetUserDir` so they have the right base directory, introducing a new path type for game metadata files like these.