### PR TITLE
Handle MEM_SEMAPHORE PM4 packets

### DIFF
--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -293,15 +293,15 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
                 const auto* mem_semaphore = reinterpret_cast<const PM4CmdMemSemaphore*>(header);
                 const auto addr = mem_semaphore->Address<VAddr>();
                 const auto select = mem_semaphore->semSel;
-                const auto client = mem_semaphore->clientCode;
                 const auto signal_type = mem_semaphore->signalType;
-                LOG_WARNING(Lib_GnmDriver, "MemSemaphore ignored: addr {:#X}, select {}, client {}, signal {}, wait {}, mailbox {}",
+                using enum PM4CmdMemSemaphore::MemSemaphoreSelect;
+                using enum PM4CmdMemSemaphore::MemSemaphoreSignalType;
+                LOG_DEBUG(Lib_GnmDriver,
+                    "MemSemaphore GFX addr = {:#X}: {}, {}",
                     addr,
-                    select.Value() == PM4CmdMemSemaphore::MemSemaphoreSelect::SignalSemaphore ? "signal" : "wait",
-                    client.Value() == PM4CmdMemSemaphore::MemSemaphoreClientCode::CP ? "CP" : std::to_string(std::to_underlying(client.Value())),
-                    std::to_underlying(signal_type.Value()) == 1 ? "increment/decrement" : "set 1/do nothing",
-                    mem_semaphore->waitOnSignal.Value(),
-                    std::to_underlying(mem_semaphore->useMailbox.Value())
+                    select.Value() == SignalSemaphore ? "signal" : "wait",
+                    signal_type.Value() == SignalIncrementOrDecrement
+                        ? "increment/decrement" : "set 1/do nothing"
                 );
                 if (rasterizer) {
                     rasterizer->GlobalBarrier();
@@ -868,15 +868,14 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
             const auto* mem_semaphore = reinterpret_cast<const PM4CmdMemSemaphore*>(header);
             const auto addr = mem_semaphore->Address<VAddr>();
             const auto select = mem_semaphore->semSel;
-            const auto client = mem_semaphore->clientCode;
             const auto signal_type = mem_semaphore->signalType;
-            LOG_WARNING(Lib_GnmDriver, "MemSemaphore ignored: addr {:#X}, select {}, client {}, signal {}, wait {}, mailbox {}",
+            using enum PM4CmdMemSemaphore::MemSemaphoreSelect;
+            using enum PM4CmdMemSemaphore::MemSemaphoreSignalType;
+            LOG_DEBUG(Lib_GnmDriver, "MemSemaphore CE addr = {:#X}: {}, {}",
                 addr,
-                select.Value() == PM4CmdMemSemaphore::MemSemaphoreSelect::SignalSemaphore ? "signal" : "wait",
-                client.Value() == PM4CmdMemSemaphore::MemSemaphoreClientCode::CP ? "CP" : std::to_string(std::to_underlying(client.Value())),
-                std::to_underlying(signal_type.Value()) == 1 ? "increment/decrement" : "set 1/do nothing",
-                mem_semaphore->waitOnSignal.Value(),
-                std::to_underlying(mem_semaphore->useMailbox.Value())
+                select.Value() == SignalSemaphore ? "signal" : "wait",
+                signal_type.Value() == SignalIncrementOrDecrement
+                    ? "increment/decrement" : "set 1/do nothing"
             );
             if (rasterizer) {
                 rasterizer->GlobalBarrier();

--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -876,15 +876,15 @@ struct PM4CmdMemSemaphore {
     };
     enum class MemSemaphoreSelect : u32 {
         SignalSemaphore = 0b110u,
-        WaitSemaphore = 0b1111u
+        WaitSemaphore = 0b111u
     };
     enum class MemSemaphoreUseMailbox : u32 {
         DoNotWaitForMailboxToBeWritten = 0u,
         WaitForMailboxToBeWritten = 1u
     };
     enum class MemSemaphoreSignalType : u32 {
-        SignalIncrementOrWait = 0u,
-        SignalSetOne = 1u
+        SignalIncrementOrDecrement = 0u,
+        SignalSetOneOrDoNothing = 1u
     };
 
     PM4Type3Header header; ///< header
@@ -906,7 +906,7 @@ struct PM4CmdMemSemaphore {
 
     template <typename T>
     T Address() const {
-        return reinterpret_cast<T>(addr_lo | u64(addr_hi) << 32);
+        return reinterpret_cast<T>(u64(addr_lo) << 3 | (u64(addr_hi) << 32));
     }
 };
 

--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -867,4 +867,47 @@ struct PM4CmdDrawIndexIndirectMulti {
     u32 draw_initiator; ///< Draw Initiator Register
 };
 
+struct PM4CmdMemSemaphore {
+    enum class MemSemaphoreClientCode : u32 {
+        CommandProcessor = 0b00u,
+        CommandBuffer = 0b01u,
+        DataBuffer = 0b10u,
+        Reserved = 0b11u,
+    };
+    enum class MemSemaphoreSelect : u32 {
+        SignalSemaphore = 0b110u,
+        WaitSemaphore = 0b1111u
+    };
+    enum class MemSemaphoreUseMailbox : u32 {
+        DoNotWaitForMailboxToBeWritten = 0u,
+        WaitForMailboxToBeWritten = 1u
+    };
+    enum class MemSemaphoreSignalType : u32 {
+        SignalIncrementOrWait = 0u,
+        SignalSetOne = 1u
+    };
+
+    PM4Type3Header header; ///< header
+    union {
+        BitField<3, 29, u32> addr_lo; ///< Semaphore address bits [31:3]
+        u32 dw1;
+    };
+    union {
+        u32 dw2;
+        BitField<0, 8, u32> addr_hi; ///< Semaphore address bits [39:32]
+        BitField<12, 1, u32>
+            waitOnSignal; ///< Wait until all outstanding EOP have completed
+        BitField<16, 1, MemSemaphoreUseMailbox>
+            useMailbox; ///< Enables waiting until mailbox is written to
+        BitField<20, 1, MemSemaphoreSignalType> signalType;
+        BitField<24, 2, MemSemaphoreClientCode> clientCode;
+        BitField<29, 3, MemSemaphoreSelect> semSel;
+    };
+
+    template <typename T>
+    T Address() const {
+        return reinterpret_cast<T>(addr_lo | u64(addr_hi) << 32);
+    }
+};
+
 } // namespace AmdGpu

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -47,6 +47,19 @@ void Rasterizer::CpSync() {
                            vk::DependencyFlagBits::eByRegion, ib_barrier, {}, {});
 }
 
+void Rasterizer::GlobalBarrier() {
+    scheduler.EndRendering();
+    auto cmdbuf = scheduler.CommandBuffer();
+
+    const vk::MemoryBarrier mem_barrier{
+        .srcAccessMask = vk::AccessFlagBits::eMemoryWrite,
+        .dstAccessMask = vk::AccessFlagBits::eMemoryRead,
+    };
+    cmdbuf.pipelineBarrier(vk::PipelineStageFlagBits::eAllCommands,
+                           vk::PipelineStageFlagBits::eAllCommands,
+                           vk::DependencyFlagBits::eByRegion, {mem_barrier}, {}, {});
+}
+
 bool Rasterizer::FilterDraw() {
     const auto& regs = liverpool->regs;
     // There are several cases (e.g. FCE, FMask/HTile decompression) where we don't need to do an

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -60,6 +60,7 @@ public:
     void UnmapMemory(VAddr addr, u64 size);
 
     void CpSync();
+    void GlobalBarrier();
     u64 Flush();
     void Finish();
 


### PR DESCRIPTION
Implements MEM_SEMAPHORE as a global barrier in the pipeline, that is probably not optimal from the performance perspective, but allows games to process further.

If you have any comments let me know and I'll try to fix 