### PR TITLE
vk_pipeline_cache: Skip pipelines with geometry shaders when unsupported.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -322,7 +322,7 @@ bool PipelineCache::RefreshGraphicsKey() {
     switch (regs.stage_enable.raw) {
     case Liverpool::ShaderStageEnable::VgtStages::EsGs: {
         if (!instance.IsGeometryStageSupported() || !IsGsFeaturesSupported()) {
-            break;
+            return false;
         }
         if (!TryBindStageRemap(Shader::Stage::Export, Shader::Stage::Vertex)) {
             return false;


### PR DESCRIPTION
Properly skip pipelines with geometry shaders when they are unsupported, instead of just skipping binding the shader stage. Otherwise games crash compiling pipelines complaining about missing stage inputs, for example from CUSA01130:
```
[Render.Vulkan] <Error> vk_platform.cpp:DebugUtilsCallback:70: VUID-RuntimeSpirv-OpEntryPoint-08743: Validation Error: [ VUID-RuntimeSpirv-OpEntryPoint-08743 ] Object 0: handle = 0xb43c50000000490, name = vs_0xaf846422_0, type = VK_OBJECT_TYPE_SHADER_MODULE; Object 1: handle = 0x5e4ce20000000497, name = fs_0xb30c6b28_0, type = VK_OBJECT_TYPE_SHADER_MODULE; | MessageID = 0x89925893 | vkCreateGraphicsPipelines(): pCreateInfos[0] (SPIR-V Interface) VK_SHADER_STAGE_FRAGMENT_BIT declared input at Location 3 Component 0 but it is not an Output declared in VK_SHADER_STAGE_VERTEX_BIT.
The Vulkan spec states: Any user-defined variables shared between the OpEntryPoint of two shader stages, and declared with Input as its Storage Class for the subsequent shader stage, must have all Location slots and Component words declared in the preceding shader stage's OpEntryPoint with Output as the Storage Class (https://vulkan.lunarg.com/doc/view/1.3.296.0/mac/1.3-extensions/vkspec.html#VUID-RuntimeSpirv-OpEntryPoint-08743)
[Render.Vulkan] <Error> vk_platform.cpp:DebugUtilsCallback:70: VUID-RuntimeSpirv-OpEntryPoint-08743: Validation Error: [ VUID-RuntimeSpirv-OpEntryPoint-08743 ] Object 0: handle = 0xb43c50000000490, name = vs_0xaf846422_0, type = VK_OBJECT_TYPE_SHADER_MODULE; Object 1: handle = 0x5e4ce20000000497, name = fs_0xb30c6b28_0, type = VK_OBJECT_TYPE_SHADER_MODULE; | MessageID = 0x89925893 | vkCreateGraphicsPipelines(): pCreateInfos[0] (SPIR-V Interface) VK_SHADER_STAGE_FRAGMENT_BIT declared input at Location 2 Component 0 but it is not an Output declared in VK_SHADER_STAGE_VERTEX_BIT.
The Vulkan spec states: Any user-defined variables shared between the OpEntryPoint of two shader stages, and declared with Input as its Storage Class for the subsequent shader stage, must have all Location slots and Component words declared in the preceding shader stage's OpEntryPoint with Output as the Storage Class (https://vulkan.lunarg.com/doc/view/1.3.296.0/mac/1.3-extensions/vkspec.html#VUID-RuntimeSpirv-OpEntryPoint-08743)
[Render.Vulkan] <Error> vk_platform.cpp:DebugUtilsCallback:70: mvk-error: VK_ERROR_INITIALIZATION_FAILED: Render pipeline compile failed (Error code 3):
Fragment input(s) `user(locn2),user(locn3)` mismatching vertex shader output type(s) or not written by vertex shader.
```