### PR TITLE
fixed hang from loading VK_EXT_TOOLING_INFO_EXTENSION_NAME without vulkan validation layers enabled

### DIFF
--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -265,7 +265,9 @@ bool Instance::CreateDevice() {
 
     // These extensions are promoted by Vulkan 1.3, but for greater compatibility we use Vulkan 1.2
     // with extensions.
-    tooling_info = add_extension(VK_EXT_TOOLING_INFO_EXTENSION_NAME);
+    if (Config ::vkValidationEnabled() || Config::isRdocEnabled()) {
+        tooling_info = add_extension(VK_EXT_TOOLING_INFO_EXTENSION_NAME);
+    }
     const bool maintenance4 = add_extension(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
     add_extension(VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME);
     add_extension(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);


### PR DESCRIPTION
currently, VK_EXT_TOOLING_INFO_EXTENSION_NAME is loaded indiscriminately, causing amd gpu + reshade users to hang indefinitely when loading a game if vulkan validation layers are disabled. both the emulator and reshade function as intended when Vulkan validation layers are enabled.

to fix this, i added a simple check that only loads the tooling info if vulkan validation layers are enabled or if renderdoc debugging is enabled. since the tooling info extension is only used for debugging purposes (afaik), it doesn't need to be loaded during regular usage, which is the only occurrence where the emulator runs into a problem.