### PR TITLE
Fix for trophy decryption

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -67,7 +67,7 @@ static int cursorHideTimeout = 5; // 5 seconds (default)
 static bool separateupdatefolder = false;
 static bool compatibilityData = false;
 static bool checkCompatibilityOnStartup = false;
-static std::string trophyKey = "";
+static std::vector<u8> trophyKey;
 
 // Gui
 std::vector<std::filesystem::path> settings_install_dirs = {};
@@ -92,11 +92,11 @@ std::string emulator_language = "en";
 // Language
 u32 m_language = 1; // english
 
-std::string getTrophyKey() {
+std::vector<u8> getTrophyKey() {
     return trophyKey;
 }
 
-void setTrophyKey(std::string key) {
+void setTrophyKey(std::vector<u8> key) {
     trophyKey = key;
 }
 
@@ -664,7 +664,7 @@ void load(const std::filesystem::path& path) {
 
     if (data.contains("Keys")) {
         const toml::value& keys = data.at("Keys");
-        trophyKey = toml::find_or<std::string>(keys, "TrophyKey", "");
+        trophyKey = toml::find<std::vector<u8>>(keys, "TrophyKey");
     }
 }
 

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -664,7 +664,9 @@ void load(const std::filesystem::path& path) {
 
     if (data.contains("Keys")) {
         const toml::value& keys = data.at("Keys");
-        trophyKey = toml::find<std::vector<u8>>(keys, "TrophyKey");
+        if (keys.contains("TrophyKey") && keys.at("TrophyKey").is_array()) {
+            trophyKey = toml::find<std::vector<u8>>(keys, "TrophyKey");
+        }
     }
 }
 

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -67,7 +67,7 @@ static int cursorHideTimeout = 5; // 5 seconds (default)
 static bool separateupdatefolder = false;
 static bool compatibilityData = false;
 static bool checkCompatibilityOnStartup = false;
-static std::vector<u8> trophyKey;
+static std::string trophyKey;
 
 // Gui
 std::vector<std::filesystem::path> settings_install_dirs = {};
@@ -92,11 +92,11 @@ std::string emulator_language = "en";
 // Language
 u32 m_language = 1; // english
 
-std::vector<u8> getTrophyKey() {
+std::string getTrophyKey() {
     return trophyKey;
 }
 
-void setTrophyKey(std::vector<u8> key) {
+void setTrophyKey(std::string key) {
     trophyKey = key;
 }
 
@@ -664,9 +664,7 @@ void load(const std::filesystem::path& path) {
 
     if (data.contains("Keys")) {
         const toml::value& keys = data.at("Keys");
-        if (keys.contains("TrophyKey") && keys.at("TrophyKey").is_array()) {
-            trophyKey = toml::find<std::vector<u8>>(keys, "TrophyKey");
-        }
+        trophyKey = toml::find_or<std::string>(keys, "TrophyKey", "");
     }
 }
 

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -15,8 +15,8 @@ void load(const std::filesystem::path& path);
 void save(const std::filesystem::path& path);
 void saveMainWindow(const std::filesystem::path& path);
 
-std::vector<u8> getTrophyKey();
-void setTrophyKey(std::vector<u8> key);
+std::string getTrophyKey();
+void setTrophyKey(std::string key);
 
 bool isNeoMode();
 bool isFullscreenMode();

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -15,8 +15,8 @@ void load(const std::filesystem::path& path);
 void save(const std::filesystem::path& path);
 void saveMainWindow(const std::filesystem::path& path);
 
-std::string getTrophyKey();
-void setTrophyKey(std::string key);
+std::vector<u8> getTrophyKey();
+void setTrophyKey(std::vector<u8> key);
 
 bool isNeoMode();
 bool isFullscreenMode();

--- a/src/core/crypto/crypto.h
+++ b/src/core/crypto/crypto.h
@@ -32,7 +32,8 @@ public:
     void aesCbcCfb128DecryptEntry(std::span<const CryptoPP::byte, 32> ivkey,
                                   std::span<CryptoPP::byte> ciphertext,
                                   std::span<CryptoPP::byte> decrypted);
-    void decryptEFSM(std::span<CryptoPP::byte, 16>, std::span<CryptoPP::byte, 16> efsmIv,
+    void decryptEFSM(std::span<CryptoPP::byte, 16> trophyKey,
+                     std::span<CryptoPP::byte, 16> NPcommID, std::span<CryptoPP::byte, 16> efsmIv,
                      std::span<CryptoPP::byte> ciphertext, std::span<CryptoPP::byte> decrypted);
     void PfsGenCryptoKey(std::span<const CryptoPP::byte, 32> ekpfs,
                          std::span<const CryptoPP::byte, 16> seed,

--- a/src/core/file_format/trp.cpp
+++ b/src/core/file_format/trp.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/config.h"
 #include "common/logging/log.h"
 #include "common/path_util.h"
 #include "trp.h"
@@ -39,6 +40,15 @@ bool TRP::Extract(const std::filesystem::path& trophyPath, const std::string tit
         LOG_CRITICAL(Common_Filesystem, "Game sce_sys directory doesn't exist");
         return false;
     }
+
+    const auto user_key = Config::getTrophyKey();
+    if (user_key.size() != 16) {
+        LOG_CRITICAL(Common_Filesystem, "Trophy decryption key is not specified");
+        return false;
+    }
+
+    const std::span<CryptoPP::byte, 16> key{(CryptoPP::byte*)user_key.data(), 16};
+
     for (int index = 0; const auto& it : std::filesystem::directory_iterator(gameSysDir)) {
         if (it.is_regular_file()) {
             GetNPcommID(trophyPath, index);
@@ -97,7 +107,7 @@ bool TRP::Extract(const std::filesystem::path& trophyPath, const std::string tit
                         return false;
                     }
                     file.Read(ESFM);
-                    crypto.decryptEFSM(np_comm_id, esfmIv, ESFM, XML); // decrypt
+                    crypto.decryptEFSM(key, np_comm_id, esfmIv, ESFM, XML); // decrypt
                     removePadding(XML);
                     std::string xml_name = entry.entry_name;
                     size_t pos = xml_name.find("ESFM");

--- a/src/core/file_format/trp.cpp
+++ b/src/core/file_format/trp.cpp
@@ -56,7 +56,6 @@ bool TRP::Extract(const std::filesystem::path& trophyPath, const std::string tit
 
     std::array<CryptoPP::byte, 16> user_key{};
     hexToBytes(user_key_str.c_str(), user_key.data());
-    const std::span<CryptoPP::byte, 16> key{user_key.data(), user_key.size()};
 
     for (int index = 0; const auto& it : std::filesystem::directory_iterator(gameSysDir)) {
         if (it.is_regular_file()) {
@@ -116,7 +115,7 @@ bool TRP::Extract(const std::filesystem::path& trophyPath, const std::string tit
                         return false;
                     }
                     file.Read(ESFM);
-                    crypto.decryptEFSM(key, np_comm_id, esfmIv, ESFM, XML); // decrypt
+                    crypto.decryptEFSM(user_key, np_comm_id, esfmIv, ESFM, XML); // decrypt
                     removePadding(XML);
                     std::string xml_name = entry.entry_name;
                     size_t pos = xml_name.find("ESFM");


### PR DESCRIPTION
Fix for memory corruption and incorrect decryption sequence.
~~NOTE: Now user should store the key as a toml array, e.g. `TrophyKey = [1, 2, 3, 4, .. ]`~~