### PR TITLE
Fix Regression #932

### DIFF
--- a/src/core/libraries/kernel/threads/semaphore.cpp
+++ b/src/core/libraries/kernel/threads/semaphore.cpp
@@ -32,6 +32,10 @@ public:
             return ORBIS_KERNEL_ERROR_EBUSY;
         }
 
+        if (timeout && *timeout == 0) {
+            return SCE_KERNEL_ERROR_ETIMEDOUT;
+        }
+
         // Create waiting thread object and add it into the list of waiters.
         WaitingThread waiter{need_count, is_fifo};
         const auto it = AddWaiter(&waiter);


### PR DESCRIPTION
A fix for games which send a timeout of 0 when calling Wait on the Semaphore