### PR TITLE
documentation: fix Linux build instructions

### DIFF
--- a/documents/building-linux.md
+++ b/documents/building-linux.md
@@ -3,28 +3,28 @@ SPDX-FileCopyrightText: 2024 shadPS4 Emulator Project
 SPDX-License-Identifier: GPL-2.0-or-later
 -->
 
-## Build shadPS4 for Linux
+## Build shadPS4 for Linux                                      
 
 ### Install the necessary tools to build shadPS4:
 
 #### Debian & Ubuntu
 ```
-sudo apt-get install build-essential libasound2-dev libpulse-dev libopenal-dev zlib1g-dev libedit-dev libvulkan-dev libudev-dev git libevdev-dev libsdl2-2.0 libsdl2-dev libjack-dev libsndio-dev qt6-base-dev qt6-tools-dev
+sudo apt install build-essential clang cmake libasound2-dev libpulse-dev libopenal-dev libssl-dev zlib1g-dev libedit-dev libvulkan-dev libudev-dev git libevdev-dev libsdl2-dev libjack-dev libsndio-dev qt6-base-dev qt6-tools-dev qt6-multimedia-dev
 ```
 
 #### Fedora
 ```
-sudo dnf install alsa-lib-devel cmake libatomic libevdev-devel libudev-devel openal-devel qt6-qtbase-devel qt6-qtbase-private-devel vulkan-devel pipewire-jack-audio-connection-kit-devel qt6-qtmultimedia-devel qt6-qtsvg-devel
+sudo dnf install alsa-lib-devel cmake libatomic libevdev-devel libudev-devel openal-devel openssl-devel qt6-qtbase-devel qt6-qtbase-private-devel vulkan-devel pipewire-jack-audio-connection-kit-devel qt6-qtmultimedia-devel qt6-qtsvg-devel qt6-qttools-devel vulkan-validation-layers
 ```
 
 #### Arch Linux
 ```
-sudo pacman -S openal cmake vulkan-validation-layers qt6-base qt6-declarative qt6-multimedia sdl2 sndio jack2 base-devel
+sudo pacman -S clang openal cmake vulkan-validation-layers qt6-base qt6-declarative qt6-multimedia sdl2 sndio jack2 base-devel
 ```
 
 #### OpenSUSE
 ```
-sudo zypper install git cmake libasound2 libpulse-devel openal-soft-devel zlib-devel libedit-devel vulkan-devel libudev-devel libqt6-qtbase-devel libqt6-qtmultimedia-devel libqt6-qtsvg-devel libQt6Gui-private-headers-devel libevdev-devel libsndio7_1 libjack-devel
+sudo zypper install clang git cmake libasound2 libpulse-devel openal-soft-devel libopenssl-devel zlib-devel libedit-devel vulkan-devel systemd-devel qt6-base-devel qt6-multimedia-devel qt6-svg-devel qt6-linguist-devel qt6-gui-private-devel libevdev-devel libsndio7 libjack-devel
 ```
 ### Cloning and compiling:
 
@@ -34,9 +34,11 @@ git clone --recursive https://github.com/shadps4-emu/shadPS4.git
 cd shadPS4
 ```
 
-Generate the build directory in the shadPS4 directory. To enable the QT GUI, pass the ```-DENABLE_QT_GUI=ON``` flag:
+Generate the build directory in the shadPS4 directory. To disable the QT GUI, remove the ```-DENABLE_QT_GUI=ON``` flag:
+
+**Note**: Clang is the compiler used for official builds and CI. If you build with GCC, you might encounter issues—please report any you find. If you choose to use GCC, we recommend building with Clang at least once before submitting a pull request.
 ```
-cmake -S . -B build/ -DENABLE_QT_GUI=ON
+cmake -S . -B build/ -DENABLE_QT_GUI=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
 ```
 
 Enter the directory:

--- a/documents/building-linux.md
+++ b/documents/building-linux.md
@@ -9,22 +9,22 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 #### Debian & Ubuntu
 ```
-sudo apt install build-essential clang cmake libasound2-dev libpulse-dev libopenal-dev libssl-dev zlib1g-dev libedit-dev libvulkan-dev libudev-dev git libevdev-dev libsdl2-dev libjack-dev libsndio-dev qt6-base-dev qt6-tools-dev qt6-multimedia-dev
+sudo apt install build-essential clang git cmake libasound2-dev libpulse-dev libopenal-dev libssl-dev zlib1g-dev libedit-dev libudev-dev libevdev-dev libsdl2-dev libjack-dev libsndio-dev qt6-base-dev qt6-tools-dev qt6-multimedia-dev libvulkan-dev vulkan-validationlayers
 ```
 
 #### Fedora
 ```
-sudo dnf install alsa-lib-devel cmake libatomic libevdev-devel libudev-devel openal-devel openssl-devel qt6-qtbase-devel qt6-qtbase-private-devel vulkan-devel pipewire-jack-audio-connection-kit-devel qt6-qtmultimedia-devel qt6-qtsvg-devel qt6-qttools-devel vulkan-validation-layers
+sudo dnf install clang cmake libatomic alsa-lib-devel pipewire-jack-audio-connection-kit-devel openal-devel openssl-devel libevdev-devel libudev-devel qt6-qtbase-devel qt6-qtbase-private-devel qt6-qtmultimedia-devel qt6-qtsvg-devel qt6-qttools-devel vulkan-devel vulkan-validation-layers
 ```
 
 #### Arch Linux
 ```
-sudo pacman -S clang openal cmake vulkan-validation-layers qt6-base qt6-declarative qt6-multimedia sdl2 sndio jack2 base-devel
+sudo pacman -S base-devel clang git cmake sndio jack2 openal qt6-base qt6-declarative qt6-multimedia sdl2 vulkan-validation-layers
 ```
 
 #### OpenSUSE
 ```
-sudo zypper install clang git cmake libasound2 libpulse-devel openal-soft-devel libopenssl-devel zlib-devel libedit-devel vulkan-devel systemd-devel qt6-base-devel qt6-multimedia-devel qt6-svg-devel qt6-linguist-devel qt6-gui-private-devel libevdev-devel libsndio7 libjack-devel
+sudo zypper install clang git cmake libasound2 libpulse-devel libsndio7 libjack-devel openal-soft-devel libopenssl-devel zlib-devel libedit-devel systemd-devel libevdev-devel qt6-base-devel qt6-multimedia-devel qt6-svg-devel qt6-linguist-devel qt6-gui-private-devel vulkan-devel vulkan-validationlayers
 ```
 ### Cloning and compiling:
 


### PR DESCRIPTION
Update the build instruction for Linux.
- Use clang when building just like in the github workflows
- Fix dependency package installation.

Tested on Ubuntu 24.04, Fedora 40, Arch Linux and OpenSUSE Tumbleweed.

In some cases, jack2 is used insteed of pipewire-jack. This should be corrected.