### PR TITLE
Small fix for EmitQuadToTriangleListIndices

### DIFF
--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -660,8 +660,8 @@ void EmitQuadToTriangleListIndices(u8* out_ptr, u32 num_vertices) {
         *out_data++ = i;
         *out_data++ = i + 1;
         *out_data++ = i + 2;
-        *out_data++ = i + 2;
         *out_data++ = i;
+        *out_data++ = i + 2;
         *out_data++ = i + 3;
     }
 }


### PR DESCRIPTION
Seems to fix #[662](https://github.com/shadps4-emu/shadPS4/issues/662) and improve the title splash for FoTNS:LP

Before

![image](https://github.com/user-attachments/assets/fd2a1925-82dc-4afa-a968-78f9d1072fe1)

![image](https://github.com/user-attachments/assets/bf5b2dd0-614b-41ea-a22d-1f70b66eff31)


After

![image](https://github.com/user-attachments/assets/8bdab76d-154a-4c88-8ad2-ec0bd6873596)

![image](https://github.com/user-attachments/assets/18ef0993-29f7-4eb9-b8e7-d2d257509153)

