### PR TITLE
Use GetSystemTimePreciseAsFileTime to fix fps timing issues

### DIFF
--- a/src/core/libraries/kernel/time_management.cpp
+++ b/src/core/libraries/kernel/time_management.cpp
@@ -148,7 +148,7 @@ int PS4_SYSV_ABI sceKernelGettimeofday(OrbisKernelTimeval* tp) {
 
 #ifdef _WIN64
     FILETIME filetime;
-    GetSystemTimeAsFileTime(&filetime);
+    GetSystemTimePreciseAsFileTime(&filetime);
 
     constexpr u64 UNIX_TIME_START = 0x295E9648864000;
     constexpr u64 TICKS_PER_SECOND = 1000000;


### PR DESCRIPTION
Improves frametime consistency at 60Hz/60fps on Windows platform.

I noticed the framerate jumping between 59fps and 60fps regularly, causing visible hitching. Some games seem to be affected worse than others. 

Here's a before and after of frametime graph:

![image](https://github.com/user-attachments/assets/9dedacfc-6902-4de4-8834-6502858664ec)

Performance on my system with this change seems about the same - possibly even a couple of % faster (the CPU spends a little less time inside sceKernelGettimeofday)