### PR TITLE
memory: Handle 0 alignment in MemoryManager::Allocate

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -96,12 +96,12 @@ PAddr MemoryManager::PoolExpand(PAddr search_start, PAddr search_end, size_t siz
 PAddr MemoryManager::Allocate(PAddr search_start, PAddr search_end, size_t size, u64 alignment,
                               int memory_type) {
     std::scoped_lock lk{mutex};
+    alignment = alignment > 0 ? alignment : 16_KB;
 
     auto dmem_area = FindDmemArea(search_start);
 
     const auto is_suitable = [&] {
-        const auto aligned_base = alignment > 0 ? Common::AlignUp(dmem_area->second.base, alignment)
-                                                : dmem_area->second.base;
+        const auto aligned_base = Common::AlignUp(dmem_area->second.base, alignment);
         const auto alignment_size = aligned_base - dmem_area->second.base;
         const auto remaining_size =
             dmem_area->second.size >= alignment_size ? dmem_area->second.size - alignment_size : 0;
@@ -114,7 +114,7 @@ PAddr MemoryManager::Allocate(PAddr search_start, PAddr search_end, size_t size,
 
     // Align free position
     PAddr free_addr = dmem_area->second.base;
-    free_addr = alignment > 0 ? Common::AlignUp(free_addr, alignment) : free_addr;
+    free_addr = Common::AlignUp(free_addr, alignment);
 
     // Add the allocated region to the list and commit its pages.
     auto& area = CarveDmemArea(free_addr, size)->second;


### PR DESCRIPTION
Similar to other memory functions, handle alignment of 0x0 to `MemoryManager::Allocate` with 16KB default, to satisfy memory mapping requirements.

Fixes crash on launch in CUSA28193 (SONIC FRONTIERS). Had some testing done and doesn't appear to be any regressions.