### PR TITLE
kernel: Quiet sceKernelWaitEventFlag error log on timeout.

### DIFF
--- a/src/core/libraries/kernel/event_flag/event_flag.cpp
+++ b/src/core/libraries/kernel/event_flag/event_flag.cpp
@@ -184,7 +184,7 @@ int PS4_SYSV_ABI sceKernelWaitEventFlag(OrbisKernelEventFlag ef, u64 bitPattern,
 
     u32 result = ef->Wait(bitPattern, wait, clear, pResultPat, pTimeout);
 
-    if (result != ORBIS_OK) {
+    if (result != ORBIS_OK && result != ORBIS_KERNEL_ERROR_ETIMEDOUT) {
         LOG_ERROR(Kernel_Event, "returned {:#x}", result);
     }
 


### PR DESCRIPTION
Another log spam reduction by not printing an error when `sceKernelWaitEventFlag` times out.