### PR TITLE
Disabling discord-rpc warnings

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -186,6 +186,7 @@ endif()
 
 # Discord RPC
 set(BUILD_EXAMPLES OFF)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
 add_subdirectory(discord-rpc/)
 target_include_directories(discord-rpc INTERFACE discord-rpc/include)
 


### PR DESCRIPTION
This disables all discord-rpc warnings going from +6000 lines of compilation log to less than 2000 (for Windows-Qt).