### PR TITLE
Disable ffmpeg DLLs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
       run: |
         mkdir upload
         move build/shadPS4.exe upload
-        windeployqt --no-compiler-runtime --no-system-d3d-compiler --no-system-dxc-compiler --dir upload upload/shadPS4.exe
+        windeployqt --no-compiler-runtime --no-ffmpeg --no-system-d3d-compiler --no-system-dxc-compiler --dir upload upload/shadPS4.exe
         Compress-Archive -Path upload/* -DestinationPath shadps4-win64-qt-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}.zip
 
     - name: Upload Windows Qt artifact


### PR DESCRIPTION
I made sure to remove the ffmpeg DLLs which reduces the size of the artifact from 31MB to 23.7MB.
These DLLs are not necessary for shadPS4 to work.
This also speeds up the download speed of updates.