### PR TITLE
resource_tracking_pass: Fix converting dimensions to float for normalization.

### DIFF
--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -586,12 +586,13 @@ void PatchImageSampleInstruction(IR::Block& block, IR::Inst& inst, Info& info,
     const auto dimensions =
         unnormalized ? ir.ImageQueryDimension(ir.Imm32(image_binding), ir.Imm32(0u), ir.Imm1(false))
                      : IR::Value{};
-    const auto get_coord = [&](u32 idx, u32 dim_idx) -> IR::Value {
-        const auto coord = get_addr_reg(idx);
+    const auto get_coord = [&](u32 coord_idx, u32 dim_idx) -> IR::Value {
+        const auto coord = get_addr_reg(coord_idx);
         if (unnormalized) {
             // Normalize the coordinate for sampling, dividing by its corresponding dimension.
-            return ir.FPDiv(coord,
-                            ir.BitCast<IR::F32>(IR::U32{ir.CompositeExtract(dimensions, dim_idx)}));
+            const auto dim =
+                ir.ConvertUToF(32, 32, IR::U32{ir.CompositeExtract(dimensions, dim_idx)});
+            return ir.FPDiv(coord, dim);
         }
         return coord;
     };


### PR DESCRIPTION
Meant to do a normal cast here, not bit cast.

Thanks @polybiusproxy for catching this.