### PR TITLE
Adding missing (IMAGE_SAMPLE) opcode

### DIFF
--- a/src/shader_recompiler/frontend/translate/vector_memory.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_memory.cpp
@@ -14,6 +14,7 @@ void Translator::EmitVectorMemory(const GcnInst& inst) {
     case Opcode::IMAGE_SAMPLE_LZ:
     case Opcode::IMAGE_SAMPLE:
     case Opcode::IMAGE_SAMPLE_L:
+    case Opcode::IMAGE_SAMPLE_L_O:
     case Opcode::IMAGE_SAMPLE_C_O:
     case Opcode::IMAGE_SAMPLE_B:
     case Opcode::IMAGE_SAMPLE_C_LZ_O:


### PR DESCRIPTION
Adding missing opcode used by Sengoku Basara: Sanada Yukimura-Den.

```
[Render.Recompiler] <Error> translate.cpp:LogMissingOpcode:452: Unknown opcode IMAGE_SAMPLE_L_O (1454, category = VectorMemory)
[Debug] <Critical> structured_control_flow.cpp:operator():835: Assertion Failed!
Shader translation has failed
```


![1](https://github.com/user-attachments/assets/ba359da8-c6ae-4f87-8745-625f3baa46c7)
