### PR TITLE
Reduce assert to a warning for extrq and insertq

### DIFF
--- a/src/core/cpu_patches.cpp
+++ b/src/core/cpu_patches.cpp
@@ -1053,7 +1053,14 @@ static bool TryExecuteIllegalInstruction(void* ctx, void* code_address) {
             }
 
             u64 index = (lowQWordSrc >> 8) & 0x3F;
-            ASSERT_MSG(length + index <= 64, "length + index must be less than or equal to 64.");
+            if (length + index > 64) {
+                // Undefined behavior if length + index is bigger than 64 according to the spec,
+                // we'll warn and continue execution.
+                LOG_WARNING(Core,
+                            "extrq at {:x} with length {} and index {} is bigger than 64, "
+                            "undefined behavior",
+                            fmt::ptr(code_address), length, index);
+            }
 
             lowQWordDst >>= index;
             lowQWordDst &= mask;
@@ -1106,7 +1113,14 @@ static bool TryExecuteIllegalInstruction(void* ctx, void* code_address) {
             }
 
             u64 index = (highQWordSrc >> 8) & 0x3F;
-            ASSERT_MSG(length + index <= 64, "length + index must be less than or equal to 64.");
+            if (length + index > 64) {
+                // Undefined behavior if length + index is bigger than 64 according to the spec,
+                // we'll warn and continue execution.
+                LOG_WARNING(Core,
+                            "insertq at {:x} with length {} and index {} is bigger than 64, "
+                            "undefined behavior",
+                            fmt::ptr(code_address), length, index);
+            }
 
             lowQWordSrc &= mask;
             lowQWordDst &= ~(mask << index);


### PR DESCRIPTION
Infamous second son hits the extrq assert during this instruction:
`extrq xmm5 (980279e5d07bb9d3), xmm4 (2f0c00003d00), rip: 90088ca84`

xmm4 has lowest 5 bits to 0 which means mask length is 0, and according to the spec a mask length of 0 means a mask of all 64 bits.

When index + length is bigger than 64 bits, the spec says it's undefined behavior. However instead of crashing it can give a warning and continue operation like normal.

~~It would be good to test on a real ps4 with homebrew in the future to get the correct behavior, it *could* be the case that it picks up bits from the high 64 bits of the xmm register, but I think it's more likely this isn't the case, since normally this instruction only operates on the low 64 bits.~~

It was tested on turtle's AMD cpu and the result is what I expected it to be. I think a warning should exist regardless since it's probably going to be quite rare, and for the very slight chance PS4's Jaguar does something different.