### PR TITLE
renderer_vulkan: Require exact image format for resolve pass.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -790,8 +790,10 @@ void Rasterizer::Resolve() {
                                                         mrt0_hint};
     VideoCore::TextureCache::RenderTargetDesc mrt1_desc{liverpool->regs.color_buffers[1],
                                                         mrt1_hint};
-    auto& mrt0_image = texture_cache.GetImage(texture_cache.FindImage(mrt0_desc));
-    auto& mrt1_image = texture_cache.GetImage(texture_cache.FindImage(mrt1_desc));
+    auto& mrt0_image =
+        texture_cache.GetImage(texture_cache.FindImage(mrt0_desc, VideoCore::FindFlags::ExactFmt));
+    auto& mrt1_image =
+        texture_cache.GetImage(texture_cache.FindImage(mrt1_desc, VideoCore::FindFlags::ExactFmt));
 
     VideoCore::SubresourceRange mrt0_range;
     mrt0_range.base.layer = liverpool->regs.color_buffers[0].view.slice_start;

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -28,6 +28,7 @@ enum class FindFlags {
     RelaxDim = 1 << 1,  ///< Do not check the dimentions of image, only address.
     RelaxSize = 1 << 2, ///< Do not check that the size matches exactly.
     RelaxFmt = 1 << 3,  ///< Do not check that format is compatible.
+    ExactFmt = 1 << 4,  ///< Require the format to be exactly the same.
 };
 DECLARE_ENUM_FLAG_OPERATORS(FindFlags)
 


### PR DESCRIPTION
Resolve pass requires the same format for source and destination, both on the AMD GPU and Vulkan sides. Ensure this by requiring the texture cache to return both render target images with the exact requested format.

Part of fixing some multisample resolve issues in Sonic Forces.