### PR TITLE
Fix list sorting for some categories

### DIFF
--- a/src/qt_gui/game_grid_frame.cpp
+++ b/src/qt_gui/game_grid_frame.cpp
@@ -102,7 +102,9 @@ void GameGridFrame::PopulateGameGrid(QVector<GameInfo> m_games_search, bool from
 
         name_label->setGraphicsEffect(shadowEffect);
         widget->setLayout(layout);
-        QString tooltipText = QString::fromStdString(m_games_[gameCounter].name);
+        QString tooltipText = QString::fromStdString(m_games_[gameCounter].name + " (" +
+                                                     m_games_[gameCounter].version + ", " +
+                                                     m_games_[gameCounter].region + ")");
         widget->setToolTip(tooltipText);
         QString tooltipStyle = QString("QToolTip {"
                                        "background-color: #ffffff;"

--- a/src/qt_gui/game_list_frame.h
+++ b/src/qt_gui/game_list_frame.h
@@ -45,9 +45,7 @@ public:
     int icon_size;
 
     static float parseAsFloat(const std::string& str, const int& offset) {
-        float num;
-        std::from_chars(str.data(), str.data() + str.size() - offset, num);
-        return num;
+        return std::stof(str.substr(0, str.size() - offset));
     }
 
     static float parseSizeMB(const std::string& size) {

--- a/src/qt_gui/game_list_frame.h
+++ b/src/qt_gui/game_list_frame.h
@@ -44,18 +44,29 @@ public:
 
     int icon_size;
 
+    static float parseAsFloat(const std::string& str, const int& offset) {
+        float num;
+        std::from_chars(str.data(), str.data() + str.size() - offset, num);
+        return num;
+    }
+
+    static float parseSizeMB(const std::string& size) {
+        float num = parseAsFloat(size, 3);
+        return (size[size.size() - 2] == 'G') ? num * 1024 : num;
+    }
+
     static bool CompareStringsAscending(GameInfo a, GameInfo b, int columnIndex) {
         switch (columnIndex) {
         case 1:
             return a.name < b.name;
         case 2:
-            return a.serial < b.serial;
+            return a.serial.substr(4) < b.serial.substr(4);
         case 3:
             return a.region < b.region;
         case 4:
-            return a.fw < b.fw;
+            return parseAsFloat(a.fw, 0) < parseAsFloat(b.fw, 0);
         case 5:
-            return a.size < b.size;
+            return parseSizeMB(b.size) < parseSizeMB(a.size);
         case 6:
             return a.version < b.version;
         case 7:
@@ -70,13 +81,13 @@ public:
         case 1:
             return a.name > b.name;
         case 2:
-            return a.serial > b.serial;
+            return a.serial.substr(4) > b.serial.substr(4);
         case 3:
             return a.region > b.region;
         case 4:
-            return a.fw > b.fw;
+            return parseAsFloat(a.fw, 0) > parseAsFloat(b.fw, 0);
         case 5:
-            return a.size > b.size;
+            return parseSizeMB(b.size) > parseSizeMB(a.size);
         case 6:
             return a.version > b.version;
         case 7:


### PR DESCRIPTION
When [the sort all menu items PR](https://github.com/shadps4-emu/shadPS4/pull/1183) was added I noticed the sorting being entirely out of order for some of the categories, so this should fix that. I've only confirmed they sort in the right order, so I'm not sure every category sorts in the right direction.

Additionally, I decided to add game info to the tool tip because I would always have to switch to list view from grid view just to see stuff like the game version, very annoying.