### PR TITLE
audio_core: Fix return value types and shift some error handling to library.

### DIFF
--- a/src/audio_core/sdl_audio.h
+++ b/src/audio_core/sdl_audio.h
@@ -14,11 +14,11 @@ public:
     SDLAudio() = default;
     virtual ~SDLAudio() = default;
 
-    int AudioOutOpen(int type, u32 samples_num, u32 freq,
+    s32 AudioOutOpen(int type, u32 samples_num, u32 freq,
                      Libraries::AudioOut::OrbisAudioOutParamFormat format);
     s32 AudioOutOutput(s32 handle, const void* ptr);
-    bool AudioOutSetVolume(s32 handle, s32 bitflag, s32* volume);
-    bool AudioOutGetStatus(s32 handle, int* type, int* channels_num);
+    s32 AudioOutSetVolume(s32 handle, s32 bitflag, s32* volume);
+    s32 AudioOutGetStatus(s32 handle, int* type, int* channels_num);
 
 private:
     struct PortOut {
@@ -33,8 +33,7 @@ private:
         bool isOpen = false;
     };
     std::shared_mutex m_mutex;
-    std::array<PortOut, 22> portsOut; // main up to 8 ports , BGM 1 port , voice up to 4 ports ,
-                                      // personal up to 4 ports , padspk up to 5 ports , aux 1 port
+    std::array<PortOut, Libraries::AudioOut::SCE_AUDIO_OUT_NUM_PORTS> portsOut;
 };
 
 } // namespace Audio

--- a/src/core/libraries/audio/audioout.h
+++ b/src/core/libraries/audio/audioout.h
@@ -11,6 +11,10 @@ namespace Libraries::AudioOut {
 
 constexpr int SCE_AUDIO_OUT_VOLUME_0DB = 32768; // max volume value
 
+// main up to 8 ports, BGM 1 port, voice up to 4 ports,
+// personal up to 4 ports, padspk up to 5 ports, aux 1 port
+constexpr int SCE_AUDIO_OUT_NUM_PORTS = 22;
+
 enum OrbisAudioOutPort {
     ORBIS_AUDIO_OUT_PORT_TYPE_MAIN = 0,
     ORBIS_AUDIO_OUT_PORT_TYPE_BGM = 1,


### PR DESCRIPTION
https://github.com/shadps4-emu/shadPS4/pull/1200 changed some of the audio out functions to return error codes instead of bool without changing the return type. This finishes that up by changing the return types and fixing how the return values are handled on the library side.

This also shifts some of the error checking over to the library side, similar to how it is done currently with `sceAudioOutOpen`, to keep the back-end logic simpler in case there are more in the future.