### PR TITLE
resource_tracking_pass: Fix type handling of sample offsets.

### DIFF
--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -507,7 +507,11 @@ void PatchImageSampleInstruction(IR::Block& block, IR::Inst& inst, Info& info,
         }
 
         // The offsets are six-bit signed integers: X=[5:0], Y=[13:8], and Z=[21:16].
-        const IR::Value arg = get_addr_reg(addr_reg++);
+        IR::Value arg = get_addr_reg(addr_reg++);
+        if (const IR::Inst* offset_inst = arg.TryInstRecursive()) {
+            ASSERT(offset_inst->GetOpcode() == IR::Opcode::BitCastF32U32);
+            arg = offset_inst->Arg(0);
+        }
 
         const auto read = [&](u32 off) -> IR::U32 {
             if (arg.IsImmediate()) {


### PR DESCRIPTION
Address registers are passed as float vectors since they are most commonly used as floats. For offsets we need to cast to U32.