### PR TITLE
PM4 Packet - Type 0

### DIFF
--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -193,6 +193,9 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
 
         switch (type) {
         case 0:
+            const u32 cnt = header->type0.NumWords();
+            dcb = NextPacket(dcb, cnt);
+            continue;
         case 1:
             UNREACHABLE_MSG("Unsupported PM4 type {}", type);
             break;


### PR DESCRIPTION
For CUSA01661

[Debug] <Critical> liverpool.cpp:ProcessGraphics:197: Unreachable code! Unsupported PM4 type 0