### PR TITLE
Use a singleton for instruction decoding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,8 +350,8 @@ set(COMMON src/common/logging/backend.cpp
            src/common/config.cpp
            src/common/config.h
            src/common/debug.h
-           src/common/disassembler.cpp
-           src/common/disassembler.h
+           src/common/decoder.cpp
+           src/common/decoder.h
            src/common/endian.h
            src/common/enum.h
            src/common/io_file.cpp

--- a/src/common/decoder.cpp
+++ b/src/common/decoder.cpp
@@ -6,14 +6,14 @@
 
 namespace Common {
 
-Decoder::Decoder() {
+DecoderImpl::DecoderImpl() {
     ZydisDecoderInit(&m_decoder, ZYDIS_MACHINE_MODE_LONG_64, ZYDIS_STACK_WIDTH_64);
     ZydisFormatterInit(&m_formatter, ZYDIS_FORMATTER_STYLE_INTEL);
 }
 
-Decoder::~Decoder() = default;
+DecoderImpl::~DecoderImpl() = default;
 
-void Decoder::printInstruction(void* code, u64 address) {
+void DecoderImpl::printInstruction(void* code, u64 address) {
     ZydisDecodedInstruction instruction;
     ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT_VISIBLE];
     ZyanStatus status =
@@ -25,7 +25,8 @@ void Decoder::printInstruction(void* code, u64 address) {
     }
 }
 
-void Decoder::printInst(ZydisDecodedInstruction& inst, ZydisDecodedOperand* operands, u64 address) {
+void DecoderImpl::printInst(ZydisDecodedInstruction& inst, ZydisDecodedOperand* operands,
+                            u64 address) {
     const int bufLen = 256;
     char szBuffer[bufLen];
     ZydisFormatterFormatInstruction(&m_formatter, &inst, operands, inst.operand_count_visible,
@@ -33,8 +34,8 @@ void Decoder::printInst(ZydisDecodedInstruction& inst, ZydisDecodedOperand* oper
     fmt::print("instruction: {}\n", szBuffer);
 }
 
-ZyanStatus Decoder::decodeInstruction(ZydisDecodedInstruction& inst, ZydisDecodedOperand* operands,
-                                      void* data, u64 size) {
+ZyanStatus DecoderImpl::decodeInstruction(ZydisDecodedInstruction& inst,
+                                          ZydisDecodedOperand* operands, void* data, u64 size) {
     return ZydisDecoderDecodeFull(&m_decoder, data, size, &inst, operands);
 }
 

--- a/src/common/decoder.cpp
+++ b/src/common/decoder.cpp
@@ -2,18 +2,18 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <fmt/format.h>
-#include "common/disassembler.h"
+#include "common/decoder.h"
 
 namespace Common {
 
-Disassembler::Disassembler() {
+Decoder::Decoder() {
     ZydisDecoderInit(&m_decoder, ZYDIS_MACHINE_MODE_LONG_64, ZYDIS_STACK_WIDTH_64);
     ZydisFormatterInit(&m_formatter, ZYDIS_FORMATTER_STYLE_INTEL);
 }
 
-Disassembler::~Disassembler() = default;
+Decoder::~Decoder() = default;
 
-void Disassembler::printInstruction(void* code, u64 address) {
+void Decoder::printInstruction(void* code, u64 address) {
     ZydisDecodedInstruction instruction;
     ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT_VISIBLE];
     ZyanStatus status =
@@ -25,13 +25,17 @@ void Disassembler::printInstruction(void* code, u64 address) {
     }
 }
 
-void Disassembler::printInst(ZydisDecodedInstruction& inst, ZydisDecodedOperand* operands,
-                             u64 address) {
+void Decoder::printInst(ZydisDecodedInstruction& inst, ZydisDecodedOperand* operands, u64 address) {
     const int bufLen = 256;
     char szBuffer[bufLen];
     ZydisFormatterFormatInstruction(&m_formatter, &inst, operands, inst.operand_count_visible,
                                     szBuffer, sizeof(szBuffer), address, ZYAN_NULL);
     fmt::print("instruction: {}\n", szBuffer);
+}
+
+ZyanStatus Decoder::decodeInstruction(ZydisDecodedInstruction& inst, ZydisDecodedOperand* operands,
+                                      void* data, u64 size) {
+    return ZydisDecoderDecodeFull(&m_decoder, data, size, &inst, operands);
 }
 
 } // namespace Common

--- a/src/common/decoder.h
+++ b/src/common/decoder.h
@@ -8,13 +8,20 @@
 
 namespace Common {
 
-class Disassembler {
+class Decoder {
 public:
-    Disassembler();
-    ~Disassembler();
+    Decoder();
+    ~Decoder();
 
     void printInst(ZydisDecodedInstruction& inst, ZydisDecodedOperand* operands, u64 address);
     void printInstruction(void* code, u64 address);
+    ZyanStatus decodeInstruction(ZydisDecodedInstruction& inst, ZydisDecodedOperand* operands,
+                                 void* data, u64 size = 15);
+
+    static Decoder& Instance() {
+        static Decoder instance;
+        return instance;
+    }
 
 private:
     ZydisDecoder m_decoder;

--- a/src/common/decoder.h
+++ b/src/common/decoder.h
@@ -4,28 +4,26 @@
 #pragma once
 
 #include <Zydis/Zydis.h>
+#include "common/singleton.h"
 #include "common/types.h"
 
 namespace Common {
 
-class Decoder {
+class DecoderImpl {
 public:
-    Decoder();
-    ~Decoder();
+    DecoderImpl();
+    ~DecoderImpl();
 
     void printInst(ZydisDecodedInstruction& inst, ZydisDecodedOperand* operands, u64 address);
     void printInstruction(void* code, u64 address);
     ZyanStatus decodeInstruction(ZydisDecodedInstruction& inst, ZydisDecodedOperand* operands,
                                  void* data, u64 size = 15);
 
-    static Decoder& Instance() {
-        static Decoder instance;
-        return instance;
-    }
-
 private:
     ZydisDecoder m_decoder;
     ZydisFormatter m_formatter;
 };
+
+using Decoder = Common::Singleton<DecoderImpl>;
 
 } // namespace Common

--- a/src/core/cpu_patches.cpp
+++ b/src/core/cpu_patches.cpp
@@ -663,8 +663,8 @@ static PatchModule* GetModule(const void* ptr) {
 static std::pair<bool, u64> TryPatch(u8* code, PatchModule* module) {
     ZydisDecodedInstruction instruction;
     ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT];
-    const auto status = Common::Decoder::Instance().decodeInstruction(instruction, operands, code,
-                                                                      module->end - code);
+    const auto status = Common::Decoder::Instance()->decodeInstruction(instruction, operands, code,
+                                                                       module->end - code);
     if (!ZYAN_SUCCESS(status)) {
         return std::make_pair(false, 1);
     }

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -69,7 +69,7 @@ static std::string DisassembleInstruction(void* code_address) {
     ZydisDecodedInstruction instruction;
     ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT];
     const auto status =
-        Common::Decoder::Instance().decodeInstruction(instruction, operands, code_address);
+        Common::Decoder::Instance()->decodeInstruction(instruction, operands, code_address);
     if (ZYAN_SUCCESS(status)) {
         ZydisFormatter formatter;
         ZydisFormatterInit(&formatter, ZYDIS_FORMATTER_STYLE_INTEL);

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -3,6 +3,7 @@
 
 #include "common/arch.h"
 #include "common/assert.h"
+#include "common/decoder.h"
 #include "core/signals.h"
 
 #ifdef _WIN32
@@ -10,7 +11,6 @@
 #else
 #include <csignal>
 #ifdef ARCH_X86_64
-#include <Zydis/Decoder.h>
 #include <Zydis/Formatter.h>
 #endif
 #endif
@@ -66,14 +66,10 @@ static std::string DisassembleInstruction(void* code_address) {
     char buffer[256] = "<unable to decode>";
 
 #ifdef ARCH_X86_64
-    ZydisDecoder decoder;
-    ZydisDecoderInit(&decoder, ZYDIS_MACHINE_MODE_LONG_64, ZYDIS_STACK_WIDTH_64);
-
     ZydisDecodedInstruction instruction;
     ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT];
-    static constexpr u64 max_length = 0x20;
     const auto status =
-        ZydisDecoderDecodeFull(&decoder, code_address, max_length, &instruction, operands);
+        Common::Decoder::Instance().decodeInstruction(instruction, operands, code_address);
     if (ZYAN_SUCCESS(status)) {
         ZydisFormatter formatter;
         ZydisFormatterInit(&formatter, ZYDIS_FORMATTER_STYLE_INTEL);


### PR DESCRIPTION
We're going to need the decoder in more places soon and don't need to do ZydisDecoderInit everywhere