### PR TITLE
compatibility_data: various fixes

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -64,6 +64,8 @@ static bool vkCrashDiagnostic = false;
 static s16 cursorState = HideCursorState::Idle;
 static int cursorHideTimeout = 5; // 5 seconds (default)
 static bool separateupdatefolder = false;
+static bool compatibilityData = false;
+static bool checkCompatibilityOnStartup = false;
 
 // Gui
 std::vector<std::filesystem::path> settings_install_dirs = {};
@@ -224,6 +226,14 @@ bool getSeparateUpdateEnabled() {
     return separateupdatefolder;
 }
 
+bool getCompatibilityEnabled() {
+    return compatibilityData;
+}
+
+bool getCheckCompatibilityOnStartup() {
+    return checkCompatibilityOnStartup;
+}
+
 void setGpuId(s32 selectedGpuId) {
     gpuId = selectedGpuId;
 }
@@ -342,6 +352,14 @@ void setSpecialPadClass(int type) {
 
 void setSeparateUpdateEnabled(bool use) {
     separateupdatefolder = use;
+}
+
+void setCompatibilityEnabled(bool use) {
+    compatibilityData = use;
+}
+
+void setCheckCompatibilityOnStartup(bool use) {
+    checkCompatibilityOnStartup = use;
 }
 
 void setMainWindowGeometry(u32 x, u32 y, u32 w, u32 h) {
@@ -544,6 +562,8 @@ void load(const std::filesystem::path& path) {
         isShowSplash = toml::find_or<bool>(general, "showSplash", true);
         isAutoUpdate = toml::find_or<bool>(general, "autoUpdate", false);
         separateupdatefolder = toml::find_or<bool>(general, "separateUpdateEnabled", false);
+        compatibilityData = toml::find_or<bool>(general, "compatibilityEnabled", false);
+        checkCompatibilityOnStartup = toml::find_or<bool>(general, "checkCompatibilityOnStartup", false);
     }
 
     if (data.contains("Input")) {
@@ -656,6 +676,8 @@ void save(const std::filesystem::path& path) {
     data["General"]["showSplash"] = isShowSplash;
     data["General"]["autoUpdate"] = isAutoUpdate;
     data["General"]["separateUpdateEnabled"] = separateupdatefolder;
+    data["General"]["compatibilityEnabled"] = compatibilityData;
+    data["General"]["checkCompatibilityOnStartup"] = checkCompatibilityOnStartup;
     data["Input"]["cursorState"] = cursorState;
     data["Input"]["cursorHideTimeout"] = cursorHideTimeout;
     data["Input"]["backButtonBehavior"] = backButtonBehavior;
@@ -775,6 +797,8 @@ void setDefaultValues() {
     m_language = 1;
     gpuId = -1;
     separateupdatefolder = false;
+    compatibilityData = false;
+    checkCompatibilityOnStartup = false;
 }
 
 } // namespace Config

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -563,7 +563,8 @@ void load(const std::filesystem::path& path) {
         isAutoUpdate = toml::find_or<bool>(general, "autoUpdate", false);
         separateupdatefolder = toml::find_or<bool>(general, "separateUpdateEnabled", false);
         compatibilityData = toml::find_or<bool>(general, "compatibilityEnabled", false);
-        checkCompatibilityOnStartup = toml::find_or<bool>(general, "checkCompatibilityOnStartup", false);
+        checkCompatibilityOnStartup =
+            toml::find_or<bool>(general, "checkCompatibilityOnStartup", false);
     }
 
     if (data.contains("Input")) {

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -21,6 +21,8 @@ bool getPlayBGM();
 int getBGMvolume();
 bool getEnableDiscordRPC();
 bool getSeparateUpdateEnabled();
+bool getCompatibilityEnabled();
+bool getCheckCompatibilityOnStartup();
 
 std::string getLogFilter();
 std::string getLogType();
@@ -69,6 +71,8 @@ void setUserName(const std::string& type);
 void setUpdateChannel(const std::string& type);
 void setSeparateUpdateEnabled(bool use);
 void setGameInstallDirs(const std::vector<std::filesystem::path>& settings_install_dirs_config);
+void setCompatibilityEnabled(bool use);
+void setCheckCompatibilityOnStartup(bool use);
 
 void setCursorState(s16 cursorState);
 void setCursorHideTimeout(int newcursorHideTimeout);

--- a/src/qt_gui/compatibility_info.cpp
+++ b/src/qt_gui/compatibility_info.cpp
@@ -4,6 +4,7 @@
 #include <QFileInfo>
 #include <QMessageBox>
 #include <QProgressDialog>
+#include <QTimer>
 
 #include "common/path_util.h"
 #include "compatibility_info.h"
@@ -22,7 +23,8 @@ void CompatibilityInfoClass::UpdateCompatibilityDatabase(QWidget* parent) {
         return;
 
     QNetworkReply* reply = FetchPage(1);
-    WaitForReply(reply);
+    if (!WaitForReply(reply))
+        return;
 
     QProgressDialog dialog(tr("Fetching compatibility data, please wait"), tr("Cancel"), 0, 0,
                            parent);
@@ -57,12 +59,17 @@ void CompatibilityInfoClass::UpdateCompatibilityDatabase(QWidget* parent) {
     }
 
     future_watcher.setFuture(QtConcurrent::map(replies, WaitForReply));
-    connect(&future_watcher, &QFutureWatcher<QByteArray>::finished, [&]() {
+    connect(&future_watcher, &QFutureWatcher<void>::finished, [&]() {
         for (int i = 0; i < remaining_pages; i++) {
-            if (replies[i]->error() == QNetworkReply::NoError) {
-                ExtractCompatibilityInfo(replies[i]->readAll());
+            if (replies[i]->bytesAvailable()) {
+                if (replies[i]->error() == QNetworkReply::NoError) {
+                    ExtractCompatibilityInfo(replies[i]->readAll());
+                }
+                replies[i]->deleteLater();
+            } else {
+                // This means the request timed out 
+                return;
             }
-            replies[i]->deleteLater();
         }
 
         QFile compatibility_file(m_compatibility_filename);
@@ -82,6 +89,16 @@ void CompatibilityInfoClass::UpdateCompatibilityDatabase(QWidget* parent) {
         compatibility_file.close();
 
         dialog.reset();
+    });
+    connect(&future_watcher, &QFutureWatcher<void>::canceled, [&]() {
+        // Cleanup if user cancels pulling data
+        for (int i = 0; i < remaining_pages; i++) {
+            if (!replies[i]->bytesAvailable()) {
+                replies[i]->deleteLater();
+            } else if (!replies[i]->isFinished()) {
+                replies[i]->abort();
+            }
+        }
     });
     connect(&dialog, &QProgressDialog::canceled, &future_watcher, &QFutureWatcher<void>::cancel);
     dialog.setRange(0, remaining_pages);
@@ -105,20 +122,34 @@ QNetworkReply* CompatibilityInfoClass::FetchPage(int page_num) {
     return reply;
 }
 
-void CompatibilityInfoClass::WaitForReply(QNetworkReply* reply) {
+bool CompatibilityInfoClass::WaitForReply(QNetworkReply* reply) {
+    // Returns true if reply succeeded, false if reply timed out
+    QTimer timer;
+    timer.setSingleShot(true);
+
     QEventLoop loop;
     connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    connect(&timer, SIGNAL(timeout()), &loop, SLOT(quit()));
+    timer.start(5000);
     loop.exec();
-    return;
+
+    if (timer.isActive()) {
+        timer.stop();
+        return true;
+    } else {
+        disconnect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
+        reply->abort();
+        return false;
+    }
 };
 
 CompatibilityEntry CompatibilityInfoClass::GetCompatibilityInfo(const std::string& serial) {
     QString title_id = QString::fromStdString(serial);
     if (m_compatibility_database.contains(title_id)) {
         {
+            QJsonObject compatibility_obj = m_compatibility_database[title_id].toObject();
             for (int os_int = 0; os_int != static_cast<int>(OSType::Last); os_int++) {
                 QString os_string = OSTypeToString.at(static_cast<OSType>(os_int));
-                QJsonObject compatibility_obj = m_compatibility_database[title_id].toObject();
                 if (compatibility_obj.contains(os_string)) {
                     QJsonObject compatibility_entry_obj = compatibility_obj[os_string].toObject();
                     CompatibilityEntry compatibility_entry{
@@ -133,7 +164,9 @@ CompatibilityEntry CompatibilityInfoClass::GetCompatibilityInfo(const std::strin
             }
         }
     }
-    return CompatibilityEntry{CompatibilityStatus::Unknown};
+
+    return CompatibilityEntry{CompatibilityStatus::Unknown, "", QDateTime::currentDateTime(), "",
+                              0};
 }
 
 bool CompatibilityInfoClass::LoadCompatibilityFile() {

--- a/src/qt_gui/compatibility_info.cpp
+++ b/src/qt_gui/compatibility_info.cpp
@@ -67,7 +67,7 @@ void CompatibilityInfoClass::UpdateCompatibilityDatabase(QWidget* parent) {
                 }
                 replies[i]->deleteLater();
             } else {
-                // This means the request timed out 
+                // This means the request timed out
                 return;
             }
         }

--- a/src/qt_gui/compatibility_info.h
+++ b/src/qt_gui/compatibility_info.h
@@ -57,6 +57,7 @@ class CompatibilityInfoClass : public QObject {
 public:
     // Please think of a better alternative
     inline static const std::unordered_map<QString, CompatibilityStatus> LabelToCompatStatus = {
+        {QStringLiteral("status-unknown"), CompatibilityStatus::Unknown},
         {QStringLiteral("status-nothing"), CompatibilityStatus::Nothing},
         {QStringLiteral("status-boots"), CompatibilityStatus::Boots},
         {QStringLiteral("status-menus"), CompatibilityStatus::Menus},
@@ -87,7 +88,7 @@ public:
     bool LoadCompatibilityFile();
     CompatibilityEntry GetCompatibilityInfo(const std::string& serial);
     void ExtractCompatibilityInfo(QByteArray response);
-    static void WaitForReply(QNetworkReply* reply);
+    static bool WaitForReply(QNetworkReply* reply);
     QNetworkReply* FetchPage(int page_num);
 
 private:

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -80,6 +80,9 @@ GameListFrame::GameListFrame(std::shared_ptr<GameInfoClass> game_info_get,
             QDesktopServices::openUrl(QUrl(m_game_info->m_games[row].compatibility.url));
         }
     });
+
+    // Disable status column for now
+    this->setColumnHidden(2, true);
 }
 
 void GameListFrame::onCurrentCellChanged(int currentRow, int currentColumn, int previousRow,

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -81,8 +81,10 @@ GameListFrame::GameListFrame(std::shared_ptr<GameInfoClass> game_info_get,
         }
     });
 
-    // Disable status column for now
-    this->setColumnHidden(2, true);
+    // Do not show status column if it is not enabled
+    if (!Config::getCompatibilityEnabled()) {
+        this->setColumnHidden(2, true);
+    }
 }
 
 void GameListFrame::onCurrentCellChanged(int currentRow, int currentColumn, int previousRow,

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -185,7 +185,7 @@ void MainWindow::CreateDockWindows() {
 
 void MainWindow::LoadGameLists() {
     // Update compatibility database
-    m_compat_info->UpdateCompatibilityDatabase(this);
+    // m_compat_info->UpdateCompatibilityDatabase(this);
     // Get game info from game folders.
     m_game_info->GetGameInfo(this);
     if (isTableList) {

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -185,7 +185,9 @@ void MainWindow::CreateDockWindows() {
 
 void MainWindow::LoadGameLists() {
     // Update compatibility database
-    // m_compat_info->UpdateCompatibilityDatabase(this);
+    if (Config::getCheckCompatibilityOnStartup()) {
+        m_compat_info->UpdateCompatibilityDatabase(this);
+    }
     // Get game info from game folders.
     m_game_info->GetGameInfo(this);
     if (isTableList) {


### PR DESCRIPTION
Addresses #1843 

* Disable compatibility data by default while issues are ironed out
* Adds timeout when fetching issue data 
* Adds configuration option to enable compatibility_data: `compatibilityEnabled`, `checkCompatibilityOnStartup`

