### PR TITLE
renderer_vulkan: Refactor surface and depth format mapping.

### DIFF
--- a/src/video_core/amdgpu/pixel_format.h
+++ b/src/video_core/amdgpu/pixel_format.h
@@ -43,6 +43,23 @@ enum class DataFormat : u32 {
     FormatBc5 = 39,
     FormatBc6 = 40,
     FormatBc7 = 41,
+    FormatFmask8_1 = 47,
+    FormatFmask8_2 = 48,
+    FormatFmask8_4 = 49,
+    FormatFmask16_1 = 50,
+    FormatFmask16_2 = 51,
+    FormatFmask32_2 = 52,
+    FormatFmask32_4 = 53,
+    FormatFmask32_8 = 54,
+    FormatFmask64_4 = 55,
+    FormatFmask64_8 = 56,
+    Format4_4 = 57,
+    Format6_5_5 = 58,
+    Format1 = 59,
+    Format1_Reversed = 60,
+    Format32_As_8 = 61,
+    Format32_As_8_8 = 62,
+    Format32_As_32_32_32_32 = 63,
 };
 
 enum class NumberFormat : u32 {

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.h
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.h
@@ -40,12 +40,26 @@ vk::SamplerMipmapMode MipFilter(AmdGpu::MipFilter filter);
 
 vk::BorderColor BorderColor(AmdGpu::BorderColor color);
 
-std::span<const vk::Format> GetAllFormats();
+struct SurfaceFormatInfo {
+    AmdGpu::DataFormat data_format;
+    AmdGpu::NumberFormat number_format;
+    vk::Format vk_format;
+    vk::FormatFeatureFlags2 flags;
+};
+std::span<const SurfaceFormatInfo> SurfaceFormats();
 
 vk::Format SurfaceFormat(AmdGpu::DataFormat data_format, AmdGpu::NumberFormat num_format);
 
 vk::Format AdjustColorBufferFormat(vk::Format base_format,
                                    Liverpool::ColorBuffer::SwapMode comp_swap, bool is_vo_surface);
+
+struct DepthFormatInfo {
+    Liverpool::DepthBuffer::ZFormat z_format;
+    Liverpool::DepthBuffer::StencilFormat stencil_format;
+    vk::Format vk_format;
+    vk::FormatFeatureFlags2 flags;
+};
+std::span<const DepthFormatInfo> DepthFormats();
 
 vk::Format DepthFormat(Liverpool::DepthBuffer::ZFormat z_format,
                        Liverpool::DepthBuffer::StencilFormat stencil_format);

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -30,11 +30,12 @@ public:
     std::string GetDriverVersionName();
 
     /// Gets a compatibility format if the format is not supported.
-    [[nodiscard]] vk::Format GetSupportedFormat(vk::Format format) const;
+    [[nodiscard]] vk::Format GetSupportedFormat(vk::Format format,
+                                                vk::FormatFeatureFlags2 flags) const;
 
     /// Re-orders a component swizzle for format compatibility, if needed.
     [[nodiscard]] vk::ComponentMapping GetSupportedComponentSwizzle(
-        vk::Format format, vk::ComponentMapping swizzle) const;
+        vk::Format format, vk::ComponentMapping swizzle, vk::FormatFeatureFlags2 flags) const;
 
     /// Returns the Vulkan instance
     vk::Instance GetInstance() const {
@@ -245,14 +246,8 @@ private:
     void CollectDeviceParameters();
     void CollectToolingInfo();
 
-    /// Determines if a format is supported for images.
-    [[nodiscard]] bool IsImageFormatSupported(vk::Format format) const;
-
-    /// Determines if a format is supported for vertex buffers.
-    [[nodiscard]] bool IsVertexFormatSupported(vk::Format format) const;
-
-    /// Gets a commonly available alternative for an unsupported pixel format.
-    vk::Format GetAlternativeFormat(const vk::Format format) const;
+    /// Determines if a format is supported for a set of feature flags.
+    [[nodiscard]] bool IsFormatSupported(vk::Format format, vk::FormatFeatureFlags2 flags) const;
 
 private:
     vk::UniqueInstance instance;

--- a/src/video_core/texture_cache/image.cpp
+++ b/src/video_core/texture_cache/image.cpp
@@ -86,6 +86,28 @@ static vk::ImageUsageFlags ImageUsageFlags(const ImageInfo& info) {
     return usage;
 }
 
+static vk::FormatFeatureFlags2 FormatFeatureFlags(const vk::ImageUsageFlags usage_flags) {
+    vk::FormatFeatureFlags2 feature_flags{};
+    if (usage_flags & vk::ImageUsageFlagBits::eTransferSrc) {
+        feature_flags |= vk::FormatFeatureFlagBits2::eTransferSrc;
+    }
+    if (usage_flags & vk::ImageUsageFlagBits::eTransferDst) {
+        feature_flags |= vk::FormatFeatureFlagBits2::eTransferDst;
+    }
+    if (usage_flags & vk::ImageUsageFlagBits::eSampled) {
+        feature_flags |= vk::FormatFeatureFlagBits2::eSampledImage;
+    }
+    if (usage_flags & vk::ImageUsageFlagBits::eColorAttachment) {
+        feature_flags |= vk::FormatFeatureFlagBits2::eColorAttachment;
+    }
+    if (usage_flags & vk::ImageUsageFlagBits::eDepthStencilAttachment) {
+        feature_flags |= vk::FormatFeatureFlagBits2::eDepthStencilAttachment;
+    }
+    // Note: StorageImage is intentionally ignored for now since it is always set, and can mess up
+    // compatibility checks.
+    return feature_flags;
+}
+
 UniqueImage::UniqueImage(vk::Device device_, VmaAllocator allocator_)
     : device{device_}, allocator{allocator_} {}
 
@@ -132,6 +154,7 @@ Image::Image(const Vulkan::Instance& instance_, Vulkan::Scheduler& scheduler_,
     }
 
     usage = ImageUsageFlags(info);
+    format_features = FormatFeatureFlags(usage);
 
     switch (info.pixel_format) {
     case vk::Format::eD16Unorm:
@@ -149,8 +172,7 @@ Image::Image(const Vulkan::Instance& instance_, Vulkan::Scheduler& scheduler_,
     }
 
     constexpr auto tiling = vk::ImageTiling::eOptimal;
-    const auto supported_format =
-        instance->GetSupportedFormat(info.pixel_format, vk::FormatFeatureFlagBits2::eSampledImage);
+    const auto supported_format = instance->GetSupportedFormat(info.pixel_format, format_features);
     const auto properties = instance->GetPhysicalDevice().getImageFormatProperties(
         supported_format, info.type, tiling, usage, flags);
     const auto supported_samples = properties.result == vk::Result::eSuccess

--- a/src/video_core/texture_cache/image.cpp
+++ b/src/video_core/texture_cache/image.cpp
@@ -149,7 +149,8 @@ Image::Image(const Vulkan::Instance& instance_, Vulkan::Scheduler& scheduler_,
     }
 
     constexpr auto tiling = vk::ImageTiling::eOptimal;
-    const auto supported_format = instance->GetSupportedFormat(info.pixel_format);
+    const auto supported_format =
+        instance->GetSupportedFormat(info.pixel_format, vk::FormatFeatureFlagBits2::eSampledImage);
     const auto properties = instance->GetPhysicalDevice().getImageFormatProperties(
         supported_format, info.type, tiling, usage, flags);
     const auto supported_samples = properties.result == vk::Result::eSuccess

--- a/src/video_core/texture_cache/image.h
+++ b/src/video_core/texture_cache/image.h
@@ -114,6 +114,7 @@ struct Image {
 
     // Resource state tracking
     vk::ImageUsageFlags usage;
+    vk::FormatFeatureFlags2 format_features;
     struct State {
         vk::Flags<vk::PipelineStageFlagBits2> pl_stage = vk::PipelineStageFlagBits2::eAllCommands;
         vk::Flags<vk::AccessFlagBits2> access_mask = vk::AccessFlagBits2::eNone;

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -164,8 +164,9 @@ ImageView::ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info
         .pNext = &usage_ci,
         .image = image.image,
         .viewType = info.type,
-        .format = instance.GetSupportedFormat(format),
-        .components = instance.GetSupportedComponentSwizzle(format, info.mapping),
+        .format = instance.GetSupportedFormat(format, vk::FormatFeatureFlagBits2::eSampledImage),
+        .components = instance.GetSupportedComponentSwizzle(
+            format, info.mapping, vk::FormatFeatureFlagBits2::eSampledImage),
         .subresourceRange{
             .aspectMask = aspect,
             .baseMipLevel = info.range.base.level,

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -164,9 +164,9 @@ ImageView::ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info
         .pNext = &usage_ci,
         .image = image.image,
         .viewType = info.type,
-        .format = instance.GetSupportedFormat(format, vk::FormatFeatureFlagBits2::eSampledImage),
-        .components = instance.GetSupportedComponentSwizzle(
-            format, info.mapping, vk::FormatFeatureFlagBits2::eSampledImage),
+        .format = instance.GetSupportedFormat(format, image.format_features),
+        .components =
+            instance.GetSupportedComponentSwizzle(format, info.mapping, image.format_features),
         .subresourceRange{
             .aspectMask = aspect,
             .baseMipLevel = info.range.base.level,


### PR DESCRIPTION
* Refactors surface and depth format mappings to be thoroughly catalogued, with a list of AMD GPU formats to their equivalent Vulkan format and possible usages from the docs. All formats that were represented before are still represented now.
* Refines boot-time format support logging to check and report using exactly the possible usages by the AMD GPU. Also downgraded to warnings since they may not be used by a game.
* Adds a few missing `DataFormat` values from the GPU docs.
* Adds a few additional format mappings where there was an equivalent Vulkan format.

There are still a few areas that could use work, for example the alternate color buffer formats are not well catalogued and the alternate format system could be refined a bit. Probably something for a future PR if I can think of a good way to clean those up.