### PR TITLE
image_view: Use array view for color/depth buffers with multiple layers.

### DIFF
--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -131,6 +131,7 @@ ImageViewInfo::ImageViewInfo(const AmdGpu::Liverpool::ColorBuffer& col_buffer,
         Vulkan::LiverpoolToVK::SurfaceFormat(col_buffer.info.format, col_buffer.NumFormat());
     range.base.layer = col_buffer.view.slice_start;
     range.extent.layers = col_buffer.NumSlices() - range.base.layer;
+    type = range.extent.layers > 1 ? vk::ImageViewType::e2DArray : vk::ImageViewType::e2D;
     format = Vulkan::LiverpoolToVK::AdjustColorBufferFormat(
         base_format, col_buffer.info.comp_swap.Value(), is_vo_surface);
 }
@@ -143,6 +144,7 @@ ImageViewInfo::ImageViewInfo(const AmdGpu::Liverpool::DepthBuffer& depth_buffer,
     is_storage = ctl.depth_write_enable;
     range.base.layer = view.slice_start;
     range.extent.layers = view.NumSlices() - range.base.layer;
+    type = range.extent.layers > 1 ? vk::ImageViewType::e2DArray : vk::ImageViewType::e2D;
 }
 
 ImageView::ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info_, Image& image,


### PR DESCRIPTION
Currently when an image view is created for a color or depth buffer, `range.extent.layers` may be set to greater than 1, but type is always defaulted to `vk::ImageViewType::e2D`. This causes the following validation error, which can crash certain drivers:
```
[Render.Vulkan] <Error> vk_platform.cpp:DebugUtilsCallback:70: VUID-VkImageViewCreateInfo-imageViewType-04973: Validation Error: [ VUID-VkImageViewCreateInfo-imageViewType-04973 ] Object 0: handle = 0x2894590000000072, name = Image 1920x1080x1 0xaeae0000:0x1200000, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x8ab1932c | vkCreateImageView(): pCreateInfo->subresourceRange.layerCount (2) must be 1 when using viewType VK_IMAGE_VIEW_TYPE_2D (try looking into VK_IMAGE_VIEW_TYPE_*_ARRAY).
The Vulkan spec states: If viewType is VK_IMAGE_VIEW_TYPE_1D, VK_IMAGE_VIEW_TYPE_2D, or VK_IMAGE_VIEW_TYPE_3D; and subresourceRange.layerCount is not VK_REMAINING_ARRAY_LAYERS, then subresourceRange.layerCount must be 1 (https://vulkan.lunarg.com/doc/view/1.3.296.0/mac/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-imageViewType-04973)
```

Instead, use `vk::ImageViewType::e2DArray` when the number of layers is greater than 1.

Fixes booting CUSA04518 on macOS.