### PR TITLE
spirv: Flush denormals if possible and runtime info refactor

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv.cpp
@@ -206,10 +206,7 @@ Id DefineMain(EmitContext& ctx, const IR::Program& program) {
     return main;
 }
 
-void DefineEntryPoint(const IR::Program& program, EmitContext& ctx, Id main) {
-    const auto& info = program.info;
-    const std::span interfaces(ctx.interfaces.data(), ctx.interfaces.size());
-    spv::ExecutionModel execution_model{};
+void SetupCapabilities(const Info& info, EmitContext& ctx) {
     ctx.AddCapability(spv::Capability::Image1D);
     ctx.AddCapability(spv::Capability::Sampled1D);
     ctx.AddCapability(spv::Capability::ImageQuery);
@@ -247,6 +244,19 @@ void DefineEntryPoint(const IR::Program& program, EmitContext& ctx, Id main) {
     if (info.uses_group_ballot) {
         ctx.AddCapability(spv::Capability::GroupNonUniformBallot);
     }
+    if (info.stage == Stage::Export || info.stage == Stage::Vertex) {
+        ctx.AddExtension("SPV_KHR_shader_draw_parameters");
+        ctx.AddCapability(spv::Capability::DrawParameters);
+    }
+    if (info.stage == Stage::Geometry) {
+        ctx.AddCapability(spv::Capability::Geometry);
+    }
+}
+
+void DefineEntryPoint(const IR::Program& program, EmitContext& ctx, Id main) {
+    const auto& info = program.info;
+    const std::span interfaces(ctx.interfaces.data(), ctx.interfaces.size());
+    spv::ExecutionModel execution_model{};
     switch (program.info.stage) {
     case Stage::Compute: {
         const std::array<u32, 3> workgroup_size{ctx.runtime_info.cs_info.workgroup_size};
@@ -290,6 +300,24 @@ void DefineEntryPoint(const IR::Program& program, EmitContext& ctx, Id main) {
     ctx.AddEntryPoint(execution_model, main, "main", interfaces);
 }
 
+void SetupFloatMode(EmitContext& ctx, const Profile& profile, const RuntimeInfo& runtime_info,
+                    Id main_func) {
+    ctx.AddExtension("SPV_KHR_float_controls");
+    const auto fp_denorm_mode = runtime_info.fp_denorm_mode32;
+    if (fp_denorm_mode == AmdGpu::FpDenormMode::InOutFlush) {
+        if (profile.support_fp32_denorm_flush) {
+            ctx.AddCapability(spv::Capability::DenormFlushToZero);
+            ctx.AddExecutionMode(main_func, spv::ExecutionMode::DenormFlushToZero, 32U);
+        }
+    } else {
+        LOG_WARNING(Render_Vulkan, "Unknown FP denorm mode {}", u32(fp_denorm_mode));
+    }
+    const auto fp_round_mode = runtime_info.fp_round_mode32;
+    if (fp_round_mode != AmdGpu::FpRoundMode::NearestEven) {
+        LOG_WARNING(Render_Vulkan, "Unknown FP rounding mode {}", u32(fp_round_mode));
+    }
+}
+
 void PatchPhiNodes(const IR::Program& program, EmitContext& ctx) {
     auto inst{program.blocks.front()->begin()};
     size_t block_index{0};
@@ -314,18 +342,8 @@ std::vector<u32> EmitSPIRV(const Profile& profile, const RuntimeInfo& runtime_in
     EmitContext ctx{profile, runtime_info, program.info, binding};
     const Id main{DefineMain(ctx, program)};
     DefineEntryPoint(program, ctx, main);
-    switch (program.info.stage) {
-    case Stage::Export:
-    case Stage::Vertex:
-        ctx.AddExtension("SPV_KHR_shader_draw_parameters");
-        ctx.AddCapability(spv::Capability::DrawParameters);
-        break;
-    case Stage::Geometry:
-        ctx.AddCapability(spv::Capability::Geometry);
-        break;
-    default:
-        break;
-    }
+    SetupCapabilities(program.info, ctx);
+    SetupFloatMode(ctx, profile, runtime_info, main);
     PatchPhiNodes(program, ctx);
     binding.user_data += program.info.ud_mask.NumRegs();
     return ctx.Assemble();

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -284,7 +284,8 @@ void EmitContext::DefineInputs() {
         frag_coord = DefineVariable(F32[4], spv::BuiltIn::FragCoord, spv::StorageClass::Input);
         frag_depth = DefineVariable(F32[1], spv::BuiltIn::FragDepth, spv::StorageClass::Output);
         front_facing = DefineVariable(U1[1], spv::BuiltIn::FrontFacing, spv::StorageClass::Input);
-        for (const auto& input : runtime_info.fs_info.inputs) {
+        for (s32 i = 0; i < runtime_info.fs_info.num_inputs; i++) {
+            const auto& input = runtime_info.fs_info.inputs[i];
             const u32 semantic = input.param_index;
             ASSERT(semantic < IR::NumParams);
             if (input.is_default && !input.is_flat) {
@@ -333,7 +334,6 @@ void EmitContext::DefineInputs() {
 
         const auto num_params = runtime_info.gs_info.in_vertex_data_size / 4 - 1u;
         for (int param_id = 0; param_id < num_params; ++param_id) {
-            const IR::Attribute param{IR::Attribute::Param0 + param_id};
             const Id type{TypeArray(F32[4], ConstU32(num_verts_in))};
             const Id id{DefineInput(type, param_id)};
             Name(id, fmt::format("in_attr{}", param_id));
@@ -394,8 +394,7 @@ void EmitContext::DefineOutputs() {
     case Stage::Geometry: {
         output_position = DefineVariable(F32[4], spv::BuiltIn::Position, spv::StorageClass::Output);
 
-        for (u32 attr_id = 0; attr_id < runtime_info.gs_info.copy_data.num_attrs; attr_id++) {
-            const IR::Attribute param{IR::Attribute::Param0 + attr_id};
+        for (u32 attr_id = 0; attr_id < info.gs_copy_data.num_attrs; attr_id++) {
             const Id id{DefineOutput(F32[4], attr_id)};
             Name(id, fmt::format("out_attr{}", attr_id));
             output_params[attr_id] = {id, output_f32, F32[1], 4u};

--- a/src/shader_recompiler/frontend/copy_shader.cpp
+++ b/src/shader_recompiler/frontend/copy_shader.cpp
@@ -7,7 +7,7 @@
 
 namespace Shader {
 
-CopyShaderData ParseCopyShader(const std::span<const u32>& code) {
+CopyShaderData ParseCopyShader(std::span<const u32> code) {
     Gcn::GcnCodeSlice code_slice{code.data(), code.data() + code.size()};
     Gcn::GcnDecodeContext decoder;
 

--- a/src/shader_recompiler/frontend/copy_shader.h
+++ b/src/shader_recompiler/frontend/copy_shader.h
@@ -16,6 +16,6 @@ struct CopyShaderData {
     u32 num_attrs{0};
 };
 
-CopyShaderData ParseCopyShader(const std::span<const u32>& code);
+CopyShaderData ParseCopyShader(std::span<const u32> code);
 
 } // namespace Shader

--- a/src/shader_recompiler/info.h
+++ b/src/shader_recompiler/info.h
@@ -3,12 +3,12 @@
 #pragma once
 
 #include <span>
-#include <vector>
 #include <boost/container/small_vector.hpp>
 #include <boost/container/static_vector.hpp>
 #include "common/assert.h"
 #include "common/types.h"
 #include "shader_recompiler/backend/bindings.h"
+#include "shader_recompiler/frontend/copy_shader.h"
 #include "shader_recompiler/ir/attribute.h"
 #include "shader_recompiler/ir/reg.h"
 #include "shader_recompiler/ir/type.h"
@@ -169,6 +169,8 @@ struct Info {
         u32 mask;
     };
     UserDataMask ud_mask{};
+
+    CopyShaderData gs_copy_data;
 
     s8 vertex_offset_sgpr = -1;
     s8 instance_offset_sgpr = -1;

--- a/src/shader_recompiler/ir/reg.h
+++ b/src/shader_recompiler/ir/reg.h
@@ -10,20 +10,6 @@
 
 namespace Shader::IR {
 
-enum class FpRoundMode : u32 {
-    NearestEven = 0,
-    PlusInf = 1,
-    MinInf = 2,
-    ToZero = 3,
-};
-
-enum class FpDenormMode : u32 {
-    InOutFlush = 0,
-    InAllowOutFlush = 1,
-    InFlushOutAllow = 2,
-    InOutAllow = 3,
-};
-
 enum class FloatClassFunc : u32 {
     SignalingNan = 1 << 0,
     QuietNan = 1 << 1,
@@ -40,13 +26,6 @@ enum class FloatClassFunc : u32 {
     Infinity = PositiveInfinity | NegativeInfinity,
 };
 DECLARE_ENUM_FLAG_OPERATORS(FloatClassFunc)
-
-union Mode {
-    BitField<0, 4, FpRoundMode> fp_round;
-    BitField<4, 2, FpDenormMode> fp_denorm_single;
-    BitField<6, 2, FpDenormMode> fp_denorm_double;
-    BitField<8, 1, u32> dx10_clamp;
-};
 
 union TextureInstInfo {
     u32 raw;

--- a/src/shader_recompiler/profile.h
+++ b/src/shader_recompiler/profile.h
@@ -19,13 +19,8 @@ struct Profile {
     bool support_float_controls{};
     bool support_separate_denorm_behavior{};
     bool support_separate_rounding_mode{};
-    bool support_fp16_denorm_preserve{};
     bool support_fp32_denorm_preserve{};
-    bool support_fp16_denorm_flush{};
     bool support_fp32_denorm_flush{};
-    bool support_fp16_signed_zero_nan_preserve{};
-    bool support_fp32_signed_zero_nan_preserve{};
-    bool support_fp64_signed_zero_nan_preserve{};
     bool support_explicit_workgroup_layout{};
     bool has_broken_spirv_clamp{};
     bool lower_left_origin_mode{};

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -4,11 +4,9 @@
 #pragma once
 
 #include <algorithm>
+#include <span>
 #include <boost/container/static_vector.hpp>
-
-#include "common/assert.h"
 #include "common/types.h"
-#include "frontend/copy_shader.h"
 #include "video_core/amdgpu/types.h"
 
 namespace Shader {
@@ -62,7 +60,8 @@ enum class VsOutput : u8 {
 using VsOutputMap = std::array<VsOutput, 4>;
 
 struct VertexRuntimeInfo {
-    boost::container::static_vector<VsOutputMap, 3> outputs;
+    u32 num_outputs;
+    std::array<VsOutputMap, 3> outputs;
     bool emulate_depth_negative_one_to_one{};
 
     bool operator==(const VertexRuntimeInfo& other) const noexcept {
@@ -79,13 +78,13 @@ struct GeometryRuntimeInfo {
     u32 out_vertex_data_size{};
     AmdGpu::PrimitiveType in_primitive;
     GsOutputPrimTypes out_primitive;
-    CopyShaderData copy_data;
+    std::span<const u32> vs_copy;
+    u64 vs_copy_hash;
 
     bool operator==(const GeometryRuntimeInfo& other) const noexcept {
         return num_invocations && other.num_invocations &&
                output_vertices == other.output_vertices && in_primitive == other.in_primitive &&
-               std::ranges::equal(out_primitive, other.out_primitive) &&
-               std::ranges::equal(copy_data.attr_map, other.copy_data.attr_map);
+               std::ranges::equal(out_primitive, other.out_primitive);
     }
 };
 
@@ -106,7 +105,8 @@ struct FragmentRuntimeInfo {
 
         auto operator<=>(const PsInput&) const noexcept = default;
     };
-    boost::container::static_vector<PsInput, 32> inputs;
+    u32 num_inputs;
+    std::array<PsInput, 32> inputs;
     struct PsColorBuffer {
         AmdGpu::NumberFormat num_format;
         MrtSwizzle mrt_swizzle;
@@ -117,7 +117,9 @@ struct FragmentRuntimeInfo {
 
     bool operator==(const FragmentRuntimeInfo& other) const noexcept {
         return std::ranges::equal(color_buffers, other.color_buffers) &&
-               std::ranges::equal(inputs, other.inputs);
+               num_inputs == other.num_inputs &&
+               std::ranges::equal(inputs.begin(), inputs.begin() + num_inputs, other.inputs.begin(),
+                                  other.inputs.begin() + num_inputs);
     }
 };
 
@@ -141,11 +143,15 @@ struct RuntimeInfo {
     u32 num_user_data;
     u32 num_input_vgprs;
     u32 num_allocated_vgprs;
-    ExportRuntimeInfo es_info;
-    VertexRuntimeInfo vs_info;
-    GeometryRuntimeInfo gs_info;
-    FragmentRuntimeInfo fs_info;
-    ComputeRuntimeInfo cs_info;
+    AmdGpu::FpDenormMode fp_denorm_mode32;
+    AmdGpu::FpRoundMode fp_round_mode32;
+    union {
+        ExportRuntimeInfo es_info;
+        VertexRuntimeInfo vs_info;
+        GeometryRuntimeInfo gs_info;
+        FragmentRuntimeInfo fs_info;
+        ComputeRuntimeInfo cs_info;
+    };
 
     RuntimeInfo(Stage stage_) : stage{stage_} {}
 

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -92,6 +92,12 @@ struct Liverpool {
         union {
             BitField<0, 6, u64> num_vgprs;
             BitField<6, 4, u64> num_sgprs;
+            BitField<10, 2, u64> priority;
+            BitField<12, 2, FpRoundMode> fp_round_mode32;
+            BitField<14, 2, FpRoundMode> fp_round_mode64;
+            BitField<16, 2, FpDenormMode> fp_denorm_mode32;
+            BitField<18, 2, FpDenormMode> fp_denorm_mode64;
+            BitField<12, 8, u64> float_mode;
             BitField<24, 2, u64> vgpr_comp_cnt; // SPI provided per-thread inputs
             BitField<33, 5, u64> num_user_regs;
         } settings;

--- a/src/video_core/amdgpu/types.h
+++ b/src/video_core/amdgpu/types.h
@@ -7,6 +7,20 @@
 
 namespace AmdGpu {
 
+enum class FpRoundMode : u32 {
+    NearestEven = 0,
+    PlusInf = 1,
+    MinInf = 2,
+    ToZero = 3,
+};
+
+enum class FpDenormMode : u32 {
+    InOutFlush = 0,
+    InAllowOutFlush = 1,
+    InFlushOutAllow = 2,
+    InOutAllow = 3,
+};
+
 // See `VGT_PRIMITIVE_TYPE` description in [Radeon Sea Islands 3D/Compute Register Reference Guide]
 enum class PrimitiveType : u32 {
     None = 0,

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -217,9 +217,10 @@ bool Instance::CreateDevice() {
     const vk::StructureChain properties_chain = physical_device.getProperties2<
         vk::PhysicalDeviceProperties2, vk::PhysicalDevicePortabilitySubsetPropertiesKHR,
         vk::PhysicalDeviceExternalMemoryHostPropertiesEXT, vk::PhysicalDeviceVulkan11Properties,
-        vk::PhysicalDevicePushDescriptorPropertiesKHR>();
+        vk::PhysicalDevicePushDescriptorPropertiesKHR, vk::PhysicalDeviceVulkan12Properties>();
     subgroup_size = properties_chain.get<vk::PhysicalDeviceVulkan11Properties>().subgroupSize;
     push_descriptor_props = properties_chain.get<vk::PhysicalDevicePushDescriptorPropertiesKHR>();
+    vk12_props = properties_chain.get<vk::PhysicalDeviceVulkan12Properties>();
     LOG_INFO(Render_Vulkan, "Physical device subgroup size {}", subgroup_size);
 
     features = feature_chain.get().features;

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -242,6 +242,11 @@ public:
         return push_descriptor_props.maxPushDescriptors;
     }
 
+    /// Returns the vulkan 1.2 physical device properties.
+    const vk::PhysicalDeviceVulkan12Properties& GetVk12Properties() const noexcept {
+        return vk12_props;
+    }
+
     /// Returns true if shaders can declare the ClipDistance attribute
     bool IsShaderClipDistanceSupported() const {
         return features.shaderClipDistance;
@@ -279,6 +284,7 @@ private:
     vk::UniqueDevice device;
     vk::PhysicalDeviceProperties properties;
     vk::PhysicalDevicePushDescriptorPropertiesKHR push_descriptor_props;
+    vk::PhysicalDeviceVulkan12Properties vk12_props;
     vk::PhysicalDeviceFeatures features;
     vk::DriverIdKHR driver_id;
     vk::UniqueDebugUtilsMessengerEXT debug_callback{};


### PR DESCRIPTION
Most shaders provided by the guest are configured to flush 32-bit denormals by default. Implement this behavior in shaders by reading the float_mode member of program settings. This will only be applied if said capability is exposed by the driver (proprietary NVIDIA doesn't support denorm flushing for example).

Additionally done a small refactor to RuntimeInfo to allow members to be stored in a union to save some storage space. This required ensuring all member structs have trivial destructors. While at it, moved GS copy shader parsing to shader generation as it doesn't need to be done on every draw that uses GS (avoids constructing an std::unordered_map on every such draw)