### PR TITLE
amdgpu: Add some resource bits for Neo mode.

### DIFF
--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -814,7 +814,9 @@ struct Liverpool {
             BitField<26, 1, u32> fmask_compression_disable_ci;
             BitField<27, 1, u32> fmask_compress_1frag_only;
             BitField<28, 1, u32> dcc_enable;
-            BitField<29, 1, u32> cmask_addr_type;
+            BitField<29, 2, u32> cmask_addr_type;
+            /// Neo-mode only
+            BitField<31, 1, u32> alt_tile_mode;
 
             u32 u32all;
         } info;

--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -263,7 +263,15 @@ struct Image {
     u64 min_lod_warn : 12;
     u64 counter_bank_id : 8;
     u64 lod_hw_cnt_en : 1;
-    u64 : 43;
+    /// Neo-mode only
+    u64 compression_en : 1;
+    /// Neo-mode only
+    u64 alpha_is_on_msb : 1;
+    /// Neo-mode only
+    u64 color_transform : 1;
+    /// Neo-mode only
+    u64 alt_tile_mode : 1;
+    u64 : 39;
 
     static constexpr Image Null() {
         Image image{};


### PR DESCRIPTION
Adds some resource bits for Neo mode to images and color buffers.

`alt_tile_mode` indicates whether to use alternate tiling mode supported by Neo GPU, which will need additional support in size calculation and detiling.

`compression_en`, `alpha_is_on_msb`, `color_transform` I believe are related to DCC. We can probably ignore these safely at least for now.

Thanks to @red-prig for this info.