### PR TITLE
renderer_vulkan: Make sure at least one viewport is set

### DIFF
--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -133,37 +133,23 @@ GraphicsPipeline::GraphicsPipeline(
         .sampleShadingEnable = false,
     };
 
-    const vk::Viewport viewport = {
-        .x = 0.0f,
-        .y = 0.0f,
-        .width = 1.0f,
-        .height = 1.0f,
-        .minDepth = 0.0f,
-        .maxDepth = 1.0f,
-    };
-
-    const vk::Rect2D scissor = {
-        .offset = {0, 0},
-        .extent = {1, 1},
-    };
-
     const vk::PipelineViewportDepthClipControlCreateInfoEXT clip_control = {
         .negativeOneToOne = key.clip_space == Liverpool::ClipSpace::MinusWToW,
     };
 
     const vk::PipelineViewportStateCreateInfo viewport_info = {
         .pNext = instance.IsDepthClipControlSupported() ? &clip_control : nullptr,
-        .viewportCount = 1,
-        .pViewports = &viewport,
-        .scissorCount = 1,
-        .pScissors = &scissor,
     };
 
     boost::container::static_vector<vk::DynamicState, 14> dynamic_states = {
-        vk::DynamicState::eViewport,           vk::DynamicState::eScissor,
-        vk::DynamicState::eBlendConstants,     vk::DynamicState::eDepthBounds,
-        vk::DynamicState::eDepthBias,          vk::DynamicState::eStencilReference,
-        vk::DynamicState::eStencilCompareMask, vk::DynamicState::eStencilWriteMask,
+        vk::DynamicState::eViewportWithCountEXT,
+        vk::DynamicState::eScissorWithCountEXT,
+        vk::DynamicState::eBlendConstants,
+        vk::DynamicState::eDepthBounds,
+        vk::DynamicState::eDepthBias,
+        vk::DynamicState::eStencilReference,
+        vk::DynamicState::eStencilCompareMask,
+        vk::DynamicState::eStencilWriteMask,
         vk::DynamicState::eStencilOpEXT,
     };
 


### PR DESCRIPTION
Avoids a validation error when all viewports are disabled, by inserting a dummy viewport and scissor making sure there is at least one defined as required by Vulkan spec.

Additionally:
* Changes dynamic viewport/scissor state to include count using `eViewportWithCountEXT`/`eScissorWithCountEXT` from `VK_EXT_extended_dynamic_state`. Allows removing initial viewport/scissor and counts from the pipeline definition.
* Consolidates the viewport and scissor calculations into one loop instead of splitting over two, plus some other minor tidying of the logic.