### PR TITLE
vk_resource_pool: Handle eErrorFragmentedPool.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_resource_pool.cpp
+++ b/src/video_core/renderer_vulkan/vk_resource_pool.cpp
@@ -153,7 +153,8 @@ vk::DescriptorSet DescriptorHeap::Commit(vk::DescriptorSetLayout set_layout) {
     }
 
     // The pool has run out. Record current tick and place it in pending list.
-    ASSERT_MSG(result == vk::Result::eErrorOutOfPoolMemory,
+    ASSERT_MSG(result == vk::Result::eErrorOutOfPoolMemory ||
+                   result == vk::Result::eErrorFragmentedPool,
                "Unexpected error during descriptor set allocation {}", vk::to_string(result));
     pending_pools.emplace_back(curr_pool, master_semaphore->CurrentTick());
     if (const auto [pool, tick] = pending_pools.front(); master_semaphore->IsFree(tick)) {


### PR DESCRIPTION
While I was debugging something related to descriptor sets, I ran into `eErrorFragmentedPool` from allocating descriptor sets. This is similar to but more specific than `eErrorOutOfPoolMemory`, and can be handled the same.