### PR TITLE
Fix update loop between release

### DIFF
--- a/src/qt_gui/check_update.cpp
+++ b/src/qt_gui/check_update.cpp
@@ -145,7 +145,9 @@ void CheckUpdate::CheckForUpdates(const bool showMessage) {
             return;
         }
 
-        QString currentRev = QString::fromStdString(Common::g_scm_rev).left(7);
+        QString currentRev = (updateChannel == "Nightly")
+                                 ? QString::fromStdString(Common::g_scm_rev).left(7)
+                                 : "v." + QString::fromStdString(Common::VERSION);
         QString currentDate = Common::g_scm_date;
 
         QDateTime dateTime = QDateTime::fromString(latestDate, Qt::ISODate);


### PR DESCRIPTION
If you use version release 0.4 which has autoUpdate, and check if there is an update for release, it will always inform you that there is a new update, as it was comparing 'commit' with 'version'

![image](https://github.com/user-attachments/assets/32895cda-3f51-4355-9e9e-905cc4f5f832)


0.3.0 has no update, but I did this test by changing version, and if release was selected as the update channel, it will compare the 'version' and not the commit.
![image](https://github.com/user-attachments/assets/619ede0a-5375-4972-ba8d-1c0c15af095b)
