### PR TITLE
video_core: fix for targets clears and copies

### DIFF
--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -398,17 +398,15 @@ ImageView& TextureCache::FindRenderTarget(BaseDesc& desc) {
     // Register meta data for this color buffer
     if (!(image.flags & ImageFlagBits::MetaRegistered)) {
         if (desc.info.meta_info.cmask_addr) {
-            surface_metas.emplace(
-                desc.info.meta_info.cmask_addr,
-                MetaDataInfo{.type = MetaDataInfo::Type::CMask, .is_cleared = true});
+            surface_metas.emplace(desc.info.meta_info.cmask_addr,
+                                  MetaDataInfo{.type = MetaDataInfo::Type::CMask});
             image.info.meta_info.cmask_addr = desc.info.meta_info.cmask_addr;
             image.flags |= ImageFlagBits::MetaRegistered;
         }
 
         if (desc.info.meta_info.fmask_addr) {
-            surface_metas.emplace(
-                desc.info.meta_info.fmask_addr,
-                MetaDataInfo{.type = MetaDataInfo::Type::FMask, .is_cleared = true});
+            surface_metas.emplace(desc.info.meta_info.fmask_addr,
+                                  MetaDataInfo{.type = MetaDataInfo::Type::FMask});
             image.info.meta_info.fmask_addr = desc.info.meta_info.fmask_addr;
             image.flags |= ImageFlagBits::MetaRegistered;
         }
@@ -428,9 +426,8 @@ ImageView& TextureCache::FindDepthTarget(BaseDesc& desc) {
     // Register meta data for this depth buffer
     if (!(image.flags & ImageFlagBits::MetaRegistered)) {
         if (desc.info.meta_info.htile_addr) {
-            surface_metas.emplace(
-                desc.info.meta_info.htile_addr,
-                MetaDataInfo{.type = MetaDataInfo::Type::HTile, .is_cleared = true});
+            surface_metas.emplace(desc.info.meta_info.htile_addr,
+                                  MetaDataInfo{.type = MetaDataInfo::Type::HTile});
             image.info.meta_info.htile_addr = desc.info.meta_info.htile_addr;
             image.flags |= ImageFlagBits::MetaRegistered;
         }

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -156,18 +156,31 @@ public:
         return surface_metas.contains(address);
     }
 
-    bool IsMetaCleared(VAddr address) const {
+    bool IsMetaCleared(VAddr address, u32 slice) const {
         const auto& it = surface_metas.find(address);
         if (it != surface_metas.end()) {
-            return it.value().is_cleared;
+            return it.value().clear_mask & (1u << slice);
         }
         return false;
     }
 
-    bool TouchMeta(VAddr address, bool is_clear) {
+    bool ClearMeta(VAddr address) {
         auto it = surface_metas.find(address);
         if (it != surface_metas.end()) {
-            it.value().is_cleared = is_clear;
+            it.value().clear_mask = u32(-1);
+            return true;
+        }
+        return false;
+    }
+
+    bool TouchMeta(VAddr address, u32 slice, bool is_clear) {
+        auto it = surface_metas.find(address);
+        if (it != surface_metas.end()) {
+            if (is_clear) {
+                it.value().clear_mask |= 1u << slice;
+            } else {
+                it.value().clear_mask &= ~(1u << slice);
+            }
             return true;
         }
         return false;
@@ -280,7 +293,7 @@ private:
             HTile,
         };
         Type type;
-        bool is_cleared;
+        u32 clear_mask{u32(-1)};
     };
     tsl::robin_map<VAddr, MetaDataInfo> surface_metas;
 };


### PR DESCRIPTION
These changes add proper handling of two scenarios with use of metadata found in TLG:
- arrayed CB/DB clears. Previously, we marked metas as dirty once correspondent attachments were bound to a render pass. Since their view information was ignored, all slices were considered as modified and clear was performed only on thefirst one. Now we track meta updates per slice;
- meta copies. The game performs depth copy for futher re-uses and together with depth surface also copies its meta. Previously we considered this case as meta clear which led to depth clear as well, now we have a heuristic to detect copy.