### PR TITLE
vulkan: Skip draw when primitive type is None.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -158,6 +158,10 @@ const GraphicsPipeline* PipelineCache::GetGraphicsPipeline() {
         LOG_TRACE(Render_Vulkan, "FMask decompression pass skipped");
         return nullptr;
     }
+    if (regs.primitive_type == Liverpool::PrimitiveType::None) {
+        LOG_TRACE(Render_Vulkan, "Primitive type 'None' skipped");
+        return nullptr;
+    }
     if (!RefreshGraphicsKey()) {
         return nullptr;
     }


### PR DESCRIPTION
Implements primitive type `None` with no draw as in the manual:
```
00 - DI_PT_NONE: DI_PT_NONE None (does not create draw trigger)
```

Used by CUSA16429 on boot.