### PR TITLE
cubeb_audio: Make sure COM is initialized on Windows.

### DIFF
--- a/src/core/libraries/audio/audioout_backend.h
+++ b/src/core/libraries/audio/audioout_backend.h
@@ -34,6 +34,9 @@ public:
 
 private:
     cubeb* ctx = nullptr;
+#ifdef _WIN32
+    bool owns_com = false;
+#endif
 };
 
 class SDLAudioOut final : public AudioOutBackend {


### PR DESCRIPTION
Cubeb does not initialize COM itself on the thread calling `cubeb_init`, we need to make sure it is initialized ourselves.

Should fix an issue some people have where everything crashes on launch with cubeb audio. 