### PR TITLE
spirv_emit_context: Prevent double-add of GS in attributes to interface.

### DIFF
--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -381,9 +381,8 @@ void EmitContext::DefineInputs() {
         for (int param_id = 0; param_id < num_params; ++param_id) {
             const Id type{TypeArray(F32[4], ConstU32(num_verts_in))};
             const Id id{DefineInput(type, param_id)};
-            Name(id, fmt::format("in_attr{}", param_id));
+            Name(id, fmt::format("gs_in_attr{}", param_id));
             input_params[param_id] = {id, input_f32, F32[1], 4};
-            interfaces.push_back(id);
         }
         break;
     }


### PR DESCRIPTION
`DefineInput` already adds the variable to `interfaces`, do not push it into `interfaces` again after. Duplicate definitions are not allowed since SPIR-V 1.4

Also renamed GS inputs from `in_attr{}` to `gs_in_attr{}` to be more clear.