### PR TITLE
shader_recompiler: Make sure RuntimeInfo is zero initialized.

### DIFF
--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -153,7 +153,10 @@ struct RuntimeInfo {
         ComputeRuntimeInfo cs_info;
     };
 
-    RuntimeInfo(Stage stage_) : stage{stage_} {}
+    RuntimeInfo(Stage stage_) {
+        memset(this, 0, sizeof(*this));
+        stage = stage_;
+    }
 
     bool operator==(const RuntimeInfo& other) const noexcept {
         switch (stage) {


### PR DESCRIPTION
Changing `RuntimeInfo` to use a union messed up zero initialization for some reason, I think related to it having a non-default constructor. This doesn't always cause problems but depending on the stack conditions it seems this can lead to bad data, for example in some games it will always crash due to this on specific shaders.

This adds a memset to the constructor to make sure it is properly initialized.