### PR TITLE
core: Replace Windows TLS code patches with exception handler.

### DIFF
--- a/src/core/tls.h
+++ b/src/core/tls.h
@@ -22,11 +22,6 @@ struct Tcb {
     void* tcb_thread;
 };
 
-#ifdef _WIN32
-/// Gets the thread local storage key for the TCB block.
-u32 GetTcbKey();
-#endif
-
 /// Sets the data pointer to the TCB block.
 void SetTcbBase(void* image_address);
 


### PR DESCRIPTION
Implements a new strategy for Windows TCB accesses using just an exception handler.

On Windows, FS segment accesses are generally guaranteed to cause an access violation. We currently take advantage of this to patch code on the fly, however instead we can actually just check if the instruction accessed FS and set the FS register. Windows doesn't seem to really care what's in the FS register, and it won't matter if the OS resets it since we can just set it back again any time a fault occurs.

By taking this approach we can eliminate the historically unreliable code patch that tries to calculate the location of the right TLS value directly in assembly. The hope is that directly populating FS base from `TlsGetValue` will be much more reliable. Plus this allows us to reliably patch any type of FS access instead of just `mov reg, fs:0x0`, although no other use patterns have been observed yet.

In the process of implementing this I moved the ahead-of-time TLS patching for Linux out of the main patching system into special patching code just for that OS, since that allows us to completely remove the access violation handler from the CPU patcher and just focus on illegal instructions at runtime. Eventually this too will hopefully go away as I want to experiment with swapping in and out the FS register on guest code entry/exit to eliminate that patch as well.

Tested this on a few games on a Windows machine I got access to, didn't find any issues.