### PR TITLE
Fix border color

### DIFF
--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -358,8 +358,8 @@ enum class MipFilter : u64 {
 };
 
 enum class BorderColor : u64 {
-    OpaqueBlack = 0,
-    TransparentBlack = 1,
+    TransparentBlack = 0,
+    OpaqueBlack = 1,
     White = 2,
     Custom = 3,
 };

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -285,10 +285,10 @@ vk::SamplerMipmapMode MipFilter(AmdGpu::MipFilter filter) {
 
 vk::BorderColor BorderColor(AmdGpu::BorderColor color) {
     switch (color) {
-    case AmdGpu::BorderColor::OpaqueBlack:
-        return vk::BorderColor::eFloatOpaqueBlack;
     case AmdGpu::BorderColor::TransparentBlack:
         return vk::BorderColor::eFloatTransparentBlack;
+    case AmdGpu::BorderColor::OpaqueBlack:
+        return vk::BorderColor::eFloatOpaqueBlack;
     case AmdGpu::BorderColor::White:
         return vk::BorderColor::eFloatOpaqueWhite;
     case AmdGpu::BorderColor::Custom:


### PR DESCRIPTION
In AMDs "CIK 3D registers v2" border color values are in the following order: `Transparent Black`, `Opaque Black`, `Opaque White`, `Custom`.