### PR TITLE
cmake: add install rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -872,3 +872,11 @@ endif()
 
 # Discord RPC
 target_link_libraries(shadps4 PRIVATE discord-rpc)
+
+# Install rules
+install(TARGETS shadps4 BUNDLE DESTINATION .)
+
+if (ENABLE_QT_GUI AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    install(FILES ".github/shadps4.desktop" DESTINATION "share/applications")
+    install(FILES ".github/shadps4.png" DESTINATION "share/icons/hicolor/512x512/apps")
+endif()


### PR DESCRIPTION
Make `cmake --install build` useful.