### PR TITLE
Fix build on GCC

### DIFF
--- a/src/video_core/texture_cache/tile_manager.cpp
+++ b/src/video_core/texture_cache/tile_manager.cpp
@@ -295,11 +295,10 @@ TileManager::TileManager(const Vulkan::Instance& instance, Vulkan::Scheduler& sc
             .bindingCount = static_cast<u32>(bindings.size()),
             .pBindings = bindings.data(),
         };
-        static auto desc_layout_pair =
+        auto [desc_layout_result, desc_layout] =
             instance.GetDevice().createDescriptorSetLayoutUnique(desc_layout_ci);
-        ASSERT_MSG(desc_layout_pair.result == vk::Result::eSuccess,
-                   "Failed to create descriptor set layout: {}",
-                   vk::to_string(desc_layout_pair.result));
+        ASSERT_MSG(desc_layout_result == vk::Result::eSuccess,
+                   "Failed to create descriptor set layout: {}", vk::to_string(desc_layout_result));
 
         const vk::PushConstantRange push_constants = {
             .stageFlags = vk::ShaderStageFlagBits::eCompute,
@@ -307,7 +306,7 @@ TileManager::TileManager(const Vulkan::Instance& instance, Vulkan::Scheduler& sc
             .size = sizeof(DetilerParams),
         };
 
-        const vk::DescriptorSetLayout set_layout = *desc_layout_pair.value;
+        const vk::DescriptorSetLayout set_layout = *desc_layout;
         const vk::PipelineLayoutCreateInfo layout_info = {
             .setLayoutCount = 1U,
             .pSetLayouts = &set_layout,

--- a/src/video_core/texture_cache/tile_manager.cpp
+++ b/src/video_core/texture_cache/tile_manager.cpp
@@ -295,10 +295,10 @@ TileManager::TileManager(const Vulkan::Instance& instance, Vulkan::Scheduler& sc
             .bindingCount = static_cast<u32>(bindings.size()),
             .pBindings = bindings.data(),
         };
-        static auto [desc_layout_result, desc_layout] =
+        static auto desc_layout_pair =
             instance.GetDevice().createDescriptorSetLayoutUnique(desc_layout_ci);
-        ASSERT_MSG(desc_layout_result == vk::Result::eSuccess,
-                   "Failed to create descriptor set layout: {}", vk::to_string(desc_layout_result));
+        ASSERT_MSG(desc_layout_pair.result == vk::Result::eSuccess,
+                   "Failed to create descriptor set layout: {}", vk::to_string(desc_layout_pair.result));
 
         const vk::PushConstantRange push_constants = {
             .stageFlags = vk::ShaderStageFlagBits::eCompute,
@@ -306,7 +306,7 @@ TileManager::TileManager(const Vulkan::Instance& instance, Vulkan::Scheduler& sc
             .size = sizeof(DetilerParams),
         };
 
-        const vk::DescriptorSetLayout set_layout = *desc_layout;
+        const vk::DescriptorSetLayout set_layout = *desc_layout_pair.value;
         const vk::PipelineLayoutCreateInfo layout_info = {
             .setLayoutCount = 1U,
             .pSetLayouts = &set_layout,

--- a/src/video_core/texture_cache/tile_manager.cpp
+++ b/src/video_core/texture_cache/tile_manager.cpp
@@ -298,7 +298,8 @@ TileManager::TileManager(const Vulkan::Instance& instance, Vulkan::Scheduler& sc
         static auto desc_layout_pair =
             instance.GetDevice().createDescriptorSetLayoutUnique(desc_layout_ci);
         ASSERT_MSG(desc_layout_pair.result == vk::Result::eSuccess,
-                   "Failed to create descriptor set layout: {}", vk::to_string(desc_layout_pair.result));
+                   "Failed to create descriptor set layout: {}",
+                   vk::to_string(desc_layout_pair.result));
 
         const vk::PushConstantRange push_constants = {
             .stageFlags = vk::ShaderStageFlagBits::eCompute,


### PR DESCRIPTION
Would cause weird compiler bug on GCC, was reported on issue #1072 which was deleted

```
in gimple_add_tmp_var, at gimplify.cc:802
  298 |         static auto [desc_layout_result, desc_layout] =
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
0x21a922a internal_error(char const*, ...)
        ???:0
0x704ec1 fancy_abort(char const*, int, char const*)
        ???:0
0xc57884 gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0xc577f5 gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0xc56969 gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0xc577f5 gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0xc57cf5 gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0xc577f5 gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0xc57cf5 gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0xc577f5 gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0xc57cf5 gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0xc577f5 gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0xc56969 gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0xc577f5 gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0xc57cf5 gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0xc577f5 gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0xc5cb4b gimplify_body(tree_node*, bool)
        ???:0
0xc5d04c gimplify_function_tree(tree_node*)
        ???:0
0xa9861b cgraph_node::analyze()
        ???:0
0xaa6eb9 symbol_table::finalize_compilation_unit()
        ???:0
```