### PR TITLE
Implement V_MED3_U32 vector ALU Opcode

### DIFF
--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -225,6 +225,7 @@ public:
     void V_MAX3_U32(bool is_signed, const GcnInst& inst);
     void V_MED3_F32(const GcnInst& inst);
     void V_MED3_I32(const GcnInst& inst);
+    void V_MED3_U32(const GcnInst& inst);
     void V_SAD(const GcnInst& inst);
     void V_SAD_U32(const GcnInst& inst);
     void V_CVT_PK_U16_U32(const GcnInst& inst);

--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -1100,7 +1100,7 @@ void Translator::V_MED3_U32(const GcnInst& inst) {
     const IR::U32 src2{GetSrc(inst.src[2])};
     const IR::U32 mmx = ir.UMin(ir.UMax(src0, src1), src2);
     SetDst(inst.dst[0], ir.UMax(ir.UMin(src0, src1), mmx));
-    }
+}
 
 void Translator::V_SAD(const GcnInst& inst) {
     const IR::U32 abs_diff = ir.IAbs(ir.ISub(GetSrc(inst.src[0]), GetSrc(inst.src[1])));

--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -357,6 +357,8 @@ void Translator::EmitVectorAlu(const GcnInst& inst) {
         return V_MED3_F32(inst);
     case Opcode::V_MED3_I32:
         return V_MED3_I32(inst);
+    case Opcode::V_MED3_U32:
+        return V_MED3_U32(inst);
     case Opcode::V_SAD_U32:
         return V_SAD_U32(inst);
     case Opcode::V_CVT_PK_U16_U32:
@@ -1091,6 +1093,14 @@ void Translator::V_MED3_I32(const GcnInst& inst) {
     const IR::U32 mmx = ir.SMin(ir.SMax(src0, src1), src2);
     SetDst(inst.dst[0], ir.SMax(ir.SMin(src0, src1), mmx));
 }
+
+void Translator::V_MED3_U32(const GcnInst& inst) {
+    const IR::U32 src0{GetSrc(inst.src[0])};
+    const IR::U32 src1{GetSrc(inst.src[1])};
+    const IR::U32 src2{GetSrc(inst.src[2])};
+    const IR::U32 mmx = ir.UMin(ir.UMax(src0, src1), src2);
+    SetDst(inst.dst[0], ir.UMax(ir.UMin(src0, src1), mmx));
+    }
 
 void Translator::V_SAD(const GcnInst& inst) {
     const IR::U32 abs_diff = ir.IAbs(ir.ISub(GetSrc(inst.src[0]), GetSrc(inst.src[1])));


### PR DESCRIPTION
Needed by The Last Guardian for getting in-game. (This commit on it's own will not make the game playable.)

Seemed almost identical to V_MED3_I32 and V_MED3_F32, with the only diffrerence being the datatype:
![image](https://github.com/user-attachments/assets/07882bfa-c4e6-4e43-8aec-26ec3396e829)
![image](https://github.com/user-attachments/assets/a6a16bbf-d167-4d49-bc86-b0b49a3558c3)

Moves the error from an opcode error to a Texel buffer stride error.
Before:
![image](https://github.com/user-attachments/assets/2728c4a8-6811-4e0f-aaa4-57a15b356fdc)
After:
![image](https://github.com/user-attachments/assets/48057827-c5ed-4599-8115-55e9b2c7f146)
(Screenshots include additional tweaks.)