### PR TITLE
file_sys: Consolidate separate update directory handling.

### DIFF
--- a/src/core/file_sys/fs.cpp
+++ b/src/core/file_sys/fs.cpp
@@ -40,7 +40,8 @@ void MntPoints::UnmountAll() {
     m_mnt_pairs.clear();
 }
 
-std::filesystem::path MntPoints::GetHostPath(std::string_view path, bool* is_read_only) {
+std::filesystem::path MntPoints::GetHostPath(std::string_view path, bool* is_read_only,
+                                             bool force_base_path) {
     // Evil games like Turok2 pass double slashes e.g /app0//game.kpf
     std::string corrected_path(path);
     size_t pos = corrected_path.find("//");
@@ -72,7 +73,7 @@ std::filesystem::path MntPoints::GetHostPath(std::string_view path, bool* is_rea
     patch_path /= rel_path;
 
     if ((corrected_path.starts_with("/app0") || corrected_path.starts_with("/hostapp")) &&
-        std::filesystem::exists(patch_path)) {
+        !force_base_path && std::filesystem::exists(patch_path)) {
         return patch_path;
     }
 
@@ -132,8 +133,10 @@ std::filesystem::path MntPoints::GetHostPath(std::string_view path, bool* is_rea
         return std::optional<std::filesystem::path>(current_path);
     };
 
-    if (const auto path = search(patch_path)) {
-        return *path;
+    if (!force_base_path) {
+        if (const auto path = search(patch_path)) {
+            return *path;
+        }
     }
     if (const auto path = search(host_path)) {
         return *path;
@@ -142,6 +145,39 @@ std::filesystem::path MntPoints::GetHostPath(std::string_view path, bool* is_rea
     // Opening the guest path will surely fail but at least gives
     // a better error message than the empty path.
     return host_path;
+}
+
+// TODO: Does not handle mount points inside mount points.
+void MntPoints::IterateDirectory(std::string_view guest_directory,
+                                 const IterateDirectoryCallback& callback) {
+    const auto base_path = GetHostPath(guest_directory, nullptr, true);
+    const auto patch_path = GetHostPath(guest_directory, nullptr, false);
+    // Only need to consider patch path if it exists and does not resolve to the same as base.
+    const auto apply_patch = base_path != patch_path && std::filesystem::exists(patch_path);
+
+    // Pass 1: Any files that existed in the base directory, using patch directory if needed.
+    if (std::filesystem::exists(base_path)) {
+        for (const auto& entry : std::filesystem::directory_iterator(base_path)) {
+            if (apply_patch) {
+                const auto patch_entry_path = patch_path / entry.path().filename();
+                if (std::filesystem::exists(patch_entry_path)) {
+                    callback(patch_entry_path, !std::filesystem::is_directory(patch_entry_path));
+                    continue;
+                }
+            }
+            callback(entry.path(), !entry.is_directory());
+        }
+    }
+
+    // Pass 2: Any files that exist only in the patch directory.
+    if (apply_patch) {
+        for (const auto& entry : std::filesystem::directory_iterator(patch_path)) {
+            const auto base_entry_path = base_path / entry.path().filename();
+            if (!std::filesystem::exists(base_entry_path)) {
+                callback(entry.path(), !entry.is_directory());
+            }
+        }
+    }
 }
 
 int HandleTable::CreateHandle() {

--- a/src/core/file_sys/fs.h
+++ b/src/core/file_sys/fs.h
@@ -36,7 +36,11 @@ public:
     void UnmountAll();
 
     std::filesystem::path GetHostPath(std::string_view guest_directory,
-                                      bool* is_read_only = nullptr);
+                                      bool* is_read_only = nullptr, bool force_base_path = false);
+    using IterateDirectoryCallback =
+        std::function<void(const std::filesystem::path& host_path, bool is_file)>;
+    void IterateDirectory(std::string_view guest_directory,
+                          const IterateDirectoryCallback& callback);
 
     const MntPair* GetMountFromHostPath(const std::string& host_path) {
         std::scoped_lock lock{m_mutex};

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -46,17 +46,6 @@ static std::map<std::string, FactoryDevice> available_device = {
 
 namespace Libraries::Kernel {
 
-auto GetDirectoryEntries(const std::filesystem::path& path) {
-    std::vector<Core::FileSys::DirEntry> files;
-    for (const auto& entry : std::filesystem::directory_iterator(path)) {
-        auto& dir_entry = files.emplace_back();
-        dir_entry.name = entry.path().filename().string();
-        dir_entry.isFile = !std::filesystem::is_directory(entry.path().string());
-    }
-
-    return files;
-}
-
 int PS4_SYSV_ABI sceKernelOpen(const char* raw_path, int flags, u16 mode) {
     LOG_INFO(Kernel_Fs, "path = {} flags = {:#x} mode = {}", raw_path, flags, mode);
     auto* h = Common::Singleton<Core::FileSys::HandleTable>::Instance();
@@ -115,7 +104,12 @@ int PS4_SYSV_ABI sceKernelOpen(const char* raw_path, int flags, u16 mode) {
             if (create) {
                 return handle; // dir already exists
             } else {
-                file->dirents = GetDirectoryEntries(file->m_host_name);
+                mnt->IterateDirectory(file->m_guest_name,
+                                      [&file](const auto& ent_path, const auto ent_is_file) {
+                                          auto& dir_entry = file->dirents.emplace_back();
+                                          dir_entry.name = ent_path.filename().string();
+                                          dir_entry.isFile = ent_is_file;
+                                      });
                 file->dirents_index = 0;
             }
         }
@@ -695,66 +689,12 @@ static int GetDents(int fd, char* buf, int nbytes, s64* basep) {
     return sizeof(OrbisKernelDirent);
 }
 
-static int HandleSeparateUpdateDents(int fd, char* buf, int nbytes, s64* basep) {
-    int dir_entries = 0;
-
-    auto* h = Common::Singleton<Core::FileSys::HandleTable>::Instance();
-    auto* mnt = Common::Singleton<Core::FileSys::MntPoints>::Instance();
-    auto* file = h->GetFile(fd);
-    auto update_dir_name = std::string{fmt::UTF(file->m_host_name.u8string()).data};
-    auto mount = mnt->GetMountFromHostPath(update_dir_name);
-    auto suffix = std::string{fmt::UTF(mount->host_path.u8string()).data};
-
-    size_t pos = update_dir_name.find("-UPDATE");
-    if (pos != std::string::npos) {
-        update_dir_name.erase(pos, 7);
-        auto guest_name = mount->mount + "/" + update_dir_name.substr(suffix.size() + 1);
-        int descriptor;
-
-        auto existent_folder = h->GetFile(update_dir_name);
-        if (!existent_folder) {
-            u32 handle = h->CreateHandle();
-            auto* new_file = h->GetFile(handle);
-            new_file->type = Core::FileSys::FileType::Directory;
-            new_file->m_guest_name = guest_name;
-            new_file->m_host_name = update_dir_name;
-            if (!std::filesystem::is_directory(new_file->m_host_name)) {
-                h->DeleteHandle(handle);
-                return dir_entries;
-            } else {
-                new_file->dirents = GetDirectoryEntries(new_file->m_host_name);
-                new_file->dirents_index = 0;
-            }
-            new_file->is_opened = true;
-            descriptor = h->GetFileDescriptor(new_file);
-        } else {
-            descriptor = h->GetFileDescriptor(existent_folder);
-        }
-
-        dir_entries = GetDents(descriptor, buf, nbytes, basep);
-        if (dir_entries == ORBIS_OK && existent_folder) {
-            existent_folder->dirents_index = 0;
-            file->dirents_index = 0;
-        }
-    }
-
-    return dir_entries;
-}
-
 int PS4_SYSV_ABI sceKernelGetdents(int fd, char* buf, int nbytes) {
-    int a = GetDents(fd, buf, nbytes, nullptr);
-    if (a == ORBIS_OK) {
-        return HandleSeparateUpdateDents(fd, buf, nbytes, nullptr);
-    }
-    return a;
+    return GetDents(fd, buf, nbytes, nullptr);
 }
 
 int PS4_SYSV_ABI sceKernelGetdirentries(int fd, char* buf, int nbytes, s64* basep) {
-    int a = GetDents(fd, buf, nbytes, basep);
-    if (a == ORBIS_OK) {
-        return HandleSeparateUpdateDents(fd, buf, nbytes, basep);
-    }
-    return a;
+    return GetDents(fd, buf, nbytes, basep);
 }
 
 s64 PS4_SYSV_ABI sceKernelPwrite(int d, void* buf, size_t nbytes, s64 offset) {

--- a/src/emulator.h
+++ b/src/emulator.h
@@ -29,7 +29,7 @@ public:
     void UpdatePlayTime(const std::string& serial);
 
 private:
-    void LoadSystemModules(const std::filesystem::path& file, std::string game_serial);
+    void LoadSystemModules(const std::string& game_serial);
 
     Core::MemoryManager* memory;
     Input::GameController* controller;


### PR DESCRIPTION
* Adds a utility for iterating contents of a guest directory, applying contents from separate update path as needed.
* Use this utility for guest dirents and loading from `sce_module`, eliminating the need to special-case separate update directory by just going through the mount point system.

In the future we could use this to handle injecting mount point directories into the entries list as well, if there are mount points within other mount points. For now it does not handle this case.