### PR TITLE
image: Add Depth_MicroTiled and Display_MicroTiled tiling modes.

### DIFF
--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -122,7 +122,9 @@ constexpr std::string_view NameOf(ImageType type) {
 
 enum class TilingMode : u32 {
     Depth_MacroTiled = 0u,
+    Depth_MicroTiled = 0x5u,
     Display_Linear = 0x8u,
+    Display_MicroTiled = 0x9u,
     Display_MacroTiled = 0xAu,
     Texture_MicroTiled = 0xDu,
     Texture_MacroTiled = 0xEu,
@@ -131,10 +133,14 @@ enum class TilingMode : u32 {
 
 constexpr std::string_view NameOf(TilingMode type) {
     switch (type) {
+    case TilingMode::Depth_MicroTiled:
+        return "Depth_MicroTiled";
     case TilingMode::Depth_MacroTiled:
         return "Depth_MacroTiled";
     case TilingMode::Display_Linear:
         return "Display_Linear";
+    case TilingMode::Display_MicroTiled:
+        return "Display_MicroTiled";
     case TilingMode::Display_MacroTiled:
         return "Display_MacroTiled";
     case TilingMode::Texture_MicroTiled:
@@ -294,8 +300,7 @@ struct Image {
 
     TilingMode GetTilingMode() const {
         if (tiling_index >= 0 && tiling_index <= 7) {
-            return tiling_index == 5 ? TilingMode::Texture_MicroTiled
-                                     : TilingMode::Depth_MacroTiled;
+            return tiling_index == 5 ? TilingMode::Depth_MicroTiled : TilingMode::Depth_MacroTiled;
         }
         return static_cast<TilingMode>(tiling_index);
     }

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -369,6 +369,8 @@ void ImageInfo::UpdateSize() {
         case AmdGpu::TilingMode::Texture_Volume:
             mip_d += (-mip_d) & 3u;
             [[fallthrough]];
+        case AmdGpu::TilingMode::Depth_MicroTiled:
+        case AmdGpu::TilingMode::Display_MicroTiled:
         case AmdGpu::TilingMode::Texture_MicroTiled: {
             std::tie(mip_info.pitch, mip_info.size) =
                 ImageSizeMicroTiled(mip_w, mip_h, bpp, num_samples);

--- a/src/video_core/texture_cache/tile_manager.cpp
+++ b/src/video_core/texture_cache/tile_manager.cpp
@@ -89,6 +89,8 @@ const DetilerContext* TileManager::GetDetiler(const Image& image) const {
     const auto format = DemoteImageFormatForDetiling(image.info.pixel_format);
 
     switch (image.info.tiling_mode) {
+    case AmdGpu::TilingMode::Depth_MicroTiled:
+    case AmdGpu::TilingMode::Display_MicroTiled:
     case AmdGpu::TilingMode::Texture_MicroTiled:
         switch (format) {
         case vk::Format::eR8Uint:


### PR DESCRIPTION
* Adds `Display_MicroTiled` (mode `0x9`), and gives `Depth_MicroTiled` (mode `0x5`) its own constant for completeness instead of mapping to `Texture_MicroTiled`.
* Adds these new tiling modes to size calculations and detiling, handled same as `Texture_MicroTiled`.

Needs validation this is the correct approach to handle these, I could not effectively debug the use of `Display_MicroTiled` in Knack Chapter 13-1 on my system.