### PR TITLE
Disable trophy pop-up with config setting

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -34,6 +34,7 @@ namespace Config {
 static bool isNeo = false;
 static bool isFullscreen = false;
 static bool playBGM = false;
+static bool isTrophyPopupDisabled = false;
 static int BGMvolume = 50;
 static bool enableDiscordRPC = false;
 static u32 screenWidth = 1280;
@@ -94,6 +95,10 @@ bool isNeoMode() {
 
 bool isFullscreenMode() {
     return isFullscreen;
+}
+
+bool getisTrophyPopupDisabled() {
+    return isTrophyPopupDisabled;
 }
 
 bool getPlayBGM() {
@@ -282,6 +287,10 @@ void setVblankDiv(u32 value) {
 
 void setFullscreenMode(bool enable) {
     isFullscreen = enable;
+}
+
+void setisTrophyPopupDisabled(bool disable) {
+    isTrophyPopupDisabled = disable;
 }
 
 void setPlayBGM(bool enable) {
@@ -531,6 +540,7 @@ void load(const std::filesystem::path& path) {
         isNeo = toml::find_or<bool>(general, "isPS4Pro", false);
         isFullscreen = toml::find_or<bool>(general, "Fullscreen", false);
         playBGM = toml::find_or<bool>(general, "playBGM", false);
+        isTrophyPopupDisabled = toml::find_or<bool>(general, "isTrophyPopupDisabled", false);
         BGMvolume = toml::find_or<int>(general, "BGMvolume", 50);
         enableDiscordRPC = toml::find_or<bool>(general, "enableDiscordRPC", true);
         logFilter = toml::find_or<std::string>(general, "logFilter", "");
@@ -646,6 +656,7 @@ void save(const std::filesystem::path& path) {
 
     data["General"]["isPS4Pro"] = isNeo;
     data["General"]["Fullscreen"] = isFullscreen;
+    data["General"]["isTrophyPopupDisabled"] = isTrophyPopupDisabled;
     data["General"]["playBGM"] = playBGM;
     data["General"]["BGMvolume"] = BGMvolume;
     data["General"]["enableDiscordRPC"] = enableDiscordRPC;
@@ -740,6 +751,7 @@ void saveMainWindow(const std::filesystem::path& path) {
 void setDefaultValues() {
     isNeo = false;
     isFullscreen = false;
+    isTrophyPopupDisabled = false;
     playBGM = false;
     BGMvolume = 50;
     enableDiscordRPC = true;

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -19,6 +19,7 @@ bool isNeoMode();
 bool isFullscreenMode();
 bool getPlayBGM();
 int getBGMvolume();
+bool getisTrophyPopupDisabled();
 bool getEnableDiscordRPC();
 bool getSeparateUpdateEnabled();
 
@@ -60,6 +61,7 @@ void setGpuId(s32 selectedGpuId);
 void setScreenWidth(u32 width);
 void setScreenHeight(u32 height);
 void setFullscreenMode(bool enable);
+void setisTrophyPopupDisabled(bool disable);
 void setPlayBGM(bool enable);
 void setBGMvolume(int volume);
 void setEnableDiscordRPC(bool enable);

--- a/src/core/libraries/np_trophy/trophy_ui.cpp
+++ b/src/core/libraries/np_trophy/trophy_ui.cpp
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <imgui.h>
 #include "common/assert.h"
+#include "common/config.h"
 #include "common/singleton.h"
 #include "imgui/imgui_std.h"
 #include "trophy_ui.h"
@@ -82,7 +83,10 @@ void TrophyUI::Draw() {
 
 void AddTrophyToQueue(const std::filesystem::path& trophyIconPath, const std::string& trophyName) {
     std::lock_guard<std::mutex> lock(queueMtx);
-    if (current_trophy_ui.has_value()) {
+
+    if (Config::getisTrophyPopupDisabled()) {
+        return;
+    } else if (current_trophy_ui.has_value()) {
         TrophyInfo new_trophy;
         new_trophy.trophy_icon_path = trophyIconPath;
         new_trophy.trophy_name = trophyName;

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -194,6 +194,7 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices, QWidge
         ui->updaterGroupBox->installEventFilter(this);
 #endif
         ui->GUIgroupBox->installEventFilter(this);
+        ui->disableTrophycheckBox->installEventFilter(this);
 
         // Input
         ui->hideCursorGroupBox->installEventFilter(this);
@@ -263,6 +264,8 @@ void SettingsDialog::LoadValuesFromConfig() {
     ui->dumpShadersCheckBox->setChecked(toml::find_or<bool>(data, "GPU", "dumpShaders", false));
     ui->nullGpuCheckBox->setChecked(toml::find_or<bool>(data, "GPU", "nullGpu", false));
     ui->playBGMCheckBox->setChecked(toml::find_or<bool>(data, "General", "playBGM", false));
+    ui->disableTrophycheckBox->setChecked(
+        toml::find_or<bool>(data, "General", "isTrophyPopupDisabled", false));
     ui->BGMVolumeSlider->setValue(toml::find_or<int>(data, "General", "BGMvolume", 50));
     ui->discordRPCCheckbox->setChecked(
         toml::find_or<bool>(data, "General", "enableDiscordRPC", true));
@@ -397,6 +400,8 @@ void SettingsDialog::updateNoteTextEdit(const QString& elementName) {
 #endif
     } else if (elementName == "GUIgroupBox") {
         text = tr("GUIgroupBox");
+    } else if (elementName == "disableTrophycheckBox") {
+        text = tr("disableTrophycheckBox");
     }
 
     // Input
@@ -485,6 +490,7 @@ void SettingsDialog::UpdateSettings() {
     Config::setBackButtonBehavior(TouchPadIndex[ui->backButtonBehaviorComboBox->currentIndex()]);
     Config::setNeoMode(ui->ps4proCheckBox->isChecked());
     Config::setFullscreenMode(ui->fullscreenCheckBox->isChecked());
+    Config::setisTrophyPopupDisabled(ui->disableTrophycheckBox->isChecked());
     Config::setPlayBGM(ui->playBGMCheckBox->isChecked());
     Config::setNeoMode(ui->ps4proCheckBox->isChecked());
     Config::setLogType(ui->logTypeComboBox->currentText().toStdString());

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -59,9 +59,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
-        <width>832</width>
-        <height>431</height>
+        <y>-97</y>
+        <width>815</width>
+        <height>618</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -470,6 +470,13 @@
                 <number>11</number>
                </property>
                <item>
+                <widget class="QCheckBox" name="disableTrophycheckBox">
+                 <property name="text">
+                  <string>Disable Trophy Pop-ups</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <layout class="QVBoxLayout" name="GUIMusicLayout">
                  <property name="topMargin">
                   <number>1</number>
@@ -560,16 +567,6 @@
                   </widget>
                  </item>
                 </layout>
-               </item>
-               <item>
-                <widget class="QWidget" name="GUIwidgetSpacer" native="true">
-                 <property name="minimumSize">
-                  <size>
-                   <width>0</width>
-                   <height>61</height>
-                  </size>
-                 </property>
-                </widget>
                </item>
               </layout>
              </widget>
@@ -696,7 +693,7 @@
                   <property name="bottomMargin">
                    <number>5</number>
                   </property>
-                  <item alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item>
                    <widget class="QSpinBox" name="idleTimeoutSpinBox">
                     <property name="enabled">
                      <bool>true</bool>

--- a/src/qt_gui/translations/en.ts
+++ b/src/qt_gui/translations/en.ts
@@ -1202,6 +1202,11 @@
 			<translation>Play Title Music:\nIf a game supports it, enable playing special music when selecting the game in the GUI.</translation>
 		</message>
 		<message>
+			<location filename="../settings_dialog.cpp" line="267"/>
+			<source>disableTrophycheckBox</source>
+			<translation>Disable Trophy Pop-ups:\nDisable in-game trophy notifications. Trophy progress can still be tracked using the Trophy Viewer (right-click the game in the main window).</translation>
+		</message>
+		<message>
 			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>Hide Cursor:\nChoose when the cursor will disappear:\nNever: You will always see the mouse.\nidle: Set a time for it to disappear after being idle.\nAlways: you will never see the mouse.</translation>


### PR DESCRIPTION
Disables the in-game notification pop-up upon earning a trophy with a config setting. Placed under GUI. Description text currently only for English.

This only prevents the pop-up, the trophy xml will still be written to, so the Trophy Viewer still functions same as before.

![image](https://github.com/user-attachments/assets/bb7d2d11-d159-4a8e-b40b-96517d0c85a7)
