### PR TITLE
Adding missing detiler format

### DIFF
--- a/src/video_core/texture_cache/tile_manager.cpp
+++ b/src/video_core/texture_cache/tile_manager.cpp
@@ -27,6 +27,7 @@ static vk::Format DemoteImageFormatForDetiling(vk::Format format) {
     case vk::Format::eR8Unorm:
         return vk::Format::eR8Uint;
     case vk::Format::eR4G4B4A4UnormPack16:
+    case vk::Format::eB5G6R5UnormPack16:
     case vk::Format::eR5G5B5A1UnormPack16:
     case vk::Format::eR8G8Unorm:
     case vk::Format::eR16Sfloat:


### PR DESCRIPTION
Adding missing detiler format used by `NARUTO SHIPPUDEN: Ultimate Ninja STORM TRILOGY`.

```
[Render.Vulkan] <Error> tile_manager.cpp:DemoteImageFormatForDetiling:78: Unexpected format for demotion B5G6R5UnormPack16
[Render.Vulkan] <Error> tile_manager.cpp:TryDetile:267: Unsupported tiled image: B5G6R5UnormPack16 (Texture_MicroTiled)
```

**Before:**
![1](https://github.com/user-attachments/assets/fa078b68-7c47-4285-8dfb-a11ab9000b26)
**After:**
![2](https://github.com/user-attachments/assets/7cecc52c-a8b5-4360-a313-b9fee5ebb85c)

##

**Note:**
- Need to disable this line, otherwise the game will crash right after launch.
https://github.com/shadps4-emu/shadPS4/blob/dfdd819e3e020104d325aeed435eda7ff1d6cb5c/src/core/libraries/ime/ime.cpp#L281

