### PR TITLE
recompiler: emit a label right after s_branch

### DIFF
--- a/src/shader_recompiler/frontend/control_flow_graph.cpp
+++ b/src/shader_recompiler/frontend/control_flow_graph.cpp
@@ -80,6 +80,8 @@ void CFG::EmitLabels() {
         if (inst.IsUnconditionalBranch()) {
             const u32 target = inst.BranchTarget(pc);
             AddLabel(target);
+            // Emit this label so that the block ends with s_branch instruction
+            AddLabel(pc + inst.length);
         } else if (inst.IsConditionalBranch()) {
             const u32 true_label = inst.BranchTarget(pc);
             const u32 false_label = pc + inst.length;


### PR DESCRIPTION
The block generation code creates blocks from label to label and without this `s_branch` instruction is ignored if the following instruction is not referenced by another label. We now insert a fake label for all code that follows this instruction so that the block ends correctly.