### PR TITLE
fs: Return nullptr when file descriptor is out of bounds.

### DIFF
--- a/src/core/file_sys/fs.cpp
+++ b/src/core/file_sys/fs.cpp
@@ -171,6 +171,9 @@ void HandleTable::DeleteHandle(int d) {
 
 File* HandleTable::GetFile(int d) {
     std::scoped_lock lock{m_mutex};
+    if (d < 0 || d >= m_files.size()) {
+        return nullptr;
+    }
     return m_files.at(d);
 }
 


### PR DESCRIPTION
`std::vector::at` can throw an exception for out-of-bounds indices, but callers expect to get a `nullptr` for invalid file descriptors. Add a bounds check and return `nullptr` to fix this.