### PR TITLE
core/memory: Fix `sceKernelMTypeProtect` setting VMA type

### DIFF
--- a/src/core/libraries/kernel/memory_management.cpp
+++ b/src/core/libraries/kernel/memory_management.cpp
@@ -228,7 +228,7 @@ int PS4_SYSV_ABI sceKernelMProtect(const void* addr, size_t size, int prot) {
 int PS4_SYSV_ABI sceKernelMTypeProtect(const void* addr, size_t size, int mtype, int prot) {
     Core::MemoryManager* memory_manager = Core::Memory::Instance();
     Core::MemoryProt protection_flags = static_cast<Core::MemoryProt>(prot);
-    return memory_manager->MTypeProtect(std::bit_cast<VAddr>(addr), size, protection_flags);
+    return memory_manager->Protect(std::bit_cast<VAddr>(addr), size, protection_flags);
 }
 
 int PS4_SYSV_ABI sceKernelDirectMemoryQuery(u64 offset, int flags, OrbisQueryInfo* query_info,

--- a/src/core/libraries/kernel/memory_management.cpp
+++ b/src/core/libraries/kernel/memory_management.cpp
@@ -228,8 +228,7 @@ int PS4_SYSV_ABI sceKernelMProtect(const void* addr, size_t size, int prot) {
 int PS4_SYSV_ABI sceKernelMTypeProtect(const void* addr, size_t size, int mtype, int prot) {
     Core::MemoryManager* memory_manager = Core::Memory::Instance();
     Core::MemoryProt protection_flags = static_cast<Core::MemoryProt>(prot);
-    return memory_manager->MTypeProtect(std::bit_cast<VAddr>(addr), size,
-                                        static_cast<Core::VMAType>(mtype), protection_flags);
+    return memory_manager->MTypeProtect(std::bit_cast<VAddr>(addr), size, protection_flags);
 }
 
 int PS4_SYSV_ABI sceKernelDirectMemoryQuery(u64 offset, int flags, OrbisQueryInfo* query_info,

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -348,62 +348,6 @@ int MemoryManager::Protect(VAddr addr, size_t size, MemoryProt prot) {
     return ORBIS_OK;
 }
 
-int MemoryManager::MTypeProtect(VAddr addr, size_t size, MemoryProt prot) {
-    std::scoped_lock lk{mutex};
-
-    // Find the virtual memory area that contains the specified address range.
-    auto it = FindVMA(addr);
-    if (it == vma_map.end() || !it->second.Contains(addr, size)) {
-        LOG_ERROR(Core, "Address range not mapped");
-        return ORBIS_KERNEL_ERROR_EINVAL;
-    }
-
-    VirtualMemoryArea& vma = it->second;
-
-    if (vma.type == VMAType::Free) {
-        LOG_ERROR(Core, "Cannot change protection on free memory region");
-        return ORBIS_KERNEL_ERROR_EINVAL;
-    }
-
-    // Validate protection flags
-    constexpr static MemoryProt valid_flags = MemoryProt::NoAccess | MemoryProt::CpuRead |
-                                              MemoryProt::CpuReadWrite | MemoryProt::GpuRead |
-                                              MemoryProt::GpuWrite | MemoryProt::GpuReadWrite;
-
-    MemoryProt invalid_flags = prot & ~valid_flags;
-    if (u32(invalid_flags) != 0 && u32(invalid_flags) != u32(MemoryProt::NoAccess)) {
-        LOG_ERROR(Core, "Invalid protection flags: prot = {:#x}, invalid flags = {:#x}", u32(prot),
-                  u32(invalid_flags));
-        return ORBIS_KERNEL_ERROR_EINVAL;
-    }
-
-    // Change protection
-    vma.prot = prot;
-
-    // Set permissions
-    Core::MemoryPermission perms{};
-
-    if (True(prot & MemoryProt::CpuRead)) {
-        perms |= Core::MemoryPermission::Read;
-    }
-    if (True(prot & MemoryProt::CpuReadWrite)) {
-        perms |= Core::MemoryPermission::ReadWrite;
-    }
-    if (True(prot & MemoryProt::GpuRead)) {
-        perms |= Core::MemoryPermission::Read;
-    }
-    if (True(prot & MemoryProt::GpuWrite)) {
-        perms |= Core::MemoryPermission::Write;
-    }
-    if (True(prot & MemoryProt::GpuReadWrite)) {
-        perms |= Core::MemoryPermission::ReadWrite;
-    }
-
-    impl.Protect(addr, size, perms);
-
-    return ORBIS_OK;
-}
-
 int MemoryManager::VirtualQuery(VAddr addr, int flags,
                                 ::Libraries::Kernel::OrbisVirtualQueryInfo* info) {
     std::scoped_lock lk{mutex};

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -348,7 +348,7 @@ int MemoryManager::Protect(VAddr addr, size_t size, MemoryProt prot) {
     return ORBIS_OK;
 }
 
-int MemoryManager::MTypeProtect(VAddr addr, size_t size, VMAType mtype, MemoryProt prot) {
+int MemoryManager::MTypeProtect(VAddr addr, size_t size, MemoryProt prot) {
     std::scoped_lock lk{mutex};
 
     // Find the virtual memory area that contains the specified address range.
@@ -377,8 +377,7 @@ int MemoryManager::MTypeProtect(VAddr addr, size_t size, VMAType mtype, MemoryPr
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
 
-    // Change type and protection
-    vma.type = mtype;
+    // Change protection
     vma.prot = prot;
 
     // Set permissions

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -166,8 +166,6 @@ public:
 
     int Protect(VAddr addr, size_t size, MemoryProt prot);
 
-    int MTypeProtect(VAddr addr, size_t size, MemoryProt prot);
-
     int VirtualQuery(VAddr addr, int flags, ::Libraries::Kernel::OrbisVirtualQueryInfo* info);
 
     int DirectMemoryQuery(PAddr addr, bool find_next,

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -166,7 +166,7 @@ public:
 
     int Protect(VAddr addr, size_t size, MemoryProt prot);
 
-    int MTypeProtect(VAddr addr, size_t size, VMAType mtype, MemoryProt prot);
+    int MTypeProtect(VAddr addr, size_t size, MemoryProt prot);
 
     int VirtualQuery(VAddr addr, int flags, ::Libraries::Kernel::OrbisVirtualQueryInfo* info);
 


### PR DESCRIPTION
Fixes a regression from https://github.com/shadps4-emu/shadPS4/pull/387.