### PR TITLE
vulkan: Limit multisampling to supported sample counts.

### DIFF
--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -718,7 +718,7 @@ vk::ClearValue ColorBufferClearValue(const AmdGpu::Liverpool::ColorBuffer& color
     return {.color = color};
 }
 
-vk::SampleCountFlagBits NumSamples(u32 num_samples) {
+vk::SampleCountFlagBits RawNumSamples(u32 num_samples) {
     switch (num_samples) {
     case 1:
         return vk::SampleCountFlagBits::e1;
@@ -733,6 +733,16 @@ vk::SampleCountFlagBits NumSamples(u32 num_samples) {
     default:
         UNREACHABLE();
     }
+}
+
+vk::SampleCountFlagBits NumSamples(u32 num_samples, vk::SampleCountFlags supported_flags) {
+    vk::SampleCountFlagBits flags = RawNumSamples(num_samples);
+    // Half sample counts until supported, with a minimum of 1.
+    while (!(supported_flags & flags) && num_samples > 1) {
+        num_samples /= 2;
+        flags = RawNumSamples(num_samples);
+    }
+    return flags;
 }
 
 } // namespace Vulkan::LiverpoolToVK

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.h
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.h
@@ -51,7 +51,7 @@ vk::Format DepthFormat(Liverpool::DepthBuffer::ZFormat z_format,
 
 vk::ClearValue ColorBufferClearValue(const AmdGpu::Liverpool::ColorBuffer& color_buffer);
 
-vk::SampleCountFlagBits NumSamples(u32 num_samples);
+vk::SampleCountFlagBits NumSamples(u32 num_samples, vk::SampleCountFlags supported_flags);
 
 void EmitQuadToTriangleListIndices(u8* out_indices, u32 num_vertices);
 

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -102,7 +102,8 @@ GraphicsPipeline::GraphicsPipeline(const Instance& instance_, Scheduler& schedul
     };
 
     const vk::PipelineMultisampleStateCreateInfo multisampling = {
-        .rasterizationSamples = LiverpoolToVK::NumSamples(key.num_samples),
+        .rasterizationSamples =
+            LiverpoolToVK::NumSamples(key.num_samples, instance.GetFramebufferSampleCounts()),
         .sampleShadingEnable = false,
     };
 

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -217,6 +217,13 @@ public:
         return min_imported_host_pointer_alignment;
     }
 
+    /// Returns the sample count flags supported by framebuffers.
+    vk::SampleCountFlags GetFramebufferSampleCounts() const {
+        return properties.limits.framebufferColorSampleCounts &
+               properties.limits.framebufferDepthSampleCounts &
+               properties.limits.framebufferStencilSampleCounts;
+    }
+
 private:
     /// Creates the logical device opportunistically enabling extensions
     bool CreateDevice();

--- a/src/video_core/texture_cache/image.cpp
+++ b/src/video_core/texture_cache/image.cpp
@@ -147,10 +147,15 @@ Image::Image(const Vulkan::Instance& instance_, Vulkan::Scheduler& scheduler_,
         break;
     }
 
+    constexpr auto tiling = vk::ImageTiling::eOptimal;
+    const auto supported_format = instance->GetSupportedFormat(info.pixel_format);
+    const auto properties = instance->GetPhysicalDevice().getImageFormatProperties(
+        supported_format, info.type, tiling, usage, flags);
+
     const vk::ImageCreateInfo image_ci = {
         .flags = flags,
         .imageType = info.type,
-        .format = instance->GetSupportedFormat(info.pixel_format),
+        .format = supported_format,
         .extent{
             .width = info.size.width,
             .height = info.size.height,
@@ -158,8 +163,8 @@ Image::Image(const Vulkan::Instance& instance_, Vulkan::Scheduler& scheduler_,
         },
         .mipLevels = static_cast<u32>(info.resources.levels),
         .arrayLayers = static_cast<u32>(info.resources.layers),
-        .samples = LiverpoolToVK::NumSamples(info.num_samples),
-        .tiling = vk::ImageTiling::eOptimal,
+        .samples = LiverpoolToVK::NumSamples(info.num_samples, properties.sampleCounts),
+        .tiling = tiling,
         .usage = usage,
         .initialLayout = vk::ImageLayout::eUndefined,
     };


### PR DESCRIPTION
Limits requested multi-sampling for framebuffers and images to the maximum supported.
* For images, this is the `sampleCount` bitmask from `VkImageFormatProperties`.
* For framebuffers, this is the intersection of the supported framebuffer color, depth, and stencil sample counts from `VkPhysicalDeviceLimits`.

When a sample count is unsupported, it divides by 2 and tries again, with a minimum of 1 sample.