### PR TITLE
Fix compiling due to typedefs varying across platforms

### DIFF
--- a/src/core/thread.cpp
+++ b/src/core/thread.cpp
@@ -141,8 +141,8 @@ void NativeThread::Initialize() {
                "Failed to allocate signal stack: {}", errno);
 
     const stack_t sig_stack = {
-        .ss_flags = 0,
         .ss_sp = sig_stack_ptr,
+        .ss_flags = 0,
         .ss_size = sig_stack_size,
     };
     ASSERT_MSG(sigaltstack(&sig_stack, nullptr) == 0, "Failed to set signal stack: {}", errno);

--- a/src/core/thread.cpp
+++ b/src/core/thread.cpp
@@ -141,9 +141,9 @@ void NativeThread::Initialize() {
                "Failed to allocate signal stack: {}", errno);
 
     const stack_t sig_stack = {
+        .ss_flags = 0,
         .ss_sp = sig_stack_ptr,
         .ss_size = sig_stack_size,
-        .ss_flags = 0,
     };
     ASSERT_MSG(sigaltstack(&sig_stack, nullptr) == 0, "Failed to set signal stack: {}", errno);
 #endif

--- a/src/core/thread.cpp
+++ b/src/core/thread.cpp
@@ -115,7 +115,7 @@ void NativeThread::Exit() {
 #else
     // Disable and free the signal stack.
     constexpr stack_t sig_stack = {
-        ss_flags: SS_DISABLE,
+        .ss_flags = SS_DISABLE,
     };
     sigaltstack(&sig_stack, nullptr);
 
@@ -140,11 +140,10 @@ void NativeThread::Initialize() {
     ASSERT_MSG(posix_memalign(&sig_stack_ptr, page_size, sig_stack_size) == 0,
                "Failed to allocate signal stack: {}", errno);
 
-    const stack_t sig_stack = {
-        ss_sp: sig_stack_ptr,
-        ss_size: sig_stack_size,
-        ss_flags: 0,
-    };
+    stack_t sig_stack;
+    sig_stack.ss_sp = sig_stack_ptr;
+    sig_stack.ss_size = sig_stack_size;
+    sig_stack.ss_flags = 0;
     ASSERT_MSG(sigaltstack(&sig_stack, nullptr) == 0, "Failed to set signal stack: {}", errno);
 #endif
 }

--- a/src/core/thread.cpp
+++ b/src/core/thread.cpp
@@ -115,7 +115,7 @@ void NativeThread::Exit() {
 #else
     // Disable and free the signal stack.
     constexpr stack_t sig_stack = {
-        .ss_flags = SS_DISABLE,
+        ss_flags: SS_DISABLE,
     };
     sigaltstack(&sig_stack, nullptr);
 
@@ -141,9 +141,9 @@ void NativeThread::Initialize() {
                "Failed to allocate signal stack: {}", errno);
 
     const stack_t sig_stack = {
-        .ss_sp = sig_stack_ptr,
-        .ss_flags = 0,
-        .ss_size = sig_stack_size,
+        ss_sp: sig_stack_ptr,
+        ss_flags: 0,
+        ss_size: sig_stack_size,
     };
     ASSERT_MSG(sigaltstack(&sig_stack, nullptr) == 0, "Failed to set signal stack: {}", errno);
 #endif

--- a/src/core/thread.cpp
+++ b/src/core/thread.cpp
@@ -142,8 +142,8 @@ void NativeThread::Initialize() {
 
     const stack_t sig_stack = {
         ss_sp: sig_stack_ptr,
-        ss_flags: 0,
         ss_size: sig_stack_size,
+        ss_flags: 0,
     };
     ASSERT_MSG(sigaltstack(&sig_stack, nullptr) == 0, "Failed to set signal stack: {}", errno);
 #endif


### PR DESCRIPTION
Fix the var ordering.

https://github.com/shadps4-emu/shadPS4/pull/1724 breaks it and CI does not catch it, as it is using clang ~~a compiler old enough to be complacent~~.

Note that I do not usually do C++ so the fix may be wrong, even though it works for me.

```c++
typedef struct
  {
    void *ss_sp;
    int ss_flags;
    size_t ss_size;
  } stack_t;
```
Fixes `error: designator order for field ‘stack_t::ss_flags’ does not match declaration order in ‘const stack_t’`


*Do squash the extra commit when merging please*