### PR TITLE
Add poll interval to libScePad

### DIFF
--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -257,6 +257,7 @@ void Emulator::Run(const std::filesystem::path& file) {
     std::jthread mainthread =
         std::jthread([this](std::stop_token stop_token) { linker->Execute(); });
 
+    window->initTimers();
     while (window->isOpen()) {
         window->waitEvent();
     }

--- a/src/input/controller.cpp
+++ b/src/input/controller.cpp
@@ -1,10 +1,13 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include <SDL3/SDL.h>
+#include "controller.h"
+
+#include "common/assert.h"
 #include "core/libraries/kernel/time_management.h"
 #include "core/libraries/pad/pad.h"
-#include "input/controller.h"
+
+#include <SDL3/SDL.h>
 
 namespace Input {
 
@@ -155,6 +158,25 @@ void GameController::TryOpenSDLController() {
 
         SetLightBarRGB(0, 0, 255);
     }
+}
+
+u32 GameController::Poll() {
+    if (m_connected) {
+        auto time = Libraries::Kernel::sceKernelGetProcessTime();
+        if (m_states_num == 0) {
+            auto diff = (time - m_last_state.time) / 1000;
+            if (diff >= 100) {
+                AddState(GetLastState());
+            }
+        } else {
+            auto index = (m_first_state - 1 + m_states_num) % MAX_STATES;
+            auto diff = (time - m_states[index].time) / 1000;
+            if (m_private[index].obtained && diff >= 100) {
+                AddState(GetLastState());
+            }
+        }
+    }
+    return 100;
 }
 
 } // namespace Input

--- a/src/input/controller.h
+++ b/src/input/controller.h
@@ -56,6 +56,7 @@ public:
     bool SetVibration(u8 smallMotor, u8 largeMotor);
     void SetTouchpadState(int touchIndex, bool touchDown, float x, float y);
     void TryOpenSDLController();
+    u32 Poll();
 
 private:
     struct StateInternal {

--- a/src/sdl_window.cpp
+++ b/src/sdl_window.cpp
@@ -4,6 +4,7 @@
 #include <SDL3/SDL_events.h>
 #include <SDL3/SDL_init.h>
 #include <SDL3/SDL_properties.h>
+#include <SDL3/SDL_timer.h>
 #include <SDL3/SDL_video.h>
 #include "common/assert.h"
 #include "common/config.h"
@@ -19,6 +20,11 @@
 #endif
 
 namespace Frontend {
+
+static Uint32 SDLCALL PollController(void* userdata, SDL_TimerID timer_id, Uint32 interval) {
+    auto* controller = reinterpret_cast<Input::GameController*>(userdata);
+    return controller->Poll();
+}
 
 WindowSDL::WindowSDL(s32 width_, s32 height_, Input::GameController* controller_,
                      std::string_view window_title)
@@ -117,6 +123,10 @@ void WindowSDL::waitEvent() {
     default:
         break;
     }
+}
+
+void WindowSDL::initTimers() {
+    SDL_AddTimer(100, &PollController, controller);
 }
 
 void WindowSDL::onResize() {

--- a/src/sdl_window.h
+++ b/src/sdl_window.h
@@ -68,6 +68,8 @@ public:
 
     void waitEvent();
 
+    void initTimers();
+
 private:
     void onResize();
     void onKeyPress(const SDL_Event* event);


### PR DESCRIPTION
Adds a maximum of 200ms delay between successful `scePadRead` calls where it returns at least one instance of state data.

Fixes Gravity Rush Remastered and Ghostbusters issue where the game loses the controller.