### PR TITLE
Remove dead vs inputs in spir-v, and don't bind corresponding vbo

### DIFF
--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -238,6 +238,10 @@ void EmitContext::DefineInputs() {
                     false,    input.instance_data_buf,
                 };
             } else {
+                if (!info.loads.GetAny(IR::Attribute::Param0 + input.binding)) {
+                    continue;
+                }
+
                 Id id{DefineInput(type, input.binding)};
                 if (input.instance_step_rate == Info::VsInput::InstanceIdType::Plain) {
                     Name(id, fmt::format("vs_instance_attr{}", input.binding));

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -138,12 +138,8 @@ bool BufferCache::BindVertexBuffers(const Shader::Info& vs_info) {
         }
 
         const auto& buffer = vs_info.ReadUd<AmdGpu::Buffer>(input.sgpr_base, input.dword_offset);
-        bool live_input = vs_info.loads.GetAny(Shader::IR::Attribute::Param0 + input.binding);
-        if (buffer.GetSize() == 0 || !live_input) {
-            if (buffer.GetSize() == 0 && live_input) {
-                LOG_WARNING(Render_Vulkan,
-                            "Vertex input looks live but has no corresponding vertex buffer");
-            }
+        if (buffer.GetSize() == 0 ||
+            !vs_info.loads.GetAny(Shader::IR::Attribute::Param0 + input.binding)) {
             continue;
         }
         guest_buffers.emplace_back(buffer);


### PR DESCRIPTION
Fixes a validation error about vkCmdSetVertexInputEXT(). If the V#
corresponding to an input semantic has size 0, BindVertexBuffers() won't
bind any buffer and wont add vulkan BindingInfo/AttributeInfo for that semantic.
Detect and remove dead vs inputs from the vs spirv so there aren't spirv Input vars without vertex input info.

Ideally when the buffer is empty, the spirv attribute should be dead.
Seen this happen because of empty V#s with dst_sel == 0001

example
[Render.Vulkan] <Error> [thread GPU_CommandProc, tid=456257] vk_platform.cpp:DebugUtilsCallback:68: VUID-vkCmdDrawIndexed-Input-07939: Validation Error: [ VUID-vkCmdDrawIndexed-Input-07939 ] Object 0: handle = 0xe5f5e400000015b9, name = vs_0x9e267629561c22fe_0, type = VK_OBJECT_TYPE_SHADER_MODULE; | MessageID = 0x8d9172cc | vkCmdDrawIndexed():  Vertex shader uses input at location 4, but it was not provided with vkCmdSetVertexInputEXT(). The Vulkan spec states: If there is a shader object bound to the VK_SHADER_STAGE_VERTEX_BIT stage or the bound graphics pipeline state was created with the VK_DYNAMIC_STATE_VERTEX_INPUT_EXT dynamic state enabled then all variables with the Input storage class decorated with Location in the Vertex Execution Model OpEntryPoint must contain a location in VkVertexInputAttributeDescription2EXT::location (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkCmdDrawIndexed-Input-07939)