### PR TITLE
Fix event flags on libSceVideoOut functions

### DIFF
--- a/src/core/libraries/videoout/video_out.cpp
+++ b/src/core/libraries/videoout/video_out.cpp
@@ -52,8 +52,7 @@ s32 PS4_SYSV_ABI sceVideoOutAddFlipEvent(Kernel::SceKernelEqueue eq, s32 handle,
     Kernel::EqueueEvent event{};
     event.event.ident = u64(OrbisVideoOutEventId::Flip);
     event.event.filter = Kernel::SceKernelEvent::Filter::VideoOut;
-    // The library only sets EV_ADD but kernel driver forces EV_CLEAR
-    event.event.flags = Kernel::SceKernelEvent::Flags::Clear;
+    event.event.flags = Kernel::SceKernelEvent::Flags::Add;
     event.event.udata = udata;
     event.event.fflags = 0;
     event.event.data = 0;
@@ -79,8 +78,7 @@ s32 PS4_SYSV_ABI sceVideoOutAddVblankEvent(Kernel::SceKernelEqueue eq, s32 handl
     Kernel::EqueueEvent event{};
     event.event.ident = u64(OrbisVideoOutEventId::Vblank);
     event.event.filter = Kernel::SceKernelEvent::Filter::VideoOut;
-    // The library only sets EV_ADD but kernel driver forces EV_CLEAR
-    event.event.flags = Kernel::SceKernelEvent::Flags::Clear;
+    event.event.flags = Kernel::SceKernelEvent::Flags::Add;
     event.event.udata = udata;
     event.event.fflags = 0;
     event.event.data = 0;


### PR DESCRIPTION
After the changes from https://github.com/shadps4-emu/shadPS4/pull/1839, we no longer need to manually set the Clear flag on VideoOut functions. 
This fixes a regression observed in Uncharted 4 (CUSA00341)