### PR TITLE
liverpool: Correct compute queue context switches

### DIFF
--- a/src/core/libraries/gnmdriver/gnmdriver.cpp
+++ b/src/core/libraries/gnmdriver/gnmdriver.cpp
@@ -2768,7 +2768,7 @@ void RegisterlibSceGnmDriver(Core::Loader::SymbolsResolver* sym) {
     }
 
     if (Config::copyGPUCmdBuffers()) {
-        liverpool->reserveCopyBufferSpace();
+        liverpool->ReserveCopyBufferSpace();
     }
 
     Platform::IrqC::Instance()->Register(Platform::InterruptId::GpuIdle, ResetSubmissionLock,

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -1292,7 +1292,7 @@ public:
         submit_cv.notify_one();
     }
 
-    void reserveCopyBufferSpace() {
+    void ReserveCopyBufferSpace() {
         GpuQueue& gfx_queue = mapped_queues[GfxQueueId];
         std::scoped_lock<std::mutex> lk(gfx_queue.m_access);
 


### PR DESCRIPTION
* Indirect buffers would always yield at least once, even when they finished executing successfully on their first call. Fix that by calling the task outside of the loop first.

* Add additional compute register backups and restores where applicable. Compute registers are distinct per queue and thus must be context switched when we switch queues. On main there could be cases where, for example, queue 1 executes some dispatches, context switches to queue 5 which loads its registers, and then context switch to queue 1 again, which has a fresh task. But this time it wouldn't properly restore that context, leading to a crash