### PR TITLE
sysmodule: Remove need for libSceRazorCpu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,7 @@ set(SYSTEM_LIBS src/core/libraries/system/commondialog.cpp
                 src/core/libraries/save_data/dialog/savedatadialog_ui.h
                 src/core/libraries/system/sysmodule.cpp
                 src/core/libraries/system/sysmodule.h
+                src/core/libraries/system/system_error.h
                 src/core/libraries/system/systemservice.cpp
                 src/core/libraries/system/systemservice.h
                 src/core/libraries/system/userservice.cpp

--- a/src/core/libraries/system/sysmodule.cpp
+++ b/src/core/libraries/system/sysmodule.cpp
@@ -9,6 +9,7 @@
 #include "core/libraries/error_codes.h"
 #include "core/libraries/libs.h"
 #include "core/libraries/system/sysmodule.h"
+#include "core/libraries/system/system_error.h"
 
 namespace Libraries::SysModule {
 
@@ -34,11 +35,23 @@ int PS4_SYSV_ABI sceSysmoduleIsCameraPreloaded() {
 
 int PS4_SYSV_ABI sceSysmoduleIsLoaded(OrbisSysModule id) {
     LOG_ERROR(Lib_SysModule, "(DUMMY) called module = {}", magic_enum::enum_name(id));
+    if (static_cast<u16>(id) == 0) {
+        LOG_ERROR(Lib_SysModule, "Invalid sysmodule ID: {:#x}", static_cast<u16>(id));
+        return ORBIS_SYSMODULE_INVALID_ID;
+    }
     return ORBIS_OK;
 }
 
-int PS4_SYSV_ABI sceSysmoduleIsLoadedInternal() {
-    LOG_ERROR(Lib_SysModule, "(STUBBED) called");
+int PS4_SYSV_ABI sceSysmoduleIsLoadedInternal(OrbisSysModuleInternal id) {
+    LOG_ERROR(Lib_SysModule, "(DUMMY) called module = {:#x}", static_cast<u32>(id));
+    if ((static_cast<u32>(id) & 0x7FFFFFFF) == 0) {
+        LOG_ERROR(Lib_SysModule, "Invalid internal sysmodule ID: {:#x}", static_cast<u32>(id));
+        return ORBIS_SYSMODULE_INVALID_ID;
+    }
+    if (id == OrbisSysModuleInternal::ORBIS_SYSMODULE_INTERNAL_RAZOR_CPU) {
+        // Internal debugging library, report as not loaded so it won't be used.
+        return ORBIS_SYSMODULE_NOT_LOADED;
+    }
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/system/sysmodule.h
+++ b/src/core/libraries/system/sysmodule.h
@@ -147,12 +147,16 @@ enum class OrbisSysModule : u16 {
     ORBIS_SYSMODULE_KEYBOARD = 0x0106,
 };
 
+enum class OrbisSysModuleInternal : u32 {
+    ORBIS_SYSMODULE_INTERNAL_RAZOR_CPU = 0x80000019, // libSceRazorCpu.sprx
+};
+
 int PS4_SYSV_ABI sceSysmoduleGetModuleHandleInternal();
 int PS4_SYSV_ABI sceSysmoduleGetModuleInfoForUnwind();
 int PS4_SYSV_ABI sceSysmoduleIsCalledFromSysModule();
 int PS4_SYSV_ABI sceSysmoduleIsCameraPreloaded();
 int PS4_SYSV_ABI sceSysmoduleIsLoaded(OrbisSysModule id);
-int PS4_SYSV_ABI sceSysmoduleIsLoadedInternal();
+int PS4_SYSV_ABI sceSysmoduleIsLoadedInternal(OrbisSysModuleInternal id);
 int PS4_SYSV_ABI sceSysmoduleLoadModule(OrbisSysModule id);
 int PS4_SYSV_ABI sceSysmoduleLoadModuleByNameInternal();
 int PS4_SYSV_ABI sceSysmoduleLoadModuleInternal();

--- a/src/core/libraries/system/system_error.h
+++ b/src/core/libraries/system/system_error.h
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+constexpr int ORBIS_SYSMODULE_INVALID_ID = 0x805A1000;
+constexpr int ORBIS_SYSMODULE_NOT_LOADED = 0x805A1001;
+constexpr int ORBIS_SYSMODULE_LOCK_FAILED = 0x805A10FF;

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -269,7 +269,7 @@ void Emulator::Run(const std::filesystem::path& file) {
 }
 
 void Emulator::LoadSystemModules(const std::filesystem::path& file, std::string game_serial) {
-    constexpr std::array<SysModules, 11> ModulesToLoad{
+    constexpr std::array<SysModules, 10> ModulesToLoad{
         {{"libSceNgs2.sprx", &Libraries::Ngs2::RegisterlibSceNgs2},
          {"libSceFiber.sprx", &Libraries::Fiber::RegisterlibSceFiber},
          {"libSceUlt.sprx", nullptr},
@@ -279,7 +279,6 @@ void Emulator::LoadSystemModules(const std::filesystem::path& file, std::string 
          {"libSceDiscMap.sprx", &Libraries::DiscMap::RegisterlibSceDiscMap},
          {"libSceRtc.sprx", &Libraries::Rtc::RegisterlibSceRtc},
          {"libSceJpegEnc.sprx", nullptr},
-         {"libSceRazorCpu.sprx", nullptr},
          {"libSceCesCs.sprx", nullptr}}};
 
     std::vector<std::filesystem::path> found_modules;


### PR DESCRIPTION
Uses of `libSceRazorCpu`, the primary current one being in `libSceFiber`, are gated behind checks that the sysmodule is loaded. Since it is only used for internal debugging and not useful to us as LLE, we can reduce the number of libraries that we need to load by always returning it as unloaded when queried.

Since I was modifying the sysmodule query functions, I also added the validity check for the sysmodule ID and related error codes.

Tested in CUSA17416 (Persona 5 Royal) and CUSA01130 (Gravity Rush: Remastered).