### PR TITLE
texture_cache: Adding some missing textures

### DIFF
--- a/src/video_core/texture_cache/tile_manager.cpp
+++ b/src/video_core/texture_cache/tile_manager.cpp
@@ -25,54 +25,69 @@ namespace VideoCore {
 
 static vk::Format DemoteImageFormatForDetiling(vk::Format format) {
     switch (format) {
-    case vk::Format::eR8Uint:
     case vk::Format::eR8Unorm:
     case vk::Format::eR8Snorm:
+    case vk::Format::eR8Uint:
+    case vk::Format::eR8Srgb:
         return vk::Format::eR8Uint;
-    case vk::Format::eR4G4B4A4UnormPack16:
-    case vk::Format::eB5G6R5UnormPack16:
-    case vk::Format::eR5G5B5A1UnormPack16:
     case vk::Format::eR8G8Unorm:
-    case vk::Format::eR16Sfloat:
-    case vk::Format::eR16Uint:
+    case vk::Format::eR8G8Snorm:
+    case vk::Format::eR8G8Uint:
+    case vk::Format::eR8G8Srgb:
     case vk::Format::eR16Unorm:
+    case vk::Format::eR16Snorm:
+    case vk::Format::eR16Uint:
+    case vk::Format::eR16Sfloat:
     case vk::Format::eD16Unorm:
+    case vk::Format::eR4G4B4A4UnormPack16:
+    case vk::Format::eR5G5B5A1UnormPack16:
+    case vk::Format::eB5G5R5A1UnormPack16:
+    case vk::Format::eB5G6R5UnormPack16:
         return vk::Format::eR8G8Uint;
-    case vk::Format::eR8G8B8A8Srgb:
-    case vk::Format::eB8G8R8A8Srgb:
-    case vk::Format::eB8G8R8A8Unorm:
     case vk::Format::eR8G8B8A8Unorm:
     case vk::Format::eR8G8B8A8Snorm:
     case vk::Format::eR8G8B8A8Uint:
-    case vk::Format::eR32Sfloat:
-    case vk::Format::eD32Sfloat:
-    case vk::Format::eR32Uint:
-    case vk::Format::eR16G16Sfloat:
+    case vk::Format::eR8G8B8A8Srgb:
+    case vk::Format::eB8G8R8A8Unorm:
+    case vk::Format::eB8G8R8A8Snorm:
+    case vk::Format::eB8G8R8A8Uint:
+    case vk::Format::eB8G8R8A8Srgb:
     case vk::Format::eR16G16Unorm:
     case vk::Format::eR16G16Snorm:
-    case vk::Format::eB10G11R11UfloatPack32:
+    case vk::Format::eR16G16Uint:
+    case vk::Format::eR16G16Sfloat:
+    case vk::Format::eR32Uint:
+    case vk::Format::eR32Sfloat:
+    case vk::Format::eD32Sfloat:
     case vk::Format::eA2B10G10R10UnormPack32:
+    case vk::Format::eA2B10G10R10SnormPack32:
+    case vk::Format::eA2B10G10R10UintPack32:
+    case vk::Format::eB10G11R11UfloatPack32:
+    case vk::Format::eE5B9G9R9UfloatPack32:
         return vk::Format::eR32Uint;
-    case vk::Format::eBc1RgbaSrgbBlock:
-    case vk::Format::eBc1RgbaUnormBlock:
-    case vk::Format::eBc4UnormBlock:
-    case vk::Format::eR32G32Sfloat:
-    case vk::Format::eR32G32Uint:
     case vk::Format::eR16G16B16A16Unorm:
+    case vk::Format::eR16G16B16A16Snorm:
     case vk::Format::eR16G16B16A16Uint:
     case vk::Format::eR16G16B16A16Sfloat:
+    case vk::Format::eR32G32Uint:
+    case vk::Format::eR32G32Sfloat:
+    case vk::Format::eBc1RgbaUnormBlock:
+    case vk::Format::eBc1RgbaSrgbBlock:
+    case vk::Format::eBc4UnormBlock:
+    case vk::Format::eBc4SnormBlock:
         return vk::Format::eR32G32Uint;
-    case vk::Format::eBc2SrgbBlock:
-    case vk::Format::eBc2UnormBlock:
-    case vk::Format::eBc3SrgbBlock:
-    case vk::Format::eBc3UnormBlock:
-    case vk::Format::eBc5UnormBlock:
-    case vk::Format::eBc5SnormBlock:
-    case vk::Format::eBc7SrgbBlock:
-    case vk::Format::eBc7UnormBlock:
-    case vk::Format::eBc6HUfloatBlock:
     case vk::Format::eR32G32B32A32Uint:
     case vk::Format::eR32G32B32A32Sfloat:
+    case vk::Format::eBc2UnormBlock:
+    case vk::Format::eBc2SrgbBlock:
+    case vk::Format::eBc3UnormBlock:
+    case vk::Format::eBc3SrgbBlock:
+    case vk::Format::eBc5UnormBlock:
+    case vk::Format::eBc5SnormBlock:
+    case vk::Format::eBc6HUfloatBlock:
+    case vk::Format::eBc6HSfloatBlock:
+    case vk::Format::eBc7UnormBlock:
+    case vk::Format::eBc7SrgbBlock:
         return vk::Format::eR32G32B32A32Uint;
     default:
         break;


### PR DESCRIPTION
Added a lot of texture formats to the detiler to deal with `Unexpected format for demotion [Texture Format]` errors.\
For better visibility in all these formats, I put them in this order:
- **Unorm**
- **Snorm**
- **Uint**
- **Srgb / Sfloat**

Adding formats as a preventative measure will avoid doing a lot of small PRs to add formats one by one.\
For the moment, the only game seen with a detiler error is [**Dead Rising**](https://github.com/shadps4-emu/shadps4-game-compatibility/issues/1853) with the missing format: **R8G8Snorm**.
And some PS1 games with the missing format **B5G5R5A1UnormPack16**