### PR TITLE
vk_platform: Enable MoltenVK debug if crash diagnostics is enabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -901,11 +901,11 @@ endif()
 if (APPLE)
   if (ENABLE_QT_GUI)
       # Include MoltenVK in the app bundle, along with an ICD file so it can be found by the system Vulkan loader if used for loading layers.
-      target_sources(shadps4 PRIVATE externals/MoltenVK/MoltenVK_icd.json)
-      set_source_files_properties(externals/MoltenVK/MoltenVK_icd.json
-          PROPERTIES MACOSX_PACKAGE_LOCATION Resources/vulkan/icd.d)
-      add_custom_command(TARGET shadps4 POST_BUILD
-          COMMAND cmake -E copy $<TARGET_LINKER_FILE:MoltenVK> $<TARGET_BUNDLE_DIR:shadps4>/Contents/Frameworks/libMoltenVK.dylib)
+      set(MVK_DYLIB ${CMAKE_CURRENT_BINARY_DIR}/externals/MoltenVK/libMoltenVK.dylib)
+      set(MVK_ICD ${CMAKE_CURRENT_SOURCE_DIR}/externals/MoltenVK/MoltenVK_icd.json)
+      target_sources(shadps4 PRIVATE ${MVK_DYLIB} ${MVK_ICD})
+      set_source_files_properties(${MVK_DYLIB} PROPERTIES MACOSX_PACKAGE_LOCATION Frameworks)
+      set_source_files_properties(${MVK_ICD} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/vulkan/icd.d)
       set_property(TARGET shadps4 APPEND PROPERTY BUILD_RPATH "@executable_path/../Frameworks")
   else()
       # For non-bundled SDL build, just do a normal library link.

--- a/src/video_core/renderer_vulkan/vk_platform.cpp
+++ b/src/video_core/renderer_vulkan/vk_platform.cpp
@@ -137,6 +137,7 @@ std::vector<const char*> GetInstanceExtensions(Frontend::WindowSystemType window
     // Add the windowing system specific extension
     std::vector<const char*> extensions;
     extensions.reserve(7);
+    extensions.push_back(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME);
 
     switch (window_type) {
     case Frontend::WindowSystemType::Headless:
@@ -347,6 +348,17 @@ vk::UniqueInstance CreateInstance(Frontend::WindowSystemType window_type, bool e
             .valueCount = 1,
             .pValues = &enable_force_barriers,
         },
+#ifdef __APPLE__
+        // MoltenVK debug mode turns on additional device loss error details, so
+        // use the crash diagnostic setting as an indicator of whether to turn it on.
+        vk::LayerSettingEXT{
+            .pLayerName = "MoltenVK",
+            .pSettingName = "MVK_CONFIG_DEBUG",
+            .type = vk::LayerSettingTypeEXT::eBool32,
+            .valueCount = 1,
+            .pValues = &enable_crash_diagnostic,
+        }
+#endif
     };
 
     vk::StructureChain<vk::InstanceCreateInfo, vk::LayerSettingsCreateInfoEXT> instance_ci_chain = {


### PR DESCRIPTION
MoltenVK has a debug mode which includes enabling more detailed GPU command buffer execution information on device loss. Since it doesn't currently support the crash diagnostic layer, enable this instead to get more crash details.

I also had to add enabling `VK_EXT_layer_settings` which was missing, as MoltenVK actually checks if it is enabled before reading layer settings.

Also fixed a CMake issue where modifying the MoltenVK sub-module would not re-bundle into the output app unless the main target was modified as well.