### PR TITLE
qt_gui: Organize settings page

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -472,7 +472,6 @@ void load(const std::filesystem::path& path) {
         }
         isShowSplash = toml::find_or<bool>(general, "showSplash", true);
         isAutoUpdate = toml::find_or<bool>(general, "autoUpdate", false);
-        backButtonBehavior = toml::find_or<std::string>(general, "backButtonBehavior", "left");
     }
 
     if (data.contains("Input")) {
@@ -480,6 +479,7 @@ void load(const std::filesystem::path& path) {
 
         cursorState = toml::find_or<int>(input, "cursorState", HideCursorState::Idle);
         cursorHideTimeout = toml::find_or<int>(input, "cursorHideTimeout", 5);
+        backButtonBehavior = toml::find_or<std::string>(input, "backButtonBehavior", "left");
         useSpecialPad = toml::find_or<bool>(input, "useSpecialPad", false);
         specialPadClass = toml::find_or<int>(input, "specialPadClass", 1);
     }
@@ -576,7 +576,7 @@ void save(const std::filesystem::path& path) {
     data["General"]["autoUpdate"] = isAutoUpdate;
     data["Input"]["cursorState"] = cursorState;
     data["Input"]["cursorHideTimeout"] = cursorHideTimeout;
-    data["General"]["backButtonBehavior"] = backButtonBehavior;
+    data["Input"]["backButtonBehavior"] = backButtonBehavior;
     data["Input"]["useSpecialPad"] = useSpecialPad;
     data["Input"]["specialPadClass"] = specialPadClass;
     data["GPU"]["screenWidth"] = screenWidth;
@@ -626,8 +626,6 @@ void setDefaultValues() {
     playBGM = false;
     BGMvolume = 50;
     enableDiscordRPC = true;
-    cursorState = HideCursorState::Idle;
-    cursorHideTimeout = 5;
     screenWidth = 1280;
     screenHeight = 720;
     logFilter = "";
@@ -638,6 +636,8 @@ void setDefaultValues() {
     } else {
         updateChannel = "Nightly";
     }
+    cursorState = HideCursorState::Idle;
+    cursorHideTimeout = 5;
     backButtonBehavior = "left";
     useSpecialPad = false;
     specialPadClass = 1;

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -20,15 +20,14 @@ bool getPlayBGM();
 int getBGMvolume();
 bool getEnableDiscordRPC();
 
-s16 getCursorState();
-int getCursorHideTimeout();
-
 std::string getLogFilter();
 std::string getLogType();
 std::string getUserName();
 std::string getUpdateChannel();
-std::string getBackButtonBehavior();
 
+s16 getCursorState();
+int getCursorHideTimeout();
+std::string getBackButtonBehavior();
 bool getUseSpecialPad();
 int getSpecialPadClass();
 
@@ -59,14 +58,14 @@ void setFullscreenMode(bool enable);
 void setPlayBGM(bool enable);
 void setBGMvolume(int volume);
 void setEnableDiscordRPC(bool enable);
-void setCursorState(s16 cursorState);
-void setCursorHideTimeout(int newcursorHideTimeout);
 void setLanguage(u32 language);
 void setNeoMode(bool enable);
 void setUserName(const std::string& type);
 void setUpdateChannel(const std::string& type);
-void setBackButtonBehavior(const std::string& type);
 
+void setCursorState(s16 cursorState);
+void setCursorHideTimeout(int newcursorHideTimeout);
+void setBackButtonBehavior(const std::string& type);
 void setUseSpecialPad(bool use);
 void setSpecialPadClass(int type);
 

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -47,8 +47,6 @@ QStringList languageNames = {"Arabic",
 const QVector<int> languageIndexes = {21, 23, 14, 6,  18, 1,  12, 22, 2,  4, 25, 24, 29, 5,  0,
                                       9,  15, 16, 17, 7,  26, 8,  11, 20, 3, 13, 27, 10, 19, 28};
 
-QStringList hideCursorStates = {"Never", "Idle", "Always"};
-
 SettingsDialog::SettingsDialog(std::span<const QString> physical_devices, QWidget* parent)
     : QDialog(parent), ui(new Ui::SettingsDialog) {
     ui->setupUi(this);
@@ -69,7 +67,14 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices, QWidge
     completer->setCaseSensitivity(Qt::CaseInsensitive);
     ui->consoleLanguageComboBox->setCompleter(completer);
 
-    ui->hideCursorComboBox->addItems(hideCursorStates);
+    ui->hideCursorComboBox->addItem(tr("Never"));
+    ui->hideCursorComboBox->addItem(tr("Idle"));
+    ui->hideCursorComboBox->addItem(tr("Always"));
+
+    ui->backButtonBehaviorComboBox->addItem(tr("Touchpad Left"), "left");
+    ui->backButtonBehaviorComboBox->addItem(tr("Touchpad Center"), "center");
+    ui->backButtonBehaviorComboBox->addItem(tr("Touchpad Right"), "right");
+    ui->backButtonBehaviorComboBox->addItem(tr("None"), "none");
 
     InitializeEmulatorLanguages();
     LoadValuesFromConfig();
@@ -101,15 +106,6 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices, QWidge
     ui->buttonBox->button(QDialogButtonBox::Apply)->setText(tr("Apply"));
     ui->buttonBox->button(QDialogButtonBox::RestoreDefaults)->setText(tr("Restore Defaults"));
     ui->buttonBox->button(QDialogButtonBox::Close)->setText(tr("Close"));
-
-    ui->backButtonBehaviorComboBox->addItem(tr("Touchpad Left"), "left");
-    ui->backButtonBehaviorComboBox->addItem(tr("Touchpad Center"), "center");
-    ui->backButtonBehaviorComboBox->addItem(tr("Touchpad Right"), "right");
-    ui->backButtonBehaviorComboBox->addItem(tr("None"), "none");
-
-    QString currentBackButtonBehavior = QString::fromStdString(Config::getBackButtonBehavior());
-    int index = ui->backButtonBehaviorComboBox->findData(currentBackButtonBehavior);
-    ui->backButtonBehaviorComboBox->setCurrentIndex(index != -1 ? index : 0);
 
     connect(ui->tabWidgetSettings, &QTabWidget::currentChanged, this,
             [this]() { ui->buttonBox->button(QDialogButtonBox::Close)->setFocus(); });
@@ -175,14 +171,6 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices, QWidge
                 rpc->shutdown();
             }
         });
-
-        connect(ui->backButtonBehaviorComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
-                this, [this](int index) {
-                    if (index >= 0 && index < ui->backButtonBehaviorComboBox->count()) {
-                        QString data = ui->backButtonBehaviorComboBox->itemData(index).toString();
-                        Config::setBackButtonBehavior(data.toStdString());
-                    }
-                });
     }
 
     // Input TAB
@@ -195,6 +183,14 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices, QWidge
 
         connect(ui->idleTimeoutSpinBox, &QSpinBox::valueChanged, this,
                 [](int index) { Config::setCursorHideTimeout(index); });
+
+        connect(ui->backButtonBehaviorComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
+                this, [this](int index) {
+                    if (index >= 0 && index < ui->backButtonBehaviorComboBox->count()) {
+                        QString data = ui->backButtonBehaviorComboBox->itemData(index).toString();
+                        Config::setBackButtonBehavior(data.toStdString());
+                    }
+                });
     }
 
     // GPU TAB
@@ -248,6 +244,11 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices, QWidge
         ui->logFilter->installEventFilter(this);
         ui->updaterGroupBox->installEventFilter(this);
         ui->GUIgroupBox->installEventFilter(this);
+
+        // Input
+        ui->cursorGroupBox->installEventFilter(this);
+        ui->hideCursorGroupBox->installEventFilter(this);
+        ui->idleTimeoutGroupBox->installEventFilter(this);
         ui->backButtonBehaviorGroupBox->installEventFilter(this);
 
         // Graphics
@@ -384,6 +385,15 @@ void SettingsDialog::updateNoteTextEdit(const QString& elementName) {
         text = tr("updaterGroupBox");
     } else if (elementName == "GUIgroupBox") {
         text = tr("GUIgroupBox");
+    }
+
+    // Input
+    if (elementName == "cursorGroupBox") {
+        text = tr("cursorGroupBox");
+    } else if (elementName == "hideCursorGroupBox") {
+        text = tr("hideCursorGroupBox");
+    } else if (elementName == "idleTimeoutGroupBox") {
+        text = tr("idleTimeoutGroupBox");
     } else if (elementName == "backButtonBehaviorGroupBox") {
         text = tr("backButtonBehaviorGroupBox");
     }

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -274,6 +274,9 @@
          <layout class="QHBoxLayout" name="generalTabHLayout_2">
           <item>
            <layout class="QVBoxLayout" name="updaterTabLayoutLeft">
+            <property name="sizeConstraint">
+             <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+            </property>
             <property name="leftMargin">
              <number>0</number>
             </property>
@@ -286,8 +289,157 @@
             <property name="bottomMargin">
              <number>0</number>
             </property>
-            <item>
+            <item alignment="Qt::AlignmentFlag::AlignTop">
              <widget class="QGroupBox" name="updaterGroupBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>275</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="title">
+               <string>Update</string>
+              </property>
+              <layout class="QVBoxLayout" name="UpdateLayout" stretch="0,0,0">
+               <property name="spacing">
+                <number>5</number>
+               </property>
+               <property name="topMargin">
+                <number>1</number>
+               </property>
+               <property name="rightMargin">
+                <number>11</number>
+               </property>
+               <property name="bottomMargin">
+                <number>11</number>
+               </property>
+               <item>
+                <widget class="QGroupBox" name="updaterComboBox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>75</height>
+                  </size>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>16777215</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="title">
+                  <string>Update Channel</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="UpdateChannelLayout">
+                  <property name="spacing">
+                   <number>7</number>
+                  </property>
+                  <property name="leftMargin">
+                   <number>11</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>11</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>11</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>11</number>
+                  </property>
+                  <item>
+                   <widget class="QComboBox" name="updateComboBox">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <item>
+                     <property name="text">
+                      <string>Release</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Nightly</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="checkUpdateButton">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>197</width>
+                   <height>28</height>
+                  </size>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>16777215</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>Check for Updates</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="updateCheckBox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="font">
+                  <font>
+                   <pointsize>11</pointsize>
+                   <bold>false</bold>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string>Check for Updates at Startup</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="GUITabLayoutMiddle" stretch="0">
+            <item alignment="Qt::AlignmentFlag::AlignTop">
+             <widget class="QGroupBox" name="GUIgroupBox">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                 <horstretch>0</horstretch>
@@ -296,204 +448,141 @@
               </property>
               <property name="minimumSize">
                <size>
-                <width>265</width>
+                <width>0</width>
                 <height>0</height>
                </size>
               </property>
               <property name="title">
-               <string>Update</string>
-              </property>
-              <widget class="QCheckBox" name="updateCheckBox">
-               <property name="geometry">
-                <rect>
-                 <x>10</x>
-                 <y>130</y>
-                 <width>261</width>
-                 <height>22</height>
-                </rect>
-               </property>
-               <property name="text">
-                <string>Check for Updates at Startup</string>
-               </property>
-              </widget>
-              <widget class="QGroupBox" name="updaterComboBox">
-               <property name="geometry">
-                <rect>
-                 <x>12</x>
-                 <y>30</y>
-                 <width>241</width>
-                 <height>65</height>
-                </rect>
-               </property>
-               <property name="title">
-                <string>Update Channel</string>
-               </property>
-               <widget class="QComboBox" name="updateComboBox">
-                <property name="geometry">
-                 <rect>
-                  <x>12</x>
-                  <y>30</y>
-                  <width>217</width>
-                  <height>28</height>
-                 </rect>
-                </property>
-                <item>
-                 <property name="text">
-                  <string>Release</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Nightly</string>
-                 </property>
-                </item>
-               </widget>
-              </widget>
-              <widget class="QPushButton" name="checkUpdateButton">
-               <property name="geometry">
-                <rect>
-                 <x>25</x>
-                 <y>100</y>
-                 <width>215</width>
-                 <height>24</height>
-                </rect>
-               </property>
-               <property name="text">
-                <string>Check for Updates</string>
-               </property>
-              </widget>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="GUITabLayoutMiddle" stretch="1">
-            <item>
-             <widget class="QGroupBox" name="GUIgroupBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
                <string>GUI Settings</string>
               </property>
-              <widget class="QWidget" name="verticalLayoutWidget_3">
-               <property name="geometry">
-                <rect>
-                 <x>10</x>
-                 <y>30</y>
-                 <width>241</width>
-                 <height>92</height>
-                </rect>
+              <layout class="QVBoxLayout" name="GUILayout">
+               <property name="topMargin">
+                <number>1</number>
                </property>
-               <layout class="QVBoxLayout" name="verticalLayout">
-                <item>
-                 <widget class="QCheckBox" name="playBGMCheckBox">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="text">
-                   <string>Play title music</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <layout class="QHBoxLayout" name="horizontalLayout">
-                  <item>
-                   <layout class="QVBoxLayout" name="verticalLayout_2">
-                    <item>
-                     <widget class="QLabel" name="label">
-                      <property name="text">
-                       <string>Volume</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QSlider" name="BGMVolumeSlider">
-                      <property name="toolTip">
-                       <string>Set the volume of the background music.</string>
-                      </property>
-                      <property name="maximum">
-                       <number>100</number>
-                      </property>
-                      <property name="singleStep">
-                       <number>10</number>
-                      </property>
-                      <property name="pageStep">
-                       <number>20</number>
-                      </property>
-                      <property name="value">
-                       <number>50</number>
-                      </property>
-                      <property name="orientation">
-                       <enum>Qt::Orientation::Horizontal</enum>
-                      </property>
-                      <property name="invertedAppearance">
-                       <bool>false</bool>
-                      </property>
-                      <property name="invertedControls">
-                       <bool>false</bool>
-                      </property>
-                      <property name="tickPosition">
-                       <enum>QSlider::TickPosition::NoTicks</enum>
-                      </property>
-                      <property name="tickInterval">
-                       <number>10</number>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                 </layout>
-                </item>
-               </layout>
-              </widget>
+               <property name="bottomMargin">
+                <number>11</number>
+               </property>
+               <item>
+                <layout class="QVBoxLayout" name="GUIMusicLayout">
+                 <property name="topMargin">
+                  <number>1</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="QCheckBox" name="playBGMCheckBox">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string>Play title music</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="GUIverticalSpacer_2">
+                   <property name="orientation">
+                    <enum>Qt::Orientation::Vertical</enum>
+                   </property>
+                   <property name="sizeType">
+                    <enum>QSizePolicy::Policy::Fixed</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>20</width>
+                     <height>2</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="label">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
+                   <property name="text">
+                    <string>Volume</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QSlider" name="BGMVolumeSlider">
+                   <property name="toolTip">
+                    <string>Set the volume of the background music.</string>
+                   </property>
+                   <property name="maximum">
+                    <number>100</number>
+                   </property>
+                   <property name="singleStep">
+                    <number>10</number>
+                   </property>
+                   <property name="pageStep">
+                    <number>20</number>
+                   </property>
+                   <property name="value">
+                    <number>50</number>
+                   </property>
+                   <property name="orientation">
+                    <enum>Qt::Orientation::Horizontal</enum>
+                   </property>
+                   <property name="invertedAppearance">
+                    <bool>false</bool>
+                   </property>
+                   <property name="invertedControls">
+                    <bool>false</bool>
+                   </property>
+                   <property name="tickPosition">
+                    <enum>QSlider::TickPosition::NoTicks</enum>
+                   </property>
+                   <property name="tickInterval">
+                    <number>10</number>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <widget class="QWidget" name="GUIwidgetSpacer" native="true">
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>61</height>
+                  </size>
+                 </property>
+                </widget>
+               </item>
+              </layout>
              </widget>
             </item>
            </layout>
           </item>
           <item>
-           <layout class="QVBoxLayout" name="ControllerTabLayoutRight" stretch="1">
+           <layout class="QVBoxLayout" name="EmptyTabLayoutRight">
             <item>
-             <widget class="QGroupBox" name="ControllerGroupBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
+             <spacer name="emptyHorizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
-              <property name="title">
-               <string>Controller Settings</string>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
               </property>
-              <widget class="QGroupBox" name="backButtonBehaviorGroupBox">
-               <property name="geometry">
-                <rect>
-                 <x>12</x>
-                 <y>30</y>
-                 <width>241</width>
-                 <height>65</height>
-                </rect>
-               </property>
-               <property name="title">
-                <string>Back Button Behavior</string>
-               </property>
-               <widget class="QComboBox" name="backButtonBehaviorComboBox">
-                <property name="geometry">
-                 <rect>
-                  <x>12</x>
-                  <y>30</y>
-                  <width>217</width>
-                  <height>28</height>
-                 </rect>
-                </property>
-               </widget>
-              </widget>
-             </widget>
+             </spacer>
             </item>
            </layout>
           </item>
@@ -510,18 +599,48 @@
          <layout class="QHBoxLayout" name="inputTabHLayoutTop" stretch="1,1,1">
           <item>
            <layout class="QVBoxLayout" name="cursorTabLayoutLeft">
-            <item>
-             <widget class="QGroupBox" name="HideCursor">
+            <property name="spacing">
+             <number>7</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item alignment="Qt::AlignmentFlag::AlignTop">
+             <widget class="QGroupBox" name="cursorGroupBox">
               <property name="title">
                <string>Cursor</string>
               </property>
               <layout class="QVBoxLayout" name="inputCursorLayout">
+               <property name="spacing">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>11</number>
+               </property>
+               <property name="bottomMargin">
+                <number>11</number>
+               </property>
                <item>
                 <widget class="QGroupBox" name="hideCursorGroupBox">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
                  <property name="title">
                   <string>Hide Cursor</string>
                  </property>
                  <layout class="QVBoxLayout" name="hideCursorLayout">
+                  <property name="spacing">
+                   <number>7</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>11</number>
+                  </property>
                   <item>
                    <widget class="QComboBox" name="hideCursorComboBox"/>
                   </item>
@@ -533,10 +652,16 @@
                  <property name="enabled">
                   <bool>true</bool>
                  </property>
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
                  <property name="minimumSize">
                   <size>
                    <width>0</width>
-                   <height>85</height>
+                   <height>0</height>
                   </size>
                  </property>
                  <property name="title">
@@ -549,19 +674,28 @@
                   <bool>false</bool>
                  </property>
                  <layout class="QHBoxLayout" name="IdleTimeoutLayout" stretch="0,0">
+                  <property name="spacing">
+                   <number>6</number>
+                  </property>
                   <property name="leftMargin">
                    <number>70</number>
                   </property>
                   <property name="topMargin">
-                   <number>11</number>
+                   <number>5</number>
                   </property>
-                  <item>
+                  <property name="rightMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>5</number>
+                  </property>
+                  <item alignment="Qt::AlignmentFlag::AlignHCenter">
                    <widget class="QSpinBox" name="idleTimeoutSpinBox">
                     <property name="enabled">
                      <bool>true</bool>
                     </property>
                     <property name="sizePolicy">
-                     <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                     <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                       <horstretch>0</horstretch>
                       <verstretch>0</verstretch>
                      </sizepolicy>
@@ -620,26 +754,80 @@
            </layout>
           </item>
           <item>
-           <layout class="QVBoxLayout" name="emptyTabLayoutMiddle">
+           <layout class="QVBoxLayout" name="ControllerTabLayoutMiddle">
             <item>
-             <spacer name="emptyHorizontalSpacerMiddle">
-              <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+             <widget class="QGroupBox" name="ControllerGroupBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
               </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
+              <property name="title">
+               <string>Controller</string>
               </property>
-             </spacer>
+              <layout class="QVBoxLayout" name="ControllerLayout">
+               <property name="spacing">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>11</number>
+               </property>
+               <property name="bottomMargin">
+                <number>11</number>
+               </property>
+               <item>
+                <widget class="QGroupBox" name="backButtonBehaviorGroupBox">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>237</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                 <property name="title">
+                  <string>Back Button Behavior</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="BackButtonLayout">
+                  <property name="leftMargin">
+                   <number>11</number>
+                  </property>
+                  <item>
+                   <widget class="QComboBox" name="backButtonBehaviorComboBox"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QWidget" name="controllerWidgetSpacer" native="true">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
             </item>
            </layout>
           </item>
           <item>
            <layout class="QVBoxLayout" name="emptyTabLayoutRight">
             <item>
-             <spacer name="emptyHorizontalSpacerRight">
+             <spacer name="emptyhorizontalSpacer">
               <property name="orientation">
                <enum>Qt::Orientation::Horizontal</enum>
               </property>

--- a/src/qt_gui/translations/en.ts
+++ b/src/qt_gui/translations/en.ts
@@ -435,6 +435,41 @@
 			<translation>Log Filter</translation>
 		</message>
 		<message>
+			<location filename="../settings_dialog.ui" line="595"/>
+			<source>Input</source>
+			<translation>Input</translation>
+		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="611"/>
+			<source>Cursor</source>
+			<translation>Cursor</translation>
+		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="635"/>
+			<source>Hide Cursor</source>
+			<translation>Hide Cursor</translation>
+		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="668"/>
+			<source>Hide Cursor Idle Timeout</source>
+			<translation>Hide Cursor Idle Timeout</translation>
+		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="595"/>
+			<source>Input</source>
+			<translation>Input</translation>
+		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="767"/>
+			<source>Controller</source>
+			<translation>Controller</translation>
+		</message>
+		<message>
+			<location filename="../settings_dialog.ui" line="797"/>
+			<source>Back Button Behavior</source>
+			<translation>Back Button Behavior</translation>
+		</message>
+		<message>
 			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Graphics</translation>
@@ -533,16 +568,6 @@
 			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>Volume</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.ui" line="455"/>
-			<source>Controller Settings</source>
-			<translation>Controller Settings</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.ui" line="467"/>
-			<source>Back Button Behavior</source>
-			<translation>Back Button Behavior</translation>
 		</message>
 	</context>
 	<context>
@@ -1032,6 +1057,41 @@
 			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Play Title Music:\nIf a game supports it, enable playing special music when selecting the game in the GUI.</translation>
+		</message>
+		<message>
+			<location filename="../settings_dialog.cpp" line="392"/>
+			<source>cursorGroupBox</source>
+			<translation>Cursor:\nChange settings related to the cursor.</translation>
+		</message>
+		<message>
+			<location filename="../settings_dialog.cpp" line="394"/>
+			<source>hideCursorGroupBox</source>
+			<translation>Hide Cursor:\nSet cursor hiding behavior.</translation>
+		</message>
+		<message>
+			<location filename="../settings_dialog.cpp" line="396"/>
+			<source>idleTimeoutGroupBox</source>
+			<translation>Hide Idle Cursor Timeout:\nThe duration (seconds) after which the cursor that has been idle hides itself.</translation>
+		</message>
+		<message>
+			<location filename="../settings_dialog.cpp" line="70"/>
+			<source>Never</source>
+			<translation>Never</translation>
+		</message>
+		<message>
+			<location filename="../settings_dialog.cpp" line="71"/>
+			<source>Idle</source>
+			<translation>Idle</translation>
+		</message>
+		<message>
+			<location filename="../settings_dialog.cpp" line="72"/>
+			<source>Always</source>
+			<translation>Always</translation>
+		</message>
+		<message>
+			<location filename="../settings_dialog.cpp" line="330"/>
+			<source>backButtonBehaviorGroupBox</source>
+			<translation>Back Button Behavior:\nAllows setting which part of the touchpad the back button will emulate a touch on.</translation>
 		</message>
 		<message>
 			<location filename="../settings_dialog.cpp" line="330"/>


### PR DESCRIPTION
* Wire up translations and descriptions for the cursor settings.
* Move controller settings to input tab and rename it to controller (to inline it with how other settings are shown).
* Fixed unnecessary double initialization of the back button setting.
* Organize statements and functions w/ respect to their tabs and some minor QOL changes for the settings UI in general.