### PR TITLE
AvPlayer: Do not align w/h to 16 with vdec2

### DIFF
--- a/src/core/libraries/avplayer/avplayer_impl.cpp
+++ b/src/core/libraries/avplayer/avplayer_impl.cpp
@@ -112,7 +112,7 @@ AvPlayer::AvPlayer(const SceAvPlayerInitData& data)
       m_state(std::make_unique<AvPlayerState>(m_init_data)) {}
 
 s32 AvPlayer::PostInit(const SceAvPlayerPostInitData& data) {
-    m_post_init_data = data;
+    m_state->PostInit(data);
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/avplayer/avplayer_impl.h
+++ b/src/core/libraries/avplayer/avplayer_impl.h
@@ -56,7 +56,6 @@ private:
 
     SceAvPlayerInitData m_init_data{};
     SceAvPlayerInitData m_init_data_original{};
-    SceAvPlayerPostInitData m_post_init_data{};
     std::mutex m_file_io_mutex{};
 
     std::atomic_bool m_has_source{};

--- a/src/core/libraries/avplayer/avplayer_source.h
+++ b/src/core/libraries/avplayer/avplayer_source.h
@@ -120,7 +120,7 @@ private:
 
 class AvPlayerSource {
 public:
-    AvPlayerSource(AvPlayerStateCallback& state);
+    AvPlayerSource(AvPlayerStateCallback& state, bool use_vdec2);
     ~AvPlayerSource();
 
     bool Init(const SceAvPlayerInitData& init_data, std::string_view path);
@@ -168,6 +168,7 @@ private:
     Frame PrepareVideoFrame(FrameBuffer buffer, const AVFrame& frame);
 
     AvPlayerStateCallback& m_state;
+    bool m_use_vdec2 = false;
 
     SceAvPlayerMemAllocator m_memory_replacement{};
     u32 m_num_output_video_framebuffers{};

--- a/src/core/libraries/avplayer/avplayer_state.cpp
+++ b/src/core/libraries/avplayer/avplayer_state.cpp
@@ -130,6 +130,10 @@ AvPlayerState::~AvPlayerState() {
     m_event_queue.Clear();
 }
 
+void AvPlayerState::PostInit(const SceAvPlayerPostInitData& post_init_data) {
+    m_post_init_data = post_init_data;
+}
+
 // Called inside GAME thread
 bool AvPlayerState::AddSource(std::string_view path, SceAvPlayerSourceType source_type) {
     if (path.empty()) {
@@ -144,7 +148,9 @@ bool AvPlayerState::AddSource(std::string_view path, SceAvPlayerSourceType sourc
             return false;
         }
 
-        m_up_source = std::make_unique<AvPlayerSource>(*this);
+        m_up_source = std::make_unique<AvPlayerSource>(
+            *this, m_post_init_data.video_decoder_init.decoderType.video_type ==
+                       SCE_AVPLAYER_VIDEO_DECODER_TYPE_SOFTWARE2);
         if (!m_up_source->Init(m_init_data, path)) {
             SetState(AvState::Error);
             m_up_source.reset();

--- a/src/core/libraries/avplayer/avplayer_state.h
+++ b/src/core/libraries/avplayer/avplayer_state.h
@@ -24,6 +24,7 @@ public:
     AvPlayerState(const SceAvPlayerInitData& init_data);
     ~AvPlayerState();
 
+    void PostInit(const SceAvPlayerPostInitData& post_init_data);
     bool AddSource(std::string_view filename, SceAvPlayerSourceType source_type);
     s32 GetStreamCount();
     bool GetStreamInfo(u32 stream_index, SceAvPlayerStreamInfo& info);
@@ -68,6 +69,7 @@ private:
     std::unique_ptr<AvPlayerSource> m_up_source;
 
     SceAvPlayerInitData m_init_data{};
+    SceAvPlayerPostInitData m_post_init_data{};
     SceAvPlayerEventReplacement m_event_replacement{};
     bool m_auto_start{};
     u8 m_default_language[4]{};


### PR DESCRIPTION
* Videodec2 seems to output unaligned frame data and some games rely on that behavior without checking crop offsets and/or frame height
* Also reduced noise in the log when the game drains video data before draining audio