### PR TITLE
Resubmit - Prevent settings from being saved when close button is pressed instead of save 

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -422,6 +422,10 @@ void setEmulatorLanguage(std::string language) {
     emulator_language = language;
 }
 
+void setGameInstallDirs(const std::vector<std::filesystem::path>& settings_install_dirs_config) {
+    settings_install_dirs = settings_install_dirs_config;
+}
+
 u32 getMainWindowGeometryX() {
     return main_window_geometry_x;
 }
@@ -673,14 +677,6 @@ void save(const std::filesystem::path& path) {
     data["Vulkan"]["crashDiagnostic"] = vkCrashDiagnostic;
     data["Debug"]["DebugDump"] = isDebugDump;
     data["Debug"]["CollectShader"] = isShaderDebug;
-    data["GUI"]["theme"] = mw_themes;
-    data["GUI"]["iconSize"] = m_icon_size;
-    data["GUI"]["sliderPos"] = m_slider_pos;
-    data["GUI"]["iconSizeGrid"] = m_icon_size_grid;
-    data["GUI"]["sliderPosGrid"] = m_slider_pos_grid;
-    data["GUI"]["gameTableMode"] = m_table_mode;
-    data["GUI"]["mw_width"] = m_window_size_W;
-    data["GUI"]["mw_height"] = m_window_size_H;
 
     std::vector<std::string> install_dirs;
     for (const auto& dirString : settings_install_dirs) {
@@ -690,6 +686,43 @@ void save(const std::filesystem::path& path) {
 
     data["GUI"]["addonInstallDir"] =
         std::string{fmt::UTF(settings_addon_install_dir.u8string()).data};
+    data["GUI"]["emulatorLanguage"] = emulator_language;
+    data["Settings"]["consoleLanguage"] = m_language;
+
+    std::ofstream file(path, std::ios::binary);
+    file << data;
+    file.close();
+}
+
+void saveMainWindow(const std::filesystem::path& path) {
+    toml::value data;
+
+    std::error_code error;
+    if (std::filesystem::exists(path, error)) {
+        try {
+            std::ifstream ifs;
+            ifs.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+            ifs.open(path, std::ios_base::binary);
+            data = toml::parse(ifs, std::string{fmt::UTF(path.filename().u8string()).data});
+        } catch (const std::exception& ex) {
+            fmt::print("Exception trying to parse config file. Exception: {}\n", ex.what());
+            return;
+        }
+    } else {
+        if (error) {
+            fmt::print("Filesystem error: {}\n", error.message());
+        }
+        fmt::print("Saving new configuration file {}\n", fmt::UTF(path.u8string()));
+    }
+
+    data["GUI"]["mw_width"] = m_window_size_W;
+    data["GUI"]["mw_height"] = m_window_size_H;
+    data["GUI"]["theme"] = mw_themes;
+    data["GUI"]["iconSize"] = m_icon_size;
+    data["GUI"]["sliderPos"] = m_slider_pos;
+    data["GUI"]["iconSizeGrid"] = m_icon_size_grid;
+    data["GUI"]["sliderPosGrid"] = m_slider_pos_grid;
+    data["GUI"]["gameTableMode"] = m_table_mode;
     data["GUI"]["geometry_x"] = main_window_geometry_x;
     data["GUI"]["geometry_y"] = main_window_geometry_y;
     data["GUI"]["geometry_w"] = main_window_geometry_w;
@@ -697,9 +730,6 @@ void save(const std::filesystem::path& path) {
     data["GUI"]["pkgDirs"] = m_pkg_viewer;
     data["GUI"]["elfDirs"] = m_elf_viewer;
     data["GUI"]["recentFiles"] = m_recent_files;
-    data["GUI"]["emulatorLanguage"] = emulator_language;
-
-    data["Settings"]["consoleLanguage"] = m_language;
 
     std::ofstream file(path, std::ios::binary);
     file << data;

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -13,6 +13,7 @@ enum HideCursorState : s16 { Never, Idle, Always };
 
 void load(const std::filesystem::path& path);
 void save(const std::filesystem::path& path);
+void saveMainWindow(const std::filesystem::path& path);
 
 bool isNeoMode();
 bool isFullscreenMode();
@@ -67,6 +68,7 @@ void setNeoMode(bool enable);
 void setUserName(const std::string& type);
 void setUpdateChannel(const std::string& type);
 void setSeparateUpdateEnabled(bool use);
+void setGameInstallDirs(const std::vector<std::filesystem::path>& settings_install_dirs_config);
 
 void setCursorState(s16 cursorState);
 void setCursorHideTimeout(int newcursorHideTimeout);

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -68,7 +68,7 @@ void setNeoMode(bool enable);
 void setUserName(const std::string& type);
 void setUpdateChannel(const std::string& type);
 void setSeparateUpdateEnabled(bool use);
-void setGameInstallDirs(const std::vector<std::filesystem::path>& settings_install_dirs_config);
+void setGameInstallDirs(std::span<const std::filesystem::path> settings_install_dirs_config);
 
 void setCursorState(s16 cursorState);
 void setCursorHideTimeout(int newcursorHideTimeout);

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -68,7 +68,7 @@ void setNeoMode(bool enable);
 void setUserName(const std::string& type);
 void setUpdateChannel(const std::string& type);
 void setSeparateUpdateEnabled(bool use);
-void setGameInstallDirs(std::span<const std::filesystem::path> settings_install_dirs_config);
+void setGameInstallDirs(const std::vector<std::filesystem::path>& settings_install_dirs_config);
 
 void setCursorState(s16 cursorState);
 void setCursorHideTimeout(int newcursorHideTimeout);

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -100,7 +100,7 @@ Emulator::Emulator() {
 
 Emulator::~Emulator() {
     const auto config_dir = Common::FS::GetUserPath(Common::FS::PathType::UserDir);
-    Config::save(config_dir / "config.toml");
+    Config::saveMainWindow(config_dir / "config.toml");
 }
 
 void Emulator::Run(const std::filesystem::path& file) {

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -35,7 +35,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
 MainWindow::~MainWindow() {
     SaveWindowState();
     const auto config_dir = Common::FS::GetUserPath(Common::FS::PathType::UserDir);
-    Config::save(config_dir / "config.toml");
+    Config::saveMainWindow(config_dir / "config.toml");
 }
 
 bool MainWindow::Init() {
@@ -1006,7 +1006,7 @@ void MainWindow::AddRecentFiles(QString filePath) {
     }
     Config::setRecentFiles(vec);
     const auto config_dir = Common::FS::GetUserPath(Common::FS::PathType::UserDir);
-    Config::save(config_dir / "config.toml");
+    Config::saveMainWindow(config_dir / "config.toml");
     CreateRecentGameActions(); // Refresh the QActions.
 }
 

--- a/src/qt_gui/settings_dialog.h
+++ b/src/qt_gui/settings_dialog.h
@@ -31,6 +31,8 @@ signals:
 
 private:
     void LoadValuesFromConfig();
+    void UpdateSettings();
+    void ResetInstallFolders();
     void InitializeEmulatorLanguages();
     void OnLanguageChanged(int index);
     void OnCursorStateChanged(s16 index);


### PR DESCRIPTION
Resubmitting PR#1679 because I accidentally deleted that branch instead of the one that was merged lol.

------------

Proposed fix for https://github.com/shadps4-emu/shadPS4/issues/1669, more detail on the issue can be seen on that page

There are actually two issues which cause settings to be saved when the close button is pressed:

MainWindow and Emulator destructor functions both call the Config::Save function, which saves every single config variable, including those changed in the config settings dialog box. To resolve this, I created another save function for just those two destructors, which save only the variables related to the main window itself, such as main window dimensions, recent files, and grid/list view settings.

Config variables are connected to each change in the config windows QT widgets, and the UI loads in these variables instead of the values saved to the config file. I rewrote this such that the config variables change value only upon saving, and that UI values are loaded from the config file

Not included in this PR is fixing how the translations are re-applied when changing emulator language.