### PR TITLE
Use UTF-8 in console

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -142,6 +142,10 @@ public:
         instance = std::unique_ptr<Impl, decltype(&Deleter)>(new Impl(log_dir / LOG_FILE, filter),
                                                              Deleter);
         initialization_in_progress_suppress_logging = false;
+#ifdef WIN32
+        // set console codepage to UTF-8
+        SetConsoleOutputCP(65001);
+#endif
     }
 
     static bool IsActive() {


### PR DESCRIPTION
I don't know if it is correct to put the code here, but I think it is correct to put it right after the console initialisation.

# Before
![image](https://github.com/user-attachments/assets/7a95ec7e-b741-43f0-90ef-25eddd0f7935)

# After
![image](https://github.com/user-attachments/assets/eb5f0839-d16e-4f8b-9ad7-318cd92f0da6)
