### PR TITLE
shader_recompiler: Use SetDst in more instructions.

### DIFF
--- a/src/shader_recompiler/frontend/translate/vector_interpolation.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_interpolation.cpp
@@ -22,17 +22,15 @@ void Translator::EmitVectorInterpolation(const GcnInst& inst) {
 // VINTRP
 
 void Translator::V_INTERP_P2_F32(const GcnInst& inst) {
-    const IR::VectorReg dst_reg{inst.dst[0].code};
     auto& attr = runtime_info.fs_info.inputs.at(inst.control.vintrp.attr);
     const IR::Attribute attrib{IR::Attribute::Param0 + attr.param_index};
-    ir.SetVectorReg(dst_reg, ir.GetAttribute(attrib, inst.control.vintrp.chan));
+    SetDst(inst.dst[0], ir.GetAttribute(attrib, inst.control.vintrp.chan));
 }
 
 void Translator::V_INTERP_MOV_F32(const GcnInst& inst) {
-    const IR::VectorReg dst_reg{inst.dst[0].code};
     auto& attr = runtime_info.fs_info.inputs.at(inst.control.vintrp.attr);
     const IR::Attribute attrib{IR::Attribute::Param0 + attr.param_index};
-    ir.SetVectorReg(dst_reg, ir.GetAttribute(attrib, inst.control.vintrp.chan));
+    SetDst(inst.dst[0], ir.GetAttribute(attrib, inst.control.vintrp.chan));
 }
 
 } // namespace Shader::Gcn


### PR DESCRIPTION
Fix up some places where the destination register was hardcoded as a basic vector register by using `SetDst` instead, to make sure all the necessary transformations are applied.

Fixes incorrect screen rendering in CUSA16429 due to a missing multiply by 2 on a destination.