### PR TITLE
renderer_vulkan: fix deadlock when resizing the SDL window

### DIFF
--- a/src/video_core/renderer_vulkan/vk_presenter.cpp
+++ b/src/video_core/renderer_vulkan/vk_presenter.cpp
@@ -636,7 +636,21 @@ void Presenter::Present(Frame* frame) {
 
     if (!swapchain.AcquireNextImage()) {
         swapchain.Recreate(window.GetWidth(), window.GetHeight());
+        if (!swapchain.AcquireNextImage()) {
+            // User resizes the window too fast and GPU can't keep up. Skip this frame.
+            LOG_WARNING(Render_Vulkan, "Skipping frame!");
+            // Free the frame for reuse
+            std::scoped_lock fl{free_mutex};
+            free_queue.push(frame);
+            free_cv.notify_one();
+            return;
+        }
     }
+
+    // Reset fence for queue submission. Do it here instead of GetRenderFrame() because we may
+    // skip frame because of slow swapchain recreation. If a frame skip occurs, we skip signal
+    // the frame's present fence and future GetRenderFrame() call will hang waiting for this frame.
+    instance.GetDevice().resetFences(frame->present_done);
 
     ImGui::Core::NewFrame();
 
@@ -775,9 +789,6 @@ Frame* Presenter::GetRenderFrame() {
             continue;
         }
     }
-
-    // Reset fence for next queue submission.
-    device.resetFences(frame->present_done);
 
     // If the window dimensions changed, recreate this frame
     if (frame->width != window.GetWidth() || frame->height != window.GetHeight()) {

--- a/src/video_core/renderer_vulkan/vk_swapchain.cpp
+++ b/src/video_core/renderer_vulkan/vk_swapchain.cpp
@@ -84,6 +84,7 @@ void Swapchain::Create(u32 width_, u32 height_, vk::SurfaceKHR surface_) {
 }
 
 void Swapchain::Recreate(u32 width_, u32 height_) {
+    LOG_DEBUG(Render_Vulkan, "Recreate the swapchain: width={} height={}", width_, height_);
     Create(width_, height_, surface);
 }
 


### PR DESCRIPTION
 Commit 400da1aa8da376d38b3c4a086bc7f656f590de2e add ability to handle recreation of the swapchain which fix black screen under XWayland. Unfortunately, that commit doesn't account for rapid swapchain recreation caused by resizing window.

 This commit aim to solve that issue by skipping frames to recreate the swapchain and delay resetting the frame's present done fence until after we know for sure we will be submitting work with it.