### PR TITLE
recompiler: fixed fragment shader built-in attribute access

### DIFF
--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -53,28 +53,73 @@ void Translator::EmitPrologue() {
         }
         break;
     case Stage::Fragment:
-        // https://github.com/chaotic-cx/mesa-mirror/blob/72326e15/src/amd/vulkan/radv_shader_args.c#L258
-        // The first two VGPRs are used for i/j barycentric coordinates. In the vast majority of
-        // cases it will be only those two, but if shader is using both e.g linear and perspective
-        // inputs it can be more For now assume that this isn't the case.
-        dst_vreg = IR::VectorReg::V2;
-        for (u32 i = 0; i < 4; i++) {
-            if (True(runtime_info.fs_info.addr_flags & Shader::PsInputFlags(1 << i))) {
-                if (True(runtime_info.fs_info.en_flags & Shader::PsInputFlags(1 << i))) {
-                    ir.SetVectorReg(dst_vreg, ir.GetAttribute(IR::Attribute::FragCoord, i));
-                } else {
-                    ir.SetVectorReg(dst_vreg, ir.Imm32(0.0f));
-                }
-                ++dst_vreg;
+        dst_vreg = IR::VectorReg::V0;
+        if (runtime_info.fs_info.addr_flags.persp_sample_ena) {
+            ++dst_vreg; // I
+            ++dst_vreg; // J
+        }
+        if (runtime_info.fs_info.addr_flags.persp_center_ena) {
+            ++dst_vreg; // I
+            ++dst_vreg; // J
+        }
+        if (runtime_info.fs_info.addr_flags.persp_centroid_ena) {
+            ++dst_vreg; // I
+            ++dst_vreg; // J
+        }
+        if (runtime_info.fs_info.addr_flags.persp_pull_model_ena) {
+            ++dst_vreg; // I/W
+            ++dst_vreg; // J/W
+            ++dst_vreg; // 1/W
+        }
+        if (runtime_info.fs_info.addr_flags.linear_sample_ena) {
+            ++dst_vreg; // I
+            ++dst_vreg; // J
+        }
+        if (runtime_info.fs_info.addr_flags.linear_center_ena) {
+            ++dst_vreg; // I
+            ++dst_vreg; // J
+        }
+        if (runtime_info.fs_info.addr_flags.linear_centroid_ena) {
+            ++dst_vreg; // I
+            ++dst_vreg; // J
+        }
+        if (runtime_info.fs_info.addr_flags.line_stipple_tex_ena) {
+            ++dst_vreg;
+        }
+        if (runtime_info.fs_info.addr_flags.pos_x_float_ena) {
+            if (runtime_info.fs_info.en_flags.pos_x_float_ena) {
+                ir.SetVectorReg(dst_vreg++, ir.GetAttribute(IR::Attribute::FragCoord, 0));
+            } else {
+                ir.SetVectorReg(dst_vreg++, ir.Imm32(0.0f));
             }
         }
-        if (True(runtime_info.fs_info.addr_flags & Shader::PsInputFlags::FrontFacing)) {
-            if (True(runtime_info.fs_info.en_flags & Shader::PsInputFlags::FrontFacing)) {
-                ir.SetVectorReg(dst_vreg, ir.GetAttributeU32(IR::Attribute::IsFrontFace));
+        if (runtime_info.fs_info.addr_flags.pos_y_float_ena) {
+            if (runtime_info.fs_info.en_flags.pos_y_float_ena) {
+                ir.SetVectorReg(dst_vreg++, ir.GetAttribute(IR::Attribute::FragCoord, 1));
             } else {
-                ir.SetVectorReg(dst_vreg, ir.Imm32(0));
+                ir.SetVectorReg(dst_vreg++, ir.Imm32(0.0f));
             }
-            ++dst_vreg;
+        }
+        if (runtime_info.fs_info.addr_flags.pos_z_float_ena) {
+            if (runtime_info.fs_info.en_flags.pos_z_float_ena) {
+                ir.SetVectorReg(dst_vreg++, ir.GetAttribute(IR::Attribute::FragCoord, 2));
+            } else {
+                ir.SetVectorReg(dst_vreg++, ir.Imm32(0.0f));
+            }
+        }
+        if (runtime_info.fs_info.addr_flags.pos_w_float_ena) {
+            if (runtime_info.fs_info.en_flags.pos_w_float_ena) {
+                ir.SetVectorReg(dst_vreg++, ir.GetAttribute(IR::Attribute::FragCoord, 3));
+            } else {
+                ir.SetVectorReg(dst_vreg++, ir.Imm32(0.0f));
+            }
+        }
+        if (runtime_info.fs_info.addr_flags.front_face_ena) {
+            if (runtime_info.fs_info.en_flags.front_face_ena) {
+                ir.SetVectorReg(dst_vreg++, ir.GetAttributeU32(IR::Attribute::IsFrontFace));
+            } else {
+                ir.SetVectorReg(dst_vreg++, ir.Imm32(0));
+            }
         }
         break;
     case Stage::Compute:

--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -59,9 +59,13 @@ void Translator::EmitPrologue() {
         // inputs it can be more For now assume that this isn't the case.
         dst_vreg = IR::VectorReg::V2;
         for (u32 i = 0; i < 4; i++) {
-            ir.SetVectorReg(dst_vreg++, ir.GetAttribute(IR::Attribute::FragCoord, i));
+            if (True(runtime_info.fs_info.en_flags & Shader::PsInputEnableFlags(1 << i))) {
+                ir.SetVectorReg(dst_vreg++, ir.GetAttribute(IR::Attribute::FragCoord, i));
+            }
         }
-        ir.SetVectorReg(dst_vreg++, ir.GetAttributeU32(IR::Attribute::IsFrontFace));
+        if (True(runtime_info.fs_info.en_flags & Shader::PsInputEnableFlags::FrontFacing)) {
+            ir.SetVectorReg(dst_vreg++, ir.GetAttributeU32(IR::Attribute::IsFrontFace));
+        }
         break;
     case Stage::Compute:
         ir.SetVectorReg(dst_vreg++, ir.GetAttributeU32(IR::Attribute::LocalInvocationId, 0));

--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -59,12 +59,22 @@ void Translator::EmitPrologue() {
         // inputs it can be more For now assume that this isn't the case.
         dst_vreg = IR::VectorReg::V2;
         for (u32 i = 0; i < 4; i++) {
-            if (True(runtime_info.fs_info.en_flags & Shader::PsInputEnableFlags(1 << i))) {
-                ir.SetVectorReg(dst_vreg++, ir.GetAttribute(IR::Attribute::FragCoord, i));
+            if (True(runtime_info.fs_info.addr_flags & Shader::PsInputFlags(1 << i))) {
+                if (True(runtime_info.fs_info.en_flags & Shader::PsInputFlags(1 << i))) {
+                    ir.SetVectorReg(dst_vreg, ir.GetAttribute(IR::Attribute::FragCoord, i));
+                } else {
+                    ir.SetVectorReg(dst_vreg, ir.Imm32(0.0f));
+                }
+                ++dst_vreg;
             }
         }
-        if (True(runtime_info.fs_info.en_flags & Shader::PsInputEnableFlags::FrontFacing)) {
-            ir.SetVectorReg(dst_vreg++, ir.GetAttributeU32(IR::Attribute::IsFrontFace));
+        if (True(runtime_info.fs_info.addr_flags & Shader::PsInputFlags::FrontFacing)) {
+            if (True(runtime_info.fs_info.en_flags & Shader::PsInputFlags::FrontFacing)) {
+                ir.SetVectorReg(dst_vreg, ir.GetAttributeU32(IR::Attribute::IsFrontFace));
+            } else {
+                ir.SetVectorReg(dst_vreg, ir.Imm32(0));
+            }
+            ++dst_vreg;
         }
         break;
     case Stage::Compute:

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -96,7 +96,7 @@ enum class MrtSwizzle : u8 {
 };
 static constexpr u32 MaxColorBuffers = 8;
 
-enum class PsInputEnableFlags : u8 {
+enum class PsInputFlags : u8 {
     None = 0,
     PosX = 1 << 0,
     PosY = 1 << 1,
@@ -104,7 +104,7 @@ enum class PsInputEnableFlags : u8 {
     PosW = 1 << 3,
     FrontFacing = 1 << 4,
 };
-DECLARE_ENUM_FLAG_OPERATORS(PsInputEnableFlags)
+DECLARE_ENUM_FLAG_OPERATORS(PsInputFlags)
 
 struct FragmentRuntimeInfo {
     struct PsInput {
@@ -115,7 +115,8 @@ struct FragmentRuntimeInfo {
 
         auto operator<=>(const PsInput&) const noexcept = default;
     };
-    PsInputEnableFlags en_flags;
+    PsInputFlags en_flags;
+    PsInputFlags addr_flags;
     u32 num_inputs;
     std::array<PsInput, 32> inputs;
     struct PsColorBuffer {
@@ -128,7 +129,8 @@ struct FragmentRuntimeInfo {
 
     bool operator==(const FragmentRuntimeInfo& other) const noexcept {
         return std::ranges::equal(color_buffers, other.color_buffers) &&
-               en_flags == other.en_flags && num_inputs == other.num_inputs &&
+               en_flags == other.en_flags && addr_flags == other.addr_flags &&
+               num_inputs == other.num_inputs &&
                std::ranges::equal(inputs.begin(), inputs.begin() + num_inputs, other.inputs.begin(),
                                   other.inputs.begin() + num_inputs);
     }

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -96,6 +96,16 @@ enum class MrtSwizzle : u8 {
 };
 static constexpr u32 MaxColorBuffers = 8;
 
+enum class PsInputEnableFlags : u8 {
+    None = 0,
+    PosX = 1 << 0,
+    PosY = 1 << 1,
+    PosZ = 1 << 2,
+    PosW = 1 << 3,
+    FrontFacing = 1 << 4,
+};
+DECLARE_ENUM_FLAG_OPERATORS(PsInputEnableFlags)
+
 struct FragmentRuntimeInfo {
     struct PsInput {
         u8 param_index;
@@ -105,6 +115,7 @@ struct FragmentRuntimeInfo {
 
         auto operator<=>(const PsInput&) const noexcept = default;
     };
+    PsInputEnableFlags en_flags;
     u32 num_inputs;
     std::array<PsInput, 32> inputs;
     struct PsColorBuffer {
@@ -117,7 +128,7 @@ struct FragmentRuntimeInfo {
 
     bool operator==(const FragmentRuntimeInfo& other) const noexcept {
         return std::ranges::equal(color_buffers, other.color_buffers) &&
-               num_inputs == other.num_inputs &&
+               en_flags == other.en_flags && num_inputs == other.num_inputs &&
                std::ranges::equal(inputs.begin(), inputs.begin() + num_inputs, other.inputs.begin(),
                                   other.inputs.begin() + num_inputs);
     }

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -7,6 +7,7 @@
 #include <span>
 #include <boost/container/static_vector.hpp>
 #include "common/types.h"
+#include "video_core/amdgpu/liverpool.h"
 #include "video_core/amdgpu/types.h"
 
 namespace Shader {
@@ -96,16 +97,6 @@ enum class MrtSwizzle : u8 {
 };
 static constexpr u32 MaxColorBuffers = 8;
 
-enum class PsInputFlags : u8 {
-    None = 0,
-    PosX = 1 << 0,
-    PosY = 1 << 1,
-    PosZ = 1 << 2,
-    PosW = 1 << 3,
-    FrontFacing = 1 << 4,
-};
-DECLARE_ENUM_FLAG_OPERATORS(PsInputFlags)
-
 struct FragmentRuntimeInfo {
     struct PsInput {
         u8 param_index;
@@ -115,8 +106,8 @@ struct FragmentRuntimeInfo {
 
         auto operator<=>(const PsInput&) const noexcept = default;
     };
-    PsInputFlags en_flags;
-    PsInputFlags addr_flags;
+    AmdGpu::Liverpool::PsInput en_flags;
+    AmdGpu::Liverpool::PsInput addr_flags;
     u32 num_inputs;
     std::array<PsInput, 32> inputs;
     struct PsColorBuffer {
@@ -129,7 +120,7 @@ struct FragmentRuntimeInfo {
 
     bool operator==(const FragmentRuntimeInfo& other) const noexcept {
         return std::ranges::equal(color_buffers, other.color_buffers) &&
-               en_flags == other.en_flags && addr_flags == other.addr_flags &&
+               en_flags.raw == other.en_flags.raw && addr_flags.raw == other.addr_flags.raw &&
                num_inputs == other.num_inputs &&
                std::ranges::equal(inputs.begin(), inputs.begin() + num_inputs, other.inputs.begin(),
                                   other.inputs.begin() + num_inputs);

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -1071,6 +1071,25 @@ struct Liverpool {
         BitField<27, 1, u32> enable_postz_overrasterization;
     };
 
+    struct PsInput {
+        u32 persp_sample_ena : 1;
+        u32 persp_center_ena : 1;
+        u32 persp_centroid_ena : 1;
+        u32 persp_pull_model_ena : 1;
+        u32 linear_sample_ena : 1;
+        u32 linear_center_ena : 1;
+        u32 linear_centroid_ena : 1;
+        u32 line_stipple_tex_ena : 1;
+        u32 pos_x_float_ena : 1;
+        u32 pos_y_float_ena : 1;
+        u32 pos_z_float_ena : 1;
+        u32 pos_w_float_ena : 1;
+        u32 front_face_ena : 1;
+        u32 ancillary_ena : 1;
+        u32 sample_coverage_ena : 1;
+        u32 pos_fixed_pt_ena : 1;
+    };
+
     union Regs {
         struct {
             INSERT_PADDING_WORDS(0x2C08);
@@ -1126,7 +1145,10 @@ struct Liverpool {
             INSERT_PADDING_WORDS(0xA191 - 0xA187);
             std::array<PsInputControl, 32> ps_inputs;
             VsOutputConfig vs_output_config;
-            INSERT_PADDING_WORDS(4);
+            INSERT_PADDING_WORDS(1);
+            PsInput ps_input_ena;
+            PsInput ps_input_addr;
+            INSERT_PADDING_WORDS(1);
             BitField<0, 6, u32> num_interp;
             INSERT_PADDING_WORDS(0xA1C3 - 0xA1B6 - 1);
             ShaderPosFormat shader_pos_format;
@@ -1388,6 +1410,8 @@ static_assert(GFX6_3D_REG_INDEX(viewports) == 0xA10F);
 static_assert(GFX6_3D_REG_INDEX(clip_user_data) == 0xA16F);
 static_assert(GFX6_3D_REG_INDEX(ps_inputs) == 0xA191);
 static_assert(GFX6_3D_REG_INDEX(vs_output_config) == 0xA1B1);
+static_assert(GFX6_3D_REG_INDEX(ps_input_ena) == 0xA1B3);
+static_assert(GFX6_3D_REG_INDEX(ps_input_addr) == 0xA1B4);
 static_assert(GFX6_3D_REG_INDEX(num_interp) == 0xA1B6);
 static_assert(GFX6_3D_REG_INDEX(shader_pos_format) == 0xA1C3);
 static_assert(GFX6_3D_REG_INDEX(z_export_format) == 0xA1C4);

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -1071,23 +1071,26 @@ struct Liverpool {
         BitField<27, 1, u32> enable_postz_overrasterization;
     };
 
-    struct PsInput {
-        u32 persp_sample_ena : 1;
-        u32 persp_center_ena : 1;
-        u32 persp_centroid_ena : 1;
-        u32 persp_pull_model_ena : 1;
-        u32 linear_sample_ena : 1;
-        u32 linear_center_ena : 1;
-        u32 linear_centroid_ena : 1;
-        u32 line_stipple_tex_ena : 1;
-        u32 pos_x_float_ena : 1;
-        u32 pos_y_float_ena : 1;
-        u32 pos_z_float_ena : 1;
-        u32 pos_w_float_ena : 1;
-        u32 front_face_ena : 1;
-        u32 ancillary_ena : 1;
-        u32 sample_coverage_ena : 1;
-        u32 pos_fixed_pt_ena : 1;
+    union PsInput {
+        u32 raw;
+        struct {
+            u32 persp_sample_ena : 1;
+            u32 persp_center_ena : 1;
+            u32 persp_centroid_ena : 1;
+            u32 persp_pull_model_ena : 1;
+            u32 linear_sample_ena : 1;
+            u32 linear_center_ena : 1;
+            u32 linear_centroid_ena : 1;
+            u32 line_stipple_tex_ena : 1;
+            u32 pos_x_float_ena : 1;
+            u32 pos_y_float_ena : 1;
+            u32 pos_z_float_ena : 1;
+            u32 pos_w_float_ena : 1;
+            u32 front_face_ena : 1;
+            u32 ancillary_ena : 1;
+            u32 sample_coverage_ena : 1;
+            u32 pos_fixed_pt_ena : 1;
+        };
     };
 
     union Regs {

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -124,21 +124,27 @@ Shader::RuntimeInfo PipelineCache::BuildRuntimeInfo(Shader::Stage stage) {
     case Shader::Stage::Fragment: {
         BuildCommon(regs.ps_program);
         info.fs_info.en_flags =
-            ((regs.ps_input_addr.pos_x_float_ena && regs.ps_input_ena.pos_x_float_ena)
-                 ? Shader::PsInputEnableFlags::PosX
-                 : Shader::PsInputEnableFlags::None) |
-            ((regs.ps_input_addr.pos_y_float_ena && regs.ps_input_ena.pos_y_float_ena)
-                 ? Shader::PsInputEnableFlags::PosY
-                 : Shader::PsInputEnableFlags::None) |
-            ((regs.ps_input_addr.pos_z_float_ena && regs.ps_input_ena.pos_z_float_ena)
-                 ? Shader::PsInputEnableFlags::PosZ
-                 : Shader::PsInputEnableFlags::None) |
-            ((regs.ps_input_addr.pos_w_float_ena && regs.ps_input_ena.pos_w_float_ena)
-                 ? Shader::PsInputEnableFlags::PosW
-                 : Shader::PsInputEnableFlags::None) |
-            ((regs.ps_input_addr.front_face_ena && regs.ps_input_ena.front_face_ena)
-                 ? Shader::PsInputEnableFlags::FrontFacing
-                 : Shader::PsInputEnableFlags::None);
+            (regs.ps_input_ena.pos_x_float_ena ? Shader::PsInputFlags::PosX
+                                               : Shader::PsInputFlags::None) |
+            (regs.ps_input_ena.pos_y_float_ena ? Shader::PsInputFlags::PosY
+                                               : Shader::PsInputFlags::None) |
+            (regs.ps_input_ena.pos_z_float_ena ? Shader::PsInputFlags::PosZ
+                                               : Shader::PsInputFlags::None) |
+            (regs.ps_input_ena.pos_w_float_ena ? Shader::PsInputFlags::PosW
+                                               : Shader::PsInputFlags::None) |
+            (regs.ps_input_ena.front_face_ena ? Shader::PsInputFlags::FrontFacing
+                                              : Shader::PsInputFlags::None);
+        info.fs_info.addr_flags =
+            (regs.ps_input_addr.pos_x_float_ena ? Shader::PsInputFlags::PosX
+                                                : Shader::PsInputFlags::None) |
+            (regs.ps_input_addr.pos_y_float_ena ? Shader::PsInputFlags::PosY
+                                                : Shader::PsInputFlags::None) |
+            (regs.ps_input_addr.pos_z_float_ena ? Shader::PsInputFlags::PosZ
+                                                : Shader::PsInputFlags::None) |
+            (regs.ps_input_addr.pos_w_float_ena ? Shader::PsInputFlags::PosW
+                                                : Shader::PsInputFlags::None) |
+            (regs.ps_input_addr.front_face_ena ? Shader::PsInputFlags::FrontFacing
+                                               : Shader::PsInputFlags::None);
         const auto& ps_inputs = regs.ps_inputs;
         info.fs_info.num_inputs = regs.num_interp;
         for (u32 i = 0; i < regs.num_interp; i++) {

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -123,6 +123,22 @@ Shader::RuntimeInfo PipelineCache::BuildRuntimeInfo(Shader::Stage stage) {
     }
     case Shader::Stage::Fragment: {
         BuildCommon(regs.ps_program);
+        info.fs_info.en_flags =
+            ((regs.ps_input_addr.pos_x_float_ena && regs.ps_input_ena.pos_x_float_ena)
+                 ? Shader::PsInputEnableFlags::PosX
+                 : Shader::PsInputEnableFlags::None) |
+            ((regs.ps_input_addr.pos_y_float_ena && regs.ps_input_ena.pos_y_float_ena)
+                 ? Shader::PsInputEnableFlags::PosY
+                 : Shader::PsInputEnableFlags::None) |
+            ((regs.ps_input_addr.pos_z_float_ena && regs.ps_input_ena.pos_z_float_ena)
+                 ? Shader::PsInputEnableFlags::PosZ
+                 : Shader::PsInputEnableFlags::None) |
+            ((regs.ps_input_addr.pos_w_float_ena && regs.ps_input_ena.pos_w_float_ena)
+                 ? Shader::PsInputEnableFlags::PosW
+                 : Shader::PsInputEnableFlags::None) |
+            ((regs.ps_input_addr.front_face_ena && regs.ps_input_ena.front_face_ena)
+                 ? Shader::PsInputEnableFlags::FrontFacing
+                 : Shader::PsInputEnableFlags::None);
         const auto& ps_inputs = regs.ps_inputs;
         info.fs_info.num_inputs = regs.num_interp;
         for (u32 i = 0; i < regs.num_interp; i++) {

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -123,28 +123,8 @@ Shader::RuntimeInfo PipelineCache::BuildRuntimeInfo(Shader::Stage stage) {
     }
     case Shader::Stage::Fragment: {
         BuildCommon(regs.ps_program);
-        info.fs_info.en_flags =
-            (regs.ps_input_ena.pos_x_float_ena ? Shader::PsInputFlags::PosX
-                                               : Shader::PsInputFlags::None) |
-            (regs.ps_input_ena.pos_y_float_ena ? Shader::PsInputFlags::PosY
-                                               : Shader::PsInputFlags::None) |
-            (regs.ps_input_ena.pos_z_float_ena ? Shader::PsInputFlags::PosZ
-                                               : Shader::PsInputFlags::None) |
-            (regs.ps_input_ena.pos_w_float_ena ? Shader::PsInputFlags::PosW
-                                               : Shader::PsInputFlags::None) |
-            (regs.ps_input_ena.front_face_ena ? Shader::PsInputFlags::FrontFacing
-                                              : Shader::PsInputFlags::None);
-        info.fs_info.addr_flags =
-            (regs.ps_input_addr.pos_x_float_ena ? Shader::PsInputFlags::PosX
-                                                : Shader::PsInputFlags::None) |
-            (regs.ps_input_addr.pos_y_float_ena ? Shader::PsInputFlags::PosY
-                                                : Shader::PsInputFlags::None) |
-            (regs.ps_input_addr.pos_z_float_ena ? Shader::PsInputFlags::PosZ
-                                                : Shader::PsInputFlags::None) |
-            (regs.ps_input_addr.pos_w_float_ena ? Shader::PsInputFlags::PosW
-                                                : Shader::PsInputFlags::None) |
-            (regs.ps_input_addr.front_face_ena ? Shader::PsInputFlags::FrontFacing
-                                               : Shader::PsInputFlags::None);
+        info.fs_info.en_flags = regs.ps_input_ena;
+        info.fs_info.addr_flags = regs.ps_input_addr;
         const auto& ps_inputs = regs.ps_inputs;
         info.fs_info.num_inputs = regs.num_interp;
         for (u32 i = 0; i < regs.num_interp; i++) {


### PR DESCRIPTION
Registers contain enable flags for built-in attributes that should be checked when recompiling in order to access the correct built-in.

Fixes inverted normals issue in BB that caused some artifacts on grass and mirrored objects (like dog fur).