### PR TITLE
specialization: Fix fetch shader field type

### DIFF
--- a/src/shader_recompiler/frontend/fetch_shader.h
+++ b/src/shader_recompiler/frontend/fetch_shader.h
@@ -58,19 +58,6 @@ struct FetchShaderData {
                }) != attributes.end();
     }
 
-    [[nodiscard]] std::pair<u32, u32> GetDrawOffsets(const AmdGpu::Liverpool::Regs& regs,
-                                                     const Info& info) const {
-        u32 vertex_offset = regs.index_offset;
-        u32 instance_offset = 0;
-        if (vertex_offset == 0 && vertex_offset_sgpr != -1) {
-            vertex_offset = info.user_data[vertex_offset_sgpr];
-        }
-        if (instance_offset_sgpr != -1) {
-            instance_offset = info.user_data[instance_offset_sgpr];
-        }
-        return {vertex_offset, instance_offset};
-    }
-
     bool operator==(const FetchShaderData& other) const {
         return attributes == other.attributes && vertex_offset_sgpr == other.vertex_offset_sgpr &&
                instance_offset_sgpr == other.instance_offset_sgpr;

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -279,6 +279,8 @@ bool PipelineCache::RefreshGraphicsKey() {
         ++remapped_cb;
     }
 
+    fetch_shader = std::nullopt;
+
     Shader::Backend::Bindings binding{};
     const auto& TryBindStageRemap = [&](Shader::Stage stage_in, Shader::Stage stage_out) -> bool {
         const auto stage_in_idx = static_cast<u32>(stage_in);


### PR DESCRIPTION
`fetch_shader_data` was not wrapped in `optional` and thus `GetProgram` would always return it as the fetch shader, regardless of whether the shader actually had a fetch shader. Normally this was harmless since vertex shaders are bound last, but in the case of geometry shaders this is not true. Changed to optional type to fix this.

With this fix I also had to fix up `GetDrawOffsets` to work when there is no fetch shader for a pipeline; it worked previously as there would unintentionally be a default-initialized fetch shader object.