### PR TITLE
videoout: Make present thread realtime on macOS.

### DIFF
--- a/src/common/thread.h
+++ b/src/common/thread.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <chrono>
 #include "common/types.h"
 
 namespace Common {
@@ -15,6 +16,8 @@ enum class ThreadPriority : u32 {
     VeryHigh = 3,
     Critical = 4,
 };
+
+void SetCurrentThreadRealtime(std::chrono::nanoseconds period_ns);
 
 void SetCurrentThreadPriority(ThreadPriority new_priority);
 


### PR DESCRIPTION
Adds a helper to set up threads with real-time scheduling, and uses it in `videoout` for the present thread to make sure the sleep timing for v-blanks is as accurate as possible. This fixes issues on macOS where presenting is too slow due to inaccurate sleep timing. I've also extended the v-blank period out to nanoseconds to make it more precise since it was actually running slightly too fast after fixing the sleep times; this may need further tuning to the exact v-blank period of the PS4, but for now it's just set for 60 FPS.

Note that the real-time scheduling helper is only implemented for macOS currently. If any other platforms need it in the future, it can be implemented for them as well, but I don't have the knowledge necessary to implement this for all platforms.