### PR TITLE
Add S_LOAD_DWORD and S_LOAD_DWORDX2

### DIFF
--- a/src/shader_recompiler/frontend/translate/scalar_memory.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_memory.cpp
@@ -9,6 +9,10 @@ static constexpr u32 SQ_SRC_LITERAL = 0xFF;
 
 void Translator::EmitScalarMemory(const GcnInst& inst) {
     switch (inst.opcode) {
+    case Opcode::S_LOAD_DWORD:
+        return S_LOAD_DWORD(1, inst);
+    case Opcode::S_LOAD_DWORDX2:
+        return S_LOAD_DWORD(2, inst);
     case Opcode::S_LOAD_DWORDX4:
         return S_LOAD_DWORD(4, inst);
     case Opcode::S_LOAD_DWORDX8:


### PR DESCRIPTION
For CUSA08034 

[Render.Recompiler] <Error> translate.cpp:LogMissingOpcode:452: Unknown opcode S_LOAD_DWORDX2 (993, category = ScalarMemory)
[Render.Recompiler] <Error> translate.cpp:LogMissingOpcode:452: Unknown opcode S_LOAD_DWORD (992, category = ScalarMemory)