### PR TITLE
Fix splash assert

### DIFF
--- a/src/core/file_format/splash.cpp
+++ b/src/core/file_format/splash.cpp
@@ -9,7 +9,7 @@
 #include "splash.h"
 
 bool Splash::Open(const std::filesystem::path& filepath) {
-    ASSERT_MSG(filepath.extension().string() != ".png", "Unexpected file format passed");
+    ASSERT_MSG(filepath.extension().string() == ".png", "Unexpected file format passed");
 
     Common::FS::IOFile file(filepath, Common::FS::FileAccessMode::Read);
     if (!file.IsOpen()) {

--- a/src/core/file_format/splash.cpp
+++ b/src/core/file_format/splash.cpp
@@ -9,7 +9,7 @@
 #include "splash.h"
 
 bool Splash::Open(const std::filesystem::path& filepath) {
-    ASSERT_MSG(filepath.stem().string() != "png", "Unexpected file format passed");
+    ASSERT_MSG(filepath.extension().string() != ".png", "Unexpected file format passed");
 
     Common::FS::IOFile file(filepath, Common::FS::FileAccessMode::Read);
     if (!file.IsOpen()) {


### PR DESCRIPTION
Splash::Open assert currently uses stem() which returns the filename without the extension. Instead, extension() should be used.

Also the comparison should use equality, not inequality.

https://en.cppreference.com/w/cpp/filesystem/path/extension
https://en.cppreference.com/w/cpp/filesystem/path/stem