### PR TITLE
shader_recompiler: Implement S_ABS_I32

### DIFF
--- a/src/shader_recompiler/frontend/translate/scalar_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_alu.cpp
@@ -102,6 +102,8 @@ void Translator::EmitScalarAlu(const GcnInst& inst) {
             return S_SAVEEXEC_B64(NegateMode::None, false, inst);
         case Opcode::S_ORN2_SAVEEXEC_B64:
             return S_SAVEEXEC_B64(NegateMode::Src1, true, inst);
+        case Opcode::S_ABS_I32:
+            return S_ABS_I32(inst);
         default:
             LogMissingOpcode(inst);
         }
@@ -618,6 +620,12 @@ void Translator::S_SAVEEXEC_B64(NegateMode negate, bool is_or, const GcnInst& in
     }
     ir.SetExec(result);
     ir.SetScc(result);
+}
+
+void Translator::S_ABS_I32(const GcnInst& inst) {
+    const auto result = ir.IAbs(GetSrc(inst.src[0]));
+    SetDst(inst.dst[0], result);
+    ir.SetScc(ir.INotEqual(result, ir.Imm32(0)));
 }
 
 // SOPC

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -113,6 +113,7 @@ public:
     void S_FF1_I32_B32(const GcnInst& inst);
     void S_GETPC_B64(u32 pc, const GcnInst& inst);
     void S_SAVEEXEC_B64(NegateMode negate, bool is_or, const GcnInst& inst);
+    void S_ABS_I32(const GcnInst& inst);
 
     // SOPC
     void S_CMP(ConditionOp cond, bool is_signed, const GcnInst& inst);


### PR DESCRIPTION
Implements the `S_ABS_I32` instruction. Used by CUSA19345 (Sonic Colors: Ultimate)