### PR TITLE
Add default value for Separate Update Folder

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -743,6 +743,7 @@ void setDefaultValues() {
     emulator_language = "en";
     m_language = 1;
     gpuId = -1;
+    separateupdatefolder = false;
 }
 
 } // namespace Config


### PR DESCRIPTION
Just noticed there's no default value set for Separate Update Folder in the default settings function, so pressing it would just retain whatever is currently set.

Setting the assumed default as false for this simple PR.