### PR TITLE
PM4 Packet - Type 0

### DIFF
--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -193,6 +193,8 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
 
         switch (type) {
         case 0:
+            // Type-0 packet 
+            dcb = NextPacket(dcb, header->type0.NumWords());
         case 1:
             UNREACHABLE_MSG("Unsupported PM4 type {}", type);
             break;


### PR DESCRIPTION
For CUSA01661

[Debug] liverpool.cpp:ProcessGraphics:197: Unreachable code! Unsupported PM4 type 0