### PR TITLE
shader_recompiler: Handle offsets for Cube images.

### DIFF
--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -592,6 +592,7 @@ void PatchImageInstruction(IR::Block& block, IR::Inst& inst, Info& info, Descrip
             inst.SetArg(arg_pos, ir.CompositeConstruct(read(0), read(8)));
             break;
         case AmdGpu::ImageType::Color3D:
+        case AmdGpu::ImageType::Cube:
             inst.SetArg(arg_pos, ir.CompositeConstruct(read(0), read(8), read(16)));
             break;
         default:


### PR DESCRIPTION
From looking at Mesa, cube textures should have 3 offsets like 3D textures.