### PR TITLE
shader_recompiler: Set array size to max UBO size when 0.

### DIFF
--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -390,11 +390,11 @@ void EmitContext::DefineBuffers() {
     for (const auto& desc : info.buffers) {
         const auto sharp = desc.GetSharp(info);
         const bool is_storage = desc.IsStorage(sharp);
+        const u32 array_size = sharp.NumDwords() != 0 ? sharp.NumDwords() : MaxUboDwords;
         const auto* data_types = True(desc.used_types & IR::Type::F32) ? &F32 : &U32;
         const Id data_type = (*data_types)[1];
-        const Id record_array_type{
-            is_storage ? TypeRuntimeArray(data_type)
-                       : TypeArray(data_type, ConstU32(std::max(sharp.NumDwords(), 1U)))};
+        const Id record_array_type{is_storage ? TypeRuntimeArray(data_type)
+                                              : TypeArray(data_type, ConstU32(array_size))};
         const Id struct_type{define_struct(record_array_type, desc.is_instance_data)};
 
         const auto storage_class =

--- a/src/shader_recompiler/info.h
+++ b/src/shader_recompiler/info.h
@@ -18,6 +18,8 @@
 namespace Shader {
 
 static constexpr size_t NumUserDataRegs = 16;
+static constexpr size_t MaxUboSize = 65536;
+static constexpr size_t MaxUboDwords = MaxUboSize >> 2;
 
 enum class TextureType : u32 {
     Color1D,
@@ -42,7 +44,6 @@ struct BufferResource {
     bool is_written{};
 
     bool IsStorage(AmdGpu::Buffer buffer) const noexcept {
-        static constexpr size_t MaxUboSize = 65536;
         return buffer.GetSize() > MaxUboSize || is_written || is_gds_buffer;
     }
 

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -211,7 +211,9 @@ bool PipelineCache::RefreshGraphicsKey() {
     key.depth_bias_enable = regs.polygon_control.NeedsBias();
 
     const auto& db = regs.depth_buffer;
-    const auto ds_format = LiverpoolToVK::DepthFormat(db.z_info.format, db.stencil_info.format);
+    const auto ds_format = instance.GetSupportedFormat(
+        LiverpoolToVK::DepthFormat(db.z_info.format, db.stencil_info.format),
+        vk::FormatFeatureFlagBits2::eDepthStencilAttachment);
     if (db.z_info.format != AmdGpu::Liverpool::DepthBuffer::ZFormat::Invalid) {
         key.depth_format = ds_format;
     } else {


### PR DESCRIPTION
Per [comment on previous PR](https://github.com/shadps4-emu/shadPS4/pull/1250#issuecomment-2395153326), change the array size 0 behavior to use maximum UBO size.