### PR TITLE
Keybord on README / Fix Play Time

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ For more information on how to test, debug and report issues with the emulator o
 
 # Keyboard mapping
 
+| Button | Function |
+|-------------|-------------|
+F10 | FPS Counter
+Ctrl+F10 | Video Debug Info
+F11 | Fullscreen
+F12 | Trigger RenderDoc Capture
+
 > [!NOTE]
 > Xbox and DualShock controllers work out of the box.
 

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -123,7 +123,7 @@ void GameListFrame::PopulateGameList() {
             formattedPlayTime = formattedPlayTime.trimmed();
             m_game_info->m_games[i].play_time = playTime.toStdString();
             if (formattedPlayTime.isEmpty()) {
-                SetTableItem(i, 7, "0");
+                SetTableItem(i, 7, QString("%1s").arg(seconds));
             } else {
                 SetTableItem(i, 7, formattedPlayTime);
             }


### PR DESCRIPTION
https://github.com/shadps4-emu/shadPS4/issues/1362
add description of what the buttons do in README:

![image](https://github.com/user-attachments/assets/14d3bb9d-0154-4a82-a90e-98a925c9fd75)

----

When you haven't played, 'Never Played' appears, but if you play for less than a minute it only shows '0', now it shows seconds if it is less than one minute

| Before | After |
|-------------|-------------|
![image](https://github.com/user-attachments/assets/c23d1e46-096e-48b1-8050-16232a435fc4) | ![image](https://github.com/user-attachments/assets/ff688f88-7bd8-4280-8056-d87529fd3a54)


