### PR TITLE
renderer_vulkan: Don't crash if Depth Format is not recognized

### DIFF
--- a/src/video_core/renderer_vulkan/liverpool_to_vk.h
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.h
@@ -71,13 +71,17 @@ vk::ClearValue ColorBufferClearValue(const AmdGpu::Liverpool::ColorBuffer& color
 
 vk::SampleCountFlagBits NumSamples(u32 num_samples, vk::SampleCountFlags supported_flags);
 
-static inline vk::Format PromoteFormatToDepth(vk::Format fmt) {
-    if (fmt == vk::Format::eR32Sfloat) {
+static vk::Format PromoteFormatToDepth(vk::Format fmt) {
+    switch (fmt) {
+    case vk::Format::eR32Sfloat:
         return vk::Format::eD32Sfloat;
-    } else if (fmt == vk::Format::eR16Unorm) {
+    case vk::Format::eR16Unorm:
         return vk::Format::eD16Unorm;
+    default:
+        LOG_ERROR(Render_Vulkan, "Unexpected Depth Format {}", vk::to_string(fmt));
+        break;
     }
-    UNREACHABLE();
+    return fmt;
 }
 
 } // namespace Vulkan::LiverpoolToVK


### PR DESCRIPTION
While it can't override Depth Format, this allows games to not crash due to this error.
Fixes **PC Building Simulator** and probably other games.

**PC Building Simulator** with this PR:
![Capture d'écran 2025-01-03 180659](https://github.com/user-attachments/assets/25046e5c-3c74-4430-a502-7986bc580bb8)
![Capture d'écran 2025-01-03 180723](https://github.com/user-attachments/assets/cfbd6551-3fdd-4b33-81ba-e10ede64a561)