### PR TITLE
Add info for QT Multimedia in documents

### DIFF
--- a/documents/building-windows.md
+++ b/documents/building-windows.md
@@ -25,7 +25,7 @@ Once you are within the installer:
 
 Beware, this requires you to create a Qt account. If you do not want to do this, please follow the MSYS2/MinGW compilation method instead.
 
-1. Under the current, non beta version of Qt (at the time of writing 6.7.3), select the option `MSVC 2022 64-bit` or similar.  
+1. Under the current, non beta version of Qt (at the time of writing 6.7.3), select the option `MSVC 2022 64-bit` or similar, as well as `QT Multimedia`.  
    If you are on Windows on ARM / Qualcomm Snapdragon Elite X, select `MSVC 2022 ARM64` instead.
 
    Go through the installation normally. If you know what you are doing, you may unselect individual components that eat up too much disk space.


### PR DESCRIPTION
QT Multimedia is mandatory for building on Windows, and it's not mentioned in the guide.

If QT Multimedia is not installed you will get this when generating Cmake:
```
  Expected Config file at
  "C:/Qt/6.7.3/msvc2022_64/lib/cmake/Qt6Multimedia/Qt6MultimediaConfig.cmake"
  does NOT exist
```
