### PR TITLE
core: Add support for Neo mode memory size.

### DIFF
--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -25,7 +25,7 @@ asm(".zerofill GUEST_SYSTEM,GUEST_SYSTEM,__guest_system,0xFBFC00000");
 
 namespace Core {
 
-static constexpr size_t BackingSize = SCE_KERNEL_MAIN_DMEM_SIZE;
+static constexpr size_t BackingSize = SCE_KERNEL_MAIN_DMEM_SIZE_PRO;
 
 #ifdef _WIN32
 

--- a/src/core/libraries/kernel/memory_management.h
+++ b/src/core/libraries/kernel/memory_management.h
@@ -7,6 +7,8 @@
 #include "common/types.h"
 
 constexpr u64 SCE_KERNEL_MAIN_DMEM_SIZE = 5056_MB; // ~ 5GB
+// TODO: Confirm this value on hardware.
+constexpr u64 SCE_KERNEL_MAIN_DMEM_SIZE_PRO = 5568_MB; // ~ 5.5GB
 
 namespace Libraries::Kernel {
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -3,6 +3,7 @@
 
 #include "common/alignment.h"
 #include "common/assert.h"
+#include "common/config.h"
 #include "common/debug.h"
 #include "core/libraries/error_codes.h"
 #include "core/libraries/kernel/memory_management.h"
@@ -39,8 +40,10 @@ MemoryManager::MemoryManager() {
 MemoryManager::~MemoryManager() = default;
 
 void MemoryManager::SetupMemoryRegions(u64 flexible_size) {
+    const auto total_size =
+        Config::isNeoMode() ? SCE_KERNEL_MAIN_DMEM_SIZE_PRO : SCE_KERNEL_MAIN_DMEM_SIZE;
     total_flexible_size = flexible_size;
-    total_direct_size = SCE_KERNEL_MAIN_DMEM_SIZE - flexible_size;
+    total_direct_size = total_size - flexible_size;
 
     // Insert an area that covers direct memory physical block.
     // Note that this should never be called after direct memory allocations have been made.

--- a/src/video_core/page_manager.cpp
+++ b/src/video_core/page_manager.cpp
@@ -142,6 +142,9 @@ struct PageManager::Impl {
     }
 
     void Protect(VAddr address, size_t size, bool allow_write) {
+        ASSERT_MSG(owned_ranges.find(address) != owned_ranges.end(),
+                   "Attempted to track non-GPU memory at address {:#x}, size {:#x}.", address,
+                   size);
 #ifdef _WIN32
         DWORD prot = allow_write ? PAGE_READWRITE : PAGE_READONLY;
         DWORD old_prot{};


### PR DESCRIPTION
Adds support for the larger PS4 Pro memory size when enabled. The value is not confirmed to be exact with hardware but aligns with expectations and at least gets games that utilize the extra memory running under Pro mode for now.

I also added an assert when the GPU page manager tries to track memory that is not mapped to the GPU, as I ran into a problem related to this while testing PS4 Pro mode. Currently when this happens it silently re-protects non-GPU memory, which can fail in confusing ways later as writes to that memory will be ignored by the signal handler and fail. Adding an assert makes it more obvious what happened.