### PR TITLE
vulkan: Use dynamic vertex buffer strides when dynamic bindings unavailable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 if(APPLE)
     enable_language(OBJC)
-    set(CMAKE_OSX_DEPLOYMENT_TARGET 11)
+    set(CMAKE_OSX_DEPLOYMENT_TARGET 14)
 endif()
 
 if (NOT CMAKE_BUILD_TYPE)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Check the build instructions for [**Linux**](https://github.com/shadps4-emu/shad
 Check the build instructions for [**macOS**](https://github.com/shadps4-emu/shadPS4/blob/main/documents/building-macos.md).
 
 > [!IMPORTANT]
-> macOS users need at least macOS 15 on Apple Silicon-based Mac devices and at least macOS 11 on Intel-based Mac devices.
+> macOS users need at least macOS 15 on Apple Silicon-based Mac devices and at least macOS 14 on Intel-based Mac devices.
 
 # Debugging and reporting issues
 

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -45,6 +45,7 @@ struct GraphicsPipelineKey {
     Liverpool::ColorBufferMask cb_shader_mask;
     std::array<Liverpool::BlendControl, Liverpool::NumColorBuffers> blend_controls;
     std::array<vk::ColorComponentFlags, Liverpool::NumColorBuffers> write_masks;
+    std::array<vk::Format, MaxVertexBufferCount> vertex_buffer_formats;
 
     bool operator==(const GraphicsPipelineKey& key) const noexcept {
         return std::memcmp(this, &key, sizeof(key)) == 0;

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -272,6 +272,7 @@ bool Instance::CreateDevice() {
     add_extension(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
     add_extension(VK_EXT_SHADER_DEMOTE_TO_HELPER_INVOCATION_EXTENSION_NAME);
     add_extension(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
+    add_extension(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
 
 #ifdef __APPLE__
     // Required by Vulkan spec if supported.


### PR DESCRIPTION
Currently when `VK_EXT_vertex_input_dynamic_state` is unsupported, the fallback fixed vertex bindings in the pipeline are not updated when user data affects the definition of the buffer by changing the stride or format. This is the root cause of a lot of vertex explosions and corrupted graphics on drivers like MoltenVK, across many games.

Instead, we can take a two-part approach:
* For changing stride, use dynamic vertex input stride from `VK_EXT_extended_dynamic_state`, which is supported on MoltenVK and any Vulkan 1.3 driver.
* For changing format, add the binding formats into the graphics key to create new pipelines.

This necessitates a minimum macOS version bump to 14, as dynamic vertex binding stride is not supported before Metal 3.1, which was introduced with macOS 14. Apple Silicon Macs already require 15, so this just affects some older Intel Macs that cannot upgrade to 14. I'm not sure how well this worked on those older models to begin with as I have never tested them, but guaranteeing higher Metal version support will make things a lot easier in general.