### PR TITLE
thread: Configure stack and guard on POSIX hosts.

### DIFF
--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -281,7 +281,7 @@ int PS4_SYSV_ABI posix_pthread_create_name_np(PthreadT* thread, const PthreadAtt
 
     /* Create thread */
     new_thread->native_thr = Core::Thread();
-    int ret = new_thread->native_thr.Create(RunThread, new_thread);
+    int ret = new_thread->native_thr.Create(RunThread, new_thread, &new_thread->attr);
     ASSERT_MSG(ret == 0, "Failed to create thread with error {}", ret);
     if (ret) {
         *thread = nullptr;

--- a/src/core/thread.cpp
+++ b/src/core/thread.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "libraries/kernel/threads/pthread.h"
 #include "thread.h"
 
 #ifdef _WIN64
@@ -15,7 +16,7 @@ Thread::Thread() : native_handle{0} {}
 
 Thread::~Thread() {}
 
-int Thread::Create(ThreadFunc func, void* arg) {
+int Thread::Create(ThreadFunc func, void* arg, const ::Libraries::Kernel::PthreadAttr* attr) {
 #ifdef _WIN64
     native_handle = CreateThread(nullptr, 0, (LPTHREAD_START_ROUTINE)func, arg, 0, nullptr);
     return native_handle ? 0 : -1;
@@ -23,6 +24,7 @@ int Thread::Create(ThreadFunc func, void* arg) {
     pthread_t* pthr = reinterpret_cast<pthread_t*>(&native_handle);
     pthread_attr_t pattr;
     pthread_attr_init(&pattr);
+    pthread_attr_setstack(&pattr, attr->stackaddr_attr, attr->stacksize_attr);
     return pthread_create(pthr, &pattr, (PthreadFunc)func, arg);
 #endif
 }

--- a/src/core/thread.h
+++ b/src/core/thread.h
@@ -5,6 +5,10 @@
 
 #include "common/types.h"
 
+namespace Libraries::Kernel {
+struct PthreadAttr;
+} // namespace Libraries::Kernel
+
 namespace Core {
 
 class Thread {
@@ -15,7 +19,7 @@ public:
     Thread();
     ~Thread();
 
-    int Create(ThreadFunc func, void* arg);
+    int Create(ThreadFunc func, void* arg, const ::Libraries::Kernel::PthreadAttr* attr);
     void Exit();
 
     uintptr_t GetHandle() {


### PR DESCRIPTION
Applies the stack and guard configurations from the guest `PthreadAttr` to the host `pthread_attr_t` on POSIX systems.

Fixes a crash on launch in CUSA08010 when the default host stack size is too small.