### PR TITLE
Added data_format=1 and num_format=7

### DIFF
--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -483,6 +483,8 @@ std::span<const SurfaceFormatInfo> SurfaceFormats() {
                                 vk::Format::eR8Uint),
         CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format8, AmdGpu::NumberFormat::Sint,
                                 vk::Format::eR8Sint),
+        CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format8, AmdGpu::NumberFormat::Float,
+                                vk::Format::eR8Unorm),
         CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format8, AmdGpu::NumberFormat::Srgb,
                                 vk::Format::eR8Srgb),
         // 16


### PR DESCRIPTION
Adding missing data format used by SONIC X SHADOW GENERATIONS
Allows you to enter the game, but the screen stays 'Shadow'  🤡

![image](https://github.com/user-attachments/assets/cf731ee6-6f73-459a-abea-9c247363c5c4)
