### PR TITLE
Handle setting Vcc in Translator::SetDst64

### DIFF
--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -439,7 +439,8 @@ void Translator::SetDst64(const InstOperand& operand, const IR::U64F64& value_ra
         ir.SetVectorReg(IR::VectorReg(operand.code + 1), hi);
         return ir.SetVectorReg(IR::VectorReg(operand.code), lo);
     case OperandField::VccLo:
-        UNREACHABLE();
+        ir.SetVccLo(lo);
+        return ir.SetVccHi(hi);
     case OperandField::VccHi:
         UNREACHABLE();
     case OperandField::M0:


### PR DESCRIPTION
I know 64bit instructions are kind of broken right now, if that is not correct let me know in the comments