### PR TITLE
Implement gamma correction in main config menu

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -64,6 +64,7 @@ static bool vkCrashDiagnostic = false;
 static s16 cursorState = HideCursorState::Idle;
 static int cursorHideTimeout = 5; // 5 seconds (default)
 static bool separateupdatefolder = false;
+static int GammaValue = 1000;
 
 // Gui
 std::vector<std::filesystem::path> settings_install_dirs = {};
@@ -224,6 +225,10 @@ bool getSeparateUpdateEnabled() {
     return separateupdatefolder;
 }
 
+int getGammaValue() {
+    return GammaValue;
+}
+
 void setGpuId(s32 selectedGpuId) {
     gpuId = selectedGpuId;
 }
@@ -342,6 +347,10 @@ void setSpecialPadClass(int type) {
 
 void setSeparateUpdateEnabled(bool use) {
     separateupdatefolder = use;
+}
+
+void setGammaValue(int value) {
+    GammaValue = value;
 }
 
 void setMainWindowGeometry(u32 x, u32 y, u32 w, u32 h) {
@@ -566,6 +575,7 @@ void load(const std::filesystem::path& path) {
         shouldDumpShaders = toml::find_or<bool>(gpu, "dumpShaders", false);
         shouldPatchShaders = toml::find_or<bool>(gpu, "patchShaders", true);
         vblankDivider = toml::find_or<int>(gpu, "vblankDivider", 1);
+        GammaValue = toml::find_or<int>(gpu, "GammaValue", 1000);
     }
 
     if (data.contains("Vulkan")) {
@@ -668,6 +678,7 @@ void save(const std::filesystem::path& path) {
     data["GPU"]["dumpShaders"] = shouldDumpShaders;
     data["GPU"]["patchShaders"] = shouldPatchShaders;
     data["GPU"]["vblankDivider"] = vblankDivider;
+    data["GPU"]["GammaValue"] = GammaValue;
     data["Vulkan"]["gpuId"] = gpuId;
     data["Vulkan"]["validation"] = vkValidation;
     data["Vulkan"]["validation_sync"] = vkValidationSync;
@@ -775,6 +786,7 @@ void setDefaultValues() {
     m_language = 1;
     gpuId = -1;
     separateupdatefolder = false;
+    GammaValue = 1000;
 }
 
 } // namespace Config

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -21,6 +21,7 @@ bool getPlayBGM();
 int getBGMvolume();
 bool getEnableDiscordRPC();
 bool getSeparateUpdateEnabled();
+int getGammaValue();
 
 std::string getLogFilter();
 std::string getLogType();
@@ -68,6 +69,7 @@ void setNeoMode(bool enable);
 void setUserName(const std::string& type);
 void setUpdateChannel(const std::string& type);
 void setSeparateUpdateEnabled(bool use);
+void setGammaValue(int value);
 void setGameInstallDirs(const std::vector<std::filesystem::path>& settings_install_dirs_config);
 
 void setCursorState(s16 cursorState);

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -27,7 +27,7 @@
 #endif
 
 namespace QtExternal {
-extern bool isGameRunning = false;
+bool isGameRunning = false;
 }
 
 MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWindow) {

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -26,7 +26,9 @@
 #include "common/discord_rpc_handler.h"
 #endif
 
-bool isGameRunning = false;
+namespace QtExternal {
+    static bool isGameRunning = false;
+}
 
 MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWindow) {
     ui->setupUi(this);
@@ -554,7 +556,9 @@ void MainWindow::CreateConnects() {
 }
 
 void MainWindow::StartGame() {
-    isGameRunning = true;
+    using namespace QtExternal;
+    QtExternal::isGameRunning = true;
+    
     BackgroundMusicPlayer::getInstance().stopMusic();
     QString gamePath = "";
     int table_mode = Config::getTableMode();

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -26,6 +26,8 @@
 #include "common/discord_rpc_handler.h"
 #endif
 
+bool isGameRunning = false;
+
 MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWindow) {
     ui->setupUi(this);
     installEventFilter(this);

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -27,7 +27,7 @@
 #endif
 
 namespace QtExternal {
-    static bool isGameRunning = false;
+extern bool isGameRunning = false;
 }
 
 MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWindow) {
@@ -558,7 +558,7 @@ void MainWindow::CreateConnects() {
 void MainWindow::StartGame() {
     using namespace QtExternal;
     QtExternal::isGameRunning = true;
-    
+
     BackgroundMusicPlayer::getInstance().stopMusic();
     QString gamePath = "";
     int table_mode = Config::getTableMode();

--- a/src/qt_gui/main_window.h
+++ b/src/qt_gui/main_window.h
@@ -23,7 +23,7 @@
 #include "pkg_viewer.h"
 
 namespace QtExternal {
-    extern bool isGameRunning;
+extern bool isGameRunning;
 }
 
 class GameListFrame;

--- a/src/qt_gui/main_window.h
+++ b/src/qt_gui/main_window.h
@@ -22,7 +22,10 @@
 #include "main_window_ui.h"
 #include "pkg_viewer.h"
 
-extern bool isGameRunning;
+namespace QtExternal {
+    extern bool isGameRunning;
+}
+
 class GameListFrame;
 
 class MainWindow : public QMainWindow {

--- a/src/qt_gui/main_window.h
+++ b/src/qt_gui/main_window.h
@@ -22,6 +22,7 @@
 #include "main_window_ui.h"
 #include "pkg_viewer.h"
 
+extern bool isGameRunning;
 class GameListFrame;
 
 class MainWindow : public QMainWindow {
@@ -70,7 +71,6 @@ private:
     QIcon RecolorIcon(const QIcon& icon, bool isWhite);
     bool isIconBlack = false;
     bool isTableList = true;
-    bool isGameRunning = false;
     QActionGroup* m_icon_size_act_group = nullptr;
     QActionGroup* m_list_mode_act_group = nullptr;
     QActionGroup* m_theme_act_group = nullptr;

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -316,7 +316,7 @@ void SettingsDialog::LoadValuesFromConfig() {
     SyncRealTimeWidgetstoConfig();
 
     float Gammafloat = static_cast<float>((ui->GammaSlider->value() / 1000.0f));
-    ui->GammaLabel->setText(QString::number(Gammafloat));
+    ui->GammaLabel->setText(QString::number(Gammafloat, 'f', 3));
 }
 
 void SettingsDialog::InitializeEmulatorLanguages() {
@@ -377,7 +377,7 @@ void SettingsDialog::OnCursorStateChanged(s16 index) {
 
 void SettingsDialog::GammaSliderChange(int value) {
     float Gammafloat = static_cast<float>((value / 1000.0f));
-    ui->GammaLabel->setText(QString::number(Gammafloat));
+    ui->GammaLabel->setText(QString::number(Gammafloat, 'f', 3));
 
     // presenter crashes if game is running, set isGameRunning to off when stop game is implemented
     if (isGameRunning) {

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -295,6 +295,7 @@ void SettingsDialog::LoadValuesFromConfig() {
         toml::find_or<bool>(data, "Vulkan", "validation_sync", false));
     ui->rdocCheckBox->setChecked(toml::find_or<bool>(data, "Vulkan", "rdocEnable", false));
     ui->GammaSlider->setValue(toml::find_or<int>(data, "GPU", "GammaValue", 1000));
+    ui->GammaLabel->setText(QString::number(ui->GammaSlider->value()));
 
 #ifdef ENABLE_UPDATER
     ui->updateCheckBox->setChecked(toml::find_or<bool>(data, "General", "autoUpdate", false));
@@ -375,6 +376,7 @@ void SettingsDialog::OnCursorStateChanged(s16 index) {
 }
 
 void SettingsDialog::GammaSliderChange(int value) {
+    ui->GammaLabel->setText(QString::number(ui->GammaSlider->value()));
     float Gammafloat = static_cast<float>((value / 1000.0f));
 
     if (isGameRunning) {

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -380,7 +380,8 @@ void SettingsDialog::GammaSliderChange(int value) {
     float Gammafloat = static_cast<float>((value / 1000.0f));
     ui->GammaLabel->setText(QString::number(Gammafloat, 'f', 3));
 
-    // GetGammaRef crashes if no game is running, set isGameRunning to false when MainWindow::StopGame is implemented
+    // GetGammaRef crashes if no game running, set isGameRunning to false
+    // when MainWindow::StopGame is implemented in the future
     if (QtExternal::isGameRunning) {
         presenter->GetGammaRef() = Gammafloat;
     }

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -217,7 +217,7 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices, QWidge
         ui->heightDivider->installEventFilter(this);
         ui->dumpShadersCheckBox->installEventFilter(this);
         ui->nullGpuCheckBox->installEventFilter(this);
-        ui->GammaSlider->installEventFilter(this);
+        ui->GammaGroupBox->installEventFilter(this);
 
         // Paths
         ui->gameFoldersGroupBox->installEventFilter(this);
@@ -451,6 +451,8 @@ void SettingsDialog::updateNoteTextEdit(const QString& elementName) {
         text = tr("dumpShadersCheckBox");
     } else if (elementName == "nullGpuCheckBox") {
         text = tr("nullGpuCheckBox");
+    } else if (elementName == "GammaGroupBox") {
+        text = tr("GammaGroupBox");
     }
 
     // Path

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -376,11 +376,12 @@ void SettingsDialog::OnCursorStateChanged(s16 index) {
 }
 
 void SettingsDialog::GammaSliderChange(int value) {
+    using namespace QtExternal;
     float Gammafloat = static_cast<float>((value / 1000.0f));
     ui->GammaLabel->setText(QString::number(Gammafloat, 'f', 3));
 
-    // presenter crashes if game is running, set isGameRunning to off when stop game is implemented
-    if (isGameRunning) {
+    // GetGammaRef crashes if no game is running, set isGameRunning to false when MainWindow::StopGame is implemented
+    if (QtExternal::isGameRunning) {
         presenter->GetGammaRef() = Gammafloat;
     }
 }

--- a/src/qt_gui/settings_dialog.h
+++ b/src/qt_gui/settings_dialog.h
@@ -36,6 +36,8 @@ private:
     void InitializeEmulatorLanguages();
     void OnLanguageChanged(int index);
     void OnCursorStateChanged(s16 index);
+    void GammaSliderChange(int value);
+    void ResetGamma();
 
     std::unique_ptr<Ui::SettingsDialog> ui;
 

--- a/src/qt_gui/settings_dialog.h
+++ b/src/qt_gui/settings_dialog.h
@@ -32,7 +32,7 @@ signals:
 private:
     void LoadValuesFromConfig();
     void UpdateSettings();
-    void ResetInstallFolders();
+    void SyncRealTimeWidgetstoConfig();
     void InitializeEmulatorLanguages();
     void OnLanguageChanged(int index);
     void OnCursorStateChanged(s16 index);

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -946,11 +946,11 @@
                 </widget>
                </item>
                <item>
-                <layout class="QHBoxLayout" name="LighterDarkerHLayout">
+                <layout class="QHBoxLayout" name="BrighterDarkerHLayout">
                  <item>
-                  <widget class="QLabel" name="LighterLabel">
+                  <widget class="QLabel" name="BrighterLabel">
                    <property name="text">
-                    <string>Lighter</string>
+                    <string>Brighter</string>
                    </property>
                   </widget>
                  </item>

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -901,7 +901,28 @@
               <property name="title">
                <string>Gamma Correction</string>
               </property>
-              <layout class="QVBoxLayout" name="verticalLayout_9">
+              <layout class="QVBoxLayout" name="verticalLayout_2">
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout_5">
+                 <item>
+                  <widget class="QLabel" name="label_4">
+                   <property name="text">
+                    <string>Current Value:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="GammaLabel">
+                   <property name="text">
+                    <string>GammaVal</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
                <item>
                 <widget class="QSlider" name="GammaSlider">
                  <property name="minimum">
@@ -916,7 +937,34 @@
                  <property name="orientation">
                   <enum>Qt::Orientation::Horizontal</enum>
                  </property>
+                 <property name="invertedAppearance">
+                  <bool>false</bool>
+                 </property>
+                 <property name="invertedControls">
+                  <bool>false</bool>
+                 </property>
                 </widget>
+               </item>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout">
+                 <item>
+                  <widget class="QLabel" name="label_3">
+                   <property name="text">
+                    <string>Lighter</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="label_2">
+                   <property name="text">
+                    <string>Darker</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
                </item>
                <item>
                 <widget class="QPushButton" name="ResetGammaButton">

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -897,15 +897,15 @@
              </widget>
             </item>
             <item>
-             <widget class="QGroupBox" name="groupBox">
+             <widget class="QGroupBox" name="GammaGroupBox">
               <property name="title">
                <string>Gamma Correction</string>
               </property>
-              <layout class="QVBoxLayout" name="verticalLayout_2">
+              <layout class="QVBoxLayout" name="GammaVLayout">
                <item>
-                <layout class="QHBoxLayout" name="horizontalLayout_5">
+                <layout class="QHBoxLayout" name="GammaLabelsHLayout">
                  <item>
-                  <widget class="QLabel" name="label_4">
+                  <widget class="QLabel" name="CurrentValueLabel">
                    <property name="text">
                     <string>Current Value:</string>
                    </property>
@@ -946,16 +946,16 @@
                 </widget>
                </item>
                <item>
-                <layout class="QHBoxLayout" name="horizontalLayout">
+                <layout class="QHBoxLayout" name="LighterDarkerHLayout">
                  <item>
-                  <widget class="QLabel" name="label_3">
+                  <widget class="QLabel" name="LighterLabel">
                    <property name="text">
                     <string>Lighter</string>
                    </property>
                   </widget>
                  </item>
                  <item>
-                  <widget class="QLabel" name="label_2">
+                  <widget class="QLabel" name="DarkerLabel">
                    <property name="text">
                     <string>Darker</string>
                    </property>

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -60,8 +60,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>832</width>
-        <height>431</height>
+        <width>815</width>
+        <height>623</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -696,7 +696,7 @@
                   <property name="bottomMargin">
                    <number>5</number>
                   </property>
-                  <item alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item>
                    <widget class="QSpinBox" name="idleTimeoutSpinBox">
                     <property name="enabled">
                      <bool>true</bool>
@@ -897,20 +897,34 @@
              </widget>
             </item>
             <item>
-             <widget class="QWidget" name="widgetgraphicsBottom" native="true">
-              <layout class="QHBoxLayout" name="widgetgraphicsBottomHLayout">
-               <property name="leftMargin">
-                <number>0</number>
-               </property>
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
-                <number>0</number>
-               </property>
+             <widget class="QGroupBox" name="groupBox">
+              <property name="title">
+               <string>Gamma Correction</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_9">
+               <item>
+                <widget class="QSlider" name="GammaSlider">
+                 <property name="minimum">
+                  <number>1</number>
+                 </property>
+                 <property name="maximum">
+                  <number>2000</number>
+                 </property>
+                 <property name="value">
+                  <number>1000</number>
+                 </property>
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Horizontal</enum>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="ResetGammaButton">
+                 <property name="text">
+                  <string>Reset Gamma</string>
+                 </property>
+                </widget>
+               </item>
               </layout>
              </widget>
             </item>

--- a/src/qt_gui/translations/en.ts
+++ b/src/qt_gui/translations/en.ts
@@ -1257,6 +1257,11 @@
 			<translation>Graphics Device:\nOn multiple GPU systems, select the GPU the emulator will use from the drop down list,\nor select "Auto Select" to automatically determine it.</translation>
 		</message>
 		<message>
+			<location filename="../settings_dialog.cpp" line="319"/>
+			<source>GammaGroupBox</source>
+			<translation>Gamma Correction:\nApplies additional processing to brighten or darken the game. Overrides and is overriden by in-game brightness settings, the last change to either will take effect.</translation>
+		</message>
+		<message>
 			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Width/Height:\nSets the size of the emulator window at launch, which can be resized during gameplay.\nThis is different from the in-game resolution.</translation>

--- a/src/video_core/renderer_vulkan/vk_presenter.cpp
+++ b/src/video_core/renderer_vulkan/vk_presenter.cpp
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "common/config.h"
 #include "common/debug.h"
 #include "common/singleton.h"
 #include "core/debug_state.h"

--- a/src/video_core/renderer_vulkan/vk_presenter.h
+++ b/src/video_core/renderer_vulkan/vk_presenter.h
@@ -5,6 +5,7 @@
 
 #include <condition_variable>
 
+#include "common/config.h"
 #include "video_core/amdgpu/liverpool.h"
 #include "video_core/renderer_vulkan/vk_instance.h"
 #include "video_core/renderer_vulkan/vk_scheduler.h"
@@ -42,7 +43,7 @@ class Rasterizer;
 
 class Presenter {
     struct PostProcessSettings {
-        float gamma = 1.0f;
+        float gamma = static_cast<float>((Config::getGammaValue() / 1000.0f));
     };
 
 public:


### PR DESCRIPTION
This PR adds a setting for Gamma correction in the settings dialog Graphics tab. While there is a gamma correction tool in the advanced debug menu, this one is intended is more accessible for regular users and the setting can also be saved (the devtools gamma setting is not currently saved).

Useful in the short term while the PR for gamma is being sorted out, in the long term also may be useful for games lacking a native Brightness setting

![image](https://github.com/user-attachments/assets/5c0af764-6c4d-423d-8eb3-4d73686babb9)


