### PR TITLE
renderer_vulkan: Remove some fallbacks and misc format queries that are no longer needed.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -68,11 +68,10 @@ std::unordered_map<vk::Format, vk::FormatProperties3> GetFormatProperties(
     }
     // Other miscellaneous formats, e.g. for color buffers, swizzles, or compatibility
     static constexpr std::array misc_formats = {
-        vk::Format::eA2R10G10B10UnormPack32, vk::Format::eA8B8G8R8UnormPack32,
-        vk::Format::eA8B8G8R8SrgbPack32,     vk::Format::eB8G8R8A8Unorm,
-        vk::Format::eB8G8R8A8Snorm,          vk::Format::eB8G8R8A8Uint,
-        vk::Format::eB8G8R8A8Sint,           vk::Format::eB8G8R8A8Srgb,
-        vk::Format::eR5G6B5UnormPack16,      vk::Format::eD24UnormS8Uint,
+        vk::Format::eA2R10G10B10UnormPack32,
+        vk::Format::eB8G8R8A8Unorm,
+        vk::Format::eB8G8R8A8Srgb,
+        vk::Format::eD24UnormS8Uint,
     };
     for (const auto& format : misc_formats) {
         if (!format_properties.contains(format)) {
@@ -582,8 +581,6 @@ bool Instance::IsFormatSupported(const vk::Format format,
 
 static vk::Format GetAlternativeFormat(const vk::Format format) {
     switch (format) {
-    case vk::Format::eB5G6R5UnormPack16:
-        return vk::Format::eR5G6B5UnormPack16;
     case vk::Format::eD16UnormS8Uint:
         return vk::Format::eD24UnormS8Uint;
     default:
@@ -601,21 +598,6 @@ vk::Format Instance::GetSupportedFormat(const vk::Format format,
         return alternative;
     }
     return format;
-}
-
-vk::ComponentMapping Instance::GetSupportedComponentSwizzle(
-    const vk::Format format, const vk::ComponentMapping swizzle,
-    const vk::FormatFeatureFlags2 flags) const {
-    if (IsFormatSupported(format, flags)) [[likely]] {
-        return swizzle;
-    }
-
-    vk::ComponentMapping supported_swizzle = swizzle;
-    if (format == vk::Format::eB5G6R5UnormPack16) {
-        // B5G6R5 -> R5G6B5
-        std::swap(supported_swizzle.r, supported_swizzle.b);
-    }
-    return supported_swizzle;
 }
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -33,10 +33,6 @@ public:
     [[nodiscard]] vk::Format GetSupportedFormat(vk::Format format,
                                                 vk::FormatFeatureFlags2 flags) const;
 
-    /// Re-orders a component swizzle for format compatibility, if needed.
-    [[nodiscard]] vk::ComponentMapping GetSupportedComponentSwizzle(
-        vk::Format format, vk::ComponentMapping swizzle, vk::FormatFeatureFlags2 flags) const;
-
     /// Returns the Vulkan instance
     vk::Instance GetInstance() const {
         return *instance;

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -141,8 +141,7 @@ ImageView::ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info
         .image = image.image,
         .viewType = info.type,
         .format = instance.GetSupportedFormat(format, image.format_features),
-        .components =
-            instance.GetSupportedComponentSwizzle(format, info.mapping, image.format_features),
+        .components = info.mapping,
         .subresourceRange{
             .aspectMask = aspect,
             .baseMipLevel = info.range.base.level,


### PR DESCRIPTION
* `B5G6R5UnormPack16` fallback was added for MoltenVK, but is no longer needed in newer versions we build in as a submodule, so remove the related code. It wasn't complete anyway since it didn't account for situations like storage image, etc.
* Remove formats from querying that are no longer used since https://github.com/shadps4-emu/shadPS4/pull/1763