### PR TITLE
build: Update MoltenVK and fix missing add_dependencies for copy.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -917,6 +917,7 @@ if (APPLE)
           DEPENDS ${MVK_DYLIB_SRC}
           COMMAND cmake -E copy ${MVK_DYLIB_SRC} ${MVK_DYLIB_DST})
       add_custom_target(CopyMoltenVK DEPENDS ${MVK_DYLIB_DST})
+      add_dependencies(CopyMoltenVK MoltenVK)
       add_dependencies(shadps4 CopyMoltenVK)
       set_property(TARGET shadps4 APPEND PROPERTY BUILD_RPATH "@executable_path/../Frameworks")
   else()


### PR DESCRIPTION
Missed this before and caught it in a CI run in my fork today without cache. Apparently this target dependency needs to be added for it to know how to make the dylib file, adding the file dependency to the copy command isn't enough alone.