### PR TITLE
Do not wait for audio packets without audio stream

### DIFF
--- a/src/core/libraries/avplayer/avplayer_impl.h
+++ b/src/core/libraries/avplayer/avplayer_impl.h
@@ -40,8 +40,6 @@ public:
     bool SetLooping(bool is_looping);
 
 private:
-    using ScePthreadMutex = Kernel::ScePthreadMutex;
-
     // Memory Replacement
     static void* PS4_SYSV_ABI Allocate(void* handle, u32 alignment, u32 size);
     static void PS4_SYSV_ABI Deallocate(void* handle, void* memory);

--- a/src/core/libraries/avplayer/avplayer_source.cpp
+++ b/src/core/libraries/avplayer/avplayer_source.cpp
@@ -439,7 +439,8 @@ void AvPlayerSource::DemuxerThread(std::stop_token stop) {
     LOG_INFO(Lib_AvPlayer, "Demuxer Thread started");
 
     while (!stop.stop_requested()) {
-        if (m_video_packets.Size() > 30 && m_audio_packets.Size() > 8) {
+        if (m_video_packets.Size() > 30 &&
+            (!m_audio_stream_index.has_value() || m_audio_packets.Size() > 8)) {
             std::this_thread::sleep_for(milliseconds(5));
             continue;
         }

--- a/src/core/libraries/avplayer/avplayer_state.h
+++ b/src/core/libraries/avplayer/avplayer_state.h
@@ -38,9 +38,6 @@ public:
     bool SetLooping(bool is_looping);
 
 private:
-    using ScePthreadMutex = Kernel::ScePthreadMutex;
-    using ScePthread = Kernel::ScePthread;
-
     // Event Replacement
     static void PS4_SYSV_ABI AutoPlayEventCallback(void* handle, s32 event_id, s32 source_id,
                                                    void* event_data);


### PR DESCRIPTION
Fixes `Sengoku Basara` spamming the "looping..." message and using a lot of memory.

Plus some cleanup.