### PR TITLE
Minor Fixes for Separate Update Folder

### DIFF
--- a/src/core/file_format/pkg.cpp
+++ b/src/core/file_format/pkg.cpp
@@ -3,6 +3,7 @@
 
 #include <zlib-ng.h>
 #include "common/io_file.h"
+#include "common/logging/formatter.h"
 #include "core/file_format/pkg.h"
 #include "core/file_format/pkg_type.h"
 
@@ -349,7 +350,8 @@ bool PKG::Extract(const std::filesystem::path& filepath, const std::filesystem::
                     auto parent_path = extract_path.parent_path();
                     auto title_id = GetTitleID();
 
-                    if (parent_path.filename() != title_id) {
+                    if (parent_path.filename() != title_id &&
+                        !fmt::UTF(extract_path.u8string()).data.ends_with("-UPDATE")) {
                         extractPaths[ndinode_counter] = parent_path / title_id;
                     } else {
                         // DLCs path has different structure

--- a/src/qt_gui/game_info.h
+++ b/src/qt_gui/game_info.h
@@ -26,8 +26,8 @@ public:
         GameInfo game;
         game.path = filePath;
         std::filesystem::path sce_folder_path = filePath / "sce_sys" / "param.sfo";
-        std::filesystem::path game_update_path =
-            std::filesystem::path(filePath.string() + "-UPDATE");
+        std::filesystem::path game_update_path = filePath;
+        game_update_path += "-UPDATE";
         if (std::filesystem::exists(game_update_path / "sce_sys" / "param.sfo")) {
             sce_folder_path = game_update_path / "sce_sys" / "param.sfo";
         }

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -295,7 +295,7 @@ public:
             Common::FS::PathToQString(game_update_path, m_games[itemID].path.concat("-UPDATE"));
             Common::FS::PathToQString(
                 dlc_path, Config::getAddonInstallDir() /
-                                Common::FS::PathFromQString(folder_path).parent_path().filename());
+                              Common::FS::PathFromQString(folder_path).parent_path().filename());
             QString message_type = tr("Game");
 
             if (selected == deleteUpdate) {

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -290,10 +290,14 @@ public:
 
         if (selected == deleteGame || selected == deleteUpdate || selected == deleteDLC) {
             bool error = false;
-            QString folder_path, game_update_path;
+            QString folder_path, game_update_path, dlc_path;
             Common::FS::PathToQString(folder_path, m_games[itemID].path);
             Common::FS::PathToQString(game_update_path, m_games[itemID].path.concat("-UPDATE"));
+            Common::FS::PathToQString(
+                dlc_path, Config::getAddonInstallDir() /
+                                Common::FS::PathFromQString(folder_path).parent_path().filename());
             QString message_type = tr("Game");
+
             if (selected == deleteUpdate) {
                 if (!Config::getSeparateUpdateEnabled()) {
                     QMessageBox::critical(
@@ -302,7 +306,8 @@ public:
                                    "config option "
                                    "to work. If you want to use this feature, please enable it.")));
                     error = true;
-                } else if (!std::filesystem::exists(m_games[itemID].path.concat("-UPDATE"))) {
+                } else if (!std::filesystem::exists(
+                               Common::FS::PathFromQString(game_update_path))) {
                     QMessageBox::critical(nullptr, tr("Error"),
                                           QString(tr("This game has no update to delete!")));
                     error = true;
@@ -311,15 +316,12 @@ public:
                     message_type = tr("Update");
                 }
             } else if (selected == deleteDLC) {
-                std::filesystem::path addon_path =
-                    Config::getAddonInstallDir() /
-                    Common::FS::PathFromQString(folder_path).parent_path().filename();
-                if (!std::filesystem::exists(addon_path)) {
+                if (!std::filesystem::exists(Common::FS::PathFromQString(dlc_path))) {
                     QMessageBox::critical(nullptr, tr("Error"),
                                           QString(tr("This game has no DLC to delete!")));
                     error = true;
                 } else {
-                    folder_path = QString::fromStdString(addon_path.string());
+                    folder_path = dlc_path;
                     message_type = tr("DLC");
                 }
             }

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -792,8 +792,6 @@ void MainWindow::InstallDragDropPkg(std::filesystem::path file, int pkgNum, int 
                     }
                 }
             } else {
-                QString gameDirPath;
-                Common::FS::PathToQString(gameDirPath, game_folder_path);
                 msgBox.setText(QString(tr("Game already installed") + "\n" + gameDirPath + "\n" +
                                        tr("Would you like to overwrite?")));
                 msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -682,9 +682,6 @@ void MainWindow::InstallDragDropPkg(std::filesystem::path file, int pkgNum, int 
         auto game_update_path = use_game_update
                                     ? game_install_dir / (std::string(pkg.GetTitleID()) + "-UPDATE")
                                     : game_folder_path;
-        if (!std::filesystem::exists(game_update_path)) {
-            std::filesystem::create_directory(game_update_path);
-        }
         QString gameDirPath;
         Common::FS::PathToQString(gameDirPath, game_folder_path);
         QDir game_dir(gameDirPath);

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -678,7 +678,7 @@ void MainWindow::InstallDragDropPkg(std::filesystem::path file, int pkgNum, int 
         auto game_install_dir = ids.getSelectedDirectory();
         auto game_folder_path = game_install_dir / pkg.GetTitleID();
         QString pkgType = QString::fromStdString(pkg.GetPkgFlags());
-        bool use_game_update = pkgType.contains("Patch") && Config::getSeparateUpdateEnabled();
+        bool use_game_update = pkgType.contains("PATCH") && Config::getSeparateUpdateEnabled();
         auto game_update_path = use_game_update
                                     ? game_install_dir / (std::string(pkg.GetTitleID()) + "-UPDATE")
                                     : game_folder_path;

--- a/src/qt_gui/translations/en.ts
+++ b/src/qt_gui/translations/en.ts
@@ -1056,6 +1056,11 @@
 			<source>fullscreenCheckBox</source>
 			<translation>Enable Full Screen:\nAutomatically puts the game window into full-screen mode.\nThis can be toggled by pressing the F11 key.</translation>
 		</message>
+                <message>
+			<location filename="../settings_dialog.cpp" line="293"/>
+			<source>separateUpdatesCheckBox</source>
+			<translation>Enable Separate Update Folder:\nEnables installing game updates into a separate folder for easy management.</translation>
+		</message>
 		<message>
 			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>


### PR DESCRIPTION
Should add a description to the enable separate update folder checkbox, remove recreating a variable (I don't know why I put that there), and remove uses of .string()