### PR TITLE
shader_recompiler: Implement V_SUBB_U32 and V_SUBBREV_U32.

### DIFF
--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -155,6 +155,8 @@ public:
     void V_SUB_I32(const GcnInst& inst);
     void V_SUBREV_I32(const GcnInst& inst);
     void V_ADDC_U32(const GcnInst& inst);
+    void V_SUBB_U32(const GcnInst& inst);
+    void V_SUBBREV_U32(const GcnInst& inst);
     void V_LDEXP_F32(const GcnInst& inst);
     void V_CVT_PKNORM_U16_F32(const GcnInst& inst);
     void V_CVT_PKRTZ_F16_F32(const GcnInst& inst);
@@ -273,7 +275,9 @@ private:
     void SetDst(const InstOperand& operand, const IR::U32F32& value);
     void SetDst64(const InstOperand& operand, const IR::U64F64& value_raw);
 
-    // Vector ALU Helprers
+    // Vector ALU Helpers
+    IR::U32 GetCarryIn(const GcnInst& inst);
+    void SetCarryOut(const GcnInst& inst, const IR::U1& carry);
     IR::U32 VMovRelSHelper(u32 src_vgprno, const IR::U32 m0);
     void VMovRelDHelper(u32 dst_vgprno, const IR::U32 src_val, const IR::U32 m0);
 


### PR DESCRIPTION
* Implement `V_SUBB_U32` and `V_SUBBREV_U32`, used by CUSA16429.
* Move carry in and out logic to helpers for supporting VOP2 and VOP3 forms.
* Add missing carry out to `V_SUB_I32` and `V_SUBREV_I32`.
* Clarify in `V_ADD_I32` and new instructions that carry out is TODO for instructions where inputs can be signed or unsigned.