### PR TITLE
Fix update on windows when path contains powershell wildcards (#1391)

### DIFF
--- a/src/qt_gui/check_update.cpp
+++ b/src/qt_gui/check_update.cpp
@@ -420,7 +420,8 @@ void CheckUpdate::Install() {
         "Remove-Item -Force -LiteralPath '%3\\update.ps1'\n"
         "Remove-Item -Force -LiteralPath '%3\\temp_download_update.zip'\n"
         "Remove-Item -Recurse -Force '%2'\n"
-        "Start-Process -FilePath '%3\\shadps4.exe' -WorkingDirectory ([WildcardPattern]::Escape('%3'))\n");
+        "Start-Process -FilePath '%3\\shadps4.exe' "
+        "-WorkingDirectory ([WildcardPattern]::Escape('%3'))\n");
     arguments << "-ExecutionPolicy"
               << "Bypass"
               << "-File" << scriptFileName;

--- a/src/qt_gui/check_update.cpp
+++ b/src/qt_gui/check_update.cpp
@@ -347,7 +347,11 @@ void CheckUpdate::DownloadUpdate(const QString& url) {
 
         QString userPath;
         Common::FS::PathToQString(userPath, Common::FS::GetUserPath(Common::FS::PathType::UserDir));
+#ifdef Q_OS_WIN
+        QString tempDownloadPath = QString(getenv("LOCALAPPDATA")) + "/Temp/temp_download_update";
+#else
         QString tempDownloadPath = userPath + "/temp_download_update";
+#endif
         QDir dir(tempDownloadPath);
         if (!dir.exists()) {
             dir.mkpath(".");
@@ -393,6 +397,11 @@ void CheckUpdate::Install() {
     QString processCommand;
 
 #ifdef Q_OS_WIN
+    // On windows, overwrite tempDirPath with AppData/Local/Temp folder
+    // due to PowerShell Expand-Archive not being able to handle correctly
+    // paths in square brackets (ie: ./[shadps4])
+    tempDirPath = QString(getenv("LOCALAPPDATA")) + "/Temp/temp_download_update";
+
     // Windows Batch Script
     scriptFileName = tempDirPath + "/update.ps1";
     scriptContent = QStringLiteral(
@@ -408,10 +417,10 @@ void CheckUpdate::Install() {
         "Start-Sleep -Seconds 3\n"
         "Copy-Item -Recurse -Force '%2\\*' '%3\\'\n"
         "Start-Sleep -Seconds 2\n"
-        "Remove-Item -Force '%3\\update.ps1'\n"
-        "Remove-Item -Force '%3\\temp_download_update.zip'\n"
-        "Start-Process '%3\\shadps4.exe'\n"
-        "Remove-Item -Recurse -Force '%2'\n");
+        "Remove-Item -Force -LiteralPath '%3\\update.ps1'\n"
+        "Remove-Item -Force -LiteralPath '%3\\temp_download_update.zip'\n"
+        "Remove-Item -Recurse -Force '%2'\n"
+        "Start-Process -FilePath '%3\\shadps4.exe' -WorkingDirectory ([WildcardPattern]::Escape('%3'))\n");
     arguments << "-ExecutionPolicy"
               << "Bypass"
               << "-File" << scriptFileName;


### PR DESCRIPTION
This pull request fixes issue #1391.
The problem was that some folder name characters (ie. '[') get recognized by some powershell commands as wildcards.

- Now update gets downloaded (on windows) to AppData\Local\Temp
- Start-Process powershell command escapes automatically wildcard characters