### PR TITLE
Resize trophy pop up size based on window size

### DIFF
--- a/src/core/libraries/np_trophy/trophy_ui.cpp
+++ b/src/core/libraries/np_trophy/trophy_ui.cpp
@@ -38,21 +38,22 @@ void TrophyUI::Finish() {
 void TrophyUI::Draw() {
     const auto& io = GetIO();
 
+    float AdjustWidth = io.DisplaySize.x / 1280;
+    float AdjustHeight = io.DisplaySize.y / 720;
     const ImVec2 window_size{
-        std::min(io.DisplaySize.x, 250.f),
-        std::min(io.DisplaySize.y, 70.f),
+        std::min(io.DisplaySize.x, (300 * AdjustWidth)),
+        std::min(io.DisplaySize.y, (70 * AdjustHeight)),
     };
 
     SetNextWindowSize(window_size);
     SetNextWindowCollapsed(false);
-    SetNextWindowPos(ImVec2(io.DisplaySize.x - 250, 50));
+    SetNextWindowPos(ImVec2(io.DisplaySize.x - (300 * AdjustWidth), (50 * AdjustHeight)));
     KeepNavHighlight();
-
     if (Begin("Trophy Window", nullptr,
               ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings |
                   ImGuiWindowFlags_NoInputs)) {
         if (trophy_icon) {
-            Image(trophy_icon.GetTexture().im_id, ImVec2(50, 50));
+            Image(trophy_icon.GetTexture().im_id, ImVec2((50 * AdjustWidth), (50 * AdjustHeight)));
             ImGui::SameLine();
         } else {
             // placeholder
@@ -61,6 +62,7 @@ void TrophyUI::Draw() {
                                                       GetColorU32(ImVec4{0.7f}));
             ImGui::Indent(60);
         }
+        SetWindowFontScale((1.2 * AdjustHeight));
         TextWrapped("Trophy earned!\n%s", trophy_name.c_str());
     }
     End();


### PR DESCRIPTION
Right now the current trophy window is hardcoded to a certain size that seems to be optimized for 720:

Main 720p window:

![image](https://github.com/user-attachments/assets/11ecf5d6-4dd5-4fec-84a3-41d650bf1167)

It looks very small however at larger window sizes:

1440p window:

![image](https://github.com/user-attachments/assets/82d3f79a-9fcc-4362-a3ec-025803416c81)

This PR adjusts the trophy window to be the same at any window size.

PR 720p window:

![image](https://github.com/user-attachments/assets/43412301-a011-4549-9afb-714dda44278e)

PR 1440p window:

![image](https://github.com/user-attachments/assets/725689c5-d685-4e5c-a9d3-f10360a3cb38)

I also increased the text size by 20% and lengthened the window to accommodate this, for better visibility. Also tested to work on fullscreen mode