### PR TITLE
scePad fixes

### DIFF
--- a/src/core/libraries/pad/pad.cpp
+++ b/src/core/libraries/pad/pad.cpp
@@ -155,6 +155,9 @@ int PS4_SYSV_ABI scePadGetFeatureReport() {
 }
 
 int PS4_SYSV_ABI scePadGetHandle(s32 userId, s32 type, s32 index) {
+    if (userId == -1) {
+        return ORBIS_PAD_ERROR_DEVICE_NO_HANDLE;
+    }
     LOG_DEBUG(Lib_Pad, "(DUMMY) called");
     return 1;
 }
@@ -246,6 +249,9 @@ int PS4_SYSV_ABI scePadMbusTerm() {
 
 int PS4_SYSV_ABI scePadOpen(s32 userId, s32 type, s32 index, const OrbisPadOpenParam* pParam) {
     LOG_INFO(Lib_Pad, "(DUMMY) called user_id = {} type = {} index = {}", userId, type, index);
+    if (userId == -1) {
+        return ORBIS_PAD_ERROR_DEVICE_NO_HANDLE;
+    }
     if (Config::getUseSpecialPad()) {
         if (type != ORBIS_PAD_PORT_TYPE_SPECIAL)
             return ORBIS_PAD_ERROR_DEVICE_NOT_CONNECTED;
@@ -346,6 +352,9 @@ int PS4_SYSV_ABI scePadReadHistory() {
 }
 
 int PS4_SYSV_ABI scePadReadState(s32 handle, OrbisPadData* pData) {
+    if (handle == ORBIS_PAD_ERROR_DEVICE_NO_HANDLE) {
+        return ORBIS_PAD_ERROR_INVALID_HANDLE;
+    }
     auto* controller = Common::Singleton<Input::GameController>::Instance();
     int connectedCount = 0;
     bool isConnected = false;


### PR DESCRIPTION
Fix the detection of 1 player .

Some games were using player keys for all the available players . 

Now player 1 plays only as player one 

One game that had this effect 

CUSA27284 - Okinawa Rush