### PR TITLE
vulkan: Fix two more validation errors.

### DIFF
--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -392,8 +392,9 @@ void EmitContext::DefineBuffers() {
         const bool is_storage = desc.IsStorage(sharp);
         const auto* data_types = True(desc.used_types & IR::Type::F32) ? &F32 : &U32;
         const Id data_type = (*data_types)[1];
-        const Id record_array_type{is_storage ? TypeRuntimeArray(data_type)
-                                              : TypeArray(data_type, ConstU32(sharp.NumDwords()))};
+        const Id record_array_type{
+            is_storage ? TypeRuntimeArray(data_type)
+                       : TypeArray(data_type, ConstU32(std::max(sharp.NumDwords(), 1U)))};
         const Id struct_type{define_struct(record_array_type, desc.is_instance_data)};
 
         const auto storage_class =

--- a/src/video_core/renderer_vulkan/vk_swapchain.cpp
+++ b/src/video_core/renderer_vulkan/vk_swapchain.cpp
@@ -197,6 +197,11 @@ void Swapchain::SetSurfaceProperties() {
 
 void Swapchain::Destroy() {
     vk::Device device = instance.GetDevice();
+    const auto wait_result = device.waitIdle();
+    if (wait_result != vk::Result::eSuccess) {
+        LOG_WARNING(Render_Vulkan, "Failed to wait for device to become idle: {}",
+                    vk::to_string(wait_result));
+    }
     if (swapchain) {
         device.destroySwapchainKHR(swapchain);
     }


### PR DESCRIPTION
Small fixes to two more validation errors:
* Fix SPIR-V error when sharp has size of 0, as array declaration needs to be at least size 1. Since size is 0 it should just be bound to null anyway.
* Fix window resize destroying semaphores before commands referencing them have finished execution, by waiting for device to become idle before destroying.