### PR TITLE
exception: Fix raising exceptions on POSIX systems

### DIFF
--- a/src/core/thread.cpp
+++ b/src/core/thread.cpp
@@ -11,6 +11,7 @@
 #else
 #include <csignal>
 #include <pthread.h>
+#include <unistd.h>
 #endif
 
 namespace Core {


### PR DESCRIPTION
Native thread handle was being interpreted wrong, it's a `pthread_t` not `pthread_t*`. Fixing this allows signals to properly fire on POSIX systems (Linux/Mac), and should fix at least some Unity games.

Also added a missing include I spotted in `core/thread.cpp` from debugging and added an error log for if `pthread_kill` fails firing a signal.