### PR TITLE
Add volume slider for title/background music

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -18,11 +18,11 @@
       "configurationType": "Debug",
       "buildRoot": "${projectDir}\\Build\\${name}",
       "installRoot": "${projectDir}\\Install\\${name}",
+      "cmakeCommandArgs": "",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
       "inheritEnvironments": [ "clang_cl_x64_x64" ],
-      "intelliSenseMode": "windows-clang-x64",
-      "cmakeCommandArgs": "-DENABLE_QT_GUI=ON -DCMAKE_PREFIX_PATH=C:\\Qt\\6.7.2\\msvc2019_64"
+      "intelliSenseMode": "windows-clang-x64"
     },
     {
       "name": "x64-Clang-RelWithDebInfo",
@@ -30,7 +30,7 @@
       "configurationType": "RelWithDebInfo",
       "buildRoot": "${projectDir}\\Build\\${name}",
       "installRoot": "${projectDir}\\Install\\${name}",
-      "cmakeCommandArgs": "-DENABLE_QT_GUI=ON -DCMAKE_PREFIX_PATH=C:\\Qt\\6.7.2\\msvc2019_64",
+      "cmakeCommandArgs": "",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
       "inheritEnvironments": [ "clang_cl_x64_x64" ],

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -18,11 +18,11 @@
       "configurationType": "Debug",
       "buildRoot": "${projectDir}\\Build\\${name}",
       "installRoot": "${projectDir}\\Install\\${name}",
-      "cmakeCommandArgs": "",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
       "inheritEnvironments": [ "clang_cl_x64_x64" ],
-      "intelliSenseMode": "windows-clang-x64"
+      "intelliSenseMode": "windows-clang-x64",
+      "cmakeCommandArgs": "-DENABLE_QT_GUI=ON -DCMAKE_PREFIX_PATH=C:\\Qt\\6.7.2\\msvc2019_64"
     },
     {
       "name": "x64-Clang-RelWithDebInfo",
@@ -30,7 +30,7 @@
       "configurationType": "RelWithDebInfo",
       "buildRoot": "${projectDir}\\Build\\${name}",
       "installRoot": "${projectDir}\\Install\\${name}",
-      "cmakeCommandArgs": "",
+      "cmakeCommandArgs": "-DENABLE_QT_GUI=ON -DCMAKE_PREFIX_PATH=C:\\Qt\\6.7.2\\msvc2019_64",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
       "inheritEnvironments": [ "clang_cl_x64_x64" ],

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -32,6 +32,7 @@ namespace Config {
 static bool isNeo = false;
 static bool isFullscreen = false;
 static bool playBGM = false;
+static int BGMvolume = 50;
 static u32 screenWidth = 1280;
 static u32 screenHeight = 720;
 static s32 gpuId = -1; // Vulkan physical device index. Set to negative for auto select
@@ -87,6 +88,10 @@ bool isFullscreenMode() {
 
 bool getPlayBGM() {
     return playBGM;
+}
+
+int getBGMvolume() {
+    return BGMvolume;
 }
 
 u32 getScreenWidth() {
@@ -247,6 +252,10 @@ void setFullscreenMode(bool enable) {
 
 void setPlayBGM(bool enable) {
     playBGM = enable;
+}
+
+void setBGMvolume(int volume) {
+    BGMvolume = volume;
 }
 
 void setLanguage(u32 language) {
@@ -412,6 +421,7 @@ void load(const std::filesystem::path& path) {
         isNeo = toml::find_or<bool>(general, "isPS4Pro", false);
         isFullscreen = toml::find_or<bool>(general, "Fullscreen", false);
         playBGM = toml::find_or<bool>(general, "playBGM", false);
+        BGMvolume = toml::find_or<int>(general, "BGMvolume", 50);
         logFilter = toml::find_or<std::string>(general, "logFilter", "");
         logType = toml::find_or<std::string>(general, "logType", "sync");
         userName = toml::find_or<std::string>(general, "userName", "shadPS4");
@@ -513,6 +523,7 @@ void save(const std::filesystem::path& path) {
     data["General"]["isPS4Pro"] = isNeo;
     data["General"]["Fullscreen"] = isFullscreen;
     data["General"]["playBGM"] = playBGM;
+    data["General"]["BGMvolume"] = BGMvolume;
     data["General"]["logFilter"] = logFilter;
     data["General"]["logType"] = logType;
     data["General"]["userName"] = userName;
@@ -565,6 +576,7 @@ void setDefaultValues() {
     isNeo = false;
     isFullscreen = false;
     playBGM = false;
+    BGMvolume = 50;
     screenWidth = 1280;
     screenHeight = 720;
     logFilter = "";

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -14,6 +14,8 @@ void save(const std::filesystem::path& path);
 bool isNeoMode();
 bool isFullscreenMode();
 bool getPlayBGM();
+int getBGMvolume();
+
 std::string getLogFilter();
 std::string getLogType();
 std::string getUserName();
@@ -49,6 +51,7 @@ void setScreenWidth(u32 width);
 void setScreenHeight(u32 height);
 void setFullscreenMode(bool enable);
 void setPlayBGM(bool enable);
+void setBGMvolume(int volume);
 void setLanguage(u32 language);
 void setNeoMode(bool enable);
 void setUserName(const std::string& type);

--- a/src/qt_gui/background_music_player.cpp
+++ b/src/qt_gui/background_music_player.cpp
@@ -10,6 +10,12 @@ BackgroundMusicPlayer::BackgroundMusicPlayer(QObject* parent) : QObject(parent) 
     m_mediaPlayer->setLoops(QMediaPlayer::Infinite);
 }
 
+void BackgroundMusicPlayer::setVolume(int volume) {
+    float linearVolume = QAudio::convertVolume(volume / 100.0f, QAudio::LogarithmicVolumeScale,
+                                               QAudio::LinearVolumeScale);
+    m_audioOutput->setVolume(linearVolume);
+}
+
 void BackgroundMusicPlayer::playMusic(const QString& snd0path) {
     if (snd0path.isEmpty()) {
         stopMusic();

--- a/src/qt_gui/background_music_player.h
+++ b/src/qt_gui/background_music_player.h
@@ -16,6 +16,7 @@ public:
         return instance;
     }
 
+    void setVolume(int volume);
     void playMusic(const QString& snd0path);
     void stopMusic();
 

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -527,7 +527,11 @@ void MainWindow::PlayBackgroundMusic() {
     int itemID = isTableList ? m_game_list_frame->currentItem()->row()
                              : m_game_grid_frame->crtRow * m_game_grid_frame->columnCnt +
                                    m_game_grid_frame->crtColumn;
-
+    if (itemID > m_game_info->m_games.size() - 1) {
+        // Can happen in grid mode
+        BackgroundMusicPlayer::getInstance().stopMusic();
+        return;
+    }
     QString snd0path;
     Common::FS::PathToQString(snd0path, m_game_info->m_games[itemID].snd0_path);
     BackgroundMusicPlayer::getInstance().playMusic(snd0path);
@@ -619,6 +623,7 @@ void MainWindow::ConfigureGuiFromSettings() {
     } else {
         ui->setlistModeGridAct->setChecked(true);
     }
+    BackgroundMusicPlayer::getInstance().setVolume(Config::getBGMvolume());
 }
 
 void MainWindow::SaveWindowState() const {

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -145,8 +145,15 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices, QWidge
 
         connect(ui->BGMVolumeSlider, &QSlider::valueChanged, this,
                 [](float val) { Config::setBGMvolume(val); });
+
         connect(ui->BGMVolumeSlider, &QSlider::valueChanged, this,
                 [](float val) { BackgroundMusicPlayer::getInstance().setVolume(val); });
+
+        connect(ui->playBGMCheckBox, &QCheckBox::stateChanged, this, [this](int state) {
+            if (state == Qt::Unchecked) {
+                BackgroundMusicPlayer::getInstance().stopMusic();
+            }
+        });
     }
 
     // GPU TAB

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -140,19 +140,16 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices, QWidge
             checkUpdate->exec();
         });
 
-        connect(ui->playBGMCheckBox, &QCheckBox::stateChanged, this,
-                [](int val) { Config::setPlayBGM(val); });
-
-        connect(ui->BGMVolumeSlider, &QSlider::valueChanged, this,
-                [](float val) { Config::setBGMvolume(val); });
-
-        connect(ui->BGMVolumeSlider, &QSlider::valueChanged, this,
-                [](float val) { BackgroundMusicPlayer::getInstance().setVolume(val); });
-
-        connect(ui->playBGMCheckBox, &QCheckBox::stateChanged, this, [this](int state) {
-            if (state == Qt::Unchecked) {
+        connect(ui->playBGMCheckBox, &QCheckBox::stateChanged, this, [](int val) {
+            Config::setPlayBGM(val);
+            if (val == Qt::Unchecked) {
                 BackgroundMusicPlayer::getInstance().stopMusic();
             }
+        });
+
+        connect(ui->BGMVolumeSlider, &QSlider::valueChanged, this, [](float val) {
+            Config::setBGMvolume(val);
+            BackgroundMusicPlayer::getInstance().setVolume(val);
         });
     }
 

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -142,6 +142,11 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices, QWidge
 
         connect(ui->playBGMCheckBox, &QCheckBox::stateChanged, this,
                 [](int val) { Config::setPlayBGM(val); });
+
+        connect(ui->BGMVolumeSlider, &QSlider::valueChanged, this,
+                [](float val) { Config::setBGMvolume(val); });
+        connect(ui->BGMVolumeSlider, &QSlider::valueChanged, this,
+                [](float val) { BackgroundMusicPlayer::getInstance().setVolume(val); });
     }
 
     // GPU TAB
@@ -231,6 +236,7 @@ void SettingsDialog::LoadValuesFromConfig() {
     ui->nullGpuCheckBox->setChecked(Config::nullGpu());
     ui->dumpPM4CheckBox->setChecked(Config::dumpPM4());
     ui->playBGMCheckBox->setChecked(Config::getPlayBGM());
+    ui->BGMVolumeSlider->setValue((Config::getBGMvolume()));
     ui->fullscreenCheckBox->setChecked(Config::isFullscreenMode());
     ui->showSplashCheckBox->setChecked(Config::showSplash());
     ui->ps4proCheckBox->setChecked(Config::isNeoMode());

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+     SPDX-License-Identifier: GPL-2.0-or-later -->
 <ui version="4.0">
  <class>SettingsDialog</class>
  <widget class="QDialog" name="SettingsDialog">

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
-     SPDX-License-Identifier: GPL-2.0-or-later -->
 <ui version="4.0">
  <class>SettingsDialog</class>
  <widget class="QDialog" name="SettingsDialog">
@@ -52,7 +50,7 @@
         <x>0</x>
         <y>0</y>
         <width>836</width>
-        <height>442</height>
+        <height>446</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -369,7 +367,7 @@
                  <x>10</x>
                  <y>30</y>
                  <width>241</width>
-                 <height>41</height>
+                 <height>71</height>
                 </rect>
                </property>
                <layout class="QVBoxLayout" name="verticalLayout">
@@ -385,6 +383,55 @@
                    <string>Play title music</string>
                   </property>
                  </widget>
+                </item>
+                <item>
+                 <layout class="QHBoxLayout" name="horizontalLayout">
+                  <item>
+                   <layout class="QVBoxLayout" name="verticalLayout_2">
+                    <item>
+                     <widget class="QLabel" name="label">
+                      <property name="text">
+                       <string>Volume</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QSlider" name="BGMVolumeSlider">
+                      <property name="toolTip">
+                       <string>Set the volume of the background music.</string>
+                      </property>
+                      <property name="maximum">
+                       <number>100</number>
+                      </property>
+                      <property name="singleStep">
+                       <number>10</number>
+                      </property>
+                      <property name="pageStep">
+                       <number>20</number>
+                      </property>
+                      <property name="value">
+                       <number>50</number>
+                      </property>
+                      <property name="orientation">
+                       <enum>Qt::Orientation::Horizontal</enum>
+                      </property>
+                      <property name="invertedAppearance">
+                       <bool>false</bool>
+                      </property>
+                      <property name="invertedControls">
+                       <bool>false</bool>
+                      </property>
+                      <property name="tickPosition">
+                       <enum>QSlider::TickPosition::NoTicks</enum>
+                      </property>
+                      <property name="tickInterval">
+                       <number>10</number>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
                 </item>
                </layout>
               </widget>

--- a/src/qt_gui/translations/ar.ts
+++ b/src/qt_gui/translations/ar.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>تشغيل موسيقى العنوان</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>الصوت</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/da_DK.ts
+++ b/src/qt_gui/translations/da_DK.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>Afspil titelsang</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>Lydstyrke</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/de.ts
+++ b/src/qt_gui/translations/de.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>Titelmusik abspielen</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>Lautstärke</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/el.ts
+++ b/src/qt_gui/translations/el.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>Αναπαραγωγή μουσικής τίτλου</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>ένταση</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/en.ts
+++ b/src/qt_gui/translations/en.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>Play title music</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>Volume</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/es_ES.ts
+++ b/src/qt_gui/translations/es_ES.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>Reproducir la música de apertura</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>Volumen</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/fa_IR.ts
+++ b/src/qt_gui/translations/fa_IR.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>پخش موسیقی عنوان</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>صدا </translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/fi.ts
+++ b/src/qt_gui/translations/fi.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>Soita otsikkomusiikkia</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>Äänenvoimakkuus</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/fr.ts
+++ b/src/qt_gui/translations/fr.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>Lire la musique du titre</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>Volume</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/hu_HU.ts
+++ b/src/qt_gui/translations/hu_HU.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>Címzene lejátszása</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>Hangerő</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/id.ts
+++ b/src/qt_gui/translations/id.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>Putar musik judul</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>Volume</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/it.ts
+++ b/src/qt_gui/translations/it.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>Riproduci musica del titolo</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>Volume</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/ja_JP.ts
+++ b/src/qt_gui/translations/ja_JP.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>タイトル音楽を再生する</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>音量</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/ko_KR.ts
+++ b/src/qt_gui/translations/ko_KR.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>Play title music</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>음량</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/lt_LT.ts
+++ b/src/qt_gui/translations/lt_LT.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>Groti antraštės muziką</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>Garsumas</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/nb.ts
+++ b/src/qt_gui/translations/nb.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>Spill tittelmusikk</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>Volum</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/nl.ts
+++ b/src/qt_gui/translations/nl.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>Titelmuziek afspelen</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>Volume</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/pl_PL.ts
+++ b/src/qt_gui/translations/pl_PL.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>Odtwórz muzykę tytułową</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>Głośność</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/pt_BR.ts
+++ b/src/qt_gui/translations/pt_BR.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>Reproduzir música de abertura</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>Volume</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/ro_RO.ts
+++ b/src/qt_gui/translations/ro_RO.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>Redă muzica titlului</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>Volum</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/ru_RU.ts
+++ b/src/qt_gui/translations/ru_RU.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>Воспроизвести музыку заголовка</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>Громкость</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/sq.ts
+++ b/src/qt_gui/translations/sq.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>Luaj muzikën e titullit</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>Volumi</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/tr_TR.ts
+++ b/src/qt_gui/translations/tr_TR.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>Başlık müziğini çal</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>Ses seviyesi</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/vi_VN.ts
+++ b/src/qt_gui/translations/vi_VN.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>Phát nhạc tiêu đề</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>Âm lượng</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/zh_CN.ts
+++ b/src/qt_gui/translations/zh_CN.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>播放标题音乐</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>音量</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>

--- a/src/qt_gui/translations/zh_TW.ts
+++ b/src/qt_gui/translations/zh_TW.ts
@@ -534,6 +534,11 @@
 			<source>Play title music</source>
 			<translation>播放標題音樂</translation>
 		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="394"/>
+			<source>Volume</source>
+			<translation>音量</translation>
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>


### PR DESCRIPTION
Added a volume slider for the title music.

![image](https://github.com/user-attachments/assets/e5522b15-725a-4a48-8e25-ea1704d3f339)

The volume is stored as an integer ranging from 0 to 100 and is applied using a logarithmic scale to better match human hearing perception.
