### PR TITLE
texture_cache: Enable anisotropic filtering

### DIFF
--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -364,6 +364,16 @@ enum class Filter : u64 {
     AnisoLinear = 3,
 };
 
+constexpr bool IsAnisoFilter(const Filter filter) {
+    switch (filter) {
+    case Filter::AnisoPoint:
+    case Filter::AnisoLinear:
+        return true;
+    default:
+        return false;
+    }
+}
+
 enum class MipFilter : u64 {
     None = 0,
     Point = 1,
@@ -434,6 +444,23 @@ struct Sampler {
 
     float MaxLod() const noexcept {
         return static_cast<float>(max_lod.Value()) / 256.0f;
+    }
+
+    float MaxAniso() const {
+        switch (max_aniso) {
+        case AnisoRatio::One:
+            return 1.0f;
+        case AnisoRatio::Two:
+            return 2.0f;
+        case AnisoRatio::Four:
+            return 4.0f;
+        case AnisoRatio::Eight:
+            return 8.0f;
+        case AnisoRatio::Sixteen:
+            return 16.0f;
+        default:
+            UNREACHABLE();
+        }
     }
 };
 

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -249,6 +249,11 @@ public:
         return properties.limits.maxSamplerLodBias;
     }
 
+    /// Returns the maximum sampler anisotropy.
+    float MaxSamplerAnisotropy() const {
+        return properties.limits.maxSamplerAnisotropy;
+    }
+
     /// Returns the maximum number of push descriptors.
     u32 MaxPushDescriptors() const {
         return push_descriptor_props.maxPushDescriptors;


### PR DESCRIPTION
Fixed blurry and smeared textures when viewed at an angle for games that use it.