### PR TITLE
pthread: Change minimum stack for HLE to additional stack.

### DIFF
--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -244,10 +244,9 @@ int PS4_SYSV_ABI posix_pthread_create_name_np(PthreadT* thread, const PthreadAtt
     new_thread->tid = ++TidCounter;
 
     if (new_thread->attr.stackaddr_attr == 0) {
-        /* Enforce minimum stack size of 128 KB */
-        static constexpr size_t MinimumStack = 128_KB;
-        auto& stacksize = new_thread->attr.stacksize_attr;
-        stacksize = std::max(stacksize, MinimumStack);
+        /* Add additional stack space for HLE */
+        static constexpr size_t AdditionalStack = 128_KB;
+        new_thread->attr.stacksize_attr += AdditionalStack;
     }
 
     if (thread_state->CreateStack(&new_thread->attr) != 0) {


### PR DESCRIPTION
May fix some remaining stack space issues with HLE.

@Emulator-Team-2 Can you check with Gintama Rumble and cubeb audio with this?