### PR TITLE
trp data extracts to game_data/serial instead of folder name

### DIFF
--- a/src/core/file_format/pkg.cpp
+++ b/src/core/file_format/pkg.cpp
@@ -249,12 +249,6 @@ bool PKG::Extract(const std::filesystem::path& filepath, const std::filesystem::
         file.Seek(currentPos);
     }
 
-    // Extract trophy files
-    if (!trp.Extract(extract_path)) {
-        // Do nothing some pkg come with no trp file.
-        // return false;
-    }
-
     // Read the seed
     std::array<u8, 16> seed;
     if (!file.Seek(pkgheader.pfs_image_offset + 0x370)) {

--- a/src/core/file_format/trp.cpp
+++ b/src/core/file_format/trp.cpp
@@ -32,8 +32,7 @@ static void removePadding(std::vector<u8>& vec) {
     }
 }
 
-bool TRP::Extract(const std::filesystem::path& trophyPath) {
-    std::filesystem::path title = trophyPath.filename();
+bool TRP::Extract(const std::filesystem::path& trophyPath, const std::string titleId) {
     std::filesystem::path gameSysDir = trophyPath / "sce_sys/trophy/";
     if (!std::filesystem::exists(gameSysDir)) {
         return false;
@@ -54,7 +53,8 @@ bool TRP::Extract(const std::filesystem::path& trophyPath) {
 
             s64 seekPos = sizeof(TrpHeader);
             std::filesystem::path trpFilesPath(
-                Common::FS::GetUserPath(Common::FS::PathType::MetaDataDir) / title / "TrophyFiles" /
+                Common::FS::GetUserPath(Common::FS::PathType::MetaDataDir) / titleId /
+                "TrophyFiles" /
                 it.path().stem());
             std::filesystem::create_directories(trpFilesPath / "Icons");
             std::filesystem::create_directory(trpFilesPath / "Xml");

--- a/src/core/file_format/trp.cpp
+++ b/src/core/file_format/trp.cpp
@@ -54,8 +54,7 @@ bool TRP::Extract(const std::filesystem::path& trophyPath, const std::string tit
             s64 seekPos = sizeof(TrpHeader);
             std::filesystem::path trpFilesPath(
                 Common::FS::GetUserPath(Common::FS::PathType::MetaDataDir) / titleId /
-                "TrophyFiles" /
-                it.path().stem());
+                "TrophyFiles" / it.path().stem());
             std::filesystem::create_directories(trpFilesPath / "Icons");
             std::filesystem::create_directory(trpFilesPath / "Xml");
 

--- a/src/core/file_format/trp.h
+++ b/src/core/file_format/trp.h
@@ -33,7 +33,7 @@ class TRP {
 public:
     TRP();
     ~TRP();
-    bool Extract(const std::filesystem::path& trophyPath);
+    bool Extract(const std::filesystem::path& trophyPath, const std::string titleId);
     void GetNPcommID(const std::filesystem::path& trophyPath, int index);
 
 private:

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -115,7 +115,7 @@ void Emulator::Run(const std::filesystem::path& file) {
                     Common::FS::GetUserPath(Common::FS::PathType::MetaDataDir) / id / "TrophyFiles";
                 if (!std::filesystem::exists(trophyDir)) {
                     TRP trp;
-                    if (!trp.Extract(file.parent_path())) {
+                    if (!trp.Extract(file.parent_path(), id)) {
                         LOG_ERROR(Loader, "Couldn't extract trophies");
                     }
                 }

--- a/src/qt_gui/trophy_viewer.cpp
+++ b/src/qt_gui/trophy_viewer.cpp
@@ -29,7 +29,7 @@ void TrophyViewer::PopulateTrophyWidget(QString title) {
     QDir dir(trophyDirQt);
     if (!dir.exists()) {
         std::filesystem::path path = Common::FS::PathFromQString(gameTrpPath_);
-        if (!trp.Extract(path))
+        if (!trp.Extract(path, title.toStdString()))
             return;
     }
     QFileInfoList dirList = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);


### PR DESCRIPTION
should fix a regression caused by the trophy refactor