### PR TITLE
Fix button Changelog

### DIFF
--- a/src/qt_gui/check_update.cpp
+++ b/src/qt_gui/check_update.cpp
@@ -213,9 +213,9 @@ void CheckUpdate::setupUI(const QString& downloadUrl, const QString& latestDate,
 
     // Don't show changelog button if:
     // The current version is a pre-release and the version to be downloaded is a release.
-    bool current_isRelease = currentRev.startsWith('v', Qt::CaseInsensitive);
-    bool latest_isRelease = latestRev.startsWith('v', Qt::CaseInsensitive);
-    if (!current_isRelease && latest_isRelease) {
+    bool current_isWIP = currentRev.endsWith("WIP", Qt::CaseInsensitive);
+    bool latest_isWIP = latestRev.endsWith("WIP", Qt::CaseInsensitive);
+    if (current_isWIP && !latest_isWIP) {
     } else {
         QTextEdit* textField = new QTextEdit(this);
         textField->setReadOnly(true);


### PR DESCRIPTION
If you are using pre-release, the view changelog button should not appear.
Should not appear because the WIP will always be more up to date than the release, so if you try to update from WIP to release there should be no changelog

![image](https://github.com/user-attachments/assets/1609b8c9-7498-4d2c-9bd7-b9d533145d4f)

In [PR 1465](https://github.com/shadps4-emu/shadPS4/pull/1465) I had made a correction to compare the 'version' in the release channel instead of the 'hash' of the commit so as not to cause a loop when trying to update between releases, and this ended up impacting this other comparison. Because before it was comparing if it started with the letter 'v' in the release channel, but now both start with 'v'. So now it will compare if they contain the word 'WIP' at the end.
As you can see in the print, it now works correctly.