### PR TITLE
post-processing: rework gamma correction

### DIFF
--- a/src/video_core/host_shaders/post_process.frag
+++ b/src/video_core/host_shaders/post_process.frag
@@ -12,8 +12,14 @@ layout(push_constant) uniform settings {
     float gamma;
 } pp;
 
+const float cutoff = 0.0031308, a = 1.055, b = 0.055, d = 12.92;
+vec3 gamma(vec3 rgb)
+{
+    return mix(a * pow(rgb, vec3(1.0 / (2.4 + 1.0 - pp.gamma))) - b, d * rgb / pp.gamma, lessThan(rgb, vec3(cutoff)));
+}
+
 void main()
 {
     vec4 color_linear = texture(texSampler, uv);
-    color = pow(color_linear, vec4(1.0/(2.2 + 1.0 - pp.gamma)));
+    color = vec4(gamma(color_linear.rgb), color_linear.a);
 }

--- a/src/video_core/renderer_vulkan/vk_presenter.cpp
+++ b/src/video_core/renderer_vulkan/vk_presenter.cpp
@@ -154,7 +154,7 @@ void Presenter::CreatePostProcessPipeline() {
     const auto& fs_module =
         Vulkan::Compile(pp_shaders[1], vk::ShaderStageFlagBits::eFragment, instance.GetDevice());
     ASSERT(fs_module);
-    Vulkan::SetObjectName(instance.GetDevice(), vs_module, "post_process.frag");
+    Vulkan::SetObjectName(instance.GetDevice(), fs_module, "post_process.frag");
 
     const std::array shaders_ci{
         vk::PipelineShaderStageCreateInfo{


### PR DESCRIPTION
fixes https://github.com/shadps4-emu/shadPS4/issues/1725
the branch is called ps5-approximating-gamma because the reference screenshots are from PS5
magic values come from https://en.wikipedia.org/wiki/SRGB

diff on src/video_core/renderer_vulkan/vk_presenter.cpp fixes what seems to me is a typo

the use of pp.gamma is also reverse with respect to current: increasing gamma thru devtools in current main decreases brightness, this PR go the other way ; can be reverted of course

EDIT:
use of pp.gamma reverted back to +1.0 - pp.gamma like in main