### PR TITLE
libraries: Add stubs for libScePlayGoDialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,6 +373,8 @@ set(JPEG_LIB src/core/libraries/jpeg/jpeg_error.h
 
 set(PLAYGO_LIB src/core/libraries/playgo/playgo.cpp
                src/core/libraries/playgo/playgo.h
+               src/core/libraries/playgo/playgo_dialog.cpp
+               src/core/libraries/playgo/playgo_dialog.h
                src/core/libraries/playgo/playgo_types.h
 )
 

--- a/src/common/logging/filter.cpp
+++ b/src/common/logging/filter.cpp
@@ -107,6 +107,7 @@ bool ParseFilterRule(Filter& instance, Iterator begin, Iterator end) {
     SUB(Lib, Png)                                                                                  \
     SUB(Lib, Jpeg)                                                                                 \
     SUB(Lib, PlayGo)                                                                               \
+    SUB(Lib, PlayGoDialog)                                                                         \
     SUB(Lib, Random)                                                                               \
     SUB(Lib, Usbd)                                                                                 \
     SUB(Lib, Ajm)                                                                                  \

--- a/src/common/logging/types.h
+++ b/src/common/logging/types.h
@@ -74,6 +74,7 @@ enum class Class : u8 {
     Lib_Png,               ///< The LibScePng implementation.
     Lib_Jpeg,              ///< The LibSceJpeg implementation.
     Lib_PlayGo,            ///< The LibScePlayGo implementation.
+    Lib_PlayGoDialog,      ///< The LibScePlayGoDialog implementation.
     Lib_Random,            ///< The libSceRandom implementation.
     Lib_Usbd,              ///< The LibSceUsbd implementation.
     Lib_Ajm,               ///< The LibSceAjm implementation.

--- a/src/core/libraries/libs.cpp
+++ b/src/core/libraries/libs.cpp
@@ -27,6 +27,7 @@
 #include "core/libraries/np_trophy/np_trophy.h"
 #include "core/libraries/pad/pad.h"
 #include "core/libraries/playgo/playgo.h"
+#include "core/libraries/playgo/playgo_dialog.h"
 #include "core/libraries/random/random.h"
 #include "core/libraries/razor_cpu/razor_cpu.h"
 #include "core/libraries/remote_play/remoteplay.h"
@@ -74,6 +75,7 @@ void InitHLELibs(Core::Loader::SymbolsResolver* sym) {
     Libraries::AppContent::RegisterlibSceAppContent(sym);
     Libraries::PngDec::RegisterlibScePngDec(sym);
     Libraries::PlayGo::RegisterlibScePlayGo(sym);
+    Libraries::PlayGo::Dialog::RegisterlibScePlayGoDialog(sym);
     Libraries::Random::RegisterlibSceRandom(sym);
     Libraries::Usbd::RegisterlibSceUsbd(sym);
     Libraries::Pad::RegisterlibScePad(sym);

--- a/src/core/libraries/playgo/playgo_dialog.cpp
+++ b/src/core/libraries/playgo/playgo_dialog.cpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "common/assert.h"
+#include "common/logging/log.h"
+#include "core/libraries/libs.h"
+#include "core/libraries/playgo/playgo_dialog.h"
+#include "core/libraries/system/commondialog.h"
+
+namespace Libraries::PlayGo::Dialog {
+
+using CommonDialog::Error;
+using CommonDialog::Result;
+using CommonDialog::Status;
+
+Error PS4_SYSV_ABI scePlayGoDialogClose() {
+    LOG_ERROR(Lib_PlayGoDialog, "(DUMMY) called");
+    return Error::OK;
+}
+
+Error PS4_SYSV_ABI scePlayGoDialogGetResult(OrbisPlayGoDialogResult* result) {
+    LOG_ERROR(Lib_PlayGoDialog, "(DUMMY) called");
+    if (result == nullptr) {
+        return Error::ARG_NULL;
+    }
+    // Result value 3 allows games to proceed.
+    result->result = static_cast<Result>(3);
+    return Error::OK;
+}
+
+Status PS4_SYSV_ABI scePlayGoDialogGetStatus() {
+    LOG_ERROR(Lib_PlayGoDialog, "(DUMMY) called");
+    return Status::FINISHED;
+}
+
+Error PS4_SYSV_ABI scePlayGoDialogInitialize() {
+    LOG_ERROR(Lib_PlayGoDialog, "(DUMMY) called");
+    return Error::OK;
+}
+
+Error PS4_SYSV_ABI scePlayGoDialogOpen(const OrbisPlayGoDialogParam* param) {
+    LOG_ERROR(Lib_PlayGoDialog, "(DUMMY) called");
+    if (param == nullptr) {
+        return Error::ARG_NULL;
+    }
+    ASSERT(param->size == sizeof(OrbisPlayGoDialogParam));
+    ASSERT(param->baseParam.size == sizeof(CommonDialog::BaseParam));
+    return Error::OK;
+}
+
+Error PS4_SYSV_ABI scePlayGoDialogTerminate() {
+    LOG_ERROR(Lib_PlayGoDialog, "(DUMMY) called");
+    return Error::OK;
+}
+
+Status PS4_SYSV_ABI scePlayGoDialogUpdateStatus() {
+    LOG_ERROR(Lib_PlayGoDialog, "(DUMMY) called");
+    return Status::FINISHED;
+}
+
+void RegisterlibScePlayGoDialog(Core::Loader::SymbolsResolver* sym) {
+    LIB_FUNCTION("fbigNQiZpm0", "libScePlayGoDialog", 1, "libScePlayGoDialog", 1, 1,
+                 scePlayGoDialogClose);
+    LIB_FUNCTION("wx9TDplJKB4", "libScePlayGoDialog", 1, "libScePlayGoDialog", 1, 1,
+                 scePlayGoDialogGetResult);
+    LIB_FUNCTION("NOAMxY2EGS0", "libScePlayGoDialog", 1, "libScePlayGoDialog", 1, 1,
+                 scePlayGoDialogGetStatus);
+    LIB_FUNCTION("fECamTJKpsM", "libScePlayGoDialog", 1, "libScePlayGoDialog", 1, 1,
+                 scePlayGoDialogInitialize);
+    LIB_FUNCTION("kHd72ukqbxw", "libScePlayGoDialog", 1, "libScePlayGoDialog", 1, 1,
+                 scePlayGoDialogOpen);
+    LIB_FUNCTION("okgIGdr5Iz0", "libScePlayGoDialog", 1, "libScePlayGoDialog", 1, 1,
+                 scePlayGoDialogTerminate);
+    LIB_FUNCTION("Yb60K7BST48", "libScePlayGoDialog", 1, "libScePlayGoDialog", 1, 1,
+                 scePlayGoDialogUpdateStatus);
+};
+
+} // namespace Libraries::PlayGo::Dialog

--- a/src/core/libraries/playgo/playgo_dialog.h
+++ b/src/core/libraries/playgo/playgo_dialog.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "common/types.h"
+#include "core/libraries/system/commondialog.h"
+
+namespace Core::Loader {
+class SymbolsResolver;
+}
+
+namespace Libraries::PlayGo::Dialog {
+
+struct OrbisPlayGoDialogParam {
+    CommonDialog::BaseParam baseParam;
+    s32 size;
+    u8 unk[0x30];
+};
+static_assert(sizeof(OrbisPlayGoDialogParam) == 0x68);
+
+struct OrbisPlayGoDialogResult {
+    u8 unk1[0x4];
+    CommonDialog::Result result;
+    u8 unk2[0x20];
+};
+static_assert(sizeof(OrbisPlayGoDialogResult) == 0x28);
+
+CommonDialog::Error PS4_SYSV_ABI scePlayGoDialogClose();
+CommonDialog::Error PS4_SYSV_ABI scePlayGoDialogGetResult(OrbisPlayGoDialogResult* result);
+CommonDialog::Status PS4_SYSV_ABI scePlayGoDialogGetStatus();
+CommonDialog::Error PS4_SYSV_ABI scePlayGoDialogInitialize();
+CommonDialog::Error PS4_SYSV_ABI scePlayGoDialogOpen(const OrbisPlayGoDialogParam* param);
+CommonDialog::Error PS4_SYSV_ABI scePlayGoDialogTerminate();
+CommonDialog::Status PS4_SYSV_ABI scePlayGoDialogUpdateStatus();
+
+void RegisterlibScePlayGoDialog(Core::Loader::SymbolsResolver* sym);
+} // namespace Libraries::PlayGo::Dialog


### PR DESCRIPTION
Adds basic stubs for libScePlayGoDialog. These stubs pretend that the dialog was opened and then finished successfully.

~~Allows CUSA16404 to progress further loading a save in PS4 Pro mode.~~ This was actually only needed because a recent commit broke PlayGo functionality, but this may be useful to have anyway.