### PR TITLE
vulkan: Only reduce viewport minDepth if using depth clip control.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -343,7 +343,10 @@ void Rasterizer::UpdateViewportScissorState() {
     boost::container::static_vector<vk::Rect2D, Liverpool::NumViewports> scissors;
 
     const float reduce_z =
-        regs.clipper_control.clip_space == AmdGpu::Liverpool::ClipSpace::MinusWToW ? 1.0f : 0.0f;
+        instance.IsDepthClipControlSupported() &&
+                regs.clipper_control.clip_space == AmdGpu::Liverpool::ClipSpace::MinusWToW
+            ? 1.0f
+            : 0.0f;
     for (u32 i = 0; i < Liverpool::NumViewports; i++) {
         const auto& vp = regs.viewports[i];
         const auto& vp_d = regs.viewport_depths[i];


### PR DESCRIPTION
Missed this from implementing depth clip control emulation in shaders. When depth clip control is unsupported and we reduce to the supported range in shaders, we also shouldn't apply the offset to the viewport `minDepth`.

There is still a lack of a fallback for missing `VK_EXT_depth_range_unrestricted` when the game adjusts the viewport depth range itself, but this fixes the case where its adjusted by us because of the clip space.