### PR TITLE
shader: Specialize on vertex input number types if needed.

### DIFF
--- a/src/shader_recompiler/info.h
+++ b/src/shader_recompiler/info.h
@@ -130,6 +130,10 @@ struct Info {
         u8 dword_offset;
         InstanceIdType instance_step_rate;
         s32 instance_data_buf;
+
+        [[nodiscard]] constexpr AmdGpu::Buffer GetSharp(const Info& info) const noexcept {
+            return info.ReadUdReg<AmdGpu::Buffer>(sgpr_base, dword_offset);
+        }
     };
     boost::container::static_vector<VsInput, 32> vs_inputs{};
 

--- a/src/shader_recompiler/profile.h
+++ b/src/shader_recompiler/profile.h
@@ -24,6 +24,7 @@ struct Profile {
     bool support_explicit_workgroup_layout{};
     bool has_broken_spirv_clamp{};
     bool lower_left_origin_mode{};
+    bool support_legacy_vertex_attributes{};
     u64 min_ssbo_alignment{};
 };
 

--- a/src/video_core/amdgpu/pixel_format.h
+++ b/src/video_core/amdgpu/pixel_format.h
@@ -10,8 +10,25 @@
 
 namespace AmdGpu {
 
+enum NumberClass {
+    Float,
+    Sint,
+    Uint,
+};
+
 [[nodiscard]] constexpr bool IsInteger(NumberFormat nfmt) {
     return nfmt == AmdGpu::NumberFormat::Sint || nfmt == AmdGpu::NumberFormat::Uint;
+}
+
+[[nodiscard]] constexpr NumberClass GetNumberClass(NumberFormat nfmt) {
+    switch (nfmt) {
+    case NumberFormat::Sint:
+        return Sint;
+    case NumberFormat::Uint:
+        return Uint;
+    default:
+        return Float;
+    }
 }
 
 [[nodiscard]] std::string_view NameOf(DataFormat fmt);

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -157,7 +157,7 @@ bool BufferCache::BindVertexBuffers(const Shader::Info& vs_info) {
             continue;
         }
 
-        const auto& buffer = vs_info.ReadUdReg<AmdGpu::Buffer>(input.sgpr_base, input.dword_offset);
+        const auto& buffer = input.GetSharp(vs_info);
         if (buffer.GetSize() == 0) {
             continue;
         }

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -55,8 +55,7 @@ GraphicsPipeline::GraphicsPipeline(const Instance& instance_, Scheduler& schedul
                 continue;
             }
 
-            const auto buffer =
-                vs_info->ReadUdReg<AmdGpu::Buffer>(input.sgpr_base, input.dword_offset);
+            const auto buffer = input.GetSharp(*vs_info);
             if (buffer.GetSize() == 0) {
                 continue;
             }

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -264,6 +264,7 @@ bool Instance::CreateDevice() {
     const bool robustness = add_extension(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
     list_restart = add_extension(VK_EXT_PRIMITIVE_TOPOLOGY_LIST_RESTART_EXTENSION_NAME);
     maintenance5 = add_extension(VK_KHR_MAINTENANCE_5_EXTENSION_NAME);
+    legacy_vertex_attributes = add_extension(VK_EXT_LEGACY_VERTEX_ATTRIBUTES_EXTENSION_NAME);
 
     // These extensions are promoted by Vulkan 1.3, but for greater compatibility we use Vulkan 1.2
     // with extensions.
@@ -399,6 +400,9 @@ bool Instance::CreateDevice() {
         vk::PhysicalDevicePrimitiveTopologyListRestartFeaturesEXT{
             .primitiveTopologyListRestart = true,
         },
+        vk::PhysicalDeviceLegacyVertexAttributesFeaturesEXT{
+            .legacyVertexAttributes = true,
+        },
 #ifdef __APPLE__
         feature_chain.get<vk::PhysicalDevicePortabilitySubsetFeaturesKHR>(),
 #endif
@@ -437,6 +441,9 @@ bool Instance::CreateDevice() {
     }
     if (!vertex_input_dynamic_state) {
         device_chain.unlink<vk::PhysicalDeviceVertexInputDynamicStateFeaturesEXT>();
+    }
+    if (!legacy_vertex_attributes) {
+        device_chain.unlink<vk::PhysicalDeviceLegacyVertexAttributesFeaturesEXT>();
     }
 
     auto [device_result, dev] = physical_device.createDeviceUnique(device_chain.get());

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -143,8 +143,14 @@ public:
         return maintenance5;
     }
 
+    /// Returns true when VK_EXT_primitive_topology_list_restart is supported.
     bool IsListRestartSupported() const {
         return list_restart;
+    }
+
+    /// Returns true when VK_EXT_legacy_vertex_attributes is supported.
+    bool IsLegacyVertexAttributesSupported() const {
+        return legacy_vertex_attributes;
     }
 
     /// Returns true when geometry shaders are supported by the device
@@ -315,6 +321,7 @@ private:
     bool null_descriptor{};
     bool maintenance5{};
     bool list_restart{};
+    bool legacy_vertex_attributes{};
     u64 min_imported_host_pointer_alignment{};
     u32 subgroup_size{};
     bool tooling_info{};


### PR DESCRIPTION
According to Vulkan spec the vertex inputs should have number type classes (float, uint, int) matching those in the shader. This adds specialization to match that.

For drivers with `VK_EXT_legacy_vertex_attributes` support, this can be skipped, as it allows mismatched types:
* Windows: NVIDIA with Proprietary 552.61.0.0+
* Linux: AMD/NVIDIA/Intel with Mesa 24.2.0+, NVIDIA with Proprietary 550.40.63.0+

Fixes validation errors like:
```
VUID-vkCmdDrawIndexed-Input-08734: Validation Error: [ VUID-vkCmdDrawIndexed-Input-08734 ] Object 0: handle = 0xc1fcef000000854c, name = vs_0xee67e28b10b611ad_0, type = VK_OBJECT_TYPE_SHADER_MODULE; | MessageID = 0x1c98f0b9 | vkCmdDrawIndexed():  vkCmdSetVertexInputEXT set pVertexAttributeDescriptions[5] (binding 5, location 5) with format VK_FORMAT_R16G16B16A16_SINT but the vertex shader input is numeric type vec4 of float32.
```