### PR TITLE
Fix path bugs & wrap seeks in an if

### DIFF
--- a/src/common/io_file.cpp
+++ b/src/common/io_file.cpp
@@ -372,6 +372,18 @@ bool IOFile::Seek(s64 offset, SeekOrigin origin) const {
         return false;
     }
 
+    u64 size = GetSize();
+    if (origin == SeekOrigin::CurrentPosition && Tell() + offset > size) {
+        LOG_ERROR(Common_Filesystem, "Seeking past the end of the file");
+        return false;
+    } else if (origin == SeekOrigin::SetOrigin && (u64)offset > size) {
+        LOG_ERROR(Common_Filesystem, "Seeking past the end of the file");
+        return false;
+    } else if (origin == SeekOrigin::End && offset > 0) {
+        LOG_ERROR(Common_Filesystem, "Seeking past the end of the file");
+        return false;
+    }
+
     errno = 0;
 
     const auto seek_result = fseeko(file, offset, ToSeekOrigin(origin)) == 0;

--- a/src/core/file_format/pkg.h
+++ b/src/core/file_format/pkg.h
@@ -103,7 +103,7 @@ public:
     PKG();
     ~PKG();
 
-    bool Open(const std::filesystem::path& filepath);
+    bool Open(const std::filesystem::path& filepath, std::string& failreason);
     void ExtractFiles(const int index);
     bool Extract(const std::filesystem::path& filepath, const std::filesystem::path& extract,
                  std::string& failreason);

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -229,7 +229,10 @@ s64 PS4_SYSV_ABI sceKernelLseek(int d, s64 offset, int whence) {
     }
 
     std::scoped_lock lk{file->m_mutex};
-    file->f.Seek(offset, origin);
+    if (!file->f.Seek(offset, origin)) {
+        LOG_CRITICAL(Kernel_Fs, "sceKernelLseek: failed to seek");
+        return SCE_KERNEL_ERROR_EINVAL;
+    }
     return file->f.Tell();
 }
 
@@ -380,7 +383,10 @@ s64 PS4_SYSV_ABI sceKernelPread(int d, void* buf, size_t nbytes, s64 offset) {
     SCOPE_EXIT {
         file->f.Seek(pos);
     };
-    file->f.Seek(offset);
+    if (!file->f.Seek(offset)) {
+        LOG_CRITICAL(Kernel_Fs, "sceKernelPread: failed to seek");
+        return ORBIS_KERNEL_ERROR_EINVAL;
+    }
     return file->f.ReadRaw<u8>(buf, nbytes);
 }
 
@@ -514,7 +520,10 @@ s64 PS4_SYSV_ABI sceKernelPwrite(int d, void* buf, size_t nbytes, s64 offset) {
     SCOPE_EXIT {
         file->f.Seek(pos);
     };
-    file->f.Seek(offset);
+    if (!file->f.Seek(offset)) {
+        LOG_CRITICAL(Kernel_Fs, "sceKernelPwrite: failed to seek");
+        return ORBIS_KERNEL_ERROR_EINVAL;
+    }
     return file->f.WriteRaw<u8>(buf, nbytes);
 }
 

--- a/src/core/loader/elf.cpp
+++ b/src/core/loader/elf.cpp
@@ -204,7 +204,10 @@ void Elf::Open(const std::filesystem::path& file_name) {
         }
 
         out.resize(num);
-        m_f.Seek(offset, SeekOrigin::SetOrigin);
+        if (!m_f.Seek(offset, SeekOrigin::SetOrigin)) {
+            LOG_CRITICAL(Loader, "Failed to seek to header tables");
+            return;
+        }
         m_f.Read(out);
     };
 
@@ -465,7 +468,10 @@ std::string Elf::ElfPHeaderStr(u16 no) {
 void Elf::LoadSegment(u64 virtual_addr, u64 file_offset, u64 size) {
     if (!is_self) {
         // It's elf file
-        m_f.Seek(file_offset, SeekOrigin::SetOrigin);
+        if (!m_f.Seek(file_offset, SeekOrigin::SetOrigin)) {
+            LOG_CRITICAL(Loader, "Failed to seek to ELF header");
+            return;
+        }
         m_f.ReadRaw<u8>(reinterpret_cast<u8*>(virtual_addr), size);
         return;
     }
@@ -479,7 +485,10 @@ void Elf::LoadSegment(u64 virtual_addr, u64 file_offset, u64 size) {
 
             if (file_offset >= phdr.p_offset && file_offset < phdr.p_offset + phdr.p_filesz) {
                 auto offset = file_offset - phdr.p_offset;
-                m_f.Seek(offset + seg.file_offset, SeekOrigin::SetOrigin);
+                if (!m_f.Seek(offset + seg.file_offset, SeekOrigin::SetOrigin)) {
+                    LOG_CRITICAL(Loader, "Failed to seek to segment");
+                    return;
+                }
                 m_f.ReadRaw<u8>(reinterpret_cast<u8*>(virtual_addr), size);
                 return;
             }

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -312,10 +312,7 @@ public:
 
         if (selected == &installPackage) {
             QStringList pkg_app_ = m_pkg_app_list[itemIndex].split(";;");
-            std::filesystem::path path(pkg_app_[9].toStdString());
-#ifdef _WIN32
-            path = std::filesystem::path(pkg_app_[9].toStdWString());
-#endif
+            std::filesystem::path path = Common::FS::PathFromQString(pkg_app_[9]);
             InstallDragDropPkg(path, 1, 1);
         }
     }

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -657,9 +657,12 @@ void MainWindow::BootGame() {
 
 void MainWindow::InstallDragDropPkg(std::filesystem::path file, int pkgNum, int nPkg) {
     if (Loader::DetectFileType(file) == Loader::FileTypes::Pkg) {
-        pkg = PKG();
-        pkg.Open(file);
         std::string failreason;
+        pkg = PKG();
+        if (!pkg.Open(file, failreason)) {
+            QMessageBox::critical(this, tr("PKG ERROR"), QString::fromStdString(failreason));
+            return;
+        }
         auto extract_path = Config::getGameInstallDir() / pkg.GetTitleID();
         QString pkgType = QString::fromStdString(pkg.GetPkgFlags());
         QString gameDirPath;

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -625,10 +625,7 @@ void MainWindow::InstallPkg() {
         int pkgNum = 0;
         for (const QString& file : fileNames) {
             ++pkgNum;
-            std::filesystem::path path(file.toStdString());
-#ifdef _WIN64
-            path = std::filesystem::path(file.toStdWString());
-#endif
+            std::filesystem::path path = Common::FS::PathFromQString(file);
             MainWindow::InstallDragDropPkg(path, pkgNum, nPkg);
         }
     }
@@ -646,10 +643,7 @@ void MainWindow::BootGame() {
             QMessageBox::critical(nullptr, tr("Game Boot"),
                                   QString(tr("Only one file can be selected!")));
         } else {
-            std::filesystem::path path(fileNames[0].toStdString());
-#ifdef _WIN64
-            path = std::filesystem::path(fileNames[0].toStdWString());
-#endif
+            std::filesystem::path path = Common::FS::PathFromQString(fileNames[0]);
             Core::Emulator emulator;
             if (!std::filesystem::exists(path)) {
                 QMessageBox::critical(nullptr, tr("Run Game"),

--- a/src/qt_gui/main_window.h
+++ b/src/qt_gui/main_window.h
@@ -110,10 +110,7 @@ protected:
             int nPkg = urlList.size();
             for (const QUrl& url : urlList) {
                 pkgNum++;
-                std::filesystem::path path(url.toLocalFile().toStdString());
-#ifdef _WIN64
-                path = std::filesystem::path(url.toLocalFile().toStdWString());
-#endif
+                std::filesystem::path path = Common::FS::PathFromQString(url.toLocalFile());
                 InstallDragDropPkg(path, pkgNum, nPkg);
             }
         }

--- a/src/qt_gui/pkg_viewer.cpp
+++ b/src/qt_gui/pkg_viewer.cpp
@@ -105,7 +105,11 @@ void PKGViewer::ProcessPKGInfo() {
     m_full_pkg_list.clear();
     for (int i = 0; i < m_pkg_list.size(); i++) {
         std::filesystem::path path = Common::FS::PathFromQString(m_pkg_list[i]);
-        package.Open(path);
+        std::string failreason;
+        if (!package.Open(path, failreason)) {
+            QMessageBox::critical(this, tr("PKG ERROR"), QString::fromStdString(failreason));
+            return;
+        }
         psf.Open(package.sfo);
         QString title_name =
             QString::fromStdString(std::string{psf.GetString("TITLE").value_or("Unknown")});

--- a/src/qt_gui/pkg_viewer.cpp
+++ b/src/qt_gui/pkg_viewer.cpp
@@ -104,10 +104,7 @@ void PKGViewer::ProcessPKGInfo() {
     m_pkg_patch_list.clear();
     m_full_pkg_list.clear();
     for (int i = 0; i < m_pkg_list.size(); i++) {
-        std::filesystem::path path(m_pkg_list[i].toStdString());
-#ifdef _WIN32
-        path = std::filesystem::path(m_pkg_list[i].toStdWString());
-#endif
+        std::filesystem::path path = Common::FS::PathFromQString(m_pkg_list[i]);
         package.Open(path);
         psf.Open(package.sfo);
         QString title_name =

--- a/src/qt_gui/trophy_viewer.cpp
+++ b/src/qt_gui/trophy_viewer.cpp
@@ -28,10 +28,7 @@ void TrophyViewer::PopulateTrophyWidget(QString title) {
 
     QDir dir(trophyDirQt);
     if (!dir.exists()) {
-        std::filesystem::path path(gameTrpPath_.toStdString());
-#ifdef _WIN64
-        path = std::filesystem::path(gameTrpPath_.toStdWString());
-#endif
+        std::filesystem::path path = Common::FS::PathFromQString(gameTrpPath_);
         if (!trp.Extract(path))
             return;
     }


### PR DESCRIPTION
These were doing both a conversion from string to path and then from wstring to path.

std::string to fs::path throws an exception on windows if the path has unicode symbols.

---

Wrapped IOFile::Seek calls in an `if` to better bug report bad seeks.