### PR TITLE
vk_rasterizer: Fix stencil clears

### DIFF
--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -47,7 +47,7 @@ void Scheduler::BeginRendering(const RenderState& new_state) {
                                  ? render_state.color_attachments.data()
                                  : nullptr,
         .pDepthAttachment = render_state.has_depth ? &render_state.depth_attachment : nullptr,
-        .pStencilAttachment = render_state.has_stencil ? &render_state.depth_attachment : nullptr,
+        .pStencilAttachment = render_state.has_stencil ? &render_state.stencil_attachment : nullptr,
     };
 
     current_cmdbuf.beginRendering(rendering_info);

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -21,6 +21,7 @@ class Instance;
 struct RenderState {
     std::array<vk::RenderingAttachmentInfo, 8> color_attachments{};
     vk::RenderingAttachmentInfo depth_attachment{};
+    vk::RenderingAttachmentInfo stencil_attachment{};
     u32 num_color_attachments{};
     bool has_depth{};
     bool has_stencil{};


### PR DESCRIPTION
Some games can use separate draws to clear depth and stencil attachments, which is configured by whether depth or stencil is enabled in configs. At the moment we only maintain a depth attachment and thus can only clear both or neither. Add a separate stencil attachment to support this.

Fixes shadows in Driveclub and might fix stencil related artifacts if that was not cleared properly