### PR TITLE
sdl_audio: Set sample frames hint and use smarter wait loop.

### DIFF
--- a/src/core/libraries/audio/cubeb_audio.cpp
+++ b/src/core/libraries/audio/cubeb_audio.cpp
@@ -42,7 +42,7 @@ public:
             .layout = get_channel_layout(),
             .prefs = CUBEB_STREAM_PREF_NONE,
         };
-        u32 latency_frames = 512;
+        u32 latency_frames = port.samples_num;
         if (const auto ret = cubeb_get_min_latency(ctx, &stream_params, &latency_frames);
             ret != CUBEB_OK) {
             LOG_WARNING(Lib_AudioOut,


### PR DESCRIPTION
* Set the `SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES` hint using port buffer sample counts, to make sure time to delivery matches as closely as possible to what the game expects.
* Updates the wait loop for outputting audio to use `SDL_GetAudioStreamQueued`, since this represents number of sample bytes queued rather than number of bytes actually processed and available on the receiving end.
* Updates the wait loop to use the guest buffer size times 4 as a threshold for waiting rather than a constant number.

This seems to fix a lot of the audio distortion the SDL backend has on my system and brings it to mostly parity with cubeb, mainly due to the sample frames hint. Does not seem to help people having issues with pipewire on all backends though.