### PR TITLE
video_core: Separate dirty flags and better gpu invalidation

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -17,7 +17,7 @@ namespace VideoCore {
 static constexpr size_t NumVertexBuffers = 32;
 static constexpr size_t GdsBufferSize = 64_KB;
 static constexpr size_t StagingBufferSize = 1_GB;
-static constexpr size_t UboStreamBufferSize = 128_MB;
+static constexpr size_t UboStreamBufferSize = 64_MB;
 
 BufferCache::BufferCache(const Vulkan::Instance& instance_, Vulkan::Scheduler& scheduler_,
                          const AmdGpu::Liverpool* liverpool_, TextureCache& texture_cache_,

--- a/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
@@ -199,7 +199,7 @@ bool ComputePipeline::BindResources(VideoCore::BufferCache& buffer_cache,
                 buffer_barriers.emplace_back(*barrier);
             }
             if (desc.is_written) {
-                texture_cache.MarkWritten(address, size);
+                texture_cache.InvalidateMemoryFromGPU(address, size);
             }
         }
         set_writes.push_back({

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -431,7 +431,7 @@ void GraphicsPipeline::BindResources(const Liverpool::Regs& regs,
                     buffer_barriers.emplace_back(*barrier);
                 }
                 if (desc.is_written) {
-                    texture_cache.MarkWritten(address, size);
+                    texture_cache.InvalidateMemoryFromGPU(address, size);
                 }
             }
             set_writes.push_back({

--- a/src/video_core/texture_cache/image.h
+++ b/src/video_core/texture_cache/image.h
@@ -5,13 +5,9 @@
 
 #include "common/enum.h"
 #include "common/types.h"
-#include "core/libraries/videoout/buffer.h"
-#include "video_core/amdgpu/liverpool.h"
-#include "video_core/amdgpu/resource.h"
 #include "video_core/renderer_vulkan/vk_common.h"
 #include "video_core/texture_cache/image_info.h"
 #include "video_core/texture_cache/image_view.h"
-#include "video_core/texture_cache/types.h"
 
 #include <optional>
 
@@ -26,7 +22,9 @@ VK_DEFINE_HANDLE(VmaAllocator)
 namespace VideoCore {
 
 enum ImageFlagBits : u32 {
-    CpuModified = 1 << 2,    ///< Contents have been modified from the CPU
+    CpuDirty = 1 << 1, ///< Contents have been modified from the CPU
+    GpuDirty = 1 << 2, ///< Contents have been modified from the GPU (valid data in buffer cache)
+    Dirty = CpuDirty | GpuDirty,
     GpuModified = 1 << 3,    ///< Contents have been modified from the GPU
     Tracked = 1 << 4,        ///< Writes and reads are being hooked from the CPU
     Registered = 1 << 6,     ///< True when the image is registered
@@ -108,7 +106,7 @@ struct Image {
     ImageInfo info;
     UniqueImage image;
     vk::ImageAspectFlags aspect_mask = vk::ImageAspectFlagBits::eColor;
-    ImageFlagBits flags = ImageFlagBits::CpuModified;
+    ImageFlagBits flags = ImageFlagBits::Dirty;
     VAddr cpu_addr = 0;
     VAddr cpu_addr_end = 0;
     std::vector<ImageViewInfo> image_view_infos;

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -51,7 +51,7 @@ public:
     void InvalidateMemory(VAddr address, size_t size);
 
     /// Marks an image as dirty if it exists at the provided address.
-    void MarkWritten(VAddr address, size_t max_size);
+    void InvalidateMemoryFromGPU(VAddr address, size_t max_size);
 
     /// Evicts any images that overlap the unmapped range.
     void UnmapMemory(VAddr cpu_addr, size_t size);


### PR DESCRIPTION
Some games like RDR keep overlapping framebuffers in the same address and have the same pitch, but different dimentions. This resulted in cases where MarkWritten would invalidate the wrong FB, leaving the one the game actually wanted to use later with data from the previous frame.

To fix this mark all overlapping images with matching address as dirty. Also separate the dirty flags for gpu and cpu dirtiness which makes the code more explicit/clear while at it