### PR TITLE
sdl: Fix use of functions that now return SDL_bool

### DIFF
--- a/src/audio_core/sdl_audio.cpp
+++ b/src/audio_core/sdl_audio.cpp
@@ -101,14 +101,14 @@ s32 SDLAudio::AudioOutOutput(s32 handle, const void* ptr) {
         return 0;
     }
     // TODO mixing channels
-    int result = SDL_PutAudioStreamData(port.stream, ptr,
-                                        port.samples_num * port.sample_size * port.channels_num);
+    SDL_bool result = SDL_PutAudioStreamData(
+        port.stream, ptr, port.samples_num * port.sample_size * port.channels_num);
     // TODO find a correct value 8192 is estimated
     while (SDL_GetAudioStreamAvailable(port.stream) > 65536) {
         SDL_Delay(0);
     }
 
-    return result;
+    return result ? ORBIS_OK : -1;
 }
 
 bool SDLAudio::AudioOutSetVolume(s32 handle, s32 bitflag, s32* volume) {

--- a/src/input/controller.cpp
+++ b/src/input/controller.cpp
@@ -127,7 +127,7 @@ void GameController::SetLightBarRGB(u8 r, u8 g, u8 b) {
 bool GameController::SetVibration(u8 smallMotor, u8 largeMotor) {
     if (m_sdl_gamepad != nullptr) {
         return SDL_RumbleGamepad(m_sdl_gamepad, (smallMotor / 255.0f) * 0xFFFF,
-                                 (largeMotor / 255.0f) * 0xFFFF, -1) == 0;
+                                 (largeMotor / 255.0f) * 0xFFFF, -1);
     }
     return true;
 }

--- a/src/sdl_window.cpp
+++ b/src/sdl_window.cpp
@@ -23,7 +23,7 @@ namespace Frontend {
 WindowSDL::WindowSDL(s32 width_, s32 height_, Input::GameController* controller_,
                      std::string_view window_title)
     : width{width_}, height{height_}, controller{controller_} {
-    if (SDL_Init(SDL_INIT_VIDEO) < 0) {
+    if (!SDL_Init(SDL_INIT_VIDEO)) {
         UNREACHABLE_MSG("Failed to initialize SDL video subsystem: {}", SDL_GetError());
     }
     SDL_InitSubSystem(SDL_INIT_AUDIO);


### PR DESCRIPTION
Recent SDL update changed some functions to return `SDL_bool` instead of an integer return code. Adjust return value handling accordingly.

Fixes missing music audio in Project Diva Future Tone.