### PR TITLE
fix lane inst decoding

### DIFF
--- a/src/shader_recompiler/frontend/translate/data_share.cpp
+++ b/src/shader_recompiler/frontend/translate/data_share.cpp
@@ -64,7 +64,6 @@ void Translator::S_BARRIER() {
 // VOP2
 
 void Translator::V_READFIRSTLANE_B32(const GcnInst& inst) {
-    const IR::ScalarReg dst{inst.dst[0].code};
     const IR::U32 value{GetSrc(inst.src[0])};
 
     if (info.stage != Stage::Compute) {


### PR DESCRIPTION
these instructions were using dst[1] for some reason, even though the data_share.cpp implementations read from dst[0].
also fix how some of the src operands are treated
fixes issues with rb4