### PR TITLE
Add nullptr check in scePthreadSetprio function

### DIFF
--- a/src/core/libraries/kernel/thread_management.cpp
+++ b/src/core/libraries/kernel/thread_management.cpp
@@ -1512,6 +1512,10 @@ int PS4_SYSV_ABI scePthreadGetprio(ScePthread thread, int* prio) {
     return ORBIS_OK;
 }
 int PS4_SYSV_ABI scePthreadSetprio(ScePthread thread, int prio) {
+    if (thread == nullptr) {
+        LOG_ERROR(Kernel_Pthread, "scePthreadSetprio: thread is nullptr");
+        return ORBIS_KERNEL_ERROR_EINVAL;
+    }
     thread->prio = prio;
     return ORBIS_OK;
 }


### PR DESCRIPTION
Apparently sometimes scePthreadSetprio gets called with 0 as thread. Guard against that.

With this, I can get past first menu and up until intro cutscene in CUSA03365 (Dark Souls III).
Before this, it crashed within a few seconds of starting up.

DS3 tries to set prio to nullptr-threads 7 times

![image](https://github.com/user-attachments/assets/1358e49f-2345-43c1-95e4-cfd2622094c9)

![image](https://github.com/user-attachments/assets/0b0b0981-2420-4795-a585-2842a678d12d)

Log with this: now crashes with `vk::Device::waitForFences: ErrorDeviceLost` in intro cutscene
[shad_log.txt](https://github.com/user-attachments/files/17091219/shad_log.txt)
