### PR TITLE
Cleaner pre-release messages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -402,6 +402,10 @@ jobs:
           fi
         done
   
+    - name: Get last commit title from main
+      id: get_commit_title
+      run: echo "title=$(git log origin/main -1 --pretty=%s)" >> $GITHUB_ENV
+    
     - name: Create Pre-Release on GitHub
       id: create_release
       uses: ncipollo/release-action@v1
@@ -411,7 +415,7 @@ jobs:
         tag: "Pre-release-shadPS4-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}"
         draft: false
         prerelease: true
-        body: ${{ github.event.head_commit.message }}
+        body: "${{ env.title }}"
         artifacts: ./artifacts/*.zip
     
     - name: Get current pre-release information

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -411,8 +411,8 @@ jobs:
         tag: "Pre-release-shadPS4-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}"
         draft: false
         prerelease: true
-        artifacts: |
-          ./artifacts/*.zip
+        body: ${{ github.event.head_commit.message }}
+        artifacts: ./artifacts/*.zip
     
     - name: Get current pre-release information
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -317,7 +317,7 @@ jobs:
     - name: Package and Upload Linux(ubuntu64) SDL artifact 
       run: |
         ls -la ${{ github.workspace }}/build/shadps4
-    
+
     - uses: actions/upload-artifact@v4
       with:
         name: shadps4-ubuntu64-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}


### PR DESCRIPTION
This should only show the commit title, without the entire message as shown in the print
![image](https://github.com/user-attachments/assets/023771fa-f265-4d19-b9e4-bd97776de4f3)
