### PR TITLE
shader_recompiler: Use correct integer type for OpImageWrite.

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -305,7 +305,7 @@ void EmitStoreBufferFormatF32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id a
     const Id tex_buffer = ctx.OpLoad(buffer.image_type, buffer.id);
     const Id coord = ctx.OpIAdd(ctx.U32[1], address, buffer.coord_offset);
     if (buffer.is_integer) {
-        value = ctx.OpBitcast(ctx.S32[4], value);
+        value = ctx.OpBitcast(buffer.result_type, value);
     }
     ctx.OpImageWrite(tex_buffer, coord, value);
 }


### PR DESCRIPTION
PR https://github.com/shadps4-emu/shadPS4/pull/837 changed the integer type for OpImageWrite from U32 to S32, which introduced the following validation error when the image type is U32:
```
VUID-VkShaderModuleCreateInfo-pCode-08737: Validation Error: [ VUID-VkShaderModuleCreateInfo-pCode-08737 ] | MessageID = 0xa5625282 | vkCreateShaderModule(): pCreateInfo->pCode (spirv-val produced an error):
Expected Image 'Sampled Type' to be the same as Texel components
  OpImageWrite %91 %92 %93
```

Instead, use `buffer.result_type` which is already either U32[4] or S32[4] depending on the image sampled type.

Fixes regressions reported in https://github.com/shadps4-emu/shadPS4/issues/869