### PR TITLE
Fix translation InstallDirSelect

### DIFF
--- a/src/qt_gui/install_dir_select.h
+++ b/src/qt_gui/install_dir_select.h
@@ -12,6 +12,8 @@
 class QLineEdit;
 
 class InstallDirSelect final : public QDialog {
+    Q_OBJECT
+
 public:
     InstallDirSelect();
     ~InstallDirSelect();
@@ -19,9 +21,6 @@ public:
     std::filesystem::path getSelectedDirectory() {
         return selected_dir;
     }
-
-private slots:
-    void BrowseGamesDirectory();
 
 private:
     QWidget* SetupInstallDirList();


### PR DESCRIPTION
without this, this InstallDirSelect screen is not translated.
BrowseGamesDirectory was removed as it is not used, probably copied from game_install_dialog.h