### PR TITLE
Fix a Qt warning

### DIFF
--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -352,7 +352,7 @@ void SettingsDialog::updateNoteTextEdit(const QString& elementName) {
     ui->descriptionText->setText(text.replace("\\n", "\n"));
 }
 
-bool SettingsDialog::eventFilter(QObject* obj, QEvent* event) {
+bool SettingsDialog::override(QObject* obj, QEvent* event) {
     if (event->type() == QEvent::Enter || event->type() == QEvent::Leave) {
         if (qobject_cast<QWidget*>(obj)) {
             bool hovered = (event->type() == QEvent::Enter);

--- a/src/qt_gui/settings_dialog.h
+++ b/src/qt_gui/settings_dialog.h
@@ -21,7 +21,7 @@ public:
     explicit SettingsDialog(std::span<const QString> physical_devices, QWidget* parent = nullptr);
     ~SettingsDialog();
 
-    bool eventFilter(QObject* obj, QEvent* event);
+    bool override(QObject* obj, QEvent* event);
     void updateNoteTextEdit(const QString& groupName);
 
     int exec() override;


### PR DESCRIPTION
I fixed two warnings that appeared since the Qt 6.7.3 update.

![image](https://github.com/user-attachments/assets/0ca97f28-50a6-4728-bab9-75a3582f441d)