### PR TITLE
misc: Add JetBrains build directories to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -417,3 +417,4 @@ FodyWeavers.xsd
 
 # JetBrains
 .idea
+cmake-build-*


### PR DESCRIPTION
Small addition to the gitignore file to ignore JetBrains IDE build directories.

They create directories named `cmake-build-(name of your build profile)`.