### PR TITLE
thread: Apply alternate signal stack to created threads.

### DIFF
--- a/src/core/thread.h
+++ b/src/core/thread.h
@@ -37,6 +37,7 @@ private:
     void* native_handle;
 #else
     uintptr_t native_handle;
+    void* sig_stack_ptr;
 #endif
     u64 tid;
 };


### PR DESCRIPTION
With guest stacks in place, if the guest asks for a very small stack size we may overflow the stack in our signal handling. Notably this can happen to more threads on macOS, since we use signal handlers more heavily for patching a few instructions not supported by Rosetta 2.

To solve this, apply an alternate signal stack to each thread created. When signal handlers execute they will switch to this alternate stack instead of executing on the thread stack.

Fixes crashes launching CUSA04551 (NieR:Automata) on macOS, probably helps Linux and some other games as well.