### PR TITLE
liverpool_to_vk: Add MRT feature flags to supported number formats.

### DIFF
--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -381,12 +381,13 @@ static constexpr vk::FormatFeatureFlags2 GetNumberFormatFeatureFlags(
     case AmdGpu::NumberFormat::Uint:
     case AmdGpu::NumberFormat::Sint:
     case AmdGpu::NumberFormat::Float:
-        return BufferRead | BufferWrite | ImageRead | ImageWrite;
+        return BufferRead | BufferWrite | ImageRead | ImageWrite | Mrt;
     case AmdGpu::NumberFormat::Uscaled:
     case AmdGpu::NumberFormat::Sscaled:
     case AmdGpu::NumberFormat::SnormNz:
         return BufferRead | ImageRead;
     case AmdGpu::NumberFormat::Srgb:
+        return ImageRead | Mrt;
     case AmdGpu::NumberFormat::Ubnorm:
     case AmdGpu::NumberFormat::UbnromNz:
     case AmdGpu::NumberFormat::Ubint:


### PR DESCRIPTION
Adds MRT feature flags to number formats that can be used as render targets. Previously left this out since it wasn't listed in the number format table, only data format, but there is info on this in the docs on color buffer registers.