### PR TITLE
shader_recompiler: Fix check for fragment depth store.

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv.cpp
@@ -284,7 +284,7 @@ void DefineEntryPoint(const IR::Program& program, EmitContext& ctx, Id main) {
             ctx.AddExtension("SPV_EXT_demote_to_helper_invocation");
             ctx.AddCapability(spv::Capability::DemoteToHelperInvocationEXT);
         }
-        if (info.stores.Get(IR::Attribute::Depth)) {
+        if (info.stores.GetAny(IR::Attribute::Depth)) {
             ctx.AddExecutionMode(main, spv::ExecutionMode::DepthReplacing);
         }
         break;


### PR DESCRIPTION
Fix check for fragment depth store for setting `DepthReplacing` execution mode.

Fixes a validation error in CUSA00068 (KNACK) due to storing depth without the correct execution mode.