### PR TITLE
shader_recompiler: Remove outdated image array warning.

### DIFF
--- a/src/shader_recompiler/frontend/translate/vector_memory.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_memory.cpp
@@ -602,10 +602,6 @@ void Translator::IMAGE_SAMPLE(const GcnInst& inst) {
 
 void Translator::IMAGE_GATHER(const GcnInst& inst) {
     const auto& mimg = inst.control.mimg;
-    if (mimg.da) {
-        LOG_WARNING(Render_Vulkan, "Image instruction declares an array");
-    }
-
     IR::VectorReg addr_reg{inst.src[0].code};
     IR::VectorReg dest_reg{inst.dst[0].code};
     const IR::ScalarReg tsharp_reg{inst.src[2].code * 4};


### PR DESCRIPTION
Remove old warning about image instruction using array since this is now handled.