### PR TITLE
Fix V_CMP_CLASS_F32

### DIFF
--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -909,6 +909,8 @@ void Translator::V_CMP_CLASS_F32(const GcnInst& inst) {
     switch (inst.dst[1].field) {
     case OperandField::VccLo:
         return ir.SetVcc(value);
+    case OperandField::ScalarGPR:
+        return ir.SetThreadBitScalarReg(IR::ScalarReg(inst.dst[1].code), value);
     default:
         UNREACHABLE();
     }


### PR DESCRIPTION
CUSA07594 

[Debug] <Critical> vector_alu.cpp:V_CMP_CLASS_F32:913: Unreachable code!

With the fix, Guilty Gear Xrd REV 2 is fully playable now.

![image](https://github.com/user-attachments/assets/d50e18d0-6e48-4d26-b331-16ea26d509ec)

#331 #496