### PR TITLE
shader_recompiler: shaer patch to manualy normalize on unsupported Vulkan UNORM/SNORM formats

### DIFF
--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -1619,4 +1619,9 @@ void IREmitter::EmitPrimitive() {
     Inst(Opcode::EmitPrimitive);
 }
 
+IR::Inst* IREmitter::CopyInst(const IR::Inst& inst) {
+    auto it{block->PrependNewInst(insertion_point, inst)};
+    return &*it;
+}
+
 } // namespace Shader::IR

--- a/src/shader_recompiler/ir/ir_emitter.h
+++ b/src/shader_recompiler/ir/ir_emitter.h
@@ -321,6 +321,8 @@ public:
     void EmitVertex();
     void EmitPrimitive();
 
+    [[nodiscard]] Inst* CopyInst(const Inst& inst);
+
 private:
     IR::Block::iterator insertion_point;
 

--- a/src/shader_recompiler/specialization.h
+++ b/src/shader_recompiler/specialization.h
@@ -26,7 +26,7 @@ struct TextureBufferSpecialization {
 };
 
 struct ImageSpecialization {
-    enum class Normalization : u8 {
+    enum class NormalizationSign : u8 {
         None,
         Signed,
         Unsigned,
@@ -34,7 +34,8 @@ struct ImageSpecialization {
 
     AmdGpu::ImageType type = AmdGpu::ImageType::Color2D;
     bool is_integer = false;
-    Normalization normalization = Normalization::None;
+    NormalizationSign normalization = NormalizationSign::None;
+    u32 normalized_components = 0;
 
     auto operator<=>(const ImageSpecialization&) const = default;
 };
@@ -88,8 +89,9 @@ struct StageSpecialization {
 
                 if (sharp.NeedsNormalizationPatch()) {
                     spec.normalization = sharp.GetNumberFmt() == AmdGpu::NumberFormat::Snorm
-                                             ? ImageSpecialization::Normalization::Signed
-                                             : ImageSpecialization::Normalization::Unsigned;
+                                             ? ImageSpecialization::NormalizationSign::Signed
+                                             : ImageSpecialization::NormalizationSign::Unsigned;
+                    spec.normalized_components = AmdGpu::NumComponents(sharp.GetDataFmt());
                 }
             });
         ForEachSharp(binding, fmasks, info->fmasks,

--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -291,6 +291,22 @@ struct Image {
         return static_cast<TilingMode>(tiling_index);
     }
 
+    bool NeedsNormalizationPatch() const {
+        if (GetNumberFmt() == AmdGpu::NumberFormat::Unorm ||
+            GetNumberFmt() == AmdGpu::NumberFormat::Snorm) {
+            switch (GetDataFmt()) {
+            case AmdGpu::DataFormat::Format32:
+            case AmdGpu::DataFormat::Format32_32:
+            case AmdGpu::DataFormat::Format32_32_32:
+            case AmdGpu::DataFormat::Format32_32_32_32:
+                return true;
+            default:
+                return false;
+            }
+        }
+        return false;
+    }
+
     bool IsTiled() const {
         return GetTilingMode() != TilingMode::Display_Linear;
     }

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -635,6 +635,33 @@ std::span<const SurfaceFormatInfo> SurfaceFormats() {
                                 vk::Format::eBc7UnormBlock),
         CreateSurfaceFormatInfo(AmdGpu::DataFormat::FormatBc7, AmdGpu::NumberFormat::Srgb,
                                 vk::Format::eBc7SrgbBlock),
+
+        /*
+         * Shaders reading/writing these formats need to be patched to normalize/unnormalize the
+         * values This is because the Vulkan doesn't support these formats directly
+         *
+         * see shader_recompiler/ir/passes/resource_tracking_pass.cpp
+         */
+        // 32
+        CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format32, AmdGpu::NumberFormat::Unorm,
+                                vk::Format::eR32Uint),
+        CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format32, AmdGpu::NumberFormat::Snorm,
+                                vk::Format::eR32Uint),
+        // 32_32
+        CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format32_32, AmdGpu::NumberFormat::Unorm,
+                                vk::Format::eR32G32Uint),
+        CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format32_32, AmdGpu::NumberFormat::Snorm,
+                                vk::Format::eR32G32Uint),
+        // 32_32_32
+        CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format32_32_32, AmdGpu::NumberFormat::Unorm,
+                                vk::Format::eR32G32B32Uint),
+        CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format32_32_32, AmdGpu::NumberFormat::Snorm,
+                                vk::Format::eR32G32B32Uint),
+        // 32_32_32_32
+        CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format32_32_32_32, AmdGpu::NumberFormat::Unorm,
+                                vk::Format::eR32G32B32A32Uint),
+        CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format32_32_32_32, AmdGpu::NumberFormat::Snorm,
+                                vk::Format::eR32G32B32A32Uint),
     };
     return formats;
 }

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -646,22 +646,22 @@ std::span<const SurfaceFormatInfo> SurfaceFormats() {
         CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format32, AmdGpu::NumberFormat::Unorm,
                                 vk::Format::eR32Uint),
         CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format32, AmdGpu::NumberFormat::Snorm,
-                                vk::Format::eR32Uint),
+                                vk::Format::eR32Sint),
         // 32_32
         CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format32_32, AmdGpu::NumberFormat::Unorm,
                                 vk::Format::eR32G32Uint),
         CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format32_32, AmdGpu::NumberFormat::Snorm,
-                                vk::Format::eR32G32Uint),
+                                vk::Format::eR32G32Sint),
         // 32_32_32
         CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format32_32_32, AmdGpu::NumberFormat::Unorm,
                                 vk::Format::eR32G32B32Uint),
         CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format32_32_32, AmdGpu::NumberFormat::Snorm,
-                                vk::Format::eR32G32B32Uint),
+                                vk::Format::eR32G32B32Sint),
         // 32_32_32_32
         CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format32_32_32_32, AmdGpu::NumberFormat::Unorm,
                                 vk::Format::eR32G32B32A32Uint),
         CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format32_32_32_32, AmdGpu::NumberFormat::Snorm,
-                                vk::Format::eR32G32B32A32Uint),
+                                vk::Format::eR32G32B32A32Sint),
     };
     return formats;
 }


### PR DESCRIPTION
Vulkan doesn't have support for SNORM/UNORM number formats for 32, 32_32, 32_32_32 and 32_32_32_32 data formats. Insteed use SINT/UINT and  normalize/unormalize on shader when reading/writing.

Maybe we don't need to specialize by number of components, I can revert that.