### PR TITLE
vulkan: Report only missing format feature flags.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -275,6 +275,9 @@ private:
     void CollectDeviceParameters();
     void CollectToolingInfo();
 
+    /// Gets the supported feature flags for a format.
+    [[nodiscard]] vk::FormatFeatureFlags2 GetFormatFeatureFlags(vk::Format format) const;
+
     /// Determines if a format is supported for a set of feature flags.
     [[nodiscard]] bool IsFormatSupported(vk::Format format, vk::FormatFeatureFlags2 flags) const;
 


### PR DESCRIPTION
Make format support logging more useful by reporting the flags that are actually unsupported instead of all requested flags.

Also don't bother trying the translation to a supported image format for reporting, just report on the base format since we want to know for more than just images. There was no effect anyway since neither of the formats checked would support all flags.