### PR TITLE
core: better memory configuration

### DIFF
--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -26,7 +26,7 @@ asm(".zerofill GUEST_SYSTEM,GUEST_SYSTEM,__guest_system,0xFBFC00000");
 
 namespace Core {
 
-static constexpr size_t BackingSize = SCE_KERNEL_MAIN_DMEM_SIZE_PRO;
+static constexpr size_t BackingSize = SCE_KERNEL_TOTAL_MEM_PRO;
 
 #ifdef _WIN32
 

--- a/src/core/libraries/kernel/memory.h
+++ b/src/core/libraries/kernel/memory.h
@@ -6,9 +6,11 @@
 #include "common/bit_field.h"
 #include "common/types.h"
 
-constexpr u64 SCE_KERNEL_MAIN_DMEM_SIZE = 5056_MB; // ~ 5GB
-// TODO: Confirm this value on hardware.
-constexpr u64 SCE_KERNEL_MAIN_DMEM_SIZE_PRO = 5568_MB; // ~ 5.5GB
+constexpr u64 SCE_KERNEL_TOTAL_MEM = 5248_MB;
+constexpr u64 SCE_KERNEL_TOTAL_MEM_PRO = 5888_MB;
+
+constexpr u64 SCE_FLEXIBLE_MEMORY_BASE = 64_MB;
+constexpr u64 SCE_FLEXIBLE_MEMORY_SIZE = 512_MB;
 
 namespace Core::Loader {
 class SymbolsResolver;
@@ -128,10 +130,6 @@ s32 PS4_SYSV_ABI sceKernelMemoryPoolCommit(void* addr, size_t len, int type, int
 s32 PS4_SYSV_ABI sceKernelMemoryPoolDecommit(void* addr, size_t len, int flags);
 
 int PS4_SYSV_ABI sceKernelMunmap(void* addr, size_t len);
-
-void* Malloc(size_t size);
-
-void Free(void* ptr);
 
 void RegisterMemory(Core::Loader::SymbolsResolver* sym);
 

--- a/src/core/libraries/np_trophy/np_trophy.cpp
+++ b/src/core/libraries/np_trophy/np_trophy.cpp
@@ -498,7 +498,7 @@ int PS4_SYSV_ABI sceNpTrophyGetTrophyInfo(OrbisNpTrophyContext context, OrbisNpT
 s32 PS4_SYSV_ABI sceNpTrophyGetTrophyUnlockState(OrbisNpTrophyContext context,
                                                  OrbisNpTrophyHandle handle,
                                                  OrbisNpTrophyFlagArray* flags, u32* count) {
-    LOG_INFO(Lib_NpTrophy, "GetTrophyUnlockState called");
+    LOG_INFO(Lib_NpTrophy, "called");
 
     if (context == ORBIS_NP_TROPHY_INVALID_CONTEXT)
         return ORBIS_NP_TROPHY_ERROR_INVALID_CONTEXT;
@@ -519,8 +519,9 @@ s32 PS4_SYSV_ABI sceNpTrophyGetTrophyUnlockState(OrbisNpTrophyContext context,
     pugi::xml_parse_result result = doc.load_file(trophy_file.native().c_str());
 
     if (!result) {
-        LOG_ERROR(Lib_NpTrophy, "Failed to open trophy xml : {}", result.description());
-        return -1;
+        LOG_ERROR(Lib_NpTrophy, "Failed to open trophy XML: {}", result.description());
+        *count = 0;
+        return ORBIS_OK;
     }
 
     int num_trophies = 0;

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -73,10 +73,55 @@ void Linker::Execute() {
     const auto* proc_param = GetProcParam();
     ASSERT(proc_param);
 
+    /* TEMP */
+    LOG_INFO(Core_Linker, "---- proc_param ----");
+    LOG_INFO(Core_Linker, "proc_param->size = 0x{:x}", proc_param->size);
+    LOG_INFO(Core_Linker, "proc_param->magic = 0x{:x}", proc_param->magic);
+    LOG_INFO(Core_Linker, "proc_param->sdk_version = 0x{:x}", proc_param->sdk_version);
+    LOG_INFO(Core_Linker, "proc_param->mem_param = {}", fmt::ptr(proc_param->mem_param));
+    LOG_INFO(Core_Linker, "proc_param->unknown1 = 0x{:x}", proc_param->unknown1);
+    /* TEMP */
+
     Core::OrbisKernelMemParam mem_param{};
     if (proc_param->size >= offsetof(OrbisProcParam, mem_param) + sizeof(OrbisKernelMemParam*)) {
         if (proc_param->mem_param) {
             mem_param = *proc_param->mem_param;
+
+            /* TEMP */
+            LOG_INFO(Core_Linker, "---- mem_param ----");
+            LOG_INFO(Core_Linker, "mem_param->size = 0x{:x}", mem_param.size);
+            LOG_INFO(Core_Linker, "mem_param->extended_page_table = {}",
+                     fmt::ptr(mem_param.extended_page_table));
+            LOG_INFO(Core_Linker, "mem_param->flexible_memory_size = {}",
+                     fmt::ptr(mem_param.flexible_memory_size));
+            LOG_INFO(Core_Linker, "mem_param->extended_memory_1 = {}",
+                     fmt::ptr(mem_param.extended_memory_1));
+            LOG_INFO(Core_Linker, "mem_param->extended_gpu_page_table = {}",
+                     fmt::ptr(mem_param.extended_gpu_page_table));
+            LOG_INFO(Core_Linker, "mem_param->extended_memory_2 = {}",
+                     fmt::ptr(mem_param.extended_memory_2));
+            LOG_INFO(Core_Linker, "mem_param->extended_cpu_page_table = {}",
+                     fmt::ptr(mem_param.extended_cpu_page_table));
+            LOG_INFO(Core_Linker, "-------------------");
+            if (mem_param.size >=
+                    offsetof(OrbisKernelMemParam, flexible_memory_size) + sizeof(u64*) &&
+                mem_param.flexible_memory_size) {
+                LOG_INFO(Core_Linker, "mem_param->flexible_memory_size = 0x{:x}",
+                         *mem_param.flexible_memory_size);
+            }
+            if (mem_param.size >= offsetof(OrbisKernelMemParam, extended_memory_1) + sizeof(u64*) &&
+                mem_param.extended_memory_1) {
+                LOG_INFO(Core_Linker, "mem_param->extended_memory_1 = 0x{:x}",
+                         *mem_param.extended_memory_1);
+            }
+            if (mem_param.size >= offsetof(OrbisKernelMemParam, extended_memory_2) + sizeof(u64*) &&
+                mem_param.extended_memory_2) {
+                LOG_INFO(Core_Linker, "mem_param->extended_memory_2 = 0x{:x}",
+                         *mem_param.extended_memory_2);
+            }
+            LOG_INFO(Core_Linker, "-------------------");
+            /* TEMP */
+
             if (mem_param.size >=
                 offsetof(OrbisKernelMemParam, flexible_memory_size) + sizeof(u64*)) {
                 if (const auto* flexible_size = mem_param.flexible_memory_size) {

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -5,6 +5,7 @@
 #include "common/arch.h"
 #include "common/assert.h"
 #include "common/config.h"
+#include "common/elf_info.h"
 #include "common/logging/log.h"
 #include "common/path_util.h"
 #include "common/string_util.h"
@@ -65,20 +66,33 @@ void Linker::Execute() {
         Relocate(m.get());
     }
 
-    // Configure used flexible memory size.
-    if (const auto* proc_param = GetProcParam()) {
-        if (proc_param->size >=
-            offsetof(OrbisProcParam, mem_param) + sizeof(OrbisKernelMemParam*)) {
-            if (const auto* mem_param = proc_param->mem_param) {
-                if (mem_param->size >=
-                    offsetof(OrbisKernelMemParam, flexible_memory_size) + sizeof(u64*)) {
-                    if (const auto* flexible_size = mem_param->flexible_memory_size) {
-                        memory->SetupMemoryRegions(*flexible_size);
-                    }
+    // Configure the direct and flexible memory regions.
+    u64 fmem_size = SCE_FLEXIBLE_MEMORY_SIZE;
+    bool use_extended_mem1 = true, use_extended_mem2 = true;
+
+    const auto* proc_param = GetProcParam();
+    ASSERT_MSG(proc_param);
+
+    Core::OrbisKernelMemParam mem_param{};
+    if (proc_param->size >= offsetof(OrbisProcParam, mem_param) + sizeof(OrbisKernelMemParam*)) {
+        if (proc_param->mem_param) {
+            mem_param = *proc_param->mem_param;
+            if (mem_param.size >=
+                offsetof(OrbisKernelMemParam, flexible_memory_size) + sizeof(u64*)) {
+                if (const auto* flexible_size = mem_param.flexible_memory_size) {
+                    fmem_size = *flexible_size + SCE_FLEXIBLE_MEMORY_BASE;
                 }
             }
         }
     }
+
+    const u64 fw_ver = Common::ElfInfo::Instance().RawFirmwareVer();
+    if (fw_ver < Common::ElfInfo::FW_50) {
+        use_extended_mem1 = mem_param.extended_memory_1 ? *mem_param.extended_memory_1 : false;
+        use_extended_mem2 = mem_param.extended_memory_2 ? *mem_param.extended_memory_2 : false;
+    }
+
+    memory->SetupMemoryRegions(fmem_size, use_extended_mem1, use_extended_mem2);
 
     main_thread.Run([this, module](std::stop_token) {
         Common::SetCurrentThreadName("GAME_MainThread");

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -138,8 +138,8 @@ void Linker::Execute() {
         mem_param.extended_memory_2 = nullptr;
     }
 
-    const u64 fw_ver = Common::ElfInfo::Instance().RawFirmwareVer();
-    if (fw_ver < Common::ElfInfo::FW_50) {
+    const u64 sdk_ver = proc_param->sdk_version;
+    if (sdk_ver < Common::ElfInfo::FW_50) {
         use_extended_mem1 = mem_param.extended_memory_1 ? *mem_param.extended_memory_1 : false;
         use_extended_mem2 = mem_param.extended_memory_2 ? *mem_param.extended_memory_2 : false;
     }

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -73,55 +73,10 @@ void Linker::Execute() {
     const auto* proc_param = GetProcParam();
     ASSERT(proc_param);
 
-    /* TEMP */
-    LOG_INFO(Core_Linker, "---- proc_param ----");
-    LOG_INFO(Core_Linker, "proc_param->size = 0x{:x}", proc_param->size);
-    LOG_INFO(Core_Linker, "proc_param->magic = 0x{:x}", proc_param->magic);
-    LOG_INFO(Core_Linker, "proc_param->sdk_version = 0x{:x}", proc_param->sdk_version);
-    LOG_INFO(Core_Linker, "proc_param->mem_param = {}", fmt::ptr(proc_param->mem_param));
-    LOG_INFO(Core_Linker, "proc_param->unknown1 = 0x{:x}", proc_param->unknown1);
-    /* TEMP */
-
     Core::OrbisKernelMemParam mem_param{};
     if (proc_param->size >= offsetof(OrbisProcParam, mem_param) + sizeof(OrbisKernelMemParam*)) {
         if (proc_param->mem_param) {
             mem_param = *proc_param->mem_param;
-
-            /* TEMP */
-            LOG_INFO(Core_Linker, "---- mem_param ----");
-            LOG_INFO(Core_Linker, "mem_param->size = 0x{:x}", mem_param.size);
-            LOG_INFO(Core_Linker, "mem_param->extended_page_table = {}",
-                     fmt::ptr(mem_param.extended_page_table));
-            LOG_INFO(Core_Linker, "mem_param->flexible_memory_size = {}",
-                     fmt::ptr(mem_param.flexible_memory_size));
-            LOG_INFO(Core_Linker, "mem_param->extended_memory_1 = {}",
-                     fmt::ptr(mem_param.extended_memory_1));
-            LOG_INFO(Core_Linker, "mem_param->extended_gpu_page_table = {}",
-                     fmt::ptr(mem_param.extended_gpu_page_table));
-            LOG_INFO(Core_Linker, "mem_param->extended_memory_2 = {}",
-                     fmt::ptr(mem_param.extended_memory_2));
-            LOG_INFO(Core_Linker, "mem_param->extended_cpu_page_table = {}",
-                     fmt::ptr(mem_param.extended_cpu_page_table));
-            LOG_INFO(Core_Linker, "-------------------");
-            if (mem_param.size >=
-                    offsetof(OrbisKernelMemParam, flexible_memory_size) + sizeof(u64*) &&
-                mem_param.flexible_memory_size) {
-                LOG_INFO(Core_Linker, "mem_param->flexible_memory_size = 0x{:x}",
-                         *mem_param.flexible_memory_size);
-            }
-            if (mem_param.size >= offsetof(OrbisKernelMemParam, extended_memory_1) + sizeof(u64*) &&
-                mem_param.extended_memory_1) {
-                LOG_INFO(Core_Linker, "mem_param->extended_memory_1 = 0x{:x}",
-                         *mem_param.extended_memory_1);
-            }
-            if (mem_param.size >= offsetof(OrbisKernelMemParam, extended_memory_2) + sizeof(u64*) &&
-                mem_param.extended_memory_2) {
-                LOG_INFO(Core_Linker, "mem_param->extended_memory_2 = 0x{:x}",
-                         *mem_param.extended_memory_2);
-            }
-            LOG_INFO(Core_Linker, "-------------------");
-            /* TEMP */
-
             if (mem_param.size >=
                 offsetof(OrbisKernelMemParam, flexible_memory_size) + sizeof(u64*)) {
                 if (const auto* flexible_size = mem_param.flexible_memory_size) {

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -71,7 +71,7 @@ void Linker::Execute() {
     bool use_extended_mem1 = true, use_extended_mem2 = true;
 
     const auto* proc_param = GetProcParam();
-    ASSERT_MSG(proc_param);
+    ASSERT(proc_param);
 
     Core::OrbisKernelMemParam mem_param{};
     if (proc_param->size >= offsetof(OrbisProcParam, mem_param) + sizeof(OrbisKernelMemParam*)) {
@@ -84,6 +84,13 @@ void Linker::Execute() {
                 }
             }
         }
+    }
+
+    if (mem_param.size < offsetof(OrbisKernelMemParam, extended_memory_1) + sizeof(u64*)) {
+        mem_param.extended_memory_1 = nullptr;
+    }
+    if (mem_param.size < offsetof(OrbisKernelMemParam, extended_memory_2) + sizeof(u64*)) {
+        mem_param.extended_memory_2 = nullptr;
     }
 
     const u64 fw_ver = Common::ElfInfo::Instance().RawFirmwareVer();

--- a/src/core/linker.h
+++ b/src/core/linker.h
@@ -22,7 +22,7 @@ struct OrbisKernelMemParam {
     u8* extended_memory_1;
     u64* extended_gpu_page_table;
     u8* extended_memory_2;
-    u64* exnteded_cpu_page_table;
+    u64* extended_cpu_page_table;
 };
 static_assert(sizeof(OrbisKernelMemParam) == 0x38);
 

--- a/src/core/linker.h
+++ b/src/core/linker.h
@@ -24,6 +24,7 @@ struct OrbisKernelMemParam {
     u8* extended_memory_2;
     u64* exnteded_cpu_page_table;
 };
+static_assert(sizeof(OrbisKernelMemParam) == 0x38);
 
 struct OrbisProcParam {
     u64 size;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -12,12 +12,7 @@
 
 namespace Core {
 
-constexpr u64 SCE_DEFAULT_FLEXIBLE_MEMORY_SIZE = 448_MB;
-
 MemoryManager::MemoryManager() {
-    // Set up the direct and flexible memory regions.
-    SetupMemoryRegions(SCE_DEFAULT_FLEXIBLE_MEMORY_SIZE);
-
     // Insert a virtual memory area that covers the entire area we manage.
     const VAddr system_managed_base = impl.SystemManagedVirtualBase();
     const size_t system_managed_size = impl.SystemManagedVirtualSize();
@@ -38,10 +33,17 @@ MemoryManager::MemoryManager() {
 
 MemoryManager::~MemoryManager() = default;
 
-void MemoryManager::SetupMemoryRegions(u64 flexible_size) {
-    const auto total_size =
-        Config::isNeoMode() ? SCE_KERNEL_MAIN_DMEM_SIZE_PRO : SCE_KERNEL_MAIN_DMEM_SIZE;
-    total_flexible_size = flexible_size;
+void MemoryManager::SetupMemoryRegions(u64 flexible_size, bool use_extended_mem1,
+                                       bool use_extended_mem2) {
+    const bool is_neo = Config::isNeoMode();
+    auto total_size = is_neo ? SCE_KERNEL_TOTAL_MEM_PRO : SCE_KERNEL_TOTAL_MEM;
+    if (!use_extended_mem1 && is_neo) {
+        total_size -= 256_MB;
+    }
+    if (!use_extended_mem2 && !is_neo) {
+        total_size -= 128_MB;
+    }
+    total_flexible_size = flexible_size - SCE_FLEXIBLE_MEMORY_BASE;
     total_direct_size = total_size - flexible_size;
 
     // Insert an area that covers direct memory physical block.

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -166,7 +166,7 @@ public:
 
     bool TryWriteBacking(void* address, const void* data, u32 num_bytes);
 
-    void SetupMemoryRegions(u64 flexible_size);
+    void SetupMemoryRegions(u64 flexible_size, bool use_extended_mem1, bool use_extended_mem2);
 
     PAddr PoolExpand(PAddr search_start, PAddr search_end, size_t size, u64 alignment);
 


### PR DESCRIPTION
This PR aims to resolve the issues from https://github.com/shadps4-emu/shadPS4/issues/825 based on @red-prig's work on kernel reverse engineering.
May also fix games that check for direct memory sizes, like The Last of Us Part II and Farming Simulator 22.

Marking as draft as this needs to be checked for regressions.