### PR TITLE
vk_platform: Fix incorrect type for MVK debug flag.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_platform.cpp
+++ b/src/video_core/renderer_vulkan/vk_platform.cpp
@@ -283,6 +283,9 @@ vk::UniqueInstance CreateInstance(Frontend::WindowSystemType window_type, bool e
         Common::FS::GetUserPathString(Common::FS::PathType::LogDir);
     const char* log_path = crash_diagnostic_path.c_str();
     vk::Bool32 enable_force_barriers = vk::True;
+#ifdef __APPLE__
+    const vk::Bool32 mvk_debug_mode = enable_crash_diagnostic ? vk::True : vk::False;
+#endif
 
     const std::array layer_setings = {
         vk::LayerSettingEXT{
@@ -356,7 +359,7 @@ vk::UniqueInstance CreateInstance(Frontend::WindowSystemType window_type, bool e
             .pSettingName = "MVK_CONFIG_DEBUG",
             .type = vk::LayerSettingTypeEXT::eBool32,
             .valueCount = 1,
-            .pValues = &enable_crash_diagnostic,
+            .pValues = &mvk_debug_mode,
         }
 #endif
     };


### PR DESCRIPTION
Caught this with address sanitizer, the flag should be a 32-bit `vk::Bool32` but a pointer to an 8-bit `bool` was being given instead. Mostly harmless but good to be correct here.