### PR TITLE
playgo: Fix loading PlayGo file.

### DIFF
--- a/src/core/file_format/playgo_chunk.h
+++ b/src/core/file_format/playgo_chunk.h
@@ -97,7 +97,6 @@ struct PlaygoChunk {
 
 class PlaygoFile {
 public:
-    bool initialized = false;
     OrbisPlayGoHandle handle = 0;
     OrbisPlayGoChunkId id = 0;
     OrbisPlayGoLocus locus = OrbisPlayGoLocus::NotDownloaded;

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -22,7 +22,6 @@
 #include "common/scm_rev.h"
 #include "common/singleton.h"
 #include "common/version.h"
-#include "core/file_format/playgo_chunk.h"
 #include "core/file_format/psf.h"
 #include "core/file_format/splash.h"
 #include "core/file_format/trp.h"
@@ -157,12 +156,6 @@ void Emulator::Run(const std::filesystem::path& file) {
                 fw_version = param_sfo->GetInteger("SYSTEM_VER").value_or(0x4700000);
                 app_version = param_sfo->GetString("APP_VER").value_or("Unknown version");
                 LOG_INFO(Loader, "Fw: {:#x} App Version: {}", fw_version, app_version);
-            } else if (entry.path().filename() == "playgo-chunk.dat") {
-                auto* playgo = Common::Singleton<PlaygoFile>::Instance();
-                auto filepath = sce_sys_folder / "playgo-chunk.dat";
-                if (!playgo->Open(filepath)) {
-                    LOG_ERROR(Loader, "PlayGo: unable to open file");
-                }
             } else if (entry.path().filename() == "pic1.png") {
                 auto* splash = Common::Singleton<Splash>::Instance();
                 if (splash->IsLoaded()) {


### PR DESCRIPTION
Recent cleanup made the PlayGo implementation stop using the `PlayGoFile` singleton, which the file is read to on startup, instead using a new instance that is never read to. This broke games that check PlayGo for file info as they would always receive an error that it was not supported.

Adds code to read the file on `scePlayGoInitialize` and removes the old singleton read code. Also fixes up how its being checked if PlayGo is initialized.

Tested with The Last Guardian.