### PR TITLE
renderer_vulkan: Bind null color attachments when target is masked out.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -279,7 +279,7 @@ bool PipelineCache::RefreshGraphicsKey() {
     // recompiler.
     for (auto cb = 0u, remapped_cb = 0u; cb < Liverpool::NumColorBuffers; ++cb) {
         auto const& col_buf = regs.color_buffers[cb];
-        if (skip_cb_binding || !col_buf) {
+        if (skip_cb_binding || !col_buf || !regs.color_target_mask.GetMask(cb)) {
             continue;
         }
         const auto base_format =
@@ -385,7 +385,8 @@ bool PipelineCache::RefreshGraphicsKey() {
     // Second pass to fill remain CB pipeline key data
     for (auto cb = 0u, remapped_cb = 0u; cb < Liverpool::NumColorBuffers; ++cb) {
         auto const& col_buf = regs.color_buffers[cb];
-        if (skip_cb_binding || !col_buf || (key.mrt_mask & (1u << cb)) == 0) {
+        if (skip_cb_binding || !col_buf || !regs.color_target_mask.GetMask(cb) ||
+            (key.mrt_mask & (1u << cb)) == 0) {
             key.color_formats[cb] = vk::Format::eUndefined;
             key.mrt_swizzles[cb] = Liverpool::ColorBuffer::SwapMode::Standard;
             continue;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -103,6 +103,17 @@ RenderState Rasterizer::PrepareRenderState(u32 mrt_mask) {
             continue;
         }
 
+        // If the color buffer is still bound but rendering to it is disabled by the target
+        // mask, we need to prevent the render area from being affected by unbound render target
+        // extents.
+        if (!regs.color_target_mask.GetMask(col_buf_id)) {
+            state.color_attachments[state.num_color_attachments++] = vk::RenderingAttachmentInfo{
+                // With VK_NULL_HANDLE, other struct members are ignored.
+                .imageView = VK_NULL_HANDLE,
+            };
+            continue;
+        }
+
         const auto& hint = liverpool->last_cb_extent[col_buf_id];
         auto& [image_id, desc] = cb_descs.emplace_back(std::piecewise_construct, std::tuple{},
                                                        std::tuple{col_buf, hint});
@@ -118,7 +129,6 @@ RenderState Rasterizer::PrepareRenderState(u32 mrt_mask) {
         const auto mip = image_view.info.range.base.level;
         state.width = std::min<u32>(state.width, std::max(image.info.size.width >> mip, 1u));
         state.height = std::min<u32>(state.height, std::max(image.info.size.height >> mip, 1u));
-        state.color_images[state.num_color_attachments] = image.image;
         state.color_attachments[state.num_color_attachments++] = {
             .imageView = *image_view.image_view,
             .imageLayout = vk::ImageLayout::eUndefined,
@@ -153,7 +163,6 @@ RenderState Rasterizer::PrepareRenderState(u32 mrt_mask) {
 
         state.width = std::min<u32>(state.width, image.info.size.width);
         state.height = std::min<u32>(state.height, image.info.size.height);
-        state.depth_image = image.image;
         state.depth_attachment = {
             .imageView = *image_view.image_view,
             .imageLayout = vk::ImageLayout::eUndefined,
@@ -716,7 +725,6 @@ void Rasterizer::BeginRendering(const GraphicsPipeline& pipeline, RenderState& s
             auto& image = texture_cache.GetImage(view.image_id);
             state.color_attachments[cb_index].imageView = *view.image_view;
             state.color_attachments[cb_index].imageLayout = image.last_state.layout;
-            state.color_images[cb_index] = image.image;
 
             const auto mip = view.info.range.base.level;
             state.width = std::min<u32>(state.width, std::max(image.info.size.width >> mip, 1u));

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -107,10 +107,7 @@ RenderState Rasterizer::PrepareRenderState(u32 mrt_mask) {
         // mask, we need to prevent the render area from being affected by unbound render target
         // extents.
         if (!regs.color_target_mask.GetMask(col_buf_id)) {
-            state.color_attachments[state.num_color_attachments++] = vk::RenderingAttachmentInfo{
-                // With VK_NULL_HANDLE, other struct members are ignored.
-                .imageView = VK_NULL_HANDLE,
-            };
+            state.color_attachments[state.num_color_attachments++].imageView = VK_NULL_HANDLE;
             continue;
         }
 

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -20,9 +20,7 @@ class Instance;
 
 struct RenderState {
     std::array<vk::RenderingAttachmentInfo, 8> color_attachments{};
-    std::array<vk::Image, 8> color_images{};
     vk::RenderingAttachmentInfo depth_attachment{};
-    vk::Image depth_image{};
     u32 num_color_attachments{};
     bool has_depth{};
     bool has_stencil{};


### PR DESCRIPTION
Reverts https://github.com/shadps4-emu/shadPS4/commit/c0d43a1a5f304d21f4b7c9457108c2d21447905e and replaces with binding a null color attachment when the color target is masked out, to make sure the targets are indexed correctly. Also removed some unused state.

Fixes black bars over right and bottom of screen in Sonic Forces.