### PR TITLE
Bump to Clang-format 18

### DIFF
--- a/.ci/clang-format.sh
+++ b/.ci/clang-format.sh
@@ -10,7 +10,7 @@ if grep -nrI '\s$' src *.yml *.txt *.md Doxyfile .gitignore .gitmodules .ci* dis
 fi
 
 # Default clang-format points to default 3.5 version one
-CLANG_FORMAT=clang-format-17
+CLANG_FORMAT=clang-format-18
 $CLANG_FORMAT --version
 
 if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     continue-on-error: true
     steps:
     - uses: actions/checkout@v4
-    - uses: fsfe/reuse-action@v4
+    - uses: fsfe/reuse-action@v5
 
   clang-format:
     runs-on: ubuntu-latest
@@ -30,9 +30,9 @@ jobs:
     - name: Install
       run: |
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main'
+        sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main'
         sudo apt update
-        sudo apt install clang-format-17
+        sudo apt install clang-format-18
     - name: Build
       env:
         COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}

--- a/src/core/devtools/widget/imgui_memory_editor.h
+++ b/src/core/devtools/widget/imgui_memory_editor.h
@@ -929,7 +929,7 @@ struct MemoryEditor {
         default:
         case ImGuiDataType_COUNT:
             break;
-        }             // Switch
+        } // Switch
         IM_ASSERT(0); // Shouldn't reach
     }
 };

--- a/src/core/libraries/kernel/event_flag/event_flag_obj.h
+++ b/src/core/libraries/kernel/event_flag/event_flag_obj.h
@@ -22,7 +22,7 @@ public:
 
     EventFlagInternal(const std::string& name, ThreadMode thread_mode, QueueMode queue_mode,
                       uint64_t bits)
-        : m_name(name), m_thread_mode(thread_mode), m_queue_mode(queue_mode), m_bits(bits){};
+        : m_name(name), m_thread_mode(thread_mode), m_queue_mode(queue_mode), m_bits(bits) {};
 
     int Wait(u64 bits, WaitMode wait_mode, ClearMode clear_mode, u64* result, u32* ptr_micros);
     int Poll(u64 bits, WaitMode wait_mode, ClearMode clear_mode, u64* result);

--- a/src/shader_recompiler/ir/breadth_first_search.h
+++ b/src/shader_recompiler/ir/breadth_first_search.h
@@ -14,8 +14,8 @@ namespace Shader::IR {
 // Use typename Instruction so the function can be used to return either const or mutable
 // Insts depending on the context.
 template <typename Instruction, typename Pred>
-auto BreadthFirstSearch(Instruction* inst, Pred&& pred)
-    -> std::invoke_result_t<Pred, Instruction*> {
+auto BreadthFirstSearch(Instruction* inst,
+                        Pred&& pred) -> std::invoke_result_t<Pred, Instruction*> {
     // Most often case the instruction is the desired already.
     if (std::optional result = pred(inst)) {
         return result;
@@ -53,8 +53,8 @@ auto BreadthFirstSearch(Instruction* inst, Pred&& pred)
 }
 
 template <typename Pred>
-auto BreadthFirstSearch(const Value& value, Pred&& pred)
-    -> std::invoke_result_t<Pred, const Inst*> {
+auto BreadthFirstSearch(const Value& value,
+                        Pred&& pred) -> std::invoke_result_t<Pred, const Inst*> {
     if (value.IsImmediate()) {
         // Nothing to do with immediates
         return std::nullopt;

--- a/src/shader_recompiler/ir/opcodes.h
+++ b/src/shader_recompiler/ir/opcodes.h
@@ -53,7 +53,7 @@ constexpr Type F64x3{Type::F64x3};
 constexpr Type F64x4{Type::F64x4};
 constexpr Type StringLiteral{Type::StringLiteral};
 
-constexpr OpcodeMeta META_TABLE[]{
+constexpr OpcodeMeta META_TABLE[] {
 #define OPCODE(name_token, type_token, ...)                                                        \
     {                                                                                              \
         .name{#name_token},                                                                        \


### PR DESCRIPTION
Since Visual Studio 17.12 we have moved from Clang 17 to 18.
I have also updated fsfe/reuse-action