### PR TITLE
native_clock: Remove unused process code.

### DIFF
--- a/src/common/native_clock.cpp
+++ b/src/common/native_clock.cpp
@@ -4,11 +4,6 @@
 #include "common/native_clock.h"
 #include "common/rdtsc.h"
 #include "common/uint128.h"
-#ifdef _WIN64
-#include <pthread_time.h>
-#else
-#include <time.h>
-#endif
 
 namespace Common {
 
@@ -32,12 +27,6 @@ u64 NativeClock::GetTimeMS(u64 base_ptc /*= 0*/) const {
 
 u64 NativeClock::GetUptime() const {
     return FencedRDTSC();
-}
-
-u64 NativeClock::GetProcessTimeUS() const {
-    timespec ret;
-    clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ret);
-    return ret.tv_nsec / 1000 + ret.tv_sec * 1000000;
 }
 
 } // namespace Common

--- a/src/common/native_clock.h
+++ b/src/common/native_clock.h
@@ -20,7 +20,6 @@ public:
     u64 GetTimeUS(u64 base_ptc = 0) const;
     u64 GetTimeMS(u64 base_ptc = 0) const;
     u64 GetUptime() const;
-    u64 GetProcessTimeUS() const;
 
 private:
     u64 rdtsc_frequency;


### PR DESCRIPTION
`GetProcessTimeUS` is unused, and getting rid of it leaves only one more file (`src/core/libraries/kernel/time.cpp`) that uses winpthreads.