### PR TITLE
ir: Add heuristic based LDS barrier pass

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -671,6 +671,7 @@ set(SHADER_RECOMPILER src/shader_recompiler/exception.h
                       src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
                       src/shader_recompiler/ir/passes/ring_access_elimination.cpp
                       src/shader_recompiler/ir/passes/shader_info_collection_pass.cpp
+                      src/shader_recompiler/ir/passes/shared_memory_barrier_pass.cpp
                       src/shader_recompiler/ir/passes/ssa_rewrite_pass.cpp
                       src/shader_recompiler/ir/abstract_syntax_list.h
                       src/shader_recompiler/ir/attribute.cpp

--- a/src/shader_recompiler/ir/passes/ir_passes.h
+++ b/src/shader_recompiler/ir/passes/ir_passes.h
@@ -6,6 +6,10 @@
 #include "shader_recompiler/ir/basic_block.h"
 #include "shader_recompiler/ir/program.h"
 
+namespace Shader {
+struct Profile;
+}
+
 namespace Shader::Optimization {
 
 void SsaRewritePass(IR::BlockList& program);
@@ -21,6 +25,6 @@ void RingAccessElimination(const IR::Program& program, const RuntimeInfo& runtim
 void TessellationPreprocess(IR::Program& program, RuntimeInfo& runtime_info);
 void HullShaderTransform(IR::Program& program, RuntimeInfo& runtime_info);
 void DomainShaderTransform(IR::Program& program, RuntimeInfo& runtime_info);
-void SharedMemoryBarrierPass(IR::Program& program);
+void SharedMemoryBarrierPass(IR::Program& program, const Profile& profile);
 
 } // namespace Shader::Optimization

--- a/src/shader_recompiler/ir/passes/ir_passes.h
+++ b/src/shader_recompiler/ir/passes/ir_passes.h
@@ -21,5 +21,6 @@ void RingAccessElimination(const IR::Program& program, const RuntimeInfo& runtim
 void TessellationPreprocess(IR::Program& program, RuntimeInfo& runtime_info);
 void HullShaderTransform(IR::Program& program, RuntimeInfo& runtime_info);
 void DomainShaderTransform(IR::Program& program, RuntimeInfo& runtime_info);
+void SharedMemoryBarrierPass(IR::Program& program);
 
 } // namespace Shader::Optimization

--- a/src/shader_recompiler/ir/passes/shared_memory_barrier_pass.cpp
+++ b/src/shader_recompiler/ir/passes/shared_memory_barrier_pass.cpp
@@ -4,11 +4,12 @@
 #include "shader_recompiler/ir/breadth_first_search.h"
 #include "shader_recompiler/ir/ir_emitter.h"
 #include "shader_recompiler/ir/program.h"
+#include "shader_recompiler/profile.h"
 
 namespace Shader::Optimization {
 
-void SharedMemoryBarrierPass(IR::Program& program) {
-    if (!program.info.uses_shared) {
+void SharedMemoryBarrierPass(IR::Program& program, const Profile& profile) {
+    if (!program.info.uses_shared || !profile.needs_lds_barriers) {
         return;
     }
     using Type = IR::AbstractSyntaxNode::Type;

--- a/src/shader_recompiler/ir/passes/shared_memory_barrier_pass.cpp
+++ b/src/shader_recompiler/ir/passes/shared_memory_barrier_pass.cpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "shader_recompiler/ir/breadth_first_search.h"
+#include "shader_recompiler/ir/ir_emitter.h"
+#include "shader_recompiler/ir/program.h"
+
+namespace Shader::Optimization {
+
+void SharedMemoryBarrierPass(IR::Program& program) {
+    if (!program.info.uses_shared) {
+        return;
+    }
+    using Type = IR::AbstractSyntaxNode::Type;
+    u32 branch_depth{};
+    for (const IR::AbstractSyntaxNode& node : program.syntax_list) {
+        if (node.type == Type::EndIf) {
+            --branch_depth;
+            continue;
+        }
+        if (node.type != Type::If) {
+            continue;
+        }
+        u32 curr_depth = branch_depth++;
+        if (curr_depth != 0) {
+            continue;
+        }
+        const IR::U1 cond = node.data.if_node.cond;
+        const auto insert_barrier = IR::BreadthFirstSearch(cond, [](IR::Inst* inst) -> std::optional<bool> {
+            if (inst->GetOpcode() == IR::Opcode::GetAttributeU32 &&
+                inst->Arg(0).Attribute() == IR::Attribute::LocalInvocationId) {
+                return true;
+            }
+            return std::nullopt;
+        });
+        if (insert_barrier) {
+            IR::Block* const merge = node.data.if_node.merge;
+            auto insert_point = std::ranges::find_if_not(merge->Instructions(), IR::IsPhi);
+            IR::IREmitter ir{*merge, insert_point};
+            ir.Barrier();
+        }
+    }
+}
+
+} // namespace Shader::Optimization

--- a/src/shader_recompiler/profile.h
+++ b/src/shader_recompiler/profile.h
@@ -27,6 +27,7 @@ struct Profile {
     bool has_broken_spirv_clamp{};
     bool lower_left_origin_mode{};
     bool needs_manual_interpolation{};
+    bool needs_lds_barriers{};
     u64 min_ssbo_alignment{};
 };
 

--- a/src/shader_recompiler/recompiler.cpp
+++ b/src/shader_recompiler/recompiler.cpp
@@ -91,7 +91,7 @@ IR::Program TranslateProgram(std::span<const u32> code, Pools& pools, Info& info
     Shader::Optimization::IdentityRemovalPass(program.blocks);
     Shader::Optimization::DeadCodeEliminationPass(program);
     Shader::Optimization::CollectShaderInfoPass(program);
-    Shader::Optimization::SharedMemoryBarrierPass(program);
+    Shader::Optimization::SharedMemoryBarrierPass(program, profile);
 
     return program;
 }

--- a/src/shader_recompiler/recompiler.cpp
+++ b/src/shader_recompiler/recompiler.cpp
@@ -91,6 +91,7 @@ IR::Program TranslateProgram(std::span<const u32> code, Pools& pools, Info& info
     Shader::Optimization::IdentityRemovalPass(program.blocks);
     Shader::Optimization::DeadCodeEliminationPass(program);
     Shader::Optimization::CollectShaderInfoPass(program);
+    Shader::Optimization::SharedMemoryBarrierPass(program);
 
     return program;
 }

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -204,6 +204,7 @@ PipelineCache::PipelineCache(const Instance& instance_, Scheduler& scheduler_,
         .supports_image_load_store_lod = instance_.IsImageLoadStoreLodSupported(),
         .needs_manual_interpolation = instance.IsFragmentShaderBarycentricSupported() &&
                                       instance.GetDriverID() == vk::DriverId::eNvidiaProprietary,
+        .needs_lds_barriers = instance.GetDriverID() == vk::DriverId::eNvidiaProprietary,
     };
     auto [cache_result, cache] = instance.GetDevice().createPipelineCacheUnique({});
     ASSERT_MSG(cache_result == vk::Result::eSuccess, "Failed to create pipeline cache: {}",


### PR DESCRIPTION
Sometimes shaders can use shared memory without appropriate barriers in ISA level. This is probably because compiler optimized them away as it found them not needed (local workgroup size 64 for example makes barriers not necessary). This adds a new IR pass that attempts to insert such barriers to avoid device loss issues and graphics artifacts on NVIDIA.

Inserting barriers right after data share write instructions is not possible as we must have the barrier be outside of the non-uniform conditional block. The process is a bit naive at the moment, but it involves walking the generated AST and for shaders that use shared memory it inserts barriers after all zero-depth divergent conditional blocks.

The zero-depth clause prevents insertion of barriers already inside non-uniform blocks as that can cause issues since not all threads are executing that block. A block is deemed non-uniform if its condition contains gl_LocalInvocationId, which is simple and effective for now, but by far not exhaustive