### PR TITLE
Fix sceKernelGetEventFilter

### DIFF
--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -346,7 +346,7 @@ int PS4_SYSV_ABI sceKernelDeleteUserEvent(SceKernelEqueue eq, int id) {
     return ORBIS_OK;
 }
 
-s16 PS4_SYSV_ABI sceKernelGetEventFilter(const SceKernelEvent* ev) {
+int PS4_SYSV_ABI sceKernelGetEventFilter(const SceKernelEvent* ev) {
     return ev->filter;
 }
 

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -21,7 +21,7 @@ class EqueueInternal;
 struct EqueueEvent;
 
 struct SceKernelEvent {
-    enum Filter : s16 {
+    enum Filter : int {
         None = 0,
         Read = -1,
         Write = -2,


### PR DESCRIPTION
Based on some testing, it appears that the `s16` return type we're using on `sceKernelGetEventFilter` is smaller than the expected return type on Windows devices. Swapping the type to `int` fixes this, and doesn't appear to impact Linux devices in any way. 
Fixes a Windows-specific issue seen in The Last of Us Remastered (CUSA00552)