### PR TITLE
renderer_vulkan: Add debug names to pipelines.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
@@ -18,6 +18,7 @@ ComputePipeline::ComputePipeline(const Instance& instance_, Scheduler& scheduler
     : Pipeline{instance_, scheduler_, desc_heap_, pipeline_cache, true}, compute_key{compute_key_} {
     auto& info = stages[int(Shader::LogicalStage::Compute)];
     info = &info_;
+    const auto debug_str = GetDebugString();
 
     const vk::PipelineShaderStageCreateInfo shader_ci = {
         .stage = vk::ShaderStageFlagBits::eCompute,
@@ -89,8 +90,9 @@ ComputePipeline::ComputePipeline(const Instance& instance_, Scheduler& scheduler
         .bindingCount = static_cast<u32>(bindings.size()),
         .pBindings = bindings.data(),
     };
+    const auto device = instance.GetDevice();
     auto [descriptor_set_result, descriptor_set] =
-        instance.GetDevice().createDescriptorSetLayoutUnique(desc_layout_ci);
+        device.createDescriptorSetLayoutUnique(desc_layout_ci);
     ASSERT_MSG(descriptor_set_result == vk::Result::eSuccess,
                "Failed to create compute descriptor set layout: {}",
                vk::to_string(descriptor_set_result));
@@ -107,6 +109,7 @@ ComputePipeline::ComputePipeline(const Instance& instance_, Scheduler& scheduler
     ASSERT_MSG(layout_result == vk::Result::eSuccess,
                "Failed to create compute pipeline layout: {}", vk::to_string(layout_result));
     pipeline_layout = std::move(layout);
+    SetObjectName(device, *pipeline_layout, "Compute PipelineLayout {}", debug_str);
 
     const vk::ComputePipelineCreateInfo compute_pipeline_ci = {
         .stage = shader_ci,
@@ -117,6 +120,7 @@ ComputePipeline::ComputePipeline(const Instance& instance_, Scheduler& scheduler
     ASSERT_MSG(pipeline_result == vk::Result::eSuccess, "Failed to create compute pipeline: {}",
                vk::to_string(pipeline_result));
     pipeline = std::move(pipe);
+    SetObjectName(device, *pipeline, "Compute Pipeline {}", debug_str);
 }
 
 ComputePipeline::~ComputePipeline() = default;

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -8,7 +8,6 @@
 
 #include "common/assert.h"
 #include "common/io_file.h"
-#include "common/scope_exit.h"
 #include "shader_recompiler/backend/spirv/emit_spirv_quad_rect.h"
 #include "shader_recompiler/frontend/fetch_shader.h"
 #include "shader_recompiler/runtime_info.h"
@@ -16,6 +15,7 @@
 #include "video_core/buffer_cache/buffer_cache.h"
 #include "video_core/renderer_vulkan/vk_graphics_pipeline.h"
 #include "video_core/renderer_vulkan/vk_instance.h"
+#include "video_core/renderer_vulkan/vk_pipeline_cache.h"
 #include "video_core/renderer_vulkan/vk_scheduler.h"
 #include "video_core/renderer_vulkan/vk_shader_util.h"
 #include "video_core/texture_cache/texture_cache.h"
@@ -36,6 +36,7 @@ GraphicsPipeline::GraphicsPipeline(
     const vk::Device device = instance.GetDevice();
     std::ranges::copy(infos, stages.begin());
     BuildDescSetLayout();
+    const auto debug_str = GetDebugString();
 
     const vk::PushConstantRange push_constants = {
         .stageFlags = gp_stage_flags,
@@ -54,6 +55,7 @@ GraphicsPipeline::GraphicsPipeline(
     ASSERT_MSG(layout_result == vk::Result::eSuccess,
                "Failed to create graphics pipeline layout: {}", vk::to_string(layout_result));
     pipeline_layout = std::move(layout);
+    SetObjectName(device, *pipeline_layout, "Graphics PipelineLayout {}", debug_str);
 
     boost::container::static_vector<vk::VertexInputBindingDescription, 32> vertex_bindings;
     boost::container::static_vector<vk::VertexInputAttributeDescription, 32> vertex_attributes;
@@ -322,6 +324,7 @@ GraphicsPipeline::GraphicsPipeline(
     ASSERT_MSG(pipeline_result == vk::Result::eSuccess, "Failed to create graphics pipeline: {}",
                vk::to_string(pipeline_result));
     pipeline = std::move(pipe);
+    SetObjectName(device, *pipeline, "Graphics Pipeline {}", debug_str);
 }
 
 GraphicsPipeline::~GraphicsPipeline() = default;

--- a/src/video_core/renderer_vulkan/vk_pipeline_common.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_common.cpp
@@ -6,6 +6,7 @@
 #include "shader_recompiler/info.h"
 #include "video_core/buffer_cache/buffer_cache.h"
 #include "video_core/renderer_vulkan/vk_instance.h"
+#include "video_core/renderer_vulkan/vk_pipeline_cache.h"
 #include "video_core/renderer_vulkan/vk_pipeline_common.h"
 #include "video_core/renderer_vulkan/vk_scheduler.h"
 #include "video_core/texture_cache/texture_cache.h"
@@ -53,6 +54,21 @@ void Pipeline::BindResources(DescriptorWrites& set_writes, const BufferBarriers&
     }
     instance.GetDevice().updateDescriptorSets(set_writes, {});
     cmdbuf.bindDescriptorSets(bind_point, *pipeline_layout, 0, desc_set, {});
+}
+
+std::string Pipeline::GetDebugString() const {
+    std::string stage_desc;
+    for (const auto& stage : stages) {
+        if (stage) {
+            const auto shader_name = PipelineCache::GetShaderName(stage->stage, stage->pgm_hash);
+            if (stage_desc.empty()) {
+                stage_desc = shader_name;
+            } else {
+                stage_desc = fmt::format("{},{}", stage_desc, shader_name);
+            }
+        }
+    }
+    return stage_desc;
 }
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_pipeline_common.h
+++ b/src/video_core/renderer_vulkan/vk_pipeline_common.h
@@ -61,6 +61,8 @@ public:
                        const Shader::PushData& push_data) const;
 
 protected:
+    [[nodiscard]] std::string GetDebugString() const;
+
     const Instance& instance;
     Scheduler& scheduler;
     DescriptorHeap& desc_heap;


### PR DESCRIPTION
Adds debug names to pipelines and their layouts. I found this very helpful for shader debugging using tools available on macOS, may be helpful for debugging elsewhere as well.

Currently the debug name just includes the type of pipeline and the shaders used in the pipeline.