### PR TITLE
Fix HLE Module loads

### DIFF
--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -247,8 +247,10 @@ void Emulator::LoadSystemModules(const std::filesystem::path& file) {
             found_modules, [&](const auto& path) { return path.filename() == module_name; });
         if (it != found_modules.end()) {
             LOG_INFO(Loader, "Loading {}", it->string());
-            linker->LoadModule(*it);
-            continue;
+            int result = linker->LoadModule(*it);
+            if (result == 0) {
+                continue;
+            }
         }
         if (init_func) {
             LOG_INFO(Loader, "Can't Load {} switching to HLE", module_name);


### PR DESCRIPTION
With the current code, if someone provides improperly dumped firmware modules, or corrupted firmware modules, the HLE module variant won't load. As we already return an error in linker->LoadModule when these issues occur, the only change needed is to make the LoadSystemModules function check for an error return.