### PR TITLE
shader_recompilers: Improvements to SSA phi generation and lane instruction elimination

### DIFF
--- a/src/shader_recompiler/frontend/control_flow_graph.cpp
+++ b/src/shader_recompiler/frontend/control_flow_graph.cpp
@@ -47,6 +47,15 @@ static IR::Condition MakeCondition(const GcnInst& inst) {
     }
 }
 
+static bool IgnoresExecMask(Opcode opcode) {
+    switch (opcode) {
+    case Opcode::V_WRITELANE_B32:
+        return true;
+    default:
+        return false;
+    }
+}
+
 static constexpr size_t LabelReserveSize = 32;
 
 CFG::CFG(Common::ObjectPool<Block>& block_pool_, std::span<const GcnInst> inst_list_)
@@ -133,20 +142,24 @@ void CFG::EmitDivergenceLabels() {
                     curr_begin = -1;
                     continue;
                 }
-                // Add a label to the instruction right after the open scope call.
-                // It is the start of a new basic block.
-                const auto& save_inst = inst_list[curr_begin];
-                const Label label = index_to_pc[curr_begin] + save_inst.length;
-                AddLabel(label);
-                // Add a label to the close scope instruction.
-                // There are 3 cases where we need to close a scope.
-                // * Close scope instruction inside the block
-                // * Close scope instruction at the end of the block (cbranch or endpgm)
-                // * Normal instruction at the end of the block
-                // For the last case we must NOT add a label as that would cause
-                // the instruction to be separated into its own basic block.
-                if (is_close) {
-                    AddLabel(index_to_pc[index]);
+                // If all instructions in the scope ignore exec masking, we shouldn't insert a scope.
+                const auto start = inst_list.begin() + curr_begin + 1;
+                if (!std::ranges::all_of(start, inst_list.begin() + index, IgnoresExecMask, &GcnInst::opcode)) {
+                    // Add a label to the instruction right after the open scope call.
+                    // It is the start of a new basic block.
+                    const auto& save_inst = inst_list[curr_begin];
+                    const Label label = index_to_pc[curr_begin] + save_inst.length;
+                    AddLabel(label);
+                    // Add a label to the close scope instruction.
+                    // There are 3 cases where we need to close a scope.
+                    // * Close scope instruction inside the block
+                    // * Close scope instruction at the end of the block (cbranch or endpgm)
+                    // * Normal instruction at the end of the block
+                    // For the last case we must NOT add a label as that would cause
+                    // the instruction to be separated into its own basic block.
+                    if (is_close) {
+                        AddLabel(index_to_pc[index]);
+                    }
                 }
                 // Reset scope begin.
                 curr_begin = -1;

--- a/src/shader_recompiler/frontend/control_flow_graph.cpp
+++ b/src/shader_recompiler/frontend/control_flow_graph.cpp
@@ -142,9 +142,11 @@ void CFG::EmitDivergenceLabels() {
                     curr_begin = -1;
                     continue;
                 }
-                // If all instructions in the scope ignore exec masking, we shouldn't insert a scope.
+                // If all instructions in the scope ignore exec masking, we shouldn't insert a
+                // scope.
                 const auto start = inst_list.begin() + curr_begin + 1;
-                if (!std::ranges::all_of(start, inst_list.begin() + index, IgnoresExecMask, &GcnInst::opcode)) {
+                if (!std::ranges::all_of(start, inst_list.begin() + index, IgnoresExecMask,
+                                         &GcnInst::opcode)) {
                     // Add a label to the instruction right after the open scope call.
                     // It is the start of a new basic block.
                     const auto& save_inst = inst_list[curr_begin];

--- a/src/shader_recompiler/ir/basic_block.cpp
+++ b/src/shader_recompiler/ir/basic_block.cpp
@@ -19,12 +19,14 @@ void Block::AppendNewInst(Opcode op, std::initializer_list<Value> args) {
 
 Block::iterator Block::PrependNewInst(iterator insertion_point, const Inst& base_inst) {
     Inst* const inst{inst_pool->Create(base_inst)};
+    inst->SetParent(this);
     return instructions.insert(insertion_point, *inst);
 }
 
 Block::iterator Block::PrependNewInst(iterator insertion_point, Opcode op,
                                       std::initializer_list<Value> args, u32 flags) {
     Inst* const inst{inst_pool->Create(op, flags)};
+    inst->SetParent(this);
     const auto result_it{instructions.insert(insertion_point, *inst)};
 
     if (inst->NumArgs() != args.size()) {

--- a/src/shader_recompiler/ir/ir_emitter.h
+++ b/src/shader_recompiler/ir/ir_emitter.h
@@ -330,6 +330,7 @@ private:
     template <typename T = Value, typename... Args>
     T Inst(Opcode op, Args... args) {
         auto it{block->PrependNewInst(insertion_point, op, {Value{args}...})};
+        it->SetParent(block);
         return T{Value{&*it}};
     }
 
@@ -347,6 +348,7 @@ private:
         u32 raw_flags{};
         std::memcpy(&raw_flags, &flags.proxy, sizeof(flags.proxy));
         auto it{block->PrependNewInst(insertion_point, op, {Value{args}...}, raw_flags)};
+        it->SetParent(block);
         return T{Value{&*it}};
     }
 };

--- a/src/shader_recompiler/ir/ir_emitter.h
+++ b/src/shader_recompiler/ir/ir_emitter.h
@@ -330,7 +330,6 @@ private:
     template <typename T = Value, typename... Args>
     T Inst(Opcode op, Args... args) {
         auto it{block->PrependNewInst(insertion_point, op, {Value{args}...})};
-        it->SetParent(block);
         return T{Value{&*it}};
     }
 
@@ -348,7 +347,6 @@ private:
         u32 raw_flags{};
         std::memcpy(&raw_flags, &flags.proxy, sizeof(flags.proxy));
         auto it{block->PrependNewInst(insertion_point, op, {Value{args}...}, raw_flags)};
-        it->SetParent(block);
         return T{Value{&*it}};
     }
 };

--- a/src/shader_recompiler/ir/microinstruction.cpp
+++ b/src/shader_recompiler/ir/microinstruction.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <algorithm>
+#include <any>
 #include <memory>
 
 #include "shader_recompiler/exception.h"
@@ -119,10 +120,10 @@ void Inst::SetArg(size_t index, Value value) {
     }
     const IR::Value arg{Arg(index)};
     if (!arg.IsImmediate()) {
-        UndoUse(arg);
+        UndoUse(arg.Inst(), index);
     }
     if (!value.IsImmediate()) {
-        Use(value);
+        Use(value.Inst(), index);
     }
     if (op == Opcode::Phi) {
         phi_args[index].second = value;
@@ -143,29 +144,32 @@ Block* Inst::PhiBlock(size_t index) const {
 
 void Inst::AddPhiOperand(Block* predecessor, const Value& value) {
     if (!value.IsImmediate()) {
-        Use(value);
+        Use(value.Inst(), phi_args.size());
     }
     phi_args.emplace_back(predecessor, value);
 }
 
 void Inst::Invalidate() {
+    ASSERT(uses.empty());
     ClearArgs();
     ReplaceOpcode(Opcode::Void);
 }
 
 void Inst::ClearArgs() {
     if (op == Opcode::Phi) {
-        for (auto& pair : phi_args) {
+        for (auto i = 0; i < phi_args.size(); i++) {
+            auto& pair = phi_args[i];
             IR::Value& value{pair.second};
             if (!value.IsImmediate()) {
-                UndoUse(value);
+                UndoUse(value.Inst(), i);
             }
         }
         phi_args.clear();
     } else {
-        for (auto& value : args) {
+        for (auto i = 0; i < args.size(); i++) {
+            auto& value = args[i];
             if (!value.IsImmediate()) {
-                UndoUse(value);
+                UndoUse(value.Inst(), i);
             }
         }
         // Reset arguments to null
@@ -174,13 +178,21 @@ void Inst::ClearArgs() {
     }
 }
 
-void Inst::ReplaceUsesWith(Value replacement) {
-    Invalidate();
-    ReplaceOpcode(Opcode::Identity);
-    if (!replacement.IsImmediate()) {
-        Use(replacement);
+void Inst::ReplaceUsesWith(Value replacement, bool preserve) {
+    // Copy since user->SetArg will mutate this->uses
+    // Could also do temp_uses = std::move(uses) but more readable
+    boost::container::list<IR::Use> temp_uses = uses;
+    for (auto& [user, operand] : temp_uses) {
+        DEBUG_ASSERT(user->Arg(operand).Inst() == this);
+        user->SetArg(operand, replacement);
     }
-    args[0] = replacement;
+    Invalidate();
+    if (preserve) {
+        // Still useful to have Identity for indirection.
+        // SSA pass would be more complicated without it
+        ReplaceOpcode(Opcode::Identity);
+        SetArg(0, replacement);
+    }
 }
 
 void Inst::ReplaceOpcode(IR::Opcode opcode) {
@@ -195,14 +207,15 @@ void Inst::ReplaceOpcode(IR::Opcode opcode) {
     op = opcode;
 }
 
-void Inst::Use(const Value& value) {
-    Inst* const inst{value.Inst()};
-    ++inst->use_count;
+void Inst::Use(Inst* used, u32 operand) {
+    DEBUG_ASSERT(0 == std::count(used->uses.begin(), used->uses.end(), IR::Use(this, operand)));
+    used->uses.emplace_front(this, operand);
 }
 
-void Inst::UndoUse(const Value& value) {
-    Inst* const inst{value.Inst()};
-    --inst->use_count;
+void Inst::UndoUse(Inst* used, u32 operand) {
+    IR::Use use(this, operand);
+    DEBUG_ASSERT(1 == std::count(used->uses.begin(), used->uses.end(), use));
+    used->uses.remove(use);
 }
 
 } // namespace Shader::IR

--- a/src/shader_recompiler/ir/microinstruction.cpp
+++ b/src/shader_recompiler/ir/microinstruction.cpp
@@ -180,8 +180,8 @@ void Inst::ClearArgs() {
 void Inst::ReplaceUsesWith(Value replacement, bool preserve) {
     // Copy since user->SetArg will mutate this->uses
     // Could also do temp_uses = std::move(uses) but more readable
-    boost::container::list<IR::Use> temp_uses = uses;
-    for (auto& [user, operand] : temp_uses) {
+    const auto temp_uses = uses;
+    for (const auto& [user, operand] : temp_uses) {
         DEBUG_ASSERT(user->Arg(operand).Inst() == this);
         user->SetArg(operand, replacement);
     }

--- a/src/shader_recompiler/ir/microinstruction.cpp
+++ b/src/shader_recompiler/ir/microinstruction.cpp
@@ -150,7 +150,6 @@ void Inst::AddPhiOperand(Block* predecessor, const Value& value) {
 }
 
 void Inst::Invalidate() {
-    ASSERT(uses.empty());
     ClearArgs();
     ReplaceOpcode(Opcode::Void);
 }

--- a/src/shader_recompiler/ir/passes/constant_propagation_pass.cpp
+++ b/src/shader_recompiler/ir/passes/constant_propagation_pass.cpp
@@ -43,7 +43,7 @@ bool FoldCommutative(IR::Inst& inst, ImmFn&& imm_fn) {
 
     if (is_lhs_immediate && is_rhs_immediate) {
         const auto result{imm_fn(Arg<T>(lhs), Arg<T>(rhs))};
-        inst.ReplaceUsesWith(IR::Value{result});
+        inst.ReplaceUsesWithAndRemove(IR::Value{result});
         return false;
     }
     if (is_lhs_immediate && !is_rhs_immediate) {
@@ -75,7 +75,7 @@ bool FoldWhenAllImmediates(IR::Inst& inst, Func&& func) {
         return false;
     }
     using Indices = std::make_index_sequence<Common::LambdaTraits<decltype(func)>::NUM_ARGS>;
-    inst.ReplaceUsesWith(EvalImmediates(inst, func, Indices{}));
+    inst.ReplaceUsesWithAndRemove(EvalImmediates(inst, func, Indices{}));
     return true;
 }
 
@@ -83,12 +83,12 @@ template <IR::Opcode op, typename Dest, typename Source>
 void FoldBitCast(IR::Inst& inst, IR::Opcode reverse) {
     const IR::Value value{inst.Arg(0)};
     if (value.IsImmediate()) {
-        inst.ReplaceUsesWith(IR::Value{std::bit_cast<Dest>(Arg<Source>(value))});
+        inst.ReplaceUsesWithAndRemove(IR::Value{std::bit_cast<Dest>(Arg<Source>(value))});
         return;
     }
     IR::Inst* const arg_inst{value.InstRecursive()};
     if (arg_inst->GetOpcode() == reverse) {
-        inst.ReplaceUsesWith(arg_inst->Arg(0));
+        inst.ReplaceUsesWithAndRemove(arg_inst->Arg(0));
         return;
     }
 }
@@ -131,7 +131,7 @@ void FoldCompositeExtract(IR::Inst& inst, IR::Opcode construct, IR::Opcode inser
     if (!result) {
         return;
     }
-    inst.ReplaceUsesWith(*result);
+    inst.ReplaceUsesWithAndRemove(*result);
 }
 
 void FoldConvert(IR::Inst& inst, IR::Opcode opposite) {
@@ -141,7 +141,7 @@ void FoldConvert(IR::Inst& inst, IR::Opcode opposite) {
     }
     IR::Inst* const producer{value.InstRecursive()};
     if (producer->GetOpcode() == opposite) {
-        inst.ReplaceUsesWith(producer->Arg(0));
+        inst.ReplaceUsesWithAndRemove(producer->Arg(0));
     }
 }
 
@@ -152,9 +152,9 @@ void FoldLogicalAnd(IR::Inst& inst) {
     const IR::Value rhs{inst.Arg(1)};
     if (rhs.IsImmediate()) {
         if (rhs.U1()) {
-            inst.ReplaceUsesWith(inst.Arg(0));
+            inst.ReplaceUsesWithAndRemove(inst.Arg(0));
         } else {
-            inst.ReplaceUsesWith(IR::Value{false});
+            inst.ReplaceUsesWithAndRemove(IR::Value{false});
         }
     }
 }
@@ -162,7 +162,7 @@ void FoldLogicalAnd(IR::Inst& inst) {
 void FoldSelect(IR::Inst& inst) {
     const IR::Value cond{inst.Arg(0)};
     if (cond.IsImmediate()) {
-        inst.ReplaceUsesWith(cond.U1() ? inst.Arg(1) : inst.Arg(2));
+        inst.ReplaceUsesWithAndRemove(cond.U1() ? inst.Arg(1) : inst.Arg(2));
     }
 }
 
@@ -173,9 +173,9 @@ void FoldLogicalOr(IR::Inst& inst) {
     const IR::Value rhs{inst.Arg(1)};
     if (rhs.IsImmediate()) {
         if (rhs.U1()) {
-            inst.ReplaceUsesWith(IR::Value{true});
+            inst.ReplaceUsesWithAndRemove(IR::Value{true});
         } else {
-            inst.ReplaceUsesWith(inst.Arg(0));
+            inst.ReplaceUsesWithAndRemove(inst.Arg(0));
         }
     }
 }
@@ -183,12 +183,12 @@ void FoldLogicalOr(IR::Inst& inst) {
 void FoldLogicalNot(IR::Inst& inst) {
     const IR::U1 value{inst.Arg(0)};
     if (value.IsImmediate()) {
-        inst.ReplaceUsesWith(IR::Value{!value.U1()});
+        inst.ReplaceUsesWithAndRemove(IR::Value{!value.U1()});
         return;
     }
     IR::Inst* const arg{value.InstRecursive()};
     if (arg->GetOpcode() == IR::Opcode::LogicalNot) {
-        inst.ReplaceUsesWith(arg->Arg(0));
+        inst.ReplaceUsesWithAndRemove(arg->Arg(0));
     }
 }
 
@@ -199,7 +199,7 @@ void FoldInverseFunc(IR::Inst& inst, IR::Opcode reverse) {
     }
     IR::Inst* const arg_inst{value.InstRecursive()};
     if (arg_inst->GetOpcode() == reverse) {
-        inst.ReplaceUsesWith(arg_inst->Arg(0));
+        inst.ReplaceUsesWithAndRemove(arg_inst->Arg(0));
         return;
     }
 }
@@ -211,7 +211,7 @@ void FoldAdd(IR::Block& block, IR::Inst& inst) {
     }
     const IR::Value rhs{inst.Arg(1)};
     if (rhs.IsImmediate() && Arg<T>(rhs) == 0) {
-        inst.ReplaceUsesWith(inst.Arg(0));
+        inst.ReplaceUsesWithAndRemove(inst.Arg(0));
         return;
     }
 }
@@ -226,7 +226,8 @@ void FoldCmpClass(IR::Block& block, IR::Inst& inst) {
     } else if ((class_mask & IR::FloatClassFunc::Finite) == IR::FloatClassFunc::Finite) {
         IR::IREmitter ir{block, IR::Block::InstructionList::s_iterator_to(inst)};
         const IR::F32 value = IR::F32{inst.Arg(0)};
-        inst.ReplaceUsesWith(ir.LogicalNot(ir.LogicalOr(ir.FPIsInf(value), ir.FPIsInf(value))));
+        inst.ReplaceUsesWithAndRemove(
+            ir.LogicalNot(ir.LogicalOr(ir.FPIsInf(value), ir.FPIsInf(value))));
     } else {
         UNREACHABLE();
     }
@@ -237,7 +238,7 @@ void FoldReadLane(IR::Inst& inst) {
     IR::Inst* prod = inst.Arg(0).InstRecursive();
     while (prod->GetOpcode() == IR::Opcode::WriteLane) {
         if (prod->Arg(2).U32() == lane) {
-            inst.ReplaceUsesWith(prod->Arg(1));
+            inst.ReplaceUsesWithAndRemove(prod->Arg(1));
             return;
         }
         prod = prod->Arg(0).InstRecursive();

--- a/src/shader_recompiler/ir/passes/constant_propagation_pass.cpp
+++ b/src/shader_recompiler/ir/passes/constant_propagation_pass.cpp
@@ -233,15 +233,51 @@ void FoldCmpClass(IR::Block& block, IR::Inst& inst) {
     }
 }
 
-void FoldReadLane(IR::Inst& inst) {
+void FoldReadLane(IR::Block& block, IR::Inst& inst) {
     const u32 lane = inst.Arg(1).U32();
     IR::Inst* prod = inst.Arg(0).InstRecursive();
-    while (prod->GetOpcode() == IR::Opcode::WriteLane) {
-        if (prod->Arg(2).U32() == lane) {
-            inst.ReplaceUsesWithAndRemove(prod->Arg(1));
+
+    const auto search_chain = [lane](const IR::Inst* prod) -> IR::Value {
+        while (prod->GetOpcode() == IR::Opcode::WriteLane) {
+            if (prod->Arg(2).U32() == lane) {
+                return prod->Arg(1);
+            }
+            prod = prod->Arg(0).InstRecursive();
+        }
+        return {};
+    };
+
+    if (prod->GetOpcode() == IR::Opcode::WriteLane) {
+        if (const IR::Value value = search_chain(prod); !value.IsEmpty()) {
+            inst.ReplaceUsesWith(value);
+        }
+        return;
+    }
+
+    if (prod->GetOpcode() == IR::Opcode::Phi) {
+        boost::container::small_vector<IR::Value, 2> phi_args;
+        for (size_t arg_index = 0; arg_index < prod->NumArgs(); ++arg_index) {
+            const IR::Inst* arg{prod->Arg(arg_index).InstRecursive()};
+            if (arg->GetOpcode() != IR::Opcode::WriteLane) {
+                return;
+            }
+            const IR::Value value = search_chain(arg);
+            if (value.IsEmpty()) {
+                continue;
+            }
+            phi_args.emplace_back(value);
+        }
+        if (std::ranges::all_of(phi_args, [&](IR::Value value) { return value == phi_args[0]; })) {
+            inst.ReplaceUsesWith(phi_args[0]);
             return;
         }
-        prod = prod->Arg(0).InstRecursive();
+        const auto insert_point = IR::Block::InstructionList::s_iterator_to(*prod);
+        IR::Inst* const new_phi{&*block.PrependNewInst(insert_point, IR::Opcode::Phi)};
+        new_phi->SetFlags(IR::Type::U32);
+        for (size_t arg_index = 0; arg_index < phi_args.size(); arg_index++) {
+            new_phi->AddPhiOperand(prod->PhiBlock(arg_index), phi_args[arg_index]);
+        }
+        inst.ReplaceUsesWith(IR::Value{new_phi});
     }
 }
 
@@ -291,7 +327,7 @@ void ConstantPropagation(IR::Block& block, IR::Inst& inst) {
     case IR::Opcode::SelectF64:
         return FoldSelect(inst);
     case IR::Opcode::ReadLane:
-        return FoldReadLane(inst);
+        return FoldReadLane(block, inst);
     case IR::Opcode::FPNeg32:
         FoldWhenAllImmediates(inst, [](f32 a) { return -a; });
         return;

--- a/src/shader_recompiler/ir/passes/lower_shared_mem_to_registers.cpp
+++ b/src/shader_recompiler/ir/passes/lower_shared_mem_to_registers.cpp
@@ -25,7 +25,7 @@ void LowerSharedMemToRegisters(IR::Program& program) {
                 });
                 ASSERT(it != ds_writes.end());
                 // Replace data read with value written.
-                inst.ReplaceUsesWith((*it)->Arg(1));
+                inst.ReplaceUsesWithAndRemove((*it)->Arg(1));
             }
         }
     }

--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -596,7 +596,7 @@ void PatchImageSampleInstruction(IR::Block& block, IR::Inst& inst, Info& info,
         }
         return ir.ImageSampleImplicitLod(handle, coords, bias, offset, inst_info);
     }();
-    inst.ReplaceUsesWith(new_inst);
+    inst.ReplaceUsesWithAndRemove(new_inst);
 }
 
 void PatchImageInstruction(IR::Block& block, IR::Inst& inst, Info& info, Descriptors& descriptors) {

--- a/src/shader_recompiler/ir/passes/ssa_rewrite_pass.cpp
+++ b/src/shader_recompiler/ir/passes/ssa_rewrite_pass.cpp
@@ -270,6 +270,7 @@ public:
         block->SsaSeal();
     }
 
+private:
     template <typename Type>
     IR::Value AddPhiOperands(Type variable, IR::Inst& phi, IR::Block* block) {
         for (IR::Block* const imm_pred : block->ImmPredecessors()) {
@@ -283,7 +284,7 @@ public:
         const size_t num_args{phi.NumArgs()};
         for (size_t arg_index = 0; arg_index < num_args; ++arg_index) {
             const IR::Value& op{phi.Arg(arg_index)};
-            if (op.Resolve() == same.Resolve() || op == IR::Value{&phi}) {
+            if (op.Resolve() == same.Resolve() || op.Resolve() == IR::Value{&phi}) {
                 // Unique value or self-reference
                 continue;
             }
@@ -308,10 +309,10 @@ public:
             ++reinsert_point;
         }
         // Reinsert the phi node and reroute all its uses to the "same" value
+        const auto users = phi.Uses();
         list.insert(reinsert_point, phi);
         phi.ReplaceUsesWith(same);
-        // TODO: Try to recursively remove all phi users, which might have become trivial
-        const auto users = phi.Uses();
+        // Try to recursively remove all phi users, which might have become trivial
         for (const auto& [user, arg_index] : users) {
             if (user->GetOpcode() == IR::Opcode::Phi) {
                 TryRemoveTrivialPhi(*user, user->GetParent(), undef_opcode);

--- a/src/shader_recompiler/ir/passes/ssa_rewrite_pass.cpp
+++ b/src/shader_recompiler/ir/passes/ssa_rewrite_pass.cpp
@@ -164,7 +164,6 @@ IR::Opcode UndefOpcode(const FlagTag) noexcept {
 enum class Status {
     Start,
     SetValue,
-    PreparePhiArgument,
     PushPhiArgument,
 };
 
@@ -253,11 +252,9 @@ public:
                 IR::Inst* const phi{stack.back().phi};
                 phi->AddPhiOperand(*stack.back().pred_it, stack.back().result);
                 ++stack.back().pred_it;
-            }
-                [[fallthrough]];
-            case Status::PreparePhiArgument:
                 prepare_phi_operand();
                 break;
+            }
             }
         } while (stack.size() > 1);
         return stack.back().result;
@@ -266,16 +263,13 @@ public:
     void SealBlock(IR::Block* block) {
         const auto it{incomplete_phis.find(block)};
         if (it != incomplete_phis.end()) {
-            for (auto& pair : it->second) {
-                auto& variant{pair.first};
-                auto& phi{pair.second};
+            for (auto& [variant, phi] : it->second) {
                 std::visit([&](auto& variable) { AddPhiOperands(variable, *phi, block); }, variant);
             }
         }
         block->SsaSeal();
     }
 
-private:
     template <typename Type>
     IR::Value AddPhiOperands(Type variable, IR::Inst& phi, IR::Block* block) {
         for (IR::Block* const imm_pred : block->ImmPredecessors()) {
@@ -317,6 +311,12 @@ private:
         list.insert(reinsert_point, phi);
         phi.ReplaceUsesWith(same);
         // TODO: Try to recursively remove all phi users, which might have become trivial
+        const auto users = phi.Uses();
+        for (const auto& [user, arg_index] : users) {
+            if (user->GetOpcode() == IR::Opcode::Phi) {
+                TryRemoveTrivialPhi(*user, user->GetParent(), undef_opcode);
+            }
+        }
         return same;
     }
 

--- a/src/shader_recompiler/ir/value.h
+++ b/src/shader_recompiler/ir/value.h
@@ -129,6 +129,14 @@ public:
     Inst& operator=(Inst&&) = delete;
     Inst(Inst&&) = delete;
 
+    IR::Block* GetParent() {
+        ASSERT(parent);
+        return parent;
+    }
+    void SetParent(IR::Block* block) {
+        parent = block;
+    }
+
     /// Get the number of uses this instruction has.
     [[nodiscard]] int UseCount() const noexcept {
         return uses.size();
@@ -214,6 +222,10 @@ public:
         return std::bit_cast<DefinitionType>(definition);
     }
 
+    const auto Uses() const {
+        return uses;
+    }
+
 private:
     struct NonTriviallyDummy {
         NonTriviallyDummy() noexcept {}
@@ -226,6 +238,7 @@ private:
     IR::Opcode op{};
     u32 flags{};
     u32 definition{};
+    IR::Block* parent{};
     union {
         NonTriviallyDummy dummy{};
         boost::container::small_vector<std::pair<Block*, Value>, 2> phi_args;
@@ -234,7 +247,7 @@ private:
 
     boost::container::list<IR::Use> uses;
 };
-static_assert(sizeof(Inst) <= 152, "Inst size unintentionally increased");
+static_assert(sizeof(Inst) <= 160, "Inst size unintentionally increased");
 
 using U1 = TypedValue<Type::U1>;
 using U8 = TypedValue<Type::U8>;

--- a/src/shader_recompiler/ir/value.h
+++ b/src/shader_recompiler/ir/value.h
@@ -129,7 +129,7 @@ public:
     Inst& operator=(Inst&&) = delete;
     Inst(Inst&&) = delete;
 
-    IR::Block* GetParent() {
+    IR::Block* GetParent() const {
         ASSERT(parent);
         return parent;
     }

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -702,7 +702,7 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, int vqid) {
                                        false);
             } else if (dma_data->src_sel == DmaDataSrc::Gds &&
                        dma_data->dst_sel == DmaDataDst::Memory) {
-                LOG_WARNING(Render_Vulkan, "GDS memory read");
+                // LOG_WARNING(Render_Vulkan, "GDS memory read");
             } else if (dma_data->src_sel == DmaDataSrc::Memory &&
                        dma_data->dst_sel == DmaDataDst::Memory) {
                 rasterizer->InlineData(dma_data->DstAddress<VAddr>(),


### PR DESCRIPTION
This PR is mostly aimed at solving issues with fur simulation and lightvolume shaders in The Last Guardian. No bugs are expected to be fixed in other games but some regression testing would be appreciated, especially in _that game_ since the latter pass was originally made to fix it.

Both of these shaders had issues with lingering ReadLane instructions that couldn't be eliminated by the simple pass because of phi nodes being in the way. Lane instructions on AMD hw allow the broadcasting of an SGPR to a specific VGPR or the opposite, the scalarization of a specific VGPR. The compiler seeks to eliminate them for two main reasons, firstly is that they are most often the byproduct of compiler (possibly trying to conserve SGPR space) and secondly is that their proper emulation on NVIDIA requires expensive shared memory setup which we would rather avoid. 

Lane instructions however present an interesting challenge, as they expose the dimensionality of the GPU registers (a single VGPR can have up to warp size distinct copies). Because we don't want to have to represent that in our IR, we perform the same trick AMD did in their SPIRV [WriteInvocationAMD](https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/AMD/SPV_AMD_shader_ballot.asciidoc#writeinvocationamd) where the input SSA value is passed to the instruction itself. This means that WriteLane instructions form chains where one follows another. When such a chain leads directly to a ReadLane chain, our work is simple and this has been handled fine for a while. This time however the WriteLane instructions were at the start of the shader and the ReadLane ones inside a nested loop, thus separated by a Phi.

But in fact those phi nodes were all _trivial_. A phi node is named trivial when it references itself or the same value some number of times, which means it can be substituted in all its users with the value it references. However ssa_rewrite pass was missing the required recursive elimination to perform this (See Algorithm 3, page 106 of the original SSA [paper](https://link.springer.com/chapter/10.1007/978-3-642-37051-9_6))

So the first commit of this PR adds a subset of the instruction use tracking implementation from @baggins183 we need and implements this elimination. In addition it solves a bug in TryRemoveTrivialPhi which prevented elimination of many trivial phis (missing Resolve call when comparing phi arg to itself). Shaders with many loops are now noticeably reduced in size/bloat (I've even seen some with 1000 less lines of GLSL code) and lane elimination pass now works with more cases than before.

However there are still cases where a phi cannot be eliminated, at the moment we only consider 2 of them. First case is the simplest which involves a phi node with distinct arguments, but following either one, leads to the same matching WriteLane

```
[000000012dff2948] %186   = WriteLane %170, %185, #30 (uses: 1)
[000000012dff2bc8] %187   = WriteLane %186, %184, #29 (uses: 2)
[000000012dff2e48] %188   = UGreaterThan %182, %181 (uses: 35)
[000000012dff3348] %189   = ConditionRef %188 (uses: 0)

Block $1
[000000012dff35c8] %190   = WriteLane %187, %183, #28 (uses: 1)
[000000012dff3848] %191   = WriteLane %190, %182, #27 (uses: 1)

Block $2
[000000012e242388] %192   = Phi [ %191, {Block $1} ], [ %187, {Block $0} ] (uses: 2)
[000000012dff3c08] %193   = ConditionRef %188 (uses: 0)

Block $3
[000000012dff3de8] %194   = ReadLane %192, #30 (uses: 1)
```

In this case we can directly replace the read lane with the value of found write lane and ignore the phi.
The second case is more involved but seen in the lightvolume shader. This shader maintains a loop counter inside a VGPR which is initialized at the start, and then loaded with read lane, incremented and stored back with write lane as seen in below pseudocode

```glsl
v26[27] = 0;
for (;;) {
    s14 = readlane(v26, 27);
    s15 = s14 + 1;
    writelane(v26, 27, s15);
    if (!(s15 < 0x80)) {
      break;
    }  
}
```

In this case we have to search the chains of each phi argument, and insert a new phi just for this write and read lane pair, replacing the read lane instruction with the phi value. This must be done to preserve the original control flow of the shader. If multiple read write pairs were inside the loop, each would get a separate phi as each dimension of VGPR must be considered a separate value,