### PR TITLE
fix: Duplicated CI run after opening a PR with a branch from official repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ name: Build and Release
 
 on:
   push:
-    branches: [ "*" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "*" ]
 


### PR DESCRIPTION
Aims to fix duplicated CI runs, like these, only running the CI when pushes to `main` happens.

![image](https://github.com/user-attachments/assets/95cd161b-fa4a-4abf-bc68-0204305cc39b)
