### PR TITLE
Fix depth bias

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -393,14 +393,12 @@ void Rasterizer::UpdateDynamicState(const GraphicsPipeline& pipeline) {
     if (regs.depth_control.depth_bounds_enable) {
         cmdbuf.setDepthBounds(regs.depth_bounds_min, regs.depth_bounds_max);
     }
-    if (regs.polygon_control.NeedsBias()) {
-        if (regs.polygon_control.enable_polygon_offset_front) {
-            cmdbuf.setDepthBias(regs.poly_offset.front_offset, regs.poly_offset.depth_bias,
-                                regs.poly_offset.front_scale);
-        } else {
-            cmdbuf.setDepthBias(regs.poly_offset.back_offset, regs.poly_offset.depth_bias,
-                                regs.poly_offset.back_scale);
-        }
+    if (regs.polygon_control.enable_polygon_offset_front) {
+        cmdbuf.setDepthBias(regs.poly_offset.front_offset, regs.poly_offset.depth_bias,
+                            regs.poly_offset.front_scale / 16.f);
+    } else if (regs.polygon_control.enable_polygon_offset_back) {
+        cmdbuf.setDepthBias(regs.poly_offset.back_offset, regs.poly_offset.depth_bias,
+                            regs.poly_offset.back_scale / 16.f);
     }
     if (regs.depth_control.stencil_enable) {
         const auto front = regs.stencil_ref_front;


### PR DESCRIPTION
Gnm uses depth bias scale in 1/16 units while Vulkan uses 1/1 units.
Before:
![Screenshot_2024-11-16_091819](https://github.com/user-attachments/assets/d672a408-31d6-4c59-a899-a1da63de2df6)
After:
![Screenshot_2024-11-16_091618](https://github.com/user-attachments/assets/f45af164-d94d-4e27-90dd-b57931ffe7aa)
