### PR TITLE
libraries: Add libSceRazorCpu HLE skeleton.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,6 +318,8 @@ set(SYSTEM_LIBS src/core/libraries/system/commondialog.cpp
                 src/core/libraries/remote_play/remoteplay.h
                 src/core/libraries/share_play/shareplay.cpp
                 src/core/libraries/share_play/shareplay.h
+                src/core/libraries/razor_cpu/razor_cpu.cpp
+                src/core/libraries/razor_cpu/razor_cpu.h
 )
 
 set(VIDEOOUT_LIB src/core/libraries/videoout/buffer.h

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -3,13 +3,14 @@
 
 #include <fstream>
 #include <string>
-#include <common/version.h>
 #include <fmt/core.h>
 #include <fmt/xchar.h> // for wstring support
 #include <toml.hpp>
-#include "common/logging/formatter.h"
+
 #include "common/path_util.h"
 #include "config.h"
+#include "logging/formatter.h"
+#include "version.h"
 
 namespace toml {
 template <typename TC, typename K>
@@ -81,7 +82,8 @@ std::vector<std::string> m_pkg_viewer;
 std::vector<std::string> m_elf_viewer;
 std::vector<std::string> m_recent_files;
 std::string emulator_language = "en";
-// Settings
+
+// Language
 u32 m_language = 1; // english
 
 bool isNeoMode() {
@@ -334,6 +336,7 @@ void setMainWindowGeometry(u32 x, u32 y, u32 w, u32 h) {
     main_window_geometry_w = w;
     main_window_geometry_h = h;
 }
+
 bool addGameInstallDir(const std::filesystem::path& dir) {
     if (std::find(settings_install_dirs.begin(), settings_install_dirs.end(), dir) ==
         settings_install_dirs.end()) {
@@ -342,47 +345,60 @@ bool addGameInstallDir(const std::filesystem::path& dir) {
     }
     return false;
 }
+
 void removeGameInstallDir(const std::filesystem::path& dir) {
     auto iterator = std::find(settings_install_dirs.begin(), settings_install_dirs.end(), dir);
     if (iterator != settings_install_dirs.end()) {
         settings_install_dirs.erase(iterator);
     }
 }
+
 void setAddonInstallDir(const std::filesystem::path& dir) {
     settings_addon_install_dir = dir;
 }
+
 void setMainWindowTheme(u32 theme) {
     mw_themes = theme;
 }
+
 void setIconSize(u32 size) {
     m_icon_size = size;
 }
+
 void setIconSizeGrid(u32 size) {
     m_icon_size_grid = size;
 }
+
 void setSliderPosition(u32 pos) {
     m_slider_pos = pos;
 }
+
 void setSliderPositionGrid(u32 pos) {
     m_slider_pos_grid = pos;
 }
+
 void setTableMode(u32 mode) {
     m_table_mode = mode;
 }
+
 void setMainWindowWidth(u32 width) {
     m_window_size_W = width;
 }
+
 void setMainWindowHeight(u32 height) {
     m_window_size_H = height;
 }
+
 void setPkgViewer(const std::vector<std::string>& pkgList) {
     m_pkg_viewer.resize(pkgList.size());
     m_pkg_viewer = pkgList;
 }
+
 void setElfViewer(const std::vector<std::string>& elfList) {
     m_elf_viewer.resize(elfList.size());
     m_elf_viewer = elfList;
 }
+
 void setRecentFiles(const std::vector<std::string>& recentFiles) {
     m_recent_files.resize(recentFiles.size());
     m_recent_files = recentFiles;
@@ -395,18 +411,23 @@ void setEmulatorLanguage(std::string language) {
 u32 getMainWindowGeometryX() {
     return main_window_geometry_x;
 }
+
 u32 getMainWindowGeometryY() {
     return main_window_geometry_y;
 }
+
 u32 getMainWindowGeometryW() {
     return main_window_geometry_w;
 }
+
 u32 getMainWindowGeometryH() {
     return main_window_geometry_h;
 }
+
 const std::vector<std::filesystem::path>& getGameInstallDirs() {
     return settings_install_dirs;
 }
+
 std::filesystem::path getAddonInstallDir() {
     if (settings_addon_install_dir.empty()) {
         // Default for users without a config file or a config file from before this option existed
@@ -414,36 +435,47 @@ std::filesystem::path getAddonInstallDir() {
     }
     return settings_addon_install_dir;
 }
+
 u32 getMainWindowTheme() {
     return mw_themes;
 }
+
 u32 getIconSize() {
     return m_icon_size;
 }
+
 u32 getIconSizeGrid() {
     return m_icon_size_grid;
 }
+
 u32 getSliderPosition() {
     return m_slider_pos;
 }
+
 u32 getSliderPositionGrid() {
     return m_slider_pos_grid;
 }
+
 u32 getTableMode() {
     return m_table_mode;
 }
+
 u32 getMainWindowWidth() {
     return m_window_size_W;
 }
+
 u32 getMainWindowHeight() {
     return m_window_size_H;
 }
+
 std::vector<std::string> getPkgViewer() {
     return m_pkg_viewer;
 }
+
 std::vector<std::string> getElfViewer() {
     return m_elf_viewer;
 }
+
 std::vector<std::string> getRecentFiles() {
     return m_recent_files;
 }
@@ -455,6 +487,7 @@ std::string getEmulatorLanguage() {
 u32 GetLanguage() {
     return m_language;
 }
+
 void load(const std::filesystem::path& path) {
     // If the configuration file does not exist, create it and return
     std::error_code error;
@@ -545,18 +578,6 @@ void load(const std::filesystem::path& path) {
         m_window_size_W = toml::find_or<int>(gui, "mw_width", 0);
         m_window_size_H = toml::find_or<int>(gui, "mw_height", 0);
 
-        // TODO Migration code, after a major release this should be removed.
-        auto old_game_install_dir = toml::find_fs_path_or(gui, "installDir", {});
-        if (!old_game_install_dir.empty()) {
-            addGameInstallDir(std::filesystem::path{old_game_install_dir});
-        } else {
-            const auto install_dir_array =
-                toml::find_or<std::vector<std::string>>(gui, "installDirs", {});
-            for (const auto& dir : install_dir_array) {
-                addGameInstallDir(std::filesystem::path{dir});
-            }
-        }
-
         settings_addon_install_dir = toml::find_fs_path_or(gui, "addonInstallDir", {});
         main_window_geometry_x = toml::find_or<int>(gui, "geometry_x", 0);
         main_window_geometry_y = toml::find_or<int>(gui, "geometry_y", 0);
@@ -575,6 +596,7 @@ void load(const std::filesystem::path& path) {
         m_language = toml::find_or<int>(settings, "consoleLanguage", 1);
     }
 }
+
 void save(const std::filesystem::path& path) {
     toml::value data;
 
@@ -654,9 +676,6 @@ void save(const std::filesystem::path& path) {
     data["GUI"]["emulatorLanguage"] = emulator_language;
 
     data["Settings"]["consoleLanguage"] = m_language;
-
-    // TODO Migration code, after a major release this should be removed.
-    data.at("GUI").as_table().erase("installDir");
 
     std::ofstream file(path, std::ios::binary);
     file << data;

--- a/src/common/logging/filter.cpp
+++ b/src/common/logging/filter.cpp
@@ -121,6 +121,7 @@ bool ParseFilterRule(Filter& instance, Iterator begin, Iterator end) {
     SUB(Lib, Fiber)                                                                                \
     SUB(Lib, Vdec2)                                                                                \
     SUB(Lib, Videodec)                                                                             \
+    SUB(Lib, RazorCpu)                                                                             \
     CLS(Frontend)                                                                                  \
     CLS(Render)                                                                                    \
     SUB(Render, Vulkan)                                                                            \

--- a/src/common/logging/types.h
+++ b/src/common/logging/types.h
@@ -88,6 +88,7 @@ enum class Class : u8 {
     Lib_Fiber,             ///< The LibSceFiber implementation.
     Lib_Vdec2,             ///< The LibSceVideodec2 implementation.
     Lib_Videodec,          ///< The LibSceVideodec implementation.
+    Lib_RazorCpu,          ///< The LibRazorCpu implementation.
     Frontend,              ///< Emulator UI
     Render,                ///< Video Core
     Render_Vulkan,         ///< Vulkan backend

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -502,7 +502,7 @@ s32 PS4_SYSV_ABI sceKernelFsync(int fd) {
 s32 PS4_SYSV_ABI posix_fsync(int fd) {
     s32 result = sceKernelFsync(fd);
     if (result < 0) {
-        LOG_ERROR(Kernel_Pthread, "posix_fstat: error = {}", result);
+        LOG_ERROR(Kernel_Pthread, "posix_fsync: error = {}", result);
         ErrSceToPosix(result);
         return -1;
     }

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -10,6 +10,7 @@
 #include "common/singleton.h"
 #include "core/file_sys/fs.h"
 #include "core/libraries/error_codes.h"
+#include "core/libraries/kernel/kernel.h"
 #include "core/libraries/kernel/memory.h"
 #include "core/libraries/libs.h"
 #include "core/linker.h"
@@ -495,6 +496,16 @@ int PS4_SYSV_ABI sceKernelMunmap(void* addr, size_t len) {
     return SCE_OK;
 }
 
+int PS4_SYSV_ABI posix_munmap(void* addr, size_t len) {
+    int result = sceKernelMunmap(addr, len);
+    if (result < 0) {
+        LOG_ERROR(Kernel_Pthread, "posix_munmap: error = {}", result);
+        ErrSceToPosix(result);
+        return -1;
+    }
+    return result;
+}
+
 void RegisterMemory(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("rTXw65xmLIA", "libkernel", 1, "libkernel", 1, 1, sceKernelAllocateDirectMemory);
     LIB_FUNCTION("B+vc2AO2Zrc", "libkernel", 1, "libkernel", 1, 1,
@@ -517,6 +528,8 @@ void RegisterMemory(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("mL8NDH86iQI", "libkernel", 1, "libkernel", 1, 1, sceKernelMapNamedFlexibleMemory);
     LIB_FUNCTION("aNz11fnnzi4", "libkernel", 1, "libkernel", 1, 1,
                  sceKernelAvailableFlexibleMemorySize);
+    LIB_FUNCTION("aNz11fnnzi4", "libkernel_avlfmem", 1, "libkernel", 1, 1,
+                 sceKernelAvailableFlexibleMemorySize);
     LIB_FUNCTION("IWIBBdTHit4", "libkernel", 1, "libkernel", 1, 1, sceKernelMapFlexibleMemory);
     LIB_FUNCTION("p5EcQeEeJAE", "libkernel", 1, "libkernel", 1, 1,
                  _sceKernelRtldSetApplicationHeapAPI);
@@ -537,6 +550,8 @@ void RegisterMemory(Core::Loader::SymbolsResolver* sym) {
 
     LIB_FUNCTION("BPE9s9vQQXo", "libkernel", 1, "libkernel", 1, 1, posix_mmap);
     LIB_FUNCTION("BPE9s9vQQXo", "libScePosix", 1, "libkernel", 1, 1, posix_mmap);
+    LIB_FUNCTION("UqDGjXA5yUM", "libkernel", 1, "libkernel", 1, 1, posix_munmap);
+    LIB_FUNCTION("UqDGjXA5yUM", "libScePosix", 1, "libkernel", 1, 1, posix_munmap);
 }
 
 } // namespace Libraries::Kernel

--- a/src/core/libraries/kernel/threads/pthread_attr.cpp
+++ b/src/core/libraries/kernel/threads/pthread_attr.cpp
@@ -303,6 +303,8 @@ void RegisterThreadAttr(Core::Loader::SymbolsResolver* sym) {
                  posix_pthread_attr_getstacksize);
     LIB_FUNCTION("VUT1ZSrHT0I", "libScePosix", 1, "libkernel", 1, 1,
                  posix_pthread_attr_getdetachstate);
+    LIB_FUNCTION("JKyG3SWyA10", "libScePosix", 1, "libkernel", 1, 1,
+                 posix_pthread_attr_setguardsize);
 
     // Orbis
     LIB_FUNCTION("4+h9EzwKF4I", "libkernel", 1, "libkernel", 1, 1,

--- a/src/core/libraries/kernel/threads/pthread_spec.cpp
+++ b/src/core/libraries/kernel/threads/pthread_spec.cpp
@@ -150,6 +150,7 @@ void RegisterSpec(Core::Loader::SymbolsResolver* sym) {
 
     // Orbis
     LIB_FUNCTION("geDaqgH9lTg", "libkernel", 1, "libkernel", 1, 1, ORBIS(posix_pthread_key_create));
+    LIB_FUNCTION("PrdHuuDekhY", "libkernel", 1, "libkernel", 1, 1, ORBIS(posix_pthread_key_delete));
     LIB_FUNCTION("eoht7mQOCmo", "libkernel", 1, "libkernel", 1, 1, posix_pthread_getspecific);
     LIB_FUNCTION("+BzXYkqYeLE", "libkernel", 1, "libkernel", 1, 1,
                  ORBIS(posix_pthread_setspecific));

--- a/src/core/libraries/libs.cpp
+++ b/src/core/libraries/libs.cpp
@@ -28,6 +28,7 @@
 #include "core/libraries/pad/pad.h"
 #include "core/libraries/playgo/playgo.h"
 #include "core/libraries/random/random.h"
+#include "core/libraries/razor_cpu/razor_cpu.h"
 #include "core/libraries/remote_play/remoteplay.h"
 #include "core/libraries/rtc/rtc.h"
 #include "core/libraries/save_data/dialog/savedatadialog.h"
@@ -87,6 +88,7 @@ void InitHLELibs(Core::Loader::SymbolsResolver* sym) {
     Libraries::SharePlay::RegisterlibSceSharePlay(sym);
     Libraries::Remoteplay::RegisterlibSceRemoteplay(sym);
     Libraries::Videodec::RegisterlibSceVideodec(sym);
+    Libraries::RazorCpu::RegisterlibSceRazorCpu(sym);
 }
 
 } // namespace Libraries

--- a/src/core/libraries/razor_cpu/razor_cpu.cpp
+++ b/src/core/libraries/razor_cpu/razor_cpu.cpp
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "razor_cpu.h"
+
+#include "common/logging/log.h"
+#include "core/libraries/error_codes.h"
+#include "core/libraries/libs.h"
+
+namespace Libraries::RazorCpu {
+
+s32 PS4_SYSV_ABI sceRazorCpuBeginLogicalFileAccess() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+void PS4_SYSV_ABI sceRazorCpuDisableFiberUserMarkers() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuEndLogicalFileAccess() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuFiberLogNameChange() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuFiberSwitch() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+bool PS4_SYSV_ABI sceRazorCpuFlushOccurred() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return false;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuGetDataTagStorageSize() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuGpuMarkerSync() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuInitDataTags() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuInitializeGpuMarkerContext() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuInitializeInternal() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+bool PS4_SYSV_ABI sceRazorCpuIsCapturing() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return false;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuJobManagerDispatch() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuJobManagerJob() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuJobManagerSequence() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuNamedSync() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuPlotValue() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuPopMarker() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuPushMarker() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuPushMarkerStatic() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuResizeTaggedBuffer() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+void PS4_SYSV_ABI sceRazorCpuSetPopMarkerCallback() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+}
+
+void PS4_SYSV_ABI sceRazorCpuSetPushMarkerCallback() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+}
+
+void PS4_SYSV_ABI sceRazorCpuSetPushMarkerStaticCallback() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuShutdownDataTags() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuStartCaptureInternal() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuStopCaptureInternal() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuSync() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuTagArray() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuTagBuffer() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuUnTagBuffer() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuWorkloadRunBegin() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuWorkloadRunEnd() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuWorkloadSubmit() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceRazorCpuWriteBookmark() {
+    LOG_DEBUG(Lib_RazorCpu, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+void RegisterlibSceRazorCpu(Core::Loader::SymbolsResolver* sym) {
+    LIB_FUNCTION("JFzLJBlYIJE", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuBeginLogicalFileAccess);
+    LIB_FUNCTION("SfRTRZ1Sh+U", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuDisableFiberUserMarkers);
+    LIB_FUNCTION("gVioM9cbiDs", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuEndLogicalFileAccess);
+    LIB_FUNCTION("G90IIOtgFQ0", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuFiberLogNameChange);
+    LIB_FUNCTION("PAytDtFGpqY", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuFiberSwitch);
+    LIB_FUNCTION("sPhrQD31ClM", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuFlushOccurred);
+    LIB_FUNCTION("B782NptkGUc", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuGetDataTagStorageSize);
+    LIB_FUNCTION("EH9Au2RlSrE", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuGpuMarkerSync);
+    LIB_FUNCTION("A7oRMdaOJP8", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuInitDataTags);
+    LIB_FUNCTION("NFwh-J-BrI0", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuInitializeGpuMarkerContext);
+    LIB_FUNCTION("ElNyedXaa4o", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuInitializeInternal);
+    LIB_FUNCTION("EboejOQvLL4", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuIsCapturing);
+    LIB_FUNCTION("dnEdyY4+klQ", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuJobManagerDispatch);
+    LIB_FUNCTION("KP+TBWGHlgs", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuJobManagerJob);
+    LIB_FUNCTION("9FowWFMEIM8", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuJobManagerSequence);
+    LIB_FUNCTION("XCuZoBSVFG8", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1, sceRazorCpuNamedSync);
+    LIB_FUNCTION("njGikRrxkC0", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1, sceRazorCpuPlotValue);
+    LIB_FUNCTION("YpkGsMXP3ew", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1, sceRazorCpuPopMarker);
+    LIB_FUNCTION("zw+celG7zSI", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1, sceRazorCpuPushMarker);
+    LIB_FUNCTION("uZrOwuNJX-M", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuPushMarkerStatic);
+    LIB_FUNCTION("D0yUjM33QqU", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuResizeTaggedBuffer);
+    LIB_FUNCTION("jqYWaTfgZs0", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuSetPopMarkerCallback);
+    LIB_FUNCTION("DJsHcEb94n0", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuSetPushMarkerCallback);
+    LIB_FUNCTION("EZtqozPTS4M", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuSetPushMarkerStaticCallback);
+    LIB_FUNCTION("emklx7RK-LY", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuShutdownDataTags);
+    LIB_FUNCTION("TIytAjYeaik", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuStartCaptureInternal);
+    LIB_FUNCTION("jWpkVWdMrsM", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuStopCaptureInternal);
+    LIB_FUNCTION("Ax7NjOzctIM", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1, sceRazorCpuSync);
+    LIB_FUNCTION("we3oTKSPSTw", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1, sceRazorCpuTagArray);
+    LIB_FUNCTION("vyjdThnQfQQ", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1, sceRazorCpuTagBuffer);
+    LIB_FUNCTION("0yNHPIkVTmw", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuUnTagBuffer);
+    LIB_FUNCTION("Crha9LvwvJM", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuWorkloadRunBegin);
+    LIB_FUNCTION("q1GxBfGHO0s", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuWorkloadRunEnd);
+    LIB_FUNCTION("6rUvx-6QmYc", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuWorkloadSubmit);
+    LIB_FUNCTION("G3brhegfyNg", "libSceRazorCpu", 1, "libSceRazorCpu", 1, 1,
+                 sceRazorCpuWriteBookmark);
+}
+
+} // namespace Libraries::RazorCpu

--- a/src/core/libraries/razor_cpu/razor_cpu.h
+++ b/src/core/libraries/razor_cpu/razor_cpu.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "common/types.h"
+
+#include <atomic>
+#include <memory>
+
+namespace Core::Loader {
+class SymbolsResolver;
+}
+
+namespace Libraries::RazorCpu {
+void RegisterlibSceRazorCpu(Core::Loader::SymbolsResolver* sym);
+} // namespace Libraries::RazorCpu

--- a/src/core/libraries/system/sysmodule.cpp
+++ b/src/core/libraries/system/sysmodule.cpp
@@ -48,10 +48,6 @@ int PS4_SYSV_ABI sceSysmoduleIsLoadedInternal(OrbisSysModuleInternal id) {
         LOG_ERROR(Lib_SysModule, "Invalid internal sysmodule ID: {:#x}", static_cast<u32>(id));
         return ORBIS_SYSMODULE_INVALID_ID;
     }
-    if (id == OrbisSysModuleInternal::ORBIS_SYSMODULE_INTERNAL_RAZOR_CPU) {
-        // Internal debugging library, report as not loaded so it won't be used.
-        return ORBIS_SYSMODULE_NOT_LOADED;
-    }
     return ORBIS_OK;
 }
 


### PR DESCRIPTION
Did a bit more looking into `libSceRazorCpu` and apparently the default behavior when the system hasn't initialized it with `sceRazorCpuInitializeInternal` is to just stub out every single function to return `ORBIS_OK` immediately.

Thus instead of pretending it isn't loaded, we can just add HLE stubs that debug log (to avoid spam) and return OK same as this default behavior, and everything works fine. This should help eliminate the log spam on some versions of PSPHD as well since it apparently does not check if the module is loaded. In the future we can also hook into these debug calls ourselves to add to our own debugging information.

Validated on Gravity Rush Remastered and Persona 5 Royal same as before.