### PR TITLE
cmake: Allow disabling discord rpc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ if(UNIX AND NOT APPLE)
 endif()
 
 option(ENABLE_QT_GUI "Enable the Qt GUI. If not selected then the emulator uses a minimal SDL-based UI instead" OFF)
+option(ENABLE_DISCORD_RPC "Enable the Discord RPC integration" ON)
 
 # First, determine whether to use CMAKE_OSX_ARCHITECTURES or CMAKE_SYSTEM_PROCESSOR.
 if (APPLE AND CMAKE_OSX_ARCHITECTURES)
@@ -405,8 +406,6 @@ set(COMMON src/common/logging/backend.cpp
            src/common/debug.h
            src/common/decoder.cpp
            src/common/decoder.h
-           src/common/discord_rpc_handler.cpp
-           src/common/discord_rpc_handler.h
            src/common/elf_info.h
            src/common/endian.h
            src/common/enum.h
@@ -446,6 +445,10 @@ set(COMMON src/common/logging/backend.cpp
            src/common/scm_rev.cpp
            src/common/scm_rev.h
 )
+
+if (ENABLE_DISCORD_RPC)
+    list(APPEND COMMON src/common/discord_rpc_handler.cpp src/common/discord_rpc_handler.h)
+endif()
 
 set(CORE src/core/aerolib/stubs.cpp
          src/core/aerolib/stubs.h
@@ -895,7 +898,9 @@ if (UNIX AND NOT APPLE)
 endif()
 
 # Discord RPC
-target_link_libraries(shadps4 PRIVATE discord-rpc)
+if (ENABLE_DISCORD_RPC)
+    target_link_libraries(shadps4 PRIVATE discord-rpc)
+endif()
 
 # Install rules
 install(TARGETS shadps4 BUNDLE DESTINATION .)

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -188,9 +188,11 @@ if (NOT TARGET pugixml::pugixml)
 endif()
 
 # Discord RPC
-set(BUILD_EXAMPLES OFF)
-add_subdirectory(discord-rpc/)
-target_include_directories(discord-rpc INTERFACE discord-rpc/include)
+if (ENABLE_DISCORD_RPC)
+    set(BUILD_EXAMPLES OFF)
+    add_subdirectory(discord-rpc/)
+    target_include_directories(discord-rpc INTERFACE discord-rpc/include)
+endif()
 
 # GCN Headers
 add_subdirectory(gcn)

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -12,7 +12,9 @@
 #include "common/memory_patcher.h"
 #endif
 #include "common/assert.h"
+#ifdef ENABLE_DISCORD_RPC
 #include "common/discord_rpc_handler.h"
+#endif
 #include "common/elf_info.h"
 #include "common/ntapi.h"
 #include "common/path_util.h"
@@ -244,6 +246,7 @@ void Emulator::Run(const std::filesystem::path& file) {
         }
     }
 
+#ifdef ENABLE_DISCORD_RPC
     // Discord RPC
     if (Config::getEnableDiscordRPC()) {
         auto* rpc = Common::Singleton<DiscordRPCHandler::RPC>::Instance();
@@ -252,6 +255,7 @@ void Emulator::Run(const std::filesystem::path& file) {
         }
         rpc->setStatusPlaying(game_info.title, id);
     }
+#endif
 
     // start execution
     std::jthread mainthread =


### PR DESCRIPTION
Discord RPC is basically abandonware at this point and may not compile everywhere