### PR TITLE
Fixed false-positive image reuploads

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -635,7 +635,7 @@ bool BufferCache::SynchronizeBufferFromImage(Buffer& buffer, VAddr device_addr, 
                "Texel buffer aliases image subresources {:x} : {:x}", device_addr,
                image.info.guest_address);
     boost::container::small_vector<vk::BufferImageCopy, 8> copies;
-    u32 offset = buffer.Offset(image.cpu_addr);
+    u32 offset = buffer.Offset(image.info.guest_address);
     const u32 num_layers = image.info.resources.layers;
     const u32 max_offset = offset + size;
     for (u32 m = 0; m < image.info.resources.levels; m++) {

--- a/src/video_core/page_manager.cpp
+++ b/src/video_core/page_manager.cpp
@@ -115,7 +115,7 @@ struct PageManager::Impl {
             // Notify rasterizer about the fault.
             const VAddr addr = msg.arg.pagefault.address;
             const VAddr addr_page = Common::AlignDown(addr, PAGESIZE);
-            rasterizer->InvalidateMemory(addr_page, PAGESIZE);
+            rasterizer->InvalidateMemory(addr, addr_page, PAGESIZE);
         }
     }
 

--- a/src/video_core/page_manager.cpp
+++ b/src/video_core/page_manager.cpp
@@ -158,7 +158,7 @@ struct PageManager::Impl {
         const bool is_write = Common::IsWriteError(context);
         if (is_write && owned_ranges.find(addr) != owned_ranges.end()) {
             const VAddr addr_aligned = Common::AlignDown(addr, PAGESIZE);
-            rasterizer->InvalidateMemory(addr_aligned, PAGESIZE);
+            rasterizer->InvalidateMemory(addr, addr_aligned, PAGESIZE);
             return true;
         }
         return false;

--- a/src/video_core/page_manager.cpp
+++ b/src/video_core/page_manager.cpp
@@ -114,7 +114,7 @@ struct PageManager::Impl {
 
             // Notify rasterizer about the fault.
             const VAddr addr = msg.arg.pagefault.address;
-            const VAddr addr_page = Common::AlignDown(addr, PAGESIZE);
+            const VAddr addr_page = GetPageAddr(addr);
             rasterizer->InvalidateMemory(addr, addr_page, PAGESIZE);
         }
     }
@@ -157,7 +157,7 @@ struct PageManager::Impl {
         const auto addr = reinterpret_cast<VAddr>(fault_address);
         const bool is_write = Common::IsWriteError(context);
         if (is_write && owned_ranges.find(addr) != owned_ranges.end()) {
-            const VAddr addr_aligned = Common::AlignDown(addr, PAGESIZE);
+            const VAddr addr_aligned = GetPageAddr(addr);
             rasterizer->InvalidateMemory(addr, addr_aligned, PAGESIZE);
             return true;
         }
@@ -173,6 +173,14 @@ PageManager::PageManager(Vulkan::Rasterizer* rasterizer_)
     : impl{std::make_unique<Impl>(rasterizer_)}, rasterizer{rasterizer_} {}
 
 PageManager::~PageManager() = default;
+
+VAddr PageManager::GetPageAddr(VAddr addr) {
+    return Common::AlignDown(addr, PAGESIZE);
+}
+
+VAddr PageManager::GetNextPageAddr(VAddr addr) {
+    return Common::AlignUp(addr + 1, PAGESIZE);
+}
 
 void PageManager::OnGpuMap(VAddr address, size_t size) {
     impl->OnMap(address, size);

--- a/src/video_core/page_manager.h
+++ b/src/video_core/page_manager.h
@@ -28,6 +28,9 @@ public:
     /// Increase/decrease the number of surface in pages touching the specified region
     void UpdatePagesCachedCount(VAddr addr, u64 size, s32 delta);
 
+    static VAddr GetPageAddr(VAddr addr);
+    static VAddr GetNextPageAddr(VAddr addr);
+
 private:
     struct Impl;
     std::unique_ptr<Impl> impl;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -792,9 +792,9 @@ u32 Rasterizer::ReadDataFromGds(u32 gds_offset) {
     return value;
 }
 
-void Rasterizer::InvalidateMemory(VAddr addr, u64 size) {
-    buffer_cache.InvalidateMemory(addr, size);
-    texture_cache.InvalidateMemory(addr, size);
+void Rasterizer::InvalidateMemory(VAddr addr, VAddr addr_aligned, u64 size) {
+    buffer_cache.InvalidateMemory(addr_aligned, size);
+    texture_cache.InvalidateMemory(addr, addr_aligned, size);
 }
 
 void Rasterizer::MapMemory(VAddr addr, u64 size) {

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -46,7 +46,7 @@ public:
 
     void InlineData(VAddr address, const void* value, u32 num_bytes, bool is_gds);
     u32 ReadDataFromGds(u32 gsd_offset);
-    void InvalidateMemory(VAddr addr, u64 size);
+    void InvalidateMemory(VAddr addr, VAddr addr_aligned, u64 size);
     void MapMemory(VAddr addr, u64 size);
     void UnmapMemory(VAddr addr, u64 size);
 

--- a/src/video_core/texture_cache/image.cpp
+++ b/src/video_core/texture_cache/image.cpp
@@ -144,8 +144,7 @@ void UniqueImage::Create(const vk::ImageCreateInfo& image_ci) {
 Image::Image(const Vulkan::Instance& instance_, Vulkan::Scheduler& scheduler_,
              const ImageInfo& info_)
     : instance{&instance_}, scheduler{&scheduler_}, info{info_},
-      image{instance->GetDevice(), instance->GetAllocator()}, cpu_addr{info.guest_address},
-      cpu_addr_end{cpu_addr + info.guest_size_bytes} {
+      image{instance->GetDevice(), instance->GetAllocator()} {
     mip_hashes.resize(info.resources.levels);
     ASSERT(info.pixel_format != vk::Format::eUndefined);
     // Here we force `eExtendedUsage` as don't know all image usage cases beforehand. In normal case

--- a/src/video_core/texture_cache/image.h
+++ b/src/video_core/texture_cache/image.h
@@ -22,9 +22,10 @@ VK_DEFINE_HANDLE(VmaAllocator)
 namespace VideoCore {
 
 enum ImageFlagBits : u32 {
-    CpuDirty = 1 << 1, ///< Contents have been modified from the CPU
+    MaybeCpuDirty = 1 << 0, ///< The page this image is in was touched before the image address
+    CpuDirty = 1 << 1,      ///< Contents have been modified from the CPU
     GpuDirty = 1 << 2, ///< Contents have been modified from the GPU (valid data in buffer cache)
-    Dirty = CpuDirty | GpuDirty,
+    Dirty = CpuDirty | GpuDirty | MaybeCpuDirty,
     GpuModified = 1 << 3,    ///< Contents have been modified from the GPU
     Tracked = 1 << 4,        ///< Writes and reads are being hooked from the CPU
     Registered = 1 << 6,     ///< True when the image is registered
@@ -130,6 +131,7 @@ struct Image {
     std::vector<State> subresource_states{};
     boost::container::small_vector<u64, 14> mip_hashes{};
     u64 tick_accessed_last{0};
+    u64 hash{0};
 
     struct {
         union {

--- a/src/video_core/texture_cache/image.h
+++ b/src/video_core/texture_cache/image.h
@@ -25,9 +25,10 @@ enum ImageFlagBits : u32 {
     MaybeCpuDirty = 1 << 0, ///< The page this image is in was touched before the image address
     CpuDirty = 1 << 1,      ///< Contents have been modified from the CPU
     GpuDirty = 1 << 2, ///< Contents have been modified from the GPU (valid data in buffer cache)
-    Dirty = CpuDirty | GpuDirty | MaybeCpuDirty,
+    Dirty = MaybeCpuDirty | CpuDirty | GpuDirty,
     GpuModified = 1 << 3,    ///< Contents have been modified from the GPU
     Tracked = 1 << 4,        ///< Writes and reads are being hooked from the CPU
+    TailTracked = 1 << 5,    ///< Writes and reads to the image tail are being hooked from the CPU
     Registered = 1 << 6,     ///< True when the image is registered
     Picked = 1 << 7,         ///< Temporary flag to mark the image as picked
     MetaRegistered = 1 << 8, ///< True when metadata for this surface is known and registered

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -95,7 +95,7 @@ public:
     ~TextureCache();
 
     /// Invalidates any image in the logical page range.
-    void InvalidateMemory(VAddr addr, VAddr addr_aligned, size_t size);
+    void InvalidateMemory(VAddr addr, VAddr page_addr, size_t size);
 
     /// Marks an image as dirty if it exists at the provided address.
     void InvalidateMemoryFromGPU(VAddr address, size_t max_size);

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -242,15 +242,15 @@ private:
 
     /// Track CPU reads and writes for image
     void TrackImage(ImageId image_id);
-
-    /// Track CPU reads and writes for image
     void TrackImageHead(ImageId image_id);
+    void TrackImageTail(ImageId image_id);
 
     /// Stop tracking CPU reads and writes for image
     void UntrackImage(ImageId image_id);
-
-    /// Stop tracking CPU reads and writes for the first page of the image
     void UntrackImageHead(ImageId image_id);
+    void UntrackImageTail(ImageId image_id);
+
+    void MarkAsMaybeDirty(ImageId image_id, Image& image);
 
     /// Removes the image and any views/surface metas that reference it.
     void DeleteImage(ImageId image_id);

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -95,7 +95,7 @@ public:
     ~TextureCache();
 
     /// Invalidates any image in the logical page range.
-    void InvalidateMemory(VAddr address, size_t size);
+    void InvalidateMemory(VAddr addr, VAddr addr_aligned, size_t size);
 
     /// Marks an image as dirty if it exists at the provided address.
     void InvalidateMemoryFromGPU(VAddr address, size_t max_size);

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -243,8 +243,14 @@ private:
     /// Track CPU reads and writes for image
     void TrackImage(ImageId image_id);
 
+    /// Track CPU reads and writes for image
+    void TrackImageHead(ImageId image_id);
+
     /// Stop tracking CPU reads and writes for image
     void UntrackImage(ImageId image_id);
+
+    /// Stop tracking CPU reads and writes for the first page of the image
+    void UntrackImageHead(ImageId image_id);
 
     /// Removes the image and any views/surface metas that reference it.
     void DeleteImage(ImageId image_id);


### PR DESCRIPTION
Should fix half of the rainbow artifacts in BloodBorne.
Big thanks to @raphaelthegreat and @psucien for helping debug and fix this.