### PR TITLE
Fix for D32Sfloat and R8Snorm Tiled image

### DIFF
--- a/src/video_core/texture_cache/tile_manager.cpp
+++ b/src/video_core/texture_cache/tile_manager.cpp
@@ -25,6 +25,7 @@ static vk::Format DemoteImageFormatForDetiling(vk::Format format) {
     switch (format) {
     case vk::Format::eR8Uint:
     case vk::Format::eR8Unorm:
+    case vk::Format::eR8Snorm:
         return vk::Format::eR8Uint;
     case vk::Format::eR4G4B4A4UnormPack16:
     case vk::Format::eB5G6R5UnormPack16:

--- a/src/video_core/texture_cache/tile_manager.cpp
+++ b/src/video_core/texture_cache/tile_manager.cpp
@@ -41,6 +41,7 @@ static vk::Format DemoteImageFormatForDetiling(vk::Format format) {
     case vk::Format::eR8G8B8A8Snorm:
     case vk::Format::eR8G8B8A8Uint:
     case vk::Format::eR32Sfloat:
+    case vk::Format::eD32Sfloat:
     case vk::Format::eR32Uint:
     case vk::Format::eR16G16Sfloat:
     case vk::Format::eR16G16Unorm:


### PR DESCRIPTION
After downloading about fifty logs on **shadps4-game-compatibility** (Since the 0.5.0 release), I found that there was only one texture format that came back each time: **D32Sfloat**.

Games impacted by the error: **The Last Guardian, The Witcher 3: Wild Hunt, Gravity Rush Remastered, Persona 5 Royal and YAKUZA 0**

Edit: I added **R8Snorm** because it is needed for **Elden Ring**. (Thanks @DanielSvoboda)