### PR TITLE
Fix for R4G4B4A4UnormPack16 Tiled image

### DIFF
--- a/src/video_core/texture_cache/tile_manager.cpp
+++ b/src/video_core/texture_cache/tile_manager.cpp
@@ -174,6 +174,7 @@ vk::Format DemoteImageFormatForDetiling(vk::Format format) {
     switch (format) {
     case vk::Format::eR8Unorm:
         return vk::Format::eR8Uint;
+    case vk::Format::eR4G4B4A4UnormPack16:
     case vk::Format::eR8G8Unorm:
     case vk::Format::eR16Sfloat:
     case vk::Format::eR16Unorm:


### PR DESCRIPTION
Fixed an error seen in Red Dead Redemption.

The error:
`[Render.Vulkan] <Error> tile_manager.cpp:DemoteImageFormatForDetiling:223: Unexpected format for demotion R4G4B4A4UnormPack16
[Render.Vulkan] <Error> tile_manager.cpp:TryDetile:398: Unsupported tiled image: R4G4B4A4UnormPack16 (Texture_MicroTiled)`

Maybe @raphaelthegreat , @psucien or @squidbus or any other dev can tell me if it's good or if changes need to be made.