### PR TITLE
Cache Windows CIs, solution by @Artalus

### DIFF
--- a/.github/workflows/linux-qt.yml
+++ b/.github/workflows/linux-qt.yml
@@ -25,10 +25,10 @@ jobs:
       run: >
        sudo apt-get update && sudo apt install libx11-dev libxext-dev libwayland-dev libfuse2 clang build-essential qt6-base-dev qt6-tools-dev
 
-    - name: Cache CMake dependency source code
+    - name: Cache CMake Configuration
       uses: actions/cache@v4
       env:
-          cache-name: ${{ runner.os }}-qt-cache-cmake-dependency-sources
+          cache-name: ${{ runner.os }}-qt-cache-cmake-configuration
       with:
           path: | 
             ${{github.workspace}}/build
@@ -36,10 +36,10 @@ jobs:
           restore-keys: |
             ${{ env.cache-name }}-
 
-    - name: Cache CMake dependency build objects
+    - name: Cache CMake Build
       uses: hendrikmuhs/ccache-action@v1.2.14
       env:
-          cache-name: ${{ runner.os }}-qt-cache-cmake-dependency-builds
+          cache-name: ${{ runner.os }}-qt-cache-cmake-build
       with:
         append-timestamp: false
         key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,10 +25,10 @@ jobs:
       run: >
        sudo apt-get update && sudo apt install libx11-dev libxext-dev libwayland-dev libfuse2 clang build-essential
 
-    - name: Cache CMake dependency source code
+    - name: Cache CMake Configuration
       uses: actions/cache@v4
       env:
-          cache-name: ${{ runner.os }}-sdl-cache-cmake-dependency-sources
+          cache-name: ${{ runner.os }}-sdl-cache-cmake-configuration
       with:
           path: | 
             ${{github.workspace}}/build
@@ -36,10 +36,10 @@ jobs:
           restore-keys: |
             ${{ env.cache-name }}-
 
-    - name: Cache CMake dependency build objects
+    - name: Cache CMake Build
       uses: hendrikmuhs/ccache-action@v1.2.14
       env:
-          cache-name: ${{ runner.os }}-sdl-cache-cmake-dependency-builds
+          cache-name: ${{ runner.os }}-sdl-cache-cmake-build
       with:
         append-timestamp: false
         key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}

--- a/.github/workflows/macos-qt.yml
+++ b/.github/workflows/macos-qt.yml
@@ -40,10 +40,10 @@ jobs:
         arch: clang_64
         archives: qtbase qttools
 
-    - name: Cache CMake dependency source code
+    - name: Cache CMake Configuration
       uses: actions/cache@v4
       env:
-          cache-name: ${{ runner.os }}-qt-cache-cmake-dependency-sources
+          cache-name: ${{ runner.os }}-qt-cache-cmake-configuration
       with:
           path: | 
             ${{github.workspace}}/build
@@ -51,10 +51,10 @@ jobs:
           restore-keys: |
             ${{ env.cache-name }}-
 
-    - name: Cache CMake dependency build objects
+    - name: Cache CMake Build
       uses: hendrikmuhs/ccache-action@v1.2.14
       env:
-          cache-name: ${{runner.os}}-qt-cache-cmake-dependency-builds
+          cache-name: ${{runner.os}}-qt-cache-cmake-build
       with:
         append-timestamp: false
         create-symlink: true

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -31,10 +31,10 @@ jobs:
         arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
         arch -x86_64 /usr/local/bin/brew install molten-vk
 
-    - name: Cache CMake dependency source code
+    - name: Cache CMake Configuration
       uses: actions/cache@v4
       env:
-          cache-name: ${{ runner.os }}-sdl-cache-cmake-dependency-sources
+          cache-name: ${{ runner.os }}-sdl-cache-cmake-configuration
       with:
           path: | 
             ${{github.workspace}}/build
@@ -42,10 +42,10 @@ jobs:
           restore-keys: |
             ${{ env.cache-name }}-
 
-    - name: Cache CMake dependency build objects
+    - name: Cache CMake Build
       uses: hendrikmuhs/ccache-action@v1.2.14
       env:
-          cache-name: ${{runner.os}}-sdl-cache-cmake-dependency-builds
+          cache-name: ${{runner.os}}-sdl-cache-cmake-build
       with:
         append-timestamp: false
         create-symlink: true

--- a/.github/workflows/windows-qt.yml
+++ b/.github/workflows/windows-qt.yml
@@ -41,8 +41,21 @@ jobs:
           restore-keys: |
             ${{ env.cache-name }}-
 
+    - name: Cache CMake dependency build objects
+      uses: hendrikmuhs/ccache-action@v1.2.14
+      env:
+          cache-name: ${{ runner.os }}-qt-cache-cmake-dependency-builds
+      with:
+        append-timestamp: false
+        key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+
+    - name: Setup VS Environment
+      uses: ilammy/msvc-dev-cmd@v1.13.0
+      with:
+        arch: amd64
+
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -T ClangCL -DENABLE_QT_GUI=ON
+      run: cmake -G Ninja -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_QT_GUI=ON -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel
@@ -50,8 +63,8 @@ jobs:
     - name: Deploy
       run: |
         mkdir upload
-        move build/Release/shadPS4.exe upload
-        windeployqt --dir upload upload/shadPS4.exe
+        move build/shadPS4.exe upload
+        windeployqt --no-compiler-runtime --dir upload upload/shadPS4.exe
         
     - name: Get date and git hash
       id: vars

--- a/.github/workflows/windows-qt.yml
+++ b/.github/workflows/windows-qt.yml
@@ -64,7 +64,7 @@ jobs:
       run: |
         mkdir upload
         move build/shadPS4.exe upload
-        windeployqt --no-compiler-runtime --dir upload upload/shadPS4.exe
+        windeployqt --no-compiler-runtime --no-system-d3d-compiler --no-system-dxc-compiler --dir upload upload/shadPS4.exe
         
     - name: Get date and git hash
       id: vars

--- a/.github/workflows/windows-qt.yml
+++ b/.github/workflows/windows-qt.yml
@@ -30,10 +30,10 @@ jobs:
         arch: win64_msvc2019_64
         archives: qtbase qttools
 
-    - name: Cache CMake dependency source code
+    - name: Cache CMake Configuration
       uses: actions/cache@v4
       env:
-          cache-name: ${{ runner.os }}-qt-cache-cmake-dependency-sources
+          cache-name: ${{ runner.os }}-qt-ninja-cache-cmake-configuration
       with:
           path: | 
             ${{github.workspace}}/build
@@ -41,10 +41,10 @@ jobs:
           restore-keys: |
             ${{ env.cache-name }}-
 
-    - name: Cache CMake dependency build objects
+    - name: Cache CMake Build
       uses: hendrikmuhs/ccache-action@v1.2.14
       env:
-          cache-name: ${{ runner.os }}-qt-cache-cmake-dependency-builds
+          cache-name: ${{ runner.os }}-qt-cache-cmake-build
       with:
         append-timestamp: false
         key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,10 +20,10 @@ jobs:
       with:
           submodules: recursive
 
-    - name: Cache CMake dependency source code
+    - name: Cache CMake Configuration
       uses: actions/cache@v4
       env:
-          cache-name: ${{ runner.os }}-sdl-cache-cmake-dependency-sources
+          cache-name: ${{ runner.os }}-sdl-ninja-cache-cmake-configuration
       with:
           path: | 
             ${{github.workspace}}/build
@@ -31,10 +31,10 @@ jobs:
           restore-keys: |
             ${{ env.cache-name }}-
 
-    - name: Cache CMake dependency build objects
+    - name: Cache CMake Build
       uses: hendrikmuhs/ccache-action@v1.2.14
       env:
-          cache-name: ${{ runner.os }}-sdl-cache-cmake-dependency-builds
+          cache-name: ${{ runner.os }}-sdl-cache-cmake-build
       with:
         append-timestamp: false
         key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,8 +31,21 @@ jobs:
           restore-keys: |
             ${{ env.cache-name }}-
 
+    - name: Cache CMake dependency build objects
+      uses: hendrikmuhs/ccache-action@v1.2.14
+      env:
+          cache-name: ${{ runner.os }}-sdl-cache-cmake-dependency-builds
+      with:
+        append-timestamp: false
+        key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+
+    - name: Setup VS Environment
+      uses: ilammy/msvc-dev-cmd@v1.13.0
+      with:
+        arch: amd64
+
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -T ClangCL
+      run: cmake -G Ninja -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel
@@ -49,4 +62,4 @@ jobs:
       with:
         name: shadps4-win64-sdl-${{ steps.vars.outputs.date }}-${{ steps.vars.outputs.shorthash }}
         path: |
-          ${{github.workspace}}/build/Release/shadPS4.exe
+          ${{github.workspace}}/build/shadPS4.exe


### PR DESCRIPTION
Windows CI time was too slow, so our hero @Artalus managed to find a way to use Ninja generator with `ccache` and bring down the build time to ~4/5 min.

- Fully resolves #542

### Extra changes

- Use simple cache names and cache step names to be more concise and cleaner for all OSes;
- Remove unused DLLs from Windows builds.

**Expect all caches to be regenerated, so the first run is not cached and will be around ~10min.**