### PR TITLE
Image binding and texture cache interface refactor (1/2)

### DIFF
--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -328,7 +328,7 @@ void* Linker::AllocateTlsForThread(bool is_primary) {
     void* addr_out{reinterpret_cast<void*>(KernelAllocBase)};
     if (is_primary) {
         const size_t tls_aligned = Common::AlignUp(total_tls_size, 16_KB);
-        const int ret = Libraries::Kernel::sceKernelMapNamedFlexibleMemory(
+        const int ret = ::Libraries::Kernel::sceKernelMapNamedFlexibleMemory(
             &addr_out, tls_aligned, 3, 0, "SceKernelPrimaryTcbTls");
         ASSERT_MSG(ret == 0, "Unable to allocate TLS+TCB for the primary thread");
     } else {

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -328,7 +328,7 @@ void* Linker::AllocateTlsForThread(bool is_primary) {
     void* addr_out{reinterpret_cast<void*>(KernelAllocBase)};
     if (is_primary) {
         const size_t tls_aligned = Common::AlignUp(total_tls_size, 16_KB);
-        const int ret = ::Libraries::Kernel::sceKernelMapNamedFlexibleMemory(
+        const int ret = Libraries::Kernel::sceKernelMapNamedFlexibleMemory(
             &addr_out, tls_aligned, 3, 0, "SceKernelPrimaryTcbTls");
         ASSERT_MSG(ret == 0, "Unable to allocate TLS+TCB for the primary thread");
     } else {

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -20,7 +20,7 @@ enum class Stage : u32 {
     Local,
     Compute,
 };
-constexpr u32 MaxStageTypes = 6;
+constexpr u32 MaxStageTypes = 7;
 
 [[nodiscard]] constexpr Stage StageFromIndex(size_t index) noexcept {
     return static_cast<Stage>(index);

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -620,10 +620,10 @@ void BufferCache::SynchronizeBuffer(Buffer& buffer, VAddr device_addr, u32 size,
 bool BufferCache::SynchronizeBufferFromImage(Buffer& buffer, VAddr device_addr, u32 size) {
     static constexpr FindFlags find_flags =
         FindFlags::NoCreate | FindFlags::RelaxDim | FindFlags::RelaxFmt | FindFlags::RelaxSize;
-    ImageInfo info{};
-    info.guest_address = device_addr;
-    info.guest_size_bytes = size;
-    const ImageId image_id = texture_cache.FindImage(info, find_flags);
+    TextureCache::BaseDesc desc{};
+    desc.info.guest_address = device_addr;
+    desc.info.guest_size_bytes = size;
+    const ImageId image_id = texture_cache.FindImage(desc, find_flags);
     if (!image_id) {
         return false;
     }

--- a/src/video_core/renderer_vulkan/vk_compute_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_compute_pipeline.h
@@ -24,13 +24,8 @@ public:
                     vk::ShaderModule module);
     ~ComputePipeline();
 
-    bool BindResources(VideoCore::BufferCache& buffer_cache,
-                       VideoCore::TextureCache& texture_cache) const;
-
 private:
     u64 compute_key;
-    const Shader::Info* info;
-    bool uses_push_descriptors{};
 };
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <xxhash.h>
+
 #include "common/types.h"
 #include "video_core/renderer_vulkan/liverpool_to_vk.h"
 #include "video_core/renderer_vulkan/vk_common.h"
@@ -14,8 +15,8 @@ class TextureCache;
 
 namespace Vulkan {
 
-static constexpr u32 MaxVertexBufferCount = 32;
 static constexpr u32 MaxShaderStages = 5;
+static constexpr u32 MaxVertexBufferCount = 32;
 
 class Instance;
 class Scheduler;
@@ -61,13 +62,6 @@ public:
                      std::span<const vk::ShaderModule> modules);
     ~GraphicsPipeline();
 
-    void BindResources(const Liverpool::Regs& regs, VideoCore::BufferCache& buffer_cache,
-                       VideoCore::TextureCache& texture_cache) const;
-
-    const Shader::Info& GetStage(Shader::Stage stage) const noexcept {
-        return *stages[u32(stage)];
-    }
-
     bool IsEmbeddedVs() const noexcept {
         static constexpr size_t EmbeddedVsHash = 0x9b2da5cf47f8c29f;
         return key.stage_hashes[u32(Shader::Stage::Vertex)] == EmbeddedVsHash;
@@ -99,9 +93,7 @@ private:
     void BuildDescSetLayout();
 
 private:
-    std::array<const Shader::Info*, MaxShaderStages> stages{};
     GraphicsPipelineKey key;
-    bool uses_push_descriptors{};
 };
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.h
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.h
@@ -38,8 +38,6 @@ struct Program {
 };
 
 class PipelineCache {
-    static constexpr size_t MaxShaderStages = 5;
-
 public:
     explicit PipelineCache(const Instance& instance, Scheduler& scheduler,
                            AmdGpu::Liverpool* liverpool);

--- a/src/video_core/renderer_vulkan/vk_pipeline_common.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_common.cpp
@@ -12,270 +12,47 @@
 
 namespace Vulkan {
 
-boost::container::static_vector<vk::DescriptorImageInfo, 32> Pipeline::image_infos;
-boost::container::static_vector<vk::BufferView, 8> Pipeline::buffer_views;
-boost::container::static_vector<vk::DescriptorBufferInfo, 32> Pipeline::buffer_infos;
-boost::container::static_vector<VideoCore::ImageId, 32> Pipeline::bound_images;
-
 Pipeline::Pipeline(const Instance& instance_, Scheduler& scheduler_, DescriptorHeap& desc_heap_,
-                   vk::PipelineCache pipeline_cache)
-    : instance{instance_}, scheduler{scheduler_}, desc_heap{desc_heap_} {}
+                   vk::PipelineCache pipeline_cache, bool is_compute_ /*= false*/)
+    : instance{instance_}, scheduler{scheduler_}, desc_heap{desc_heap_}, is_compute{is_compute_} {}
 
 Pipeline::~Pipeline() = default;
 
-void Pipeline::BindBuffers(VideoCore::BufferCache& buffer_cache,
-                           VideoCore::TextureCache& texture_cache, const Shader::Info& stage,
-                           Shader::Backend::Bindings& binding, Shader::PushData& push_data,
-                           DescriptorWrites& set_writes, BufferBarriers& buffer_barriers) const {
-    using BufferBindingInfo = std::pair<VideoCore::BufferId, AmdGpu::Buffer>;
-    static boost::container::static_vector<BufferBindingInfo, 32> buffer_bindings;
+void Pipeline::BindResources(DescriptorWrites& set_writes, const BufferBarriers& buffer_barriers,
+                             const Shader::PushData& push_data) const {
+    const auto cmdbuf = scheduler.CommandBuffer();
+    const auto bind_point =
+        IsCompute() ? vk::PipelineBindPoint::eCompute : vk::PipelineBindPoint::eGraphics;
 
-    buffer_bindings.clear();
-
-    for (const auto& desc : stage.buffers) {
-        const auto vsharp = desc.GetSharp(stage);
-        if (!desc.is_gds_buffer && vsharp.base_address != 0 && vsharp.GetSize() > 0) {
-            const auto buffer_id = buffer_cache.FindBuffer(vsharp.base_address, vsharp.GetSize());
-            buffer_bindings.emplace_back(buffer_id, vsharp);
-        } else {
-            buffer_bindings.emplace_back(VideoCore::BufferId{}, vsharp);
-        }
+    if (!buffer_barriers.empty()) {
+        const auto dependencies = vk::DependencyInfo{
+            .dependencyFlags = vk::DependencyFlagBits::eByRegion,
+            .bufferMemoryBarrierCount = u32(buffer_barriers.size()),
+            .pBufferMemoryBarriers = buffer_barriers.data(),
+        };
+        scheduler.EndRendering();
+        cmdbuf.pipelineBarrier2(dependencies);
     }
 
-    using TexBufferBindingInfo = std::pair<VideoCore::BufferId, AmdGpu::Buffer>;
-    static boost::container::static_vector<TexBufferBindingInfo, 32> texbuffer_bindings;
+    const auto stage_flags = IsCompute() ? vk::ShaderStageFlagBits::eCompute : gp_stage_flags;
+    cmdbuf.pushConstants(*pipeline_layout, stage_flags, 0u, sizeof(push_data), &push_data);
 
-    texbuffer_bindings.clear();
-
-    for (const auto& desc : stage.texture_buffers) {
-        const auto vsharp = desc.GetSharp(stage);
-        if (vsharp.base_address != 0 && vsharp.GetSize() > 0 &&
-            vsharp.GetDataFmt() != AmdGpu::DataFormat::FormatInvalid) {
-            const auto buffer_id = buffer_cache.FindBuffer(vsharp.base_address, vsharp.GetSize());
-            texbuffer_bindings.emplace_back(buffer_id, vsharp);
-        } else {
-            texbuffer_bindings.emplace_back(VideoCore::BufferId{}, vsharp);
-        }
+    // Bind descriptor set.
+    if (set_writes.empty()) {
+        return;
     }
 
-    // Bind the flattened user data buffer as a UBO so it's accessible to the shader
-    if (stage.has_readconst) {
-        const auto [vk_buffer, offset] = buffer_cache.ObtainHostUBO(stage.flattened_ud_buf);
-        buffer_infos.emplace_back(vk_buffer->Handle(), offset,
-                                  stage.flattened_ud_buf.size() * sizeof(u32));
-        set_writes.push_back({
-            .dstSet = VK_NULL_HANDLE,
-            .dstBinding = binding.unified++,
-            .dstArrayElement = 0,
-            .descriptorCount = 1,
-            .descriptorType = vk::DescriptorType::eUniformBuffer,
-            .pBufferInfo = &buffer_infos.back(),
-        });
-        ++binding.buffer;
+    if (uses_push_descriptors) {
+        cmdbuf.pushDescriptorSetKHR(bind_point, *pipeline_layout, 0, set_writes);
+        return;
     }
 
-    // Second pass to re-bind buffers that were updated after binding
-    for (u32 i = 0; i < buffer_bindings.size(); i++) {
-        const auto& [buffer_id, vsharp] = buffer_bindings[i];
-        const auto& desc = stage.buffers[i];
-        const bool is_storage = desc.IsStorage(vsharp);
-        if (!buffer_id) {
-            if (desc.is_gds_buffer) {
-                const auto* gds_buf = buffer_cache.GetGdsBuffer();
-                buffer_infos.emplace_back(gds_buf->Handle(), 0, gds_buf->SizeBytes());
-            } else if (instance.IsNullDescriptorSupported()) {
-                buffer_infos.emplace_back(VK_NULL_HANDLE, 0, VK_WHOLE_SIZE);
-            } else {
-                auto& null_buffer = buffer_cache.GetBuffer(VideoCore::NULL_BUFFER_ID);
-                buffer_infos.emplace_back(null_buffer.Handle(), 0, VK_WHOLE_SIZE);
-            }
-        } else {
-            const auto [vk_buffer, offset] = buffer_cache.ObtainBuffer(
-                vsharp.base_address, vsharp.GetSize(), desc.is_written, false, buffer_id);
-            const u32 alignment =
-                is_storage ? instance.StorageMinAlignment() : instance.UniformMinAlignment();
-            const u32 offset_aligned = Common::AlignDown(offset, alignment);
-            const u32 adjust = offset - offset_aligned;
-            ASSERT(adjust % 4 == 0);
-            push_data.AddOffset(binding.buffer, adjust);
-            buffer_infos.emplace_back(vk_buffer->Handle(), offset_aligned,
-                                      vsharp.GetSize() + adjust);
-        }
-
-        set_writes.push_back({
-            .dstSet = VK_NULL_HANDLE,
-            .dstBinding = binding.unified++,
-            .dstArrayElement = 0,
-            .descriptorCount = 1,
-            .descriptorType = is_storage ? vk::DescriptorType::eStorageBuffer
-                                         : vk::DescriptorType::eUniformBuffer,
-            .pBufferInfo = &buffer_infos.back(),
-        });
-        ++binding.buffer;
+    const auto desc_set = desc_heap.Commit(*desc_layout);
+    for (auto& set_write : set_writes) {
+        set_write.dstSet = desc_set;
     }
-
-    const auto null_buffer_view =
-        instance.IsNullDescriptorSupported() ? VK_NULL_HANDLE : buffer_cache.NullBufferView();
-    for (u32 i = 0; i < texbuffer_bindings.size(); i++) {
-        const auto& [buffer_id, vsharp] = texbuffer_bindings[i];
-        const auto& desc = stage.texture_buffers[i];
-        vk::BufferView& buffer_view = buffer_views.emplace_back(null_buffer_view);
-        if (buffer_id) {
-            const u32 alignment = instance.TexelBufferMinAlignment();
-            const auto [vk_buffer, offset] = buffer_cache.ObtainBuffer(
-                vsharp.base_address, vsharp.GetSize(), desc.is_written, true, buffer_id);
-            const u32 fmt_stride = AmdGpu::NumBits(vsharp.GetDataFmt()) >> 3;
-            ASSERT_MSG(fmt_stride == vsharp.GetStride(),
-                       "Texel buffer stride must match format stride");
-            const u32 offset_aligned = Common::AlignDown(offset, alignment);
-            const u32 adjust = offset - offset_aligned;
-            ASSERT(adjust % fmt_stride == 0);
-            push_data.AddOffset(binding.buffer, adjust / fmt_stride);
-            buffer_view =
-                vk_buffer->View(offset_aligned, vsharp.GetSize() + adjust, desc.is_written,
-                                vsharp.GetDataFmt(), vsharp.GetNumberFmt());
-            if (auto barrier =
-                    vk_buffer->GetBarrier(desc.is_written ? vk::AccessFlagBits2::eShaderWrite
-                                                          : vk::AccessFlagBits2::eShaderRead,
-                                          vk::PipelineStageFlagBits2::eComputeShader)) {
-                buffer_barriers.emplace_back(*barrier);
-            }
-            if (desc.is_written) {
-                texture_cache.InvalidateMemoryFromGPU(vsharp.base_address, vsharp.GetSize());
-            }
-        }
-
-        set_writes.push_back({
-            .dstSet = VK_NULL_HANDLE,
-            .dstBinding = binding.unified++,
-            .dstArrayElement = 0,
-            .descriptorCount = 1,
-            .descriptorType = desc.is_written ? vk::DescriptorType::eStorageTexelBuffer
-                                              : vk::DescriptorType::eUniformTexelBuffer,
-            .pTexelBufferView = &buffer_view,
-        });
-        ++binding.buffer;
-    }
-}
-
-void Pipeline::BindTextures(VideoCore::TextureCache& texture_cache, const Shader::Info& stage,
-                            Shader::Backend::Bindings& binding,
-                            DescriptorWrites& set_writes) const {
-    using ImageBindingInfo = std::pair<VideoCore::ImageId, VideoCore::TextureCache::TextureDesc>;
-    static boost::container::static_vector<ImageBindingInfo, 32> image_bindings;
-
-    image_bindings.clear();
-
-    for (const auto& image_desc : stage.images) {
-        const auto tsharp = image_desc.GetSharp(stage);
-        if (texture_cache.IsMeta(tsharp.Address())) {
-            LOG_WARNING(Render_Vulkan, "Unexpected metadata read by a shader (texture)");
-        }
-
-        if (tsharp.GetDataFmt() == AmdGpu::DataFormat::FormatInvalid) {
-            image_bindings.emplace_back(std::piecewise_construct, std::tuple{}, std::tuple{});
-            continue;
-        }
-
-        auto& [image_id, desc] = image_bindings.emplace_back(std::piecewise_construct, std::tuple{},
-                                                             std::tuple{tsharp, image_desc});
-        image_id = texture_cache.FindImage(desc);
-        auto& image = texture_cache.GetImage(image_id);
-        ASSERT(False(image.flags & VideoCore::ImageFlagBits::Virtual));
-        if (image.binding.is_bound) {
-            // The image is already bound. In case if it is about to be used as storage we need
-            // to force general layout on it.
-            image.binding.force_general |= image_desc.is_storage;
-        }
-        if (image.binding.is_target) {
-            // The image is already bound as target. Since we read and output to it need to force
-            // general layout too.
-            image.binding.force_general = 1u;
-        }
-        image.binding.is_bound = 1u;
-    }
-
-    // Second pass to re-bind images that were updated after binding
-    for (auto& [image_id, desc] : image_bindings) {
-        bool is_storage = desc.type == VideoCore::TextureCache::BindingType::Storage;
-        if (!image_id) {
-            if (instance.IsNullDescriptorSupported()) {
-                image_infos.emplace_back(VK_NULL_HANDLE, VK_NULL_HANDLE, vk::ImageLayout::eGeneral);
-            } else {
-                auto& null_image = texture_cache.GetImageView(VideoCore::NULL_IMAGE_VIEW_ID);
-                image_infos.emplace_back(VK_NULL_HANDLE, *null_image.image_view,
-                                         vk::ImageLayout::eGeneral);
-            }
-        } else {
-            if (auto& old_image = texture_cache.GetImage(image_id);
-                old_image.binding.needs_rebind) {
-                old_image.binding.Reset(); // clean up previous image binding state
-                image_id = texture_cache.FindImage(desc);
-            }
-
-            bound_images.emplace_back(image_id);
-
-            auto& image = texture_cache.GetImage(image_id);
-            auto& image_view = texture_cache.FindTexture(image_id, desc.view_info);
-
-            if (image.binding.force_general || image.binding.is_target) {
-                image.Transit(vk::ImageLayout::eGeneral,
-                              vk::AccessFlagBits2::eShaderRead |
-                                  (image.info.IsDepthStencil()
-                                       ? vk::AccessFlagBits2::eDepthStencilAttachmentWrite
-                                       : vk::AccessFlagBits2::eColorAttachmentWrite),
-                              {});
-            } else {
-                if (is_storage) {
-                    image.Transit(vk::ImageLayout::eGeneral,
-                                  vk::AccessFlagBits2::eShaderRead |
-                                      vk::AccessFlagBits2::eShaderWrite,
-                                  desc.view_info.range);
-                } else {
-                    const auto new_layout = image.info.IsDepthStencil()
-                                                ? vk::ImageLayout::eDepthStencilReadOnlyOptimal
-                                                : vk::ImageLayout::eShaderReadOnlyOptimal;
-                    image.Transit(new_layout, vk::AccessFlagBits2::eShaderRead,
-                                  desc.view_info.range);
-                }
-            }
-            image.usage.storage |= is_storage;
-            image.usage.texture |= !is_storage;
-
-            image_infos.emplace_back(VK_NULL_HANDLE, *image_view.image_view,
-                                     image.last_state.layout);
-        }
-
-        set_writes.push_back({
-            .dstSet = VK_NULL_HANDLE,
-            .dstBinding = binding.unified++,
-            .dstArrayElement = 0,
-            .descriptorCount = 1,
-            .descriptorType =
-                is_storage ? vk::DescriptorType::eStorageImage : vk::DescriptorType::eSampledImage,
-            .pImageInfo = &image_infos.back(),
-        });
-    }
-
-    for (const auto& sampler : stage.samplers) {
-        auto ssharp = sampler.GetSharp(stage);
-        if (sampler.disable_aniso) {
-            const auto& tsharp = stage.images[sampler.associated_image].GetSharp(stage);
-            if (tsharp.base_level == 0 && tsharp.last_level == 0) {
-                ssharp.max_aniso.Assign(AmdGpu::AnisoRatio::One);
-            }
-        }
-        const auto vk_sampler = texture_cache.GetSampler(ssharp);
-        image_infos.emplace_back(vk_sampler, VK_NULL_HANDLE, vk::ImageLayout::eGeneral);
-        set_writes.push_back({
-            .dstSet = VK_NULL_HANDLE,
-            .dstBinding = binding.unified++,
-            .dstArrayElement = 0,
-            .descriptorCount = 1,
-            .descriptorType = vk::DescriptorType::eSampler,
-            .pImageInfo = &image_infos.back(),
-        });
-    }
+    instance.GetDevice().updateDescriptorSets(set_writes, {});
+    cmdbuf.bindDescriptorSets(bind_point, *pipeline_layout, 0, desc_set, {});
 }
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_pipeline_common.h
+++ b/src/video_core/renderer_vulkan/vk_pipeline_common.h
@@ -6,10 +6,10 @@
 #include "shader_recompiler/backend/bindings.h"
 #include "shader_recompiler/info.h"
 #include "video_core/renderer_vulkan/vk_common.h"
+#include "video_core/texture_cache/texture_cache.h"
 
 namespace VideoCore {
 class BufferCache;
-class TextureCache;
 } // namespace VideoCore
 
 namespace Vulkan {
@@ -42,6 +42,12 @@ public:
 
     void BindTextures(VideoCore::TextureCache& texture_cache, const Shader::Info& stage,
                       Shader::Backend::Bindings& binding, DescriptorWrites& set_writes) const;
+    void ResetBindings(VideoCore::TextureCache& texture_cache) const {
+        for (auto& image_id : bound_images) {
+            texture_cache.GetImage(image_id).binding.Reset();
+        }
+        bound_images.clear();
+    }
 
 protected:
     const Instance& instance;
@@ -53,6 +59,7 @@ protected:
     static boost::container::static_vector<vk::DescriptorImageInfo, 32> image_infos;
     static boost::container::static_vector<vk::BufferView, 8> buffer_views;
     static boost::container::static_vector<vk::DescriptorBufferInfo, 32> buffer_infos;
+    static boost::container::static_vector<VideoCore::ImageId, 32> bound_images;
 };
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_presenter.h
+++ b/src/video_core/renderer_vulkan/vk_presenter.h
@@ -55,8 +55,8 @@ public:
 
     Frame* PrepareFrame(const Libraries::VideoOut::BufferAttributeGroup& attribute,
                         VAddr cpu_address, bool is_eop) {
-        const auto info = VideoCore::ImageInfo{attribute, cpu_address};
-        const auto image_id = texture_cache.FindImage(info);
+        auto desc = VideoCore::TextureCache::VideoOutDesc{attribute, cpu_address};
+        const auto image_id = texture_cache.FindImage(desc);
         texture_cache.UpdateImage(image_id, is_eop ? nullptr : &flip_scheduler);
         return PrepareFrameInternal(image_id, is_eop);
     }
@@ -68,9 +68,11 @@ public:
     VideoCore::Image& RegisterVideoOutSurface(
         const Libraries::VideoOut::BufferAttributeGroup& attribute, VAddr cpu_address) {
         vo_buffers_addr.emplace_back(cpu_address);
-        const auto info = VideoCore::ImageInfo{attribute, cpu_address};
-        const auto image_id = texture_cache.FindImage(info);
-        return texture_cache.GetImage(image_id);
+        auto desc = VideoCore::TextureCache::VideoOutDesc{attribute, cpu_address};
+        const auto image_id = texture_cache.FindImage(desc);
+        auto& image = texture_cache.GetImage(image_id);
+        image.usage.vo_surface = 1u;
+        return image;
     }
 
     bool IsVideoOutSurface(const AmdGpu::Liverpool::ColorBuffer& color_buffer) {

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -116,7 +116,7 @@ RenderState Rasterizer::PrepareRenderState(u32 mrt_mask) {
         auto& [image_id, desc] = cb_descs.emplace_back(std::piecewise_construct, std::tuple{},
                                                        std::tuple{col_buf, hint});
         const auto& image_view = texture_cache.FindRenderTarget(desc);
-        image_id = image_view.image_id;
+        image_id = bound_images.emplace_back(image_view.image_id);
         auto& image = texture_cache.GetImage(image_id);
         image.binding.is_target = 1u;
 
@@ -149,7 +149,7 @@ RenderState Rasterizer::PrepareRenderState(u32 mrt_mask) {
                             std::tuple{regs.depth_buffer, regs.depth_view, regs.depth_control,
                                        htile_address, hint});
         const auto& image_view = texture_cache.FindDepthTarget(desc);
-        image_id = image_view.image_id;
+        image_id = bound_images.emplace_back(image_view.image_id);
         auto& image = texture_cache.GetImage(image_id);
         image.binding.is_target = 1u;
 
@@ -181,7 +181,6 @@ void Rasterizer::Draw(bool is_indexed, u32 index_offset) {
         return;
     }
 
-    const auto cmdbuf = scheduler.CommandBuffer();
     const auto& regs = liverpool->regs;
     const GraphicsPipeline* pipeline = pipeline_cache.GetGraphicsPipeline();
     if (!pipeline) {
@@ -190,10 +189,8 @@ void Rasterizer::Draw(bool is_indexed, u32 index_offset) {
 
     auto state = PrepareRenderState(pipeline->GetMrtMask());
 
-    try {
-        pipeline->BindResources(regs, buffer_cache, texture_cache);
-    } catch (...) {
-        UNREACHABLE();
+    if (!BindResources(pipeline)) {
+        return;
     }
 
     const auto& vs_info = pipeline->GetStage(Shader::Stage::Vertex);
@@ -205,6 +202,9 @@ void Rasterizer::Draw(bool is_indexed, u32 index_offset) {
 
     const auto [vertex_offset, instance_offset] = vs_info.GetDrawOffsets();
 
+    const auto cmdbuf = scheduler.CommandBuffer();
+    cmdbuf.bindPipeline(vk::PipelineBindPoint::eGraphics, pipeline->Handle());
+
     if (is_indexed) {
         cmdbuf.drawIndexed(num_indices, regs.num_instances.NumInstances(), 0, s32(vertex_offset),
                            instance_offset);
@@ -215,7 +215,7 @@ void Rasterizer::Draw(bool is_indexed, u32 index_offset) {
                     instance_offset);
     }
 
-    pipeline->ResetBindings(texture_cache);
+    ResetBindings();
 }
 
 void Rasterizer::DrawIndirect(bool is_indexed, VAddr arg_address, u32 offset, u32 stride,
@@ -237,10 +237,8 @@ void Rasterizer::DrawIndirect(bool is_indexed, VAddr arg_address, u32 offset, u3
     ASSERT_MSG(regs.primitive_type != AmdGpu::PrimitiveType::RectList,
                "Unsupported primitive type for indirect draw");
 
-    try {
-        pipeline->BindResources(regs, buffer_cache, texture_cache);
-    } catch (...) {
-        UNREACHABLE();
+    if (!BindResources(pipeline)) {
+        return;
     }
 
     const auto& vs_info = pipeline->GetStage(Shader::Stage::Vertex);
@@ -263,6 +261,8 @@ void Rasterizer::DrawIndirect(bool is_indexed, VAddr arg_address, u32 offset, u3
     // instance offsets will be automatically applied by Vulkan from indirect args buffer.
 
     const auto cmdbuf = scheduler.CommandBuffer();
+    cmdbuf.bindPipeline(vk::PipelineBindPoint::eGraphics, pipeline->Handle());
+
     if (is_indexed) {
         ASSERT(sizeof(VkDrawIndexedIndirectCommand) == stride);
 
@@ -283,7 +283,7 @@ void Rasterizer::DrawIndirect(bool is_indexed, VAddr arg_address, u32 offset, u3
         }
     }
 
-    pipeline->ResetBindings(texture_cache);
+    ResetBindings();
 }
 
 void Rasterizer::DispatchDirect() {
@@ -296,20 +296,15 @@ void Rasterizer::DispatchDirect() {
         return;
     }
 
-    try {
-        const auto has_resources = pipeline->BindResources(buffer_cache, texture_cache);
-        if (!has_resources) {
-            return;
-        }
-    } catch (...) {
-        UNREACHABLE();
+    if (!BindResources(pipeline)) {
+        return;
     }
 
     scheduler.EndRendering();
     cmdbuf.bindPipeline(vk::PipelineBindPoint::eCompute, pipeline->Handle());
     cmdbuf.dispatch(cs_program.dim_x, cs_program.dim_y, cs_program.dim_z);
 
-    pipeline->ResetBindings(texture_cache);
+    ResetBindings();
 }
 
 void Rasterizer::DispatchIndirect(VAddr address, u32 offset, u32 size) {
@@ -322,13 +317,8 @@ void Rasterizer::DispatchIndirect(VAddr address, u32 offset, u32 size) {
         return;
     }
 
-    try {
-        const auto has_resources = pipeline->BindResources(buffer_cache, texture_cache);
-        if (!has_resources) {
-            return;
-        }
-    } catch (...) {
-        UNREACHABLE();
+    if (!BindResources(pipeline)) {
+        return;
     }
 
     scheduler.EndRendering();
@@ -336,7 +326,7 @@ void Rasterizer::DispatchIndirect(VAddr address, u32 offset, u32 size) {
     const auto [buffer, base] = buffer_cache.ObtainBuffer(address + offset, size, false);
     cmdbuf.dispatchIndirect(buffer->Handle(), base);
 
-    pipeline->ResetBindings(texture_cache);
+    ResetBindings();
 }
 
 u64 Rasterizer::Flush() {
@@ -350,13 +340,328 @@ void Rasterizer::Finish() {
     scheduler.Finish();
 }
 
+bool Rasterizer::BindResources(const Pipeline* pipeline) {
+    buffer_infos.clear();
+    buffer_views.clear();
+    image_infos.clear();
+
+    const auto& regs = liverpool->regs;
+
+    if (pipeline->IsCompute()) {
+        const auto& info = pipeline->GetStage(Shader::Stage::Compute);
+
+        // Most of the time when a metadata is updated with a shader it gets cleared. It means
+        // we can skip the whole dispatch and update the tracked state instead. Also, it is not
+        // intended to be consumed and in such rare cases (e.g. HTile introspection, CRAA) we
+        // will need its full emulation anyways. For cases of metadata read a warning will be
+        // logged.
+        const auto IsMetaUpdate = [&](const auto& desc) {
+            const VAddr address = desc.GetSharp(info).base_address;
+            if (desc.is_written) {
+                if (texture_cache.TouchMeta(address, true)) {
+                    LOG_TRACE(Render_Vulkan, "Metadata update skipped");
+                    return true;
+                }
+            } else {
+                if (texture_cache.IsMeta(address)) {
+                    LOG_WARNING(Render_Vulkan, "Unexpected metadata read by a CS shader (buffer)");
+                }
+            }
+            return false;
+        };
+
+        for (const auto& desc : info.buffers) {
+            if (desc.is_gds_buffer) {
+                continue;
+            }
+            if (IsMetaUpdate(desc)) {
+                return false;
+            }
+        }
+        for (const auto& desc : info.texture_buffers) {
+            if (IsMetaUpdate(desc)) {
+                return false;
+            }
+        }
+    }
+
+    set_writes.clear();
+    buffer_barriers.clear();
+
+    // Bind resource buffers and textures.
+    Shader::PushData push_data{};
+    Shader::Backend::Bindings binding{};
+
+    for (const auto* stage : pipeline->GetStages()) {
+        if (!stage) {
+            continue;
+        }
+        if (stage->uses_step_rates) {
+            push_data.step0 = regs.vgt_instance_step_rate_0;
+            push_data.step1 = regs.vgt_instance_step_rate_1;
+        }
+        stage->PushUd(binding, push_data);
+
+        BindBuffers(*stage, binding, push_data, set_writes, buffer_barriers);
+        BindTextures(*stage, binding, set_writes);
+    }
+
+    pipeline->BindResources(set_writes, buffer_barriers, push_data);
+
+    return true;
+}
+
+void Rasterizer::BindBuffers(const Shader::Info& stage, Shader::Backend::Bindings& binding,
+                             Shader::PushData& push_data, Pipeline::DescriptorWrites& set_writes,
+                             Pipeline::BufferBarriers& buffer_barriers) {
+    buffer_bindings.clear();
+
+    for (const auto& desc : stage.buffers) {
+        const auto vsharp = desc.GetSharp(stage);
+        if (!desc.is_gds_buffer && vsharp.base_address != 0 && vsharp.GetSize() > 0) {
+            const auto buffer_id = buffer_cache.FindBuffer(vsharp.base_address, vsharp.GetSize());
+            buffer_bindings.emplace_back(buffer_id, vsharp);
+        } else {
+            buffer_bindings.emplace_back(VideoCore::BufferId{}, vsharp);
+        }
+    }
+
+    texbuffer_bindings.clear();
+
+    for (const auto& desc : stage.texture_buffers) {
+        const auto vsharp = desc.GetSharp(stage);
+        if (vsharp.base_address != 0 && vsharp.GetSize() > 0 &&
+            vsharp.GetDataFmt() != AmdGpu::DataFormat::FormatInvalid) {
+            const auto buffer_id = buffer_cache.FindBuffer(vsharp.base_address, vsharp.GetSize());
+            texbuffer_bindings.emplace_back(buffer_id, vsharp);
+        } else {
+            texbuffer_bindings.emplace_back(VideoCore::BufferId{}, vsharp);
+        }
+    }
+
+    // Bind the flattened user data buffer as a UBO so it's accessible to the shader
+    if (stage.has_readconst) {
+        const auto [vk_buffer, offset] = buffer_cache.ObtainHostUBO(stage.flattened_ud_buf);
+        buffer_infos.emplace_back(vk_buffer->Handle(), offset,
+                                  stage.flattened_ud_buf.size() * sizeof(u32));
+        set_writes.push_back({
+            .dstSet = VK_NULL_HANDLE,
+            .dstBinding = binding.unified++,
+            .dstArrayElement = 0,
+            .descriptorCount = 1,
+            .descriptorType = vk::DescriptorType::eUniformBuffer,
+            .pBufferInfo = &buffer_infos.back(),
+        });
+        ++binding.buffer;
+    }
+
+    // Second pass to re-bind buffers that were updated after binding
+    for (u32 i = 0; i < buffer_bindings.size(); i++) {
+        const auto& [buffer_id, vsharp] = buffer_bindings[i];
+        const auto& desc = stage.buffers[i];
+        const bool is_storage = desc.IsStorage(vsharp);
+        if (!buffer_id) {
+            if (desc.is_gds_buffer) {
+                const auto* gds_buf = buffer_cache.GetGdsBuffer();
+                buffer_infos.emplace_back(gds_buf->Handle(), 0, gds_buf->SizeBytes());
+            } else if (instance.IsNullDescriptorSupported()) {
+                buffer_infos.emplace_back(VK_NULL_HANDLE, 0, VK_WHOLE_SIZE);
+            } else {
+                auto& null_buffer = buffer_cache.GetBuffer(VideoCore::NULL_BUFFER_ID);
+                buffer_infos.emplace_back(null_buffer.Handle(), 0, VK_WHOLE_SIZE);
+            }
+        } else {
+            const auto [vk_buffer, offset] = buffer_cache.ObtainBuffer(
+                vsharp.base_address, vsharp.GetSize(), desc.is_written, false, buffer_id);
+            const u32 alignment =
+                is_storage ? instance.StorageMinAlignment() : instance.UniformMinAlignment();
+            const u32 offset_aligned = Common::AlignDown(offset, alignment);
+            const u32 adjust = offset - offset_aligned;
+            ASSERT(adjust % 4 == 0);
+            push_data.AddOffset(binding.buffer, adjust);
+            buffer_infos.emplace_back(vk_buffer->Handle(), offset_aligned,
+                                      vsharp.GetSize() + adjust);
+        }
+
+        set_writes.push_back({
+            .dstSet = VK_NULL_HANDLE,
+            .dstBinding = binding.unified++,
+            .dstArrayElement = 0,
+            .descriptorCount = 1,
+            .descriptorType = is_storage ? vk::DescriptorType::eStorageBuffer
+                                         : vk::DescriptorType::eUniformBuffer,
+            .pBufferInfo = &buffer_infos.back(),
+        });
+        ++binding.buffer;
+    }
+
+    const auto null_buffer_view =
+        instance.IsNullDescriptorSupported() ? VK_NULL_HANDLE : buffer_cache.NullBufferView();
+    for (u32 i = 0; i < texbuffer_bindings.size(); i++) {
+        const auto& [buffer_id, vsharp] = texbuffer_bindings[i];
+        const auto& desc = stage.texture_buffers[i];
+        vk::BufferView& buffer_view = buffer_views.emplace_back(null_buffer_view);
+        if (buffer_id) {
+            const u32 alignment = instance.TexelBufferMinAlignment();
+            const auto [vk_buffer, offset] = buffer_cache.ObtainBuffer(
+                vsharp.base_address, vsharp.GetSize(), desc.is_written, true, buffer_id);
+            const u32 fmt_stride = AmdGpu::NumBits(vsharp.GetDataFmt()) >> 3;
+            ASSERT_MSG(fmt_stride == vsharp.GetStride(),
+                       "Texel buffer stride must match format stride");
+            const u32 offset_aligned = Common::AlignDown(offset, alignment);
+            const u32 adjust = offset - offset_aligned;
+            ASSERT(adjust % fmt_stride == 0);
+            push_data.AddOffset(binding.buffer, adjust / fmt_stride);
+            buffer_view =
+                vk_buffer->View(offset_aligned, vsharp.GetSize() + adjust, desc.is_written,
+                                vsharp.GetDataFmt(), vsharp.GetNumberFmt());
+            if (auto barrier =
+                    vk_buffer->GetBarrier(desc.is_written ? vk::AccessFlagBits2::eShaderWrite
+                                                          : vk::AccessFlagBits2::eShaderRead,
+                                          vk::PipelineStageFlagBits2::eComputeShader)) {
+                buffer_barriers.emplace_back(*barrier);
+            }
+            if (desc.is_written) {
+                texture_cache.InvalidateMemoryFromGPU(vsharp.base_address, vsharp.GetSize());
+            }
+        }
+
+        set_writes.push_back({
+            .dstSet = VK_NULL_HANDLE,
+            .dstBinding = binding.unified++,
+            .dstArrayElement = 0,
+            .descriptorCount = 1,
+            .descriptorType = desc.is_written ? vk::DescriptorType::eStorageTexelBuffer
+                                              : vk::DescriptorType::eUniformTexelBuffer,
+            .pTexelBufferView = &buffer_view,
+        });
+        ++binding.buffer;
+    }
+}
+
+void Rasterizer::BindTextures(const Shader::Info& stage, Shader::Backend::Bindings& binding,
+                              Pipeline::DescriptorWrites& set_writes) {
+    image_bindings.clear();
+
+    for (const auto& image_desc : stage.images) {
+        const auto tsharp = image_desc.GetSharp(stage);
+        if (texture_cache.IsMeta(tsharp.Address())) {
+            LOG_WARNING(Render_Vulkan, "Unexpected metadata read by a shader (texture)");
+        }
+
+        if (tsharp.GetDataFmt() == AmdGpu::DataFormat::FormatInvalid) {
+            image_bindings.emplace_back(std::piecewise_construct, std::tuple{}, std::tuple{});
+            continue;
+        }
+
+        auto& [image_id, desc] = image_bindings.emplace_back(std::piecewise_construct, std::tuple{},
+                                                             std::tuple{tsharp, image_desc});
+        image_id = texture_cache.FindImage(desc);
+        auto& image = texture_cache.GetImage(image_id);
+        ASSERT(False(image.flags & VideoCore::ImageFlagBits::Virtual));
+        if (image.binding.is_bound) {
+            // The image is already bound. In case if it is about to be used as storage we need
+            // to force general layout on it.
+            image.binding.force_general |= image_desc.is_storage;
+        }
+        if (image.binding.is_target) {
+            // The image is already bound as target. Since we read and output to it need to force
+            // general layout too.
+            image.binding.force_general = 1u;
+        }
+        image.binding.is_bound = 1u;
+    }
+
+    // Second pass to re-bind images that were updated after binding
+    for (auto& [image_id, desc] : image_bindings) {
+        bool is_storage = desc.type == VideoCore::TextureCache::BindingType::Storage;
+        if (!image_id) {
+            if (instance.IsNullDescriptorSupported()) {
+                image_infos.emplace_back(VK_NULL_HANDLE, VK_NULL_HANDLE, vk::ImageLayout::eGeneral);
+            } else {
+                auto& null_image = texture_cache.GetImageView(VideoCore::NULL_IMAGE_VIEW_ID);
+                image_infos.emplace_back(VK_NULL_HANDLE, *null_image.image_view,
+                                         vk::ImageLayout::eGeneral);
+            }
+        } else {
+            if (auto& old_image = texture_cache.GetImage(image_id);
+                old_image.binding.needs_rebind) {
+                old_image.binding.Reset(); // clean up previous image binding state
+                image_id = texture_cache.FindImage(desc);
+            }
+
+            bound_images.emplace_back(image_id);
+
+            auto& image = texture_cache.GetImage(image_id);
+            auto& image_view = texture_cache.FindTexture(image_id, desc.view_info);
+
+            if (image.binding.force_general || image.binding.is_target) {
+                image.Transit(vk::ImageLayout::eGeneral,
+                              vk::AccessFlagBits2::eShaderRead |
+                                  (image.info.IsDepthStencil()
+                                       ? vk::AccessFlagBits2::eDepthStencilAttachmentWrite
+                                       : vk::AccessFlagBits2::eColorAttachmentWrite),
+                              {});
+            } else {
+                if (is_storage) {
+                    image.Transit(vk::ImageLayout::eGeneral,
+                                  vk::AccessFlagBits2::eShaderRead |
+                                      vk::AccessFlagBits2::eShaderWrite,
+                                  desc.view_info.range);
+                } else {
+                    const auto new_layout = image.info.IsDepthStencil()
+                                                ? vk::ImageLayout::eDepthStencilReadOnlyOptimal
+                                                : vk::ImageLayout::eShaderReadOnlyOptimal;
+                    image.Transit(new_layout, vk::AccessFlagBits2::eShaderRead,
+                                  desc.view_info.range);
+                }
+            }
+            image.usage.storage |= is_storage;
+            image.usage.texture |= !is_storage;
+
+            image_infos.emplace_back(VK_NULL_HANDLE, *image_view.image_view,
+                                     image.last_state.layout);
+        }
+
+        set_writes.push_back({
+            .dstSet = VK_NULL_HANDLE,
+            .dstBinding = binding.unified++,
+            .dstArrayElement = 0,
+            .descriptorCount = 1,
+            .descriptorType =
+                is_storage ? vk::DescriptorType::eStorageImage : vk::DescriptorType::eSampledImage,
+            .pImageInfo = &image_infos.back(),
+        });
+    }
+
+    for (const auto& sampler : stage.samplers) {
+        auto ssharp = sampler.GetSharp(stage);
+        if (sampler.disable_aniso) {
+            const auto& tsharp = stage.images[sampler.associated_image].GetSharp(stage);
+            if (tsharp.base_level == 0 && tsharp.last_level == 0) {
+                ssharp.max_aniso.Assign(AmdGpu::AnisoRatio::One);
+            }
+        }
+        const auto vk_sampler = texture_cache.GetSampler(ssharp);
+        image_infos.emplace_back(vk_sampler, VK_NULL_HANDLE, vk::ImageLayout::eGeneral);
+        set_writes.push_back({
+            .dstSet = VK_NULL_HANDLE,
+            .dstBinding = binding.unified++,
+            .dstArrayElement = 0,
+            .descriptorCount = 1,
+            .descriptorType = vk::DescriptorType::eSampler,
+            .pImageInfo = &image_infos.back(),
+        });
+    }
+}
+
 void Rasterizer::BeginRendering(const GraphicsPipeline& pipeline, RenderState& state) {
     int cb_index = 0;
     for (auto& [image_id, desc] : cb_descs) {
         if (auto& old_img = texture_cache.GetImage(image_id); old_img.binding.needs_rebind) {
             auto& view = texture_cache.FindRenderTarget(desc);
             ASSERT(view.image_id != image_id);
-            image_id = view.image_id;
+            image_id = bound_images.emplace_back(view.image_id);
             auto& image = texture_cache.GetImage(view.image_id);
             state.color_attachments[cb_index].imageView = *view.image_view;
             state.color_attachments[cb_index].imageLayout = image.last_state.layout;
@@ -367,7 +672,6 @@ void Rasterizer::BeginRendering(const GraphicsPipeline& pipeline, RenderState& s
             state.height = std::min<u32>(state.height, std::max(image.info.size.height >> mip, 1u));
             ASSERT(old_img.info.size.width == state.width);
             ASSERT(old_img.info.size.height == state.height);
-            old_img.binding.Reset();
         }
         auto& image = texture_cache.GetImage(image_id);
         if (image.binding.force_general) {
@@ -383,7 +687,6 @@ void Rasterizer::BeginRendering(const GraphicsPipeline& pipeline, RenderState& s
         }
         image.usage.render_target = 1u;
         state.color_attachments[cb_index].imageLayout = image.last_state.layout;
-        image.binding.Reset();
         ++cb_index;
     }
 
@@ -416,7 +719,6 @@ void Rasterizer::BeginRendering(const GraphicsPipeline& pipeline, RenderState& s
         state.depth_attachment.imageLayout = image.last_state.layout;
         image.usage.depth_target = true;
         image.usage.stencil = has_stencil;
-        image.binding.Reset();
     }
 
     scheduler.BeginRendering(state);

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -558,7 +558,6 @@ void Rasterizer::BindTextures(const Shader::Info& stage, Shader::Backend::Bindin
                                                              std::tuple{tsharp, image_desc});
         image_id = texture_cache.FindImage(desc);
         auto& image = texture_cache.GetImage(image_id);
-        ASSERT(False(image.flags & VideoCore::ImageFlagBits::Virtual));
         if (image.binding.is_bound) {
             // The image is already bound. In case if it is about to be used as storage we need
             // to force general layout on it.

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -65,6 +65,21 @@ private:
 
     bool FilterDraw();
 
+    void BindBuffers(const Shader::Info& stage, Shader::Backend::Bindings& binding,
+                     Shader::PushData& push_data, Pipeline::DescriptorWrites& set_writes,
+                     Pipeline::BufferBarriers& buffer_barriers);
+
+    void BindTextures(const Shader::Info& stage, Shader::Backend::Bindings& binding,
+                      Pipeline::DescriptorWrites& set_writes);
+
+    bool BindResources(const Pipeline* pipeline);
+    void ResetBindings() {
+        for (auto& image_id : bound_images) {
+            texture_cache.GetImage(image_id).binding.Reset();
+        }
+        bound_images.clear();
+    }
+
 private:
     const Instance& instance;
     Scheduler& scheduler;
@@ -79,6 +94,20 @@ private:
         std::pair<VideoCore::ImageId, VideoCore::TextureCache::RenderTargetDesc>, 8>
         cb_descs;
     std::optional<std::pair<VideoCore::ImageId, VideoCore::TextureCache::DepthTargetDesc>> db_desc;
+    boost::container::static_vector<vk::DescriptorImageInfo, 32> image_infos;
+    boost::container::static_vector<vk::BufferView, 8> buffer_views;
+    boost::container::static_vector<vk::DescriptorBufferInfo, 32> buffer_infos;
+    boost::container::static_vector<VideoCore::ImageId, 64> bound_images;
+
+    Pipeline::DescriptorWrites set_writes;
+    Pipeline::BufferBarriers buffer_barriers;
+
+    using BufferBindingInfo = std::pair<VideoCore::BufferId, AmdGpu::Buffer>;
+    boost::container::static_vector<BufferBindingInfo, 32> buffer_bindings;
+    using TexBufferBindingInfo = std::pair<VideoCore::BufferId, AmdGpu::Buffer>;
+    boost::container::static_vector<TexBufferBindingInfo, 32> texbuffer_bindings;
+    using ImageBindingInfo = std::pair<VideoCore::ImageId, VideoCore::TextureCache::TextureDesc>;
+    boost::container::static_vector<ImageBindingInfo, 32> image_bindings;
 };
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -19,6 +19,7 @@ class MemoryManager;
 namespace Vulkan {
 
 class Scheduler;
+class RenderState;
 class GraphicsPipeline;
 
 class Rasterizer {
@@ -54,7 +55,8 @@ public:
     void Finish();
 
 private:
-    void BeginRendering(const GraphicsPipeline& pipeline);
+    RenderState PrepareRenderState(u32 mrt_mask);
+    void BeginRendering(const GraphicsPipeline& pipeline, RenderState& state);
     void Resolve();
 
     void UpdateDynamicState(const GraphicsPipeline& pipeline);
@@ -72,6 +74,11 @@ private:
     AmdGpu::Liverpool* liverpool;
     Core::MemoryManager* memory;
     PipelineCache pipeline_cache;
+
+    boost::container::static_vector<
+        std::pair<VideoCore::ImageId, VideoCore::TextureCache::RenderTargetDesc>, 8>
+        cb_descs;
+    std::optional<std::pair<VideoCore::ImageId, VideoCore::TextureCache::DepthTargetDesc>> db_desc;
 };
 
 } // namespace Vulkan

--- a/src/video_core/texture_cache/image.cpp
+++ b/src/video_core/texture_cache/image.cpp
@@ -61,6 +61,15 @@ bool ImageInfo::IsDepthStencil() const {
     }
 }
 
+bool ImageInfo::HasStencil() const {
+    if (pixel_format == vk::Format::eD32SfloatS8Uint ||
+        pixel_format == vk::Format::eD24UnormS8Uint ||
+        pixel_format == vk::Format::eD16UnormS8Uint) {
+        return true;
+    }
+    return false;
+}
+
 static vk::ImageUsageFlags ImageUsageFlags(const ImageInfo& info) {
     vk::ImageUsageFlags usage = vk::ImageUsageFlagBits::eTransferSrc |
                                 vk::ImageUsageFlagBits::eTransferDst |
@@ -137,20 +146,28 @@ Image::Image(const Vulkan::Instance& instance_, Vulkan::Scheduler& scheduler_,
     : instance{&instance_}, scheduler{&scheduler_}, info{info_},
       image{instance->GetDevice(), instance->GetAllocator()}, cpu_addr{info.guest_address},
       cpu_addr_end{cpu_addr + info.guest_size_bytes} {
+    if (info.props.is_virtual) {
+        flags |= ImageFlagBits::Virtual;
+        return;
+    }
+
     mip_hashes.resize(info.resources.levels);
     ASSERT(info.pixel_format != vk::Format::eUndefined);
     // Here we force `eExtendedUsage` as don't know all image usage cases beforehand. In normal case
     // the texture cache should re-create the resource with the usage requested
     vk::ImageCreateFlags flags{vk::ImageCreateFlagBits::eMutableFormat |
                                vk::ImageCreateFlagBits::eExtendedUsage};
-    if (info.props.is_cube || (info.type == vk::ImageType::e2D && info.resources.layers >= 6)) {
+    const bool can_be_cube = (info.type == vk::ImageType::e2D) &&
+                             (info.resources.layers % 6 == 0) &&
+                             (info.size.width == info.size.height);
+    if (info.props.is_cube || can_be_cube) {
         flags |= vk::ImageCreateFlagBits::eCubeCompatible;
     } else if (info.props.is_volume) {
         flags |= vk::ImageCreateFlagBits::e2DArrayCompatible;
     }
 
-    usage = ImageUsageFlags(info);
-    format_features = FormatFeatureFlags(usage);
+    usage_flags = ImageUsageFlags(info);
+    format_features = FormatFeatureFlags(usage_flags);
 
     switch (info.pixel_format) {
     case vk::Format::eD16Unorm:
@@ -170,7 +187,7 @@ Image::Image(const Vulkan::Instance& instance_, Vulkan::Scheduler& scheduler_,
     constexpr auto tiling = vk::ImageTiling::eOptimal;
     const auto supported_format = instance->GetSupportedFormat(info.pixel_format, format_features);
     const auto properties = instance->GetPhysicalDevice().getImageFormatProperties(
-        supported_format, info.type, tiling, usage, flags);
+        supported_format, info.type, tiling, usage_flags, flags);
     const auto supported_samples = properties.result == vk::Result::eSuccess
                                        ? properties.value.sampleCounts
                                        : vk::SampleCountFlagBits::e1;
@@ -188,7 +205,7 @@ Image::Image(const Vulkan::Instance& instance_, Vulkan::Scheduler& scheduler_,
         .arrayLayers = static_cast<u32>(info.resources.layers),
         .samples = LiverpoolToVK::NumSamples(info.num_samples, supported_samples),
         .tiling = tiling,
-        .usage = usage,
+        .usage = usage_flags,
         .initialLayout = vk::ImageLayout::eUndefined,
     };
 

--- a/src/video_core/texture_cache/image.cpp
+++ b/src/video_core/texture_cache/image.cpp
@@ -146,11 +146,6 @@ Image::Image(const Vulkan::Instance& instance_, Vulkan::Scheduler& scheduler_,
     : instance{&instance_}, scheduler{&scheduler_}, info{info_},
       image{instance->GetDevice(), instance->GetAllocator()}, cpu_addr{info.guest_address},
       cpu_addr_end{cpu_addr + info.guest_size_bytes} {
-    if (info.props.is_virtual) {
-        flags |= ImageFlagBits::Virtual;
-        return;
-    }
-
     mip_hashes.resize(info.resources.levels);
     ASSERT(info.pixel_format != vk::Format::eUndefined);
     // Here we force `eExtendedUsage` as don't know all image usage cases beforehand. In normal case

--- a/src/video_core/texture_cache/image.h
+++ b/src/video_core/texture_cache/image.h
@@ -22,7 +22,6 @@ VK_DEFINE_HANDLE(VmaAllocator)
 namespace VideoCore {
 
 enum ImageFlagBits : u32 {
-    Virtual = 1 << 0,  ///< Image doesn't have Vk object representation and used only for tracking
     CpuDirty = 1 << 1, ///< Contents have been modified from the CPU
     GpuDirty = 1 << 2, ///< Contents have been modified from the GPU (valid data in buffer cache)
     Dirty = CpuDirty | GpuDirty,

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -245,7 +245,6 @@ ImageInfo::ImageInfo(const Libraries::VideoOut::BufferAttributeGroup& group,
     size.width = attrib.width;
     size.height = attrib.height;
     pitch = attrib.tiling_mode == TilingMode::Linear ? size.width : (size.width + 127) & (~127);
-    usage.vo_buffer = true;
     num_bits = attrib.pixel_format != VideoOutFormat::A16R16G16B16Float ? 32 : 64;
     ASSERT(num_bits == 32);
 
@@ -277,7 +276,6 @@ ImageInfo::ImageInfo(const AmdGpu::Liverpool::ColorBuffer& buffer,
     resources.layers = buffer.NumSlices();
     meta_info.cmask_addr = buffer.info.fast_clear ? buffer.CmaskAddress() : 0;
     meta_info.fmask_addr = buffer.info.compression ? buffer.FmaskAddress() : 0;
-    usage.render_target = true;
 
     guest_address = buffer.Address();
     const auto color_slice_sz = buffer.GetColorSliceSize();
@@ -299,9 +297,6 @@ ImageInfo::ImageInfo(const AmdGpu::Liverpool::DepthBuffer& buffer, u32 num_slice
     pitch = buffer.Pitch();
     resources.layers = num_slices;
     meta_info.htile_addr = buffer.z_info.tile_surface_en ? htile_address : 0;
-    usage.depth_target = true;
-    usage.stencil =
-        buffer.stencil_info.format != AmdGpu::Liverpool::DepthBuffer::StencilFormat::Invalid;
 
     guest_address = buffer.Address();
     const auto depth_slice_sz = buffer.GetDepthSliceSize();
@@ -330,7 +325,6 @@ ImageInfo::ImageInfo(const AmdGpu::Image& image, const Shader::ImageResource& de
     resources.layers = image.NumLayers(desc.is_array);
     num_samples = image.NumSamples();
     num_bits = NumBits(image.GetDataFmt());
-    usage.texture = true;
 
     guest_address = image.Address();
 
@@ -392,7 +386,6 @@ void ImageInfo::UpdateSize() {
         }
         }
         mip_info.size *= mip_d;
-
         mip_info.offset = guest_size_bytes;
         mips_layout.emplace_back(mip_info);
         guest_size_bytes += mip_info.size;
@@ -400,79 +393,87 @@ void ImageInfo::UpdateSize() {
     guest_size_bytes *= resources.layers;
 }
 
-bool ImageInfo::IsMipOf(const ImageInfo& info) const {
+int ImageInfo::IsMipOf(const ImageInfo& info) const {
     if (!IsCompatible(info)) {
-        return false;
+        return -1;
+    }
+
+    if (IsTilingCompatible(info.tiling_idx, tiling_idx)) {
+        return -1;
     }
 
     // Currently we expect only on level to be copied.
     if (resources.levels != 1) {
-        return false;
+        return -1;
     }
 
-    const int mip = info.resources.levels - resources.levels;
-    if (mip < 1) {
-        return false;
+    if (info.mips_layout.empty()) {
+        UNREACHABLE();
     }
+
+    // Find mip
+    auto mip = -1;
+    for (auto m = 0; m < info.mips_layout.size(); ++m) {
+        if (guest_address == (info.guest_address + info.mips_layout[m].offset)) {
+            mip = m;
+            break;
+        }
+    }
+
+    if (mip < 0) {
+        return -1;
+    }
+    ASSERT(mip != 0);
 
     const auto mip_w = std::max(info.size.width >> mip, 1u);
     const auto mip_h = std::max(info.size.height >> mip, 1u);
     if ((size.width != mip_w) || (size.height != mip_h)) {
-        return false;
+        return -1;
     }
 
     const auto mip_d = std::max(info.size.depth >> mip, 1u);
     if (info.type == vk::ImageType::e3D && type == vk::ImageType::e2D) {
         // In case of 2D array to 3D copy, make sure we have proper number of layers.
         if (resources.layers != mip_d) {
-            return false;
+            return -1;
         }
     } else {
         if (type != info.type) {
-            return false;
+            return -1;
         }
     }
 
-    // Check if the mip has correct size.
-    if (info.mips_layout.size() <= mip || info.mips_layout[mip].size != guest_size_bytes) {
-        return false;
-    }
-
-    // Ensure that address matches too.
-    if ((info.guest_address + info.mips_layout[mip].offset) != guest_address) {
-        return false;
-    }
-
-    return true;
+    return mip;
 }
 
-bool ImageInfo::IsSliceOf(const ImageInfo& info) const {
+int ImageInfo::IsSliceOf(const ImageInfo& info) const {
     if (!IsCompatible(info)) {
-        return false;
+        return -1;
     }
 
     // Array slices should be of the same type.
     if (type != info.type) {
-        return false;
+        return -1;
     }
 
     // 2D dimensions of both images should be the same.
     if ((size.width != info.size.width) || (size.height != info.size.height)) {
-        return false;
+        return -1;
     }
 
     // Check for size alignment.
     const bool slice_size = info.guest_size_bytes / info.resources.layers;
     if (guest_size_bytes % slice_size != 0) {
-        return false;
+        return -1;
     }
 
     // Ensure that address is aligned too.
-    if (((info.guest_address - guest_address) % guest_size_bytes) != 0) {
-        return false;
+    const auto addr_diff = guest_address - info.guest_address;
+    if ((addr_diff % guest_size_bytes) != 0) {
+        return -1;
     }
 
-    return true;
+    return addr_diff / guest_size_bytes;
 }
 
 } // namespace VideoCore

--- a/src/video_core/texture_cache/image_info.h
+++ b/src/video_core/texture_cache/image_info.h
@@ -28,14 +28,28 @@ struct ImageInfo {
     bool IsBlockCoded() const;
     bool IsPacked() const;
     bool IsDepthStencil() const;
+    bool HasStencil() const;
 
-    bool IsMipOf(const ImageInfo& info) const;
-    bool IsSliceOf(const ImageInfo& info) const;
+    int IsMipOf(const ImageInfo& info) const;
+    int IsSliceOf(const ImageInfo& info) const;
 
     /// Verifies if images are compatible for subresource merging.
     bool IsCompatible(const ImageInfo& info) const {
-        return (pixel_format == info.pixel_format && tiling_idx == info.tiling_idx &&
-                num_samples == info.num_samples && num_bits == info.num_bits);
+        return (pixel_format == info.pixel_format && num_samples == info.num_samples &&
+                num_bits == info.num_bits);
+    }
+
+    bool IsTilingCompatible(u32 lhs, u32 rhs) const {
+        if (lhs == rhs) {
+            return true;
+        }
+        if (lhs == 0x0e && rhs == 0x0d) {
+            return true;
+        }
+        if (lhs == 0x0d && rhs == 0x0e) {
+            return true;
+        }
+        return false;
     }
 
     void UpdateSize();
@@ -47,20 +61,12 @@ struct ImageInfo {
     } meta_info{};
 
     struct {
-        u32 texture : 1;
-        u32 storage : 1;
-        u32 render_target : 1;
-        u32 depth_target : 1;
-        u32 stencil : 1;
-        u32 vo_buffer : 1;
-    } usage{}; // Usage data tracked during image lifetime
-
-    struct {
         u32 is_cube : 1;
         u32 is_volume : 1;
         u32 is_tiled : 1;
         u32 is_pow2 : 1;
         u32 is_block : 1;
+        u32 is_virtual : 1;
     } props{}; // Surface properties with impact on various calculation factors
 
     vk::Format pixel_format = vk::Format::eUndefined;
@@ -81,6 +87,9 @@ struct ImageInfo {
     VAddr guest_address{0};
     u32 guest_size_bytes{0};
     u32 tiling_idx{0}; // TODO: merge with existing!
+
+    VAddr stencil_addr{0};
+    u32 stencil_size{0};
 };
 
 } // namespace VideoCore

--- a/src/video_core/texture_cache/image_info.h
+++ b/src/video_core/texture_cache/image_info.h
@@ -66,7 +66,6 @@ struct ImageInfo {
         u32 is_tiled : 1;
         u32 is_pow2 : 1;
         u32 is_block : 1;
-        u32 is_virtual : 1;
     } props{}; // Surface properties with impact on various calculation factors
 
     vk::Format pixel_format = vk::Format::eUndefined;

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -149,7 +149,7 @@ ImageViewInfo::ImageViewInfo(const AmdGpu::Liverpool::DepthBuffer& depth_buffer,
 ImageView::ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info_, Image& image,
                      ImageId image_id_)
     : image_id{image_id_}, info{info_} {
-    vk::ImageViewUsageCreateInfo usage_ci{.usage = image.usage};
+    vk::ImageViewUsageCreateInfo usage_ci{.usage = image.usage_flags};
     if (!info.is_storage) {
         usage_ci.usage &= ~vk::ImageUsageFlagBits::eStorage;
     }

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -71,8 +71,7 @@ public:
     struct RenderTargetDesc : public BaseDesc {
         RenderTargetDesc(const AmdGpu::Liverpool::ColorBuffer& buffer,
                          const AmdGpu::Liverpool::CbDbExtent& hint = {})
-            : BaseDesc{BindingType::RenderTarget, ImageInfo{buffer, hint},
-                       ImageViewInfo{buffer, false}} {}
+            : BaseDesc{BindingType::RenderTarget, ImageInfo{buffer, hint}, ImageViewInfo{buffer}} {}
     };
 
     struct DepthTargetDesc : public BaseDesc {

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -43,8 +43,56 @@ class TextureCache {
     using PageTable = MultiLevelPageTable<Traits>;
 
 public:
-    explicit TextureCache(const Vulkan::Instance& instance, Vulkan::Scheduler& scheduler,
-                          BufferCache& buffer_cache, PageManager& tracker);
+    enum class BindingType : u32 {
+        Texture,
+        Storage,
+        RenderTarget,
+        DepthTarget,
+        VideoOut,
+    };
+
+    struct BaseDesc {
+        ImageInfo info;
+        ImageViewInfo view_info;
+        BindingType type{BindingType::Texture};
+
+        BaseDesc() = default;
+        BaseDesc(BindingType type_, ImageInfo info_, ImageViewInfo view_info_) noexcept
+            : info{std::move(info_)}, view_info{std::move(view_info_)}, type{type_} {}
+    };
+
+    struct TextureDesc : public BaseDesc {
+        TextureDesc() = default;
+        TextureDesc(const AmdGpu::Image& image, const Shader::ImageResource& desc)
+            : BaseDesc{desc.is_storage ? BindingType::Storage : BindingType::Texture,
+                       ImageInfo{image, desc}, ImageViewInfo{image, desc}} {}
+    };
+
+    struct RenderTargetDesc : public BaseDesc {
+        RenderTargetDesc(const AmdGpu::Liverpool::ColorBuffer& buffer,
+                         const AmdGpu::Liverpool::CbDbExtent& hint = {})
+            : BaseDesc{BindingType::RenderTarget, ImageInfo{buffer, hint},
+                       ImageViewInfo{buffer, false}} {}
+    };
+
+    struct DepthTargetDesc : public BaseDesc {
+        DepthTargetDesc(const AmdGpu::Liverpool::DepthBuffer& buffer,
+                        const AmdGpu::Liverpool::DepthView& view,
+                        const AmdGpu::Liverpool::DepthControl& ctl, VAddr htile_address,
+                        const AmdGpu::Liverpool::CbDbExtent& hint = {})
+            : BaseDesc{BindingType::DepthTarget,
+                       ImageInfo{buffer, view.NumSlices(), htile_address, hint},
+                       ImageViewInfo{buffer, view, ctl}} {}
+    };
+
+    struct VideoOutDesc : public BaseDesc {
+        VideoOutDesc(const Libraries::VideoOut::BufferAttributeGroup& group, VAddr cpu_address)
+            : BaseDesc{BindingType::VideoOut, ImageInfo{group, cpu_address}, ImageViewInfo{}} {}
+    };
+
+public:
+    TextureCache(const Vulkan::Instance& instance, Vulkan::Scheduler& scheduler,
+                 BufferCache& buffer_cache, PageManager& tracker);
     ~TextureCache();
 
     /// Invalidates any image in the logical page range.
@@ -57,18 +105,16 @@ public:
     void UnmapMemory(VAddr cpu_addr, size_t size);
 
     /// Retrieves the image handle of the image with the provided attributes.
-    [[nodiscard]] ImageId FindImage(const ImageInfo& info, FindFlags flags = {});
+    [[nodiscard]] ImageId FindImage(BaseDesc& desc, FindFlags flags = {});
 
     /// Retrieves an image view with the properties of the specified image id.
     [[nodiscard]] ImageView& FindTexture(ImageId image_id, const ImageViewInfo& view_info);
 
     /// Retrieves the render target with specified properties
-    [[nodiscard]] ImageView& FindRenderTarget(const ImageInfo& image_info,
-                                              const ImageViewInfo& view_info);
+    [[nodiscard]] ImageView& FindRenderTarget(BaseDesc& desc);
 
     /// Retrieves the depth target with specified properties
-    [[nodiscard]] ImageView& FindDepthTarget(const ImageInfo& image_info,
-                                             const ImageViewInfo& view_info);
+    [[nodiscard]] ImageView& FindDepthTarget(BaseDesc& desc);
 
     /// Updates image contents if it was modified by CPU.
     void UpdateImage(ImageId image_id, Vulkan::Scheduler* custom_scheduler = nullptr) {
@@ -77,11 +123,13 @@ public:
         RefreshImage(image, custom_scheduler);
     }
 
-    [[nodiscard]] ImageId ResolveOverlap(const ImageInfo& info, ImageId cache_img_id,
-                                         ImageId merged_image_id);
+    [[nodiscard]] std::tuple<ImageId, int, int> ResolveOverlap(const ImageInfo& info,
+                                                               BindingType binding,
+                                                               ImageId cache_img_id,
+                                                               ImageId merged_image_id);
 
     /// Resolves depth overlap and either re-creates the image or returns existing one
-    [[nodiscard]] ImageId ResolveDepthOverlap(const ImageInfo& requested_info,
+    [[nodiscard]] ImageId ResolveDepthOverlap(const ImageInfo& requested_info, BindingType binding,
                                               ImageId cache_img_id);
 
     [[nodiscard]] ImageId ExpandImage(const ImageInfo& info, ImageId image_id);


### PR DESCRIPTION
This brings better overlap management and fixes some of the previously observed issues in depth aliasing and mipgens. Known 

Leftovers to address in Pt.2:
* Image size calculation is still a bit off for small CB/DB surfaces
* ~Missing MS macro tile params LUTs~
* Depth sub resources won't be merged, and whole image will be created instead
* In case if a sub resource on right overlap is both a mip and a slice, only mip case will be handled
* Views on particular slices aren't handled
* Missing stencil registration