### PR TITLE
Package windows symbols with actions builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'push' }}
 
 env:
-  BUILD_TYPE: Release
+  BUILD_TYPE: RelWithDebInfo
 
 jobs:
   reuse:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,11 +94,18 @@ jobs:
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel $env:NUMBER_OF_PROCESSORS
 
+    - name: Deploy and Package
+      run: |
+        mkdir upload
+        move build/shadPS4.exe upload
+        move build/shadPS4.pdb upload
+        Compress-Archive -Path upload/* -DestinationPath shadps4-win64-sdl-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}.zip
+
     - name: Upload Windows SDL artifact
       uses: actions/upload-artifact@v4
       with:
         name: shadps4-win64-sdl-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}
-        path: ${{github.workspace}}/build/shadPS4.exe
+        path: upload/
 
   windows-qt:
     runs-on: windows-latest
@@ -152,6 +159,7 @@ jobs:
       run: |
         mkdir upload
         move build/shadPS4.exe upload
+        move build/shadPS4.pdb upload
         windeployqt --no-compiler-runtime --no-system-d3d-compiler --no-system-dxc-compiler --dir upload upload/shadPS4.exe
         Compress-Archive -Path upload/* -DestinationPath shadps4-win64-qt-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}.zip
 


### PR DESCRIPTION
This commit packages up the symbol files (for Windows builds), so it is possible to debug a crash in official builds.

I packaged it up with the corresponding package. It increases the zip file size a lot, so maybe folks would prefer it to be packaged separately. Creating the PR to open up that discussion.