### PR TITLE
DmaData and Recompiler fixes

### DIFF
--- a/src/shader_recompiler/frontend/control_flow_graph.cpp
+++ b/src/shader_recompiler/frontend/control_flow_graph.cpp
@@ -80,6 +80,7 @@ void CFG::EmitLabels() {
         if (inst.IsUnconditionalBranch()) {
             const u32 target = inst.BranchTarget(pc);
             AddLabel(target);
+            AddLabel(pc + inst.length);
         } else if (inst.IsConditionalBranch()) {
             const u32 true_label = inst.BranchTarget(pc);
             const u32 false_label = pc + inst.length;

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -569,25 +569,39 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
                     break;
                 }
                 if (dma_data->src_sel == DmaDataSrc::Data && dma_data->dst_sel == DmaDataDst::Gds) {
+                    LOG_CRITICAL(Render_Vulkan, "DmaData Data ({}) -> Gds {:#x}, {} bytes",
+                                 dma_data->data, dma_data->dst_addr_lo, dma_data->NumBytes());
                     rasterizer->InlineData(dma_data->dst_addr_lo, &dma_data->data, sizeof(u32),
                                            true);
                 } else if (dma_data->src_sel == DmaDataSrc::Memory &&
                            dma_data->dst_sel == DmaDataDst::Gds) {
-                    rasterizer->InlineData(dma_data->dst_addr_lo,
-                                           dma_data->SrcAddress<const void*>(),
-                                           dma_data->NumBytes(), true);
+                    LOG_CRITICAL(Render_Vulkan, "DmaData Memory {:#x} -> Gds {:#x}, {} bytes",
+                                 dma_data->SrcAddress<VAddr>(), dma_data->dst_addr_lo,
+                                 dma_data->NumBytes());
+                    rasterizer->CopyBuffer(dma_data->dst_addr_lo, dma_data->SrcAddress<VAddr>(),
+                                           dma_data->NumBytes(), true, false);
                 } else if (dma_data->src_sel == DmaDataSrc::Data &&
                            dma_data->dst_sel == DmaDataDst::Memory) {
+                    LOG_CRITICAL(Render_Vulkan, "DmaData Data ({}) -> Memory {:#x}, {} bytes",
+                                 dma_data->data, dma_data->DstAddress<uintptr_t>(),
+                                 dma_data->NumBytes());
                     rasterizer->InlineData(dma_data->DstAddress<VAddr>(), &dma_data->data,
                                            sizeof(u32), false);
                 } else if (dma_data->src_sel == DmaDataSrc::Gds &&
                            dma_data->dst_sel == DmaDataDst::Memory) {
-                    // LOG_WARNING(Render_Vulkan, "GDS memory read");
+                    LOG_CRITICAL(Render_Vulkan, "DmaData Gds {:#x} -> Memory {:#x}, {} bytes",
+                                 dma_data->src_addr_lo, dma_data->DstAddress<uintptr_t>(),
+                                 dma_data->NumBytes());
+                    rasterizer->CopyBuffer(dma_data->DstAddress<VAddr>(), dma_data->src_addr_lo,
+                                           dma_data->NumBytes(), false, true);
                 } else if (dma_data->src_sel == DmaDataSrc::Memory &&
                            dma_data->dst_sel == DmaDataDst::Memory) {
-                    rasterizer->InlineData(dma_data->DstAddress<VAddr>(),
-                                           dma_data->SrcAddress<const void*>(),
-                                           dma_data->NumBytes(), false);
+                    LOG_CRITICAL(Render_Vulkan, "DmaData Memory {:#x} -> Memory {:#x}, {} bytes",
+                                 dma_data->SrcAddress<uintptr_t>(),
+                                 dma_data->DstAddress<uintptr_t>(), dma_data->NumBytes());
+                    rasterizer->CopyBuffer(dma_data->DstAddress<VAddr>(),
+                                           dma_data->SrcAddress<VAddr>(), dma_data->NumBytes(),
+                                           false, false);
                 } else {
                     UNREACHABLE_MSG("WriteData src_sel = {}, dst_sel = {}",
                                     u32(dma_data->src_sel.Value()), u32(dma_data->dst_sel.Value()));
@@ -728,23 +742,37 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, int vqid) {
                 break;
             }
             if (dma_data->src_sel == DmaDataSrc::Data && dma_data->dst_sel == DmaDataDst::Gds) {
+                LOG_CRITICAL(Render_Vulkan, "DmaData Data ({}) -> Gds {:#x}, {} bytes",
+                             dma_data->data, dma_data->dst_addr_lo, dma_data->NumBytes());
                 rasterizer->InlineData(dma_data->dst_addr_lo, &dma_data->data, sizeof(u32), true);
             } else if (dma_data->src_sel == DmaDataSrc::Memory &&
                        dma_data->dst_sel == DmaDataDst::Gds) {
-                rasterizer->InlineData(dma_data->dst_addr_lo, dma_data->SrcAddress<const void*>(),
-                                       dma_data->NumBytes(), true);
+                LOG_CRITICAL(Render_Vulkan, "DmaData Memory {:#x} -> Gds {:#x}, {} bytes",
+                             dma_data->SrcAddress<VAddr>(), dma_data->dst_addr_lo,
+                             dma_data->NumBytes());
+                rasterizer->CopyBuffer(dma_data->dst_addr_lo, dma_data->SrcAddress<VAddr>(),
+                                       dma_data->NumBytes(), true, false);
             } else if (dma_data->src_sel == DmaDataSrc::Data &&
                        dma_data->dst_sel == DmaDataDst::Memory) {
+                LOG_CRITICAL(Render_Vulkan, "DmaData Data ({}) -> Memory {:#x}, {} bytes",
+                             dma_data->data, dma_data->DstAddress<uintptr_t>(),
+                             dma_data->NumBytes());
                 rasterizer->InlineData(dma_data->DstAddress<VAddr>(), &dma_data->data, sizeof(u32),
                                        false);
             } else if (dma_data->src_sel == DmaDataSrc::Gds &&
                        dma_data->dst_sel == DmaDataDst::Memory) {
-                // LOG_WARNING(Render_Vulkan, "GDS memory read");
+                LOG_CRITICAL(Render_Vulkan, "DmaData Gds {:#x} -> Memory {:#x}, {} bytes",
+                             dma_data->src_addr_lo, dma_data->DstAddress<uintptr_t>(),
+                             dma_data->NumBytes());
+                rasterizer->CopyBuffer(dma_data->DstAddress<VAddr>(), dma_data->src_addr_lo,
+                                       dma_data->NumBytes(), false, true);
             } else if (dma_data->src_sel == DmaDataSrc::Memory &&
                        dma_data->dst_sel == DmaDataDst::Memory) {
-                rasterizer->InlineData(dma_data->DstAddress<VAddr>(),
-                                       dma_data->SrcAddress<const void*>(), dma_data->NumBytes(),
-                                       false);
+                LOG_CRITICAL(Render_Vulkan, "DmaData Memory {:#x} -> Memory {:#x}, {} bytes",
+                             dma_data->SrcAddress<uintptr_t>(), dma_data->DstAddress<uintptr_t>(),
+                             dma_data->NumBytes());
+                rasterizer->CopyBuffer(dma_data->DstAddress<VAddr>(), dma_data->SrcAddress<VAddr>(),
+                                       dma_data->NumBytes(), false, false);
             } else {
                 UNREACHABLE_MSG("WriteData src_sel = {}, dst_sel = {}",
                                 u32(dma_data->src_sel.Value()), u32(dma_data->dst_sel.Value()));

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -569,36 +569,22 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
                     break;
                 }
                 if (dma_data->src_sel == DmaDataSrc::Data && dma_data->dst_sel == DmaDataDst::Gds) {
-                    LOG_CRITICAL(Render_Vulkan, "DmaData Data ({}) -> Gds {:#x}, {} bytes",
-                                 dma_data->data, dma_data->dst_addr_lo, dma_data->NumBytes());
                     rasterizer->InlineData(dma_data->dst_addr_lo, &dma_data->data, sizeof(u32),
                                            true);
                 } else if (dma_data->src_sel == DmaDataSrc::Memory &&
                            dma_data->dst_sel == DmaDataDst::Gds) {
-                    LOG_CRITICAL(Render_Vulkan, "DmaData Memory {:#x} -> Gds {:#x}, {} bytes",
-                                 dma_data->SrcAddress<VAddr>(), dma_data->dst_addr_lo,
-                                 dma_data->NumBytes());
                     rasterizer->CopyBuffer(dma_data->dst_addr_lo, dma_data->SrcAddress<VAddr>(),
                                            dma_data->NumBytes(), true, false);
                 } else if (dma_data->src_sel == DmaDataSrc::Data &&
                            dma_data->dst_sel == DmaDataDst::Memory) {
-                    LOG_CRITICAL(Render_Vulkan, "DmaData Data ({}) -> Memory {:#x}, {} bytes",
-                                 dma_data->data, dma_data->DstAddress<uintptr_t>(),
-                                 dma_data->NumBytes());
                     rasterizer->InlineData(dma_data->DstAddress<VAddr>(), &dma_data->data,
                                            sizeof(u32), false);
                 } else if (dma_data->src_sel == DmaDataSrc::Gds &&
                            dma_data->dst_sel == DmaDataDst::Memory) {
-                    LOG_CRITICAL(Render_Vulkan, "DmaData Gds {:#x} -> Memory {:#x}, {} bytes",
-                                 dma_data->src_addr_lo, dma_data->DstAddress<uintptr_t>(),
-                                 dma_data->NumBytes());
                     rasterizer->CopyBuffer(dma_data->DstAddress<VAddr>(), dma_data->src_addr_lo,
                                            dma_data->NumBytes(), false, true);
                 } else if (dma_data->src_sel == DmaDataSrc::Memory &&
                            dma_data->dst_sel == DmaDataDst::Memory) {
-                    LOG_CRITICAL(Render_Vulkan, "DmaData Memory {:#x} -> Memory {:#x}, {} bytes",
-                                 dma_data->SrcAddress<uintptr_t>(),
-                                 dma_data->DstAddress<uintptr_t>(), dma_data->NumBytes());
                     rasterizer->CopyBuffer(dma_data->DstAddress<VAddr>(),
                                            dma_data->SrcAddress<VAddr>(), dma_data->NumBytes(),
                                            false, false);
@@ -742,35 +728,21 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, int vqid) {
                 break;
             }
             if (dma_data->src_sel == DmaDataSrc::Data && dma_data->dst_sel == DmaDataDst::Gds) {
-                LOG_CRITICAL(Render_Vulkan, "DmaData Data ({}) -> Gds {:#x}, {} bytes",
-                             dma_data->data, dma_data->dst_addr_lo, dma_data->NumBytes());
                 rasterizer->InlineData(dma_data->dst_addr_lo, &dma_data->data, sizeof(u32), true);
             } else if (dma_data->src_sel == DmaDataSrc::Memory &&
                        dma_data->dst_sel == DmaDataDst::Gds) {
-                LOG_CRITICAL(Render_Vulkan, "DmaData Memory {:#x} -> Gds {:#x}, {} bytes",
-                             dma_data->SrcAddress<VAddr>(), dma_data->dst_addr_lo,
-                             dma_data->NumBytes());
                 rasterizer->CopyBuffer(dma_data->dst_addr_lo, dma_data->SrcAddress<VAddr>(),
                                        dma_data->NumBytes(), true, false);
             } else if (dma_data->src_sel == DmaDataSrc::Data &&
                        dma_data->dst_sel == DmaDataDst::Memory) {
-                LOG_CRITICAL(Render_Vulkan, "DmaData Data ({}) -> Memory {:#x}, {} bytes",
-                             dma_data->data, dma_data->DstAddress<uintptr_t>(),
-                             dma_data->NumBytes());
                 rasterizer->InlineData(dma_data->DstAddress<VAddr>(), &dma_data->data, sizeof(u32),
                                        false);
             } else if (dma_data->src_sel == DmaDataSrc::Gds &&
                        dma_data->dst_sel == DmaDataDst::Memory) {
-                LOG_CRITICAL(Render_Vulkan, "DmaData Gds {:#x} -> Memory {:#x}, {} bytes",
-                             dma_data->src_addr_lo, dma_data->DstAddress<uintptr_t>(),
-                             dma_data->NumBytes());
                 rasterizer->CopyBuffer(dma_data->DstAddress<VAddr>(), dma_data->src_addr_lo,
                                        dma_data->NumBytes(), false, true);
             } else if (dma_data->src_sel == DmaDataSrc::Memory &&
                        dma_data->dst_sel == DmaDataDst::Memory) {
-                LOG_CRITICAL(Render_Vulkan, "DmaData Memory {:#x} -> Memory {:#x}, {} bytes",
-                             dma_data->SrcAddress<uintptr_t>(), dma_data->DstAddress<uintptr_t>(),
-                             dma_data->NumBytes());
                 rasterizer->CopyBuffer(dma_data->DstAddress<VAddr>(), dma_data->SrcAddress<VAddr>(),
                                        dma_data->NumBytes(), false, false);
             } else {

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -87,6 +87,7 @@ public:
 
     /// Writes a value to GPU buffer.
     void InlineData(VAddr address, const void* value, u32 num_bytes, bool is_gds);
+    void CopyBuffer(VAddr dst, VAddr src, u32 num_bytes, bool dst_gds, bool src_gds);
 
     [[nodiscard]] std::pair<Buffer*, u32> ObtainHostUBO(std::span<const u32> data);
 

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -263,7 +263,6 @@ void Rasterizer::DrawIndirect(bool is_indexed, VAddr arg_address, u32 offset, u3
     }
 
     auto state = PrepareRenderState(pipeline->GetMrtMask());
-
     if (!BindResources(pipeline)) {
         return;
     }
@@ -353,6 +352,9 @@ void Rasterizer::DispatchIndirect(VAddr address, u32 offset, u32 size) {
     if (!BindResources(pipeline)) {
         return;
     }
+
+    LOG_CRITICAL(Render_Vulkan, "DispatchIndirect addr = {:#x}",
+                 std::bit_cast<uintptr_t>(address + offset));
 
     scheduler.EndRendering();
 
@@ -838,6 +840,10 @@ void Rasterizer::Resolve() {
 
 void Rasterizer::InlineData(VAddr address, const void* value, u32 num_bytes, bool is_gds) {
     buffer_cache.InlineData(address, value, num_bytes, is_gds);
+}
+
+void Rasterizer::CopyBuffer(VAddr dst, VAddr src, u32 num_bytes, bool dst_gds, bool src_gds) {
+    buffer_cache.CopyBuffer(dst, src, num_bytes, dst_gds, src_gds);
 }
 
 u32 Rasterizer::ReadDataFromGds(u32 gds_offset) {

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -263,6 +263,7 @@ void Rasterizer::DrawIndirect(bool is_indexed, VAddr arg_address, u32 offset, u3
     }
 
     auto state = PrepareRenderState(pipeline->GetMrtMask());
+
     if (!BindResources(pipeline)) {
         return;
     }
@@ -352,9 +353,6 @@ void Rasterizer::DispatchIndirect(VAddr address, u32 offset, u32 size) {
     if (!BindResources(pipeline)) {
         return;
     }
-
-    LOG_CRITICAL(Render_Vulkan, "DispatchIndirect addr = {:#x}",
-                 std::bit_cast<uintptr_t>(address + offset));
 
     scheduler.EndRendering();
 

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -53,6 +53,7 @@ public:
     void ScopedMarkerInsertColor(const std::string_view& str, const u32 color);
 
     void InlineData(VAddr address, const void* value, u32 num_bytes, bool is_gds);
+    void CopyBuffer(VAddr dst, VAddr src, u32 num_bytes, bool dst_gds, bool src_gds);
     u32 ReadDataFromGds(u32 gsd_offset);
     bool InvalidateMemory(VAddr addr, u64 size);
     bool IsMapped(VAddr addr, u64 size);


### PR DESCRIPTION
`DmaData`: handler now prefers copying GPU buffers over CPU. If readback attempt is encountered it will create a GPU buffer still until readback is properly implemented.

Recompiler: fix branch linker for `s_branch` instructions reading dead code. The issue resulted in `s_branch` instruction being ignored. We now insert a fake label for all code that follows this instruction so that the block ends on it.

This whole change should fix GS particle effects in bloodborne.
