### PR TITLE
shader_recompiler: Define fragment output type based on number format.

### DIFF
--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -120,6 +120,7 @@ void EmitContext::DefineArithmeticTypes() {
 
     output_f32 = Name(TypePointer(spv::StorageClass::Output, F32[1]), "output_f32");
     output_u32 = Name(TypePointer(spv::StorageClass::Output, U32[1]), "output_u32");
+    output_s32 = Name(TypePointer(spv::StorageClass::Output, S32[1]), "output_s32");
 
     full_result_i32x2 = Name(TypeStruct(S32[1], S32[1]), "full_result_i32x2");
     full_result_u32x2 = Name(TypeStruct(U32[1], U32[1]), "full_result_u32x2");
@@ -151,21 +152,21 @@ const VectorIds& GetAttributeType(EmitContext& ctx, AmdGpu::NumberFormat fmt) {
     UNREACHABLE_MSG("Invalid attribute type {}", fmt);
 }
 
-EmitContext::SpirvAttribute EmitContext::GetAttributeInfo(AmdGpu::NumberFormat fmt, Id id) {
+EmitContext::SpirvAttribute EmitContext::GetAttributeInfo(AmdGpu::NumberFormat fmt, Id id,
+                                                          bool output) {
     switch (fmt) {
     case AmdGpu::NumberFormat::Float:
     case AmdGpu::NumberFormat::Unorm:
     case AmdGpu::NumberFormat::Snorm:
     case AmdGpu::NumberFormat::SnormNz:
-        return {id, input_f32, F32[1], 4};
-    case AmdGpu::NumberFormat::Uint:
-        return {id, input_u32, U32[1], 4};
-    case AmdGpu::NumberFormat::Sint:
-        return {id, input_s32, S32[1], 4};
     case AmdGpu::NumberFormat::Sscaled:
-        return {id, input_f32, F32[1], 4};
     case AmdGpu::NumberFormat::Uscaled:
-        return {id, input_f32, F32[1], 4};
+    case AmdGpu::NumberFormat::Srgb:
+        return {id, output ? output_f32 : input_f32, F32[1], 4};
+    case AmdGpu::NumberFormat::Uint:
+        return {id, output ? output_u32 : input_u32, U32[1], 4};
+    case AmdGpu::NumberFormat::Sint:
+        return {id, output ? output_s32 : input_s32, S32[1], 4};
     default:
         break;
     }
@@ -247,7 +248,7 @@ void EmitContext::DefineInputs() {
                 } else {
                     Name(id, fmt::format("vs_in_attr{}", input.binding));
                 }
-                input_params[input.binding] = GetAttributeInfo(input.fmt, id);
+                input_params[input.binding] = GetAttributeInfo(input.fmt, id, false);
                 interfaces.push_back(id);
             }
         }
@@ -320,10 +321,12 @@ void EmitContext::DefineOutputs() {
                 continue;
             }
             const u32 num_components = info.stores.NumComponents(mrt);
-            frag_color[i] = DefineOutput(F32[num_components], i);
-            frag_num_comp[i] = num_components;
-            Name(frag_color[i], fmt::format("frag_color{}", i));
-            interfaces.push_back(frag_color[i]);
+            const AmdGpu::NumberFormat num_format{runtime_info.fs_info.color_buffers[i].num_format};
+            const Id type{GetAttributeType(*this, num_format)[num_components]};
+            const Id id = DefineOutput(type, i);
+            Name(id, fmt::format("frag_color{}", i));
+            frag_outputs[i] = GetAttributeInfo(num_format, id, true);
+            interfaces.push_back(id);
         }
         break;
     default:

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -162,11 +162,11 @@ EmitContext::SpirvAttribute EmitContext::GetAttributeInfo(AmdGpu::NumberFormat f
     case AmdGpu::NumberFormat::Sscaled:
     case AmdGpu::NumberFormat::Uscaled:
     case AmdGpu::NumberFormat::Srgb:
-        return {id, output ? output_f32 : input_f32, F32[1], 4};
+        return {id, output ? output_f32 : input_f32, F32[1], 4, false};
     case AmdGpu::NumberFormat::Uint:
-        return {id, output ? output_u32 : input_u32, U32[1], 4};
+        return {id, output ? output_u32 : input_u32, U32[1], 4, true};
     case AmdGpu::NumberFormat::Sint:
-        return {id, output ? output_s32 : input_s32, S32[1], 4};
+        return {id, output ? output_s32 : input_s32, S32[1], 4, true};
     default:
         break;
     }
@@ -237,9 +237,13 @@ void EmitContext::DefineInputs() {
                                                                                              : 1;
                 // Note that we pass index rather than Id
                 input_params[input.binding] = {
-                    rate_idx, input_u32,
-                    U32[1],   input.num_components,
-                    false,    input.instance_data_buf,
+                    rate_idx,
+                    input_u32,
+                    U32[1],
+                    input.num_components,
+                    true,
+                    false,
+                    input.instance_data_buf,
                 };
             } else {
                 Id id{DefineInput(type, input.binding)};

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -236,6 +236,7 @@ public:
         Id pointer_type;
         Id component_type;
         u32 num_components;
+        bool is_integer{};
         bool is_default{};
         s32 buffer_handle{-1};
     };

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -166,6 +166,7 @@ public:
     Id input_s32{};
     Id output_u32{};
     Id output_f32{};
+    Id output_s32{};
 
     boost::container::small_vector<Id, 16> interfaces;
 
@@ -177,8 +178,6 @@ public:
     Id frag_coord{};
     Id front_facing{};
     Id frag_depth{};
-    std::array<Id, 8> frag_color{};
-    std::array<u32, 8> frag_num_comp{};
     Id clip_distances{};
     Id cull_distances{};
 
@@ -242,6 +241,7 @@ public:
     };
     std::array<SpirvAttribute, 32> input_params{};
     std::array<SpirvAttribute, 32> output_params{};
+    std::array<SpirvAttribute, 8> frag_outputs{};
 
 private:
     void DefineArithmeticTypes();
@@ -254,7 +254,7 @@ private:
     void DefineImagesAndSamplers();
     void DefineSharedMemory();
 
-    SpirvAttribute GetAttributeInfo(AmdGpu::NumberFormat fmt, Id id);
+    SpirvAttribute GetAttributeInfo(AmdGpu::NumberFormat fmt, Id id, bool output);
 };
 
 } // namespace Shader::Backend::SPIRV

--- a/src/shader_recompiler/frontend/translate/export.cpp
+++ b/src/shader_recompiler/frontend/translate/export.cpp
@@ -25,7 +25,7 @@ void Translator::EmitExport(const GcnInst& inst) {
             return comp;
         }
         const u32 index = u32(attrib) - u32(IR::Attribute::RenderTarget0);
-        switch (runtime_info.fs_info.mrt_swizzles[index]) {
+        switch (runtime_info.fs_info.color_buffers[index].mrt_swizzle) {
         case MrtSwizzle::Identity:
             return comp;
         case MrtSwizzle::Alt:

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -80,10 +80,16 @@ struct FragmentRuntimeInfo {
         auto operator<=>(const PsInput&) const noexcept = default;
     };
     boost::container::static_vector<PsInput, 32> inputs;
-    std::array<MrtSwizzle, MaxColorBuffers> mrt_swizzles;
+    struct PsColorBuffer {
+        AmdGpu::NumberFormat num_format;
+        MrtSwizzle mrt_swizzle;
+
+        auto operator<=>(const PsColorBuffer&) const noexcept = default;
+    };
+    std::array<PsColorBuffer, MaxColorBuffers> color_buffers;
 
     bool operator==(const FragmentRuntimeInfo& other) const noexcept {
-        return std::ranges::equal(mrt_swizzles, other.mrt_swizzles) &&
+        return std::ranges::equal(color_buffers, other.color_buffers) &&
                std::ranges::equal(inputs, other.inputs);
     }
 };

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -26,6 +26,7 @@ using Liverpool = AmdGpu::Liverpool;
 struct GraphicsPipelineKey {
     std::array<size_t, MaxShaderStages> stage_hashes;
     std::array<vk::Format, Liverpool::NumColorBuffers> color_formats;
+    std::array<AmdGpu::NumberFormat, Liverpool::NumColorBuffers> color_num_formats;
     std::array<Liverpool::ColorBuffer::SwapMode, Liverpool::NumColorBuffers> mrt_swizzles;
     vk::Format depth_format;
     vk::Format stencil_format;

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -95,10 +95,6 @@ Shader::RuntimeInfo PipelineCache::BuildRuntimeInfo(Shader::Stage stage) {
     case Shader::Stage::Fragment: {
         info.num_user_data = regs.ps_program.settings.num_user_regs;
         info.num_allocated_vgprs = regs.ps_program.settings.num_vgprs * 4;
-        std::ranges::transform(graphics_key.mrt_swizzles, info.fs_info.mrt_swizzles.begin(),
-                               [](Liverpool::ColorBuffer::SwapMode mode) {
-                                   return static_cast<Shader::MrtSwizzle>(mode);
-                               });
         const auto& ps_inputs = regs.ps_inputs;
         for (u32 i = 0; i < regs.num_interp; i++) {
             info.fs_info.inputs.push_back({
@@ -107,6 +103,12 @@ Shader::RuntimeInfo PipelineCache::BuildRuntimeInfo(Shader::Stage stage) {
                 .is_flat = bool(ps_inputs[i].flat_shade),
                 .default_value = u8(ps_inputs[i].default_value),
             });
+        }
+        for (u32 i = 0; i < Shader::MaxColorBuffers; i++) {
+            info.fs_info.color_buffers[i] = {
+                .num_format = graphics_key.color_num_formats[i],
+                .mrt_swizzle = static_cast<Shader::MrtSwizzle>(graphics_key.mrt_swizzles[i]),
+            };
         }
         break;
     }
@@ -244,6 +246,7 @@ bool PipelineCache::RefreshGraphicsKey() {
     // attachments. This might be not a case as HW color buffers can be bound in an arbitrary
     // order. We need to do some arrays compaction at this stage
     key.color_formats.fill(vk::Format::eUndefined);
+    key.color_num_formats.fill(AmdGpu::NumberFormat::Unorm);
     key.blend_controls.fill({});
     key.write_masks.fill({});
     key.mrt_swizzles.fill(Liverpool::ColorBuffer::SwapMode::Standard);
@@ -260,6 +263,7 @@ bool PipelineCache::RefreshGraphicsKey() {
         const bool is_vo_surface = renderer->IsVideoOutSurface(col_buf);
         key.color_formats[remapped_cb] = LiverpoolToVK::AdjustColorBufferFormat(
             base_format, col_buf.info.comp_swap.Value(), false /*is_vo_surface*/);
+        key.color_num_formats[remapped_cb] = col_buf.NumFormat();
         if (base_format == key.color_formats[remapped_cb]) {
             key.mrt_swizzles[remapped_cb] = col_buf.info.comp_swap.Value();
         }


### PR DESCRIPTION
* Expand fragment shader runtime info for render targets to include the number format.
* Declare fragment shader render target outputs with the correct number type.
* Cast to the correct output number type in `EmitSetAttribute`.
* Fix a misplaced brace, a wrong exception message, and the param pointer type in `OutputAttrPointer` (currently always the same as what was hardcoded, but use the right field in case it isn't in the future).

This fixes at least two shaders in CUSA16429 which were trying to output to R32Uint targets with float type, causing SPIR-V errors.