### PR TITLE
video_core: IMAGEGATHER4_C_O

### DIFF
--- a/src/shader_recompiler/frontend/decode.cpp
+++ b/src/shader_recompiler/frontend/decode.cpp
@@ -313,8 +313,6 @@ void GcnDecodeContext::repairOperandType() {
         m_instruction.src[2].type = ScalarType::Uint64;
         break;
     case Opcode::IMAGE_GATHER4_C:
-        m_instruction.src[0].type = ScalarType::Any;
-        break;
     case Opcode::IMAGE_GATHER4_C_O:
         m_instruction.src[0].type = ScalarType::Any;
         break;

--- a/src/shader_recompiler/frontend/decode.cpp
+++ b/src/shader_recompiler/frontend/decode.cpp
@@ -315,6 +315,9 @@ void GcnDecodeContext::repairOperandType() {
     case Opcode::IMAGE_GATHER4_C:
         m_instruction.src[0].type = ScalarType::Any;
         break;
+    case Opcode::IMAGE_GATHER4_C_O:
+        m_instruction.src[0].type = ScalarType::Any;
+        break;
     default:
         break;
     }

--- a/src/shader_recompiler/frontend/format.cpp
+++ b/src/shader_recompiler/frontend/format.cpp
@@ -3625,8 +3625,8 @@ constexpr std::array<InstFormat, 112> InstructionFormatMIMG = {{
     {InstClass::VectorMemImgSmp, InstCategory::VectorMemory, 4, 1, ScalarType::Uint32,
      ScalarType::Float32},
     // 88 = IMAGE_GATHER4_C_O
-    {InstClass::VectorMemImgSmp, InstCategory::VectorMemory, 4, 1, ScalarType::Undefined,
-     ScalarType::Undefined},
+    {InstClass::VectorMemImgSmp, InstCategory::VectorMemory, 4, 1, ScalarType::Uint32,
+     ScalarType::Float32},
     // 89 = IMAGE_GATHER4_C_CL_O
     {InstClass::VectorMemImgSmp, InstCategory::VectorMemory, 4, 1, ScalarType::Undefined,
      ScalarType::Undefined},

--- a/src/shader_recompiler/frontend/translate/vector_memory.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_memory.cpp
@@ -144,6 +144,7 @@ void Translator::EmitVectorMemory(const GcnInst& inst) {
         // Image gather operations
     case Opcode::IMAGE_GATHER4_LZ:
     case Opcode::IMAGE_GATHER4_C:
+    case Opcode::IMAGE_GATHER4_C_O:
     case Opcode::IMAGE_GATHER4_C_LZ:
     case Opcode::IMAGE_GATHER4_LZ_O:
         return IMAGE_GATHER(inst);

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.h
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.h
@@ -73,7 +73,7 @@ void EmitQuadToTriangleListIndices(u8* out_indices, u32 num_vertices);
 static inline vk::Format PromoteFormatToDepth(vk::Format fmt) {
     if (fmt == vk::Format::eR32Sfloat) {
         return vk::Format::eD32Sfloat;
-    } else if (fmt == vk::Format::eR16Unorm) {
+    } else if (fmt == vk::Format::eR16Unorm || fmt == vk::Format::eR8Unorm) {
         return vk::Format::eD16Unorm;
     }
     UNREACHABLE();

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.h
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.h
@@ -73,7 +73,7 @@ void EmitQuadToTriangleListIndices(u8* out_indices, u32 num_vertices);
 static inline vk::Format PromoteFormatToDepth(vk::Format fmt) {
     if (fmt == vk::Format::eR32Sfloat) {
         return vk::Format::eD32Sfloat;
-    } else if (fmt == vk::Format::eR16Unorm || fmt == vk::Format::eR8Unorm) {
+    } else if (fmt == vk::Format::eR16Unorm) {
         return vk::Format::eD16Unorm;
     }
     UNREACHABLE();


### PR DESCRIPTION
Adds IMAGGATHER4_C_O for Lego City Undercover and Crash Team Racing Nitro Fueled.
Used to promote eR8Unorm to depth to allow Everybody's Golf to boot as so:
![everybodysgolf](https://github.com/user-attachments/assets/99b255f9-1d14-457a-a3bd-1eab98e55d25)
but have been asked to remove.