### PR TITLE
cubeb_audio: Add failsafe timeout for output and more logging.

### DIFF
--- a/src/core/libraries/audio/audioout_backend.h
+++ b/src/core/libraries/audio/audioout_backend.h
@@ -33,6 +33,8 @@ public:
     std::unique_ptr<PortBackend> Open(PortOut& port) override;
 
 private:
+    static void LogCallback(const char* fmt, ...);
+
     cubeb* ctx = nullptr;
 };
 


### PR DESCRIPTION
* Add a timeout to the cubeb ring buffer wait, up to two times the duration of an audio buffer, to try to avoid unexpected stalls.
* If the wait timed out and not all audio data could be written, log the dropped frames.
* Add log callback to get more information from cubeb.

@Emulator-Team-2 Please check what Disgaea 4 Complete does with this.