### PR TITLE
Qt: Start Maximized

### DIFF
--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -51,6 +51,7 @@ bool MainWindow::Init() {
     SetLastUsedTheme();
     SetLastIconSizeBullet();
     GetPhysicalDevices();
+    showMaximized();
     // show ui
     setMinimumSize(350, minimumSizeHint().height());
     std::string window_title = "";


### PR DESCRIPTION
This allows the Qt interface to start maximized because the interface does not save it.