### PR TITLE
Implement V_MUL_HI_I32 Vector ALU Opcode

### DIFF
--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -247,6 +247,7 @@ public:
     void V_MAX_F64(const GcnInst& inst);
     void V_MUL_LO_U32(const GcnInst& inst);
     void V_MUL_HI_U32(bool is_signed, const GcnInst& inst);
+    void V_MUL_HI_I32(bool is_signed, const GcnInst& inst);
     void V_MAD_U64_U32(const GcnInst& inst);
 
     // Vector interpolation

--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -387,6 +387,8 @@ void Translator::EmitVectorAlu(const GcnInst& inst) {
         return V_MUL_LO_U32(inst);
     case Opcode::V_MUL_HI_U32:
         return V_MUL_HI_U32(false, inst);
+    case Opcode::V_MUL_HI_I32:
+        return V_MUL_HI_U32(false, inst);
     case Opcode::V_MUL_LO_I32:
         return V_MUL_LO_U32(inst);
     case Opcode::V_MAD_U64_U32:


### PR DESCRIPTION
Implementation of **V_MUL_HI_I32** Vector ALU Opcode.
Required for **Farming Simulator 22**.
Before the game crashed but now it goes ingame.

Before:
`[Render.Recompiler] <Error> translate.cpp:LogMissingOpcode:503: Unknown opcode V_MUL_HI_I32 (898, category = VectorALU)`

After:
![After1](https://github.com/user-attachments/assets/8f8a5e10-1631-4db6-a8f6-e250ce720518)
![After2](https://github.com/user-attachments/assets/c28f1ff4-444a-40e5-b03c-a1fb7b94f8ff)