### PR TITLE
cmake: unbundle half library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ find_package(Boost 1.84.0 CONFIG)
 find_package(FFmpeg 5.1.2 MODULE)
 find_package(fmt 10.2.0 CONFIG)
 find_package(glslang 14.2.0 CONFIG)
+find_package(half 1.12.0 MODULE)
 find_package(magic_enum 0.9.6 CONFIG)
 find_package(RenderDoc 1.6.0 MODULE)
 find_package(SDL3 3.1.2 CONFIG)
@@ -773,7 +774,7 @@ endif()
 
 create_target_directory_groups(shadps4)
 
-target_link_libraries(shadps4 PRIVATE magic_enum::magic_enum fmt::fmt toml11::toml11 tsl::robin_map xbyak::xbyak Tracy::TracyClient RenderDoc::API FFmpeg::ffmpeg Dear_ImGui gcn half)
+target_link_libraries(shadps4 PRIVATE magic_enum::magic_enum fmt::fmt toml11::toml11 tsl::robin_map xbyak::xbyak Tracy::TracyClient RenderDoc::API FFmpeg::ffmpeg Dear_ImGui gcn half::half)
 target_link_libraries(shadps4 PRIVATE Boost::headers GPUOpen::VulkanMemoryAllocator sirit Vulkan::Headers xxHash::xxhash Zydis::Zydis glslang::SPIRV glslang::glslang SDL3::SDL3 pugixml::pugixml)
 
 target_compile_definitions(shadps4 PRIVATE IMGUI_USER_CONFIG="imgui/imgui_config.h")

--- a/cmake/Findhalf.cmake
+++ b/cmake/Findhalf.cmake
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+find_path(half_INCLUDE_DIR NAMES half.hpp PATH_SUFFIXES half)
+
+if (half_INCLUDE_DIR)
+    file(STRINGS "${half_INCLUDE_DIR}/half.hpp" _ver_line
+        REGEX "^// Version [0-9.]+$"
+        LIMIT_COUNT 1
+    )
+    string(REGEX MATCH "[0-9.]+" half_VERSION "${_ver_line}")
+    unset(_ver_line)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(half
+    REQUIRED_VARS half_INCLUDE_DIR
+    VERSION_VAR half_VERSION
+)
+
+if (half_FOUND AND NOT TARGET half::half)
+    add_library(half::half INTERFACE IMPORTED)
+    set_target_properties(half::half PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${half_INCLUDE_DIR}"
+    )
+endif()
+
+mark_as_advanced(half_INCLUDE_DIR)

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -142,8 +142,11 @@ if (WIN32)
 endif()
 
 # half
-add_library(half INTERFACE)
-target_include_directories(half INTERFACE half/include)
+if (NOT TARGET half::half)
+    add_library(half INTERFACE)
+    target_include_directories(half INTERFACE half/include)
+    add_library(half::half ALIAS half)
+endif()
 
 if (APPLE)
     # date


### PR DESCRIPTION
For information the submodule version is `1.12.0` but a version `2.2.0` is available [here](https://half.sourceforge.net/).
