### PR TITLE
qt: Create addons directory if it does not exist.

### DIFF
--- a/src/common/path_util.h
+++ b/src/common/path_util.h
@@ -44,7 +44,6 @@ constexpr auto DOWNLOAD_DIR = "download";
 constexpr auto CAPTURES_DIR = "captures";
 constexpr auto CHEATS_DIR = "cheats";
 constexpr auto PATCHES_DIR = "patches";
-constexpr auto ADDONS_DIR = "addcont";
 constexpr auto METADATA_DIR = "game_data";
 
 // Filenames

--- a/src/qt_gui/game_install_dialog.cpp
+++ b/src/qt_gui/game_install_dialog.cpp
@@ -111,11 +111,18 @@ void GameInstallDialog::Save() {
         return;
     }
 
-    if (addonsDirectory.isEmpty() || !QDir(addonsDirectory).exists() ||
-        !QDir::isAbsolutePath(addonsDirectory)) {
+    if (addonsDirectory.isEmpty() || !QDir::isAbsolutePath(addonsDirectory)) {
         QMessageBox::critical(this, tr("Error"),
                               "The value for location to install DLC is not valid.");
         return;
+    }
+    QDir addonsDir(addonsDirectory);
+    if (!addonsDir.exists()) {
+        if (!addonsDir.mkpath(".")) {
+            QMessageBox::critical(this, tr("Error"),
+                                  "The DLC install location could not be created.");
+            return;
+        }
     }
 
     Config::setGameInstallDir(Common::FS::PathFromQString(gamesDirectory));


### PR DESCRIPTION
Automatically creates the configured addons directory on first time setup if it does not exist. This would happen previously when it was a fixed user path, but stopped happening when it was made configurable.

Also removed a constant that is no longer used from when the directory was made configurable.