### PR TITLE
CI: Switch to Windows 2025 & Reduce Warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,14 +14,14 @@ env:
 
 jobs:
   reuse:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
     - uses: actions/checkout@v4
     - uses: fsfe/reuse-action@v5
 
   clang-format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
     - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
       run: ./.ci/clang-format.sh
       
   get-info:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       date: ${{ steps.vars.outputs.date }}
       shorthash: ${{ steps.vars.outputs.shorthash }}
@@ -57,7 +57,7 @@ jobs:
         echo "fullhash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
   windows-sdl:
-    runs-on: windows-latest
+    runs-on: windows-2025
     needs: get-info
     steps:
     - uses: actions/checkout@v4
@@ -101,7 +101,7 @@ jobs:
         path: ${{github.workspace}}/build/shadPS4.exe
 
   windows-qt:
-    runs-on: windows-latest
+    runs-on: windows-2025
     needs: get-info
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
- Upgrade to **Windows 2025** because `windows-latest` uses `windows-2022` by default
- Added `-DCMAKE_C_FLAGS_RELEASE=-Ofast` `-DCMAKE_CXX_FLAGS_RELEASE=-Ofast`  because by default it uses the `-O3` optimization (**-Ofast** uses the **-O3** optimizations but with additional ones)

Main:
![Before1](https://github.com/user-attachments/assets/9571a1dd-353b-4f15-bc45-1988abc764f5)

This PR:
![After1](https://github.com/user-attachments/assets/de4884fb-2111-47c5-89e6-64998c5c65d8)

- 3 Warnings less by replacing `ubuntu-latest` with `ubuntu-24.04`
![CI-Warnings](https://github.com/user-attachments/assets/d9e6b45d-aa22-4017-9138-fcd8b7346324)