### PR TITLE
liverpool: Flush vulkan work on task finish

### DIFF
--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -123,6 +123,10 @@ void Liverpool::Process(std::stop_token stoken) {
             if (task.done()) {
                 task.destroy();
 
+                if (rasterizer) {
+                    rasterizer->Flush();
+                }
+
                 std::scoped_lock lock{queue.m_access};
                 queue.submits.pop();
 
@@ -134,10 +138,6 @@ void Liverpool::Process(std::stop_token stoken) {
 
         if (submit_done) {
             VideoCore::EndCapture();
-
-            if (rasterizer) {
-                rasterizer->Flush();
-            }
             submit_done = false;
         }
 


### PR DESCRIPTION
Ensures we feed the GPU work more frequently, by increasing frequency of submissions from entire frame to once every submitted command list. Should give small performance boost to heavy 3D games or games that submit a lot of commands