### PR TITLE
equeue: Fix regression from Filter type.

### DIFF
--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -21,7 +21,7 @@ class EqueueInternal;
 struct EqueueEvent;
 
 struct SceKernelEvent {
-    enum Filter : int {
+    enum Filter : s16 {
         None = 0,
         Read = -1,
         Write = -2,


### PR DESCRIPTION
Revert change to Filter type from https://github.com/shadps4-emu/shadPS4/commit/90912233967f97b41d4ed8017eae15667adf1547 as it should still be s16. Just changing the return type of `sceKernelGetEventFilter` is enough to cast it to the right output value from that function.