### PR TITLE
fix for "shadPS4" not being given on linux volume mixers

### DIFF
--- a/src/sdl_window.cpp
+++ b/src/sdl_window.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <SDL3/SDL_events.h>
+#include <SDL3/SDL_hints.h>
 #include <SDL3/SDL_init.h>
 #include <SDL3/SDL_properties.h>
 #include <SDL3/SDL_timer.h>
@@ -68,6 +69,9 @@ static Uint32 SDLCALL PollController(void* userdata, SDL_TimerID timer_id, Uint3
 WindowSDL::WindowSDL(s32 width_, s32 height_, Input::GameController* controller_,
                      std::string_view window_title)
     : width{width_}, height{height_}, controller{controller_} {
+    if (!SDL_SetHint(SDL_HINT_APP_NAME,"shadPS4")) {
+        UNREACHABLE_MSG("Failed to set SDL window hint: {}", SDL_GetError());
+    }
     if (!SDL_Init(SDL_INIT_VIDEO)) {
         UNREACHABLE_MSG("Failed to initialize SDL video subsystem: {}", SDL_GetError());
     }

--- a/src/sdl_window.cpp
+++ b/src/sdl_window.cpp
@@ -69,7 +69,7 @@ static Uint32 SDLCALL PollController(void* userdata, SDL_TimerID timer_id, Uint3
 WindowSDL::WindowSDL(s32 width_, s32 height_, Input::GameController* controller_,
                      std::string_view window_title)
     : width{width_}, height{height_}, controller{controller_} {
-    if (!SDL_SetHint(SDL_HINT_APP_NAME,"shadPS4")) {
+    if (!SDL_SetHint(SDL_HINT_APP_NAME, "shadPS4")) {
         UNREACHABLE_MSG("Failed to set SDL window hint: {}", SDL_GetError());
     }
     if (!SDL_Init(SDL_INIT_VIDEO)) {


### PR DESCRIPTION
small patch to display the shadPS4 name inside of the volume mixer on Linux instead of the generic SDL_Application name

New:
![image](https://github.com/user-attachments/assets/58eef3ec-0667-4fbb-9262-f0ad0f25aea6)

Old:
![image](https://github.com/user-attachments/assets/a0d80527-5563-47d7-9d6b-4bcb0b770f03)
