### PR TITLE
fs: Fix wrong mounts being matched by partial guest path.

### DIFF
--- a/src/core/file_sys/fs.cpp
+++ b/src/core/file_sys/fs.cpp
@@ -10,16 +10,28 @@
 
 namespace Core::FileSys {
 
+std::string RemoveTrailingSlashes(const std::string& path) {
+    // Remove trailing slashes to make comparisons simpler.
+    std::string path_sanitized = path;
+    while (path_sanitized.ends_with("/")) {
+        path_sanitized.pop_back();
+    }
+    return path_sanitized;
+}
+
 void MntPoints::Mount(const std::filesystem::path& host_folder, const std::string& guest_folder,
                       bool read_only) {
     std::scoped_lock lock{m_mutex};
-    m_mnt_pairs.emplace_back(host_folder, guest_folder, read_only);
+    const auto guest_folder_sanitized = RemoveTrailingSlashes(guest_folder);
+    m_mnt_pairs.emplace_back(host_folder, guest_folder_sanitized, read_only);
 }
 
 void MntPoints::Unmount(const std::filesystem::path& host_folder, const std::string& guest_folder) {
     std::scoped_lock lock{m_mutex};
-    auto it = std::remove_if(m_mnt_pairs.begin(), m_mnt_pairs.end(),
-                             [&](const MntPair& pair) { return pair.mount == guest_folder; });
+    const auto guest_folder_sanitized = RemoveTrailingSlashes(guest_folder);
+    auto it = std::remove_if(m_mnt_pairs.begin(), m_mnt_pairs.end(), [&](const MntPair& pair) {
+        return pair.mount == guest_folder_sanitized;
+    });
     m_mnt_pairs.erase(it, m_mnt_pairs.end());
 }
 
@@ -47,7 +59,8 @@ std::filesystem::path MntPoints::GetHostPath(std::string_view path, bool* is_rea
     }
 
     // Nothing to do if getting the mount itself.
-    if (corrected_path == mount->mount) {
+    const auto corrected_path_sanitized = RemoveTrailingSlashes(corrected_path);
+    if (corrected_path_sanitized == mount->mount) {
         return mount->host_path;
     }
 

--- a/src/core/file_sys/fs.h
+++ b/src/core/file_sys/fs.h
@@ -22,7 +22,7 @@ class MntPoints {
 public:
     struct MntPair {
         std::filesystem::path host_path;
-        std::string mount; // e.g /app0/
+        std::string mount; // e.g /app0
         bool read_only;
     };
 
@@ -39,8 +39,11 @@ public:
 
     const MntPair* GetMount(const std::string& guest_path) {
         std::scoped_lock lock{m_mutex};
-        const auto it = std::ranges::find_if(
-            m_mnt_pairs, [&](const auto& mount) { return guest_path.starts_with(mount.mount); });
+        const auto it = std::ranges::find_if(m_mnt_pairs, [&](const auto& mount) {
+            // When doing starts-with check, add a trailing slash to make sure we don't match
+            // against only part of the mount path.
+            return guest_path == mount.mount || guest_path.starts_with(mount.mount + "/");
+        });
         return it == m_mnt_pairs.end() ? nullptr : &*it;
     }
 


### PR DESCRIPTION
Currently when finding the mount for a guest path, if one of the mounts is a prefix of another mount, the wrong mount may be matched. For example, if both `/addcont3` and `/addcont30` are mounted, the path `/addcont30/file` may match with `/addcont3` despite being the wrong mount.

To fix this:
* Added sanitization to make sure the `mount` guest path has no trailing slash, to help with the following change.
* Changed the mount find condition to check if either the paths are equal (path is exactly the mount path) or path starts with the mount path plus a trailing slash (either exactly the mount path with trailing slash or a sub-path of the mount).

Fixes loading DLC songs in CUSA12636 and CUSA12380.