### PR TITLE
kernel: Fix new pthreads code on macOS.

### DIFF
--- a/src/core/libraries/kernel/threads.h
+++ b/src/core/libraries/kernel/threads.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <functional>
+#include "common/polyfill_thread.h"
 #include "core/libraries/kernel/threads/pthread.h"
 
 namespace Core::Loader {

--- a/src/core/libraries/kernel/threads/event_flag.cpp
+++ b/src/core/libraries/kernel/threads/event_flag.cpp
@@ -3,6 +3,7 @@
 
 #include <condition_variable>
 #include <mutex>
+#include <thread>
 
 #include "common/assert.h"
 #include "common/logging/log.h"

--- a/src/core/libraries/kernel/threads/mutex.cpp
+++ b/src/core/libraries/kernel/threads/mutex.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <thread>
 #include "common/assert.h"
 #include "common/scope_exit.h"
 #include "common/types.h"

--- a/src/core/libraries/kernel/threads/pthread.h
+++ b/src/core/libraries/kernel/threads/pthread.h
@@ -7,6 +7,7 @@
 #include <forward_list>
 #include <list>
 #include <mutex>
+#include <semaphore>
 #include <shared_mutex>
 #include <boost/intrusive/list.hpp>
 

--- a/src/core/libraries/kernel/threads/semaphore.cpp
+++ b/src/core/libraries/kernel/threads/semaphore.cpp
@@ -4,6 +4,7 @@
 #include <condition_variable>
 #include <list>
 #include <mutex>
+#include <semaphore>
 #include "common/assert.h"
 #include "common/logging/log.h"
 #include "core/libraries/error_codes.h"

--- a/src/core/libraries/kernel/time.cpp
+++ b/src/core/libraries/kernel/time.cpp
@@ -16,6 +16,9 @@
 #include "common/ntapi.h"
 
 #else
+#if __APPLE__
+#include <date/tz.h>
+#endif
 #include <sys/time.h>
 #include <time.h>
 #include <unistd.h>

--- a/src/core/libraries/kernel/time.h
+++ b/src/core/libraries/kernel/time.h
@@ -33,7 +33,8 @@ struct OrbisKernelTimespec {
 
     std::chrono::system_clock::time_point TimePoint() const noexcept {
         using namespace std::chrono;
-        const auto duration = seconds{tv_sec} + nanoseconds{tv_nsec};
+        const auto duration =
+            duration_cast<system_clock::duration>(seconds{tv_sec} + nanoseconds{tv_nsec});
         return system_clock::time_point{duration};
     }
 };

--- a/src/core/libraries/network/net_ctl_obj.cpp
+++ b/src/core/libraries/network/net_ctl_obj.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <algorithm>
 #include "core/libraries/network/net_ctl_codes.h"
 #include "core/libraries/network/net_ctl_obj.h"
 #include "core/tls.h"


### PR DESCRIPTION
PR is for the `more-kernel` branch, not `main`.

* Adds missing includes.
* Casts timespec duration to be supported by the clock type. Really I think this should be using `steady_clock` anyway since `system_clock` is sensitive to user time changes on all platforms, but at least as far as compatibility with macOS is concerned casting should be fine for now.
* Cleans up the TCB management code for macOS to work with the new thread code. Primarily there were two issues:
  * Relied on `SetTcbBase(nullptr)` when a thread finished running for cleanup, which was no longer being done. To make things simple it now just uses a `pthread_key_t` with a destructor to make sure the LDT allocations get cleaned up. It also guards against multiple `SetTcbBase` calls in a thread by reusing the allocated page.
  * The `ldt_entry` was not getting zero initialized and could contain incorrect data depending on the stack, and some of the threading changes exposed this problem.

Tested a few games and the changes are working on macOS now.