### PR TITLE
vulkan: Use closest available equivalent to missing clamp modes.

### DIFF
--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -199,8 +199,17 @@ vk::SamplerAddressMode ClampMode(AmdGpu::ClampMode mode) {
         return vk::SamplerAddressMode::eMirroredRepeat;
     case AmdGpu::ClampMode::ClampLastTexel:
         return vk::SamplerAddressMode::eClampToEdge;
+    case AmdGpu::ClampMode::MirrorOnceHalfBorder:
+    case AmdGpu::ClampMode::MirrorOnceBorder:
+        LOG_WARNING(Render_Vulkan, "Unimplemented clamp mode {}, using closest equivalent.",
+                    static_cast<u32>(mode));
+        [[fallthrough]];
     case AmdGpu::ClampMode::MirrorOnceLastTexel:
         return vk::SamplerAddressMode::eMirrorClampToEdge;
+    case AmdGpu::ClampMode::ClampHalfBorder:
+        LOG_WARNING(Render_Vulkan, "Unimplemented clamp mode {}, using closest equivalent.",
+                    static_cast<u32>(mode));
+        [[fallthrough]];
     case AmdGpu::ClampMode::ClampBorder:
         return vk::SamplerAddressMode::eClampToBorder;
     default:

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -309,6 +309,7 @@ bool Instance::CreateDevice() {
             .separateDepthStencilLayouts = vk12_features.separateDepthStencilLayouts,
             .hostQueryReset = vk12_features.hostQueryReset,
             .timelineSemaphore = vk12_features.timelineSemaphore,
+            .samplerMirrorClampToEdge = vk12_features.samplerMirrorClampToEdge,
         },
         vk::PhysicalDeviceMaintenance4FeaturesKHR{
             .maintenance4 = true,


### PR DESCRIPTION
Adding support for these clamp modes will likely require non-trivial sampler addressing emulation in shaders. For now, warn and use the closest available equivalent to enable games that use them to function.

Also set `samplerMirrorClampToEdge` in the Vulkan 1.2 features since it is required for using `vk::SamplerAddressMode::eMirrorClampToEdge`.