### PR TITLE
Fix Shortcut

### DIFF
--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -451,7 +451,7 @@ private:
             pShellLink->SetWorkingDirectory((LPCWSTR)QFileInfo(exePath).absolutePath().utf16());
 
             // Set arguments, eboot.bin file location
-            QString arguments = QString("\"%1\"").arg(targetPath);
+            QString arguments = QString("-g \"%1\"").arg(targetPath);
             pShellLink->SetArguments((LPCWSTR)arguments.utf16());
 
             // Set the icon for the shortcut


### PR DESCRIPTION
**If you had shortcuts, you will need to create them again.**

[PR-1507](https://github.com/shadps4-emu/shadPS4/pull/1507) added some arguments that are listed below, and this ended up breaking the shortcut.

```
Usage: shadps4 [options] <elf or eboot.bin path>
Options:
  -g, --game <path|ID>          Specify game path to launch
  -p, --patch <patch_file>      Apply specified patch file
  -f, --fullscreen <true|false> Specify window initial fullscreen state. Does not overwrite the config file.
  -h, --help                    Display this help message
```

- [ ] Is it necessary to make any correction for linux? test