### PR TITLE
settings-dialog: use grid layout

### DIFF
--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -42,160 +42,42 @@
   </property>
   <layout class="QVBoxLayout" name="settingsDialogLayout">
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QTabWidget" name="tabWidgetSettings">
      <property name="enabled">
       <bool>true</bool>
      </property>
-     <property name="frameShape">
-      <enum>QFrame::Shape::NoFrame</enum>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <property name="widgetResizable">
-      <bool>true</bool>
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <widget class="QTabWidget" name="tabWidgetSettings">
-      <property name="enabled">
+     <widget class="QScrollArea" name="generalTab">
+      <property name="widgetResizable">
        <bool>true</bool>
       </property>
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>-97</y>
-        <width>815</width>
-        <height>618</height>
-       </rect>
-      </property>
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="currentIndex">
-       <number>0</number>
-      </property>
-      <widget class="QWidget" name="generalTab">
-       <attribute name="title">
-        <string>General</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="generalTabVLayout" stretch="0,0">
+      <attribute name="title">
+       <string>General</string>
+      </attribute>
+      <widget class="QWidget" name="generalTabContents">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>822</width>
+         <height>487</height>
+        </rect>
+       </property>
+       <layout class="QVBoxLayout" name="generalTabVLayout" stretch="0">
         <item>
-         <layout class="QHBoxLayout" name="generalTabHLayoutTop" stretch="1,1,1">
-          <item>
-           <layout class="QVBoxLayout" name="systemTabLayoutLeft">
-            <item>
-             <widget class="QGroupBox" name="SystemSettings">
-              <property name="title">
-               <string>System</string>
-              </property>
-              <layout class="QVBoxLayout" name="emuSettingsLayout">
-               <item>
-                <widget class="QGroupBox" name="consoleLanguageGroupBox">
-                 <property name="title">
-                  <string>Console Language</string>
-                 </property>
-                 <layout class="QVBoxLayout" name="settingsLayout">
-                  <item>
-                   <widget class="QComboBox" name="consoleLanguageComboBox"/>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="emulatorLanguageGroupBox">
-                 <property name="title">
-                  <string>Emulator Language</string>
-                 </property>
-                 <layout class="QVBoxLayout" name="langSettingsLayout">
-                  <item>
-                   <widget class="QComboBox" name="emulatorLanguageComboBox"/>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="emulatorTabLayoutMiddle">
-            <item>
-             <widget class="QGroupBox" name="emulatorSettingsGroupBox">
-              <property name="title">
-               <string>Emulator</string>
-              </property>
-              <layout class="QVBoxLayout" name="additionalSettingsVLayout">
-               <item>
-                <layout class="QVBoxLayout" name="emulatorverticalLayout">
-                 <item>
-                  <widget class="QCheckBox" name="fullscreenCheckBox">
-                   <property name="text">
-                    <string>Enable Fullscreen</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QCheckBox" name="separateUpdatesCheckBox">
-                   <property name="text">
-                    <string>Enable Separate Update Folder</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QCheckBox" name="showSplashCheckBox">
-                   <property name="text">
-                    <string>Show Splash</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QCheckBox" name="ps4proCheckBox">
-                   <property name="text">
-                    <string>Is PS4 Pro</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QCheckBox" name="discordRPCCheckbox">
-                   <property name="text">
-                    <string>Enable Discord Rich Presence</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <layout class="QVBoxLayout" name="vLayoutUserName">
-                 <property name="spacing">
-                  <number>6</number>
-                 </property>
-                 <property name="leftMargin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <layout class="QHBoxLayout" name="hLayoutUserName">
-                   <item>
-                    <widget class="QGroupBox" name="userName">
-                     <property name="title">
-                      <string>Username</string>
-                     </property>
-                     <layout class="QVBoxLayout" name="userNameLayout">
-                      <item>
-                       <widget class="QLineEdit" name="userNameLineEdit"/>
-                      </item>
-                     </layout>
-                    </widget>
-                   </item>
-                  </layout>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
+         <layout class="QGridLayout" name="gridLayout">
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item row="0" column="2">
            <layout class="QVBoxLayout" name="loggerTabLayoutRight">
             <item>
              <widget class="QGroupBox" name="loggerGroupBox">
@@ -275,12 +157,129 @@
             </item>
            </layout>
           </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="generalTabHLayout_2">
-          <item>
+          <item row="0" column="0">
+           <layout class="QVBoxLayout" name="systemTabLayoutLeft">
+            <item>
+             <widget class="QGroupBox" name="SystemSettings">
+              <property name="title">
+               <string>System</string>
+              </property>
+              <layout class="QVBoxLayout" name="emuSettingsLayout">
+               <item>
+                <widget class="QGroupBox" name="consoleLanguageGroupBox">
+                 <property name="title">
+                  <string>Console Language</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="settingsLayout">
+                  <item>
+                   <widget class="QComboBox" name="consoleLanguageComboBox"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="emulatorLanguageGroupBox">
+                 <property name="title">
+                  <string>Emulator Language</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="langSettingsLayout">
+                  <item>
+                   <widget class="QComboBox" name="emulatorLanguageComboBox"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="0" column="1">
+           <layout class="QVBoxLayout" name="emulatorTabLayoutMiddle">
+            <item>
+             <widget class="QGroupBox" name="emulatorSettingsGroupBox">
+              <property name="title">
+               <string>Emulator</string>
+              </property>
+              <layout class="QVBoxLayout" name="additionalSettingsVLayout">
+               <item>
+                <layout class="QVBoxLayout" name="emulatorverticalLayout">
+                 <property name="spacing">
+                  <number>10</number>
+                 </property>
+                 <item>
+                  <widget class="QCheckBox" name="fullscreenCheckBox">
+                   <property name="text">
+                    <string>Enable Fullscreen</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QCheckBox" name="separateUpdatesCheckBox">
+                   <property name="text">
+                    <string>Enable Separate Update Folder</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QCheckBox" name="showSplashCheckBox">
+                   <property name="text">
+                    <string>Show Splash</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QCheckBox" name="ps4proCheckBox">
+                   <property name="text">
+                    <string>Is PS4 Pro</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QCheckBox" name="discordRPCCheckbox">
+                   <property name="text">
+                    <string>Enable Discord Rich Presence</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <layout class="QVBoxLayout" name="vLayoutUserName">
+                 <property name="spacing">
+                  <number>6</number>
+                 </property>
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <layout class="QHBoxLayout" name="hLayoutUserName">
+                   <item>
+                    <widget class="QGroupBox" name="userName">
+                     <property name="title">
+                      <string>Username</string>
+                     </property>
+                     <layout class="QVBoxLayout" name="userNameLayout">
+                      <item>
+                       <widget class="QLineEdit" name="userNameLineEdit"/>
+                      </item>
+                     </layout>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                </layout>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="1" column="0">
            <layout class="QVBoxLayout" name="updaterTabLayoutLeft">
+            <property name="spacing">
+             <number>-1</number>
+            </property>
             <property name="sizeConstraint">
              <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
             </property>
@@ -296,7 +295,7 @@
             <property name="bottomMargin">
              <number>0</number>
             </property>
-            <item alignment="Qt::AlignmentFlag::AlignTop">
+            <item>
              <widget class="QGroupBox" name="updaterGroupBox">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
@@ -306,7 +305,7 @@
               </property>
               <property name="minimumSize">
                <size>
-                <width>265</width>
+                <width>0</width>
                 <height>0</height>
                </size>
               </property>
@@ -321,7 +320,7 @@
               </property>
               <layout class="QVBoxLayout" name="UpdateLayout" stretch="0,0,0">
                <property name="spacing">
-                <number>5</number>
+                <number>10</number>
                </property>
                <property name="topMargin">
                 <number>1</number>
@@ -343,7 +342,7 @@
                  <property name="minimumSize">
                   <size>
                    <width>0</width>
-                   <height>75</height>
+                   <height>0</height>
                   </size>
                  </property>
                  <property name="maximumSize">
@@ -404,8 +403,8 @@
                  </property>
                  <property name="minimumSize">
                   <size>
-                   <width>197</width>
-                   <height>28</height>
+                   <width>0</width>
+                   <height>0</height>
                   </size>
                  </property>
                  <property name="maximumSize">
@@ -443,7 +442,7 @@
             </item>
            </layout>
           </item>
-          <item>
+          <item row="1" column="1">
            <layout class="QVBoxLayout" name="GUITabLayoutMiddle" stretch="0">
             <item alignment="Qt::AlignmentFlag::AlignTop">
              <widget class="QGroupBox" name="GUIgroupBox">
@@ -477,6 +476,19 @@
                 </widget>
                </item>
                <item>
+                <widget class="QCheckBox" name="playBGMCheckBox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Play title music</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <layout class="QVBoxLayout" name="GUIMusicLayout">
                  <property name="topMargin">
                   <number>1</number>
@@ -485,20 +497,7 @@
                   <number>0</number>
                  </property>
                  <item>
-                  <widget class="QCheckBox" name="playBGMCheckBox">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string>Play title music</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="GUIverticalSpacer_2">
+                  <spacer name="GUIverticalSpacer_3">
                    <property name="orientation">
                     <enum>Qt::Orientation::Vertical</enum>
                    </property>
@@ -508,7 +507,7 @@
                    <property name="sizeHint" stdset="0">
                     <size>
                      <width>20</width>
-                     <height>2</height>
+                     <height>13</height>
                     </size>
                    </property>
                   </spacer>
@@ -573,7 +572,7 @@
             </item>
            </layout>
           </item>
-          <item>
+          <item row="1" column="2">
            <layout class="QVBoxLayout" name="CompatTabLayoutRight" stretch="0">
             <item alignment="Qt::AlignmentFlag::AlignTop">
              <widget class="QGroupBox" name="CompatgroupBox">
@@ -593,6 +592,9 @@
                <string>Game Compatibility</string>
               </property>
               <layout class="QVBoxLayout" name="CompatLayout">
+               <property name="spacing">
+                <number>10</number>
+               </property>
                <property name="topMargin">
                 <number>1</number>
                </property>
@@ -614,53 +616,56 @@
                 </widget>
                </item>
                <item>
-                <layout class="QVBoxLayout" name="UpdateCompatLayout">
-                 <property name="topMargin">
-                  <number>1</number>
+                <widget class="QPushButton" name="updateCompatibilityButton">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
                  </property>
-                 <property name="bottomMargin">
-                  <number>0</number>
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
                  </property>
-                 <item>
-                  <widget class="QPushButton" name="updateCompatibilityButton">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="minimumSize">
-                    <size>
-                     <width>197</width>
-                     <height>28</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>16777215</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                   <property name="text">
-                    <string>Update Compatibility Database</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-              </item>
-            </layout>
-            </widget>
+                 <property name="maximumSize">
+                  <size>
+                   <width>16777215</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>Update Compatibility Database</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
         </item>
        </layout>
-       </item>
-       </layout>
-       </item>
-       </layout>
       </widget>
-      <widget class="QWidget" name="inputTab">
-       <attribute name="title">
-        <string>Input</string>
-       </attribute>
+     </widget>
+     <widget class="QScrollArea" name="inputTab">
+      <property name="widgetResizable">
+       <bool>true</bool>
+      </property>
+      <attribute name="title">
+       <string>Input</string>
+      </attribute>
+      <widget class="QWidget" name="inputTabContents">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>396</width>
+         <height>222</height>
+        </rect>
+       </property>
        <layout class="QVBoxLayout" name="inputTabVLayout" stretch="0,0">
         <item>
          <layout class="QHBoxLayout" name="inputTabHLayoutTop" stretch="1,1,1">
@@ -769,8 +774,8 @@
                     </property>
                     <property name="minimumSize">
                      <size>
-                      <width>80</width>
-                      <height>30</height>
+                      <width>0</width>
+                      <height>0</height>
                      </size>
                     </property>
                     <property name="maximumSize">
@@ -856,7 +861,7 @@
                  </property>
                  <property name="minimumSize">
                   <size>
-                   <width>237</width>
+                   <width>0</width>
                    <height>0</height>
                   </size>
                  </property>
@@ -935,10 +940,23 @@
         </item>
        </layout>
       </widget>
-      <widget class="QWidget" name="grphicsTab">
-       <attribute name="title">
-        <string>Graphics</string>
-       </attribute>
+     </widget>
+     <widget class="QScrollArea" name="graphicsTab">
+      <property name="widgetResizable">
+       <bool>true</bool>
+      </property>
+      <attribute name="title">
+       <string>Graphics</string>
+      </attribute>
+      <widget class="QWidget" name="graphicsTabLayout">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>536</width>
+         <height>192</height>
+        </rect>
+       </property>
        <layout class="QVBoxLayout" name="graphicsTabVLayout" stretch="0,0">
         <item>
          <layout class="QHBoxLayout" name="graphicsTabHLayout" stretch="1,1,1">
@@ -1173,58 +1191,54 @@
         </item>
        </layout>
       </widget>
-      <widget class="QWidget" name="pathsTab">
-       <attribute name="title">
-        <string>Paths</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="inputTabVLayout" stretch="0">
+     </widget>
+     <widget class="QScrollArea" name="pathsTab">
+      <property name="widgetResizable">
+       <bool>true</bool>
+      </property>
+      <attribute name="title">
+       <string>Paths</string>
+      </attribute>
+      <widget class="QWidget" name="pathsTabContents">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>146</width>
+         <height>215</height>
+        </rect>
+       </property>
+       <layout class="QVBoxLayout" name="pathsTabLayout" stretch="0">
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <layout class="QHBoxLayout" name="pathsTabVLayout">
           <item>
            <widget class="QGroupBox" name="gameFoldersGroupBox">
             <property name="title">
              <string>Game Folders</string>
             </property>
-            <widget class="QListWidget" name="gameFoldersListWidget">
-             <property name="geometry">
-              <rect>
-               <x>0</x>
-               <y>20</y>
-               <width>401</width>
-               <height>331</height>
-              </rect>
-             </property>
-            </widget>
-            <widget class="QPushButton" name="addFolderButton">
-             <property name="geometry">
-              <rect>
-               <x>100</x>
-               <y>360</y>
-               <width>91</width>
-               <height>24</height>
-              </rect>
-             </property>
-             <property name="text">
-              <string>Add...</string>
-             </property>
-            </widget>
-            <widget class="QPushButton" name="removeFolderButton">
-             <property name="geometry">
-              <rect>
-               <x>199</x>
-               <y>360</y>
-               <width>91</width>
-               <height>24</height>
-              </rect>
-             </property>
-             <property name="text">
-              <string>Remove</string>
-             </property>
-            </widget>
+            <layout class="QVBoxLayout" name="verticalLayout">
+             <item>
+              <widget class="QPushButton" name="removeFolderButton">
+               <property name="text">
+                <string>Remove</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="addFolderButton">
+               <property name="text">
+                <string>Add...</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QListWidget" name="gameFoldersListWidget"/>
+             </item>
+            </layout>
            </widget>
           </item>
           <item>
-           <spacer name="horizontalSpacer_2">
+           <spacer name="horizontalSpacer">
             <property name="orientation">
              <enum>Qt::Orientation::Horizontal</enum>
             </property>
@@ -1243,10 +1257,23 @@
         </item>
        </layout>
       </widget>
-      <widget class="QWidget" name="debugTab">
-       <attribute name="title">
-        <string>Debug</string>
-       </attribute>
+     </widget>
+     <widget class="QScrollArea" name="debugTab">
+      <property name="widgetResizable">
+       <bool>true</bool>
+      </property>
+      <attribute name="title">
+       <string>Debug</string>
+      </attribute>
+      <widget class="QWidget" name="debugTabContents">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>288</width>
+         <height>163</height>
+        </rect>
+       </property>
        <layout class="QVBoxLayout" name="debugTabVLayout" stretch="0,1">
         <item>
          <layout class="QHBoxLayout" name="debugTabHLayout" stretch="1">


### PR DESCRIPTION
* Changes general tab to use grid layout 
* `QScrollArea` is now correctly placed as a child of `QTabWidget`