### PR TITLE
qt: Error if installing DLC without game.

### DIFF
--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -673,6 +673,12 @@ void MainWindow::InstallDragDropPkg(std::filesystem::path file, int pkgNum, int 
             QMessageBox::critical(this, tr("PKG ERROR"), QString::fromStdString(failreason));
             return;
         }
+        if (!psf.Open(pkg.sfo)) {
+            QMessageBox::critical(this, tr("PKG ERROR"),
+                                  "Could not read SFO. Check log for details");
+            return;
+        }
+        auto category = psf.GetString("CATEGORY");
         InstallDirSelect ids;
         ids.exec();
         auto game_install_dir = ids.getSelectedDirectory();
@@ -689,12 +695,6 @@ void MainWindow::InstallDragDropPkg(std::filesystem::path file, int pkgNum, int 
             QMessageBox msgBox;
             msgBox.setWindowTitle(tr("PKG Extraction"));
 
-            if (!psf.Open(pkg.sfo)) {
-                QMessageBox::critical(this, tr("PKG ERROR"),
-                                      "Could not read SFO. Check log for details");
-                return;
-            }
-
             std::string content_id;
             if (auto value = psf.GetString("CONTENT_ID"); value.has_value()) {
                 content_id = std::string{*value};
@@ -709,7 +709,6 @@ void MainWindow::InstallDragDropPkg(std::filesystem::path file, int pkgNum, int 
             QString addonDirPath;
             Common::FS::PathToQString(addonDirPath, addon_extract_path);
             QDir addon_dir(addonDirPath);
-            auto category = psf.GetString("CATEGORY");
 
             if (pkgType.contains("PATCH")) {
                 QString pkg_app_version;
@@ -802,9 +801,10 @@ void MainWindow::InstallDragDropPkg(std::filesystem::path file, int pkgNum, int 
             }
         } else {
             // Do nothing;
-            if (pkgType.contains("PATCH")) {
-                QMessageBox::information(this, tr("PKG Extraction"),
-                                         tr("PKG is a patch, please install the game first!"));
+            if (pkgType.contains("PATCH") || category == "ac") {
+                QMessageBox::information(
+                    this, tr("PKG Extraction"),
+                    tr("PKG is a patch or DLC, please install the game first!"));
                 return;
             }
             // what else?


### PR DESCRIPTION
Currently if you try to install DLC without the game installed first, it will install it incorrectly as if it is a game, because the logic to check for updates and DLC only happens if the game directory exists.

The whole game vs update vs DLC package install code could use some cleaning up in general to address logic holes like this, but to at least prevent the issue for now, error if the user attempts to install DLC without the game installed.