### PR TITLE
core: Add wrapper for calling into guest code.

### DIFF
--- a/src/core/libraries/avplayer/avplayer.h
+++ b/src/core/libraries/avplayer/avplayer.h
@@ -161,7 +161,20 @@ struct SceAvPlayerFileReplacement {
     SceAvPlayerSizeFile size;
 };
 
-typedef void PS4_SYSV_ABI (*SceAvPlayerEventCallback)(void* p, s32 event, s32 src_id, void* data);
+enum SceAvPlayerEvents {
+    SCE_AVPLAYER_STATE_STOP = 0x01,
+    SCE_AVPLAYER_STATE_READY = 0x02,
+    SCE_AVPLAYER_STATE_PLAY = 0x03,
+    SCE_AVPLAYER_STATE_PAUSE = 0x04,
+    SCE_AVPLAYER_STATE_BUFFERING = 0x05,
+    SCE_AVPLAYER_TIMED_TEXT_DELIVERY = 0x10,
+    SCE_AVPLAYER_WARNING_ID = 0x20,
+    SCE_AVPLAYER_ENCRYPTION = 0x30,
+    SCE_AVPLAYER_DRM_ERROR = 0x40
+};
+
+typedef void PS4_SYSV_ABI (*SceAvPlayerEventCallback)(void* p, SceAvPlayerEvents event, s32 src_id,
+                                                      void* data);
 
 struct SceAvPlayerEventReplacement {
     void* object_ptr;
@@ -274,18 +287,6 @@ enum SceAvPlayerAvSyncMode {
 };
 
 typedef int PS4_SYSV_ABI (*SceAvPlayerLogCallback)(void* p, const char* format, va_list args);
-
-enum SceAvPlayerEvents {
-    SCE_AVPLAYER_STATE_STOP = 0x01,
-    SCE_AVPLAYER_STATE_READY = 0x02,
-    SCE_AVPLAYER_STATE_PLAY = 0x03,
-    SCE_AVPLAYER_STATE_PAUSE = 0x04,
-    SCE_AVPLAYER_STATE_BUFFERING = 0x05,
-    SCE_AVPLAYER_TIMED_TEXT_DELIVERY = 0x10,
-    SCE_AVPLAYER_WARNING_ID = 0x20,
-    SCE_AVPLAYER_ENCRYPTION = 0x30,
-    SCE_AVPLAYER_DRM_ERROR = 0x40
-};
 
 void RegisterlibSceAvPlayer(Core::Loader::SymbolsResolver* sym);
 

--- a/src/core/libraries/avplayer/avplayer_state.h
+++ b/src/core/libraries/avplayer/avplayer_state.h
@@ -39,8 +39,8 @@ public:
 
 private:
     // Event Replacement
-    static void PS4_SYSV_ABI AutoPlayEventCallback(void* handle, s32 event_id, s32 source_id,
-                                                   void* event_data);
+    static void PS4_SYSV_ABI AutoPlayEventCallback(void* handle, SceAvPlayerEvents event_id,
+                                                   s32 source_id, void* event_data);
 
     void OnWarning(u32 id) override;
     void OnError() override;

--- a/src/core/libraries/network/net_ctl_obj.cpp
+++ b/src/core/libraries/network/net_ctl_obj.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/singleton.h"
+#include "core/linker.h"
 #include "net_ctl_codes.h"
 #include "net_ctl_obj.h"
 
@@ -57,18 +59,22 @@ s32 Libraries::NetCtl::NetCtlInternal::registerNpToolkitCallback(
 
 void Libraries::NetCtl::NetCtlInternal::checkCallback() {
     std::unique_lock lock{m_mutex};
+    auto* linker = Common::Singleton<Core::Linker>::Instance();
     for (auto& callback : callbacks) {
         if (callback.func != nullptr) {
-            callback.func(ORBIS_NET_CTL_EVENT_TYPE_DISCONNECTED, callback.arg);
+            linker->ExecuteGuest(callback.func, ORBIS_NET_CTL_EVENT_TYPE_DISCONNECTED,
+                                 callback.arg);
         }
     }
 }
 
 void Libraries::NetCtl::NetCtlInternal::checkNpToolkitCallback() {
     std::unique_lock lock{m_mutex};
+    auto* linker = Common::Singleton<Core::Linker>::Instance();
     for (auto& callback : nptoolCallbacks) {
         if (callback.func != nullptr) {
-            callback.func(ORBIS_NET_CTL_EVENT_TYPE_DISCONNECTED, callback.arg);
+            linker->ExecuteGuest(callback.func, ORBIS_NET_CTL_EVENT_TYPE_DISCONNECTED,
+                                 callback.arg);
         }
     }
 }

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -9,6 +9,7 @@
 #include "common/string_util.h"
 #include "core/aerolib/aerolib.h"
 #include "core/cpu_patches.h"
+#include "core/linker.h"
 #include "core/loader/dwarf.h"
 #include "core/memory.h"
 #include "core/module.h"
@@ -69,8 +70,9 @@ Module::~Module() = default;
 
 s32 Module::Start(size_t args, const void* argp, void* param) {
     LOG_INFO(Core_Linker, "Module started : {}", name);
+    auto* linker = Common::Singleton<Core::Linker>::Instance();
     const VAddr addr = dynamic_info.init_virtual_addr + GetBaseAddress();
-    return reinterpret_cast<EntryFunc>(addr)(args, argp, param);
+    return linker->ExecuteGuest(reinterpret_cast<EntryFunc>(addr), args, argp, param);
 }
 
 void Module::LoadModuleToMemory(u32& max_tls_index) {


### PR DESCRIPTION
Adds a wrapper for calling into guest code, allowing us to perform any required prologue or epilogue.

Currently this function just makes sure that the current thread has a patch stack and guest TLS set up before calling guest code. In the future it could be used for things like managing the FS segment on Linux.

Also fixes a type inconsistency in an AvPlayer callback which was causing type issues with the new wrapper.