### PR TITLE
semaphore: Fix returned iterator from AddWaiter

### DIFF
--- a/src/core/libraries/kernel/threads/semaphore.cpp
+++ b/src/core/libraries/kernel/threads/semaphore.cpp
@@ -165,8 +165,7 @@ public:
         while (it != wait_list.end() && (*it)->priority > waiter->priority) {
             ++it;
         }
-        wait_list.insert(it, waiter);
-        return it;
+        return wait_list.insert(it, waiter);
     }
 
     WaitList wait_list;


### PR DESCRIPTION
Fix the returned iterator from `AddWaiter` in kernel semaphores.

Fixes booting Hatsune Miku: Project DIVA X Update 1.02