### PR TITLE
graphics_pipeline: Move some depth configuration to dynamic state

### DIFF
--- a/src/core/libraries/kernel/thread_management.cpp
+++ b/src/core/libraries/kernel/thread_management.cpp
@@ -1069,7 +1069,16 @@ ScePthread PThreadPool::Create(const char* name) {
         }
     }
 
+#ifdef _WIN64
     auto* ret = new PthreadInternal{};
+#else
+    // TODO: Linux specific hack
+    static u8* hint_address = reinterpret_cast<u8*>(0x7FFFFC000ULL);
+    auto* ret = reinterpret_cast<PthreadInternal*>(
+        mmap(hint_address, sizeof(PthreadInternal), PROT_READ | PROT_WRITE,
+             MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0));
+    hint_address += Common::AlignUp(sizeof(PthreadInternal), 4_KB);
+#endif
     ret->is_free = false;
     ret->is_detached = false;
     ret->is_almost_done = false;

--- a/src/core/libraries/kernel/thread_management.cpp
+++ b/src/core/libraries/kernel/thread_management.cpp
@@ -654,7 +654,7 @@ int PS4_SYSV_ABI scePthreadCondInit(ScePthreadCond* cond, const ScePthreadCondat
     int result = pthread_cond_init(&(*cond)->cond, &(*attr)->cond_attr);
 
     if (name != nullptr) {
-        LOG_INFO(Kernel_Pthread, "name={}, result={}", (*cond)->name, result);
+        LOG_TRACE(Kernel_Pthread, "name={}, result={}", (*cond)->name, result);
     }
 
     switch (result) {
@@ -1069,16 +1069,7 @@ ScePthread PThreadPool::Create(const char* name) {
         }
     }
 
-#ifdef _WIN64
     auto* ret = new PthreadInternal{};
-#else
-    // TODO: Linux specific hack
-    static u8* hint_address = reinterpret_cast<u8*>(0x7FFFFC000ULL);
-    auto* ret = reinterpret_cast<PthreadInternal*>(
-        mmap(hint_address, sizeof(PthreadInternal), PROT_READ | PROT_WRITE,
-             MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0));
-    hint_address += Common::AlignUp(sizeof(PthreadInternal), 4_KB);
-#endif
     ret->is_free = false;
     ret->is_detached = false;
     ret->is_almost_done = false;

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -492,6 +492,11 @@ struct Liverpool {
         CullMode CullingMode() const {
             return static_cast<CullMode>(cull_front | cull_back << 1);
         }
+
+        bool NeedsBias() const {
+            return enable_polygon_offset_back || enable_polygon_offset_front ||
+                   enable_polygon_offset_para;
+        }
     };
 
     union VsOutputConfig {

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -306,11 +306,18 @@ struct Liverpool {
         BitField<30, 1, u32> enable_color_writes_on_depth_fail;
         BitField<31, 1, u32> disable_color_writes_on_depth_pass;
 
-        static constexpr u32 Mask() {
-            return decltype(stencil_enable)::mask | decltype(depth_enable)::mask |
-                   decltype(depth_write_enable)::mask | decltype(depth_bounds_enable)::mask |
-                   decltype(depth_func)::mask | decltype(backface_enable)::mask |
-                   decltype(stencil_ref_func)::mask | decltype(stencil_bf_func)::mask;
+        constexpr u32 DepthState() const {
+            static constexpr u32 DepthMask =
+                decltype(depth_enable)::mask | decltype(depth_write_enable)::mask |
+                decltype(depth_bounds_enable)::mask | decltype(depth_func)::mask;
+            return raw & DepthMask;
+        }
+
+        constexpr u32 StencilState() const {
+            static constexpr u32 StencilMask =
+                decltype(stencil_enable)::mask | decltype(backface_enable)::mask |
+                decltype(stencil_ref_func)::mask | decltype(stencil_bf_func)::mask;
+            return raw & StencilMask;
         }
     };
 

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -305,20 +305,6 @@ struct Liverpool {
         BitField<20, 3, CompareFunc> stencil_bf_func;
         BitField<30, 1, u32> enable_color_writes_on_depth_fail;
         BitField<31, 1, u32> disable_color_writes_on_depth_pass;
-
-        constexpr u32 DepthState() const {
-            static constexpr u32 DepthMask =
-                decltype(depth_enable)::mask | decltype(depth_write_enable)::mask |
-                decltype(depth_bounds_enable)::mask | decltype(depth_func)::mask;
-            return raw & DepthMask;
-        }
-
-        constexpr u32 StencilState() const {
-            static constexpr u32 StencilMask =
-                decltype(stencil_enable)::mask | decltype(backface_enable)::mask |
-                decltype(stencil_ref_func)::mask | decltype(stencil_bf_func)::mask;
-            return raw & StencilMask;
-        }
     };
 
     enum class StencilFunc : u32 {
@@ -348,11 +334,6 @@ struct Liverpool {
         BitField<12, 4, StencilFunc> stencil_fail_back;
         BitField<16, 4, StencilFunc> stencil_zpass_back;
         BitField<20, 4, StencilFunc> stencil_zfail_back;
-        BitField<24, 8, u32> padding;
-
-        static constexpr u32 Mask() {
-            return ~decltype(padding)::mask;
-        }
     };
 
     union StencilRefMask {

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -305,6 +305,13 @@ struct Liverpool {
         BitField<20, 3, CompareFunc> stencil_bf_func;
         BitField<30, 1, u32> enable_color_writes_on_depth_fail;
         BitField<31, 1, u32> disable_color_writes_on_depth_pass;
+
+        static constexpr u32 Mask() {
+            return decltype(stencil_enable)::mask | decltype(depth_enable)::mask |
+                   decltype(depth_write_enable)::mask | decltype(depth_bounds_enable)::mask |
+                   decltype(depth_func)::mask | decltype(backface_enable)::mask |
+                   decltype(stencil_ref_func)::mask | decltype(stencil_bf_func)::mask;
+        }
     };
 
     enum class StencilFunc : u32 {
@@ -334,6 +341,11 @@ struct Liverpool {
         BitField<12, 4, StencilFunc> stencil_fail_back;
         BitField<16, 4, StencilFunc> stencil_zpass_back;
         BitField<20, 4, StencilFunc> stencil_zfail_back;
+        BitField<24, 8, u32> padding;
+
+        static constexpr u32 Mask() {
+            return ~decltype(padding)::mask;
+        }
     };
 
     union StencilRefMask {
@@ -505,6 +517,11 @@ struct Liverpool {
 
         u32 GetMask(int buf_id) const {
             return (raw >> (buf_id * 4)) & 0xfu;
+        }
+
+        void SetMask(int buf_id, u32 mask) {
+            raw &= ~(0xf << (buf_id * 4));
+            raw |= (mask << (buf_id * 4));
         }
     };
 

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -95,9 +95,6 @@ GraphicsPipeline::GraphicsPipeline(const Instance& instance_, Scheduler& schedul
                          ? vk::FrontFace::eClockwise
                          : vk::FrontFace::eCounterClockwise,
         .depthBiasEnable = bool(key.depth_bias_enable),
-        .depthBiasConstantFactor = key.depth_bias_const_factor,
-        .depthBiasClamp = key.depth_bias_clamp,
-        .depthBiasSlopeFactor = key.depth_bias_slope_factor,
         .lineWidth = 1.0f,
     };
 
@@ -134,9 +131,10 @@ GraphicsPipeline::GraphicsPipeline(const Instance& instance_, Scheduler& schedul
     };
 
     boost::container::static_vector<vk::DynamicState, 14> dynamic_states = {
-        vk::DynamicState::eViewport,       vk::DynamicState::eScissor,
-        vk::DynamicState::eBlendConstants, vk::DynamicState::eDepthBounds,
-        vk::DynamicState::eDepthBias,
+        vk::DynamicState::eViewport,           vk::DynamicState::eScissor,
+        vk::DynamicState::eBlendConstants,     vk::DynamicState::eDepthBounds,
+        vk::DynamicState::eDepthBias,          vk::DynamicState::eStencilReference,
+        vk::DynamicState::eStencilCompareMask, vk::DynamicState::eStencilWriteMask,
     };
 
     if (instance.IsColorWriteEnableSupported()) {
@@ -163,9 +161,6 @@ GraphicsPipeline::GraphicsPipeline(const Instance& instance_, Scheduler& schedul
             .passOp = LiverpoolToVK::StencilOp(key.stencil.stencil_zpass_front),
             .depthFailOp = LiverpoolToVK::StencilOp(key.stencil.stencil_zfail_front),
             .compareOp = LiverpoolToVK::CompareOp(key.depth_stencil.stencil_ref_func),
-            .compareMask = key.stencil_ref_front.stencil_mask,
-            .writeMask = key.stencil_ref_front.stencil_write_mask,
-            .reference = key.stencil_ref_front.stencil_test_val,
         },
         .back{
             .failOp = LiverpoolToVK::StencilOp(key.depth_stencil.backface_enable
@@ -180,12 +175,7 @@ GraphicsPipeline::GraphicsPipeline(const Instance& instance_, Scheduler& schedul
             .compareOp = LiverpoolToVK::CompareOp(key.depth_stencil.backface_enable
                                                       ? key.depth_stencil.stencil_bf_func.Value()
                                                       : key.depth_stencil.stencil_ref_func.Value()),
-            .compareMask = key.stencil_ref_back.stencil_mask,
-            .writeMask = key.stencil_ref_back.stencil_write_mask,
-            .reference = key.stencil_ref_back.stencil_test_val,
         },
-        .minDepthBounds = key.depth_bounds_min,
-        .maxDepthBounds = key.depth_bounds_max,
     };
 
     auto stage = u32(Shader::Stage::Vertex);

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -153,33 +153,33 @@ GraphicsPipeline::GraphicsPipeline(const Instance& instance_, Scheduler& schedul
     };
 
     const vk::PipelineDepthStencilStateCreateInfo depth_info = {
-        .depthTestEnable = key.depth.depth_enable,
-        .depthWriteEnable = key.depth.depth_write_enable,
-        .depthCompareOp = LiverpoolToVK::CompareOp(key.depth.depth_func),
-        .depthBoundsTestEnable = key.depth.depth_bounds_enable,
-        .stencilTestEnable = key.depth.stencil_enable,
+        .depthTestEnable = key.depth_stencil.depth_enable,
+        .depthWriteEnable = key.depth_stencil.depth_write_enable,
+        .depthCompareOp = LiverpoolToVK::CompareOp(key.depth_stencil.depth_func),
+        .depthBoundsTestEnable = key.depth_stencil.depth_bounds_enable,
+        .stencilTestEnable = key.depth_stencil.stencil_enable,
         .front{
             .failOp = LiverpoolToVK::StencilOp(key.stencil.stencil_fail_front),
             .passOp = LiverpoolToVK::StencilOp(key.stencil.stencil_zpass_front),
             .depthFailOp = LiverpoolToVK::StencilOp(key.stencil.stencil_zfail_front),
-            .compareOp = LiverpoolToVK::CompareOp(key.depth.stencil_ref_func),
+            .compareOp = LiverpoolToVK::CompareOp(key.depth_stencil.stencil_ref_func),
             .compareMask = key.stencil_ref_front.stencil_mask,
             .writeMask = key.stencil_ref_front.stencil_write_mask,
             .reference = key.stencil_ref_front.stencil_test_val,
         },
         .back{
-            .failOp = LiverpoolToVK::StencilOp(key.depth.backface_enable
+            .failOp = LiverpoolToVK::StencilOp(key.depth_stencil.backface_enable
                                                    ? key.stencil.stencil_fail_back.Value()
                                                    : key.stencil.stencil_fail_front.Value()),
-            .passOp = LiverpoolToVK::StencilOp(key.depth.backface_enable
+            .passOp = LiverpoolToVK::StencilOp(key.depth_stencil.backface_enable
                                                    ? key.stencil.stencil_zpass_back.Value()
                                                    : key.stencil.stencil_zpass_front.Value()),
-            .depthFailOp = LiverpoolToVK::StencilOp(key.depth.backface_enable
+            .depthFailOp = LiverpoolToVK::StencilOp(key.depth_stencil.backface_enable
                                                         ? key.stencil.stencil_zfail_back.Value()
                                                         : key.stencil.stencil_zfail_front.Value()),
-            .compareOp = LiverpoolToVK::CompareOp(key.depth.backface_enable
-                                                      ? key.depth.stencil_bf_func.Value()
-                                                      : key.depth.stencil_ref_func.Value()),
+            .compareOp = LiverpoolToVK::CompareOp(key.depth_stencil.backface_enable
+                                                      ? key.depth_stencil.stencil_bf_func.Value()
+                                                      : key.depth_stencil.stencil_ref_func.Value()),
             .compareMask = key.stencil_ref_back.stencil_mask,
             .writeMask = key.stencil_ref_back.stencil_write_mask,
             .reference = key.stencil_ref_back.stencil_test_val,

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -292,6 +292,7 @@ GraphicsPipeline::~GraphicsPipeline() = default;
 
 void GraphicsPipeline::BuildDescSetLayout() {
     u32 binding{};
+    boost::container::small_vector<vk::DescriptorSetLayoutBinding, 32> bindings;
     for (const auto* stage : stages) {
         if (!stage) {
             continue;

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -134,9 +134,9 @@ GraphicsPipeline::GraphicsPipeline(const Instance& instance_, Scheduler& schedul
     };
 
     boost::container::static_vector<vk::DynamicState, 14> dynamic_states = {
-        vk::DynamicState::eViewport,
-        vk::DynamicState::eScissor,
-        vk::DynamicState::eBlendConstants,
+        vk::DynamicState::eViewport,       vk::DynamicState::eScissor,
+        vk::DynamicState::eBlendConstants, vk::DynamicState::eDepthBounds,
+        vk::DynamicState::eDepthBias,
     };
 
     if (instance.IsColorWriteEnableSupported()) {

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -37,7 +37,7 @@ struct GraphicsPipelineKey {
     float depth_bias_slope_factor;
     float depth_bias_clamp;
     u32 depth_bias_enable;
-    u32 num_samples = 1;
+    u32 num_samples;
     Liverpool::StencilControl stencil;
     Liverpool::StencilRefMask stencil_ref_front;
     Liverpool::StencilRefMask stencil_ref_back;
@@ -48,7 +48,7 @@ struct GraphicsPipelineKey {
     Liverpool::CullMode cull_mode;
     Liverpool::FrontFace front_face;
     Liverpool::ClipSpace clip_space;
-    Liverpool::ColorBufferMask cb_shader_mask{};
+    Liverpool::ColorBufferMask cb_shader_mask;
     std::array<Liverpool::BlendControl, Liverpool::NumColorBuffers> blend_controls;
     std::array<vk::ColorComponentFlags, Liverpool::NumColorBuffers> write_masks;
 

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -31,16 +31,9 @@ struct GraphicsPipelineKey {
     vk::Format stencil_format;
 
     Liverpool::DepthControl depth_stencil;
-    float depth_bounds_min;
-    float depth_bounds_max;
-    float depth_bias_const_factor;
-    float depth_bias_slope_factor;
-    float depth_bias_clamp;
     u32 depth_bias_enable;
     u32 num_samples;
     Liverpool::StencilControl stencil;
-    Liverpool::StencilRefMask stencil_ref_front;
-    Liverpool::StencilRefMask stencil_ref_back;
     Liverpool::PrimitiveType prim_type;
     u32 enable_primitive_restart;
     u32 primitive_restart_index;

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -30,7 +30,7 @@ struct GraphicsPipelineKey {
     vk::Format depth_format;
     vk::Format stencil_format;
 
-    Liverpool::DepthControl depth;
+    Liverpool::DepthControl depth_stencil;
     float depth_bounds_min;
     float depth_bounds_max;
     float depth_bias_const_factor;
@@ -91,7 +91,7 @@ public:
     }
 
     bool IsDepthEnabled() const {
-        return key.depth.depth_enable.Value();
+        return key.depth_stencil.depth_enable.Value();
     }
 
 private:

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -100,7 +100,6 @@ private:
     std::array<const Shader::Info*, MaxShaderStages> stages{};
     GraphicsPipelineKey key;
     bool uses_push_descriptors{};
-    boost::container::small_vector<vk::DescriptorSetLayoutBinding, 32> bindings;
 };
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -210,26 +210,8 @@ bool PipelineCache::RefreshGraphicsKey() {
                                  !regs.depth_render_control.depth_clear_enable;
         key.depth_stencil.raw |= regs.depth_control.DepthState();
         key.depth_stencil.depth_write_enable.Assign(depth_write);
-        if (key.depth_stencil.depth_bounds_enable) {
-            key.depth_bounds_min = regs.depth_bounds_min;
-            key.depth_bounds_max = regs.depth_bounds_max;
-        }
-        key.depth_bias_enable = regs.polygon_control.enable_polygon_offset_back ||
-                                regs.polygon_control.enable_polygon_offset_front ||
-                                regs.polygon_control.enable_polygon_offset_para;
-        if (key.depth_bias_enable) {
-            if (regs.polygon_control.enable_polygon_offset_front) {
-                key.depth_bias_const_factor = regs.poly_offset.front_offset;
-                key.depth_bias_slope_factor = regs.poly_offset.front_scale;
-            } else {
-                key.depth_bias_const_factor = regs.poly_offset.back_offset;
-                key.depth_bias_slope_factor = regs.poly_offset.back_scale;
-            }
-            key.depth_bias_clamp = regs.poly_offset.depth_bias;
-        }
 
         const auto ds_format = LiverpoolToVK::DepthFormat(db.z_info.format, db.stencil_info.format);
-
         if (db.z_info.format != AmdGpu::Liverpool::DepthBuffer::ZFormat::Invalid) {
             key.depth_format = ds_format;
         } else {

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -167,6 +167,7 @@ const GraphicsPipeline* PipelineCache::GetGraphicsPipeline() {
     }
     const auto [it, is_new] = graphics_pipelines.try_emplace(graphics_key);
     if (is_new) {
+        LOG_INFO(Render_Vulkan, "New pipeline");
         it.value() = std::make_unique<GraphicsPipeline>(
             instance, scheduler, desc_heap, graphics_key, *pipeline_cache, infos, modules);
     }

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -210,6 +210,7 @@ bool PipelineCache::RefreshGraphicsKey() {
                                  !regs.depth_render_control.depth_clear_enable;
         key.depth_stencil.raw |= regs.depth_control.DepthState();
         key.depth_stencil.depth_write_enable.Assign(depth_write);
+        key.depth_bias_enable = regs.polygon_control.NeedsBias();
 
         const auto ds_format = LiverpoolToVK::DepthFormat(db.z_info.format, db.stencil_info.format);
         if (db.z_info.format != AmdGpu::Liverpool::DepthBuffer::ZFormat::Invalid) {

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -167,7 +167,6 @@ const GraphicsPipeline* PipelineCache::GetGraphicsPipeline() {
     }
     const auto [it, is_new] = graphics_pipelines.try_emplace(graphics_key);
     if (is_new) {
-        LOG_INFO(Render_Vulkan, "New pipeline");
         it.value() = std::make_unique<GraphicsPipeline>(
             instance, scheduler, desc_heap, graphics_key, *pipeline_cache, infos, modules);
     }

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.h
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.h
@@ -74,8 +74,10 @@ private:
     Shader::Pools pools;
     tsl::robin_map<size_t, Program*> program_cache;
     Common::ObjectPool<Program> program_pool;
-    tsl::robin_map<size_t, std::unique_ptr<ComputePipeline>> compute_pipelines;
-    tsl::robin_map<GraphicsPipelineKey, std::unique_ptr<GraphicsPipeline>> graphics_pipelines;
+    Common::ObjectPool<GraphicsPipeline> graphics_pipeline_pool;
+    Common::ObjectPool<ComputePipeline> compute_pipeline_pool;
+    tsl::robin_map<size_t, ComputePipeline*> compute_pipelines;
+    tsl::robin_map<GraphicsPipelineKey, GraphicsPipeline*> graphics_pipelines;
     std::array<const Shader::Info*, MaxShaderStages> infos{};
     std::array<vk::ShaderModule, MaxShaderStages> modules{};
     GraphicsPipelineKey graphics_key{};

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -309,6 +309,31 @@ void Rasterizer::UpdateDynamicState(const GraphicsPipeline& pipeline) {
                                 regs.poly_offset.back_scale);
         }
     }
+    if (regs.depth_control.stencil_enable) {
+        const auto front = regs.stencil_ref_front;
+        const auto back = regs.stencil_ref_back;
+        if (front.stencil_test_val == back.stencil_test_val) {
+            cmdbuf.setStencilReference(vk::StencilFaceFlagBits::eFrontAndBack,
+                                       front.stencil_test_val);
+        } else {
+            cmdbuf.setStencilReference(vk::StencilFaceFlagBits::eFront, front.stencil_test_val);
+            cmdbuf.setStencilReference(vk::StencilFaceFlagBits::eBack, back.stencil_test_val);
+        }
+        if (front.stencil_write_mask == back.stencil_write_mask) {
+            cmdbuf.setStencilWriteMask(vk::StencilFaceFlagBits::eFrontAndBack,
+                                       front.stencil_write_mask);
+        } else {
+            cmdbuf.setStencilWriteMask(vk::StencilFaceFlagBits::eFront, front.stencil_write_mask);
+            cmdbuf.setStencilWriteMask(vk::StencilFaceFlagBits::eBack, back.stencil_write_mask);
+        }
+        if (front.stencil_mask == back.stencil_mask) {
+            cmdbuf.setStencilCompareMask(vk::StencilFaceFlagBits::eFrontAndBack,
+                                         front.stencil_mask);
+        } else {
+            cmdbuf.setStencilCompareMask(vk::StencilFaceFlagBits::eFront, front.stencil_mask);
+            cmdbuf.setStencilCompareMask(vk::StencilFaceFlagBits::eBack, back.stencil_mask);
+        }
+    }
 }
 
 void Rasterizer::UpdateViewportScissorState() {

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -297,6 +297,18 @@ void Rasterizer::UpdateDynamicState(const GraphicsPipeline& pipeline) {
         cmdbuf.setColorWriteEnableEXT(write_ens);
         cmdbuf.setColorWriteMaskEXT(0, write_masks);
     }
+    if (regs.depth_control.depth_bounds_enable) {
+        cmdbuf.setDepthBounds(regs.depth_bounds_min, regs.depth_bounds_max);
+    }
+    if (regs.polygon_control.NeedsBias()) {
+        if (regs.polygon_control.enable_polygon_offset_front) {
+            cmdbuf.setDepthBias(regs.poly_offset.front_offset, regs.poly_offset.depth_bias,
+                                regs.poly_offset.front_scale);
+        } else {
+            cmdbuf.setDepthBias(regs.poly_offset.back_offset, regs.poly_offset.depth_bias,
+                                regs.poly_offset.back_scale);
+        }
+    }
 }
 
 void Rasterizer::UpdateViewportScissorState() {


### PR DESCRIPTION
Some of these depth/stencil states can change very significantly between frames even and cased a lot of unnecessary pipeline recompilation. Move them to dynamic state to solve this (these states are supported by Vulkan 1.0 so should be good compatibility wise)