### PR TITLE
Don't attempt to promote eR8G8B8A8Unorm to depth

### DIFF
--- a/src/video_core/renderer_vulkan/liverpool_to_vk.h
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.h
@@ -57,14 +57,16 @@ vk::SampleCountFlagBits NumSamples(u32 num_samples, vk::SampleCountFlags support
 void EmitQuadToTriangleListIndices(u8* out_indices, u32 num_vertices);
 
 static inline vk::Format PromoteFormatToDepth(vk::Format fmt) {
-    if (fmt == vk::Format::eR32Sfloat) {
+    switch (fmt) {
+    case vk::Format::eR32Sfloat:
         return vk::Format::eD32Sfloat;
-    } else if (fmt == vk::Format::eR16Unorm) {
+    case vk::Format::eR16Unorm:
         return vk::Format::eD16Unorm;
-    } else if (fmt == vk::Format::eR8G8B8A8Unorm) {
+    case vk::Format::eR8G8B8A8Unorm:
         return fmt;
+    default:
+        UNREACHABLE();
     }
-    UNREACHABLE();
 }
 
 } // namespace Vulkan::LiverpoolToVK

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.h
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.h
@@ -61,6 +61,8 @@ static inline vk::Format PromoteFormatToDepth(vk::Format fmt) {
         return vk::Format::eD32Sfloat;
     } else if (fmt == vk::Format::eR16Unorm) {
         return vk::Format::eD16Unorm;
+    } else if (fmt == vk::Format::eR8G8B8A8Unorm) {
+        return fmt;
     }
     UNREACHABLE();
 }


### PR DESCRIPTION
Because eR8G8B8A8Unorm already has depth, it doesn't need to be converted. I also replaced the `else if` statement with a `switch`.

This fixes a crash in **Zombie Army Trilogy** (CUSA01837), but another error causes the game to crash right afterwards.