### PR TITLE
texture_cache: Improve support for stencil reads

### DIFF
--- a/src/core/libraries/audio3d/audio3d.cpp
+++ b/src/core/libraries/audio3d/audio3d.cpp
@@ -80,7 +80,7 @@ int PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported(OrbisAudio3dPortId uiPortI
 
 int PS4_SYSV_ABI sceAudio3dPortGetQueueLevel(OrbisAudio3dPortId uiPortId, u32* pQueueLevel,
                                              u32* pQueueAvailable) {
-    LOG_INFO(Lib_Audio3d, "uiPortId = {}", uiPortId);
+    LOG_TRACE(Lib_Audio3d, "uiPortId = {}", uiPortId);
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/gnmdriver/gnmdriver.cpp
+++ b/src/core/libraries/gnmdriver/gnmdriver.cpp
@@ -971,7 +971,7 @@ s32 PS4_SYSV_ABI sceGnmFindResourcesPublic() {
 }
 
 void PS4_SYSV_ABI sceGnmFlushGarlic() {
-    LOG_WARNING(Lib_GnmDriver, "(STUBBED) called");
+    LOG_TRACE(Lib_GnmDriver, "(STUBBED) called");
 }
 
 int PS4_SYSV_ABI sceGnmGetCoredumpAddress() {

--- a/src/core/libraries/libc_internal/libc_internal.cpp
+++ b/src/core/libraries/libc_internal/libc_internal.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <cmath>
+#include <cstdio>
 
 #include "common/assert.h"
 #include "common/logging/log.h"
@@ -63,6 +64,15 @@ size_t PS4_SYSV_ABI internal_strlen(const char* str) {
 
 char* PS4_SYSV_ABI internal_strncpy(char* dest, const char* src, std::size_t count) {
     return std::strncpy(dest, src, count);
+}
+
+int PS4_SYSV_ABI internal_strncpy_s(char* dest, size_t destsz, const char* src, size_t count) {
+#ifdef _WIN64
+    return strncpy_s(dest, destsz, src, count);
+#else
+    std::strcpy(dest, src);
+    return 0;
+#endif
 }
 
 char* PS4_SYSV_ABI internal_strcat(char* dest, const char* src) {
@@ -237,6 +247,8 @@ void RegisterlibSceLibcInternal(Core::Loader::SymbolsResolver* sym) {
                  internal_strlen);
     LIB_FUNCTION("6sJWiWSRuqk", "libSceLibcInternal", 1, "libSceLibcInternal", 1, 1,
                  internal_strncpy);
+    LIB_FUNCTION("YNzNkJzYqEg", "libSceLibcInternal", 1, "libSceLibcInternal", 1, 1,
+                 internal_strncpy_s);
     LIB_FUNCTION("Ls4tzzhimqQ", "libSceLibcInternal", 1, "libSceLibcInternal", 1, 1,
                  internal_strcat);
     LIB_FUNCTION("ob5xAW4ln-0", "libSceLibcInternal", 1, "libSceLibcInternal", 1, 1,

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -266,7 +266,7 @@ void Emulator::Run(const std::filesystem::path& file) {
 }
 
 void Emulator::LoadSystemModules(const std::filesystem::path& file, std::string game_serial) {
-    constexpr std::array<SysModules, 10> ModulesToLoad{
+    constexpr std::array<SysModules, 13> ModulesToLoad{
         {{"libSceNgs2.sprx", &Libraries::Ngs2::RegisterlibSceNgs2},
          {"libSceFiber.sprx", &Libraries::Fiber::RegisterlibSceFiber},
          {"libSceUlt.sprx", nullptr},
@@ -276,7 +276,10 @@ void Emulator::LoadSystemModules(const std::filesystem::path& file, std::string 
          {"libSceDiscMap.sprx", &Libraries::DiscMap::RegisterlibSceDiscMap},
          {"libSceRtc.sprx", &Libraries::Rtc::RegisterlibSceRtc},
          {"libSceJpegEnc.sprx", &Libraries::JpegEnc::RegisterlibSceJpegEnc},
-         {"libSceCesCs.sprx", nullptr}}};
+         {"libSceCesCs.sprx", nullptr},
+         {"libSceFont.sprx", nullptr},
+         {"libSceFontFt.sprx", nullptr},
+         {"libSceFreeTypeOt.sprx", nullptr}}};
 
     std::vector<std::filesystem::path> found_modules;
     const auto& sys_module_path = Common::FS::GetUserPath(Common::FS::PathType::SysModuleDir);

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -431,6 +431,10 @@ struct Liverpool {
             return u64(z_read_base) << 8;
         }
 
+        u64 StencilAddress() const {
+            return u64(stencil_read_base) << 8;
+        }
+
         u32 NumSamples() const {
             return 1u << z_info.num_samples; // spec doesn't say it is a log2
         }

--- a/src/video_core/texture_cache/image.cpp
+++ b/src/video_core/texture_cache/image.cpp
@@ -145,8 +145,10 @@ Image::Image(const Vulkan::Instance& instance_, Vulkan::Scheduler& scheduler_,
              const ImageInfo& info_)
     : instance{&instance_}, scheduler{&scheduler_}, info{info_},
       image{instance->GetDevice(), instance->GetAllocator()} {
+    if (info.pixel_format == vk::Format::eUndefined) {
+        return;
+    }
     mip_hashes.resize(info.resources.levels);
-    ASSERT(info.pixel_format != vk::Format::eUndefined);
     // Here we force `eExtendedUsage` as don't know all image usage cases beforehand. In normal case
     // the texture cache should re-create the resource with the usage requested
     vk::ImageCreateFlags flags{vk::ImageCreateFlagBits::eMutableFormat |

--- a/src/video_core/texture_cache/image.h
+++ b/src/video_core/texture_cache/image.h
@@ -93,8 +93,6 @@ struct Image {
     }
 
     void AssociateDepth(ImageId image_id) {
-        ASSERT_MSG(!depth_id || image_id == depth_id,
-                   "Stencil attachment bound to multiple depth targets");
         depth_id = image_id;
     }
 

--- a/src/video_core/texture_cache/image.h
+++ b/src/video_core/texture_cache/image.h
@@ -92,6 +92,12 @@ struct Image {
         return image_view_ids[std::distance(image_view_infos.begin(), it)];
     }
 
+    void AssociateDepth(ImageId image_id) {
+        ASSERT_MSG(!depth_id || image_id == depth_id,
+                   "Stencil attachment bound to multiple depth targets");
+        depth_id = image_id;
+    }
+
     boost::container::small_vector<vk::ImageMemoryBarrier2, 32> GetBarriers(
         vk::ImageLayout dst_layout, vk::Flags<vk::AccessFlagBits2> dst_mask,
         vk::PipelineStageFlags2 dst_stage, std::optional<SubresourceRange> subres_range);
@@ -116,6 +122,7 @@ struct Image {
     VAddr track_addr_end = 0;
     std::vector<ImageViewInfo> image_view_infos;
     std::vector<ImageViewId> image_view_ids;
+    ImageId depth_id{};
 
     // Resource state tracking
     struct {

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -298,6 +298,9 @@ ImageInfo::ImageInfo(const AmdGpu::Liverpool::DepthBuffer& buffer, u32 num_slice
     resources.layers = num_slices;
     meta_info.htile_addr = buffer.z_info.tile_surface_en ? htile_address : 0;
 
+    stencil_addr = buffer.StencilAddress();
+    stencil_size = pitch * size.height * sizeof(u8);
+
     guest_address = buffer.Address();
     const auto depth_slice_sz = buffer.GetDepthSliceSize();
     guest_size_bytes = depth_slice_sz * num_slices;

--- a/src/video_core/texture_cache/image_info.h
+++ b/src/video_core/texture_cache/image_info.h
@@ -69,7 +69,7 @@ struct ImageInfo {
     } props{}; // Surface properties with impact on various calculation factors
 
     vk::Format pixel_format = vk::Format::eUndefined;
-    vk::ImageType type = vk::ImageType::e1D;
+    vk::ImageType type = vk::ImageType::e2D;
     SubresourceExtent resources;
     Extent3D size{1, 1, 1};
     u32 num_bits{};

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -170,7 +170,7 @@ ImageView::ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info
         format = image.info.pixel_format;
         aspect = vk::ImageAspectFlagBits::eDepth;
     }
-    if (image.aspect_mask & vk::ImageAspectFlagBits::eStencil && format == vk::Format::eR8Unorm) {
+    if (image.aspect_mask & vk::ImageAspectFlagBits::eStencil && format == vk::Format::eR8Uint) {
         format = image.info.pixel_format;
         aspect = vk::ImageAspectFlagBits::eStencil;
     }

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -447,7 +447,11 @@ ImageView& TextureCache::FindDepthTarget(BaseDesc& desc) {
     if (desc.info.stencil_addr != 0) {
         ImageId stencil_id{};
         ForEachImageInRegion(desc.info.stencil_addr, desc.info.stencil_size,
-                             [&](ImageId image_id, Image&) { stencil_id = image_id; });
+                             [&](ImageId image_id, Image& image) {
+                                 if (image.info.guest_address == desc.info.stencil_addr) {
+                                     stencil_id = image_id;
+                                 }
+                             });
         if (!stencil_id) {
             ImageInfo info{};
             info.guest_address = desc.info.stencil_addr;

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -443,6 +443,23 @@ ImageView& TextureCache::FindDepthTarget(BaseDesc& desc) {
         }
     }
 
+    // If there is a stencil attachment, link depth and stencil.
+    if (desc.info.stencil_addr != 0) {
+        ImageId stencil_id{};
+        ForEachImageInRegion(desc.info.stencil_addr, desc.info.stencil_size,
+                             [&](ImageId image_id, Image&) { stencil_id = image_id; });
+        if (!stencil_id) {
+            ImageInfo info{};
+            info.guest_address = desc.info.stencil_addr;
+            info.guest_size_bytes = desc.info.stencil_size;
+            info.size = desc.info.size;
+            stencil_id = slot_images.insert(instance, scheduler, info);
+            RegisterImage(stencil_id);
+        }
+        Image& image = slot_images[stencil_id];
+        image.AssociateDepth(image_id);
+    }
+
     return RegisterImageView(image_id, desc.view_info);
 }
 


### PR DESCRIPTION
Some games can not only read depth buffer but also stencil. On AMD hw stencil attachment is entirely separate from depth and has a separate address DB_STENCIL_READ_BASE/DB_STENCIL_WRITE_BASE. Vulkan doesn't support separate depth and stencil attachments however so we have to make a combined depth-stencil image.

To support this, when fetching a depth target with stencil also bound, create a dummy image in the cache to represent stencil, but doesn't allocate any vulkan image. When binding textures, if such an image is found, redirect the access to associated depth image