### PR TITLE
vk_instance: Remove unused dynamic state 2 features struct

### DIFF
--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -379,7 +379,6 @@ bool Instance::CreateDevice() {
         vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT{
             .extendedDynamicState = true,
         },
-        vk::PhysicalDeviceExtendedDynamicState2FeaturesEXT{},
         vk::PhysicalDeviceExtendedDynamicState3FeaturesEXT{
             .extendedDynamicState3ColorWriteMask = true,
         },


### PR DESCRIPTION
Very small fix from https://github.com/shadps4-emu/shadPS4/pull/1528, this got added but is not used and the extension is not enabled, which results in a validation error.