### PR TITLE
Fix copyGpuBuffers when resize invalidates commands in flight

### DIFF
--- a/src/core/libraries/gnmdriver/gnmdriver.cpp
+++ b/src/core/libraries/gnmdriver/gnmdriver.cpp
@@ -2667,6 +2667,10 @@ void RegisterlibSceGnmDriver(Core::Loader::SymbolsResolver* sym) {
         sdk_version = 0;
     }
 
+    if (Config::copyGPUCmdBuffers()) {
+        liverpool->reserveCopyBufferSpace();
+    }
+
     Platform::IrqC::Instance()->Register(Platform::InterruptId::GpuIdle, ResetSubmissionLock,
                                          nullptr);
 

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -660,6 +660,12 @@ std::pair<std::span<const u32>, std::span<const u32>> Liverpool::CopyCmdBuffers(
     std::span<const u32> dcb, std::span<const u32> ccb) {
     auto& queue = mapped_queues[GfxQueueId];
 
+    // std::vector resize can invalidate spans for commands in flight
+    ASSERT_MSG(queue.dcb_buffer.capacity() >= queue.dcb_buffer_offset + dcb.size(),
+               "dcb copy buffer out of reserved space");
+    ASSERT_MSG(queue.ccb_buffer.capacity() >= queue.ccb_buffer_offset + ccb.size(),
+               "ccb copy buffer out of reserved space");
+
     queue.dcb_buffer.resize(
         std::max(queue.dcb_buffer.size(), queue.dcb_buffer_offset + dcb.size()));
     queue.ccb_buffer.resize(

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -1088,6 +1088,15 @@ public:
         submit_cv.notify_one();
     }
 
+    void reserveCopyBufferSpace() {
+        GpuQueue& gfx_queue = mapped_queues[GfxQueueId];
+        std::scoped_lock<std::mutex> lk(gfx_queue.m_access);
+
+        constexpr size_t gfx_reserved_size = (2 << 21) / sizeof(u32); // 2MB
+        gfx_queue.ccb_buffer.reserve(gfx_reserved_size);
+        gfx_queue.dcb_buffer.reserve(gfx_reserved_size);
+    }
+
 private:
     struct Task {
         struct promise_type {

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -1092,9 +1092,9 @@ public:
         GpuQueue& gfx_queue = mapped_queues[GfxQueueId];
         std::scoped_lock<std::mutex> lk(gfx_queue.m_access);
 
-        constexpr size_t gfx_reserved_size = (2 << 21) / sizeof(u32); // 2MB
-        gfx_queue.ccb_buffer.reserve(gfx_reserved_size);
-        gfx_queue.dcb_buffer.reserve(gfx_reserved_size);
+        constexpr size_t GfxReservedSize = 2_MB >> 2;
+        gfx_queue.ccb_buffer.reserve(GfxReservedSize);
+        gfx_queue.dcb_buffer.reserve(GfxReservedSize);
     }
 
 private:


### PR DESCRIPTION
now PT with copyGpuBuffers=true fails at the same place as =false :)