### PR TITLE
Load Eboot/Modules from Separate Update Folder

### DIFF
--- a/src/core/file_sys/fs.cpp
+++ b/src/core/file_sys/fs.cpp
@@ -58,7 +58,8 @@ std::filesystem::path MntPoints::GetHostPath(std::string_view guest_directory, b
 
     std::filesystem::path patch_path = mount->host_path;
     patch_path += "-UPDATE";
-    if (corrected_path.starts_with("/app0/") && std::filesystem::exists(patch_path / rel_path)) {
+    if ((corrected_path.starts_with("/app0") || corrected_path.starts_with("/hostapp")) &&
+        std::filesystem::exists(patch_path / rel_path)) {
         host_path = patch_path / rel_path;
     }
 

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -304,7 +304,8 @@ public:
                         nullptr, tr("Error"),
                         QString(tr("This feature requires the 'Enable Separate Update Folder' "
                                    "config option "
-                                   "to work. If you want to use this feature, please enable it.")));
+                                   "to work. If you want to use this feature, please enable it and "
+                                   "make sure a separated update is installed.")));
                     error = true;
                 } else if (!std::filesystem::exists(
                                Common::FS::PathFromQString(game_update_path))) {


### PR DESCRIPTION
Load eboot and sce_module modules from separate update folder. Should make separate updates finally complete, but this will need to be tested with lots of games with different module setups.

![version-number](https://github.com/user-attachments/assets/85aa3225-ab11-4414-b5ab-b2562f31d593)
