### PR TITLE
fix: fix #1457 again by moving av_err2str to a common header

### DIFF
--- a/src/common/support/avdec.h
+++ b/src/common/support/avdec.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+// support header file for libav
+
+// The av_err2str macro in libavutil/error.h does not play nice with C++
+#ifdef av_err2str
+#undef av_err2str
+#include <string>
+av_always_inline std::string av_err2string(int errnum) {
+    char errbuf[AV_ERROR_MAX_STRING_SIZE];
+    return av_make_error_string(errbuf, AV_ERROR_MAX_STRING_SIZE, errnum);
+}
+#define av_err2str(err) av_err2string(err).c_str()
+#endif // av_err2str

--- a/src/core/libraries/ajm/ajm_mp3.cpp
+++ b/src/core/libraries/ajm/ajm_mp3.cpp
@@ -12,6 +12,8 @@ extern "C" {
 #include <libswresample/swresample.h>
 }
 
+#include "common/support/avdec.h"
+
 namespace Libraries::Ajm {
 
 // Following tables have been reversed from AJM library

--- a/src/core/libraries/avplayer/avplayer_source.cpp
+++ b/src/core/libraries/avplayer/avplayer_source.cpp
@@ -18,16 +18,7 @@ extern "C" {
 #include <libswscale/swscale.h>
 }
 
-// The av_err2str macro in libavutil/error.h does not play nice with C++
-#ifdef av_err2str
-#undef av_err2str
-#include <string>
-av_always_inline std::string av_err2string(int errnum) {
-    char errbuf[AV_ERROR_MAX_STRING_SIZE];
-    return av_make_error_string(errbuf, AV_ERROR_MAX_STRING_SIZE, errnum);
-}
-#define av_err2str(err) av_err2string(err).c_str()
-#endif // av_err2str
+#include "common/support/avdec.h"
 
 namespace Libraries::AvPlayer {
 

--- a/src/core/libraries/videodec/videodec2_impl.cpp
+++ b/src/core/libraries/videodec/videodec2_impl.cpp
@@ -7,16 +7,7 @@
 #include "common/logging/log.h"
 #include "core/libraries/videodec/videodec_error.h"
 
-// The av_err2str macro in libavutil/error.h does not play nice with C++
-#ifdef av_err2str
-#undef av_err2str
-#include <string>
-av_always_inline std::string av_err2string(int errnum) {
-    char errbuf[AV_ERROR_MAX_STRING_SIZE];
-    return av_make_error_string(errbuf, AV_ERROR_MAX_STRING_SIZE, errnum);
-}
-#define av_err2str(err) av_err2string(err).c_str()
-#endif // av_err2str
+#include "common/support/avdec.h"
 
 namespace Libraries::Vdec2 {
 

--- a/src/core/libraries/videodec/videodec_impl.cpp
+++ b/src/core/libraries/videodec/videodec_impl.cpp
@@ -8,16 +8,7 @@
 #include "common/logging/log.h"
 #include "core/libraries/videodec/videodec_error.h"
 
-// The av_err2str macro in libavutil/error.h does not play nice with C++
-#ifdef av_err2str
-#undef av_err2str
-#include <string>
-av_always_inline std::string av_err2string(int errnum) {
-    char errbuf[AV_ERROR_MAX_STRING_SIZE];
-    return av_make_error_string(errbuf, AV_ERROR_MAX_STRING_SIZE, errnum);
-}
-#define av_err2str(err) av_err2string(err).c_str()
-#endif // av_err2str
+#include "common/support/avdec.h"
 
 namespace Libraries::Videodec {
 


### PR DESCRIPTION
With the regression of #1457 happening a second time, I suggest moving the macro redefinition to a separate header so maintenance and remediation is easier to deal with as the macro will now exist in four distinct places.

Place relocate `common/support/avdec.h` if needed.