### PR TITLE
shader_recompiler: Read image format info directly from sharps instead of storing in shader info.

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
@@ -187,7 +187,8 @@ Id EmitImageFetch(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, const
 Id EmitImageQueryDimensions(EmitContext& ctx, IR::Inst* inst, u32 handle, Id lod, bool has_mips) {
     const auto& texture = ctx.images[handle & 0xFFFF];
     const Id image = ctx.OpLoad(texture.image_type, texture.id);
-    const auto type = ctx.info.images[handle & 0xFFFF].type;
+    const auto sharp = ctx.info.images[handle & 0xFFFF].GetSharp(ctx.info);
+    const auto type = sharp.GetBoundType();
     const Id zero = ctx.u32_zero_value;
     const auto mips{[&] { return has_mips ? ctx.OpImageQueryLevels(ctx.U32[1], image) : zero; }};
     const bool uses_lod{type != AmdGpu::ImageType::Color2DMsaa && !texture.is_storage};

--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -435,7 +435,6 @@ void Translator::EmitFetch(const GcnInst& inst) {
 
         const u32 num_components = AmdGpu::NumComponents(buffer.GetDataFmt());
         info.vs_inputs.push_back({
-            .fmt = buffer.GetNumberFmt(),
             .binding = attrib.semantic,
             .num_components = std::min<u16>(attrib.num_elements, num_components),
             .sgpr_base = attrib.sgpr_base,

--- a/src/shader_recompiler/info.h
+++ b/src/shader_recompiler/info.h
@@ -57,7 +57,6 @@ using BufferResourceList = boost::container::small_vector<BufferResource, 16>;
 
 struct TextureBufferResource {
     u32 sharp_idx;
-    AmdGpu::NumberFormat nfmt;
     bool is_written{};
 
     constexpr AmdGpu::Buffer GetSharp(const Info& info) const noexcept;
@@ -66,8 +65,6 @@ using TextureBufferResourceList = boost::container::small_vector<TextureBufferRe
 
 struct ImageResource {
     u32 sharp_idx;
-    AmdGpu::ImageType type;
-    AmdGpu::NumberFormat nfmt;
     bool is_storage{};
     bool is_depth{};
     bool is_atomic{};
@@ -123,13 +120,16 @@ struct Info {
             Plain = 3,
         };
 
-        AmdGpu::NumberFormat fmt;
         u16 binding;
         u16 num_components;
         u8 sgpr_base;
         u8 dword_offset;
         InstanceIdType instance_step_rate;
         s32 instance_data_buf;
+
+        [[nodiscard]] constexpr AmdGpu::Buffer GetSharp(const Info& info) const noexcept {
+            return info.ReadUdReg<AmdGpu::Buffer>(sgpr_base, dword_offset);
+        }
     };
     boost::container::static_vector<VsInput, 32> vs_inputs{};
 

--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -381,7 +381,6 @@ void PatchTextureBufferInstruction(IR::Block& block, IR::Inst& inst, Info& info,
     const auto buffer = info.ReadUdSharp<AmdGpu::Buffer>(sharp);
     const s32 binding = descriptors.Add(TextureBufferResource{
         .sharp_idx = sharp,
-        .nfmt = buffer.GetNumberFmt(),
         .is_written = inst.GetOpcode() == IR::Opcode::StoreBufferFormatF32,
     });
 
@@ -660,11 +659,8 @@ void PatchImageInstruction(IR::Block& block, IR::Inst& inst, Info& info, Descrip
         }
     }
 
-    const auto type = image.IsPartialCubemap() ? AmdGpu::ImageType::Color2DArray : image.GetType();
     u32 image_binding = descriptors.Add(ImageResource{
         .sharp_idx = tsharp,
-        .type = type,
-        .nfmt = image.GetNumberFmt(),
         .is_storage = is_storage,
         .is_depth = bool(inst_info.is_depth),
         .is_atomic = IsImageAtomicInstruction(inst),

--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -621,7 +621,6 @@ void PatchImageInstruction(IR::Block& block, IR::Inst& inst, Info& info, Descrip
     auto image = info.ReadUdSharp<AmdGpu::Image>(tsharp);
     if (!image.Valid()) {
         LOG_ERROR(Render_Vulkan, "Shader compiled with unbound image!");
-        image = AmdGpu::Image::Null();
     }
     ASSERT(image.GetType() != AmdGpu::ImageType::Invalid);
     const bool is_storage = IsImageStorageInstruction(inst);

--- a/src/shader_recompiler/specialization.h
+++ b/src/shader_recompiler/specialization.h
@@ -75,8 +75,7 @@ struct StageSpecialization {
                      });
         ForEachSharp(binding, images, info->images,
                      [](auto& spec, const auto& desc, AmdGpu::Image sharp) {
-                         spec.type = sharp.IsPartialCubemap() ? AmdGpu::ImageType::Color2DArray
-                                                              : sharp.GetType();
+                         spec.type = sharp.GetBoundType();
                          spec.is_integer = AmdGpu::IsInteger(sharp.GetNumberFmt());
                      });
         ForEachSharp(binding, fmasks, info->fmasks,

--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -304,6 +304,10 @@ struct Image {
         const auto viewed_slice = last_array - base_array + 1;
         return GetType() == ImageType::Cube && viewed_slice < 6;
     }
+
+    ImageType GetBoundType() const noexcept {
+        return IsPartialCubemap() ? ImageType::Color2DArray : GetType();
+    }
 };
 static_assert(sizeof(Image) == 32); // 256bits
 

--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -176,18 +176,6 @@ struct Image {
     u64 lod_hw_cnt_en : 1;
     u64 : 43;
 
-    static constexpr Image Null() {
-        Image image{};
-        image.data_format = u64(DataFormat::Format8_8_8_8);
-        image.dst_sel_x = 4;
-        image.dst_sel_y = 5;
-        image.dst_sel_z = 6;
-        image.dst_sel_w = 7;
-        image.tiling_index = u64(TilingMode::Texture_MicroTiled);
-        image.type = u64(ImageType::Color2D);
-        return image;
-    }
-
     bool Valid() const {
         return (type & 0x8u) != 0;
     }
@@ -269,18 +257,21 @@ struct Image {
     }
 
     ImageType GetType() const noexcept {
-        return static_cast<ImageType>(type);
+        return Valid() ? static_cast<ImageType>(type) : ImageType::Color2D;
     }
 
     DataFormat GetDataFmt() const noexcept {
-        return static_cast<DataFormat>(data_format);
+        return Valid() ? static_cast<DataFormat>(data_format) : DataFormat::Format8_8_8_8;
     }
 
     NumberFormat GetNumberFmt() const noexcept {
-        return static_cast<NumberFormat>(num_format);
+        return Valid() ? static_cast<NumberFormat>(num_format) : NumberFormat::Unorm;
     }
 
     TilingMode GetTilingMode() const {
+        if (!Valid()) {
+            return TilingMode::Texture_MicroTiled;
+        }
         if (tiling_index >= 0 && tiling_index <= 7) {
             return tiling_index == 5 ? TilingMode::Texture_MicroTiled
                                      : TilingMode::Depth_MacroTiled;

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -157,7 +157,7 @@ bool BufferCache::BindVertexBuffers(const Shader::Info& vs_info) {
             continue;
         }
 
-        const auto& buffer = vs_info.ReadUdReg<AmdGpu::Buffer>(input.sgpr_base, input.dword_offset);
+        const auto& buffer = input.GetSharp(vs_info);
         if (buffer.GetSize() == 0) {
             continue;
         }

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -55,8 +55,7 @@ GraphicsPipeline::GraphicsPipeline(const Instance& instance_, Scheduler& schedul
                 continue;
             }
 
-            const auto buffer =
-                vs_info->ReadUdReg<AmdGpu::Buffer>(input.sgpr_base, input.dword_offset);
+            const auto buffer = input.GetSharp(*vs_info);
             if (buffer.GetSize() == 0) {
                 continue;
             }

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -349,8 +349,7 @@ bool PipelineCache::RefreshGraphicsKey() {
                 input.instance_step_rate == Shader::Info::VsInput::InstanceIdType::OverStepRate1) {
                 continue;
             }
-            const auto& buffer =
-                vs_info->ReadUdReg<AmdGpu::Buffer>(input.sgpr_base, input.dword_offset);
+            const auto& buffer = input.GetSharp(*vs_info);
             if (buffer.GetSize() == 0) {
                 continue;
             }

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -87,12 +87,9 @@ ImageViewInfo::ImageViewInfo(const AmdGpu::Image& image, const Shader::ImageReso
         range.extent.levels = image.last_level - image.base_level + 1;
     }
     range.extent.layers = image.last_array - image.base_array + 1;
-    type = ConvertImageViewType(image.GetType());
+    type = ConvertImageViewType(image.GetBoundType());
 
-    // Adjust view type for partial cubemaps and arrays
-    if (image.IsPartialCubemap()) {
-        type = vk::ImageViewType::e2DArray;
-    }
+    // Adjust view type for arrays
     if (type == vk::ImageViewType::eCube) {
         if (desc.is_array) {
             type = vk::ImageViewType::eCubeArray;


### PR DESCRIPTION
Bit of cleanup removing some of the format data stored in `Shader::Info` structures in favor of always reading it from the sharps.