### PR TITLE
shader_recompiler: patch fmask access instructions

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
@@ -176,6 +176,7 @@ Id EmitImageFetch(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, const
     ImageOperands operands;
     operands.AddOffset(ctx, offset);
     operands.Add(spv::ImageOperandsMask::Lod, lod);
+    operands.Add(spv::ImageOperandsMask::Sample, ms);
     const Id texel =
         texture.is_storage
             ? ctx.OpImageRead(result_type, image, coords, operands.mask, operands.operands)

--- a/src/shader_recompiler/info.h
+++ b/src/shader_recompiler/info.h
@@ -87,6 +87,14 @@ struct SamplerResource {
 };
 using SamplerResourceList = boost::container::small_vector<SamplerResource, 16>;
 
+struct FMaskResource {
+    u32 sgpr_base;
+    u32 dword_offset;
+
+    constexpr AmdGpu::Image GetSharp(const Info& info) const noexcept;
+};
+using FMaskResourceList = boost::container::small_vector<FMaskResource, 16>;
+
 struct PushData {
     static constexpr u32 BufOffsetIndex = 2;
     static constexpr u32 UdRegsIndex = 4;
@@ -179,6 +187,7 @@ struct Info {
     TextureBufferResourceList texture_buffers;
     ImageResourceList images;
     SamplerResourceList samplers;
+    FMaskResourceList fmasks;
 
     std::span<const u32> user_data;
     Stage stage;
@@ -261,6 +270,10 @@ constexpr AmdGpu::Image ImageResource::GetSharp(const Info& info) const noexcept
 
 constexpr AmdGpu::Sampler SamplerResource::GetSharp(const Info& info) const noexcept {
     return inline_sampler ? inline_sampler : info.ReadUd<AmdGpu::Sampler>(sgpr_base, dword_offset);
+}
+
+constexpr AmdGpu::Image FMaskResource::GetSharp(const Info& info) const noexcept {
+    return info.ReadUd<AmdGpu::Image>(sgpr_base, dword_offset);
 }
 
 } // namespace Shader

--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -719,12 +719,13 @@ void PatchImageInstruction(IR::Block& block, IR::Inst& inst, Info& info, Descrip
             [[fallthrough]];
         case AmdGpu::ImageType::Color2D: // x, y
             [[fallthrough]];
-        case AmdGpu::ImageType::Color2DMsaa: //x, y. (sample is passed on different argument)
+        case AmdGpu::ImageType::Color2DMsaa: // x, y. (sample is passed on different argument)
             return {ir.CompositeConstruct(body->Arg(0), body->Arg(1)), body->Arg(2), body->Arg(3)};
         case AmdGpu::ImageType::Color2DArray: // x, y, slice
             [[fallthrough]];
         case AmdGpu::ImageType::Color3D: // x, y, z
-            return {ir.CompositeConstruct(body->Arg(0), body->Arg(1), body->Arg(2)), body->Arg(3), body->Arg(4)};
+            return {ir.CompositeConstruct(body->Arg(0), body->Arg(1), body->Arg(2)), body->Arg(3),
+                    body->Arg(4)};
         case AmdGpu::ImageType::Cube: // x, y, face
             return {PatchCubeCoord(ir, body->Arg(0), body->Arg(1), body->Arg(2), is_storage,
                                    inst_info.is_array),

--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -295,6 +295,10 @@ struct Image {
         return GetTilingMode() != TilingMode::Display_Linear;
     }
 
+    bool IsFmask() const noexcept {
+        return GetDataFmt() >= DataFormat::FormatFmask8_1 && GetDataFmt() <= DataFormat::FormatFmask64_8;
+    }
+
     bool IsPartialCubemap() const {
         const auto viewed_slice = last_array - base_array + 1;
         return GetType() == ImageType::Cube && viewed_slice < 6;

--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -296,7 +296,8 @@ struct Image {
     }
 
     bool IsFmask() const noexcept {
-        return GetDataFmt() >= DataFormat::FormatFmask8_1 && GetDataFmt() <= DataFormat::FormatFmask64_8;
+        return GetDataFmt() >= DataFormat::FormatFmask8_1 &&
+               GetDataFmt() <= DataFormat::FormatFmask64_8;
     }
 
     bool IsPartialCubemap() const {


### PR DESCRIPTION
Patch some instructions that access fmask image bound to shader.

This PR patches those reads into constant values and removes the binding all together.

Probable we need to patch more opcodes and do some more testing.

Journey now doesn't assert on liverpool_to_vk.cpp. Insteed it crashes further on image.cpp::236 on the following line of code of the VideoCore::Image::Transit function:

```c++
ASSERT(subres_idx < subresource_states.size());
```

I don't think this is related to this PR bu I might be wrong.

More testing with more games that access fmask is needed.