### PR TITLE
ci: Change to macOS 15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,7 +162,7 @@ jobs:
         path: upload/
 
   macos-sdl:
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: get-info
     steps:
     - uses: actions/checkout@v4
@@ -218,7 +218,7 @@ jobs:
         path: shadps4-macos-sdl.tar.gz
 
   macos-qt:
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: get-info
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub removed Xcode 16 from macOS 14 images which are still mapped as latest since 15 is new. Change over to macOS 15 images explicitly to fix build.