### PR TITLE
shader_recompiler: Implement IMAGE_GATHER4_C_LZ_O opcode

### DIFF
--- a/src/shader_recompiler/frontend/format.cpp
+++ b/src/shader_recompiler/frontend/format.cpp
@@ -3642,8 +3642,8 @@ constexpr std::array<InstFormat, 112> InstructionFormatMIMG = {{
     {InstClass::VectorMemImgSmp, InstCategory::VectorMemory, 4, 1, ScalarType::Undefined,
      ScalarType::Undefined},
     // 95 = IMAGE_GATHER4_C_LZ_O
-    {InstClass::VectorMemImgSmp, InstCategory::VectorMemory, 4, 1, ScalarType::Undefined,
-     ScalarType::Undefined},
+    {InstClass::VectorMemImgSmp, InstCategory::VectorMemory, 4, 1, ScalarType::Uint32,
+     ScalarType::Float32},
     // 96 = IMAGE_GET_LOD
     {InstClass::VectorMemImgUt, InstCategory::VectorMemory, 4, 1, ScalarType::Float32,
      ScalarType::Float32},

--- a/src/shader_recompiler/frontend/translate/vector_memory.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_memory.cpp
@@ -147,6 +147,7 @@ void Translator::EmitVectorMemory(const GcnInst& inst) {
     case Opcode::IMAGE_GATHER4_C_O:
     case Opcode::IMAGE_GATHER4_C_LZ:
     case Opcode::IMAGE_GATHER4_LZ_O:
+    case Opcode::IMAGE_GATHER4_C_LZ_O:
         return IMAGE_GATHER(inst);
 
         // Image misc operations


### PR DESCRIPTION
This opcode is used by Crash Team Racing Nitro Fueled. I don't have any other opcodes I can test locally, but if there are other IMAGE_GATHER4 opcodes I should add into this PR, please let me know. 