### PR TITLE
Save main window together with config to avoid rare crash

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -692,6 +692,7 @@ void save(const std::filesystem::path& path) {
     std::ofstream file(path, std::ios::binary);
     file << data;
     file.close();
+    saveMainWindow(path);
 }
 
 void saveMainWindow(const std::filesystem::path& path) {


### PR DESCRIPTION
Sorry again for the trouble, but apparently its possible to never trigger the main window or emulator destructors under certain conditions which are currently the two usual ways to save main window variables after my changes in the previous PR. This means the config file misses certain entries and crashes on the following run. This fix ensures prevention of these crashes by saving Main window variables on each config save, which includes the initial config generation