### PR TITLE
config: Add option to change DLC install path.

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -8,6 +8,7 @@
 #include <fmt/xchar.h> // for wstring support
 #include <toml.hpp>
 #include "common/logging/formatter.h"
+#include "common/path_util.h"
 #include "config.h"
 
 namespace toml {
@@ -59,6 +60,7 @@ static bool vkCrashDiagnostic = false;
 
 // Gui
 std::filesystem::path settings_install_dir = {};
+std::filesystem::path settings_addon_install_dir = {};
 u32 main_window_geometry_x = 400;
 u32 main_window_geometry_y = 400;
 u32 main_window_geometry_w = 1280;
@@ -299,6 +301,9 @@ void setMainWindowGeometry(u32 x, u32 y, u32 w, u32 h) {
 void setGameInstallDir(const std::filesystem::path& dir) {
     settings_install_dir = dir;
 }
+void setAddonInstallDir(const std::filesystem::path& dir) {
+    settings_addon_install_dir = dir;
+}
 void setMainWindowTheme(u32 theme) {
     mw_themes = theme;
 }
@@ -354,6 +359,13 @@ u32 getMainWindowGeometryH() {
 }
 std::filesystem::path getGameInstallDir() {
     return settings_install_dir;
+}
+std::filesystem::path getAddonInstallDir() {
+    if (settings_addon_install_dir.empty()) {
+        // Default for users without a config file or a config file from before this option existed
+        return Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "addcont";
+    }
+    return settings_addon_install_dir;
 }
 u32 getMainWindowTheme() {
     return mw_themes;
@@ -482,6 +494,7 @@ void load(const std::filesystem::path& path) {
         m_window_size_W = toml::find_or<int>(gui, "mw_width", 0);
         m_window_size_H = toml::find_or<int>(gui, "mw_height", 0);
         settings_install_dir = toml::find_fs_path_or(gui, "installDir", {});
+        settings_addon_install_dir = toml::find_fs_path_or(gui, "addonInstallDir", {});
         main_window_geometry_x = toml::find_or<int>(gui, "geometry_x", 0);
         main_window_geometry_y = toml::find_or<int>(gui, "geometry_y", 0);
         main_window_geometry_w = toml::find_or<int>(gui, "geometry_w", 0);
@@ -556,6 +569,8 @@ void save(const std::filesystem::path& path) {
     data["GUI"]["mw_width"] = m_window_size_W;
     data["GUI"]["mw_height"] = m_window_size_H;
     data["GUI"]["installDir"] = std::string{fmt::UTF(settings_install_dir.u8string()).data};
+    data["GUI"]["addonInstallDir"] =
+        std::string{fmt::UTF(settings_addon_install_dir.u8string()).data};
     data["GUI"]["geometry_x"] = main_window_geometry_x;
     data["GUI"]["geometry_y"] = main_window_geometry_y;
     data["GUI"]["geometry_w"] = main_window_geometry_w;

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -76,6 +76,7 @@ bool vkCrashDiagnosticEnabled();
 // Gui
 void setMainWindowGeometry(u32 x, u32 y, u32 w, u32 h);
 void setGameInstallDir(const std::filesystem::path& dir);
+void setAddonInstallDir(const std::filesystem::path& dir);
 void setMainWindowTheme(u32 theme);
 void setIconSize(u32 size);
 void setIconSizeGrid(u32 size);
@@ -94,6 +95,7 @@ u32 getMainWindowGeometryY();
 u32 getMainWindowGeometryW();
 u32 getMainWindowGeometryH();
 std::filesystem::path getGameInstallDir();
+std::filesystem::path getAddonInstallDir();
 u32 getMainWindowTheme();
 u32 getIconSize();
 u32 getIconSizeGrid();

--- a/src/common/path_util.cpp
+++ b/src/common/path_util.cpp
@@ -119,7 +119,6 @@ static auto UserPaths = [] {
     create_path(PathType::CapturesDir, user_dir / CAPTURES_DIR);
     create_path(PathType::CheatsDir, user_dir / CHEATS_DIR);
     create_path(PathType::PatchesDir, user_dir / PATCHES_DIR);
-    create_path(PathType::AddonsDir, user_dir / ADDONS_DIR);
     create_path(PathType::MetaDataDir, user_dir / METADATA_DIR);
 
     return paths;

--- a/src/common/path_util.h
+++ b/src/common/path_util.h
@@ -26,7 +26,6 @@ enum class PathType {
     CapturesDir,    // Where rdoc captures are stored.
     CheatsDir,      // Where cheats are stored.
     PatchesDir,     // Where patches are stored.
-    AddonsDir,      // Where additional content is stored.
     MetaDataDir,    // Where game metadata (e.g. trophies and menu backgrounds) is stored.
 };
 

--- a/src/core/libraries/app_content/app_content.cpp
+++ b/src/core/libraries/app_content/app_content.cpp
@@ -5,6 +5,7 @@
 
 #include "app_content.h"
 #include "common/assert.h"
+#include "common/config.h"
 #include "common/io_file.h"
 #include "common/logging/log.h"
 #include "common/path_util.h"
@@ -59,8 +60,7 @@ int PS4_SYSV_ABI sceAppContentAddcontMount(u32 service_label,
                                            OrbisAppContentMountPoint* mount_point) {
     LOG_INFO(Lib_AppContent, "called");
 
-    const auto& mount_dir = Common::FS::GetUserPath(Common::FS::PathType::AddonsDir) / title_id /
-                            entitlement_label->data;
+    const auto& mount_dir = Config::getAddonInstallDir() / title_id / entitlement_label->data;
     auto* mnt = Common::Singleton<Core::FileSys::MntPoints>::Instance();
 
     for (int i = 0; i < addcont_count; i++) {
@@ -246,7 +246,7 @@ int PS4_SYSV_ABI sceAppContentInitialize(const OrbisAppContentInitParam* initPar
     LOG_ERROR(Lib_AppContent, "(DUMMY) called");
     auto* param_sfo = Common::Singleton<PSF>::Instance();
 
-    const auto addons_dir = Common::FS::GetUserPath(Common::FS::PathType::AddonsDir);
+    const auto addons_dir = Config::getAddonInstallDir();
     if (const auto value = param_sfo->GetString("TITLE_ID"); value.has_value()) {
         title_id = *value;
     } else {

--- a/src/qt_gui/game_install_dialog.h
+++ b/src/qt_gui/game_install_dialog.h
@@ -16,13 +16,16 @@ public:
     ~GameInstallDialog();
 
 private slots:
-    void Browse();
+    void BrowseGamesDirectory();
+    void BrowseAddonsDirectory();
 
 private:
     QWidget* SetupGamesDirectory();
+    QWidget* SetupAddonsDirectory();
     QWidget* SetupDialogActions();
     void Save();
 
 private:
     QLineEdit* m_gamesDirectory;
+    QLineEdit* m_addonsDirectory;
 };

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -687,8 +687,8 @@ void MainWindow::InstallDragDropPkg(std::filesystem::path file, int pkgNum, int 
             }
             std::string entitlement_label = Common::SplitString(content_id, '-')[2];
 
-            auto addon_extract_path = Common::FS::GetUserPath(Common::FS::PathType::AddonsDir) /
-                                      pkg.GetTitleID() / entitlement_label;
+            auto addon_extract_path =
+                Config::getAddonInstallDir() / pkg.GetTitleID() / entitlement_label;
             QString addonDirPath;
             Common::FS::PathToQString(addonDirPath, addon_extract_path);
             QDir addon_dir(addonDirPath);


### PR DESCRIPTION
Adds a config option to change the DLC install path. It's useful to be able to point this to a directory of DLC contents independent of your config and other user data, same as how the game path works.

For users with existing config files, the current DLC path is defaulted to. When a user is opening the emulator for the first time, a DLC directory option will appear next to the game directory option, with the path inside the user directory filled in as the default in case the user does not care.