### PR TITLE
shader_recompiler: Emulate unnormalized sampler coordinates in shader.

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_floating_point.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_floating_point.cpp
@@ -87,6 +87,14 @@ Id EmitFPMul64(EmitContext& ctx, IR::Inst* inst, Id a, Id b) {
     return Decorate(ctx, inst, ctx.OpFMul(ctx.F64[1], a, b));
 }
 
+Id EmitFPDiv32(EmitContext& ctx, IR::Inst* inst, Id a, Id b) {
+    return Decorate(ctx, inst, ctx.OpFDiv(ctx.F32[1], a, b));
+}
+
+Id EmitFPDiv64(EmitContext& ctx, IR::Inst* inst, Id a, Id b) {
+    return Decorate(ctx, inst, ctx.OpFDiv(ctx.F64[1], a, b));
+}
+
 Id EmitFPNeg16(EmitContext& ctx, Id value) {
     return ctx.OpFNegate(ctx.F16[1], value);
 }

--- a/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
@@ -189,6 +189,8 @@ Id EmitFPMin64(EmitContext& ctx, Id a, Id b);
 Id EmitFPMul16(EmitContext& ctx, IR::Inst* inst, Id a, Id b);
 Id EmitFPMul32(EmitContext& ctx, IR::Inst* inst, Id a, Id b);
 Id EmitFPMul64(EmitContext& ctx, IR::Inst* inst, Id a, Id b);
+Id EmitFPDiv32(EmitContext& ctx, IR::Inst* inst, Id a, Id b);
+Id EmitFPDiv64(EmitContext& ctx, IR::Inst* inst, Id a, Id b);
 Id EmitFPNeg16(EmitContext& ctx, Id value);
 Id EmitFPNeg32(EmitContext& ctx, Id value);
 Id EmitFPNeg64(EmitContext& ctx, Id value);

--- a/src/shader_recompiler/frontend/translate/vector_memory.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_memory.cpp
@@ -527,6 +527,7 @@ IR::Value EmitImageSample(IR::IREmitter& ir, const GcnInst& inst, const IR::Scal
     info.has_offset.Assign(flags.test(MimgModifier::Offset));
     info.has_lod.Assign(flags.any(MimgModifier::Lod));
     info.is_array.Assign(mimg.da);
+    info.is_unnormalized.Assign(mimg.unrm);
 
     if (gather) {
         info.gather_comp.Assign(std::bit_width(mimg.dmask) - 1);

--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -692,6 +692,20 @@ F32F64 IREmitter::FPMul(const F32F64& a, const F32F64& b) {
     }
 }
 
+F32F64 IREmitter::FPDiv(const F32F64& a, const F32F64& b) {
+    if (a.Type() != b.Type()) {
+        UNREACHABLE_MSG("Mismatching types {} and {}", a.Type(), b.Type());
+    }
+    switch (a.Type()) {
+    case Type::F32:
+        return Inst<F32>(Opcode::FPDiv32, a, b);
+    case Type::F64:
+        return Inst<F64>(Opcode::FPDiv64, a, b);
+    default:
+        ThrowInvalidType(a.Type());
+    }
+}
+
 F32F64 IREmitter::FPFma(const F32F64& a, const F32F64& b, const F32F64& c) {
     if (a.Type() != b.Type() || a.Type() != c.Type()) {
         UNREACHABLE_MSG("Mismatching types {}, {}, and {}", a.Type(), b.Type(), c.Type());

--- a/src/shader_recompiler/ir/ir_emitter.h
+++ b/src/shader_recompiler/ir/ir_emitter.h
@@ -158,6 +158,7 @@ public:
     [[nodiscard]] F32F64 FPAdd(const F32F64& a, const F32F64& b);
     [[nodiscard]] F32F64 FPSub(const F32F64& a, const F32F64& b);
     [[nodiscard]] F32F64 FPMul(const F32F64& a, const F32F64& b);
+    [[nodiscard]] F32F64 FPDiv(const F32F64& a, const F32F64& b);
     [[nodiscard]] F32F64 FPFma(const F32F64& a, const F32F64& b, const F32F64& c);
 
     [[nodiscard]] F32F64 FPAbs(const F32F64& value);

--- a/src/shader_recompiler/ir/opcodes.inc
+++ b/src/shader_recompiler/ir/opcodes.inc
@@ -184,6 +184,8 @@ OPCODE(FPMin32,                                             F32,            F32,
 OPCODE(FPMin64,                                             F64,            F64,            F64,                                                            )
 OPCODE(FPMul32,                                             F32,            F32,            F32,                                                            )
 OPCODE(FPMul64,                                             F64,            F64,            F64,                                                            )
+OPCODE(FPDiv32,                                             F32,            F32,            F32,                                                            )
+OPCODE(FPDiv64,                                             F64,            F64,            F64,                                                            )
 OPCODE(FPNeg32,                                             F32,            F32,                                                                            )
 OPCODE(FPNeg64,                                             F64,            F64,                                                                            )
 OPCODE(FPRecip32,                                           F32,            F32,                                                                            )

--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -420,36 +420,35 @@ void PatchImageSampleInstruction(IR::Block& block, IR::Inst& inst, Info& info,
                                  Descriptors& descriptors, const IR::Inst* producer,
                                  const u32 image_binding, const AmdGpu::Image& image) {
     // Read sampler sharp. This doesn't exist for IMAGE_LOAD/IMAGE_STORE instructions
-    const auto sampler_binding = [&] -> std::pair<u32, AmdGpu::Sampler> {
+    const auto [sampler_binding, sampler] = [&] -> std::pair<u32, AmdGpu::Sampler> {
         ASSERT(producer->GetOpcode() == IR::Opcode::CompositeConstructU32x2);
         const IR::Value& handle = producer->Arg(1);
         // Inline sampler resource.
         if (handle.IsImmediate()) {
             LOG_WARNING(Render_Vulkan, "Inline sampler detected");
             const auto inline_sampler = AmdGpu::Sampler{.raw0 = handle.U32()};
-            return {descriptors.Add(SamplerResource{
-                        .sharp_idx = std::numeric_limits<u32>::max(),
-                        .inline_sampler = inline_sampler,
-                    }),
-                    inline_sampler};
+            const auto binding = descriptors.Add(SamplerResource{
+                .sharp_idx = std::numeric_limits<u32>::max(),
+                .inline_sampler = inline_sampler,
+            });
+            return {binding, inline_sampler};
         }
         // Normal sampler resource.
         const auto ssharp_handle = handle.InstRecursive();
         const auto& [ssharp_ud, disable_aniso] = TryDisableAnisoLod0(ssharp_handle);
         const auto ssharp = TrackSharp(ssharp_ud, info);
-        return {descriptors.Add(SamplerResource{
-                    .sharp_idx = ssharp,
-                    .associated_image = image_binding,
-                    .disable_aniso = disable_aniso,
-                }),
-                info.ReadUdSharp<AmdGpu::Sampler>(ssharp)};
+        const auto binding = descriptors.Add(SamplerResource{
+            .sharp_idx = ssharp,
+            .associated_image = image_binding,
+            .disable_aniso = disable_aniso,
+        });
+        return {binding, info.ReadUdSharp<AmdGpu::Sampler>(ssharp)};
     }();
-    const auto& sampler = sampler_binding.second;
 
     IR::IREmitter ir{block, IR::Block::InstructionList::s_iterator_to(inst)};
 
     const auto inst_info = inst.Flags<IR::TextureInstInfo>();
-    const IR::U32 handle = ir.Imm32(image_binding | sampler_binding.first << 16);
+    const IR::U32 handle = ir.Imm32(image_binding | sampler_binding << 16);
 
     IR::Inst* body1 = inst.Arg(1).InstRecursive();
     IR::Inst* body2 = inst.Arg(2).InstRecursive();
@@ -549,7 +548,8 @@ void PatchImageSampleInstruction(IR::Block& block, IR::Inst& inst, Info& info,
     const auto dimensions =
         unnormalized ? ir.ImageQueryDimension(ir.Imm32(image_binding), ir.Imm32(0u), ir.Imm1(false))
                      : IR::Value{};
-    const auto fix_coord = [&](IR::F32 coord, u32 dim_idx) -> IR::Value {
+    const auto get_coord = [&](u32 idx, u32 dim_idx) -> IR::Value {
+        const auto coord = get_addr_reg(idx);
         if (unnormalized) {
             // Normalize the coordinate for sampling, dividing by its corresponding dimension.
             return ir.FPDiv(coord,
@@ -563,29 +563,25 @@ void PatchImageSampleInstruction(IR::Block& block, IR::Inst& inst, Info& info,
         switch (image.GetType()) {
         case AmdGpu::ImageType::Color1D: // x
             addr_reg = addr_reg + 1;
-            return fix_coord(get_addr_reg(addr_reg - 1), 0);
+            return get_coord(addr_reg - 1, 0);
         case AmdGpu::ImageType::Color1DArray: // x, slice
             [[fallthrough]];
         case AmdGpu::ImageType::Color2D: // x, y
             addr_reg = addr_reg + 2;
-            return ir.CompositeConstruct(fix_coord(get_addr_reg(addr_reg - 2), 0),
-                                         fix_coord(get_addr_reg(addr_reg - 1), 1));
+            return ir.CompositeConstruct(get_coord(addr_reg - 2, 0), get_coord(addr_reg - 1, 1));
         case AmdGpu::ImageType::Color2DArray: // x, y, slice
             [[fallthrough]];
         case AmdGpu::ImageType::Color2DMsaa: // x, y, frag
             addr_reg = addr_reg + 3;
-            return ir.CompositeConstruct(fix_coord(get_addr_reg(addr_reg - 3), 0),
-                                         fix_coord(get_addr_reg(addr_reg - 2), 1),
+            return ir.CompositeConstruct(get_coord(addr_reg - 3, 0), get_coord(addr_reg - 2, 1),
                                          get_addr_reg(addr_reg - 1));
         case AmdGpu::ImageType::Color3D: // x, y, z
             addr_reg = addr_reg + 3;
-            return ir.CompositeConstruct(fix_coord(get_addr_reg(addr_reg - 3), 0),
-                                         fix_coord(get_addr_reg(addr_reg - 2), 1),
-                                         fix_coord(get_addr_reg(addr_reg - 1), 2));
+            return ir.CompositeConstruct(get_coord(addr_reg - 3, 0), get_coord(addr_reg - 2, 1),
+                                         get_coord(addr_reg - 1, 2));
         case AmdGpu::ImageType::Cube: // x, y, face
             addr_reg = addr_reg + 3;
-            return PatchCubeCoord(ir, fix_coord(get_addr_reg(addr_reg - 3), 0),
-                                  fix_coord(get_addr_reg(addr_reg - 2), 1),
+            return PatchCubeCoord(ir, get_coord(addr_reg - 3, 0), get_coord(addr_reg - 2, 1),
                                   get_addr_reg(addr_reg - 1), false, inst_info.is_array);
         default:
             UNREACHABLE();

--- a/src/shader_recompiler/ir/reg.h
+++ b/src/shader_recompiler/ir/reg.h
@@ -40,7 +40,8 @@ union TextureInstInfo {
     BitField<6, 2, u32> gather_comp;
     BitField<8, 1, u32> has_derivatives;
     BitField<9, 1, u32> is_array;
-    BitField<10, 1, u32> is_gather;
+    BitField<10, 1, u32> is_unnormalized;
+    BitField<11, 1, u32> is_gather;
 };
 
 union BufferInstInfo {

--- a/src/video_core/texture_cache/sampler.cpp
+++ b/src/video_core/texture_cache/sampler.cpp
@@ -25,7 +25,7 @@ Sampler::Sampler(const Vulkan::Instance& instance, const AmdGpu::Sampler& sample
         .minLod = sampler.MinLod(),
         .maxLod = sampler.MaxLod(),
         .borderColor = LiverpoolToVK::BorderColor(sampler.border_color_type),
-        .unnormalizedCoordinates = bool(sampler.force_unnormalized),
+        .unnormalizedCoordinates = false, // Handled in shader due to Vulkan limitations.
     };
     auto [sampler_result, smplr] = instance.GetDevice().createSamplerUnique(sampler_ci);
     ASSERT_MSG(sampler_result == vk::Result::eSuccess, "Failed to create sampler: {}",


### PR DESCRIPTION
Vulkan [imposes a number of restrictions](https://registry.khronos.org/vulkan/specs/latest/man/html/VkSamplerCreateInfo.html) on samplers with `unnormalizedCoordinates = true`. In most cases seeing `force_unnormalized` used by games, these restrictions seem to be violated, using address modes, compare ops, LOD levels, and sampling instructions that are not allowed.

Instead, emulate unnormalized coordinates in shaders by querying the dimensions and dividing the unnormalized coordinates to turn them into normalized coordinates. This also allows us to implement the unnormalized per-instruction flag.

Used by some shaders in CUSA16404 and CUSA05637.