### PR TITLE
video_core: clean-up of indirect draws logic

### DIFF
--- a/src/core/libraries/gnmdriver/gnmdriver.cpp
+++ b/src/core/libraries/gnmdriver/gnmdriver.cpp
@@ -703,7 +703,7 @@ s32 PS4_SYSV_ABI sceGnmDrawIndexIndirectCountMulti(u32* cmdbuf, u32 size, u32 da
         cmdbuf[3] = (count_addr != 0 ? 1u : 0u) << 0x1e;
         cmdbuf[4] = max_count;
         *(u64*)(&cmdbuf[5]) = count_addr;
-        cmdbuf[7] = AmdGpu::Liverpool::DrawIndexedIndirectArgsSize;
+        cmdbuf[7] = sizeof(DrawIndexedIndirectArgs);
         cmdbuf[8] = 0;
 
         cmdbuf += 9;

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -410,7 +410,7 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
                 const auto* draw_indirect = reinterpret_cast<const PM4CmdDrawIndirect*>(header);
                 const auto offset = draw_indirect->data_offset;
                 const auto ib_address = mapped_queues[GfxQueueId].indirect_args_addr;
-                const auto size = sizeof(PM4CmdDrawIndirect::DrawInstancedArgs);
+                const auto size = sizeof(DrawIndirectArgs);
                 if (DebugState.DumpingCurrentReg()) {
                     DebugState.PushRegsDump(base_addr, reinterpret_cast<uintptr_t>(header), regs);
                 }
@@ -427,7 +427,7 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
                     reinterpret_cast<const PM4CmdDrawIndexIndirect*>(header);
                 const auto offset = draw_index_indirect->data_offset;
                 const auto ib_address = mapped_queues[GfxQueueId].indirect_args_addr;
-                const auto size = sizeof(PM4CmdDrawIndexIndirect::DrawIndexInstancedArgs);
+                const auto size = sizeof(DrawIndexedIndirectArgs);
                 if (DebugState.DumpingCurrentReg()) {
                     DebugState.PushRegsDump(base_addr, reinterpret_cast<uintptr_t>(header), regs);
                 }
@@ -442,10 +442,9 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
             }
             case PM4ItOpcode::DrawIndexIndirectCountMulti: {
                 const auto* draw_index_indirect =
-                    reinterpret_cast<const PM4CmdDrawIndexIndirect*>(header);
+                    reinterpret_cast<const PM4CmdDrawIndexIndirectMulti*>(header);
                 const auto offset = draw_index_indirect->data_offset;
                 const auto ib_address = mapped_queues[GfxQueueId].indirect_args_addr;
-                const auto size = sizeof(PM4CmdDrawIndexIndirect::DrawIndexInstancedArgs);
                 if (DebugState.DumpingCurrentReg()) {
                     DebugState.PushRegsDump(base_addr, reinterpret_cast<uintptr_t>(header), regs);
                 }
@@ -453,7 +452,7 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
                     const auto cmd_address = reinterpret_cast<const void*>(header);
                     rasterizer->ScopeMarkerBegin(
                         fmt::format("dcb:{}:DrawIndexIndirectCountMulti", cmd_address));
-                    rasterizer->DrawIndirect(true, ib_address, offset, size,
+                    rasterizer->DrawIndirect(true, ib_address, offset, draw_index_indirect->stride,
                                              draw_index_indirect->count,
                                              draw_index_indirect->countAddr);
                     rasterizer->ScopeMarkerEnd();

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -57,8 +57,6 @@ struct Liverpool {
     static constexpr u32 ConfigRegWordOffset = 0x2000;
     static constexpr u32 ShRegWordOffset = 0x2C00;
     static constexpr u32 NumRegs = 0xD000;
-    static constexpr u32 DrawIndirectArgsSize = 0x10u;
-    static constexpr u32 DrawIndexedIndirectArgsSize = 0x14u;
 
     using UserData = std::array<u32, NumShaderUserData>;
 

--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -778,14 +778,15 @@ struct PM4CmdDispatchIndirect {
     u32 dispatch_initiator; ///< Dispatch Initiator Register
 };
 
-struct PM4CmdDrawIndirect {
-    struct DrawInstancedArgs {
-        u32 vertex_count_per_instance;
-        u32 instance_count;
-        u32 start_vertex_location;
-        u32 start_instance_location;
-    };
+struct DrawIndirectArgs {
+    u32 vertex_count_per_instance;
+    u32 instance_count;
+    u32 start_vertex_location;
+    u32 start_instance_location;
+};
+static_assert(sizeof(DrawIndirectArgs) == 0x10u);
 
+struct PM4CmdDrawIndirect {
     PM4Type3Header header; ///< header
     u32 data_offset;       ///< Byte aligned offset where the required data structure starts
     union {
@@ -801,15 +802,16 @@ struct PM4CmdDrawIndirect {
     u32 draw_initiator; ///< Draw Initiator Register
 };
 
-struct PM4CmdDrawIndexIndirect {
-    struct DrawIndexInstancedArgs {
-        u32 index_count_per_instance;
-        u32 instance_count;
-        u32 start_index_location;
-        u32 base_vertex_location;
-        u32 start_instance_location;
-    };
+struct DrawIndexedIndirectArgs {
+    u32 index_count_per_instance;
+    u32 instance_count;
+    u32 start_index_location;
+    u32 base_vertex_location;
+    u32 start_instance_location;
+};
+static_assert(sizeof(DrawIndexedIndirectArgs) == 0x14u);
 
+struct PM4CmdDrawIndexIndirect {
     PM4Type3Header header; ///< header
     u32 data_offset;       ///< Byte aligned offset where the required data structure starts
     union {
@@ -822,16 +824,29 @@ struct PM4CmdDrawIndexIndirect {
         BitField<0, 16, u32> start_inst_loc; ///< Offset where the CP will write the
                                              ///< StartInstanceLocation it fetched from memory
     };
+    u32 draw_initiator; ///< Draw Initiator Register
+};
 
+struct PM4CmdDrawIndexIndirectMulti {
+    PM4Type3Header header; ///< header
+    u32 data_offset;       ///< Byte aligned offset where the required data structure starts
+    union {
+        u32 dw2;
+        BitField<0, 16, u32> base_vtx_loc; ///< Offset where the CP will write the
+                                           ///< BaseVertexLocation it fetched from memory
+    };
+    union {
+        u32 dw3;
+        BitField<0, 16, u32> start_inst_loc; ///< Offset where the CP will write the
+                                             ///< StartInstanceLocation it fetched from memory
+    };
     union {
         u32 dw4;
-        struct {
-            BitField<0, 16, u32> drawIndexLoc; ///< register offset to write the Draw Index count
-            BitField<30, 1, u32>
-                countIndirectEnable; ///< Indicates the data structure count is in memory
-            BitField<31, 1, u32>
-                drawIndexEnable; ///< Enables writing of Draw Index count to DRAW_INDEX_LOC
-        };
+        BitField<0, 16, u32> drawIndexLoc; ///< register offset to write the Draw Index count
+        BitField<30, 1, u32>
+            countIndirectEnable; ///< Indicates the data structure count is in memory
+        BitField<31, 1, u32>
+            drawIndexEnable; ///< Enables writing of Draw Index count to DRAW_INDEX_LOC
     };
     u32 count;          ///< Count of data structures to loop through before going to next packet
     u64 countAddr;      ///< DWord aligned Address[31:2]; Valid if countIndirectEnable is set


### PR DESCRIPTION
A bit of code cleanup, indexed and multiCount packets definitions separated (in accordance to GCN ref headers), fixed count buffer size calculation