### PR TITLE
vk_instance: Enable additional debug tagging if crash diagnostics is enabled.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -92,13 +92,15 @@ std::string GetReadableVersion(u32 version) {
 Instance::Instance(bool enable_validation, bool enable_crash_diagnostic)
     : instance{CreateInstance(Frontend::WindowSystemType::Headless, enable_validation,
                               enable_crash_diagnostic)},
-      physical_devices{EnumeratePhysicalDevices(instance)} {}
+      physical_devices{EnumeratePhysicalDevices(instance)},
+      crash_diagnostic{enable_crash_diagnostic} {}
 
 Instance::Instance(Frontend::WindowSDL& window, s32 physical_device_index,
                    bool enable_validation /*= false*/, bool enable_crash_diagnostic /*= false*/)
     : instance{CreateInstance(window.GetWindowInfo().type, enable_validation,
                               enable_crash_diagnostic)},
-      physical_devices{EnumeratePhysicalDevices(instance)} {
+      physical_devices{EnumeratePhysicalDevices(instance)},
+      crash_diagnostic{enable_crash_diagnostic} {
     if (enable_validation) {
         debug_callback = CreateDebugCallback(*instance);
     }

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -81,7 +81,7 @@ public:
 
     /// Returns true when a known debugging tool is attached.
     bool HasDebuggingToolAttached() const {
-        return has_renderdoc || has_nsight_graphics;
+        return crash_diagnostic || has_renderdoc || has_nsight_graphics;
     }
 
     /// Returns true if anisotropic filtering is supported
@@ -338,6 +338,7 @@ private:
     u32 subgroup_size{};
     bool tooling_info{};
     bool debug_utils_supported{};
+    bool crash_diagnostic{};
     bool has_nsight_graphics{};
     bool has_renderdoc{};
 };


### PR DESCRIPTION
Some additional object debug labels are only applied if a debugging tool is attached. Consider enabled crash diagnostics as permitting adding this additional labeling, to provide more info in the output.