### PR TITLE
Redefined ffmpeg's av_err2str macro to be c++ friendly

### DIFF
--- a/documents/building-linux.md
+++ b/documents/building-linux.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 #### Debian & Ubuntu
 ```
-sudo apt-get install build-essential libasound2-dev libpulse-dev libopenal-dev zlib1g-dev libedit-dev libvulkan-dev libudev-dev git libevdev-dev libsdl2-2.0 libsdl2-dev libjack-dev libsndio-dev
+sudo apt-get install build-essential libasound2-dev libpulse-dev libopenal-dev zlib1g-dev libedit-dev libvulkan-dev libudev-dev git libevdev-dev libsdl2-2.0 libsdl2-dev libjack-dev libsndio-dev qt6-base-dev qt6-tools-dev
 ```
 
 #### Fedora
@@ -34,9 +34,9 @@ git clone --recursive https://github.com/shadps4-emu/shadPS4.git
 cd shadPS4
 ```
 
-Generate the build directory in the shadPS4 directory:
+Generate the build directory in the shadPS4 directory. To enable the QT GUI, pass the ```-DENABLE_QT_GUI=ON``` flag:
 ```
-cmake -S . -B build/
+cmake -S . -B build/ -DENABLE_QT_GUI=ON
 ```
 
 Enter the directory:
@@ -49,8 +49,11 @@ Use make to build the project:
 cmake --build . --parallel$(nproc)
 ```
 
-Now run the emulator:
-
+Now run the emulator. If QT is enabled:
+```
+./shadps4
+```
+Otherwise, specify the path to your PKG's boot file:
 ```
 ./shadps4 /"PATH"/"TO"/"GAME"/"FOLDER"/eboot.bin
 ```

--- a/src/core/libraries/avplayer/avplayer_source.cpp
+++ b/src/core/libraries/avplayer/avplayer_source.cpp
@@ -20,7 +20,7 @@ extern "C" {
 #include <libswscale/swscale.h>
 }
 
-// The av_err2str macro in libavutil/error.h does not play nice with C++ 
+// The av_err2str macro in libavutil/error.h does not play nice with C++
 #ifdef av_err2str
 #undef av_err2str
 #include <string>
@@ -29,7 +29,7 @@ av_always_inline std::string av_err2string(int errnum) {
     return av_make_error_string(errbuf, AV_ERROR_MAX_STRING_SIZE, errnum);
 }
 #define av_err2str(err) av_err2string(err).c_str()
-#endif  // av_err2str
+#endif // av_err2str
 
 namespace Libraries::AvPlayer {
 

--- a/src/core/libraries/avplayer/avplayer_source.cpp
+++ b/src/core/libraries/avplayer/avplayer_source.cpp
@@ -21,7 +21,6 @@ extern "C" {
 }
 
 // The av_err2str macro in libavutil/error.h does not play nice with C++ 
-// More info: https://github.com/joncampbell123/composite-video-simulator/issues/5
 #ifdef av_err2str
 #undef av_err2str
 #include <string>

--- a/src/core/libraries/avplayer/avplayer_source.cpp
+++ b/src/core/libraries/avplayer/avplayer_source.cpp
@@ -20,6 +20,18 @@ extern "C" {
 #include <libswscale/swscale.h>
 }
 
+// The av_err2str macro in libavutil/error.h does not play nice with C++ 
+// More info: https://github.com/joncampbell123/composite-video-simulator/issues/5
+#ifdef av_err2str
+#undef av_err2str
+#include <string>
+av_always_inline std::string av_err2string(int errnum) {
+    char errbuf[AV_ERROR_MAX_STRING_SIZE];
+    return av_make_error_string(errbuf, AV_ERROR_MAX_STRING_SIZE, errnum);
+}
+#define av_err2str(err) av_err2string(err).c_str()
+#endif  // av_err2str
+
 namespace Libraries::AvPlayer {
 
 using namespace Kernel;

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -577,7 +577,7 @@ void MainWindow::SaveWindowState() const {
 void MainWindow::InstallPkg() {
     QFileDialog dialog;
     dialog.setFileMode(QFileDialog::ExistingFiles);
-    dialog.setNameFilter(tr("PKG File (*.PKG)"));
+    dialog.setNameFilter(tr("PKG File (*.PKG *.pkg)"));
     if (dialog.exec()) {
         QStringList fileNames = dialog.selectedFiles();
         int nPkg = fileNames.size();


### PR DESCRIPTION
When compiling on Ubuntu 24.04, the definition of ```av_err2str``` in ```externals/ffmpeg-core/include/libavutil/error.h``` throws a compiler error when attempting to use the macro in a c++ environment (namely ```src/core/libraries/avplayer/avplayer_source.cpp```). 

This fix redefines the macro in a 'c++ friendly' manner without modifying the external library and generates no additional compiler warnings in my experience using g++13 or clang18.

More info: https://github.com/joncampbell123/composite-video-simulator/issues/5