### PR TITLE
Fix for D16Unorm Tiled image

### DIFF
--- a/src/video_core/texture_cache/tile_manager.cpp
+++ b/src/video_core/texture_cache/tile_manager.cpp
@@ -32,6 +32,7 @@ static vk::Format DemoteImageFormatForDetiling(vk::Format format) {
     case vk::Format::eR8G8Unorm:
     case vk::Format::eR16Sfloat:
     case vk::Format::eR16Unorm:
+    case vk::Format::eD16Unorm:
         return vk::Format::eR8G8Uint;
     case vk::Format::eR8G8B8A8Srgb:
     case vk::Format::eB8G8R8A8Srgb:


### PR DESCRIPTION
Fixed an error seen in **Pure Farming 2018**.

The error:
`[Render.Vulkan] <Error> tile_manager.cpp:DemoteImageFormatForDetiling:80: Unexpected format for demotion D16Unorm`
`[Render.Vulkan] <Error> tile_manager.cpp:TryDetile:269: Unsupported tiled image: D16Unorm (Texture_MicroTiled)`