### PR TITLE
Revert "core: fix patch paths applying when no folder exists"

### DIFF
--- a/src/core/file_sys/fs.cpp
+++ b/src/core/file_sys/fs.cpp
@@ -56,12 +56,11 @@ std::filesystem::path MntPoints::GetHostPath(std::string_view path, bool* is_rea
     std::filesystem::path host_path = mount->host_path / rel_path;
     std::filesystem::path patch_path = mount->host_path;
     patch_path += "-UPDATE";
+    patch_path /= rel_path;
 
-    if (corrected_path.starts_with("/app0") || corrected_path.starts_with("/hostapp")) {
-        if (std::filesystem::exists(patch_path)) {
-            patch_path /= rel_path;
-            return patch_path;
-        }
+    if ((corrected_path.starts_with("/app0") || corrected_path.starts_with("/hostapp")) &&
+        std::filesystem::exists(patch_path)) {
+        return patch_path;
     }
 
     if (!NeedsCaseInsensitiveSearch) {


### PR DESCRIPTION
Revert separate updates path check change, which is causing it to use the patch path for all files instead of just ones that exist in the patch.

@ElBread3 is working on a fix for the UE issue this was intended to fix.