### PR TITLE
 amdgpu: Fix buffer comparison by naming padding fields for initialization.

### DIFF
--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -23,7 +23,7 @@ enum class CompSwizzle : u32 {
 // Table 8.5 Buffer Resource Descriptor [Sea Islands Series Instruction Set Architecture]
 struct Buffer {
     u64 base_address : 44;
-    u64 : 4;
+    u64 _padding0 : 4;
     u64 stride : 14;
     u64 cache_swizzle : 1;
     u64 swizzle_enable : 1;
@@ -37,7 +37,7 @@ struct Buffer {
     u32 element_size : 2;
     u32 index_stride : 2;
     u32 add_tid_enable : 1;
-    u32 : 6;
+    u32 _padding1 : 6;
     u32 type : 2; // overlaps with T# type, so should be 0 for buffer
 
     bool Valid() const {


### PR DESCRIPTION
Comparing two buffers was not working because `memcmp` is not guaranteed to work properly for bitfield structs with anonymous padding, as the padding is not initialized.

This was causing some shaders to balloon in binding count since buffers were not properly being matched and de-duplicated. It also caused pipeline compilation failures in CUSA16429 since two different permutations could have different memcmp results in de-duplication and thus compile with different buffer bindings.