### PR TITLE
Disable userfaultfd again by making it opt-in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -887,10 +887,10 @@ if (ENABLE_DISCORD_RPC)
     target_compile_definitions(shadps4 PRIVATE ENABLE_DISCORD_RPC)
 endif()
 
-# https://github.com/shadps4-emu/shadPS4/issues/1704
-#if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-#    target_compile_definitions(shadps4 PRIVATE ENABLE_USERFAULTFD)
-#endif()
+# Optional due to https://github.com/shadps4-emu/shadPS4/issues/1704
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND ENABLE_USERFAULTFD)
+    target_compile_definitions(shadps4 PRIVATE ENABLE_USERFAULTFD)
+endif()
 
 if (APPLE)
   option(USE_SYSTEM_VULKAN_LOADER "Enables using the system Vulkan loader instead of directly linking with MoltenVK. Useful for loading validation layers." OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -887,9 +887,10 @@ if (ENABLE_DISCORD_RPC)
     target_compile_definitions(shadps4 PRIVATE ENABLE_DISCORD_RPC)
 endif()
 
-if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-    target_compile_definitions(shadps4 PRIVATE ENABLE_USERFAULTFD)
-endif()
+# https://github.com/shadps4-emu/shadPS4/issues/1704
+#if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+#    target_compile_definitions(shadps4 PRIVATE ENABLE_USERFAULTFD)
+#endif()
 
 if (APPLE)
   option(USE_SYSTEM_VULKAN_LOADER "Enables using the system Vulkan loader instead of directly linking with MoltenVK. Useful for loading validation layers." OFF)


### PR DESCRIPTION
Fixes/works around #1704

Seems like enabling userfaultfd either causes various crashes on boot or mid-game.

Let's make it opt-in for now, until that is resolved.

https://github.com/shadps4-emu/shadPS4/issues/1704#issuecomment-2526263846 suggested to bake it as a CMAKE flag instead of a hardcode disable, so this PR was changed to do this.