### PR TITLE
Add other 64-bit floating point shader instructions

### DIFF
--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -138,9 +138,14 @@ public:
     void V_FLOOR_F32(const GcnInst& inst);
     void V_SUB_F32(const GcnInst& inst);
     void V_RCP_F32(const GcnInst& inst);
+    void V_RCP_F64(const GcnInst& inst);
     void V_FMA_F32(const GcnInst& inst);
+    void V_FMA_F64(const GcnInst& inst);
     void V_CMP_F32(ConditionOp op, bool set_exec, const GcnInst& inst);
     void V_MAX_F32(const GcnInst& inst, bool is_legacy = false);
+    void V_ADD_F64(const GcnInst& inst);
+    void V_MUL_F64(const GcnInst& inst);
+    void V_MIN_F64(const GcnInst& inst);
     void V_MAX_F64(const GcnInst& inst);
     void V_MAX_U32(bool is_signed, const GcnInst& inst);
     void V_RSQ_F32(const GcnInst& inst);

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -143,9 +143,7 @@ public:
     void V_FMA_F64(const GcnInst& inst);
     void V_CMP_F32(ConditionOp op, bool set_exec, const GcnInst& inst);
     void V_MAX_F32(const GcnInst& inst, bool is_legacy = false);
-    void V_ADD_F64(const GcnInst& inst);
     void V_MUL_F64(const GcnInst& inst);
-    void V_MIN_F64(const GcnInst& inst);
     void V_MAX_F64(const GcnInst& inst);
     void V_MAX_U32(bool is_signed, const GcnInst& inst);
     void V_RSQ_F32(const GcnInst& inst);

--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -179,6 +179,8 @@ void Translator::EmitVectorAlu(const GcnInst& inst) {
         return V_MUL_F32(inst);
     case Opcode::V_RCP_F32:
         return V_RCP_F32(inst);
+    case Opcode::V_RCP_F64:
+        return V_RCP_F64(inst);
     case Opcode::V_LDEXP_F32:
         return V_LDEXP_F32(inst);
     case Opcode::V_FRACT_F32:
@@ -196,8 +198,16 @@ void Translator::EmitVectorAlu(const GcnInst& inst) {
     case Opcode::V_FMA_F32:
     case Opcode::V_MADAK_F32:
         return V_FMA_F32(inst);
+    case Opcode::V_FMA_F64:
+        return V_FMA_F64(inst);
     case Opcode::V_MAX_F32:
         return V_MAX_F32(inst);
+    case Opcode::V_ADD_F64:
+        return V_ADD_F64(inst);
+    case Opcode::V_MUL_F64:
+        return V_MUL_F64(inst);
+    case Opcode::V_MIN_F64:
+        return V_MIN_F64(inst);
     case Opcode::V_MAX_F64:
         return V_MAX_F64(inst);
     case Opcode::V_RSQ_F32:
@@ -537,6 +547,18 @@ void Translator::V_FMA_F32(const GcnInst& inst) {
     SetDst(inst.dst[0], ir.FPFma(src0, src1, src2));
 }
 
+void Translator::V_RCP_F64(const GcnInst& inst) {
+    const IR::F64 src0{GetSrc<IR::F64>(inst.src[0])};
+    SetDst64(inst.dst[0], ir.FPRecip(src0));
+}
+
+void Translator::V_FMA_F64(const GcnInst& inst) {
+    const IR::F64 src0{GetSrc<IR::F64>(inst.src[0])};
+    const IR::F64 src1{GetSrc<IR::F64>(inst.src[1])};
+    const IR::F64 src2{GetSrc<IR::F64>(inst.src[2])};
+    SetDst64(inst.dst[0], ir.FPFma(src0, src1, src2));
+}
+
 void Translator::V_CMP_F32(ConditionOp op, bool set_exec, const GcnInst& inst) {
     const IR::F32 src0{GetSrc<IR::F32>(inst.src[0])};
     const IR::F32 src1{GetSrc<IR::F32>(inst.src[1])};
@@ -582,6 +604,24 @@ void Translator::V_MAX_F32(const GcnInst& inst, bool is_legacy) {
     const IR::F32 src0{GetSrc<IR::F32>(inst.src[0])};
     const IR::F32 src1{GetSrc<IR::F32>(inst.src[1])};
     SetDst(inst.dst[0], ir.FPMax(src0, src1, is_legacy));
+}
+
+void Translator::V_ADD_F64(const GcnInst& inst) {
+    const IR::F64 src0{GetSrc64<IR::F64>(inst.src[0])};
+    const IR::F64 src1{GetSrc64<IR::F64>(inst.src[1])};
+    SetDst64(inst.dst[0], ir.FPAdd(src0, src1));
+}
+
+void Translator::V_MUL_F64(const GcnInst& inst) {
+    const IR::F64 src0{GetSrc64<IR::F64>(inst.src[0])};
+    const IR::F64 src1{GetSrc64<IR::F64>(inst.src[1])};
+    SetDst64(inst.dst[0], ir.FPMul(src0, src1));
+}
+
+void Translator::V_MIN_F64(const GcnInst& inst) {
+    const IR::F64 src0{GetSrc64<IR::F64>(inst.src[0])};
+    const IR::F64 src1{GetSrc64<IR::F64>(inst.src[1])};
+    SetDst64(inst.dst[0], ir.FPMin(src0, src1));
 }
 
 void Translator::V_MAX_F64(const GcnInst& inst) {

--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -202,12 +202,8 @@ void Translator::EmitVectorAlu(const GcnInst& inst) {
         return V_FMA_F64(inst);
     case Opcode::V_MAX_F32:
         return V_MAX_F32(inst);
-    case Opcode::V_ADD_F64:
-        return V_ADD_F64(inst);
     case Opcode::V_MUL_F64:
         return V_MUL_F64(inst);
-    case Opcode::V_MIN_F64:
-        return V_MIN_F64(inst);
     case Opcode::V_MAX_F64:
         return V_MAX_F64(inst);
     case Opcode::V_RSQ_F32:
@@ -606,22 +602,10 @@ void Translator::V_MAX_F32(const GcnInst& inst, bool is_legacy) {
     SetDst(inst.dst[0], ir.FPMax(src0, src1, is_legacy));
 }
 
-void Translator::V_ADD_F64(const GcnInst& inst) {
-    const IR::F64 src0{GetSrc64<IR::F64>(inst.src[0])};
-    const IR::F64 src1{GetSrc64<IR::F64>(inst.src[1])};
-    SetDst64(inst.dst[0], ir.FPAdd(src0, src1));
-}
-
 void Translator::V_MUL_F64(const GcnInst& inst) {
     const IR::F64 src0{GetSrc64<IR::F64>(inst.src[0])};
     const IR::F64 src1{GetSrc64<IR::F64>(inst.src[1])};
     SetDst64(inst.dst[0], ir.FPMul(src0, src1));
-}
-
-void Translator::V_MIN_F64(const GcnInst& inst) {
-    const IR::F64 src0{GetSrc64<IR::F64>(inst.src[0])};
-    const IR::F64 src1{GetSrc64<IR::F64>(inst.src[1])};
-    SetDst64(inst.dst[0], ir.FPMin(src0, src1));
 }
 
 void Translator::V_MAX_F64(const GcnInst& inst) {

--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -548,14 +548,14 @@ void Translator::V_FMA_F32(const GcnInst& inst) {
 }
 
 void Translator::V_RCP_F64(const GcnInst& inst) {
-    const IR::F64 src0{GetSrc<IR::F64>(inst.src[0])};
+    const IR::F64 src0{GetSrc64<IR::F64>(inst.src[0])};
     SetDst64(inst.dst[0], ir.FPRecip(src0));
 }
 
 void Translator::V_FMA_F64(const GcnInst& inst) {
-    const IR::F64 src0{GetSrc<IR::F64>(inst.src[0])};
-    const IR::F64 src1{GetSrc<IR::F64>(inst.src[1])};
-    const IR::F64 src2{GetSrc<IR::F64>(inst.src[2])};
+    const IR::F64 src0{GetSrc64<IR::F64>(inst.src[0])};
+    const IR::F64 src1{GetSrc64<IR::F64>(inst.src[1])};
+    const IR::F64 src2{GetSrc64<IR::F64>(inst.src[2])};
     SetDst64(inst.dst[0], ir.FPFma(src0, src1, src2));
 }
 


### PR DESCRIPTION
For CUSA00897 https://github.com/shadps4-emu/shadPS4/issues/496

[Render.Recompiler] translate.cpp:LogMissingOpcode:452: Unknown opcode V_MUL_F64 (891, category = VectorALU)
[Render.Recompiler] translate.cpp:LogMissingOpcode:452: Unknown opcode V_FMA_F64 (866, category = VectorALU)
[Render.Recompiler] translate.cpp:LogMissingOpcode:452: Unknown opcode V_RCP_F64 (510, category = VectorALU)