### PR TITLE
renderer_vulkan: Various attachment cleanup and fixes.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -85,10 +85,6 @@ public:
         return key.mrt_mask;
     }
 
-    bool IsDepthEnabled() const {
-        return key.depth_stencil.depth_enable.Value();
-    }
-
     [[nodiscard]] bool IsPrimitiveListTopology() const {
         return key.prim_type == AmdGpu::PrimitiveType::PointList ||
                key.prim_type == AmdGpu::PrimitiveType::LineList ||

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -74,7 +74,6 @@ private:
 
     void UpdateDynamicState(const GraphicsPipeline& pipeline);
     void UpdateViewportScissorState();
-    void UpdateDepthStencilState();
 
     bool FilterDraw();
 

--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -30,7 +30,7 @@ void Scheduler::BeginRendering(const RenderState& new_state) {
     is_rendering = true;
     render_state = new_state;
 
-    const auto witdh =
+    const auto width =
         render_state.width != std::numeric_limits<u32>::max() ? render_state.width : 1;
     const auto height =
         render_state.height != std::numeric_limits<u32>::max() ? render_state.height : 1;
@@ -39,7 +39,7 @@ void Scheduler::BeginRendering(const RenderState& new_state) {
         .renderArea =
             {
                 .offset = {0, 0},
-                .extent = {witdh, height},
+                .extent = {width, height},
             },
         .layerCount = 1,
         .colorAttachmentCount = render_state.num_color_attachments,

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -266,7 +266,7 @@ ImageInfo::ImageInfo(const AmdGpu::Liverpool::ColorBuffer& buffer,
     props.is_tiled = buffer.IsTiled();
     tiling_mode = buffer.GetTilingMode();
     pixel_format = LiverpoolToVK::SurfaceFormat(buffer.info.format, buffer.NumFormat());
-    num_samples = 1 << buffer.attrib.num_fragments_log2;
+    num_samples = buffer.NumSamples();
     num_bits = NumBits(buffer.info.format);
     type = vk::ImageType::e2D;
     size.width = hint.Valid() ? hint.width : buffer.Pitch();
@@ -289,7 +289,7 @@ ImageInfo::ImageInfo(const AmdGpu::Liverpool::DepthBuffer& buffer, u32 num_slice
     props.is_tiled = false;
     pixel_format = LiverpoolToVK::DepthFormat(buffer.z_info.format, buffer.stencil_info.format);
     type = vk::ImageType::e2D;
-    num_samples = 1 << buffer.z_info.num_samples; // spec doesn't say it is a log2
+    num_samples = buffer.NumSamples();
     num_bits = buffer.NumBits();
     size.width = hint.Valid() ? hint.width : buffer.Pitch();
     size.height = hint.Valid() ? hint.height : buffer.Height();


### PR DESCRIPTION
* Add helper functions for depth/stencil buffer validity and use where these checks would happen.
* Move pipeline multisampling calculation to simple helper function and use where needed.
* Change out duplicated instances of buffer sample count logic with existing `NumSamples()` function.
* Make depth/stencil attachment formats and bindings more state-consistent.
* Do not bother attaching color buffers when mode is `Disable`, since none will be used.
* Handle resolve pass with single-sampled source by just doing a copy, as single-sample source resolve is not allowed in Vulkan.
* Skip scissor indices that do not have corresponding viewports.
* Misc typo fixes and dead code removal.

Fixes some validation errors in games like CUSA05637.