### PR TITLE
shader_recompiler: Set correct operand field for VOP3b sdst.

### DIFF
--- a/src/shader_recompiler/frontend/decode.cpp
+++ b/src/shader_recompiler/frontend/decode.cpp
@@ -654,7 +654,7 @@ void GcnDecodeContext::decodeInstructionVOP3(uint64_t hexInstruction) {
 
     OpcodeVOP3 vop3Op = static_cast<OpcodeVOP3>(op);
     if (IsVop3BEncoding(m_instruction.opcode)) {
-        m_instruction.dst[1].field = OperandField::ScalarGPR;
+        m_instruction.dst[1].field = getOperandField(sdst);
         m_instruction.dst[1].type = ScalarType::Uint64;
         m_instruction.dst[1].code = sdst;
     } else {


### PR DESCRIPTION
Fix a regression from the carry changes due to the carry out possibly having an incorrect field type with VOP3 encoding.