### PR TITLE
ci: add missing libs to enable Wayland backend for Qt and SDL

### DIFF
--- a/.github/linux-appimage-qt.sh
+++ b/.github/linux-appimage-qt.sh
@@ -9,6 +9,8 @@ fi
 
 export Qt6_DIR="/usr/lib/qt6"
 export PATH="$Qt6_DIR/bin:$PATH"
+export EXTRA_QT_PLUGINS="waylandcompositor"
+export EXTRA_PLATFORM_PLUGINS="libqwayland-egl.so;libqwayland-generic.so"
 
 # Prepare Tools for building the AppImage
 wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -291,7 +291,7 @@ jobs:
         submodules: recursive
 
     - name: Install dependencies
-      run: sudo apt-get update && sudo apt install -y libx11-dev libxext-dev libwayland-dev libfuse2 clang build-essential libasound2-dev libpulse-dev libopenal-dev
+      run: sudo apt-get update && sudo apt install -y libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 clang build-essential libasound2-dev libpulse-dev libopenal-dev
 
     - name: Cache CMake Configuration
       uses: actions/cache@v4 
@@ -347,7 +347,7 @@ jobs:
         submodules: recursive
 
     - name: Install dependencies
-      run: sudo apt-get update && sudo apt install -y libx11-dev libxext-dev libwayland-dev libfuse2 clang build-essential qt6-base-dev qt6-tools-dev qt6-multimedia-dev libasound2-dev libpulse-dev libopenal-dev
+      run: sudo apt-get update && sudo apt install -y libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 clang build-essential qt6-base-dev qt6-tools-dev qt6-multimedia-dev libasound2-dev libpulse-dev libopenal-dev
 
     - name: Cache CMake Configuration
       uses: actions/cache@v4 


### PR DESCRIPTION
Currently, only X11 is detected and enabled for SDL3 by CMake. This PR enables the Wayland backend for SDL.