### PR TITLE
Added sceKernelRmdir

### DIFF
--- a/src/common/io_file.cpp
+++ b/src/common/io_file.cpp
@@ -192,8 +192,9 @@ int IOFile::Open(const fs::path& path, FileAccessMode mode, FileType type, FileS
 #endif
 
     if (!IsOpen()) {
-        LOG_ERROR(Common_Filesystem, "Failed to open the file at path={}",
-                  PathToUTF8String(file_path));
+        const auto ec = std::error_code{result, std::generic_category()};
+        LOG_ERROR(Common_Filesystem, "Failed to open the file at path={}, error_message={}",
+                  PathToUTF8String(file_path), ec.message());
     }
 
     return result;

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -329,7 +329,7 @@ int PS4_SYSV_ABI sceKernelRmdir(const char* path, u16 mode) {
     }
 
     if (!std::filesystem::exists(dir_name)) {
-        return 0;
+        return ORBIS_OK;
     }
 
     int result = std::filesystem::remove_all(dir_name);
@@ -338,11 +338,7 @@ int PS4_SYSV_ABI sceKernelRmdir(const char* path, u16 mode) {
     if (error == 0) {
         return ORBIS_OK;
     }
-
-    if (result < 0) {
-        return ErrnoToSceKernelError(error); // error - 0x7ffe0000;
-    }
-    return result;
+    return ErrnoToSceKernelError(error); // error - 0x7ffe0000;
 }
 
 int PS4_SYSV_ABI sceKernelStat(const char* path, OrbisKernelStat* sb) {


### PR DESCRIPTION
This PR adds sceKernelRmdir, a function often used by Unreal Engine 4 games such as Street Fighter V, as well as makes IOFile::Open() log the error message just like IOFile::Close()