### PR TITLE
http: Reduce sceHttpWaitRequest stub log to debug.

### DIFF
--- a/src/core/libraries/network/http.cpp
+++ b/src/core/libraries/network/http.cpp
@@ -582,8 +582,8 @@ int PS4_SYSV_ABI sceHttpUriUnescape() {
 }
 
 int PS4_SYSV_ABI sceHttpWaitRequest() {
-    LOG_ERROR(Lib_Http, "(STUBBED) called");
-    return ORBIS_OK;
+    LOG_DEBUG(Lib_Http, "(STUBBED) called");
+    return 0; // Number of events returned
 }
 
 void RegisterlibSceHttp(Core::Loader::SymbolsResolver* sym) {


### PR DESCRIPTION
Reduce the stub log of `sceHttpWaitRequest` to make logs more readable for games that constantly spam it, regardless of if there are any active requests.