### PR TITLE
Using a more standard data directory for linux

### DIFF
--- a/src/common/path_util.cpp
+++ b/src/common/path_util.cpp
@@ -95,6 +95,14 @@ static auto UserPaths = [] {
         user_dir =
             std::filesystem::path(getenv("HOME")) / "Library" / "Application Support" / "shadPS4";
     }
+#elif defined(__linux__)
+    auto user_dir = std::filesystem::current_path() / PORTABLE_DIR;
+    // Check if the "user" directory exists in the current path:
+    if (!std::filesystem::exists(user_dir)) {
+        // If it doesn't exist, use the new hardcoded path:
+        user_dir =
+            std::filesystem::path(getenv("HOME")) / ".local" / "share" / "shadPS4";
+    }
 #else
     const auto user_dir = std::filesystem::current_path() / PORTABLE_DIR;
 #endif

--- a/src/common/path_util.cpp
+++ b/src/common/path_util.cpp
@@ -99,8 +99,13 @@ static auto UserPaths = [] {
     auto user_dir = std::filesystem::current_path() / PORTABLE_DIR;
     // Check if the "user" directory exists in the current path:
     if (!std::filesystem::exists(user_dir)) {
-        // If it doesn't exist, use the new hardcoded path:
-        user_dir = std::filesystem::path(getenv("HOME")) / ".local" / "share" / "shadPS4";
+        // If it doesn't exist, use XDG_DATA_HOME if it is set, and provide a standard default
+        const char* xdg_data_home = getenv("XDG_DATA_HOME");
+        if (xdg_data_home != nullptr && strlen(xdg_data_home) > 0) {
+            user_dir = std::filesystem::path(xdg_data_home) / "shadPS4";
+        } else {
+            user_dir = std::filesystem::path(getenv("HOME")) / ".local" / "share" / "shadPS4";
+        }
     }
 #else
     const auto user_dir = std::filesystem::current_path() / PORTABLE_DIR;

--- a/src/common/path_util.cpp
+++ b/src/common/path_util.cpp
@@ -100,8 +100,7 @@ static auto UserPaths = [] {
     // Check if the "user" directory exists in the current path:
     if (!std::filesystem::exists(user_dir)) {
         // If it doesn't exist, use the new hardcoded path:
-        user_dir =
-            std::filesystem::path(getenv("HOME")) / ".local" / "share" / "shadPS4";
+        user_dir = std::filesystem::path(getenv("HOME")) / ".local" / "share" / "shadPS4";
     }
 #else
     const auto user_dir = std::filesystem::current_path() / PORTABLE_DIR;


### PR DESCRIPTION
Currently, running the emulator will generate a "user" directory wherever it is being run from. This can cause issues when the program was installed as a package on linux, because the user folder will end up in the user's home directory. In my case, it caused a strange interaction with the dolphin emulator, because dolphin started using shadPS4's user directory to save data. Using `$HOME/.local/share/shadPS4` should avoid any clashes with other programs.