### PR TITLE
shader_recompiler: Exclude non-float results from output modifiers.

### DIFF
--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -281,12 +281,15 @@ template IR::F64 Translator::GetSrc64<IR::F64>(const InstOperand&);
 
 void Translator::SetDst(const InstOperand& operand, const IR::U32F32& value) {
     IR::U32F32 result = value;
-    if (operand.output_modifier.multiplier != 0.f) {
-        result = ir.FPMul(result, ir.Imm32(operand.output_modifier.multiplier));
+    if (value.Type() == IR::Type::F32) {
+        if (operand.output_modifier.multiplier != 0.f) {
+            result = ir.FPMul(result, ir.Imm32(operand.output_modifier.multiplier));
+        }
+        if (operand.output_modifier.clamp) {
+            result = ir.FPSaturate(value);
+        }
     }
-    if (operand.output_modifier.clamp) {
-        result = ir.FPSaturate(value);
-    }
+
     switch (operand.field) {
     case OperandField::ScalarGPR:
         return ir.SetScalarReg(IR::ScalarReg(operand.code), result);

--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -567,8 +567,7 @@ void Translator::V_ADDC_U32(const GcnInst& inst) {
     const IR::U32 scarry = IR::U32{ir.Select(carry, ir.Imm32(1), ir.Imm32(0))};
     const IR::U32 result = ir.IAdd(ir.IAdd(src0, src1), scarry);
 
-    const IR::VectorReg dst_reg{inst.dst[0].code};
-    ir.SetVectorReg(dst_reg, result);
+    SetDst(inst.dst[0], result);
 
     const IR::U1 less_src0 = ir.ILessThan(result, src0, false);
     const IR::U1 less_src1 = ir.ILessThan(result, src1, false);


### PR DESCRIPTION
* Exclude non-floating point result values from output modifiers as defined in the spec. This is also already how we treat source input modifiers and destination output modifiers for 64-bit values.
* Re-enable `SetDst` for `V_ADDC_U32` as this fixes the issue.