### PR TITLE
Implement missing Clamp Modes

### DIFF
--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -201,8 +201,14 @@ vk::SamplerAddressMode ClampMode(AmdGpu::ClampMode mode) {
         return vk::SamplerAddressMode::eClampToEdge;
     case AmdGpu::ClampMode::MirrorOnceLastTexel:
         return vk::SamplerAddressMode::eMirrorClampToEdge;
+    case AmdGpu::ClampMode::ClampHalfBorder:
+        return vk::SamplerAddressMode::eClampToBorder;
+    case AmdGpu::ClampMode::MirrorOnceHalfBorder:
+        return vk::SamplerAddressMode::eMirrorClampToEdge;
     case AmdGpu::ClampMode::ClampBorder:
         return vk::SamplerAddressMode::eClampToBorder;
+    case AmdGpu::ClampMode::MirrorOnceBorder:
+        return vk::SamplerAddressMode::eMirrorClampToEdge;
     default:
         UNREACHABLE();
     }

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -201,14 +201,10 @@ vk::SamplerAddressMode ClampMode(AmdGpu::ClampMode mode) {
         return vk::SamplerAddressMode::eClampToEdge;
     case AmdGpu::ClampMode::MirrorOnceLastTexel:
         return vk::SamplerAddressMode::eMirrorClampToEdge;
-    case AmdGpu::ClampMode::ClampHalfBorder:
-        return vk::SamplerAddressMode::eClampToBorder;
     case AmdGpu::ClampMode::MirrorOnceHalfBorder:
         return vk::SamplerAddressMode::eMirrorClampToEdge;
     case AmdGpu::ClampMode::ClampBorder:
         return vk::SamplerAddressMode::eClampToBorder;
-    case AmdGpu::ClampMode::MirrorOnceBorder:
-        return vk::SamplerAddressMode::eMirrorClampToEdge;
     default:
         UNREACHABLE();
     }


### PR DESCRIPTION
Fixes an emulator crash on the character selection screen in the DENGEKI BUNKO FIGHTING CLIMAX IGNITION.

```
[Debug] <Critical> liverpool_to_vk.cpp:ClampMode:207: Unreachable code!

```

![1](https://github.com/user-attachments/assets/58bd898d-5caa-44e1-b79d-ebc4942f97ba)

Note: The game requires the `copyGpuBuffers` option set to “true”.

