### PR TITLE
config: Don't load config in the Emulator class

### DIFF
--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -45,10 +45,6 @@ Frontend::WindowSDL* g_window = nullptr;
 namespace Core {
 
 Emulator::Emulator() {
-    // Read configuration file.
-    const auto config_dir = Common::FS::GetUserPath(Common::FS::PathType::UserDir);
-    Config::load(config_dir / "config.toml");
-
     // Initialize NT API functions and set high priority
 #ifdef _WIN32
     Common::NtApi::Initialize();


### PR DESCRIPTION
Allows overriding of configs in frontends.

Fix set fullscreen not working when specified in the CLI.

Cc: @kalaposfos13.