### PR TITLE
Moved opcode to it's proper location

### DIFF
--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -161,6 +161,7 @@ public:
     // VOP1
     void V_MOV(const GcnInst& inst);
     void V_READFIRSTLANE_B32(const GcnInst& inst);
+    void V_CVT_F64_I32(const GcnInst& inst);
     void V_CVT_F32_I32(const GcnInst& inst);
     void V_CVT_F32_U32(const GcnInst& inst);
     void V_CVT_U32_F32(const GcnInst& inst);
@@ -170,7 +171,6 @@ public:
     void V_CVT_FLR_I32_F32(const GcnInst& inst);
     void V_CVT_OFF_F32_I4(const GcnInst& inst);
     void V_CVT_F32_UBYTE(u32 index, const GcnInst& inst);
-    void V_CVT_F64_I32(const GcnInst& inst);
     void V_FRACT_F32(const GcnInst& inst);
     void V_TRUNC_F32(const GcnInst& inst);
     void V_CEIL_F32(const GcnInst& inst);

--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -99,6 +99,8 @@ void Translator::EmitVectorAlu(const GcnInst& inst) {
         return V_MOV(inst);
     case Opcode::V_READFIRSTLANE_B32:
         return V_READFIRSTLANE_B32(inst);
+    case Opcode::V_CVT_F64_I32:
+        return V_CVT_F64_I32(inst);
     case Opcode::V_CVT_F32_I32:
         return V_CVT_F32_I32(inst);
     case Opcode::V_CVT_F32_U32:
@@ -123,8 +125,6 @@ void Translator::EmitVectorAlu(const GcnInst& inst) {
         return V_CVT_F32_UBYTE(2, inst);
     case Opcode::V_CVT_F32_UBYTE3:
         return V_CVT_F32_UBYTE(3, inst);
-    case Opcode::V_CVT_F64_I32:
-        return V_CVT_F64_I32(inst);
     case Opcode::V_FRACT_F32:
         return V_FRACT_F32(inst);
     case Opcode::V_TRUNC_F32:
@@ -612,6 +612,11 @@ void Translator::V_MOV(const GcnInst& inst) {
     SetDst(inst.dst[0], GetSrc<IR::F32>(inst.src[0]));
 }
 
+void Translator::V_CVT_F64_I32(const GcnInst& inst) {
+    const IR::U32 src0{GetSrc(inst.src[0])};
+    SetDst64(inst.dst[0], ir.ConvertSToF(64, 32, src0));
+}
+
 void Translator::V_CVT_F32_I32(const GcnInst& inst) {
     const IR::U32 src0{GetSrc(inst.src[0])};
     SetDst(inst.dst[0], ir.ConvertSToF(32, 32, src0));
@@ -662,11 +667,6 @@ void Translator::V_CVT_F32_UBYTE(u32 index, const GcnInst& inst) {
     const IR::U32 src0{GetSrc(inst.src[0])};
     const IR::U32 byte = ir.BitFieldExtract(src0, ir.Imm32(8 * index), ir.Imm32(8));
     SetDst(inst.dst[0], ir.ConvertUToF(32, 32, byte));
-}
-
-void Translator::V_CVT_F64_I32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0])};
-    SetDst64(inst.dst[0], ir.ConvertSToF(64, 32, src0));
 }
 
 void Translator::V_FRACT_F32(const GcnInst& inst) {


### PR DESCRIPTION
Please, don't place opcodes where you think they'll fit. They have opcode index that you can use to sort them