### PR TITLE
shader_recompiler: Shader param fixups

### DIFF
--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -240,9 +240,9 @@ public:
         bool is_default{};
         s32 buffer_handle{-1};
     };
-    std::array<SpirvAttribute, 32> input_params{};
-    std::array<SpirvAttribute, 32> output_params{};
-    std::array<SpirvAttribute, 8> frag_outputs{};
+    std::array<SpirvAttribute, IR::NumParams> input_params{};
+    std::array<SpirvAttribute, IR::NumParams> output_params{};
+    std::array<SpirvAttribute, IR::NumRenderTargets> frag_outputs{};
 
 private:
     void DefineArithmeticTypes();
@@ -255,7 +255,8 @@ private:
     void DefineImagesAndSamplers();
     void DefineSharedMemory();
 
-    SpirvAttribute GetAttributeInfo(AmdGpu::NumberFormat fmt, Id id, bool output);
+    SpirvAttribute GetAttributeInfo(AmdGpu::NumberFormat fmt, Id id, u32 num_components,
+                                    bool output);
 };
 
 } // namespace Shader::Backend::SPIRV


### PR DESCRIPTION
* Use `GetAttributeInfo` to construct attribute infos more to simplify correct construction.
* Allow passing `num_components` to `GetAttributeInfo`. Currently still always 4 but more correct this way.
* Add asserts to make sure input parameters array is not overrun.
* Fix missing boolean parameter and incorrect pointer type in one of the input attribute declarations.
* Use existing constants for params and fragment outputs array sizes.
* Misc style cleanup.