### PR TITLE
Cleaner pre-release messages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -402,6 +402,15 @@ jobs:
           fi
         done
   
+    - name: Get latest release information
+      id: get_latest_release
+      env:
+        GITHUB_TOKEN: ${{ secrets.SHADPS4_TOKEN_REPO }}
+      run: |
+        api_url="https://api.github.com/repos/${{ github.repository }}"
+        latest_release_info=$(curl -H "Authorization: token $GITHUB_TOKEN" "$api_url/releases/latest")
+        echo "last_release_tag=$(echo "$latest_release_info" | jq -r '.tag_name')" >> $GITHUB_ENV
+
     - name: Create Pre-Release on GitHub
       id: create_release
       uses: ncipollo/release-action@v1
@@ -411,8 +420,8 @@ jobs:
         tag: "Pre-release-shadPS4-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}"
         draft: false
         prerelease: true
-        artifacts: |
-          ./artifacts/*.zip
+        body: "Full Changelog: [${{ env.last_release_tag }}...${{ needs.get-info.outputs.shorthash }}](https://github.com/shadps4-emu/shadPS4/compare/${{ env.last_release_tag }}...${{ needs.get-info.outputs.shorthash }})"
+        artifacts: ./artifacts/*.zip
     
     - name: Get current pre-release information
       env:


### PR DESCRIPTION
Instead of showing all the content and just the latest commit,
It will show the link to all the changes between the latest release and the pre-release
Thus, making it cleaner and clearer what is being changed

Before:
![image](https://github.com/user-attachments/assets/023771fa-f265-4d19-b9e4-bd97776de4f3)

After:
![image](https://github.com/user-attachments/assets/a36a24a5-ccca-42ea-82b4-46fc32ffcd45)
