### PR TITLE
Update Discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you encounter problems or have doubts, do not hesitate to look at the [**Quic
 
 To verify that a game works, you can look at [**shadPS4 Game Compatibility**](https://github.com/shadps4-emu/shadps4-game-compatibility).
 
-To discuss shadPS4 development, suggest ideas or to ask for help, join our [**Discord server**](https://discord.gg/MyZRaBngxA).
+To discuss shadPS4 development, suggest ideas or to ask for help, join our [**Discord server**](https://discord.gg/bFJxfftGW6).
 
 To get the latest news, go to our [**X (Twitter)**](https://x.com/shadps4) or our [**website**](https://shadps4.net/).
 


### PR DESCRIPTION
The current Discord link was made before we enabled the "accept the rules" on Discord. This leads to users who use the current link to enter the Discord server to skip this moderation step. Updating the link to one created after we enabled this should fix this.