### PR TITLE
Implement S_ABSDIFF_I32 shader instruction

### DIFF
--- a/src/shader_recompiler/frontend/translate/scalar_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_alu.cpp
@@ -84,6 +84,8 @@ void Translator::EmitScalarAlu(const GcnInst& inst) {
             return S_MAX_U32(false, inst);
         case Opcode::S_MAX_I32:
             return S_MAX_U32(true, inst);
+        case Opcode::S_ABSDIFF_I32:
+            return S_ABSDIFF_I32(inst);
         case Opcode::S_WQM_B64:
             break;
         default:
@@ -561,6 +563,13 @@ void Translator::S_MIN_U32(bool is_signed, const GcnInst& inst) {
     const IR::U32 result = ir.IMin(src0, src1, is_signed);
     SetDst(inst.dst[0], result);
     ir.SetScc(ir.IEqual(result, src0));
+}
+
+void Translator::S_ABSDIFF_I32(const GcnInst& inst) {
+    const IR::U32 src0{GetSrc(inst.src[0])};
+    const IR::U32 src1{GetSrc(inst.src[1])};
+    const IR::U32 result{ir.IAbs(ir.ISub(src0, src1))};
+    SetDst(inst.dst[0], result);
 }
 
 } // namespace Shader::Gcn

--- a/src/shader_recompiler/frontend/translate/scalar_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_alu.cpp
@@ -570,6 +570,7 @@ void Translator::S_ABSDIFF_I32(const GcnInst& inst) {
     const IR::U32 src1{GetSrc(inst.src[1])};
     const IR::U32 result{ir.IAbs(ir.ISub(src0, src1))};
     SetDst(inst.dst[0], result);
+    ir.SetScc(ir.INotEqual(result, ir.Imm32(0)));
 }
 
 } // namespace Shader::Gcn

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -103,8 +103,8 @@ public:
     void S_ADDK_I32(const GcnInst& inst);
     void S_MAX_U32(bool is_signed, const GcnInst& inst);
     void S_MIN_U32(bool is_signed, const GcnInst& inst);
-    void S_CMPK(ConditionOp cond, bool is_signed, const GcnInst& inst);
     void S_ABSDIFF_I32(const GcnInst& inst);
+    void S_CMPK(ConditionOp cond, bool is_signed, const GcnInst& inst);
 
     // Scalar Memory
     void S_LOAD_DWORD(int num_dwords, const GcnInst& inst);

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -104,6 +104,7 @@ public:
     void S_MAX_U32(bool is_signed, const GcnInst& inst);
     void S_MIN_U32(bool is_signed, const GcnInst& inst);
     void S_CMPK(ConditionOp cond, bool is_signed, const GcnInst& inst);
+    void S_ABSDIFF_I32(const GcnInst& inst);
 
     // Scalar Memory
     void S_LOAD_DWORD(int num_dwords, const GcnInst& inst);


### PR DESCRIPTION
Implements the S_ABSDIFF_I32 (Scalar ALU 44) shader instruction.

This fixes a crash in **Atelier Lulua \~The Scion of Arland~** after the opening movie, and is likely used in other Atelier games. Atelier Lulua now hangs on the loading screen after the opening.

[AMD documentation ](https://www.amd.com/content/dam/amd/en/documents/radeon-tech-docs/instruction-set-architectures/rdna2-shader-instruction-set-architecture.pdf)was used as reference.

![screenshot](https://github.com/user-attachments/assets/3c48d1bc-36e7-42b5-9d6a-91fb0aa8f09a)
