### PR TITLE
Displays FPS before frame latency

### DIFF
--- a/src/core/devtools/layer.cpp
+++ b/src/core/devtools/layer.cpp
@@ -254,7 +254,7 @@ void L::DrawAdvanced() {
 
 void L::DrawSimple() {
     const auto io = GetIO();
-    Text("Frame time: %.3f ms (%.1f FPS)", 1000.0f / io.Framerate, io.Framerate);
+    Text("%.1f FPS (%.2f ms)", io.Framerate, 1000.0f / io.Framerate);
 }
 
 static void LoadSettings(const char* line) {
@@ -338,6 +338,7 @@ void L::Draw() {
         const auto fn = DebugState.flip_frame_count.load();
         frame_graph.AddFrame(fn, io.DeltaTime);
     }
+
     if (IsKeyPressed(ImGuiKey_F10, false)) {
         if (io.KeyCtrl) {
             show_advanced_debug = !show_advanced_debug;


### PR DESCRIPTION
I think for a normal user it is more important to see the FPS rather than the frame latency.

Before:
![Before](https://github.com/user-attachments/assets/ebb27f14-51d5-459a-9755-557a413091d6)

After:
![After](https://github.com/user-attachments/assets/7ca89ef4-9b47-4f30-bf45-52495c009e96)