### PR TITLE
qt: Do not run emulator on separate thread on Mac.

### DIFF
--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -1098,10 +1098,16 @@ void MainWindow::StartEmulator(std::filesystem::path path) {
         QMessageBox::critical(nullptr, tr("Run Game"), QString(tr("Game is already running!")));
         return;
     }
+    isGameRunning = true;
+#ifdef __APPLE__
+    // SDL on macOS requires main thread.
+    Core::Emulator emulator;
+    emulator.Run(path);
+#else
     std::thread emulator_thread([=] {
         Core::Emulator emulator;
         emulator.Run(path);
     });
     emulator_thread.detach();
-    isGameRunning = true;
+#endif
 }


### PR DESCRIPTION
SDL on macOS requires running on main thread due to Cocoa restrictions.

Fixes crash introduced on launch of any game.