### PR TITLE
Linux unlink implementation

### DIFF
--- a/src/common/io_file.cpp
+++ b/src/common/io_file.cpp
@@ -231,7 +231,7 @@ void IOFile::Unlink() {
 
     // Mark the file for deletion
     // TODO: Also remove the file path?
-#if _WIN64
+#ifdef _WIN64
     FILE_DISPOSITION_INFORMATION disposition;
     IO_STATUS_BLOCK iosb;
 
@@ -242,7 +242,11 @@ void IOFile::Unlink() {
     NtSetInformationFile(hfile, &iosb, &disposition, sizeof(disposition),
                          FileDispositionInformation);
 #else
-    UNREACHABLE_MSG("Missing Linux implementation");
+    if (unlink(file_path.c_str()) != 0) {
+        const auto ec = std::error_code{errno, std::generic_category()};
+        LOG_ERROR(Common_Filesystem, "Failed to unlink the file at path={}, ec_message={}",
+                  PathToUTF8String(file_path), ec.message());
+    }
 #endif
 }
 


### PR DESCRIPTION
This makes CUSA06171 (patapon) playable on Linux, at least until the IME dialog deadlock.