### PR TITLE
shader_recompiler/frontend: Implement `bitcmp` instructions

### DIFF
--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -174,6 +174,13 @@ T Translator::GetSrc(const InstOperand& operand) {
             value = ir.GetM0();
         }
         break;
+    case OperandField::Scc:
+        if constexpr (is_float) {
+            UNREACHABLE();
+        } else {
+            value = ir.BitCast<IR::U32>(ir.GetScc());
+        }
+        break;
     default:
         UNREACHABLE();
     }

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -114,6 +114,7 @@ public:
 
     // SOPC
     void S_CMP(ConditionOp cond, bool is_signed, const GcnInst& inst);
+    void S_BITCMP(bool compare_mode, u32 bits, const GcnInst& inst);
 
     // SOPP
     void S_BARRIER();

--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -60,6 +60,11 @@ F64 IREmitter::Imm64(f64 value) const {
 }
 
 template <>
+IR::U32 IREmitter::BitCast<IR::U32, IR::U1>(const IR::U1& value) {
+    return IR::U32{Select(value, Imm32(1), Imm32(0))};
+}
+
+template <>
 IR::U32 IREmitter::BitCast<IR::U32, IR::F32>(const IR::F32& value) {
     return Inst<IR::U32>(Opcode::BitCastU32F32, value);
 }


### PR DESCRIPTION
Seen on PSPHD. Also implements getting the `scc` register with `GetSrc` - required for these instructions:
```
s_or_b32        vcc_lo, vcc_hi, scc
/*snip*/
s_or_b32        s0, vcc_hi, scc
/*snip/*
s_or_b32        s1, scc, vcc_hi
```