### PR TITLE
Set High Priority for Windows

### DIFF
--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -42,9 +42,10 @@ Emulator::Emulator() {
     const auto config_dir = Common::FS::GetUserPath(Common::FS::PathType::UserDir);
     Config::load(config_dir / "config.toml");
 
-    // Initialize NT API functions
+    // Initialize NT API functions and set high priority
 #ifdef _WIN32
     Common::NtApi::Initialize();
+    SetPriorityClass(GetCurrentProcess(), ABOVE_NORMAL_PRIORITY_CLASS);
 #endif
 
     // Start logger.


### PR DESCRIPTION
Inspired by Cemu source code, I added the feature that shadPS4 process is "above normal" instead of "normal".
This can surely improve performance. (Only available for Windows!)