### PR TITLE
recompiler: fix how srt pass handles step rate sharps in special case

### DIFF
--- a/src/shader_recompiler/ir/passes/flatten_extended_userdata_pass.cpp
+++ b/src/shader_recompiler/ir/passes/flatten_extended_userdata_pass.cpp
@@ -148,16 +148,20 @@ static void GenerateSrtProgram(Info& info, PassInfo& pass_info) {
     // Special case for V# step rate buffers in fetch shader
     for (const auto [sgpr_base, dword_offset, num_dwords] : info.srt_info.srt_reservations) {
         // get pointer to V#
-        c.mov(r10d, ptr[rdi + (sgpr_base << 2)]);
-
+        if (sgpr_base != IR::NumScalarRegs) {
+            PushPtr(c, sgpr_base);
+        }
         u32 src_off = dword_offset << 2;
 
         for (auto j = 0; j < num_dwords; j++) {
-            c.mov(r11d, ptr[r10d + src_off]);
+            c.mov(r11d, ptr[rdi + src_off]);
             c.mov(ptr[rsi + (pass_info.dst_off_dw << 2)], r11d);
 
             src_off += 4;
             ++pass_info.dst_off_dw;
+        }
+        if (sgpr_base != IR::NumScalarRegs) {
+            PopPtr(c);
         }
     }
 


### PR DESCRIPTION
In the SRT code path there has to be special handling for step rate buffers read inside the fetch shader because fetch shaders aren't actually recompiled.
The original SRT commit handled step rate buffers by making a "reservation" in the flattened user data buffer when a sharp was found during fetch shader parsing, which the JIT program would fill in.

The bug is that r10d (32 bit) was used to hold the indirect pointer used to find the step rate V#. Generalize by using Push/PopPtr to put the ptr in %rdi which also mask off the high ptr bits like Info::ReadUdReg