### PR TITLE
Silence unhandled case warns

### DIFF
--- a/src/shader_recompiler/frontend/decode.cpp
+++ b/src/shader_recompiler/frontend/decode.cpp
@@ -162,6 +162,8 @@ uint32_t GcnDecodeContext::getEncodingLength(InstEncoding encoding) {
     case InstEncoding::EXP:
         instLength = sizeof(uint64_t);
         break;
+    default:
+        break;
     }
     return instLength;
 }
@@ -216,6 +218,8 @@ uint32_t GcnDecodeContext::getOpMapOffset(InstEncoding encoding) {
         break;
     case InstEncoding::VOP2:
         offset = (uint32_t)OpcodeMap::OP_MAP_VOP2;
+        break;
+    default:
         break;
     }
     return offset;
@@ -311,6 +315,8 @@ void GcnDecodeContext::repairOperandType() {
     case Opcode::IMAGE_GATHER4_C:
         m_instruction.src[0].type = ScalarType::Any;
         break;
+    default:
+        break;
     }
 }
 
@@ -363,6 +369,8 @@ void GcnDecodeContext::decodeInstruction32(InstEncoding encoding, GcnCodeSlice& 
     case InstEncoding::VINTRP:
         decodeInstructionVINTRP(hexInstruction);
         break;
+    default:
+        break;
     }
 }
 
@@ -386,6 +394,8 @@ void GcnDecodeContext::decodeInstruction64(InstEncoding encoding, GcnCodeSlice& 
         break;
     case InstEncoding::EXP:
         decodeInstructionEXP(hexInstruction);
+        break;
+    default:
         break;
     }
 }
@@ -994,6 +1004,8 @@ u32 GcnDecodeContext::getMimgModifier(Opcode opcode) {
     case Opcode::IMAGE_SAMPLE_C_CD_CL_O:
         flags.set(MimgModifier::Pcf, MimgModifier::CoarseDerivative, MimgModifier::LodClamp,
                   MimgModifier::Offset);
+        break;
+    default:
         break;
     }
 

--- a/src/shader_recompiler/frontend/format.cpp
+++ b/src/shader_recompiler/frontend/format.cpp
@@ -3718,6 +3718,8 @@ InstFormat InstructionFormat(InstEncoding encoding, uint32_t opcode) {
         return InstructionFormatSOP2[opcode];
     case InstEncoding::VOP2:
         return InstructionFormatVOP2[opcode];
+    default:
+        return {};
     }
     UNREACHABLE();
     return {};

--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -1360,6 +1360,8 @@ U16U32U64 IREmitter::UConvert(size_t result_bitsize, const U16U32U64& value) {
         switch (value.Type()) {
         case Type::U16:
             return Inst<U32>(Opcode::ConvertU32U16, value);
+        default:
+            break;
         }
     default:
         break;

--- a/src/shader_recompiler/ir/value.cpp
+++ b/src/shader_recompiler/ir/value.cpp
@@ -81,6 +81,7 @@ bool Value::operator==(const Value& other) const {
     case Type::F64x2:
     case Type::F64x3:
     case Type::F64x4:
+    default:
         break;
     }
     UNREACHABLE_MSG("Invalid type {}", type);


### PR DESCRIPTION
```
  [4/8] Building CXX object CMakeFiles\shadps4.dir\src\shader_recompiler\frontend\format.cpp.obj
D:\git\shadPS4\src\shader_recompiler\frontend\format.cpp(3688,13): warning : enumeration value 'ILLEGAL' not handled in switch [-Wswitch]
   3688 |     switch (encoding) {
        |             ^~~~~~~~
  1 warning generated.
  [5/8] Building CXX object CMakeFiles\shadps4.dir\src\shader_recompiler\ir\value.cpp.obj
D:\git\shadPS4\src\shader_recompiler\ir\value.cpp(48,13): warning : enumeration value 'SystemValue' not handled in switch [-Wswitch]
     48 |     switch (type) {
        |             ^~~~
  1 warning generated.
  [6/8] Building CXX object CMakeFiles\shadps4.dir\src\shader_recompiler\frontend\decode.cpp.obj
D:\git\shadPS4\src\shader_recompiler\frontend\decode.cpp(143,13): warning : enumeration value 'ILLEGAL' not handled in switch [-Wswitch]
    143 |     switch (encoding) {
        |             ^~~~~~~~
D:\git\shadPS4\src\shader_recompiler\frontend\decode.cpp(171,13): warning : enumeration value 'ILLEGAL' not handled in switch [-Wswitch]
    171 |     switch (encoding) {
        |             ^~~~~~~~
D:\git\shadPS4\src\shader_recompiler\frontend\decode.cpp(301,13): warning : 833 enumeration values not handled in switch: 'S_ADD_U32', 'S_SUB_U32', 'S_ADD_I32'... [-Wswitch]
    301 |     switch (m_instruction.opcode) {
        |             ^~~~~~~~~~~~~~~~~~~~
D:\git\shadPS4\src\shader_recompiler\frontend\decode.cpp(335,13): warning : 7 enumeration values not handled in switch: 'ILLEGAL', 'VOP3', 'DS'... [-Wswitch]
    335 |     switch (encoding) {
        |             ^~~~~~~~
D:\git\shadPS4\src\shader_recompiler\frontend\decode.cpp(371,13): warning : 11 enumeration values not handled in switch: 'VOP2', 'ILLEGAL', 'VOPC'... [-Wswitch]
    371 |     switch (encoding) {
        |             ^~~~~~~~
D:\git\shadPS4\src\shader_recompiler\frontend\decode.cpp(803,13): warning : 773 enumeration values not handled in switch: 'S_ADD_U32', 'S_SUB_U32', 'S_ADD_I32'... [-Wswitch]
    803 |     switch (opcode) {
        |             ^~~~~~
  6 warnings generated.
  [7/8] Building CXX object CMakeFiles\shadps4.dir\src\shader_recompiler\ir\ir_emitter.cpp.obj
D:\git\shadPS4\src\shader_recompiler\ir\ir_emitter.cpp(1360,23): warning : 25 enumeration values not handled in switch: 'Void', 'Opaque', 'ScalarReg'... [-Wswitch]
   1360 |         switch (value.Type()) {
        |                 ~~~~~~^~~~~~
  1 warning generated.
```