### PR TITLE
Fix settings descriptions

### DIFF
--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -352,7 +352,7 @@ void SettingsDialog::updateNoteTextEdit(const QString& elementName) {
     ui->descriptionText->setText(text.replace("\\n", "\n"));
 }
 
-bool SettingsDialog::override(QObject* obj, QEvent* event) {
+bool SettingsDialog::eventFilter(QObject* obj, QEvent* event) {
     if (event->type() == QEvent::Enter || event->type() == QEvent::Leave) {
         if (qobject_cast<QWidget*>(obj)) {
             bool hovered = (event->type() == QEvent::Enter);

--- a/src/qt_gui/settings_dialog.h
+++ b/src/qt_gui/settings_dialog.h
@@ -21,7 +21,7 @@ public:
     explicit SettingsDialog(std::span<const QString> physical_devices, QWidget* parent = nullptr);
     ~SettingsDialog();
 
-    bool override(QObject* obj, QEvent* event);
+    bool eventFilter(QObject* obj, QEvent* event) override;
     void updateNoteTextEdit(const QString& groupName);
 
     int exec() override;


### PR DESCRIPTION
They were broken by https://github.com/shadps4-emu/shadPS4/pull/1249, but this is the correct way to fix the qt warning