### PR TITLE
Working touchpad support

### DIFF
--- a/src/core/libraries/pad/pad.cpp
+++ b/src/core/libraries/pad/pad.cpp
@@ -368,7 +368,8 @@ int PS4_SYSV_ABI scePadReadState(s32 handle, OrbisPadData* pData) {
     pData->angularVelocity.x = 0.0f;
     pData->angularVelocity.y = 0.0f;
     pData->angularVelocity.z = 0.0f;
-    pData->touchData.touchNum = (state.touchpad[0].state ? 1 : 0) + (state.touchpad[1].state ? 1 : 0);
+    pData->touchData.touchNum =
+        (state.touchpad[0].state ? 1 : 0) + (state.touchpad[1].state ? 1 : 0);
     pData->touchData.touch[0].x = state.touchpad[0].x;
     pData->touchData.touch[0].y = state.touchpad[0].y;
     pData->touchData.touch[0].id = 1;

--- a/src/core/libraries/pad/pad.cpp
+++ b/src/core/libraries/pad/pad.cpp
@@ -368,12 +368,12 @@ int PS4_SYSV_ABI scePadReadState(s32 handle, OrbisPadData* pData) {
     pData->angularVelocity.x = 0.0f;
     pData->angularVelocity.y = 0.0f;
     pData->angularVelocity.z = 0.0f;
-    pData->touchData.touchNum = 0;
-    pData->touchData.touch[0].x = 0;
-    pData->touchData.touch[0].y = 0;
+    pData->touchData.touchNum = (state.touchpad[0].state ? 1 : 0) + (state.touchpad[1].state ? 1 : 0);
+    pData->touchData.touch[0].x = state.touchpad[0].x;
+    pData->touchData.touch[0].y = state.touchpad[0].y;
     pData->touchData.touch[0].id = 1;
-    pData->touchData.touch[1].x = 0;
-    pData->touchData.touch[1].y = 0;
+    pData->touchData.touch[1].x = state.touchpad[1].x;
+    pData->touchData.touch[1].y = state.touchpad[1].y;
     pData->touchData.touch[1].id = 2;
     pData->timestamp = state.time;
     pData->connected = true;   // isConnected; //TODO fix me proper


### PR DESCRIPTION
Tested on a PS5 controller plugged in via USB on Windows 11. It appears to be working as one would expect, but there can be some weirdness when you press the touchpad really fast (it doesn't register the correct side of the touchpad in that case sometimes). I filed an issue with SDL since it is a bug within that project that causes this behavior https://github.com/libsdl-org/SDL/issues/11085.

I attempted to also get the back button on other controllers to trigger the left side of the touchpad, but haven't gotten a working version of that yet (and there would likely need to be a setting in shadPS4 to set whether the user wanted it to be left/right/center/none of the touchpad for the back button) so I'll leave that for a future PR (https://github.com/shadps4-emu/shadPS4/pull/1258).