### PR TITLE
Improve keyboard navigation in game list

### DIFF
--- a/src/qt_gui/game_grid_frame.cpp
+++ b/src/qt_gui/game_grid_frame.cpp
@@ -42,9 +42,11 @@ void GameGridFrame::onCurrentCellChanged(int currentRow, int currentColumn, int 
 
     auto itemID = (crtRow * columnCnt) + currentColumn;
     if (itemID > m_game_info->m_games.count() - 1) {
+        validCellSelected = false;
         BackgroundMusicPlayer::getInstance().stopMusic();
         return;
     }
+    validCellSelected = true;
     SetGridBackgroundImage(crtRow, crtColumn);
     auto snd0Path = QString::fromStdString(m_game_info->m_games[itemID].snd0_path.string());
     PlayBackgroundMusic(snd0Path);
@@ -165,4 +167,8 @@ void GameGridFrame::RefreshGridBackgroundImage() {
         palette.setColor(QPalette::Highlight, transparentColor);
         this->setPalette(palette);
     }
+}
+
+bool GameGridFrame::IsValidCellSelected() {
+    return validCellSelected;
 }

--- a/src/qt_gui/game_grid_frame.cpp
+++ b/src/qt_gui/game_grid_frame.cpp
@@ -22,7 +22,7 @@ GameGridFrame::GameGridFrame(std::shared_ptr<GameInfoClass> game_info_get, QWidg
     this->setContextMenuPolicy(Qt::CustomContextMenu);
     PopulateGameGrid(m_game_info->m_games, false);
 
-    connect(this, &QTableWidget::cellClicked, this, &GameGridFrame::SetGridBackgroundImage);
+    connect(this, &QTableWidget::currentCellChanged, this, &GameGridFrame::onCurrentCellChanged);
 
     connect(this->verticalScrollBar(), &QScrollBar::valueChanged, this,
             &GameGridFrame::RefreshGridBackgroundImage);
@@ -31,22 +31,31 @@ GameGridFrame::GameGridFrame(std::shared_ptr<GameInfoClass> game_info_get, QWidg
     connect(this, &QTableWidget::customContextMenuRequested, this, [=, this](const QPoint& pos) {
         m_gui_context_menus.RequestGameMenu(pos, m_game_info->m_games, this, false);
     });
-    connect(this, &QTableWidget::cellClicked, this, [&]() {
-        cellClicked = true;
-        crtRow = this->currentRow();
-        crtColumn = this->currentColumn();
-        columnCnt = this->columnCount();
-    });
 }
 
-void GameGridFrame::PlayBackgroundMusic(QTableWidgetItem* item) {
-    if (!item) {
+void GameGridFrame::onCurrentCellChanged(int currentRow, int currentColumn, int previousRow,
+                                         int previousColumn) {
+    cellClicked = true;
+    crtRow = currentRow;
+    crtColumn = currentColumn;
+    columnCnt = this->columnCount();
+
+    auto itemID = (crtRow * columnCnt) + currentColumn;
+    if (itemID > m_game_info->m_games.count() - 1) {
         BackgroundMusicPlayer::getInstance().stopMusic();
         return;
     }
-    QString snd0path;
-    Common::FS::PathToQString(snd0path, m_game_info->m_games[item->row()].snd0_path);
-    BackgroundMusicPlayer::getInstance().playMusic(snd0path);
+    SetGridBackgroundImage(crtRow, crtColumn);
+    auto snd0Path = QString::fromStdString(m_game_info->m_games[itemID].snd0_path.string());
+    PlayBackgroundMusic(snd0Path);
+}
+
+void GameGridFrame::PlayBackgroundMusic(QString path) {
+    if (path.isEmpty()) {
+        BackgroundMusicPlayer::getInstance().stopMusic();
+        return;
+    }
+    BackgroundMusicPlayer::getInstance().playMusic(path);
 }
 
 void GameGridFrame::PopulateGameGrid(QVector<GameInfo> m_games_search, bool fromSearch) {

--- a/src/qt_gui/game_grid_frame.h
+++ b/src/qt_gui/game_grid_frame.h
@@ -30,10 +30,12 @@ private:
     GuiContextMenus m_gui_context_menus;
     std::shared_ptr<GameInfoClass> m_game_info;
     std::shared_ptr<QVector<GameInfo>> m_games_shared;
+    bool validCellSelected = false;
 
 public:
     explicit GameGridFrame(std::shared_ptr<GameInfoClass> game_info_get, QWidget* parent = nullptr);
     void PopulateGameGrid(QVector<GameInfo> m_games, bool fromSearch);
+    bool IsValidCellSelected();
 
     bool cellClicked = false;
     int icon_size;

--- a/src/qt_gui/game_grid_frame.h
+++ b/src/qt_gui/game_grid_frame.h
@@ -20,7 +20,9 @@ Q_SIGNALS:
 public Q_SLOTS:
     void SetGridBackgroundImage(int row, int column);
     void RefreshGridBackgroundImage();
-    void PlayBackgroundMusic(QTableWidgetItem* item);
+    void PlayBackgroundMusic(QString path);
+    void onCurrentCellChanged(int currentRow, int currentColumn, int previousRow,
+                              int previousColumn);
 
 private:
     QImage backgroundImage;

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -41,7 +41,7 @@ GameListFrame::GameListFrame(std::shared_ptr<GameInfoClass> game_info_get, QWidg
     this->horizontalHeader()->setSectionResizeMode(3, QHeaderView::Fixed);
     PopulateGameList();
 
-    connect(this, &QTableWidget::itemClicked, this, &GameListFrame::SetListBackgroundImage);
+    connect(this, &QTableWidget::currentCellChanged, this, &GameListFrame::onCurrentCellChanged);
     connect(this->verticalScrollBar(), &QScrollBar::valueChanged, this,
             &GameListFrame::RefreshListBackgroundImage);
     connect(this->horizontalScrollBar(), &QScrollBar::valueChanged, this,
@@ -67,6 +67,16 @@ GameListFrame::GameListFrame(std::shared_ptr<GameInfoClass> game_info_get, QWidg
     connect(this, &QTableWidget::customContextMenuRequested, this, [=, this](const QPoint& pos) {
         m_gui_context_menus.RequestGameMenu(pos, m_game_info->m_games, this, true);
     });
+}
+
+void GameListFrame::onCurrentCellChanged(int currentRow, int currentColumn, int previousRow,
+                                         int previousColumn) {
+    QTableWidgetItem* item = this->item(currentRow, currentColumn);
+    if (!item) {
+        return;
+    }
+    SetListBackgroundImage(item);
+    PlayBackgroundMusic(item);
 }
 
 void GameListFrame::PlayBackgroundMusic(QTableWidgetItem* item) {

--- a/src/qt_gui/game_list_frame.h
+++ b/src/qt_gui/game_list_frame.h
@@ -23,6 +23,8 @@ public Q_SLOTS:
     void SortNameAscending(int columnIndex);
     void SortNameDescending(int columnIndex);
     void PlayBackgroundMusic(QTableWidgetItem* item);
+    void onCurrentCellChanged(int currentRow, int currentColumn, int previousRow,
+                              int previousColumn);
 
 private:
     void SetTableItem(int row, int column, QString itemStr);

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -1040,6 +1040,6 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event) {
                 return true;
             }
         }
-        return QMainWindow::eventFilter(obj, event);
     }
+    return QMainWindow::eventFilter(obj, event);
 }

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -1034,8 +1034,11 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event) {
     if (event->type() == QEvent::KeyPress) {
         QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
         if (keyEvent->key() == Qt::Key_Enter || keyEvent->key() == Qt::Key_Return) {
-            MainWindow::StartGame();
-            return true;
+            auto tblMode = Config::getTableMode();
+            if (tblMode != 2 && (tblMode != 1 || m_game_grid_frame->IsValidCellSelected())) {
+                StartGame();
+                return true;
+            }
         }
         return QMainWindow::eventFilter(obj, event);
     }

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <QDockWidget>
+#include <QKeyEvent>
 #include <QProgressDialog>
 
 #include <common/scm_rev.h>
@@ -21,6 +22,7 @@
 
 MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWindow) {
     ui->setupUi(this);
+    installEventFilter(this);
     setAttribute(Qt::WA_DeleteOnClose);
 }
 
@@ -306,6 +308,7 @@ void MainWindow::CreateConnects() {
     });
     // List
     connect(ui->setlistModeListAct, &QAction::triggered, m_dock_widget.data(), [this]() {
+        BackgroundMusicPlayer::getInstance().stopMusic();
         m_dock_widget->setWidget(m_game_list_frame.data());
         m_game_grid_frame->hide();
         m_elf_viewer->hide();
@@ -322,6 +325,7 @@ void MainWindow::CreateConnects() {
     });
     // Grid
     connect(ui->setlistModeGridAct, &QAction::triggered, m_dock_widget.data(), [this]() {
+        BackgroundMusicPlayer::getInstance().stopMusic();
         m_dock_widget->setWidget(m_game_grid_frame.data());
         m_game_grid_frame->show();
         m_game_list_frame->hide();
@@ -338,6 +342,7 @@ void MainWindow::CreateConnects() {
     });
     // Elf
     connect(ui->setlistElfAct, &QAction::triggered, m_dock_widget.data(), [this]() {
+        BackgroundMusicPlayer::getInstance().stopMusic();
         m_dock_widget->setWidget(m_elf_viewer.data());
         m_game_grid_frame->hide();
         m_game_list_frame->hide();
@@ -512,29 +517,6 @@ void MainWindow::CreateConnects() {
             isIconBlack = false;
         }
     });
-
-    connect(m_game_grid_frame.get(), &QTableWidget::cellClicked, this,
-            &MainWindow::PlayBackgroundMusic);
-    connect(m_game_list_frame.get(), &QTableWidget::cellClicked, this,
-            &MainWindow::PlayBackgroundMusic);
-}
-
-void MainWindow::PlayBackgroundMusic() {
-    if (isGameRunning || !Config::getPlayBGM()) {
-        BackgroundMusicPlayer::getInstance().stopMusic();
-        return;
-    }
-    int itemID = isTableList ? m_game_list_frame->currentItem()->row()
-                             : m_game_grid_frame->crtRow * m_game_grid_frame->columnCnt +
-                                   m_game_grid_frame->crtColumn;
-    if (itemID > m_game_info->m_games.size() - 1) {
-        // Can happen in grid mode
-        BackgroundMusicPlayer::getInstance().stopMusic();
-        return;
-    }
-    QString snd0path;
-    Common::FS::PathToQString(snd0path, m_game_info->m_games[itemID].snd0_path);
-    BackgroundMusicPlayer::getInstance().playMusic(snd0path);
 }
 
 void MainWindow::StartGame() {
@@ -1046,4 +1028,15 @@ void MainWindow::OnLanguageChanged(const std::string& locale) {
     Config::setEmulatorLanguage(locale);
 
     LoadTranslation();
+}
+
+bool MainWindow::eventFilter(QObject* obj, QEvent* event) {
+    if (event->type() == QEvent::KeyPress) {
+        QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+        if (keyEvent->key() == Qt::Key_Enter || keyEvent->key() == Qt::Key_Return) {
+            MainWindow::StartGame();
+            return true;
+        }
+        return QMainWindow::eventFilter(obj, event);
+    }
 }

--- a/src/qt_gui/main_window.h
+++ b/src/qt_gui/main_window.h
@@ -94,6 +94,8 @@ private:
     QTranslator* translator;
 
 protected:
+    bool eventFilter(QObject* obj, QEvent* event) override;
+
     void dragEnterEvent(QDragEnterEvent* event1) override {
         if (event1->mimeData()->hasUrls()) {
             event1->acceptProposedAction();


### PR DESCRIPTION
Keyboard navigation in games list or games grid was always possible, but wouldn't change the background image or play the correct background music.

With this PR, the proper background image is set and music is played, both in list and grid mode.
Playback is stopped when switching between view modes. 

Pressing enter or return starts the currently selected game