### PR TITLE
Fix AutoUpdate Issue with Non-Latin Usernames/Directories

### DIFF
--- a/src/qt_gui/check_update.cpp
+++ b/src/qt_gui/check_update.cpp
@@ -536,6 +536,7 @@ void CheckUpdate::Install() {
     QFile scriptFile(scriptFileName);
     if (scriptFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
         QTextStream out(&scriptFile);
+        scriptFile.write("\xEF\xBB\xBF");
 #ifdef Q_OS_WIN
         out << scriptContent.arg(binaryStartingUpdate).arg(tempDirPath).arg(rootPath);
 #endif

--- a/src/qt_gui/check_update.cpp
+++ b/src/qt_gui/check_update.cpp
@@ -15,6 +15,7 @@
 #include <QNetworkRequest>
 #include <QProcess>
 #include <QPushButton>
+#include <QStandardPaths>
 #include <QString>
 #include <QStringList>
 #include <QTextEdit>
@@ -348,7 +349,9 @@ void CheckUpdate::DownloadUpdate(const QString& url) {
         QString userPath;
         Common::FS::PathToQString(userPath, Common::FS::GetUserPath(Common::FS::PathType::UserDir));
 #ifdef Q_OS_WIN
-        QString tempDownloadPath = QString(getenv("LOCALAPPDATA")) + "/Temp/temp_download_update";
+        QString tempDownloadPath =
+            QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) +
+            "/Temp/temp_download_update";
 #else
         QString tempDownloadPath = userPath + "/temp_download_update";
 #endif
@@ -397,10 +400,11 @@ void CheckUpdate::Install() {
     QString processCommand;
 
 #ifdef Q_OS_WIN
-    // On windows, overwrite tempDirPath with AppData/Local/Temp folder
+    // On windows, overwrite tempDirPath with AppData/Roaming/shadps4/Temp folder
     // due to PowerShell Expand-Archive not being able to handle correctly
     // paths in square brackets (ie: ./[shadps4])
-    tempDirPath = QString(getenv("LOCALAPPDATA")) + "/Temp/temp_download_update";
+    tempDirPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) +
+                  "/Temp/temp_download_update";
 
     // Windows Batch Script
     scriptFileName = tempDirPath + "/update.ps1";


### PR DESCRIPTION
With this update, users who have usernames with Russian or other non-Latin characters can now use AutoUpdate without encountering the error shown in the image below.

1. **UTF-8 BOM Encoding for .ps1 File**
   - The `.ps1` file containing PowerShell commands is now saved with UTF-8 BOM encoding.  
   - Added `scriptFile.write("\xEF\xBB\xBF");` to ensure the correct encoding.

2. **Fix for Non-Latin Characters in Folder Paths**
   - The change to use `QStandardPaths::writableLocation` ensures proper handling of non-Latin characters (e.g., Russian characters) in folder paths. 
   - Previously, the old method failed to recognize and display these characters correctly.

3. **Temporary Folder Path Update**
   - The temporary download location has been changed due to the use of this code, from::
     ```
     AppData/Local/Temp/temp_download_update
     ```
     to:
     ```
     AppData/Roaming/shadps4/Temp/temp_download_update
     ```


![Error Screenshot](https://github.com/user-attachments/assets/ac3fde03-8f1f-4e35-9a5e-18750dcdbd99)

### Testing

- Print of the test I did with the code running in a folder in Russian (Администратор)
  ![Test Screenshot](https://github.com/user-attachments/assets/e534b047-d74d-477b-8fd9-92693995752a)

- It was also tested by a user on discord who presented the problem, and with his user it worked correctly.