### PR TITLE
core: Reduce some library log spam.

### DIFF
--- a/src/core/libraries/kernel/event_flag/event_flag.cpp
+++ b/src/core/libraries/kernel/event_flag/event_flag.cpp
@@ -137,7 +137,7 @@ int PS4_SYSV_ABI sceKernelPollEventFlag(OrbisKernelEventFlag ef, u64 bitPattern,
 
     auto result = ef->Poll(bitPattern, wait, clear, pResultPat);
 
-    if (result != ORBIS_OK) {
+    if (result != ORBIS_OK && result != ORBIS_KERNEL_ERROR_EBUSY) {
         LOG_ERROR(Kernel_Event, "returned {}", result);
     }
 

--- a/src/core/libraries/system/systemservice.cpp
+++ b/src/core/libraries/system/systemservice.cpp
@@ -1717,7 +1717,7 @@ int PS4_SYSV_ABI sceSystemServiceGetAppType() {
 
 s32 PS4_SYSV_ABI
 sceSystemServiceGetDisplaySafeAreaInfo(OrbisSystemServiceDisplaySafeAreaInfo* info) {
-    LOG_INFO(Lib_SystemService, "called");
+    LOG_DEBUG(Lib_SystemService, "called");
     if (info == nullptr) {
         LOG_ERROR(Lib_SystemService, "OrbisSystemServiceDisplaySafeAreaInfo is null");
         return ORBIS_SYSTEM_SERVICE_ERROR_PARAMETER;


### PR DESCRIPTION
Two tweaks to make some games' logs more readable:
* Don't log error when `sceKernelPollEventFlag` returns `ORBIS_KERNEL_ERROR_EBUSY`, which can be very common and expected.
* Reduce `sceSystemServiceGetDisplaySafeAreaInfo` to debug as some games spam it a lot.