### PR TITLE
image_view: Correct view format for D16Unorm images as well.

### DIFF
--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -161,11 +161,12 @@ ImageView::ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info
     if (!info.is_storage) {
         usage_ci.usage &= ~vk::ImageUsageFlagBits::eStorage;
     }
-    // When sampling D32 texture from shader, the T# specifies R32 Float format so adjust it.
+    // When sampling D32/D16 texture from shader, the T# specifies R32/R16 format so adjust it.
     vk::Format format = info.format;
     vk::ImageAspectFlags aspect = image.aspect_mask;
     if (image.aspect_mask & vk::ImageAspectFlagBits::eDepth &&
-        (format == vk::Format::eR32Sfloat || format == vk::Format::eD32Sfloat)) {
+        (format == vk::Format::eR32Sfloat || format == vk::Format::eD32Sfloat ||
+         format == vk::Format::eR16Unorm || format == vk::Format::eD16Unorm)) {
         format = image.info.pixel_format;
         aspect = vk::ImageAspectFlagBits::eDepth;
     }


### PR DESCRIPTION
Observed Bloodborne using `R16Unorm` format to view a `D16Unorm` image for some decals when attacking enemies. Adds this case to the existing format adjustment logic used for `R32Sfloat`/`D32Sfloat` to fix validation errors that can also result in crashes.