### PR TITLE
renderer_vulkan: Simplify depth pipeline state and move stencil to dynamic state.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -123,7 +123,7 @@ GraphicsPipeline::GraphicsPipeline(
         .frontFace = key.front_face == Liverpool::FrontFace::Clockwise
                          ? vk::FrontFace::eClockwise
                          : vk::FrontFace::eCounterClockwise,
-        .depthBiasEnable = bool(key.depth_bias_enable),
+        .depthBiasEnable = key.depth_bias_enable,
         .lineWidth = 1.0f,
     };
 
@@ -164,6 +164,7 @@ GraphicsPipeline::GraphicsPipeline(
         vk::DynamicState::eBlendConstants,     vk::DynamicState::eDepthBounds,
         vk::DynamicState::eDepthBias,          vk::DynamicState::eStencilReference,
         vk::DynamicState::eStencilCompareMask, vk::DynamicState::eStencilWriteMask,
+        vk::DynamicState::eStencilOpEXT,
     };
 
     if (instance.IsColorWriteEnableSupported()) {
@@ -182,31 +183,11 @@ GraphicsPipeline::GraphicsPipeline(
     };
 
     const vk::PipelineDepthStencilStateCreateInfo depth_info = {
-        .depthTestEnable = key.depth_stencil.depth_enable,
-        .depthWriteEnable = key.depth_stencil.depth_write_enable,
-        .depthCompareOp = LiverpoolToVK::CompareOp(key.depth_stencil.depth_func),
-        .depthBoundsTestEnable = key.depth_stencil.depth_bounds_enable,
-        .stencilTestEnable = key.depth_stencil.stencil_enable,
-        .front{
-            .failOp = LiverpoolToVK::StencilOp(key.stencil.stencil_fail_front),
-            .passOp = LiverpoolToVK::StencilOp(key.stencil.stencil_zpass_front),
-            .depthFailOp = LiverpoolToVK::StencilOp(key.stencil.stencil_zfail_front),
-            .compareOp = LiverpoolToVK::CompareOp(key.depth_stencil.stencil_ref_func),
-        },
-        .back{
-            .failOp = LiverpoolToVK::StencilOp(key.depth_stencil.backface_enable
-                                                   ? key.stencil.stencil_fail_back.Value()
-                                                   : key.stencil.stencil_fail_front.Value()),
-            .passOp = LiverpoolToVK::StencilOp(key.depth_stencil.backface_enable
-                                                   ? key.stencil.stencil_zpass_back.Value()
-                                                   : key.stencil.stencil_zpass_front.Value()),
-            .depthFailOp = LiverpoolToVK::StencilOp(key.depth_stencil.backface_enable
-                                                        ? key.stencil.stencil_zfail_back.Value()
-                                                        : key.stencil.stencil_zfail_front.Value()),
-            .compareOp = LiverpoolToVK::CompareOp(key.depth_stencil.backface_enable
-                                                      ? key.depth_stencil.stencil_bf_func.Value()
-                                                      : key.depth_stencil.stencil_ref_func.Value()),
-        },
+        .depthTestEnable = key.depth_test_enable,
+        .depthWriteEnable = key.depth_write_enable,
+        .depthCompareOp = key.depth_compare_op,
+        .depthBoundsTestEnable = key.depth_bounds_test_enable,
+        .stencilTestEnable = key.stencil_test_enable,
     };
 
     boost::container::static_vector<vk::PipelineShaderStageCreateInfo, MaxShaderStages>

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -36,12 +36,17 @@ struct GraphicsPipelineKey {
     vk::Format depth_format;
     vk::Format stencil_format;
 
-    bool depth_test_enable;
-    bool depth_write_enable;
-    bool depth_bounds_test_enable;
-    bool depth_bias_enable;
+    struct {
+        bool depth_test_enable : 1;
+        bool depth_write_enable : 1;
+        bool depth_bounds_test_enable : 1;
+        bool depth_bias_enable : 1;
+        bool stencil_test_enable : 1;
+        // Must be named to be zero-initialized.
+        u8 _unused : 3;
+    };
     vk::CompareOp depth_compare_op;
-    bool stencil_test_enable;
+
     u32 num_samples;
     u32 mrt_mask;
     AmdGpu::PrimitiveType prim_type;

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -36,11 +36,14 @@ struct GraphicsPipelineKey {
     vk::Format depth_format;
     vk::Format stencil_format;
 
-    Liverpool::DepthControl depth_stencil;
-    u32 depth_bias_enable;
+    bool depth_test_enable;
+    bool depth_write_enable;
+    bool depth_bounds_test_enable;
+    bool depth_bias_enable;
+    vk::CompareOp depth_compare_op;
+    bool stencil_test_enable;
     u32 num_samples;
     u32 mrt_mask;
-    Liverpool::StencilControl stencil;
     AmdGpu::PrimitiveType prim_type;
     u32 enable_primitive_restart;
     u32 primitive_restart_index;


### PR DESCRIPTION
First of some changes I'm planning to cut down on pipeline key complexity, reducing the potential pipeline permutations needed.

This change moves the remaining stencil test configuration state (front/back face stencil ops) to dynamic state, using `VK_EXT_extended_dynamic_state` which we already require and is included as part of any Vulkan 1.3 driver. With that out of the way, it also cuts down the amount of depth state that can change the key by replacing the full depth control register data with just a couple of flags still needed to toggle different depth/stencil tests.