### PR TITLE
Fix deadlocks by enabling reuse of exited threads

### DIFF
--- a/src/core/libraries/kernel/thread_management.h
+++ b/src/core/libraries/kernel/thread_management.h
@@ -119,7 +119,7 @@ struct PthreadSemInternal {
 
 class PThreadPool {
 public:
-    ScePthread Create();
+    ScePthread Create(const char* name);
 
 private:
     std::vector<ScePthread> m_threads;


### PR DESCRIPTION
This change fixes the deadlock issue in Bloodborne and potentially other games where threads are regularly exiting/starting. 