### PR TITLE
Adding Optimizations to Compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -917,6 +917,9 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src/imgui/renderer)
 add_dependencies(shadps4 ImGui_Resources)
 target_include_directories(shadps4 PRIVATE ${IMGUI_RESOURCES_INCLUDE})
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments")
+target_compile_options(shadps4 PRIVATE $<$<CONFIG:Release>:-O3>)
+
 if (ENABLE_QT_GUI)
     set_target_properties(shadps4 PROPERTIES
 #       WIN32_EXECUTABLE ON


### PR DESCRIPTION
I added some compilation optimizations.
I disabled the warnings "warning: argument unused during compilation: '/Zc:preprocessor' [-Wunused-command-line-argument]"
If this is not correct, maybe **@abouvier** can help me because he knows a lot about CMake ;)