### PR TITLE
renderer_vulkan: add support for Polygon draws

### DIFF
--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -117,6 +117,7 @@ vk::PrimitiveTopology PrimitiveType(AmdGpu::PrimitiveType type) {
     case AmdGpu::PrimitiveType::PatchPrimitive:
         return vk::PrimitiveTopology::ePatchList;
     case AmdGpu::PrimitiveType::QuadList:
+    case AmdGpu::PrimitiveType::Polygon:
         // Needs to generate index buffer on the fly.
         return vk::PrimitiveTopology::eTriangleList;
     case AmdGpu::PrimitiveType::RectList:

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.h
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.h
@@ -98,6 +98,15 @@ void ConvertQuadToTriangleListIndices(u8* out_ptr, const u8* in_ptr, u32 num_ver
     }
 }
 
+inline void EmitPolygonToTriangleListIndices(u8* out_ptr, u32 num_vertices) {
+    u16* out_data = reinterpret_cast<u16*>(out_ptr);
+    for (u16 i = 1; i < num_vertices - 1; i++) {
+        *out_data++ = 0;
+        *out_data++ = i;
+        *out_data++ = i + 1;
+    }
+}
+
 static inline vk::Format PromoteFormatToDepth(vk::Format fmt) {
     if (fmt == vk::Format::eR32Sfloat) {
         return vk::Format::eD32Sfloat;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -246,11 +246,12 @@ void Rasterizer::DrawIndirect(bool is_indexed, VAddr arg_address, u32 offset, u3
     }
 
     const auto& regs = liverpool->regs;
-    if (regs.primitive_type == AmdGpu::PrimitiveType::QuadList) {
-        // For QuadList we use generated index buffer to convert quads to triangles. Since it
+    if (regs.primitive_type == AmdGpu::PrimitiveType::QuadList ||
+        regs.primitive_type == AmdGpu::PrimitiveType::Polygon) {
+        // We use a generated index buffer to convert quad lists and polygons to triangles. Since it
         // changes type of the draw, arguments are not valid for this case. We need to run a
         // conversion pass to repack the indirect arguments buffer first.
-        LOG_WARNING(Render_Vulkan, "QuadList primitive type is not supported for indirect draw");
+        LOG_WARNING(Render_Vulkan, "Primitive type is not supported for indirect draw");
         return;
     }
 


### PR DESCRIPTION
The Polygon primitive type works by having a specified \**N\** amount of vertices and having the GPU figure out how to fill said primitive—this primitive type is obsolete by now so modern rendering APIs do not support this primitive.

To emulate this, we can use the same approach for quad lists; generate an index buffer on the CPU and draw as triangle lists. Specifically for polygons, we can triangulate these by anchoring the first vertex of the polygon and connecting it with the current and next vertices.

![imagen](https://github.com/user-attachments/assets/c1455636-712e-4228-be56-d4444a6e6b25)
