### PR TITLE
shader_recompiler: Rework image read/write emit.

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
@@ -395,14 +395,13 @@ Id EmitImageGather(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords,
                    const IR::Value& offset);
 Id EmitImageGatherDref(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords,
                        const IR::Value& offset, Id dref);
-Id EmitImageFetch(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id lod,
-                  const IR::Value& offset, Id ms);
 Id EmitImageQueryDimensions(EmitContext& ctx, IR::Inst* inst, u32 handle, Id lod, bool skip_mips);
 Id EmitImageQueryLod(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords);
 Id EmitImageGradient(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id derivatives_dx,
                      Id derivatives_dy, const IR::Value& offset, const IR::Value& lod_clamp);
-Id EmitImageRead(EmitContext& ctx, IR::Inst* inst, const IR::Value& index, Id coords, Id lod);
-void EmitImageWrite(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id lod, Id color);
+Id EmitImageRead(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id lod, Id ms);
+void EmitImageWrite(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id lod, Id ms,
+                    Id color);
 
 Id EmitImageAtomicIAdd32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id value);
 Id EmitImageAtomicSMin32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id value);

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -772,7 +772,7 @@ Id ImageType(EmitContext& ctx, const ImageResource& desc, Id sampled_type) {
     const auto image = desc.GetSharp(ctx.info);
     const auto format = desc.is_atomic ? GetFormat(image) : spv::ImageFormat::Unknown;
     const auto type = image.GetBoundType();
-    const u32 sampled = desc.is_storage ? 2 : 1;
+    const u32 sampled = desc.IsStorage(image) ? 2 : 1;
     switch (type) {
     case AmdGpu::ImageType::Color1D:
         return ctx.TypeImage(sampled_type, spv::Dim::Dim1D, false, false, false, sampled, format);
@@ -800,6 +800,7 @@ void EmitContext::DefineImagesAndSamplers() {
         const auto sharp = image_desc.GetSharp(info);
         const auto nfmt = sharp.GetNumberFmt();
         const bool is_integer = AmdGpu::IsInteger(nfmt);
+        const bool is_storage = image_desc.IsStorage(sharp);
         const VectorIds& data_types = GetAttributeType(*this, nfmt);
         const Id sampled_type = data_types[1];
         const Id image_type{ImageType(*this, image_desc, sampled_type)};
@@ -811,11 +812,11 @@ void EmitContext::DefineImagesAndSamplers() {
         images.push_back({
             .data_types = &data_types,
             .id = id,
-            .sampled_type = image_desc.is_storage ? sampled_type : TypeSampledImage(image_type),
+            .sampled_type = is_storage ? sampled_type : TypeSampledImage(image_type),
             .pointer_type = pointer_type,
             .image_type = image_type,
             .is_integer = is_integer,
-            .is_storage = image_desc.is_storage,
+            .is_storage = is_storage,
         });
         interfaces.push_back(id);
     }

--- a/src/shader_recompiler/frontend/translate/vector_memory.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_memory.cpp
@@ -420,13 +420,13 @@ void Translator::IMAGE_LOAD(bool has_mip, const GcnInst& inst) {
 
     IR::TextureInstInfo info{};
     info.has_lod.Assign(has_mip);
-    const IR::Value texel = ir.ImageFetch(handle, body, {}, {}, {}, info);
+    const IR::Value texel = ir.ImageRead(handle, body, {}, {}, info);
 
     for (u32 i = 0; i < 4; i++) {
         if (((mimg.dmask >> i) & 1) == 0) {
             continue;
         }
-        IR::F32 value = IR::F32{ir.CompositeExtract(texel, i)};
+        IR::U32 value = IR::U32{ir.CompositeExtract(texel, i)};
         ir.SetVectorReg(dest_reg++, value);
     }
 }
@@ -454,7 +454,7 @@ void Translator::IMAGE_STORE(bool has_mip, const GcnInst& inst) {
         comps.push_back(ir.GetVectorReg<IR::F32>(data_reg++));
     }
     const IR::Value value = ir.CompositeConstruct(comps[0], comps[1], comps[2], comps[3]);
-    ir.ImageWrite(handle, body, {}, value, info);
+    ir.ImageWrite(handle, body, {}, {}, value, info);
 }
 
 void Translator::IMAGE_GET_RESINFO(const GcnInst& inst) {

--- a/src/shader_recompiler/info.h
+++ b/src/shader_recompiler/info.h
@@ -49,11 +49,11 @@ struct BufferResource {
     u8 instance_attrib{};
     bool is_written{};
 
-    bool IsStorage(AmdGpu::Buffer buffer) const noexcept {
+    [[nodiscard]] bool IsStorage(const AmdGpu::Buffer& buffer) const noexcept {
         return buffer.GetSize() > MaxUboSize || is_written || is_gds_buffer;
     }
 
-    constexpr AmdGpu::Buffer GetSharp(const Info& info) const noexcept;
+    [[nodiscard]] constexpr AmdGpu::Buffer GetSharp(const Info& info) const noexcept;
 };
 using BufferResourceList = boost::container::small_vector<BufferResource, 16>;
 
@@ -61,18 +61,24 @@ struct TextureBufferResource {
     u32 sharp_idx;
     bool is_written{};
 
-    constexpr AmdGpu::Buffer GetSharp(const Info& info) const noexcept;
+    [[nodiscard]] constexpr AmdGpu::Buffer GetSharp(const Info& info) const noexcept;
 };
 using TextureBufferResourceList = boost::container::small_vector<TextureBufferResource, 16>;
 
 struct ImageResource {
     u32 sharp_idx;
-    bool is_storage{};
     bool is_depth{};
     bool is_atomic{};
     bool is_array{};
+    bool is_read{};
+    bool is_written{};
 
-    constexpr AmdGpu::Image GetSharp(const Info& info) const noexcept;
+    [[nodiscard]] bool IsStorage(const AmdGpu::Image& image) const noexcept {
+        // Need cube as storage when used with ImageRead.
+        return is_written || (is_read && image.GetBoundType() == AmdGpu::ImageType::Cube);
+    }
+
+    [[nodiscard]] constexpr AmdGpu::Image GetSharp(const Info& info) const noexcept;
 };
 using ImageResourceList = boost::container::small_vector<ImageResource, 16>;
 

--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -1630,11 +1630,6 @@ Value IREmitter::ImageGatherDref(const Value& handle, const Value& coords, const
     return Inst(Opcode::ImageGatherDref, Flags{info}, handle, coords, offset, dref);
 }
 
-Value IREmitter::ImageFetch(const Value& handle, const Value& coords, const U32& lod,
-                            const Value& offset, const U32& multisampling, TextureInstInfo info) {
-    return Inst(Opcode::ImageFetch, Flags{info}, handle, coords, lod, offset, multisampling);
-}
-
 Value IREmitter::ImageQueryDimension(const Value& handle, const IR::U32& lod,
                                      const IR::U1& skip_mips) {
     return Inst(Opcode::ImageQueryDimensions, handle, lod, skip_mips);
@@ -1657,13 +1652,13 @@ Value IREmitter::ImageGradient(const Value& handle, const Value& coords,
 }
 
 Value IREmitter::ImageRead(const Value& handle, const Value& coords, const U32& lod,
-                           TextureInstInfo info) {
-    return Inst(Opcode::ImageRead, Flags{info}, handle, coords, lod);
+                           const U32& multisampling, TextureInstInfo info) {
+    return Inst(Opcode::ImageRead, Flags{info}, handle, coords, lod, multisampling);
 }
 
 void IREmitter::ImageWrite(const Value& handle, const Value& coords, const U32& lod,
-                           const Value& color, TextureInstInfo info) {
-    Inst(Opcode::ImageWrite, Flags{info}, handle, coords, lod, color);
+                           const U32& multisampling, const Value& color, TextureInstInfo info) {
+    Inst(Opcode::ImageWrite, Flags{info}, handle, coords, lod, multisampling, color);
 }
 
 // Debug print maps to SPIRV's NonSemantic DebugPrintf instruction

--- a/src/shader_recompiler/ir/ir_emitter.h
+++ b/src/shader_recompiler/ir/ir_emitter.h
@@ -325,17 +325,14 @@ public:
                                     TextureInstInfo info);
     [[nodiscard]] Value ImageGatherDref(const Value& handle, const Value& coords,
                                         const Value& offset, const F32& dref, TextureInstInfo info);
-    [[nodiscard]] Value ImageFetch(const Value& handle, const Value& coords, const U32& lod,
-                                   const Value& offset, const U32& multisampling,
-                                   TextureInstInfo info);
     [[nodiscard]] Value ImageGradient(const Value& handle, const Value& coords,
                                       const Value& derivatives_dx, const Value& derivatives_dy,
                                       const Value& offset, const F32& lod_clamp,
                                       TextureInstInfo info);
     [[nodiscard]] Value ImageRead(const Value& handle, const Value& coords, const U32& lod,
-                                  TextureInstInfo info);
-    void ImageWrite(const Value& handle, const Value& coords, const U32& lod, const Value& color,
-                    TextureInstInfo info);
+                                  const U32& multisampling, TextureInstInfo info);
+    void ImageWrite(const Value& handle, const Value& coords, const U32& lod,
+                    const U32& multisampling, const Value& color, TextureInstInfo info);
 
     void EmitVertex();
     void EmitPrimitive();

--- a/src/shader_recompiler/ir/opcodes.inc
+++ b/src/shader_recompiler/ir/opcodes.inc
@@ -338,12 +338,11 @@ OPCODE(ImageSampleDrefImplicitLod,                          F32x4,          Opaq
 OPCODE(ImageSampleDrefExplicitLod,                          F32x4,          Opaque,         Opaque,         F32,            F32,            Opaque,         )
 OPCODE(ImageGather,                                         F32x4,          Opaque,         Opaque,         Opaque,                                         )
 OPCODE(ImageGatherDref,                                     F32x4,          Opaque,         Opaque,         Opaque,         F32,                            )
-OPCODE(ImageFetch,                                          F32x4,          Opaque,         Opaque,         U32,            Opaque,         Opaque,         )
 OPCODE(ImageQueryDimensions,                                U32x4,          Opaque,         U32,            U1,                                             )
 OPCODE(ImageQueryLod,                                       F32x4,          Opaque,         Opaque,                                                         )
 OPCODE(ImageGradient,                                       F32x4,          Opaque,         Opaque,         Opaque,         Opaque,         Opaque,         F32,         )
-OPCODE(ImageRead,                                           U32x4,          Opaque,         Opaque,         U32,                                            )
-OPCODE(ImageWrite,                                          Void,           Opaque,         Opaque,         U32,            U32x4,                          )
+OPCODE(ImageRead,                                           U32x4,          Opaque,         Opaque,         U32,            U32,                            )
+OPCODE(ImageWrite,                                          Void,           Opaque,         Opaque,         U32,            U32,            U32x4,          )
 
 // Image atomic operations
 OPCODE(ImageAtomicIAdd32,                                   U32,            Opaque,         Opaque,         U32,                                            )

--- a/src/shader_recompiler/specialization.h
+++ b/src/shader_recompiler/specialization.h
@@ -39,10 +39,12 @@ struct TextureBufferSpecialization {
 struct ImageSpecialization {
     AmdGpu::ImageType type = AmdGpu::ImageType::Color2D;
     bool is_integer = false;
+    bool is_storage = false;
     u32 dst_select = 0;
 
     bool operator==(const ImageSpecialization& other) const {
         return type == other.type && is_integer == other.is_integer &&
+               is_storage == other.is_storage &&
                (dst_select != 0 ? dst_select == other.dst_select : true);
     }
 };
@@ -114,7 +116,8 @@ struct StageSpecialization {
                      [](auto& spec, const auto& desc, AmdGpu::Image sharp) {
                          spec.type = sharp.GetBoundType();
                          spec.is_integer = AmdGpu::IsInteger(sharp.GetNumberFmt());
-                         if (desc.is_storage) {
+                         spec.is_storage = desc.IsStorage(sharp);
+                         if (spec.is_storage) {
                              spec.dst_select = sharp.DstSelect();
                          }
                      });

--- a/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
@@ -58,8 +58,9 @@ ComputePipeline::ComputePipeline(const Instance& instance_, Scheduler& scheduler
     for (const auto& image : info->images) {
         bindings.push_back({
             .binding = binding++,
-            .descriptorType = image.is_storage ? vk::DescriptorType::eStorageImage
-                                               : vk::DescriptorType::eSampledImage,
+            .descriptorType = image.IsStorage(image.GetSharp(*info))
+                                  ? vk::DescriptorType::eStorageImage
+                                  : vk::DescriptorType::eSampledImage,
             .descriptorCount = 1,
             .stageFlags = vk::ShaderStageFlagBits::eCompute,
         });

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -378,8 +378,9 @@ void GraphicsPipeline::BuildDescSetLayout() {
         for (const auto& image : stage->images) {
             bindings.push_back({
                 .binding = binding++,
-                .descriptorType = image.is_storage ? vk::DescriptorType::eStorageImage
-                                                   : vk::DescriptorType::eSampledImage,
+                .descriptorType = image.IsStorage(image.GetSharp(*stage))
+                                      ? vk::DescriptorType::eStorageImage
+                                      : vk::DescriptorType::eSampledImage,
                 .descriptorCount = 1,
                 .stageFlags = gp_stage_flags,
             });

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -655,7 +655,7 @@ void Rasterizer::BindTextures(const Shader::Info& stage, Shader::Backend::Bindin
         if (image->binding.is_bound) {
             // The image is already bound. In case if it is about to be used as storage we need
             // to force general layout on it.
-            image->binding.force_general |= image_desc.is_storage;
+            image->binding.force_general |= image_desc.IsStorage(tsharp);
         }
         if (image->binding.is_target) {
             // The image is already bound as target. Since we read and output to it need to force

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -51,7 +51,7 @@ vk::ComponentSwizzle ConvertComponentSwizzle(u32 dst_sel) {
 }
 
 ImageViewInfo::ImageViewInfo(const AmdGpu::Image& image, const Shader::ImageResource& desc) noexcept
-    : is_storage{desc.is_storage} {
+    : is_storage{desc.IsStorage(image)} {
     const auto dfmt = image.GetDataFmt();
     auto nfmt = image.GetNumberFmt();
     if (is_storage && nfmt == AmdGpu::NumberFormat::Srgb) {

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -65,7 +65,7 @@ public:
     struct TextureDesc : public BaseDesc {
         TextureDesc() = default;
         TextureDesc(const AmdGpu::Image& image, const Shader::ImageResource& desc)
-            : BaseDesc{desc.is_storage ? BindingType::Storage : BindingType::Texture,
+            : BaseDesc{desc.IsStorage(image) ? BindingType::Storage : BindingType::Texture,
                        ImageInfo{image, desc}, ImageViewInfo{image, desc}} {}
     };
 


### PR DESCRIPTION
* Refactor ImageFetch and ImageRead IR together.
* Handle cube case and better handle mip case for ImageRead instruction.
  * For cube case, need to force storage image to use OpImageRead.
* Handle multisampling case for ImageWrite instruction.