### PR TITLE
add R8Uint in image Detiling

### DIFF
--- a/src/video_core/texture_cache/tile_manager.cpp
+++ b/src/video_core/texture_cache/tile_manager.cpp
@@ -172,6 +172,7 @@ void ConvertTileToLinear(u8* dst, const u8* src, u32 width, u32 height, bool is_
 
 vk::Format DemoteImageFormatForDetiling(vk::Format format) {
     switch (format) {
+    case vk::Format::eR8Uint:
     case vk::Format::eR8Unorm:
         return vk::Format::eR8Uint;
     case vk::Format::eR4G4B4A4UnormPack16:


### PR DESCRIPTION
used by InFamous, and maybe other games
```
[Render.Vulkan] <Error> tile_manager.cpp:DemoteImageFormatForDetiling:226: Unexpected format for demotion R8Uint
```