### PR TITLE
Fixed DS_SWIZZLE_32

### DIFF
--- a/src/shader_recompiler/frontend/translate/data_share.cpp
+++ b/src/shader_recompiler/frontend/translate/data_share.cpp
@@ -158,13 +158,12 @@ void Translator::DS_WRITE(int bit_size, bool is_signed, bool is_pair, bool strid
 void Translator::DS_SWIZZLE_B32(const GcnInst& inst) {
     const u8 offset0 = inst.control.ds.offset0;
     const u8 offset1 = inst.control.ds.offset1;
-    const IR::U32 src{GetSrc(inst.src[1])};
+    const IR::U32 src{GetSrc(inst.src[0])};
     // ASSERT(offset1 & 0x80);
     const IR::U32 lane_id = ir.LaneId();
     const IR::U32 id_in_group = ir.BitwiseAnd(lane_id, ir.Imm32(0b11));
     const IR::U32 base = ir.ShiftLeftLogical(id_in_group, ir.Imm32(1));
-    const IR::U32 index =
-        ir.IAdd(lane_id, ir.BitFieldExtract(ir.Imm32(offset0), base, ir.Imm32(2)));
+    const IR::U32 index = ir.BitFieldExtract(ir.Imm32(offset0), base, ir.Imm32(2));
     SetDst(inst.dst[0], ir.QuadShuffle(src, index));
 }
 


### PR DESCRIPTION
According to the specs `DS_SWIZZLE_32` should not add `LaneID` to the resulting index. Also it should take the first argument from `src[0]`.
This fixes floor flickering in some locations and walls flickering in another location in _that game_.