### PR TITLE
renderer_vulkan: Add support for indexed QuadList draw.

### DIFF
--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -726,19 +726,6 @@ vk::Format DepthFormat(DepthBuffer::ZFormat z_format, DepthBuffer::StencilFormat
     return format->vk_format;
 }
 
-void EmitQuadToTriangleListIndices(u8* out_ptr, u32 num_vertices) {
-    static constexpr u16 NumVerticesPerQuad = 4;
-    u16* out_data = reinterpret_cast<u16*>(out_ptr);
-    for (u16 i = 0; i < num_vertices; i += NumVerticesPerQuad) {
-        *out_data++ = i;
-        *out_data++ = i + 1;
-        *out_data++ = i + 2;
-        *out_data++ = i;
-        *out_data++ = i + 2;
-        *out_data++ = i + 3;
-    }
-}
-
 vk::ClearValue ColorBufferClearValue(const AmdGpu::Liverpool::ColorBuffer& color_buffer) {
     const auto comp_swap = color_buffer.info.comp_swap.Value();
     const auto format = color_buffer.info.format.Value();

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.h
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.h
@@ -68,7 +68,33 @@ vk::ClearValue ColorBufferClearValue(const AmdGpu::Liverpool::ColorBuffer& color
 
 vk::SampleCountFlagBits NumSamples(u32 num_samples, vk::SampleCountFlags supported_flags);
 
-void EmitQuadToTriangleListIndices(u8* out_indices, u32 num_vertices);
+static constexpr u16 NumVerticesPerQuad = 4;
+
+inline void EmitQuadToTriangleListIndices(u8* out_ptr, u32 num_vertices) {
+    u16* out_data = reinterpret_cast<u16*>(out_ptr);
+    for (u16 i = 0; i < num_vertices; i += NumVerticesPerQuad) {
+        *out_data++ = i;
+        *out_data++ = i + 1;
+        *out_data++ = i + 2;
+        *out_data++ = i;
+        *out_data++ = i + 2;
+        *out_data++ = i + 3;
+    }
+}
+
+template <typename T>
+void ConvertQuadToTriangleListIndices(u8* out_ptr, const u8* in_ptr, u32 num_vertices) {
+    T* out_data = reinterpret_cast<T*>(out_ptr);
+    const T* in_data = reinterpret_cast<const T*>(in_ptr);
+    for (u16 i = 0; i < num_vertices; i += NumVerticesPerQuad) {
+        *out_data++ = in_data[i];
+        *out_data++ = in_data[i + 1];
+        *out_data++ = in_data[i + 2];
+        *out_data++ = in_data[i];
+        *out_data++ = in_data[i + 2];
+        *out_data++ = in_data[i + 3];
+    }
+}
 
 static inline vk::Format PromoteFormatToDepth(vk::Format fmt) {
     if (fmt == vk::Format::eR32Sfloat) {


### PR DESCRIPTION
Currently in the case of an indexed QuadList draw, the support code just ignores the index buffer and creates a new one with default vertex order. Instead, convert the existing index buffer to the new vertex order. Needed to move the index buffer generation/conversion to header functions to simplify templating.

Fixes vertex explosions from some effects in CUSA17416 - Persona 5 Royal, for example the pink splashes when walking.