### PR TITLE
QOL: Set Log Filter On Save

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -144,6 +144,10 @@ public:
         initialization_in_progress_suppress_logging = false;
     }
 
+    static bool IsActive() {
+        return instance != nullptr;
+    }
+
     static void Start() {
         instance->StartBackendThread();
     }
@@ -273,6 +277,10 @@ private:
 
 void Initialize(std::string_view log_file) {
     Impl::Initialize(log_file.empty() ? LOG_FILE : log_file);
+}
+
+bool IsActive() {
+    return Impl::IsActive();
 }
 
 void Start() {

--- a/src/common/logging/backend.h
+++ b/src/common/logging/backend.h
@@ -13,6 +13,8 @@ class Filter;
 /// Initializes the logging system. This should be the first thing called in main.
 void Initialize(std::string_view log_file = "");
 
+bool IsActive();
+
 /// Starts the logging threads.
 void Start();
 

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -4,8 +4,8 @@
 #include <QCompleter>
 #include <QDirIterator>
 
-#include "common/logging/filter.h"
 #include "common/logging/backend.h"
+#include "common/logging/filter.h"
 #include "main_window.h"
 #include "settings_dialog.h"
 #include "ui_settings_dialog.h"

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -4,6 +4,8 @@
 #include <QCompleter>
 #include <QDirIterator>
 
+#include "common/logging/filter.h"
+#include "common/logging/backend.h"
 #include "main_window.h"
 #include "settings_dialog.h"
 #include "ui_settings_dialog.h"
@@ -77,6 +79,11 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices, QWidge
                 } else if (button == ui->buttonBox->button(QDialogButtonBox::RestoreDefaults)) {
                     Config::setDefaultValues();
                     LoadValuesFromConfig();
+                }
+                if (Common::Log::IsActive()) {
+                    Common::Log::Filter filter;
+                    filter.ParseFilterString(Config::getLogFilter());
+                    Common::Log::SetGlobalFilter(filter);
                 }
             });
 


### PR DESCRIPTION
It's really annoying to have to reboot a game just to change a log filter, so this should make it so that when save is pressed, it sets the log filter without having to.