### PR TITLE
shader_recompiler: Fixups from stencil changes

### DIFF
--- a/src/shader_recompiler/frontend/translate/export.cpp
+++ b/src/shader_recompiler/frontend/translate/export.cpp
@@ -13,7 +13,7 @@ void Translator::EmitExport(const GcnInst& inst) {
 
     const auto& exp = inst.control.exp;
     const IR::Attribute attrib{exp.target};
-    if (attrib == IR::Attribute::Depth && exp.en != 1) {
+    if (attrib == IR::Attribute::Depth && exp.en != 0 && exp.en != 1) {
         LOG_WARNING(Render_Vulkan, "Unsupported depth export");
         return;
     }

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -131,7 +131,8 @@ ImageView::ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info
         format = image.info.pixel_format;
         aspect = vk::ImageAspectFlagBits::eDepth;
     }
-    if (image.aspect_mask & vk::ImageAspectFlagBits::eStencil && format == vk::Format::eR8Uint) {
+    if (image.aspect_mask & vk::ImageAspectFlagBits::eStencil &&
+        (format == vk::Format::eR8Uint || format == vk::Format::eR8Unorm)) {
         format = image.info.pixel_format;
         aspect = vk::ImageAspectFlagBits::eStencil;
     }


### PR DESCRIPTION
* `exp.en == 0` case for depth export is also fine and does not need log message.
* Some games will try to read stencil as `R8Unorm`, add to clause for stencil image view for now to avoid crashes but likely needs further work to make the read correct in shader.