### PR TITLE
cpu_patches: Patch just-in-time using signal handlers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,6 +437,8 @@ set(CORE src/core/aerolib/stubs.cpp
          src/core/module.cpp
          src/core/module.h
          src/core/platform.h
+         src/core/signals.cpp
+         src/core/signals.h
          src/core/tls.cpp
          src/core/tls.h
          src/core/virtual_memory.cpp

--- a/src/core/cpu_patches.h
+++ b/src/core/cpu_patches.h
@@ -3,10 +3,6 @@
 
 #pragma once
 
-namespace Xbyak {
-class CodeGenerator;
-}
-
 namespace Core {
 
 /// Initializes a stack for the current thread for use by patch implementations.
@@ -15,7 +11,11 @@ void InitializeThreadPatchStack();
 /// Cleans up the patch stack for the current thread.
 void CleanupThreadPatchStack();
 
-/// Patches CPU instructions that cannot run as-is on the host.
-void PatchInstructions(u64 segment_addr, u64 segment_size, Xbyak::CodeGenerator& c);
+/// Registers a module for patching, providing an area to generate trampoline code.
+void RegisterPatchModule(void* module_ptr, u64 module_size, void* trampoline_area_ptr,
+                         u64 trampoline_area_size);
+
+/// Applies CPU patches that need to be done before beginning executions.
+void PrePatchInstructions(u64 segment_addr, u64 segment_size);
 
 } // namespace Core

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include <xbyak/xbyak.h>
 #include "common/alignment.h"
 #include "common/arch.h"
 #include "common/assert.h"
@@ -94,9 +93,11 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
     LoadOffset += CODE_BASE_INCR * (1 + aligned_base_size / CODE_BASE_INCR);
     LOG_INFO(Core_Linker, "Loading module {} to {}", name, fmt::ptr(*out_addr));
 
+#ifdef ARCH_X86_64
     // Initialize trampoline generator.
     void* trampoline_addr = std::bit_cast<void*>(base_virtual_addr + aligned_base_size);
-    Xbyak::CodeGenerator c(TrampolineSize, trampoline_addr);
+    RegisterPatchModule(*out_addr, aligned_base_size, trampoline_addr, TrampolineSize);
+#endif
 
     LOG_INFO(Core_Linker, "======== Load Module to Memory ========");
     LOG_INFO(Core_Linker, "base_virtual_addr ......: {:#018x}", base_virtual_addr);
@@ -137,7 +138,7 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
             add_segment(elf_pheader[i]);
 #ifdef ARCH_X86_64
             if (elf_pheader[i].p_flags & PF_EXEC) {
-                PatchInstructions(segment_addr, segment_file_size, c);
+                PrePatchInstructions(segment_addr, segment_file_size);
             }
 #endif
             break;

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "common/arch.h"
+#include "common/assert.h"
+#include "core/signals.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <csignal>
+#ifdef ARCH_X86_64
+#include <Zydis/Decoder.h>
+#include <Zydis/Formatter.h>
+#endif
+#endif
+
+namespace Core {
+
+#if defined(_WIN32)
+
+static LONG WINAPI SignalHandler(EXCEPTION_POINTERS* pExp) noexcept {
+    const auto* signals = Signals::Instance();
+
+    auto* code_address = reinterpret_cast<void*>(pExp->ContextRecord->Rip);
+
+    bool handled = false;
+    switch (pExp->ExceptionRecord->ExceptionCode) {
+    case EXCEPTION_ACCESS_VIOLATION:
+        handled = signals->DispatchAccessViolation(
+            code_address, reinterpret_cast<void*>(pExp->ExceptionRecord->ExceptionInformation[1]),
+            pExp->ExceptionRecord->ExceptionInformation[0] == 1);
+        break;
+    case EXCEPTION_ILLEGAL_INSTRUCTION:
+        handled = signals->DispatchIllegalInstruction(code_address);
+        break;
+    default:
+        break;
+    }
+
+    return handled ? EXCEPTION_CONTINUE_EXECUTION : EXCEPTION_CONTINUE_SEARCH;
+}
+
+#else
+
+#ifdef __APPLE__
+#if defined(ARCH_X86_64)
+#define CODE_ADDRESS(ctx) reinterpret_cast<void*>((ctx)->uc_mcontext->__ss.__rip)
+#define IS_WRITE_ERROR(ctx) ((ctx)->uc_mcontext->__es.__err & 0x2)
+#elif defined(ARCH_ARM64)
+#define CODE_ADDRESS(ctx) reinterpret_cast<void*>((ctx)->uc_mcontext->__ss.__pc)
+#define IS_WRITE_ERROR(ctx) ((ctx)->uc_mcontext->__es.__esr & 0x40)
+#endif
+#else
+#if defined(ARCH_X86_64)
+#define CODE_ADDRESS(ctx) reinterpret_cast<void*>((ctx)->uc_mcontext.gregs[REG_RIP])
+#define IS_WRITE_ERROR(ctx) ((ctx)->uc_mcontext.gregs[REG_ERR] & 0x2)
+#endif
+#endif
+
+#ifndef IS_WRITE_ERROR
+#error "Missing IS_WRITE_ERROR() implementation for target OS and CPU architecture.
+#endif
+
+static std::string DisassembleInstruction(void* code_address) {
+    char buffer[256] = "<unable to decode>";
+
+#ifdef ARCH_X86_64
+    ZydisDecoder decoder;
+    ZydisDecoderInit(&decoder, ZYDIS_MACHINE_MODE_LONG_64, ZYDIS_STACK_WIDTH_64);
+
+    ZydisDecodedInstruction instruction;
+    ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT];
+    static constexpr u64 max_length = 0x20;
+    const auto status =
+        ZydisDecoderDecodeFull(&decoder, code_address, max_length, &instruction, operands);
+    if (ZYAN_SUCCESS(status)) {
+        ZydisFormatter formatter;
+        ZydisFormatterInit(&formatter, ZYDIS_FORMATTER_STYLE_INTEL);
+        ZydisFormatterFormatInstruction(&formatter, &instruction, operands,
+                                        instruction.operand_count_visible, buffer, sizeof(buffer),
+                                        reinterpret_cast<u64>(code_address), ZYAN_NULL);
+    }
+#endif
+
+    return buffer;
+}
+
+static void SignalHandler(int sig, siginfo_t* info, void* raw_context) {
+    const auto* ctx = static_cast<ucontext_t*>(raw_context);
+    const auto* signals = Signals::Instance();
+
+    auto* code_address = CODE_ADDRESS(ctx);
+
+    switch (sig) {
+    case SIGSEGV:
+    case SIGBUS:
+        if (const bool is_write = IS_WRITE_ERROR(ctx);
+            !signals->DispatchAccessViolation(code_address, info->si_addr, is_write)) {
+            UNREACHABLE_MSG("Unhandled access violation at code address {}: {} address {}",
+                            fmt::ptr(code_address), is_write ? "Write to" : "Read from",
+                            fmt::ptr(info->si_addr));
+        }
+        break;
+    case SIGILL:
+        if (!signals->DispatchIllegalInstruction(code_address)) {
+            UNREACHABLE_MSG("Unhandled illegal instruction at code address {}: {}",
+                            fmt::ptr(code_address), DisassembleInstruction(code_address));
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+#endif
+
+SignalDispatch::SignalDispatch() {
+#if defined(_WIN32)
+    ASSERT_MSG(handle = AddVectoredExceptionHandler(0, SignalHandler),
+               "Failed to register exception handler.");
+#else
+    constexpr struct sigaction action {
+        .sa_flags = SA_SIGINFO | SA_ONSTACK, .sa_sigaction = SignalHandler, .sa_mask = 0,
+    };
+    ASSERT_MSG(sigaction(SIGSEGV, &action, nullptr) == 0 &&
+                   sigaction(SIGBUS, &action, nullptr) == 0,
+               "Failed to register access violation signal handler.");
+    ASSERT_MSG(sigaction(SIGILL, &action, nullptr) == 0,
+               "Failed to register illegal instruction signal handler.");
+#endif
+}
+
+SignalDispatch::~SignalDispatch() {
+#if defined(_WIN32)
+    ASSERT_MSG(RemoveVectoredExceptionHandler(handle), "Failed to remove exception handler.");
+#else
+    constexpr struct sigaction action {
+        .sa_flags = 0, .sa_handler = SIG_DFL, .sa_mask = 0,
+    };
+    ASSERT_MSG(sigaction(SIGSEGV, &action, nullptr) == 0 &&
+                   sigaction(SIGBUS, &action, nullptr) == 0,
+               "Failed to remove access violation signal handler.");
+    ASSERT_MSG(sigaction(SIGILL, &action, nullptr) == 0,
+               "Failed to remove illegal instruction signal handler.");
+#endif
+}
+
+bool SignalDispatch::DispatchAccessViolation(void* code_address, void* fault_address,
+                                             bool is_write) const {
+    for (const auto& [handler, _] : access_violation_handlers) {
+        if (handler(code_address, fault_address, is_write)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool SignalDispatch::DispatchIllegalInstruction(void* code_address) const {
+    for (const auto& [handler, _] : illegal_instruction_handlers) {
+        if (handler(code_address)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace Core

--- a/src/core/signals.h
+++ b/src/core/signals.h
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <set>
+#include "common/singleton.h"
+
+namespace Core {
+
+using AccessViolationHandler = bool (*)(void* code_address, void* fault_address, bool is_write);
+using IllegalInstructionHandler = bool (*)(void* code_address);
+
+/// Receives OS signals and dispatches to the appropriate handlers.
+class SignalDispatch {
+public:
+    SignalDispatch();
+    ~SignalDispatch();
+
+    /// Registers a handler for memory access violation signals.
+    void RegisterAccessViolationHandler(const AccessViolationHandler& handler, u32 priority) {
+        access_violation_handlers.emplace(handler, priority);
+    }
+
+    /// Registers a handler for illegal instruction signals.
+    void RegisterIllegalInstructionHandler(const IllegalInstructionHandler& handler, u32 priority) {
+        illegal_instruction_handlers.emplace(handler, priority);
+    }
+
+    /// Dispatches an access violation signal, returning whether it was successfully handled.
+    bool DispatchAccessViolation(void* code_address, void* fault_address, bool is_write) const;
+
+    /// Dispatches an illegal instruction signal, returning whether it was successfully handled.
+    bool DispatchIllegalInstruction(void* code_address) const;
+
+private:
+    template <typename T>
+    struct HandlerEntry {
+        T handler;
+        u32 priority;
+
+        std::strong_ordering operator<=>(const HandlerEntry& right) const {
+            return priority <=> right.priority;
+        }
+    };
+    std::set<HandlerEntry<AccessViolationHandler>> access_violation_handlers;
+    std::set<HandlerEntry<IllegalInstructionHandler>> illegal_instruction_handlers;
+
+#ifdef _WIN32
+    void* handle{};
+#endif
+};
+
+using Signals = Common::Singleton<SignalDispatch>;
+
+} // namespace Core

--- a/src/video_core/page_manager.cpp
+++ b/src/video_core/page_manager.cpp
@@ -2,22 +2,16 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <thread>
+#include <boost/icl/interval_set.hpp>
 #include "common/alignment.h"
-#include "common/arch.h"
 #include "common/assert.h"
 #include "common/error.h"
+#include "core/signals.h"
 #include "video_core/page_manager.h"
 #include "video_core/renderer_vulkan/vk_rasterizer.h"
 
 #ifndef _WIN64
-#include <fcntl.h>
-#include <poll.h>
-#include <signal.h>
-#include <sys/ioctl.h>
 #include <sys/mman.h>
-#ifdef ENABLE_USERFAULTFD
-#include <linux/userfaultfd.h>
-#endif
 #else
 #include <windows.h>
 #endif
@@ -27,207 +21,49 @@ namespace VideoCore {
 constexpr size_t PAGESIZE = 4_KB;
 constexpr size_t PAGEBITS = 12;
 
-#ifdef _WIN64
 struct PageManager::Impl {
     Impl(Vulkan::Rasterizer* rasterizer_) {
         rasterizer = rasterizer_;
 
-        veh_handle = AddVectoredExceptionHandler(0, GuestFaultSignalHandler);
-        ASSERT_MSG(veh_handle, "Failed to register an exception handler");
+        // Should be called first.
+        constexpr auto priority = std::numeric_limits<u32>::min();
+        Core::Signals::Instance()->RegisterAccessViolationHandler(GuestFaultSignalHandler,
+                                                                  priority);
     }
 
-    void OnMap(VAddr address, size_t size) {}
+    void OnMap(VAddr address, size_t size) {
+        owned_ranges += boost::icl::interval<VAddr>::right_open(address, address + size);
+    }
 
-    void OnUnmap(VAddr address, size_t size) {}
+    void OnUnmap(VAddr address, size_t size) {
+        owned_ranges -= boost::icl::interval<VAddr>::right_open(address, address + size);
+    }
 
     void Protect(VAddr address, size_t size, bool allow_write) {
+#ifdef _WIN32
         DWORD prot = allow_write ? PAGE_READWRITE : PAGE_READONLY;
         DWORD old_prot{};
         BOOL result = VirtualProtect(std::bit_cast<LPVOID>(address), size, prot, &old_prot);
         ASSERT_MSG(result != 0, "Region protection failed");
-    }
-
-    static LONG WINAPI GuestFaultSignalHandler(EXCEPTION_POINTERS* pExp) noexcept {
-        const u32 ec = pExp->ExceptionRecord->ExceptionCode;
-        if (ec == EXCEPTION_ACCESS_VIOLATION) {
-            const auto info = pExp->ExceptionRecord->ExceptionInformation;
-            if (info[0] == 1) { // Write violation
-                const VAddr addr_aligned = Common::AlignDown(info[1], PAGESIZE);
-                rasterizer->InvalidateMemory(addr_aligned, PAGESIZE);
-                return EXCEPTION_CONTINUE_EXECUTION;
-            } /* else {
-                UNREACHABLE();
-            }*/
-        }
-        return EXCEPTION_CONTINUE_SEARCH; // pass further
-    }
-
-    inline static Vulkan::Rasterizer* rasterizer;
-    void* veh_handle{};
-};
-#elif ENABLE_USERFAULTFD
-struct PageManager::Impl {
-    Impl(Vulkan::Rasterizer* rasterizer_) : rasterizer{rasterizer_} {
-        uffd = syscall(__NR_userfaultfd, O_CLOEXEC | O_NONBLOCK);
-        ASSERT_MSG(uffd != -1, "{}", Common::GetLastErrorMsg());
-
-        // Request uffdio features from kernel.
-        uffdio_api api;
-        api.api = UFFD_API;
-        api.features = UFFD_FEATURE_THREAD_ID;
-        const int ret = ioctl(uffd, UFFDIO_API, &api);
-        ASSERT(ret == 0 && api.api == UFFD_API);
-
-        // Create uffd handler thread
-        ufd_thread = std::jthread([&](std::stop_token token) { UffdHandler(token); });
-    }
-
-    void OnMap(VAddr address, size_t size) {
-        uffdio_register reg;
-        reg.range.start = address;
-        reg.range.len = size;
-        reg.mode = UFFDIO_REGISTER_MODE_WP;
-        const int ret = ioctl(uffd, UFFDIO_REGISTER, &reg);
-        ASSERT_MSG(ret != -1, "Uffdio register failed");
-    }
-
-    void OnUnmap(VAddr address, size_t size) {
-        uffdio_range range;
-        range.start = address;
-        range.len = size;
-        const int ret = ioctl(uffd, UFFDIO_UNREGISTER, &range);
-        ASSERT_MSG(ret != -1, "Uffdio unregister failed");
-    }
-
-    void Protect(VAddr address, size_t size, bool allow_write) {
-        uffdio_writeprotect wp;
-        wp.range.start = address;
-        wp.range.len = size;
-        wp.mode = allow_write ? 0 : UFFDIO_WRITEPROTECT_MODE_WP;
-        const int ret = ioctl(uffd, UFFDIO_WRITEPROTECT, &wp);
-        ASSERT_MSG(ret != -1, "Uffdio writeprotect failed with error: {}",
-                   Common::GetLastErrorMsg());
-    }
-
-    void UffdHandler(std::stop_token token) {
-        while (!token.stop_requested()) {
-            pollfd pollfd;
-            pollfd.fd = uffd;
-            pollfd.events = POLLIN;
-
-            // Block until the descriptor is ready for data reads.
-            const int pollres = poll(&pollfd, 1, -1);
-            switch (pollres) {
-            case -1:
-                perror("Poll userfaultfd");
-                continue;
-                break;
-            case 0:
-                continue;
-            case 1:
-                break;
-            default:
-                UNREACHABLE_MSG("Unexpected number of descriptors {} out of poll", pollres);
-            }
-
-            // We don't want an error condition to have occured.
-            ASSERT_MSG(!(pollfd.revents & POLLERR), "POLLERR on userfaultfd");
-
-            // We waited until there is data to read, we don't care about anything else.
-            if (!(pollfd.revents & POLLIN)) {
-                continue;
-            }
-
-            // Read message from kernel.
-            uffd_msg msg;
-            const int readret = read(uffd, &msg, sizeof(msg));
-            ASSERT_MSG(readret != -1 || errno == EAGAIN, "Unexpected result of uffd read");
-            if (errno == EAGAIN) {
-                continue;
-            }
-            ASSERT_MSG(readret == sizeof(msg), "Unexpected short read, exiting");
-            ASSERT(msg.arg.pagefault.flags & UFFD_PAGEFAULT_FLAG_WP);
-
-            // Notify rasterizer about the fault.
-            const VAddr addr = msg.arg.pagefault.address;
-            const VAddr addr_page = Common::AlignDown(addr, PAGESIZE);
-            rasterizer->InvalidateMemory(addr_page, PAGESIZE);
-        }
-    }
-
-    Vulkan::Rasterizer* rasterizer;
-    std::jthread ufd_thread;
-    int uffd;
-};
 #else
-
-#if defined(__APPLE__)
-
-#if defined(ARCH_X86_64)
-#define IS_WRITE_ERROR(ctx) ((ctx)->uc_mcontext->__es.__err & 0x2)
-#elif defined(ARCH_ARM64)
-#define IS_WRITE_ERROR(ctx) ((ctx)->uc_mcontext->__es.__esr & 0x40)
-#endif
-
-#else
-
-#if defined(ARCH_X86_64)
-#define IS_WRITE_ERROR(ctx) ((ctx)->uc_mcontext.gregs[REG_ERR] & 0x2)
-#endif
-
-#endif
-
-#ifndef IS_WRITE_ERROR
-#error "Missing IS_WRITE_ERROR() implementation for target OS and CPU architecture.
-#endif
-
-struct PageManager::Impl {
-    Impl(Vulkan::Rasterizer* rasterizer_) {
-        rasterizer = rasterizer_;
-
-#ifdef __APPLE__
-        // Read-only memory write results in SIGBUS on Apple.
-        static constexpr int SignalType = SIGBUS;
-#else
-        static constexpr int SignalType = SIGSEGV;
-#endif
-        sigset_t signal_mask;
-        sigemptyset(&signal_mask);
-        sigaddset(&signal_mask, SignalType);
-
-        using HandlerType = decltype(sigaction::sa_sigaction);
-
-        struct sigaction guest_access_fault {};
-        guest_access_fault.sa_flags = SA_SIGINFO | SA_ONSTACK;
-        guest_access_fault.sa_sigaction = &GuestFaultSignalHandler;
-        guest_access_fault.sa_mask = signal_mask;
-        sigaction(SignalType, &guest_access_fault, nullptr);
-    }
-
-    void OnMap(VAddr address, size_t size) {}
-
-    void OnUnmap(VAddr address, size_t size) {}
-
-    void Protect(VAddr address, size_t size, bool allow_write) {
         mprotect(reinterpret_cast<void*>(address), size,
                  PROT_READ | (allow_write ? PROT_WRITE : 0));
+#endif
     }
 
-    static void GuestFaultSignalHandler(int sig, siginfo_t* info, void* raw_context) {
-        ucontext_t* ctx = reinterpret_cast<ucontext_t*>(raw_context);
-        const VAddr address = reinterpret_cast<VAddr>(info->si_addr);
-        if (IS_WRITE_ERROR(ctx)) {
-            const VAddr addr_aligned = Common::AlignDown(address, PAGESIZE);
+    static bool GuestFaultSignalHandler(void* code_address, void* fault_address, bool is_write) {
+        const auto addr = reinterpret_cast<VAddr>(fault_address);
+        if (is_write && owned_ranges.find(addr) != owned_ranges.end()) {
+            const VAddr addr_aligned = Common::AlignDown(addr, PAGESIZE);
             rasterizer->InvalidateMemory(addr_aligned, PAGESIZE);
-        } else {
-            // Read not supported!
-            UNREACHABLE();
+            return true;
         }
+        return false;
     }
 
     inline static Vulkan::Rasterizer* rasterizer;
+    inline static boost::icl::interval_set<VAddr> owned_ranges;
 };
-#endif
 
 PageManager::PageManager(Vulkan::Rasterizer* rasterizer_)
     : impl{std::make_unique<Impl>(rasterizer_)}, rasterizer{rasterizer_} {}


### PR DESCRIPTION
Reworks the patching system to patch on demand using a signal handler, instead of completely ahead of time.

The current system works on the assumption that just scanning down segments will generally work out without becoming misaligned by data or patching data as if it were code. In practice this generally works, but there are some games where it does not and code that needs patching will be missed.

Instead, we can discover instructions that need patching by actually running the code and trapping signals on bad instructions. I've introduced a platform-common way of registering multiple handlers for a signal, captured using either vectored exception handlers on Windows or signal handlers on POSIX systems, and wired up both this and the existing page manager to it.

One caveat is that when running under Rosetta 2 on macOS, for whatever reason patching an instruction at the beginning of a page does not work. It just acts like the instruction was not patched and raises SIGILL again. I've tried a few things to get around this but couldn't figure it out, so I left a workaround to patch instructions at the beginning of each code page ahead of time on macOS.

Tested this by running through a few games on macOS that need these patches. Needs testing on other OSes since this impacts TCB access patches and GPU page invalidation.

One game fixed by this is CUSA02799, which currently crashes on launch on ARM64 macOS due to a missed BMI1 instruction patch.