### PR TITLE
Fix for adding game folders

### DIFF
--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -521,7 +521,6 @@ void SettingsDialog::UpdateSettings() {
 #endif
 
     BackgroundMusicPlayer::getInstance().setVolume(ui->BGMVolumeSlider->value());
-    ResetInstallFolders();
 }
 
 void SettingsDialog::ResetInstallFolders() {


### PR DESCRIPTION
Another minor fix, removed a function call (accidentally left in) to reset game folders in the save function when it should only be in the close button connect. This fixes adding and removing additional game install folders.