### PR TITLE
Reduce USBD Log Spamming

### DIFF
--- a/src/core/libraries/usbd/usbd.cpp
+++ b/src/core/libraries/usbd/usbd.cpp
@@ -10,327 +10,327 @@
 namespace Libraries::Usbd {
 
 int PS4_SYSV_ABI sceUsbdAllocTransfer() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdAttachKernelDriver() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdBulkTransfer() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdCancelTransfer() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdCheckConnected() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdClaimInterface() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdClearHalt() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdClose() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdControlTransfer() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdControlTransferGetData() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdControlTransferGetSetup() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdDetachKernelDriver() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdEventHandlerActive() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdEventHandlingOk() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdExit() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdFillBulkTransfer() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdFillControlSetup() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdFillControlTransfer() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdFillInterruptTransfer() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdFillIsoTransfer() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdFreeConfigDescriptor() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdFreeDeviceList() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdFreeTransfer() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdGetActiveConfigDescriptor() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdGetBusNumber() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdGetConfigDescriptor() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdGetConfigDescriptorByValue() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdGetConfiguration() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdGetDescriptor() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdGetDevice() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdGetDeviceAddress() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdGetDeviceDescriptor() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdGetDeviceList() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdGetDeviceSpeed() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdGetIsoPacketBuffer() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdGetMaxIsoPacketSize() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdGetMaxPacketSize() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdGetStringDescriptor() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdGetStringDescriptorAscii() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdHandleEvents() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdHandleEventsLocked() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdHandleEventsTimeout() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_DEBUG(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdInit() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return 0x80240005; // Skip
 }
 
 int PS4_SYSV_ABI sceUsbdInterruptTransfer() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdKernelDriverActive() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdLockEvents() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdLockEventWaiters() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdOpen() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdOpenDeviceWithVidPid() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdRefDevice() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdReleaseInterface() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdResetDevice() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdSetConfiguration() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdSetInterfaceAltSetting() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdSetIsoPacketLengths() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdSubmitTransfer() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdTryLockEvents() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdUnlockEvents() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdUnlockEventWaiters() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdUnrefDevice() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceUsbdWaitForEvent() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI Func_65F6EF33E38FFF50() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI Func_97F056BAD90AADE7() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI Func_C55104A33B35B264() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI Func_D56B43060720B1E0() {
-    LOG_ERROR(Lib_Usbd, "(STUBBED)called");
+    LOG_ERROR(Lib_Usbd, "(STUBBED) called");
     return ORBIS_OK;
 }
 


### PR DESCRIPTION
Drastically reduces spam in the log of `[Lib.Usbd] <Error> usbd.cpp:sceUsbdHandleEventsTimeout:218: (STUBBED)called` which can be spammed more than 461,000 times!
Which loses a lot of performance and makes the startup of some games longer.
It also makes **big log files** (**34MB for 1 minute**).
I notably corrected an error because it says `(STUBBED)called` whereas in all the other libraries it says `(STUBBED) called`.

![image1](https://github.com/user-attachments/assets/4fd834d5-712f-4a72-b062-567bcce06973)
![image2](https://github.com/user-attachments/assets/9daa76c3-1ff6-48c3-a393-897a005871fb)
