### PR TITLE
renderer_vulkan: Render polygons using triangle fans.

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -83,7 +83,7 @@ public:
                            const std::optional<Shader::Gcn::FetchShaderData>& fetch_shader);
 
     /// Bind host index buffer for the current draw.
-    u32 BindIndexBuffer(bool& is_indexed, u32 index_offset);
+    void BindIndexBuffer(u32 index_offset);
 
     /// Writes a value to GPU buffer.
     void InlineData(VAddr address, const void* value, u32 num_bytes, bool is_gds);

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -103,6 +103,7 @@ vk::PrimitiveTopology PrimitiveType(AmdGpu::PrimitiveType type) {
     case AmdGpu::PrimitiveType::TriangleList:
         return vk::PrimitiveTopology::eTriangleList;
     case AmdGpu::PrimitiveType::TriangleFan:
+    case AmdGpu::PrimitiveType::Polygon:
         return vk::PrimitiveTopology::eTriangleFan;
     case AmdGpu::PrimitiveType::TriangleStrip:
         return vk::PrimitiveTopology::eTriangleStrip;
@@ -116,9 +117,6 @@ vk::PrimitiveTopology PrimitiveType(AmdGpu::PrimitiveType type) {
         return vk::PrimitiveTopology::eTriangleStripWithAdjacency;
     case AmdGpu::PrimitiveType::PatchPrimitive:
         return vk::PrimitiveTopology::ePatchList;
-    case AmdGpu::PrimitiveType::Polygon:
-        // Needs to generate index buffer on the fly.
-        return vk::PrimitiveTopology::eTriangleList;
     case AmdGpu::PrimitiveType::QuadList:
     case AmdGpu::PrimitiveType::RectList:
         return vk::PrimitiveTopology::ePatchList;

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.h
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.h
@@ -70,15 +70,6 @@ vk::ClearValue ColorBufferClearValue(const AmdGpu::Liverpool::ColorBuffer& color
 
 vk::SampleCountFlagBits NumSamples(u32 num_samples, vk::SampleCountFlags supported_flags);
 
-inline void EmitPolygonToTriangleListIndices(u8* out_ptr, u32 num_vertices) {
-    u16* out_data = reinterpret_cast<u16*>(out_ptr);
-    for (u16 i = 1; i < num_vertices - 1; i++) {
-        *out_data++ = 0;
-        *out_data++ = i;
-        *out_data++ = i + 1;
-    }
-}
-
 static inline vk::Format PromoteFormatToDepth(vk::Format fmt) {
     if (fmt == vk::Format::eR32Sfloat) {
         return vk::Format::eD32Sfloat;


### PR DESCRIPTION
Remembered today that polygons and triangle fans are exactly the same except in lines mode, so use that instead of a generated triangle list index buffer, which allows us to also easily support polygons for indexed and indirect draws and completely remove the remaining re-indexing code.

For lines mode, our current workaround doesn't work for that either anyway since we convert it to triangles. If we find a game using polygons in lines mode for some reason we will need an alternate solution for that.