### PR TITLE
GUI TR: remove 'location'

### DIFF
--- a/src/qt_gui/translations/ar.ts
+++ b/src/qt_gui/translations/ar.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>حول shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 هو محاكي تجريبي مفتوح المصدر لجهاز PlayStation 4.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>يجب عدم استخدام هذا البرنامج لتشغيل الألعاب التي لم تحصل عليها بشكل قانوني.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>فتح المجلد</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>جارٍ تحميل قائمة الألعاب، يرجى الانتظار :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>إلغاء</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>...جارٍ التحميل</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - اختر المجلد</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Select which directory you want to install to.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - اختر المجلد</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>مجلد تثبيت الألعاب</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>تصفح</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>خطأ</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>قيمة موقع تثبيت الألعاب غير صالحة.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>إنشاء اختصار</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>الغش / التصحيحات</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>عارض SFO</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>عارض الجوائز</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>فتح المجلد...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>فتح مجلد اللعبة</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>فتح مجلد بيانات الحفظ</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>فتح مجلد السجل</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>...نسخ المعلومات</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>نسخ الاسم</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>نسخ الرقم التسلسلي</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>نسخ الكل</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Delete...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Delete Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Delete Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Delete DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>إنشاء اختصار</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>تم إنشاء الاختصار بنجاح!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>خطأ</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>خطأ في إنشاء الاختصار</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>PKG تثبيت</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>This feature requires the 'Enable Separate Update Folder' config option to work. If you want to use this feature, please enable it.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>This game has no update to delete!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>This game has no DLC to delete!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Delete %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Are you sure you want to delete %1's %2 directory?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Elf فتح/إضافة مجلد</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>(PKG) تثبيت الحزم</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>تشغيل اللعبة</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>تحقق من التحديثات</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>shadPS4 حول</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>...تكوين</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>.pkg تثبيت التطبيق من ملف</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>الألعاب الأخيرة</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>خروج</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>الخروج من shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>الخروج من التطبيق.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>إظهار قائمة الألعاب</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>تحديث قائمة الألعاب</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>صغير جدًا</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>صغير</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>متوسط</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>كبير</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>عرض القائمة</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>عرض الشبكة</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>عارض Elf</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>دليل تثبيت اللعبة</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>تنزيل الغش/التصحيحات</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>تفريغ قائمة الألعاب</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>عارض PKG</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>...بحث</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>ملف</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>عرض</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>أيقونات قائمة الألعاب</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>وضع قائمة الألعاب</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>الإعدادات</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>الأدوات</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>السمات</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>مساعدة</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>داكن</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>فاتح</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>أخضر</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>أزرق</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>بنفسجي</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>شريط الأدوات</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>ققائمة الألعاب</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * إصدار Vulkan غير مدعوم</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>تنزيل الغش لجميع الألعاب المثبتة</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>تنزيل التصحيحات لجميع الألعاب</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>اكتمل التنزيل</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>لقد قمت بتنزيل الغش لجميع الألعاب التي قمت بتثبيتها.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>!تم تنزيل التصحيحات بنجاح</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>.تم تنزيل جميع التصحيحات المتاحة لجميع الألعاب</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation> :الألعاب</translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>PKG (*.PKG) ملف</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>ELF (*.bin *.elf *.oelf) ملفات</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>تشغيل اللعبة</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>!يمكن تحديد ملف واحد فقط</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>PKG استخراج</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>تم اكتشاف تصحيح!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation> :واللعبة تتطابق إصدارات PKG</translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>هل ترغب في الكتابة فوق الملف الموجود؟</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation> :أقدم من الإصدار المثبت PKG Version %1</translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation> :اللعبة مثبتة</translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation> :هل ترغب في تثبيت التصحيح</translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>تثبيت المحتوى القابل للتنزيل</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>هل ترغب في تثبيت المحتوى القابل للتنزيل: 1%؟</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation> :المحتوى القابل للتنزيل مثبت بالفعل</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>اللعبة مثبتة بالفعل</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>!PKG هو تصحيح، يرجى تثبيت اللعبة أولاً</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>PKG خطأ في</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>PKG %1/%2 جاري استخراج</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>اكتمل الاستخراج</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>تم تثبيت اللعبة بنجاح في %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>يبدو أن الملف ليس ملف PKG صالحًا</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>فتح المجلد</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>عارض الجوائز</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>الإعدادات</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>عام</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>النظام</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>لغة وحدة التحكم</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>لغة المحاكي</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>المحاكي</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>تمكين ملء الشاشة</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>إظهار شاشة البداية</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>PS4 Pro هل هو</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>تفعيل حالة الثراء في ديسكورد</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>اسم المستخدم</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>المسجل</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>نوع السجل</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>مرشح السجل</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>إدخال</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>مؤشر</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>إخفاء المؤشر</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>مهلة إخفاء المؤشر عند الخمول</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>التحكم</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>سلوك زر العودة</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>الرسومات</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>جهاز الرسومات</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>العرض</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>الارتفاع</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Vblank مقسم</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>متقدم</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>تمكين تفريغ الشيدرات</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>تمكين وحدة معالجة الرسومات الفارغة</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>المسارات</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>مجلدات اللعبة</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>إضافة...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>إزالة</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>تصحيح الأخطاء</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>تمكين تفريغ التصحيح</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Vulkan تمكين طبقات التحقق من</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Vulkan تمكين التحقق من تزامن</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>RenderDoc تمكين تصحيح أخطاء</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>تحديث</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>تحقق من التحديثات عند بدء التشغيل</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>قناة التحديث</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>التحقق من التحديثات</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>إعدادات الواجهة</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Disable Trophy Pop-ups</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>تشغيل موسيقى العنوان</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Update Compatibility Database On Startup</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Game Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Display Compatibility Data</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Update Compatibility Database</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>الصوت</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>ققائمة الألعاب</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * إصدار Vulkan غير مدعوم</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>تنزيل الغش لجميع الألعاب المثبتة</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>تنزيل التصحيحات لجميع الألعاب</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>اكتمل التنزيل</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>لقد قمت بتنزيل الغش لجميع الألعاب التي قمت بتثبيتها.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>!تم تنزيل التصحيحات بنجاح</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>.تم تنزيل جميع التصحيحات المتاحة لجميع الألعاب</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation> :الألعاب</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>PKG (*.PKG) ملف</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>ELF (*.bin *.elf *.oelf) ملفات</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>تشغيل اللعبة</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>!يمكن تحديد ملف واحد فقط</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>PKG استخراج</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>تم اكتشاف تصحيح!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation> :واللعبة تتطابق إصدارات PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>هل ترغب في الكتابة فوق الملف الموجود؟</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation> :أقدم من الإصدار المثبت PKG Version %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation> :اللعبة مثبتة</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation> :هل ترغب في تثبيت التصحيح</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>تثبيت المحتوى القابل للتنزيل</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>هل ترغب في تثبيت المحتوى القابل للتنزيل: 1%؟</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation> :المحتوى القابل للتنزيل مثبت بالفعل</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>اللعبة مثبتة بالفعل</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>!PKG هو تصحيح، يرجى تثبيت اللعبة أولاً</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>PKG خطأ في</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>PKG %1/%2 جاري استخراج</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>اكتمل الاستخراج</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>تم تثبيت اللعبة بنجاح في %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>يبدو أن الملف ليس ملف PKG صالحًا</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Cheats / Patches for </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>الغش والتصحيحات هي ميزات تجريبية.\nاستخدمها بحذر.\n\nقم بتنزيل الغش بشكل فردي عن طريق اختيار المستودع والنقر على زر التنزيل.\nفي علامة تبويب التصحيحات، يمكنك تنزيل جميع التصحيحات دفعة واحدة، واختيار ما تريد استخدامه، وحفظ اختياراتك.\n\nنظرًا لأننا لا نقوم بتطوير الغش/التصحيحات،\nيرجى الإبلاغ عن أي مشاكل إلى مؤلف الغش.\n\nهل قمت بإنشاء غش جديد؟ قم بزيارة:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>لا تتوفر صورة</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>الرقم التسلسلي: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>الإصدار: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>الحجم: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>اختر ملف الغش:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>المستودع:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>تنزيل الغش</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>حذف الملف</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>لم يتم اختيار أي ملفات.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>يمكنك حذف الغش الذي لا تريده بعد تنزيله.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>هل تريد حذف الملف المحدد؟\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>اختر ملف التصحيح:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>تنزيل التصحيحات</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>حفظ</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>الغش</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>التصحيحات</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>خطأ</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>لم يتم اختيار أي تصحيح.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>تعذر فتح files.json للقراءة.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>لم يتم العثور على ملف تصحيح للرقم التسلسلي الحالي.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>تعذر فتح الملف للقراءة.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>تعذر فتح الملف للكتابة.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation> :فشل في تحليل XML</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>نجاح</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>تم حفظ الخيارات بنجاح.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>مصدر غير صالح</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>المصدر المحدد غير صالح.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>الملف موجود</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>الملف موجود بالفعل. هل تريد استبداله؟</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>:فشل في حفظ الملف</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>:فشل في تنزيل الملف</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>لم يتم العثور على الغش</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>لم يتم العثور على غش لهذه اللعبة في هذا الإصدار من المستودع المحدد. حاول استخدام مستودع آخر أو إصدار آخر من اللعبة.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>تم تنزيل الغش بنجاح</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>لقد نجحت في تنزيل الغش لهذا الإصدار من اللعبة من المستودع المحدد. يمكنك محاولة التنزيل من مستودع آخر. إذا كان متاحًا، يمكنك اختياره عن طريق تحديد الملف من القائمة.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>:فشل في الحفظ</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>:فشل في التنزيل</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>اكتمل التنزيل</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>تم تنزيل التصحيحات بنجاح! تم تنزيل جميع التصحيحات لجميع الألعاب، ولا داعي لتنزيلها بشكل فردي لكل لعبة كما هو الحال مع الغش. إذا لم يظهر التحديث، قد يكون السبب أنه غير متوفر للإصدار وسيريال اللعبة المحدد.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>فشل في تحليل بيانات JSON من HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>.HTML فشل في استرجاع صفحة</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>اللعبة في الإصدار: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>الباتش الذي تم تنزيله يعمل فقط على الإصدار: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>قد تحتاج إلى تحديث لعبتك.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>إشعار عدم التوافق</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation> :فشل في فتح الملف</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation> :خطأ في XML</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>فشل في فتح files.json للكتابة</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation> :المؤلف</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation> :المجلد غير موجود</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>فشل في فتح files.json للقراءة.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>:الاسم</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>لا يمكن تطبيق الغش قبل بدء اللعبة.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>حفظ</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>تطبيق</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>استعادة الإعدادات الافتراضية</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>إغلاق</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>وجّه الماوس نحو خيار لعرض وصفه.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>لغة الجهاز:\nتحدد لغة اللعبة التي يستخدمها جهاز PS4.\nيوصى بضبطها على لغة يدعمها الجهاز، والتي قد تختلف حسب المنطقة.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>لغة المحاكي:\nتحدد لغة واجهة المستخدم الخاصة بالمحاكي.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>تمكين وضع ملء الشاشة:\nيجعل نافذة اللعبة تنتقل تلقائيًا إلى وضع ملء الشاشة.\nيمكن التبديل بالضغط على المفتاح F11.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Enable Separate Update Folder:\nEnables installing game updates into a separate folder for easy management.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>إظهار شاشة البداية:\nيعرض شاشة البداية الخاصة باللعبة (صورة خاصة) أثناء بدء التشغيل.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>هل هو PS4 Pro:\nيجعل المحاكي يعمل كـ PS4 PRO، مما قد يتيح ميزات خاصة في الألعاب التي تدعمه.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>تفعيل حالة الثراء في ديسكورد:\nيعرض أيقونة المحاكي ومعلومات ذات صلة على ملفك الشخصي في ديسكورد.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>اسم المستخدم:\nيضبط اسم حساب PS4، الذي قد يتم عرضه في بعض الألعاب.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>نوع السجل:\nيضبط ما إذا كان سيتم مزامنة مخرجات نافذة السجل للأداء. قد يؤثر سلبًا على المحاكاة.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>فلتر السجل:\nيقوم بتصفية السجل لطباعة معلومات محددة فقط.\nأمثلة: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" المستويات: Trace, Debug, Info, Warning, Error, Critical - بالترتيب، مستوى محدد يخفي جميع المستويات التي تسبقه ويعرض جميع المستويات بعده.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>تحديث: Release: إصدارات رسمية تصدر شهريًا، قد تكون قديمة بعض الشيء، لكنها أكثر استقرارًا واختبارًا. Nightly: إصدارات تطوير تحتوي على أحدث الميزات والإصلاحات، لكنها قد تحتوي على أخطاء وأقل استقرارًا.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>تشغيل موسيقى العنوان:\nإذا كانت اللعبة تدعم ذلك، قم بتمكين تشغيل موسيقى خاصة عند اختيار اللعبة في واجهة المستخدم.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Disable Trophy Pop-ups:\nDisable in-game trophy notifications. Trophy progress can still be tracked using the Trophy Viewer (right-click the game in the main window).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>إخفاء المؤشر:\nاختر متى سيختفي المؤشر:\nأبداً: سترى الفأرة دائماً.\nعاطل: حدد وقتاً لاختفائه بعد أن يكون غير مستخدم.\nدائماً: لن ترى الفأرة أبداً.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>حدد وقتاً لاختفاء الفأرة بعد أن تكون غير مستخدم.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>سلوك زر العودة:\nيضبط زر العودة في وحدة التحكم ليحاكي الضغط على الموضع المحدد على لوحة اللمس في PS4.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Display Compatibility Data:\nDisplays game compatibility information in table view. Enable "Update Compatibility On Startup" to get up-to-date information.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Update Compatibility On Startup:\nAutomatically update the compatibility database when shadPS4 starts.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Update Compatibility Database:\nImmediately update the compatibility database.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>أبداً</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>خامل</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>دائماً</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>لوحة اللمس اليسرى</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>لوحة اللمس اليمنى</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>وسط لوحة اللمس</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>لا شيء</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>جهاز الرسومات:\nعلى الأنظمة متعددة وحدات معالجة الرسومات، اختر وحدة معالجة الرسومات التي سيستخدمها المحاكي من قائمة منسدلة،\nأو اختر "Auto Select" لتحديدها تلقائيًا.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>العرض / الارتفاع:\nيضبط حجم نافذة المحاكي عند التشغيل، والذي يمكن تغيير حجمه أثناء اللعب.\nهذا يختلف عن دقة اللعبة نفسها.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>مقسم معدل التحديث:\nيتم مضاعفة معدل الإطارات الذي يتم تحديث المحاكي به بواسطة هذا الرقم. قد يؤدي تغيير هذا إلى آثار سلبية، مثل زيادة سرعة اللعبة أو كسر الوظائف الأساسية التي لا تتوقع هذا التغيير!</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>تمكين تفريغ الـ Shaders:\nلأغراض تصحيح الأخطاء التقنية، يحفظ الـ Shaders الخاصة باللعبة في مجلد أثناء التشغيل.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>تمكين GPU الافتراضية:\nلأغراض تصحيح الأخطاء التقنية، يقوم بتعطيل عرض اللعبة كما لو لم يكن هناك بطاقة رسومات.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>مجلدات اللعبة:\nقائمة بالمجلدات للتحقق من الألعاب المثبتة.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>إضافة:\nأضف مجلداً إلى القائمة.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>إزالة:\nأزل مجلداً من القائمة.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>تمكين تفريغ التصحيح:\nيحفظ رموز الاستيراد والتصدير ومعلومات رأس الملف للبرنامج الحالي لجهاز PS4 إلى دليل.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>تمكين طبقات التحقق من Vulkan:\nيتيح نظام يتحقق من حالة مشغل Vulkan ويسجل معلومات حول حالته الداخلية. سيؤدي هذا إلى تقليل الأداء ومن المحتمل تغيير سلوك المحاكاة.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>تمكين التحقق من تزامن Vulkan:\nيتيح نظام يتحقق من توقيت مهام عرض Vulkan. سيؤدي ذلك إلى تقليل الأداء ومن المحتمل تغيير سلوك المحاكاة.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>تمكين تصحيح RenderDoc:\nإذا تم التمكين، سيوفر المحاكي توافقًا مع Renderdoc لالتقاط وتحليل الإطار الذي يتم عرضه حاليًا.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Cheats / Patches for </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>الغش والتصحيحات هي ميزات تجريبية.\nاستخدمها بحذر.\n\nقم بتنزيل الغش بشكل فردي عن طريق اختيار المستودع والنقر على زر التنزيل.\nفي علامة تبويب التصحيحات، يمكنك تنزيل جميع التصحيحات دفعة واحدة، واختيار ما تريد استخدامه، وحفظ اختياراتك.\n\nنظرًا لأننا لا نقوم بتطوير الغش/التصحيحات،\nيرجى الإبلاغ عن أي مشاكل إلى مؤلف الغش.\n\nهل قمت بإنشاء غش جديد؟ قم بزيارة:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>لا تتوفر صورة</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>الرقم التسلسلي: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>الإصدار: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>الحجم: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>اختر ملف الغش:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>المستودع:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>تنزيل الغش</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>حذف الملف</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>لم يتم اختيار أي ملفات.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>يمكنك حذف الغش الذي لا تريده بعد تنزيله.</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>هل تريد حذف الملف المحدد؟\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>اختر ملف التصحيح:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>تنزيل التصحيحات</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>حفظ</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>الغش</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>التصحيحات</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>خطأ</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>لم يتم اختيار أي تصحيح.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>تعذر فتح files.json للقراءة.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>لم يتم العثور على ملف تصحيح للرقم التسلسلي الحالي.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>تعذر فتح الملف للقراءة.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>تعذر فتح الملف للكتابة.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation> :فشل في تحليل XML</translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>نجاح</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>تم حفظ الخيارات بنجاح.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>مصدر غير صالح</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>المصدر المحدد غير صالح.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>الملف موجود</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>الملف موجود بالفعل. هل تريد استبداله؟</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>:فشل في حفظ الملف</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>:فشل في تنزيل الملف</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>لم يتم العثور على الغش</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>لم يتم العثور على غش لهذه اللعبة في هذا الإصدار من المستودع المحدد. حاول استخدام مستودع آخر أو إصدار آخر من اللعبة.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>تم تنزيل الغش بنجاح</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>لقد نجحت في تنزيل الغش لهذا الإصدار من اللعبة من المستودع المحدد. يمكنك محاولة التنزيل من مستودع آخر. إذا كان متاحًا، يمكنك اختياره عن طريق تحديد الملف من القائمة.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>:فشل في الحفظ</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>:فشل في التنزيل</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>اكتمل التنزيل</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>تم تنزيل التصحيحات بنجاح! تم تنزيل جميع التصحيحات لجميع الألعاب، ولا داعي لتنزيلها بشكل فردي لكل لعبة كما هو الحال مع الغش. إذا لم يظهر التحديث، قد يكون السبب أنه غير متوفر للإصدار وسيريال اللعبة المحدد.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>فشل في تحليل بيانات JSON من HTML.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>.HTML فشل في استرجاع صفحة</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>اللعبة في الإصدار: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>الباتش الذي تم تنزيله يعمل فقط على الإصدار: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>قد تحتاج إلى تحديث لعبتك.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>إشعار عدم التوافق</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation> :فشل في فتح الملف</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation> :خطأ في XML</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>فشل في فتح files.json للكتابة</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation> :المؤلف</translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation> :المجلد غير موجود</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>فشل في فتح files.json للقراءة.</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>:الاسم</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>لا يمكن تطبيق الغش قبل بدء اللعبة.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>أيقونة</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>اسم</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>سيريال</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>منطقة</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>البرمجيات الثابتة</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>حجم</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>إصدار</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>مسار</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>وقت اللعب</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Never Played</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Compatibility is untested</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Game does not initialize properly / crashes the emulator</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Game boots, but only displays a blank screen</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Game displays an image but does not go past the menu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Game has game-breaking glitches or unplayable performance</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>محدث تلقائي</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>خطأ</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>خطأ في الشبكة:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>فشل في تحليل معلومات التحديث.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>لم يتم العثور على أي إصدارات مسبقة.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>بيانات الإصدار غير صالحة.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>لم يتم العثور على عنوان URL للتنزيل للأصل المحدد.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>نسختك محدثة بالفعل!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>تحديث متاح</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>قناة التحديث</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>الإصدار الحالي</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>آخر إصدار</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>هل تريد التحديث؟</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>عرض سجل التغييرات</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>تحقق من التحديثات عند بدء التشغيل</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>تحديث</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>لا</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>إخفاء سجل التغييرات</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>تغييرات</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>حدث خطأ في الشبكة أثناء محاولة الوصول إلى عنوان URL</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>اكتمل التنزيل</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>تم تنزيل التحديث، اضغط على OK للتثبيت.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>فشل في حفظ ملف التحديث في</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>بدء التحديث...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>فشل في إنشاء ملف سكريبت التحديث</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/da_DK.ts
+++ b/src/qt_gui/translations/da_DK.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>About shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 is an experimental open-source emulator for the PlayStation 4.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>This software should not be used to play games you have not legally obtained.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Open Folder</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Loading game list, please wait :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>Cancel</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Loading...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Choose directory</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Select which directory you want to install to.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Choose directory</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Directory to install games</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Browse</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>The value for location to install games is not valid.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>Create Shortcut</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>Trick / Patches</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>SFO Viewer</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophy Viewer</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>Åbn Mappe...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>Åbn Spilmappe</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>Åbn Gem Data Mappe</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>Åbn Log Mappe</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>Copy info...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>Copy Name</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>Copy Serial</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>Copy All</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Delete...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Delete Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Delete Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Delete DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>Shortcut creation</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>Shortcut created successfully!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>Error creating shortcut!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>Install PKG</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>This feature requires the 'Enable Separate Update Folder' config option to work. If you want to use this feature, please enable it.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>This game has no update to delete!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>This game has no DLC to delete!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Delete %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Are you sure you want to delete %1's %2 directory?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Open/Add Elf Folder</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>Install Packages (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Boot Game</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>Tjek for opdateringer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>About shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Configure...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>Install application from a .pkg file</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Recent Games</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Exit</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>Exit shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Exit the application.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Show Game List</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Game List Refresh</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Tiny</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Small</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Medium</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Large</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>List View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Grid View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Elf Viewer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Game Install Directory</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>Download Tricks / Patches</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Dump Game List</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>PKG Viewer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Search...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>File</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Game List Icons</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Game List Mode</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Settings</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Utils</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Themes</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>Hjælp</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Dark</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Light</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Green</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Blue</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Violet</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>toolBar</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>Spiloversigt</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * Ikke understøttet Vulkan-version</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>Hent snyd til alle installerede spil</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>Hent patches til alle spil</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Download fuldført</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>Du har hentet snyd til alle de spil, du har installeret.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>Patcher hentet med succes!</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>Alle patches til alle spil er blevet hentet.</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>Spil: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>PKG-fil (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>ELF-filer (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>Spil-boot</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>Kun én fil kan vælges!</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>PKG-udtrækning</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>Opdatering detekteret!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>PKG og spilversioner matcher: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>Vil du overskrive?</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>PKG Version %1 er ældre end den installerede version: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>Spillet er installeret: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>Vil du installere opdateringen: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>DLC Installation</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>Vil du installere DLC: %1?</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC allerede installeret:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>Spillet er allerede installeret</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>PKG er en patch, venligst installer spillet først!</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>PKG FEJL</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>Udvinding af PKG %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>Udvinding afsluttet</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>Spillet blev installeret succesfuldt på %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>Filen ser ikke ud til at være en gyldig PKG-fil</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Open Folder</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophy Viewer</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Settings</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>General</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>System</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>Console Language</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Emulator Language</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Emulator</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Enable Fullscreen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Show Splash</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>Is PS4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Aktiver Discord Rich Presence</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Username</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Logger</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Log Type</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Log Filter</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>Indtastning</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>Markør</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>Skjul markør</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>Timeout for skjul markør ved inaktivitet</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>Controller</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>Tilbageknap adfærd</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Graphics</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Graphics Device</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Width</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Height</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Vblank Divider</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Advanced</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Enable Shaders Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>Enable NULL GPU</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>Stier</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>Spilmapper</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>Tilføj...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>Fjern</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Debug</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Enable Debug Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Enable Vulkan Validation Layers</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Enable Vulkan Synchronization Validation</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>Enable RenderDoc Debugging</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>Opdatering</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Tjek for opdateringer ved start</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>Opdateringskanal</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>Tjek for opdateringer</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>GUI-Indstillinger</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Disable Trophy Pop-ups</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>Afspil titelsang</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Update Compatibility Database On Startup</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Game Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Display Compatibility Data</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Update Compatibility Database</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>Lydstyrke</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>Spiloversigt</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * Ikke understøttet Vulkan-version</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>Hent snyd til alle installerede spil</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>Hent patches til alle spil</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>Download fuldført</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>Du har hentet snyd til alle de spil, du har installeret.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>Patcher hentet med succes!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>Alle patches til alle spil er blevet hentet.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>Spil: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>PKG-fil (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>ELF-filer (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>Spil-boot</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>Kun én fil kan vælges!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>PKG-udtrækning</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>Opdatering detekteret!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>PKG og spilversioner matcher: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>Vil du overskrive?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>PKG Version %1 er ældre end den installerede version: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>Spillet er installeret: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>Vil du installere opdateringen: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>DLC Installation</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>Vil du installere DLC: %1?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC allerede installeret:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>Spillet er allerede installeret</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>PKG er en patch, venligst installer spillet først!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>PKG FEJL</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>Udvinding af PKG %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>Udvinding afsluttet</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>Spillet blev installeret succesfuldt på %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>Filen ser ikke ud til at være en gyldig PKG-fil</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Cheats / Patches for </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>Cheats/Patches er eksperimentelle.\nBrug med forsigtighed.\n\nDownload cheats individuelt ved at vælge lageret og klikke på download-knappen.\nUnder fanen Patches kan du downloade alle patches på én gang, vælge hvilke du vil bruge og gemme valget.\n\nDa vi ikke udvikler cheats/patches,\nvenligst rapporter problemer til cheat-udvikleren.\n\nHar du lavet en ny cheat? Besøg:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>Ingen billede tilgængelig</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>Serienummer: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>Version: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>Størrelse: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>Vælg snyd-fil:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>Repository:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>Hent snyd</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>Slet fil</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>Ingen filer valgt.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>Du kan slette de snyd, du ikke ønsker, efter at have hentet dem.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>Ønsker du at slette den valgte fil?\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>Vælg patch-fil:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>Hent patches</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>Gem</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>Snyd</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>Patches</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>Fejl</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>Ingen patch valgt.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>Kan ikke åbne files.json til læsning.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>Ingen patch-fil fundet for det nuværende serienummer.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>Kan ikke åbne filen til læsning.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>Kan ikke åbne filen til skrivning.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>Kunne ikke analysere XML: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>Succes</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>Indstillinger gemt med succes.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>Ugyldig kilde</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>Den valgte kilde er ugyldig.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>Fil findes</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>Filen findes allerede. Vil du erstatte den?</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>Kunne ikke gemme fil:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>Kunne ikke hente fil:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>Snyd ikke fundet</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>Ingen snyd fundet til dette spil i denne version af det valgte repository, prøv et andet repository eller en anden version af spillet.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>Snyd hentet med succes</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>Du har succesfuldt hentet snyd for denne version af spillet fra det valgte repository. Du kan prøve at hente fra et andet repository, hvis det er tilgængeligt, vil det også være muligt at bruge det ved at vælge filen fra listen.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>Kunne ikke gemme:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>Kunne ikke hente:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>Download fuldført</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>Patcher hentet med succes! Alle patches til alle spil er blevet hentet, der er ikke behov for at hente dem individuelt for hvert spil, som det sker med snyd. Hvis opdateringen ikke vises, kan det være, at den ikke findes for den specifikke serie og version af spillet.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>Kunne ikke analysere JSON-data fra HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>Kunne ikke hente HTML-side.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>Spillet er i version: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>Den downloadede patch fungerer kun på version: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>Du skal muligvis opdatere dit spil.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>Uforenelighedsmeddelelse</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>Kunne ikke åbne fil:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>XML FEJL:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>Kunne ikke åbne files.json til skrivning</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>Forfatter: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>Mappe findes ikke:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>Kunne ikke åbne files.json til læsning.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>Navn:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>Kan ikke anvende snyd før spillet er startet.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>Gem</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>Anvend</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>Gendan standardindstillinger</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>Luk</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>Peg musen over et valg for at vise dets beskrivelse.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Konsolsprog:\nIndstiller sproget, som PS4-spillet bruger.\nDet anbefales at indstille dette til et sprog, som spillet understøtter, hvilket kan variere efter region.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>Emulatorsprog:\nIndstiller sproget i emulatorens brugergrænseflade.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>Aktiver fuld skærm:\nSætter automatisk spilvinduet i fuld skærm.\nDette kan skiftes ved at trykke på F11-tasten.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Enable Separate Update Folder:\nEnables installing game updates into a separate folder for easy management.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>Vis startskærm:\nViser en startskærm (speciel grafik) under opstarten.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>Er det en PS4 Pro:\nGør det muligt for emulatoren at fungere som en PS4 PRO, hvilket kan aktivere visse funktioner i spil, der understøtter det.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>Aktiver Discord Rich Presence:\nViser emulatorikonet og relevante oplysninger på din Discord-profil.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>Brugernavn:\nIndstiller PS4-kontoens navn, som kan blive vist i nogle spil.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>Logtype:\nIndstiller, om logvinduets output vil blive synkroniseret for at øge ydeevnen. Dette kan påvirke emulatorens ydeevne negativt.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Logfilter:\nFiltrerer loggen for kun at udskrive bestemte oplysninger.\nEksempler: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" Niveaus: Trace, Debug, Info, Warning, Error, Critical - i rækkefølge, et valgt niveau skjuler alle forudgående niveauer og viser alle efterfølgende niveauer.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>Opdatering:\nRelease: Officielle builds, der frigives månedligt, som kan være meget ældre, men mere stabile og testet.\nNightly: Udviklerbuilds med de nyeste funktioner og rettelser, men som kan indeholde fejl og være mindre stabile.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Titelsmusikafspilning:\nHvis spillet understøtter det, aktiver speciel musik, når spillet vælges i brugergrænsefladen.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Disable Trophy Pop-ups:\nDisable in-game trophy notifications. Trophy progress can still be tracked using the Trophy Viewer (right-click the game in the main window).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>Skjul Cursor:\nVælg hvornår cursoren skal forsvinde:\nAldrig: Du vil altid se musen.\nInaktiv: Indstil en tid for, hvornår den skal forsvinde efter at være inaktiv.\nAltid: du vil aldrig se musen.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>Indstil en tid for, at musen skal forsvinde efter at være inaktiv.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>Tilbageknap Adfærd:\nIndstiller controllerens tilbageknap til at efterligne tryk på den angivne position på PS4 berøringsflade.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Display Compatibility Data:\nDisplays game compatibility information in table view. Enable "Update Compatibility On Startup" to get up-to-date information.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Update Compatibility On Startup:\nAutomatically update the compatibility database when shadPS4 starts.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Update Compatibility Database:\nImmediately update the compatibility database.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>Aldrig</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>Inaktiv</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>Altid</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>Berøringsplade Venstre</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>Berøringsplade Højre</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>Berøringsplade Center</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>Ingen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>Grafikadapter:\nPå systemer med flere GPU'er skal du vælge den GPU, emulatoren vil bruge fra en rullemenu,\neller vælge "Auto Select" for at vælge den automatisk.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Skærmopløsning:\nIndstiller emulatorvinduets størrelse under afspilning, som kan ændres under afspilning.\nDette er forskelligt fra selve spillets opløsning.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Opdateringshastighedsdeler:\nMultiplicerer den frekvens, som emulatoren opdaterer billedet med, med dette tal. Ændring af dette kan have negative effekter, såsom hurtigere spil eller ødelagte funktioner!</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>Aktiver dumping af Shaders:\nTil teknisk fejlfinding gemmer det spillets shaders i en mappe under afspilning.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Aktiver virtuel GPU:\nTil teknisk fejlfinding deaktiverer det spilvisning, som om der ikke var et grafikkort.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>Spilmappen:\nListen over mapper til at tjekke for installerede spil.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>Tilføj:\nTilføj en mappe til listen.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>Fjern:\nFjern en mappe fra listen.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>Aktiver debugging-dump:\nGemmer import/export-symboler og headeroplysninger for det aktuelle PS4-program til en mappe.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Aktiver Vulkan-valideringslag:\nAktiverer et system, der validerer Vulkan-driverens tilstand og logger oplysninger om dens interne tilstand. Dette vil reducere ydeevnen og kan muligvis ændre emulatorens adfærd.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Aktiver Vulkan-synkroniseringsvalidering:\nAktiverer et system, der validerer tidspunktet for Vulkan's renderingsopgaver. Dette vil reducere ydeevnen og kan muligvis ændre emulatorens adfærd.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>Aktiver RenderDoc-fejlfinding:\nHvis aktiveret, giver det emulatoren mulighed for kompatibilitet med Renderdoc til at fange og analysere det aktuelle gengivne billede.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Cheats / Patches for </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>Cheats/Patches er eksperimentelle.\nBrug med forsigtighed.\n\nDownload cheats individuelt ved at vælge lageret og klikke på download-knappen.\nUnder fanen Patches kan du downloade alle patches på én gang, vælge hvilke du vil bruge og gemme valget.\n\nDa vi ikke udvikler cheats/patches,\nvenligst rapporter problemer til cheat-udvikleren.\n\nHar du lavet en ny cheat? Besøg:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>Ingen billede tilgængelig</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>Serienummer: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>Version: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>Størrelse: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>Vælg snyd-fil:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>Repository:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>Hent snyd</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>Slet fil</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>Ingen filer valgt.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>Du kan slette de snyd, du ikke ønsker, efter at have hentet dem.</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>Ønsker du at slette den valgte fil?\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>Vælg patch-fil:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>Hent patches</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>Gem</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>Snyd</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>Patches</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Fejl</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>Ingen patch valgt.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>Kan ikke åbne files.json til læsning.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>Ingen patch-fil fundet for det nuværende serienummer.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>Kan ikke åbne filen til læsning.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>Kan ikke åbne filen til skrivning.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>Kunne ikke analysere XML: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>Succes</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>Indstillinger gemt med succes.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>Ugyldig kilde</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>Den valgte kilde er ugyldig.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>Fil findes</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>Filen findes allerede. Vil du erstatte den?</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>Kunne ikke gemme fil:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>Kunne ikke hente fil:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>Snyd ikke fundet</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>Ingen snyd fundet til dette spil i denne version af det valgte repository, prøv et andet repository eller en anden version af spillet.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>Snyd hentet med succes</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>Du har succesfuldt hentet snyd for denne version af spillet fra det valgte repository. Du kan prøve at hente fra et andet repository, hvis det er tilgængeligt, vil det også være muligt at bruge det ved at vælge filen fra listen.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>Kunne ikke gemme:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>Kunne ikke hente:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Download fuldført</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>Patcher hentet med succes! Alle patches til alle spil er blevet hentet, der er ikke behov for at hente dem individuelt for hvert spil, som det sker med snyd. Hvis opdateringen ikke vises, kan det være, at den ikke findes for den specifikke serie og version af spillet.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>Kunne ikke analysere JSON-data fra HTML.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>Kunne ikke hente HTML-side.</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>Spillet er i version: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>Den downloadede patch fungerer kun på version: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>Du skal muligvis opdatere dit spil.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>Uforenelighedsmeddelelse</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>Kunne ikke åbne fil:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>XML FEJL:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>Kunne ikke åbne files.json til skrivning</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>Forfatter: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>Mappe findes ikke:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>Kunne ikke åbne files.json til læsning.</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>Navn:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>Kan ikke anvende snyd før spillet er startet.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>Ikon</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>Navn</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>Seriel</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>Region</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>Firmware</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>Størrelse</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>Version</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>Sti</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>Spilletid</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Never Played</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Compatibility is untested</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Game does not initialize properly / crashes the emulator</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Game boots, but only displays a blank screen</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Game displays an image but does not go past the menu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Game has game-breaking glitches or unplayable performance</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>Automatisk opdatering</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>Fejl</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>Netsværksfejl:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>Kunne ikke analysere opdateringsoplysninger.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>Ingen forhåndsudgivelser fundet.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>Ugyldige udgivelsesdata.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>Ingen download-URL fundet for den specificerede aktiver.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>Din version er allerede opdateret!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>Opdatering tilgængelig</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>Opdateringskanal</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>Nuværende version</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>Nyeste version</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>Vil du opdatere?</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>Vis ændringslog</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Tjek for opdateringer ved start</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>Opdater</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>Nej</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>Skjul ændringslog</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>Ændringer</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>Netsværksfejl opstod, mens der blev forsøgt at få adgang til URL'en</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>Download fuldført</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>Opdateringen er blevet downloadet, tryk på OK for at installere.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>Kunne ikke gemme opdateringsfilen på</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>Starter opdatering...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>Kunne ikke oprette opdateringsscriptfilen</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/de.ts
+++ b/src/qt_gui/translations/de.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>Über shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 ist ein experimenteller Open-Source-Emulator für die Playstation 4.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>Diese Software soll nicht dazu benutzt werden illegal kopierte Spiele zu spielen.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Ordner öffnen</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Lade Spielliste, bitte warten :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>Abbrechen</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Lade...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Wähle Ordner</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Select which directory you want to install to.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Wähle Ordner</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Installationsverzeichnis für Spiele</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Durchsuchen</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Fehler</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>Der ausgewählte Ordner ist nicht gültig.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>Verknüpfung erstellen</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>Cheats / Patches</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>SFO anzeigen</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophäen anzeigen</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>Ordner öffnen...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>Spielordner öffnen</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>Speicherordner öffnen</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>Protokollordner öffnen</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>Infos kopieren...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>Namen kopieren</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>Seriennummer kopieren</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>Alles kopieren</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Delete...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Delete Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Delete Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Delete DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>Verknüpfungserstellung</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>Verknüpfung erfolgreich erstellt!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>Fehler</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>Fehler beim Erstellen der Verknüpfung!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>PKG installieren</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>This feature requires the 'Enable Separate Update Folder' config option to work. If you want to use this feature, please enable it.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>This game has no update to delete!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>This game has no DLC to delete!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Delete %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Are you sure you want to delete %1's %2 directory?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Elf-Ordner öffnen/hinzufügen</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>Pakete installieren (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Spiel starten</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>Nach Updates suchen</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>Über shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Konfigurieren...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>Installiere Anwendung aus .pkg-Datei</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Zuletzt gespielt</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Beenden</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>shadPS4 beenden</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Die Anwendung beenden.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Spielliste anzeigen</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Spielliste aktualisieren</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Winzig</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Klein</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Mittel</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Groß</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>Listenansicht</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Gitteransicht</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Elf-Ansicht</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Installationsverzeichnis für Spiele</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>Cheats / Patches herunterladen</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Spielliste ausgeben</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>PKG-Ansicht</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Suchen...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>Datei</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>Ansicht</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Game List Icons</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Spiellisten-Symoble</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Einstellungen</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Werkzeuge</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Stile</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>Hilfe</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Dunkel</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Hell</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Grün</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Blau</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Violett</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>toolBar</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>Spieleliste</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * Nicht unterstützte Vulkan-Version</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>Cheats für alle installierten Spiele herunterladen</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>Patches für alle Spiele herunterladen</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Download abgeschlossen</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>Sie haben Cheats für alle installierten Spiele heruntergeladen.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>Patches erfolgreich heruntergeladen!</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>Alle Patches für alle Spiele wurden heruntergeladen.</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>Spiele: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>PKG-Datei (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>ELF-Dateien (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>Spiel-Start</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>Es kann nur eine Datei ausgewählt werden!</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>PKG-Extraktion</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>Patch erkannt!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>PKG- und Spielversionen stimmen überein: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>Willst du überschreiben?</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>PKG-Version %1 ist älter als die installierte Version: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>Spiel ist installiert: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>Willst du den Patch installieren: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>DLC-Installation</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>Willst du den DLC installieren: %1?</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC bereits installiert:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>Spiel bereits installiert</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>PKG ist ein Patch, bitte installieren Sie zuerst das Spiel!</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>PKG-FEHLER</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>Extrahiere PKG %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>Extraktion abgeschlossen</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>Spiel erfolgreich installiert auf %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>Die Datei scheint keine gültige PKG-Datei zu sein</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Ordner öffnen</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophäenansicht</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Einstellungen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>Allgemein</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>System</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>Konsolensprache</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Emulatorsprache</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Emulator</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Vollbild aktivieren</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Startbildschirm anzeigen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>Ist PS4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Discord Rich Presence aktivieren</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Benutzername</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Logger</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Logtyp</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Log-Filter</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>Eingabe</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>Cursor</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>Cursor ausblenden</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>Inaktivitätszeitüberschreitung zum Ausblenden des Cursors</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>Controller</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>Verhalten der Zurück-Taste</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Grafik</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Grafikgerät</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Breite</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Höhe</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Vblank-Teiler</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Erweitert</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Shader-Dumping aktivieren</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>NULL GPU aktivieren</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>Pfad</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>Spieleordner</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>Hinzufügen...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>Entfernen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Debug</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Debug-Dumping aktivieren</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Vulkan Validations-Ebenen aktivieren</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Vulkan Synchronisations-Validierung aktivieren</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>RenderDoc-Debugging aktivieren</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>Aktualisieren</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Beim Start nach Updates suchen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>Update-Kanal</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>Nach Updates suchen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>GUI-Einstellungen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Disable Trophy Pop-ups</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>Titelmusik abspielen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Update Compatibility Database On Startup</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Game Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Display Compatibility Data</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Update Compatibility Database</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>Lautstärke</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>Spieleliste</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * Nicht unterstützte Vulkan-Version</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>Cheats für alle installierten Spiele herunterladen</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>Patches für alle Spiele herunterladen</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>Download abgeschlossen</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>Sie haben Cheats für alle installierten Spiele heruntergeladen.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>Patches erfolgreich heruntergeladen!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>Alle Patches für alle Spiele wurden heruntergeladen.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>Spiele: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>PKG-Datei (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>ELF-Dateien (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>Spiel-Start</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>Es kann nur eine Datei ausgewählt werden!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>PKG-Extraktion</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>Patch erkannt!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>PKG- und Spielversionen stimmen überein: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>Willst du überschreiben?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>PKG-Version %1 ist älter als die installierte Version: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>Spiel ist installiert: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>Willst du den Patch installieren: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>DLC-Installation</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>Willst du den DLC installieren: %1?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC bereits installiert:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>Spiel bereits installiert</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>PKG ist ein Patch, bitte installieren Sie zuerst das Spiel!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>PKG-FEHLER</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>Extrahiere PKG %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>Extraktion abgeschlossen</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>Spiel erfolgreich installiert auf %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>Die Datei scheint keine gültige PKG-Datei zu sein</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Cheats / Patches for </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>Cheats/Patches sind experimentell.\nVerwende sie mit Vorsicht.\n\nLade Cheats einzeln herunter, indem du das Repository auswählst und auf die Download-Schaltfläche klickst.\nAuf der Registerkarte Patches kannst du alle Patches auf einmal herunterladen, auswählen, welche du verwenden möchtest, und die Auswahl speichern.\n\nDa wir die Cheats/Patches nicht entwickeln,\nbitte melde Probleme an den Cheat-Autor.\n\nHast du einen neuen Cheat erstellt? Besuche:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>Kein Bild verfügbar</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>Seriennummer: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>Version: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>Größe: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>Cheat-Datei auswählen:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>Repository:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>Cheats herunterladen</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>Datei löschen</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>Keine Dateien ausgewählt.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>Du kannst die Cheats, die du nicht möchtest, nach dem Herunterladen löschen.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>Willst du die ausgewählte Datei löschen?\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>Patch-Datei auswählen:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>Patches herunterladen</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>Speichern</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>Cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>Patches</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>Fehler</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>Kein Patch ausgewählt.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>Kann files.json nicht zum Lesen öffnen.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>Keine Patch-Datei für die aktuelle Seriennummer gefunden.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>Kann die Datei nicht zum Lesen öffnen.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>Kann die Datei nicht zum Schreiben öffnen.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>Fehler beim Parsen von XML: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>Erfolg</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>Optionen erfolgreich gespeichert.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>Ungültige Quelle</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>Die ausgewählte Quelle ist ungültig.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>Datei existiert</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>Datei existiert bereits. Möchtest du sie ersetzen?</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>Fehler beim Speichern der Datei:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>Fehler beim Herunterladen der Datei:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>Cheats nicht gefunden</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>Keine Cheats für dieses Spiel in dieser Version des gewählten Repositories gefunden. Versuche es mit einem anderen Repository oder einer anderen Version des Spiels.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>Cheats erfolgreich heruntergeladen</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>Du hast erfolgreich Cheats für diese Version des Spiels aus dem gewählten Repository heruntergeladen. Du kannst auch versuchen, Cheats von einem anderen Repository herunterzuladen. Wenn verfügbar, kannst du sie auswählen, indem du die Datei aus der Liste auswählst.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>Speichern fehlgeschlagen:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>Herunterladen fehlgeschlagen:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>Download abgeschlossen</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>Patches erfolgreich heruntergeladen! Alle Patches für alle Spiele wurden heruntergeladen, es ist nicht notwendig, sie einzeln für jedes Spiel herunterzuladen, wie es bei Cheats der Fall ist. Wenn der Patch nicht angezeigt wird, könnte es sein, dass er für die spezifische Seriennummer und Version des Spiels nicht existiert.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>Fehler beim Parsen der JSON-Daten aus HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>Fehler beim Abrufen der HTML-Seite.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>Das Spiel ist in der Version: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>Der heruntergeladene Patch funktioniert nur in der Version: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>Sie müssen möglicherweise Ihr Spiel aktualisieren.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>Inkompatibilitätsbenachrichtigung</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>Fehler beim Öffnen der Datei:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>XML-Fehler:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>Kann files.json nicht zum Schreiben öffnen</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>Autor: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>Verzeichnis existiert nicht:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>Kann files.json nicht zum Lesen öffnen.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>Name:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>Kann keine Cheats anwenden, bevor das Spiel gestartet ist.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>Speichern</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>Übernehmen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>Werkseinstellungen wiederherstellen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>Schließen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>Bewege die Maus über eine Option, um deren Beschreibung anzuzeigen.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Konsolensprache:\nLegt die Sprache fest, die das PS4-Spiel verwendet.\nEs wird empfohlen, diese auf eine vom Spiel unterstützte Sprache einzustellen, die je nach Region unterschiedlich sein kann.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>Emulatorsprache:\nLegt die Sprache der Emulator-Benutzeroberfläche fest.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>Vollbildmodus aktivieren:\nSchaltet das Spielfenster automatisch in den Vollbildmodus.\nKann durch Drücken der F11-Taste umgeschaltet werden.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Enable Separate Update Folder:\nEnables installing game updates into a separate folder for easy management.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>Startbildschirm anzeigen:\nZeigt beim Start einen speziellen Bildschirm (Splash) des Spiels an.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>Ist es eine PS4 Pro:\nErmöglicht es dem Emulator, als PS4 PRO zu arbeiten, was in Spielen, die dies unterstützen, spezielle Funktionen aktivieren kann.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>Discord Rich Presence aktivieren:\nZeigt das Emulator-Icon und relevante Informationen in deinem Discord-Profil an.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>Benutzername:\nLegt den Namen des PS4-Kontos fest, der in einigen Spielen angezeigt werden kann.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>Protokolltyp:\nLegt fest, ob die Ausgabe des Protokollfensters synchronisiert wird, um die Leistung zu verbessern. Dies kann sich negativ auf die Emulation auswirken.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Protokollfilter:\nFiltert das Protokoll so, dass nur bestimmte Informationen ausgegeben werden.\nBeispiele: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" Ebenen: Trace, Debug, Info, Warning, Error, Critical - in dieser Reihenfolge, ein ausgewähltes Level blendet alle vorherigen Ebenen aus und zeigt alle nachfolgenden an.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>Update:\nRelease: Offizielle Builds, die monatlich veröffentlicht werden, können viel älter sein, aber stabiler und getestet.\nNightly: Entwickler-Builds, die die neuesten Funktionen und Fehlerbehebungen enthalten, aber Fehler enthalten und weniger stabil sein können.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Wiedergabe der Titelmusik:\nWenn das Spiel dies unterstützt, wird beim Auswählen des Spiels in der Benutzeroberfläche spezielle Musik abgespielt.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Disable Trophy Pop-ups:\nDisable in-game trophy notifications. Trophy progress can still be tracked using the Trophy Viewer (right-click the game in the main window).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>Maus ausblenden:\nWählen Sie, wann der Cursor verschwinden soll:\nNie: Sie sehen die Maus immer.\nInaktiv: Legen Sie eine Zeit fest, nach der sie nach Inaktivität verschwindet.\nImmer: Sie sehen die Maus niemals.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>Stellen Sie eine Zeit ein, nach der die Maus nach Inaktivität verschwinden soll.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>Zurück-Button Verhalten:\nStellt die Zurück-Taste des Controllers so ein, dass sie das Antippen der angegebenen Position auf dem PS4-Touchpad emuliert.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Display Compatibility Data:\nDisplays game compatibility information in table view. Enable "Update Compatibility On Startup" to get up-to-date information.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Update Compatibility On Startup:\nAutomatically update the compatibility database when shadPS4 starts.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Update Compatibility Database:\nImmediately update the compatibility database.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>Niemals</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>Im Leerlauf</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>Immer</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>Touchpad Links</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>Touchpad Rechts</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>Touchpad Mitte</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>Keine</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>Grafikkarte:\nAuf Systemen mit mehreren GPUs wählen Sie aus einem Dropdown-Menü die GPU aus, die der Emulator verwenden wird,\noder wählen Sie "Auto Select", um sie automatisch auszuwählen.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Auflösung:\nLegt die Größe des Emulator-Fensters während der Wiedergabe fest, die während der Wiedergabe geändert werden kann.\nDies unterscheidet sich von der tatsächlichen Spielauflösung.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Framerate-Teiler:\nMultipliziert die Bildrate, mit der der Emulator aktualisiert wird, mit diesem Wert. Dies kann sich negativ auswirken, wie z.B. beschleunigtes Gameplay oder Funktionsstörungen!</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>Shader-Dumping aktivieren:\nZum technischen Debuggen speichert es die Shaders des Spiels in einem Ordner während der Wiedergabe.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Virtuelle GPU aktivieren:\nFür das technische Debugging deaktiviert es die Spielanzeige, als ob keine Grafikkarte vorhanden wäre.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>Spieleordner:\nDie Liste der Ordner, in denen nach installierten Spielen gesucht wird.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>Hinzufügen:\nFügen Sie einen Ordner zur Liste hinzu.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>Entfernen:\nEntfernen Sie einen Ordner aus der Liste.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>Debug-Dump aktivieren:\nSpeichert Import-/Exportsymbole und Headerinformationen des aktuellen PS4-Programms in einem Verzeichnis.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Vulkan-Validierungsebenen aktivieren:\nAktiviert ein System, das den Zustand des Vulkan-Treibers validiert und Informationen über dessen internen Zustand protokolliert. Dies verringert die Leistung und kann möglicherweise das Verhalten der Emulation ändern.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Vulkan-Synchronisationsvalidierung aktivieren:\nAktiviert ein System, das die Zeitplanung der Rendering-Aufgaben von Vulkan validiert. Dies wird die Leistung verringern und kann möglicherweise das Verhalten der Emulation ändern.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>RenderDoc-Debugging aktivieren:\nWenn aktiviert, bietet der Emulator Kompatibilität mit Renderdoc zur Erfassung und Analyse des aktuell gerenderten Frames.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Cheats / Patches for </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>Cheats/Patches sind experimentell.\nVerwende sie mit Vorsicht.\n\nLade Cheats einzeln herunter, indem du das Repository auswählst und auf die Download-Schaltfläche klickst.\nAuf der Registerkarte Patches kannst du alle Patches auf einmal herunterladen, auswählen, welche du verwenden möchtest, und die Auswahl speichern.\n\nDa wir die Cheats/Patches nicht entwickeln,\nbitte melde Probleme an den Cheat-Autor.\n\nHast du einen neuen Cheat erstellt? Besuche:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>Kein Bild verfügbar</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>Seriennummer: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>Version: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>Größe: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>Cheat-Datei auswählen:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>Repository:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>Cheats herunterladen</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>Datei löschen</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>Keine Dateien ausgewählt.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>Du kannst die Cheats, die du nicht möchtest, nach dem Herunterladen löschen.</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>Willst du die ausgewählte Datei löschen?\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>Patch-Datei auswählen:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>Patches herunterladen</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>Speichern</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>Cheats</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>Patches</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Fehler</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>Kein Patch ausgewählt.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>Kann files.json nicht zum Lesen öffnen.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>Keine Patch-Datei für die aktuelle Seriennummer gefunden.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>Kann die Datei nicht zum Lesen öffnen.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>Kann die Datei nicht zum Schreiben öffnen.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>Fehler beim Parsen von XML: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>Erfolg</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>Optionen erfolgreich gespeichert.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>Ungültige Quelle</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>Die ausgewählte Quelle ist ungültig.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>Datei existiert</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>Datei existiert bereits. Möchtest du sie ersetzen?</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>Fehler beim Speichern der Datei:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>Fehler beim Herunterladen der Datei:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>Cheats nicht gefunden</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>Keine Cheats für dieses Spiel in dieser Version des gewählten Repositories gefunden. Versuche es mit einem anderen Repository oder einer anderen Version des Spiels.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>Cheats erfolgreich heruntergeladen</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>Du hast erfolgreich Cheats für diese Version des Spiels aus dem gewählten Repository heruntergeladen. Du kannst auch versuchen, Cheats von einem anderen Repository herunterzuladen. Wenn verfügbar, kannst du sie auswählen, indem du die Datei aus der Liste auswählst.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>Speichern fehlgeschlagen:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>Herunterladen fehlgeschlagen:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Download abgeschlossen</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>Patches erfolgreich heruntergeladen! Alle Patches für alle Spiele wurden heruntergeladen, es ist nicht notwendig, sie einzeln für jedes Spiel herunterzuladen, wie es bei Cheats der Fall ist. Wenn der Patch nicht angezeigt wird, könnte es sein, dass er für die spezifische Seriennummer und Version des Spiels nicht existiert.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>Fehler beim Parsen der JSON-Daten aus HTML.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>Fehler beim Abrufen der HTML-Seite.</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>Das Spiel ist in der Version: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>Der heruntergeladene Patch funktioniert nur in der Version: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>Sie müssen möglicherweise Ihr Spiel aktualisieren.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>Inkompatibilitätsbenachrichtigung</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>Fehler beim Öffnen der Datei:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>XML-Fehler:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>Kann files.json nicht zum Schreiben öffnen</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>Autor: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>Verzeichnis existiert nicht:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>Kann files.json nicht zum Lesen öffnen.</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>Name:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>Kann keine Cheats anwenden, bevor das Spiel gestartet ist.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>Symbol</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>Name</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>Seriennummer</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>Region</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>Firmware</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>Größe</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>Version</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>Pfad</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>Spielzeit</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Never Played</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Compatibility is untested</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Game does not initialize properly / crashes the emulator</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Game boots, but only displays a blank screen</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Game displays an image but does not go past the menu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Game has game-breaking glitches or unplayable performance</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>Automatischer Aktualisierer</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>Fehler</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>Netzwerkfehler:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>Fehler beim Parsen der Aktualisierungsinformationen.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>Keine Vorabveröffentlichungen gefunden.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>Ungültige Versionsdaten.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>Keine Download-URL für das angegebene Asset gefunden.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>Ihre Version ist bereits aktuell!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>Aktualisierung verfügbar</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>Update-Kanal</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>Aktuelle Version</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>Neueste Version</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>Möchten Sie aktualisieren?</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>Änderungsprotokoll anzeigen</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Beim Start nach Updates suchen</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>Aktualisieren</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>Nein</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>Änderungsprotokoll ausblenden</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>Änderungen</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>Beim Zugriff auf die URL ist ein Netzwerkfehler aufgetreten</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>Download abgeschlossen</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>Die Aktualisierung wurde heruntergeladen, drücken Sie OK, um zu installieren.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>Fehler beim Speichern der Aktualisierungsdatei in</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>Aktualisierung wird gestartet...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>Fehler beim Erstellen der Aktualisierungs-Skriptdatei</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/el.ts
+++ b/src/qt_gui/translations/el.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>About shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 is an experimental open-source emulator for the PlayStation 4.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>This software should not be used to play games you have not legally obtained.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Open Folder</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Loading game list, please wait :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>Cancel</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Loading...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Choose directory</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Select which directory you want to install to.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Choose directory</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Directory to install games</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Browse</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>The value for location to install games is not valid.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>Create Shortcut</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>Kodikí / Enimeróseis</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>SFO Viewer</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophy Viewer</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>Άνοιγμα Φακέλου...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>Άνοιγμα Φακέλου Παιχνιδιού</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>Άνοιγμα Φακέλου Αποθηκευμένων Δεδομένων</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>Άνοιγμα Φακέλου Καταγραφής</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>Copy info...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>Copy Name</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>Copy Serial</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>Copy All</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Delete...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Delete Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Delete Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Delete DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>Shortcut creation</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>Shortcut created successfully!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>Error creating shortcut!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>Install PKG</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>This feature requires the 'Enable Separate Update Folder' config option to work. If you want to use this feature, please enable it.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>This game has no update to delete!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>This game has no DLC to delete!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Delete %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Are you sure you want to delete %1's %2 directory?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Open/Add Elf Folder</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>Install Packages (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Boot Game</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>Έλεγχος για ενημερώσεις</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>About shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Configure...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>Install application from a .pkg file</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Recent Games</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Exit</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>Exit shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Exit the application.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Show Game List</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Game List Refresh</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Tiny</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Small</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Medium</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Large</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>List View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Grid View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Elf Viewer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Game Install Directory</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>Κατεβάστε Κωδικούς / Ενημερώσεις</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Dump Game List</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>PKG Viewer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Search...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>File</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Game List Icons</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Game List Mode</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Settings</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Utils</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Themes</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>Βοήθεια</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Dark</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Light</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Green</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Blue</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Violet</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>toolBar</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>Λίστα παιχνιδιών</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * Μη υποστηριζόμενη έκδοση Vulkan</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>Λήψη Cheats για όλα τα εγκατεστημένα παιχνίδια</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>Λήψη Patches για όλα τα παιχνίδια</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Η λήψη ολοκληρώθηκε</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>Έχετε κατεβάσει cheats για όλα τα εγκατεστημένα παιχνίδια.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>Τα Patches κατέβηκαν επιτυχώς!</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>Όλα τα διαθέσιμα Patches για όλα τα παιχνίδια έχουν κατέβει.</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>Παιχνίδια: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>Αρχείο PKG (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>Αρχεία ELF (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>Εκκίνηση παιχνιδιού</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>Μπορεί να επιλεγεί μόνο ένα αρχείο!</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>Εξαγωγή PKG</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>Αναγνώριση ενημέρωσης!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>Οι εκδόσεις PKG και παιχνιδιού ταιριάζουν: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>Θέλετε να αντικαταστήσετε;</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>Η έκδοση PKG %1 είναι παλαιότερη από την εγκατεστημένη έκδοση: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>Το παιχνίδι είναι εγκατεστημένο: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>Θέλετε να εγκαταστήσετε την ενημέρωση: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>Εγκατάσταση DLC</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>Θέλετε να εγκαταστήσετε το DLC: %1;</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC ήδη εγκατεστημένο:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>Παιχνίδι ήδη εγκατεστημένο</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>Το PKG είναι patch, παρακαλώ εγκαταστήστε πρώτα το παιχνίδι!</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>ΣΦΑΛΜΑ PKG</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>Εξαγωγή PKG %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>Η εξαγωγή ολοκληρώθηκε</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>Το παιχνίδι εγκαταστάθηκε επιτυχώς στο %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>Η αρχείο δεν φαίνεται να είναι έγκυρο αρχείο PKG</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Open Folder</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophy Viewer</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Settings</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>General</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>System</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>Console Language</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Emulator Language</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Emulator</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Enable Fullscreen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Show Splash</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>Is PS4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Ενεργοποίηση Discord Rich Presence</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Username</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Logger</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Log Type</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Log Filter</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>Είσοδος</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>Δείκτης</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>Απόκρυψη δείκτη</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>Χρόνος αδράνειας απόκρυψης δείκτη</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>Controller</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>Συμπεριφορά κουμπιού επιστροφής</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Graphics</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Graphics Device</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Width</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Height</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Vblank Divider</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Advanced</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Enable Shaders Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>Enable NULL GPU</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>Διαδρομές</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>Φάκελοι παιχνιδιών</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>Προσθήκη...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>Αφαίρεση</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Debug</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Enable Debug Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Enable Vulkan Validation Layers</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Enable Vulkan Synchronization Validation</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>Enable RenderDoc Debugging</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>Ενημέρωση</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Έλεγχος για ενημερώσεις κατά την εκκίνηση</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>Κανάλι Ενημέρωσης</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>Έλεγχος για ενημερώσεις</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>Ρυθμίσεις GUI</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Disable Trophy Pop-ups</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>Αναπαραγωγή μουσικής τίτλου</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Update Compatibility Database On Startup</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Game Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Display Compatibility Data</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Update Compatibility Database</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>ένταση</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>Λίστα παιχνιδιών</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * Μη υποστηριζόμενη έκδοση Vulkan</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>Λήψη Cheats για όλα τα εγκατεστημένα παιχνίδια</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>Λήψη Patches για όλα τα παιχνίδια</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>Η λήψη ολοκληρώθηκε</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>Έχετε κατεβάσει cheats για όλα τα εγκατεστημένα παιχνίδια.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>Τα Patches κατέβηκαν επιτυχώς!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>Όλα τα διαθέσιμα Patches για όλα τα παιχνίδια έχουν κατέβει.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>Παιχνίδια: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>Αρχείο PKG (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>Αρχεία ELF (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>Εκκίνηση παιχνιδιού</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>Μπορεί να επιλεγεί μόνο ένα αρχείο!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>Εξαγωγή PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>Αναγνώριση ενημέρωσης!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>Οι εκδόσεις PKG και παιχνιδιού ταιριάζουν: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>Θέλετε να αντικαταστήσετε;</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>Η έκδοση PKG %1 είναι παλαιότερη από την εγκατεστημένη έκδοση: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>Το παιχνίδι είναι εγκατεστημένο: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>Θέλετε να εγκαταστήσετε την ενημέρωση: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>Εγκατάσταση DLC</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>Θέλετε να εγκαταστήσετε το DLC: %1;</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC ήδη εγκατεστημένο:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>Παιχνίδι ήδη εγκατεστημένο</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>Το PKG είναι patch, παρακαλώ εγκαταστήστε πρώτα το παιχνίδι!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>ΣΦΑΛΜΑ PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>Εξαγωγή PKG %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>Η εξαγωγή ολοκληρώθηκε</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>Το παιχνίδι εγκαταστάθηκε επιτυχώς στο %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>Η αρχείο δεν φαίνεται να είναι έγκυρο αρχείο PKG</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Cheats / Patches for </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>Οι cheats/patches είναι πειραματικά.\nΧρησιμοποιήστε τα με προσοχή.\n\nΚατεβάστε τους cheats μεμονωμένα επιλέγοντας το αποθετήριο και κάνοντας κλικ στο κουμπί λήψης.\nΣτην καρτέλα Patches, μπορείτε να κατεβάσετε όλα τα patches ταυτόχρονα, να επιλέξετε ποια θέλετε να χρησιμοποιήσετε και να αποθηκεύσετε την επιλογή.\n\nΔεδομένου ότι δεν αναπτύσσουμε τους cheats/patches,\nπαρακαλώ αναφέρετε προβλήματα στον δημιουργό του cheat.\n\nΔημιουργήσατε ένα νέο cheat; Επισκεφθείτε:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>Δεν διατίθεται εικόνα</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>Σειριακός αριθμός: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>Έκδοση: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>Μέγεθος: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>Επιλέξτε αρχείο Cheat:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>Αποθετήριο:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>Λήψη Cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>Διαγραφή αρχείου</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>Δεν έχουν επιλεγεί αρχεία.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>Μπορείτε να διαγράψετε τα cheats που δεν θέλετε μετά τη λήψη τους.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>Θέλετε να διαγράψετε το επιλεγμένο αρχείο;\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>Επιλέξτε αρχείο Patch:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>Λήψη Patches</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>Αποθήκευση</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>Cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>Patches</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>Σφάλμα</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>Δεν έχει επιλεγεί κανένα patch.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>Αδυναμία ανοίγματος του files.json για ανάγνωση.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>Δεν βρέθηκε αρχείο patch για τον τρέχοντα σειριακό αριθμό.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>Αδυναμία ανοίγματος του αρχείου για ανάγνωση.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>Αδυναμία ανοίγματος του αρχείου για εγγραφή.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>Αποτυχία ανάλυσης XML: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>Επιτυχία</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>Οι ρυθμίσεις αποθηκεύτηκαν επιτυχώς.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>Μη έγκυρη Πηγή</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>Η επιλεγμένη πηγή είναι μη έγκυρη.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>Η αρχείο υπάρχει</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>Η αρχείο υπάρχει ήδη. Θέλετε να την αντικαταστήσετε;</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>Αποτυχία αποθήκευσης αρχείου:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>Αποτυχία λήψης αρχείου:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>Δεν βρέθηκαν Cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>Δεν βρέθηκαν cheats για αυτό το παιχνίδι στην τρέχουσα έκδοση του επιλεγμένου αποθετηρίου. Δοκιμάστε να κατεβάσετε από άλλο αποθετήριο ή άλλη έκδοση του παιχνιδιού.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>Cheats κατεβάστηκαν επιτυχώς</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>Κατεβάσατε επιτυχώς cheats για αυτή την έκδοση του παιχνιδιού από το επιλεγμένο αποθετήριο. Μπορείτε να δοκιμάσετε να κατεβάσετε από άλλο αποθετήριο. Αν είναι διαθέσιμο, μπορείτε να το επιλέξετε επιλέγοντας το αρχείο από τη λίστα.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>Αποτυχία αποθήκευσης:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>Αποτυχία λήψης:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>Η λήψη ολοκληρώθηκε</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>Τα Patches κατεβάστηκαν επιτυχώς! Όλα τα Patches για όλα τα παιχνίδια έχουν κατέβει, δεν είναι απαραίτητο να τα κατεβάσετε ένα-ένα για κάθε παιχνίδι, όπως με τα Cheats. Εάν η ενημέρωση δεν εμφανίζεται, μπορεί να μην υπάρχει για τον συγκεκριμένο σειριακό αριθμό και έκδοση του παιχνιδιού.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>Αποτυχία ανάλυσης δεδομένων JSON από HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>Αποτυχία ανάκτησης σελίδας HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>Το παιχνίδι είναι στην έκδοση: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>Η ληφθείσα ενημέρωση λειτουργεί μόνο στην έκδοση: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>Μπορεί να χρειαστεί να ενημερώσετε το παιχνίδι σας.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>Ειδοποίηση ασυμβατότητας</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>Αποτυχία ανοίγματος αρχείου:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>ΣΦΑΛΜΑ XML:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>Αποτυχία ανοίγματος του files.json για εγγραφή</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>Συγγραφέας: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>Ο φάκελος δεν υπάρχει:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>Αποτυχία ανοίγματος του files.json για ανάγνωση.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>Όνομα:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>Δεν μπορείτε να εφαρμόσετε cheats πριν ξεκινήσει το παιχνίδι.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>Αποθήκευση</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>Εφαρμογή</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>Επαναφορά Προεπιλογών</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>Κλείσιμο</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>Τοποθετήστε το ποντίκι σας πάνω σε μια επιλογή για να εμφανίσετε την περιγραφή της.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Γλώσσα Κονσόλας:\nΡυθμίζει τη γλώσσα που θα χρησιμοποιήσει το παιχνίδι PS4.\nΣυνιστάται να επιλέξετε μία από τις γλώσσες που υποστηρίζονται από το παιχνίδι, η οποία ενδέχεται να διαφέρει ανάλογα με την περιοχή.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>Γλώσσα Εξομοιωτή:\nΡυθμίζει τη γλώσσα του γραφικού περιβάλλοντος του εξομοιωτή.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>Ενεργοποίηση Πλήρους Οθόνης:\nΑυτόματα μετατρέπει το παράθυρο του παιχνιδιού σε λειτουργία πλήρους οθόνης.\nΜπορεί να ενεργοποιηθεί/απενεργοποιηθεί πατώντας το πλήκτρο F11.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Enable Separate Update Folder:\nEnables installing game updates into a separate folder for easy management.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>Εμφάνιση Splash Screen:\nΕμφανίζει ειδική γραφική οθόνη κατά την εκκίνηση.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>Είναι PS4 Pro:\nΕπιτρέπει στον εξομοιωτή να λειτουργεί σαν PS4 PRO, κάτι που μπορεί να ενεργοποιήσει συγκεκριμένες λειτουργίες σε παιχνίδια που το υποστηρίζουν.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>Ενεργοποίηση Discord Rich Presence:\nΕμφανίζει το εικονίδιο του emulator και σχετικές πληροφορίες στο προφίλ σας στο Discord.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>Όνομα Χρήστη:\nΟρίζει το όνομα του λογαριασμού PS4, το οποίο μπορεί να εμφανιστεί σε ορισμένα παιχνίδια.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>Τύπος Καταγραφής:\nΚαθορίζει αν η έξοδος του παραθύρου καταγραφής θα συγχρονιστεί για αύξηση της απόδοσης. Αυτό μπορεί να επηρεάσει αρνητικά τις επιδόσεις του εξομοιωτή.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Φίλτρο Καταγραφής:\nΦιλτράρει τις καταγραφές ώστε να εκτυπώνονται μόνο συγκεκριμένες πληροφορίες.\nΠαραδείγματα: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" Επίπεδα: Trace, Debug, Info, Warning, Error, Critical - με τη σειρά αυτή, κάθε επίπεδο που επιλέγεται αποκλείει τα προηγούμενα και εμφανίζει τα επόμενα επίπεδα.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>Ενημερώσεις:\nRelease: Επίσημες εκδόσεις που κυκλοφορούν μηνιαίως, είναι παλαιότερες αλλά πιο σταθερές και δοκιμασμένες.\nNightly: Εκδόσεις προγραμματιστών με νέες δυνατότητες και διορθώσεις, αλλά μπορεί να περιέχουν σφάλματα και να είναι λιγότερο σταθερές.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Αναπαραγωγή Μουσικής Τίτλων:\nΕάν το παιχνίδι το υποστηρίζει, ενεργοποιεί ειδική μουσική κατά την επιλογή του παιχνιδιού από τη διεπαφή χρήστη.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Disable Trophy Pop-ups:\nDisable in-game trophy notifications. Trophy progress can still be tracked using the Trophy Viewer (right-click the game in the main window).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>Απόκρυψη Κέρσορα:\nΕπιλέξτε πότε θα εξαφανιστεί ο κέρσορας:\nΠοτέ: θα βλέπετε πάντα το ποντίκι.\nΑδρανές: ορίστε έναν χρόνο για να εξαφανιστεί μετά από αδράνεια.\nΠάντα: δεν θα δείτε ποτέ το ποντίκι.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>Ορίστε έναν χρόνο για να εξαφανιστεί το ποντίκι μετά από αδράνεια.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>Συμπεριφορά Κουμπιού Επιστροφής:\nΟρίζει το κουμπί επιστροφής του ελεγκτή να προσομοιώνει το πάτημα της καθορισμένης θέσης στην οθόνη αφής PS4.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Display Compatibility Data:\nDisplays game compatibility information in table view. Enable "Update Compatibility On Startup" to get up-to-date information.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Update Compatibility On Startup:\nAutomatically update the compatibility database when shadPS4 starts.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Update Compatibility Database:\nImmediately update the compatibility database.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>Ποτέ</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>Αδρανής</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>Πάντα</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>Touchpad Αριστερά</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>Touchpad Δεξιά</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>Κέντρο Touchpad</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>Κανένα</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>Προσαρμογέας Γραφικών:\nΣε συστήματα με πολλές GPU, επιλέξτε από το μενού την GPU που θα χρησιμοποιήσει ο εξομοιωτής,\nή επιλέξτε "Auto Select" για αυτόματη επιλογή.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Ανάλυση Οθόνης:\nΚαθορίζει το μέγεθος του παραθύρου του εξομοιωτή κατά την αναπαραγωγή, το οποίο μπορεί να αλλάξει κατά τη διάρκεια του παιχνιδιού.\nΑυτό είναι διαφορετικό από την ανάλυση του ίδιου του παιχνιδιού.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Διαιρέτης Συχνότητας Ανανέωσης:\nΠολλαπλασιάζει τον ρυθμό με τον οποίο ο εξομοιωτής ενημερώνει την εικόνα με αυτόν τον αριθμό. Η αλλαγή αυτής της ρύθμισης μπορεί να έχει αρνητικές επιπτώσεις, όπως ταχύτερο παιχνίδι ή σπασμένες λειτουργίες!</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>Ενεργοποίηση Καταγραφής Σκιάσεων (Shaders):\nΓια τεχνικό εντοπισμό σφαλμάτων, αποθηκεύει τις σκιάσεις του παιχνιδιού σε φάκελο κατά τη διάρκεια της αναπαραγωγής.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Ενεργοποίηση Εικονικής GPU:\nΓια τεχνικό εντοπισμό σφαλμάτων, απενεργοποιεί την εμφάνιση του παιχνιδιού σαν να μην υπάρχει κάρτα γραφικών.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>Φάκελοι Παιχνιδιών:\nΗ λίστα των φακέλων για έλεγχο των εγκατεστημένων παιχνιδιών.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>Προσθήκη:\nΠροσθέστε έναν φάκελο στη λίστα.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>Αφαίρεση:\nΑφαιρέστε έναν φάκελο από τη λίστα.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>Ενεργοποίηση Καταγραφής Αποσφαλμάτωσης:\nΑποθηκεύει τα σύμβολα εισαγωγής/εξαγωγής και τις κεφαλίδες πληροφοριών του τρέχοντος προγράμματος PS4 σε έναν φάκελο.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Ενεργοποίηση Επικύρωσης Vulkan:\nΕνεργοποιεί ένα σύστημα που επικυρώνει την κατάσταση του προγράμματος οδήγησης Vulkan και καταγράφει πληροφορίες για την εσωτερική του κατάσταση. Αυτό θα μειώσει την απόδοση και ενδέχεται να αλλάξει τη συμπεριφορά του εξομοιωτή.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Ενεργοποίηση Επικύρωσης Συγχρονισμού Vulkan:\nΕνεργοποιεί ένα σύστημα που επικυρώνει τον συγχρονισμό των εργασιών απόδοσης του Vulkan. Αυτό θα μειώσει την απόδοση και ενδέχεται να αλλάξει τη συμπεριφορά του εξομοιωτή.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>Ενεργοποίηση Καταγραφής RenderDoc:\nΌταν είναι ενεργοποιημένο, ο εξομοιωτής είναι συμβατός με το RenderDoc για τη λήψη και ανάλυση του τρέχοντος καρέ.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Cheats / Patches for </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>Οι cheats/patches είναι πειραματικά.\nΧρησιμοποιήστε τα με προσοχή.\n\nΚατεβάστε τους cheats μεμονωμένα επιλέγοντας το αποθετήριο και κάνοντας κλικ στο κουμπί λήψης.\nΣτην καρτέλα Patches, μπορείτε να κατεβάσετε όλα τα patches ταυτόχρονα, να επιλέξετε ποια θέλετε να χρησιμοποιήσετε και να αποθηκεύσετε την επιλογή.\n\nΔεδομένου ότι δεν αναπτύσσουμε τους cheats/patches,\nπαρακαλώ αναφέρετε προβλήματα στον δημιουργό του cheat.\n\nΔημιουργήσατε ένα νέο cheat; Επισκεφθείτε:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>Δεν διατίθεται εικόνα</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>Σειριακός αριθμός: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>Έκδοση: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>Μέγεθος: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>Επιλέξτε αρχείο Cheat:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>Αποθετήριο:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>Λήψη Cheats</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>Διαγραφή αρχείου</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>Δεν έχουν επιλεγεί αρχεία.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>Μπορείτε να διαγράψετε τα cheats που δεν θέλετε μετά τη λήψη τους.</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>Θέλετε να διαγράψετε το επιλεγμένο αρχείο;\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>Επιλέξτε αρχείο Patch:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>Λήψη Patches</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>Αποθήκευση</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>Cheats</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>Patches</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Σφάλμα</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>Δεν έχει επιλεγεί κανένα patch.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>Αδυναμία ανοίγματος του files.json για ανάγνωση.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>Δεν βρέθηκε αρχείο patch για τον τρέχοντα σειριακό αριθμό.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>Αδυναμία ανοίγματος του αρχείου για ανάγνωση.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>Αδυναμία ανοίγματος του αρχείου για εγγραφή.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>Αποτυχία ανάλυσης XML: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>Επιτυχία</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>Οι ρυθμίσεις αποθηκεύτηκαν επιτυχώς.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>Μη έγκυρη Πηγή</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>Η επιλεγμένη πηγή είναι μη έγκυρη.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>Η αρχείο υπάρχει</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>Η αρχείο υπάρχει ήδη. Θέλετε να την αντικαταστήσετε;</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>Αποτυχία αποθήκευσης αρχείου:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>Αποτυχία λήψης αρχείου:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>Δεν βρέθηκαν Cheats</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>Δεν βρέθηκαν cheats για αυτό το παιχνίδι στην τρέχουσα έκδοση του επιλεγμένου αποθετηρίου. Δοκιμάστε να κατεβάσετε από άλλο αποθετήριο ή άλλη έκδοση του παιχνιδιού.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>Cheats κατεβάστηκαν επιτυχώς</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>Κατεβάσατε επιτυχώς cheats για αυτή την έκδοση του παιχνιδιού από το επιλεγμένο αποθετήριο. Μπορείτε να δοκιμάσετε να κατεβάσετε από άλλο αποθετήριο. Αν είναι διαθέσιμο, μπορείτε να το επιλέξετε επιλέγοντας το αρχείο από τη λίστα.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>Αποτυχία αποθήκευσης:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>Αποτυχία λήψης:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Η λήψη ολοκληρώθηκε</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>Τα Patches κατεβάστηκαν επιτυχώς! Όλα τα Patches για όλα τα παιχνίδια έχουν κατέβει, δεν είναι απαραίτητο να τα κατεβάσετε ένα-ένα για κάθε παιχνίδι, όπως με τα Cheats. Εάν η ενημέρωση δεν εμφανίζεται, μπορεί να μην υπάρχει για τον συγκεκριμένο σειριακό αριθμό και έκδοση του παιχνιδιού.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>Αποτυχία ανάλυσης δεδομένων JSON από HTML.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>Αποτυχία ανάκτησης σελίδας HTML.</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>Το παιχνίδι είναι στην έκδοση: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>Η ληφθείσα ενημέρωση λειτουργεί μόνο στην έκδοση: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>Μπορεί να χρειαστεί να ενημερώσετε το παιχνίδι σας.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>Ειδοποίηση ασυμβατότητας</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>Αποτυχία ανοίγματος αρχείου:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>ΣΦΑΛΜΑ XML:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>Αποτυχία ανοίγματος του files.json για εγγραφή</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>Συγγραφέας: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>Ο φάκελος δεν υπάρχει:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>Αποτυχία ανοίγματος του files.json για ανάγνωση.</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>Όνομα:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>Δεν μπορείτε να εφαρμόσετε cheats πριν ξεκινήσει το παιχνίδι.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>Εικονίδιο</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>Όνομα</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>Σειριακός αριθμός</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>Περιοχή</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>Λογισμικό</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>Μέγεθος</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>Έκδοση</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>Διαδρομή</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>Χρόνος παιχνιδιού</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Never Played</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Compatibility is untested</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Game does not initialize properly / crashes the emulator</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Game boots, but only displays a blank screen</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Game displays an image but does not go past the menu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Game has game-breaking glitches or unplayable performance</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>Αυτόματος Ενημερωτής</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>Σφάλμα</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>Σφάλμα δικτύου:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>Αποτυχία ανάλυσης πληροφοριών ενημέρωσης.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>Δεν βρέθηκαν προ-κυκλοφορίες.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>Μη έγκυρα δεδομένα έκδοσης.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>Δεν βρέθηκε URL λήψης για το συγκεκριμένο στοιχείο.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>Η έκδοσή σας είναι ήδη ενημερωμένη!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>Διαθέσιμη Ενημέρωση</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>Κανάλι Ενημέρωσης</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>Τρέχουσα Έκδοση</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>Τελευταία Έκδοση</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>Θέλετε να ενημερώσετε;</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>Εμφάνιση Ιστορικού Αλλαγών</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Έλεγχος για ενημερώσεις κατά την εκκίνηση</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>Ενημέρωση</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>Όχι</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>Απόκρυψη Ιστορικού Αλλαγών</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>Αλλαγές</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>Σφάλμα δικτύου κατά την προσπάθεια πρόσβασης στη διεύθυνση URL</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>Λήψη ολοκληρώθηκε</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>Η ενημέρωση έχει ληφθεί, πατήστε OK για να εγκαταστήσετε.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>Αποτυχία αποθήκευσης του αρχείου ενημέρωσης στο</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>Εκκίνηση Ενημέρωσης...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>Αποτυχία δημιουργίας του αρχείου σεναρίου ενημέρωσης</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/en.ts
+++ b/src/qt_gui/translations/en.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>About shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 is an experimental open-source emulator for the PlayStation 4.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>This software should not be used to play games you have not legally obtained.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Open Folder</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Loading game list, please wait :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>Cancel</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Loading...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Choose directory</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Select which directory you want to install to.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Choose directory</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Directory to install games</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Browse</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>The value for location to install games is not valid.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>Create Shortcut</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>Cheats / Patches</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>SFO Viewer</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophy Viewer</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>Open Folder...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>Open Game Folder</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>Open Save Data Folder</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>Open Log Folder</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>Copy info...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>Copy Name</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>Copy Serial</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>Copy All</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Delete...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Delete Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Delete Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Delete DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>Shortcut creation</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>Shortcut created successfully!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>Error creating shortcut!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>Install PKG</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>This feature requires the 'Enable Separate Update Folder' config option to work. If you want to use this feature, please enable it.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>This game has no update to delete!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>This game has no DLC to delete!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Delete %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Are you sure you want to delete %1's %2 directory?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Open/Add Elf Folder</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>Install Packages (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Boot Game</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>Check for Updates</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>About shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Configure...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>Install application from a .pkg file</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Recent Games</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Exit</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>Exit shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Exit the application.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Show Game List</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Game List Refresh</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Tiny</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Small</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Medium</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Large</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>List View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Grid View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Elf Viewer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Game Install Directory</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>Download Cheats / Patches</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Dump Game List</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>PKG Viewer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Search...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>File</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Game List Icons</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Game List Mode</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Settings</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Utils</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Themes</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>Help</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Dark</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Light</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Green</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Blue</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Violet</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>toolBar</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>Game List</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * Unsupported Vulkan Version</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>Download Cheats For All Installed Games</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>Download Patches For All Games</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Download Complete</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>You have downloaded cheats for all the games you have installed.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>Patches Downloaded Successfully!</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>All Patches available for all games have been downloaded.</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>Games: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>PKG File (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>ELF files (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>Game Boot</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>Only one file can be selected!</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>PKG Extraction</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>Patch detected!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>PKG and Game versions match: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>Would you like to overwrite?</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>PKG Version %1 is older than installed version: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>Game is installed: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>Would you like to install Patch: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>DLC Installation</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>Would you like to install DLC: %1?</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC already installed:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>Game already installed</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>PKG is a patch, please install the game first!</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>PKG ERROR</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>Extracting PKG %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>Extraction Finished</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>Game successfully installed at %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>File doesn't appear to be a valid PKG file</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Open Folder</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophy Viewer</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Settings</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>General</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>System</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>Console Language</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Emulator Language</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Emulator</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Enable Fullscreen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Show Splash</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>Is PS4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Enable Discord Rich Presence</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Username</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Logger</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Log Type</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Log Filter</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>Input</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>Cursor</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>Hide Cursor</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>Hide Cursor Idle Timeout</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>Controller</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>Back Button Behavior</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Graphics</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Graphics Device</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Width</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Height</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Vblank Divider</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Advanced</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Enable Shaders Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>Enable NULL GPU</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>Paths</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>Game Folders</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>Add...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>Remove</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Debug</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Enable Debug Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Enable Vulkan Validation Layers</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Enable Vulkan Synchronization Validation</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>Enable RenderDoc Debugging</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>Update</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Check for Updates at Startup</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>Update Channel</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>Check for Updates</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>GUI Settings</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Disable Trophy Pop-ups</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>Play title music</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Update Compatibility Database On Startup</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Game Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Display Compatibility Data</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Update Compatibility Database</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>Volume</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>Game List</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * Unsupported Vulkan Version</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>Download Cheats For All Installed Games</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>Download Patches For All Games</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>Download Complete</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>You have downloaded cheats for all the games you have installed.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>Patches Downloaded Successfully!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>All Patches available for all games have been downloaded.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>Games: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>PKG File (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>ELF files (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>Game Boot</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>Only one file can be selected!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>PKG Extraction</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>Patch detected!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>PKG and Game versions match: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>Would you like to overwrite?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>PKG Version %1 is older than installed version: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>Game is installed: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>Would you like to install Patch: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>DLC Installation</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>Would you like to install DLC: %1?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC already installed:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>Game already installed</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>PKG is a patch, please install the game first!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>PKG ERROR</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>Extracting PKG %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>Extraction Finished</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>Game successfully installed at %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>File doesn't appear to be a valid PKG file</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Cheats / Patches for </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>Cheats/Patches are experimental.\nUse with caution.\n\nDownload cheats individually by selecting the repository and clicking the download button.\nIn the Patches tab, you can download all patches at once, choose which ones you want to use, and save your selection.\n\nSince we do not develop the Cheats/Patches,\nplease report issues to the cheat author.\n\nCreated a new cheat? Visit:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>No Image Available</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>Serial: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>Version: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>Size: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>Select Cheat File:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>Repository:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>Download Cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>Delete File</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>No files selected.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>You can delete the cheats you don't want after downloading them.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>Do you want to delete the selected file?\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>Select Patch File:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>Download Patches</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>Save</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>Cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>Patches</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>Error</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>No patch selected.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>Unable to open files.json for reading.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>No patch file found for the current serial.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>Unable to open the file for reading.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>Unable to open the file for writing.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>Failed to parse XML: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>Success</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>Options saved successfully.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>Invalid Source</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>The selected source is invalid.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>File Exists</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>File already exists. Do you want to replace it?</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>Failed to save file:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>Failed to download file:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>Cheats Not Found</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>No Cheats found for this game in this version of the selected repository,try another repository or a different version of the game.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>Cheats Downloaded Successfully</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>You have successfully downloaded the cheats for this version of the game from the selected repository. You can try downloading from another repository, if it is available it will also be possible to use it by selecting the file from the list.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>Failed to save:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>Failed to download:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>Download Complete</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>Patches Downloaded Successfully! All Patches available for all games have been downloaded, there is no need to download them individually for each game as happens in Cheats. If the patch does not appear, it may be that it does not exist for the specific serial and version of the game.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>Failed to parse JSON data from HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>Failed to retrieve HTML page.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>The game is in version: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>The downloaded patch only works on version: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>You may need to update your game.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>Incompatibility Notice</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>Failed to open file:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>XML ERROR:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>Failed to open files.json for writing</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>Author: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>Directory does not exist:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>Failed to open files.json for reading.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>Name:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>Can't apply cheats before the game is started.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>Save</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>Apply</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>Restore Defaults</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>Close</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>Point your mouse at an option to display its description.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Console Language:\nSets the language that the PS4 game uses.\nIt's recommended to set this to a language the game supports, which will vary by region.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>Emulator Language:\nSets the language of the emulator's user interface.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>Enable Full Screen:\nAutomatically puts the game window into full-screen mode.\nThis can be toggled by pressing the F11 key.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Enable Separate Update Folder:\nEnables installing game updates into a separate folder for easy management.\nThis can be manually created by adding the extracted update to the game folder with the name "CUSA00000-UPDATE" where the CUSA ID matches the game's ID.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>Show Splash Screen:\nShows the game's splash screen (a special image) while the game is starting.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>Is PS4 Pro:\nMakes the emulator act as a PS4 PRO, which may enable special features in games that support it.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>Enable Discord Rich Presence:\nDisplays the emulator icon and relevant information on your Discord profile.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>Username:\nSets the PS4's account username, which may be displayed by some games.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>Log Type:\nSets whether to synchronize the output of the log window for performance. May have adverse effects on emulation.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Log Filter:\nFilters the log to only print specific information.\nExamples: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical"\nLevels: Trace, Debug, Info, Warning, Error, Critical - in this order, a specific level silences all levels preceding it in the list and logs every level after it.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>Update:\nRelease: Official versions released every month that may be very outdated, but are more reliable and tested.\nNightly: Development versions that have all the latest features and fixes, but may contain bugs and are less stable.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Play Title Music:\nIf a game supports it, enable playing special music when selecting the game in the GUI.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Disable Trophy Pop-ups:\nDisable in-game trophy notifications. Trophy progress can still be tracked using the Trophy Viewer (right-click the game in the main window).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>Hide Cursor:\nChoose when the cursor will disappear:\nNever: You will always see the mouse.\nidle: Set a time for it to disappear after being idle.\nAlways: you will never see the mouse.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>Hide Idle Cursor Timeout:\nThe duration (seconds) after which the cursor that has been idle hides itself.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>Back Button Behavior:\nSets the controller's back button to emulate tapping the specified position on the PS4 touchpad.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Display Compatibility Data:\nDisplays game compatibility information in table view. Enable "Update Compatibility On Startup" to get up-to-date information.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Update Compatibility On Startup:\nAutomatically update the compatibility database when shadPS4 starts.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Update Compatibility Database:\nImmediately update the compatibility database.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>Never</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>Idle</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>Always</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>Touchpad Left</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>Touchpad Right</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>Touchpad Center</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>None</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>Graphics Device:\nOn multiple GPU systems, select the GPU the emulator will use from the drop down list,\nor select "Auto Select" to automatically determine it.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Width/Height:\nSets the size of the emulator window at launch, which can be resized during gameplay.\nThis is different from the in-game resolution.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Vblank Divider:\nThe frame rate at which the emulator refreshes at is multiplied by this number. Changing this may have adverse effects, such as increasing the game speed, or breaking critical game functionality that does not expect this to change!</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>Enable Shaders Dumping:\nFor the sake of technical debugging, saves the games shaders to a folder as they render.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Enable Null GPU:\nFor the sake of technical debugging, disables game rendering as if there were no graphics card.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>Game Folders:\nThe list of folders to check for installed games.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>Add:\nAdd a folder to the list.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>Remove:\nRemove a folder from the list.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>Enable Debug Dumping:\nSaves the import and export symbols and file header information of the currently running PS4 program to a directory.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Enable Vulkan Validation Layers:\nEnables a system that validates the state of the Vulkan renderer and logs information about its internal state.\nThis will reduce performance and likely change the behavior of emulation.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Enable Vulkan Synchronization Validation:\nEnables a system that validates the timing of Vulkan rendering tasks.\nThis will reduce performance and likely change the behavior of emulation.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>Enable RenderDoc Debugging:\nIf enabled, the emulator will provide compatibility with Renderdoc to allow capture and analysis of the currently rendered frame.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Cheats / Patches for </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>Cheats/Patches are experimental.\nUse with caution.\n\nDownload cheats individually by selecting the repository and clicking the download button.\nIn the Patches tab, you can download all patches at once, choose which ones you want to use, and save your selection.\n\nSince we do not develop the Cheats/Patches,\nplease report issues to the cheat author.\n\nCreated a new cheat? Visit:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>No Image Available</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>Serial: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>Version: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>Size: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>Select Cheat File:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>Repository:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>Download Cheats</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>Delete File</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>No files selected.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>You can delete the cheats you don't want after downloading them.</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>Do you want to delete the selected file?\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>Select Patch File:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>Download Patches</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>Save</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>Cheats</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>Patches</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Error</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>No patch selected.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>Unable to open files.json for reading.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>No patch file found for the current serial.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>Unable to open the file for reading.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>Unable to open the file for writing.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>Failed to parse XML: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>Success</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>Options saved successfully.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>Invalid Source</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>The selected source is invalid.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>File Exists</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>File already exists. Do you want to replace it?</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>Failed to save file:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>Failed to download file:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>Cheats Not Found</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>No Cheats found for this game in this version of the selected repository,try another repository or a different version of the game.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>Cheats Downloaded Successfully</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>You have successfully downloaded the cheats for this version of the game from the selected repository. You can try downloading from another repository, if it is available it will also be possible to use it by selecting the file from the list.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>Failed to save:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>Failed to download:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Download Complete</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>Patches Downloaded Successfully! All Patches available for all games have been downloaded, there is no need to download them individually for each game as happens in Cheats. If the patch does not appear, it may be that it does not exist for the specific serial and version of the game.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>Failed to parse JSON data from HTML.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>Failed to retrieve HTML page.</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>The game is in version: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>The downloaded patch only works on version: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>You may need to update your game.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>Incompatibility Notice</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>Failed to open file:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>XML ERROR:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>Failed to open files.json for writing</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>Author: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>Directory does not exist:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>Failed to open files.json for reading.</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>Name:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>Can't apply cheats before the game is started.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>Icon</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>Name</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>Serial</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>Region</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>Firmware</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>Size</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>Version</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>Path</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>Play Time</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Never Played</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Compatibility is untested</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Game does not initialize properly / crashes the emulator</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Game boots, but only displays a blank screen</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Game displays an image but does not go past the menu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Game has game-breaking glitches or unplayable performance</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>Auto Updater</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>Network error:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>Failed to parse update information.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>No pre-releases found.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>Invalid release data.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>No download URL found for the specified asset.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>Your version is already up to date!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>Update Available</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>Update Channel</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>Current Version</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>Latest Version</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>Do you want to update?</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>Show Changelog</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Check for Updates at Startup</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>Update</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>No</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>Hide Changelog</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>Changes</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>Network error occurred while trying to access the URL</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>Download Complete</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>The update has been downloaded, press OK to install.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>Failed to save the update file at</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>Starting Update...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>Failed to create the update script file</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/es_ES.ts
+++ b/src/qt_gui/translations/es_ES.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>Acerca de shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 es un emulador experimental de código abierto para la PlayStation 4.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>Este software no debe utilizarse para jugar juegos que hayas obtenido ilegalmente.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Abrir carpeta</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Cargando lista de juegos, por favor espera :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>Cancelar</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Cargando...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Elegir carpeta</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Select which directory you want to install to.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Elegir carpeta</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Carpeta para instalar juegos</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Buscar</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>El valor para la ubicación de instalación de los juegos no es válido.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>Crear acceso directo</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>Trucos / Parches</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>Vista SFO</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>Ver trofeos</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>Abrir Carpeta...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>Abrir Carpeta del Juego</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>Abrir Carpeta de Datos Guardados</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>Abrir Carpeta de Registros</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>Copiar información...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>Copiar nombre</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>Copiar número de serie</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>Copiar todo</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Delete...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Delete Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Delete Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Delete DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>Acceso directo creado</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>¡Acceso directo creado con éxito!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>¡Error al crear el acceso directo!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>Instalar PKG</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>This feature requires the 'Enable Separate Update Folder' config option to work. If you want to use this feature, please enable it.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>This game has no update to delete!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>This game has no DLC to delete!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Delete %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Are you sure you want to delete %1's %2 directory?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Abrir/Agregar carpeta Elf</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>Instalar paquetes (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Iniciar juego</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>Buscar actualizaciones</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>Acerca de shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Configurar...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>Instalar aplicación desde un archivo .pkg</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Juegos recientes</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Salir</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>Salir de shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Salir de la aplicación.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Mostrar lista de juegos</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Actualizar lista de juegos</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Muy pequeño</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Pequeño</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Mediano</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Grande</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>Vista de lista</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Vista de cuadrícula</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Vista Elf</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Carpeta de instalación de los juegos</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>Descargar Trucos / Parches</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Volcar lista de juegos</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>Vista PKG</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Buscar...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>Archivo</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>Vista</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Iconos de los juegos</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Tipo de lista</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Configuración</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Utilidades</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Temas</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>Ayuda</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Oscuro</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Claro</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Verde</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Azul</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Violeta</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>Barra de herramientas</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>Lista de juegos</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * Versión de Vulkan no soportada</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>Descargar trucos para todos los juegos instalados</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>Descargar parches para todos los juegos</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Descarga completa</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>Has descargado trucos para todos los juegos que tienes instalados.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>¡Parches descargados exitosamente!</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>Todos los parches disponibles han sido descargados para todos los juegos.</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>Juegos: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>Archivo PKG (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>Archivos ELF (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>Inicio del juego</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>¡Solo se puede seleccionar un archivo!</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>Extracción de PKG</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>¡Actualización detectada!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>Las versiones de PKG y del juego coinciden: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>¿Desea sobrescribir?</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>La versión de PKG %1 es más antigua que la versión instalada: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>El juego está instalado: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>¿Desea instalar la actualización: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>Instalación de DLC</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>¿Desea instalar el DLC: %1?</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC ya instalado:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>Juego ya instalado</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>PKG es un parche, ¡por favor instala el juego primero!</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>ERROR PKG</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>Extrayendo PKG %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>Extracción terminada</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>Juego instalado exitosamente en %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>El archivo parece no ser un archivo PKG válido</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Abrir carpeta</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Vista de trofeos</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Configuración</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>General</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>Sistema</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>Idioma de la consola</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Idioma del emulador</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Emulador</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Habilitar pantalla completa</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Mostrar splash</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>Modo PS4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Habilitar Discord Rich Presence</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Nombre de usuario</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Registro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Tipo de registro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Filtro de registro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>Entrada</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>Cursor</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>Ocultar cursor</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>Tiempo de espera para ocultar cursor inactivo</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>Controlador</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>Comportamiento del botón de retroceso</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Gráficos</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Dispositivo gráfico</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Ancho</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Alto</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Divisor de Vblank</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Avanzado</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Habilitar volcado de shaders</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>Habilitar GPU NULL</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>Rutas</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>Carpetas de juego</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>Añadir...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>Eliminar</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Depuración</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Habilitar volcado de depuración</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Habilitar capas de validación de Vulkan</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Habilitar validación de sincronización de Vulkan</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>Habilitar depuración de RenderDoc</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>Actualización</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Buscar actualizaciones al iniciar</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>Canal de Actualización</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>Verificar actualizaciones</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>Configuraciones de la Interfaz</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Disable Trophy Pop-ups</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>Reproducir la música de apertura</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Update Compatibility Database On Startup</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Game Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Display Compatibility Data</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Update Compatibility Database</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>Volumen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>Lista de juegos</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * Versión de Vulkan no soportada</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>Descargar trucos para todos los juegos instalados</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>Descargar parches para todos los juegos</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>Descarga completa</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>Has descargado trucos para todos los juegos que tienes instalados.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>¡Parches descargados exitosamente!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>Todos los parches disponibles han sido descargados para todos los juegos.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>Juegos: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>Archivo PKG (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>Archivos ELF (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>Inicio del juego</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>¡Solo se puede seleccionar un archivo!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>Extracción de PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>¡Actualización detectada!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>Las versiones de PKG y del juego coinciden: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>¿Desea sobrescribir?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>La versión de PKG %1 es más antigua que la versión instalada: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>El juego está instalado: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>¿Desea instalar la actualización: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>Instalación de DLC</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>¿Desea instalar el DLC: %1?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC ya instalado:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>Juego ya instalado</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>PKG es un parche, ¡por favor instala el juego primero!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>ERROR PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>Extrayendo PKG %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>Extracción terminada</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>Juego instalado exitosamente en %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>El archivo parece no ser un archivo PKG válido</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Cheats / Patches for </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>Los cheats/patches son experimentales.\nÚselos con precaución.\n\nDescargue los cheats individualmente seleccionando el repositorio y haciendo clic en el botón de descarga.\nEn la pestaña Patches, puede descargar todos los patches a la vez, elegir cuáles desea usar y guardar la selección.\n\nComo no desarrollamos los Cheats/Patches,\npor favor informe los problemas al autor del cheat.\n\n¿Creaste un nuevo cheat? Visita:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>No hay imagen disponible</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>Número de serie: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>Versión: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>Tamaño: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>Seleccionar archivo de trucos:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>Repositorio:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>Descargar trucos</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>Eliminar archivo</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>No se han seleccionado archivos.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>Puedes eliminar los trucos que no quieras una vez descargados.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>¿Deseas eliminar el archivo seleccionado?\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>Seleccionar archivo de parche:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>Descargar parches</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>Guardar</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>Trucos</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>Parches</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>Error</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>No se ha seleccionado ningún parche.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>No se puede abrir files.json para lectura.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>No se encontró ningún archivo de parche para el número de serie actual.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>No se puede abrir el archivo para lectura.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>No se puede abrir el archivo para escritura.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>Error al analizar XML: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>Éxito</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>Opciones guardadas exitosamente.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>Fuente inválida</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>La fuente seleccionada es inválida.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>El archivo ya existe</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>El archivo ya existe. ¿Deseas reemplazarlo?</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>Error al guardar el archivo:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>Error al descargar el archivo:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>Trucos no encontrados</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>No se encontraron trucos para este juego en esta versión del repositorio seleccionado,intenta con otro repositorio o con una versión diferente del juego.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>Trucos descargados exitosamente</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>Has descargado exitosamente los trucos para esta versión del juego desde el repositorio seleccionado. Puedes intentar descargar desde otro repositorio; si está disponible, también será posible usarlo seleccionando el archivo de la lista.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>Error al guardar:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>Error al descargar:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>Descarga completa</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>¡Parches descargados exitosamente! Todos los parches disponibles para todos los juegos han sido descargados, no es necesario descargarlos individualmente para cada juego como ocurre con los trucos. Si el parche no aparece, puede ser que no exista para el número de serie y versión específicos del juego.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>Error al analizar los datos JSON del HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>Error al recuperar la página HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>El juego está en la versión: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>El parche descargado solo funciona en la versión: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>Puede que necesites actualizar tu juego.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>Aviso de incompatibilidad</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>Error al abrir el archivo:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>ERROR XML:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>Error al abrir files.json para escritura</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>Autor: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>El directorio no existe:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>Error al abrir files.json para lectura.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>Nombre:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>No se pueden aplicar trucos antes de que se inicie el juego.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>Guardar</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>Aplicar</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>Restaurar Valores Predeterminados</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>Cerrar</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>Coloque el mouse sobre una opción para mostrar su descripción.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Idioma de la Consola:\nEstablece el idioma que utiliza el juego de PS4.\nSe recomienda configurarlo a un idioma que el juego soporte, lo cual varía por región.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>Idioma del Emulador:\nConfigura el idioma de la interfaz de usuario del emulador.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>Habilitar Pantalla Completa:\nColoca automáticamente la ventana del juego en modo de pantalla completa.\nEsto se puede alternar presionando la tecla F11.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Enable Separate Update Folder:\nEnables installing game updates into a separate folder for easy management.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>Mostrar Pantalla de Inicio:\nMuestra la pantalla de inicio del juego (una imagen especial) mientras el juego se está iniciando.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>Es PS4 Pro:\nHace que el emulador actúe como una PS4 PRO, lo que puede habilitar funciones especiales en los juegos que lo admitan.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>Habilitar Discord Rich Presence:\nMuestra el ícono del emulador y la información relevante en tu perfil de Discord.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>Nombre de Usuario:\nEstablece el nombre de usuario de la cuenta de PS4, que puede ser mostrado por algunos juegos.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>Tipo de Registro:\nEstablece si sincronizar la salida de la ventana de registro para mejorar el rendimiento. Puede tener efectos adversos en la emulación.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Filtro de Registro:\nFiltra el registro para imprimir solo información específica.\nEjemplos: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" Niveles: Trace, Debug, Info, Warning, Error, Critical - en este orden, un nivel específico silencia todos los niveles anteriores en la lista y registra cada nivel posterior.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>Actualización:\nRelease: Versiones oficiales lanzadas cada mes que pueden estar muy desactualizadas, pero son más confiables y están probadas.\nNightly: Versiones de desarrollo que tienen todas las últimas funciones y correcciones, pero pueden contener errores y son menos estables.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Reproducir Música del Título:\nSi un juego lo admite, habilita la reproducción de música especial al seleccionar el juego en la interfaz gráfica.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Disable Trophy Pop-ups:\nDisable in-game trophy notifications. Trophy progress can still be tracked using the Trophy Viewer (right-click the game in the main window).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>Ocultar Cursor:\nElija cuándo desaparecerá el cursor:\nNunca: Siempre verá el mouse.\nInactivo: Establezca un tiempo para que desaparezca después de estar inactivo.\nSiempre: nunca verá el mouse.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>Establezca un tiempo para que el mouse desaparezca después de estar inactivo.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>Comportamiento del Botón Atrás:\nEstablece el botón atrás del controlador para emular el toque en la posición especificada en el touchpad del PS4.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Display Compatibility Data:\nDisplays game compatibility information in table view. Enable "Update Compatibility On Startup" to get up-to-date information.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Update Compatibility On Startup:\nAutomatically update the compatibility database when shadPS4 starts.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Update Compatibility Database:\nImmediately update the compatibility database.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>Nunca</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>Inactivo</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>Siempre</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>Touchpad Izquierda</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>Touchpad Derecha</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>Centro del Touchpad</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>Ninguno</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>Dispositivo Gráfico:\nEn sistemas con múltiples GPU, selecciona la GPU que el emulador utilizará de la lista desplegable,\o selecciona "Auto Select" para determinarla automáticamente.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Anchura/Altura:\nEstablece el tamaño de la ventana del emulador al iniciar, que se puede redimensionar durante el juego.\nEsto es diferente de la resolución en el juego.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Divisor de Vblank:\nLa tasa de cuadros a la que se refresca el emulador se multiplica por este número. Cambiar esto puede tener efectos adversos, como aumentar la velocidad del juego, o romper la funcionalidad crítica del juego que no espera que esto cambie.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>Habilitar la Volcadura de Sombras:\nPor el bien de la depuración técnica, guarda las sombras del juego en una carpeta mientras se renderizan.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Habilitar GPU Nula:\nPor el bien de la depuración técnica, desactiva el renderizado del juego como si no hubiera tarjeta gráfica.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>Carpetas de Juegos:\nLa lista de carpetas para verificar los juegos instalados.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>Añadir:\nAgregar una carpeta a la lista.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>Eliminar:\nEliminar una carpeta de la lista.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>Habilitar la Volcadura de Depuración:\nGuarda los símbolos de importación y exportación y la información del encabezado del archivo del programa de PS4 que se está ejecutando actualmente en un directorio.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Habilitar Capas de Validación de Vulkan:\nHabilita un sistema que valida el estado del renderizador de Vulkan y registra información sobre su estado interno. Esto reducirá el rendimiento y probablemente cambiará el comportamiento de la emulación.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Habilitar Validación de Sincronización de Vulkan:\nHabilita un sistema que valida el tiempo de las tareas de renderizado de Vulkan. Esto reducirá el rendimiento y probablemente cambiará el comportamiento de la emulación.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>Habilitar Depuración de RenderDoc:\nSi se habilita, el emulador proporcionará compatibilidad con Renderdoc para permitir la captura y análisis del fotograma actualmente renderizado.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Cheats / Patches for </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>Los cheats/patches son experimentales.\nÚselos con precaución.\n\nDescargue los cheats individualmente seleccionando el repositorio y haciendo clic en el botón de descarga.\nEn la pestaña Patches, puede descargar todos los patches a la vez, elegir cuáles desea usar y guardar la selección.\n\nComo no desarrollamos los Cheats/Patches,\npor favor informe los problemas al autor del cheat.\n\n¿Creaste un nuevo cheat? Visita:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>No hay imagen disponible</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>Número de serie: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>Versión: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>Tamaño: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>Seleccionar archivo de trucos:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>Repositorio:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>Descargar trucos</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>Eliminar archivo</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>No se han seleccionado archivos.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>Puedes eliminar los trucos que no quieras una vez descargados.</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>¿Deseas eliminar el archivo seleccionado?\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>Seleccionar archivo de parche:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>Descargar parches</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>Guardar</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>Trucos</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>Parches</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Error</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>No se ha seleccionado ningún parche.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>No se puede abrir files.json para lectura.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>No se encontró ningún archivo de parche para el número de serie actual.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>No se puede abrir el archivo para lectura.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>No se puede abrir el archivo para escritura.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>Error al analizar XML: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>Éxito</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>Opciones guardadas exitosamente.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>Fuente inválida</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>La fuente seleccionada es inválida.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>El archivo ya existe</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>El archivo ya existe. ¿Deseas reemplazarlo?</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>Error al guardar el archivo:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>Error al descargar el archivo:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>Trucos no encontrados</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>No se encontraron trucos para este juego en esta versión del repositorio seleccionado,intenta con otro repositorio o con una versión diferente del juego.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>Trucos descargados exitosamente</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>Has descargado exitosamente los trucos para esta versión del juego desde el repositorio seleccionado. Puedes intentar descargar desde otro repositorio; si está disponible, también será posible usarlo seleccionando el archivo de la lista.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>Error al guardar:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>Error al descargar:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Descarga completa</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>¡Parches descargados exitosamente! Todos los parches disponibles para todos los juegos han sido descargados, no es necesario descargarlos individualmente para cada juego como ocurre con los trucos. Si el parche no aparece, puede ser que no exista para el número de serie y versión específicos del juego.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>Error al analizar los datos JSON del HTML.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>Error al recuperar la página HTML.</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>El juego está en la versión: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>El parche descargado solo funciona en la versión: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>Puede que necesites actualizar tu juego.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>Aviso de incompatibilidad</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>Error al abrir el archivo:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>ERROR XML:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>Error al abrir files.json para escritura</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>Autor: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>El directorio no existe:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>Error al abrir files.json para lectura.</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>Nombre:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>No se pueden aplicar trucos antes de que se inicie el juego.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>Icono</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>Nombre</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>Numero de serie</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>Región</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>Firmware</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>Tamaño</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>Versión</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>Ruta</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>Tiempo de Juego</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Never Played</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Compatibility is untested</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Game does not initialize properly / crashes the emulator</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Game boots, but only displays a blank screen</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Game displays an image but does not go past the menu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Game has game-breaking glitches or unplayable performance</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>Actualizador Automático</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>Error de red:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>Error al analizar la información de actualización.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>No se encontraron prelanzamientos.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>Datos de versión no válidos.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>No se encontró URL de descarga para el activo especificado.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>¡Su versión ya está actualizada!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>Actualización disponible</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>Canal de Actualización</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>Versión actual</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>Última versión</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>¿Quieres actualizar?</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>Mostrar registro de cambios</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Buscar actualizaciones al iniciar</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>Actualizar</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>No</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>Ocultar registro de cambios</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>Cambios</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>Se produjo un error de red al intentar acceder a la URL</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>Descarga completa</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>La actualización se ha descargado, presione Aceptar para instalar.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>No se pudo guardar el archivo de actualización en</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>Iniciando actualización...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>No se pudo crear el archivo del script de actualización</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/fa_IR.ts
+++ b/src/qt_gui/translations/fa_IR.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>درباره ShadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>ShadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>یک شبیه ساز متن باز برای پلی استیشن 4 است. </translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>این برنامه نباید برای بازی هایی که شما به صورت غیرقانونی به دست آوردید استفاده شود.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>فولدر را بازکن</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>درحال بارگیری لیست بازی ها,لطفا کمی صبرکنید :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>لغو</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>...درحال بارگیری</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>ShadPS4 - انتخاب محل نصب بازی</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>محلی را که می‌خواهید در آن نصب شود، انتخاب کنید.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>ShadPS4 - انتخاب محل نصب بازی</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>محل نصب بازی ها</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>انتخاب دستی</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>ارور</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>.مکان داده شده برای نصب بازی درست نمی باشد</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="39"/>
 			<source>Create Shortcut</source>
 			<translation>ایجاد میانبر</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>چیت/پچ ها</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="41"/>
 			<source>SFO Viewer</source>
 			<translation>SFO مشاهده</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="42"/>
 			<source>Trophy Viewer</source>
 			<translation>مشاهده جوایز</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>باز کردن پوشه...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>باز کردن پوشه بازی</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>پوشه ذخیره داده را باز کنید</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>باز کردن پوشه لاگ</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Copy info...</source>
 			<translation>...کپی کردن اطلاعات</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Copy Name</source>
 			<translation>کپی کردن نام</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Copy Serial</source>
 			<translation>کپی کردن سریال</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="53"/>
 			<source>Copy All</source>
 			<translation>کپی کردن تمامی مقادیر</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>حذف...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>حذف بازی</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>حذف به‌روزرسانی</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>حذف محتوای اضافی (DLC)</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="173"/>
 			<source>Shortcut creation</source>
 			<translation>ایجاد میانبر</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="174"/>
 			<source>Shortcut created successfully!</source>
 			<translation>میانبر با موفقیت ساخته شد!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="177"/>
 			<source>Error</source>
 			<translation>ارور</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="178"/>
 			<source>Error creating shortcut!</source>
 			<translation>مشکلی در هنگام ساخت میانبر بوجود آمد!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="253"/>
 			<source>Install PKG</source>
 			<translation>نصب PKG</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>بازی</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>این قابلیت نیازمند فعال‌سازی گزینه تنظیمات «ایجاد پوشه جداگانه برای به‌روزرسانی» است. در صورت تمایل به استفاده از این قابلیت، لطفاً آن را فعال کنید.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>این بازی به‌روزرسانی‌ای برای حذف ندارد!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>به‌روزرسانی</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>این بازی محتوای اضافی (DLC) برای حذف ندارد!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>حذف %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Are you sure you want to delete %1's %2 directory?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>ELF بازکردن/ساختن پوشه</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>نصب بسته (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>اجرای بازی</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>به روز رسانی را بررسی کنید</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>ShadPS4 درباره</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>...تنظیمات</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>.PKG نصب بازی از فایل</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>بازی های اخیر</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>خروج</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>ShadPS4 بستن</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>بستن برنامه</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>نشان دادن بازی ها</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>رفرش لیست بازی ها</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>کوچک ترین</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>کوچک</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>متوسط</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>بزرگ</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>نمایش لیست</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>شبکه ای (چهارخونه)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>مشاهده گر Elf</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>محل نصب بازی</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>دانلود چیت/پچ</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>استخراج لیست بازی ها</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>PKG مشاهده گر</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>جست و جو...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>فایل</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>شخصی سازی</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>آیکون ها</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>حالت نمایش لیست بازی ها</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>تنظیمات</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>ابزارها</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>تم ها</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>کمک</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>تیره</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>روشن</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>سبز</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>آبی</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>بنفش</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>نوار ابزار</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>لیست بازی</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation>شما پشتیبانی نمیشود Vulkan ورژن *</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>دانلود چیت برای همه بازی ها</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>دانلود پچ برای همه بازی ها</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>دانلود کامل شد✅</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>چیت برای همه بازی های شما دانلودشد✅</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>پچ ها با موفقیت دانلود شد✅</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>✅تمام پچ های موجود برای همه بازی های شما دانلود شد</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>بازی ها:</translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>PKG فایل (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>ELF فایل های (*.bin *.elf *.oelf) </translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>اجرای بازی</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>فقط یک فایل انتخاب کنید!</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>PKG استخراج فایل</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>پچ شناسایی شد!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>و نسخه بازی همخوانی دارد PKG فایل:</translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>آیا مایل به جایگزینی فایل هستید؟</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>نسخه فایل PKG %1 قدیمی تر از نسخه نصب شده است:</translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>بازی نصب شد:</translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>آیا مایل به نصب پچ هستید:</translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>نصب DLC</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>آیا مایل به نصب DLC هستید: %1 </translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>قبلا نصب شده DLC این:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>این بازی قبلا نصب شده</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>فایل انتخاب شده یک پچ است, لطفا اول بازی را نصب کنید</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>PKG ارور فایل</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>درحال استخراج PKG %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>استخراج به پایان رسید</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>بازی با موفقیت در %1 نصب شد</translation>
+		</message>
+		<message>
+			<source>File doesn&apos;t appear to be a valid PKG file</source>
+			<translation>  این فایل یک PKG درست به نظر نمی آید</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>بازکردن پوشه</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>مشاهده جوایز</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>تنظیمات</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>عمومی</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>سیستم</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>زبان کنسول</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>زبان شبیه ساز</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>شبیه ساز</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>تمام صفحه</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>فعال‌سازی پوشه جداگانه برای به‌روزرسانی</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Splash نمایش</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>PS4 Pro حالت</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Discord Rich Presence را فعال کنید</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>نام کاربری</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Logger</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Log نوع</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Log فیلتر</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>ورودی</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>نشانگر</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>پنهان کردن نشانگر</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>مخفی کردن زمان توقف مکان نما</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>دسته بازی</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>رفتار دکمه بازگشت</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>گرافیک</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>کارت گرافیک مورداستفاده</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>عرض</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>طول</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>تقسیم‌کننده Vblank</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>...بیشتر</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>فعال‌سازی ذخیره‌سازی شیدرها</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>NULL GPU فعال کردن</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>مسیرها</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>پوشه های بازی</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>افزودن...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>حذف</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>دیباگ</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Debug Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Vulkan Validation Layers</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Vulkan Synchronization Validation</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>RenderDoc Debugging</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>به‌روزرسانی</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>بررسی به‌روزرسانی‌ها در زمان راه‌اندازی</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>کانال به‌روزرسانی</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>بررسی به‌روزرسانی‌ها</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>تنظیمات رابط کاربری</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>غیرفعال کردن نمایش جوایز</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>پخش موسیقی عنوان</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>به‌روزرسانی پایگاه داده سازگاری هنگام راه‌اندازی</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>سازگاری بازی با سیستم</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>نمایش داده‌های سازگاری</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>به‌روزرسانی پایگاه داده سازگاری</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>صدا</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>لیست بازی</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation>شما پشتیبانی نمیشود Vulkan ورژن *</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>دانلود چیت برای همه بازی ها</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>دانلود پچ برای همه بازی ها</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>دانلود کامل شد✅</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>چیت برای همه بازی های شما دانلودشد✅</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>پچ ها با موفقیت دانلود شد✅</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>✅تمام پچ های موجود برای همه بازی های شما دانلود شد</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>بازی ها:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>PKG فایل (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>ELF فایل های (*.bin *.elf *.oelf) </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>اجرای بازی</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>فقط یک فایل انتخاب کنید!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>PKG استخراج فایل</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>پچ شناسایی شد!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>و نسخه بازی همخوانی دارد PKG فایل:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>آیا مایل به جایگزینی فایل هستید؟</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>نسخه فایل PKG %1 قدیمی تر از نسخه نصب شده است:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>بازی نصب شد:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>آیا مایل به نصب پچ هستید:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>نصب DLC</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>آیا مایل به نصب DLC هستید: %1 </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>قبلا نصب شده DLC این:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>این بازی قبلا نصب شده</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>فایل انتخاب شده یک پچ است, لطفا اول بازی را نصب کنید</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>PKG ارور فایل</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>درحال استخراج PKG %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>استخراج به پایان رسید</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>بازی با موفقیت در %1 نصب شد</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn&apos;t appear to be a valid PKG file</source>
-			<translation>  این فایل یک PKG درست به نظر نمی آید</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation> چیت / پچ برای </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>defaultTextEdit_MSG</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>تصویری موجود نمی باشد</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>سریال: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>نسخه: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>حجم: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>فایل چیت را انتخاب کنید:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>:منبع</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>دانلود چیت ها</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>حذف فایل</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>فایلی انتخاب نشده.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don&apos;t want after downloading them.</source>
-			<translation>شما میتوانید بعد از دانلود چیت هایی که نمیخواهید را پاک کنید</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>آیا میخواهید فایل های انتخاب شده را پاک کنید؟ \n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>فایل پچ را انتخاب کنید</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>دانلود کردن پچ ها</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>ذخیره</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>چیت ها</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>پچ ها</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>ارور</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>هیچ پچ انتخاب نشده</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>.json مشکل در خواندن فایل</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>هیچ فایل پچ برای سریال بازی شما پیدا نشد.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>خطا در خواندن فایل</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>خطا در نوشتن فایل</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>انجام نشد XML تجزیه فایل:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>عملیات موفق بود</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation >تغییرات با موفقیت ذخیره شد✅</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>منبع نامعتبر❌</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>منبع انتخاب شده نامعتبر است</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>فایل وجود دارد</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>فایل از قبل وجود دارد. آیا می خواهید آن را جایگزین کنید؟</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>ذخیره فایل موفقیت آمیز نبود:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>خطا در دانلود فایل:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>چیت یافت نشد</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>متاسفانه هیچ چیتی از منبع انتخاب شده پیدا نشد! شما میتوانید منابع دیگری را برای دانلود انتخاب و یا چیت های خود را به صورت دستی واردکنید.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>دانلود چیت ها موفقیت آمیز بود✅</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>تمامی چیت های موجود برای این بازی از منبع انتخاب شده دانلود شد! شما همچنان میتوانید چیت های دیگری را ازمنابع مختلف دانلود کنید و درصورت موجود بودن از آنها استفاده کنید.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>خطا در ذخیره اطلاعات:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>خطا در دانلود❌</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>دانلود کامل شد</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>پچ ها با موفقیت بارگیری شدند! تمام وصله های موجود برای همه بازی ها دانلود شده اند، نیازی به دانلود جداگانه آنها برای هر بازی نیست، همانطور که در Cheats اتفاق می افتد. اگر پچ ظاهر نشد، ممکن است برای سریال و نسخه خاصی از بازی وجود نداشته باشد.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>HTML از JSON خطا در تجزیه اطلاعات.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>HTML خطا دربازیابی صفحه</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>بازی در نسخه: %1 است</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>وصله دانلود شده فقط در نسخه: %1 کار می کند</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>شاید لازم باشد بازی خود را به روز کنید.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>اطلاعیه عدم سازگاری</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>خطا در اجرای فایل:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>XML ERROR:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>.json خطا در نوشتن فایل</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>تولید کننده: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>پوشه وجود ندارد:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>.json خطا در خواندن فایل</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>نام:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>قبل از شروع بازی نمی توانید تقلب ها را اعمال کنید.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>ذخیره</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>اعمال</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>بازیابی پیش فرض ها</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>بستن</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>ماوس خود را بر روی یک گزینه قرار دهید تا توضیحات آن نمایش داده شود.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Console Language:\nSets the language that the PS4 game uses.\nIt's recommended to set this to a language the game supports, which will vary by region.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>زبان شبیه‌ساز:\nزبان رابط کاربری شبیه‌ساز را انتخاب می‌کند.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>فعال‌سازی تمام صفحه:\nپنجره بازی را به‌طور خودکار به حالت تمام صفحه در می‌آورد.\nبرای تغییر این حالت می‌توانید کلید F11 را فشار دهید.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>فعال‌سازی پوشه جداگانه برای به‌روزرسانی:\nامکان نصب به‌روزرسانی‌های بازی در یک پوشه جداگانه برای مدیریت راحت‌تر را فراهم می‌کند.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>نمایش صفحه شروع:\nصفحه شروع بازی (تصویری ویژه) را هنگام بارگذاری بازی نمایش می‌دهد.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>حالت PS4 Pro:\nشبیه‌ساز را به‌عنوان PS4 Pro شبیه‌سازی می‌کند که ممکن است ویژگی‌های ویژه‌ای را در بازی‌های پشتیبانی‌شده فعال کند.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>فعال کردن Discord Rich Presence:\nآیکون شبیه ساز و اطلاعات مربوطه را در نمایه Discord شما نمایش می دهد.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>نام کاربری:\nنام کاربری حساب PS4 را تنظیم می‌کند که ممکن است توسط برخی بازی‌ها نمایش داده شود.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>نوع لاگ:\nتنظیم می‌کند که آیا خروجی پنجره لاگ برای بهبود عملکرد همگام‌سازی شود یا خیر. این ممکن است تأثیر منفی بر شبیه‌سازی داشته باشد.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Log Filter:\nFilters the log to only print specific information.\nExamples: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" Levels: Trace, Debug, Info, Warning, Error, Critical - in this order, a specific level silences all levels preceding it in the list and logs every level after it.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>به‌روزرسانی:\nانتشار: نسخه‌های رسمی که هر ماه منتشر می‌شوند و ممکن است بسیار قدیمی باشند، اما پایدارتر و تست‌ شده‌تر هستند.\nشبانه: نسخه‌های توسعه‌ای که شامل جدیدترین ویژگی‌ها و اصلاحات هستند، اما ممکن است دارای اشکال باشند و کمتر پایدار باشند.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>پخش موسیقی عنوان:\nIدر صورتی که بازی از آن پشتیبانی کند، پخش موسیقی ویژه هنگام انتخاب بازی در رابط کاربری را فعال می‌کند.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>غیرفعال کردن نمایش جوایز:\nنمایش اعلان‌های جوایز درون بازی را غیرفعال می‌کند. پیشرفت جوایز همچنان از طریق نمایشگر جوایز (کلیک راست روی بازی در پنجره اصلی) قابل پیگیری است..</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>پنهان کردن نشانگر:\nانتخاب کنید که نشانگر چه زمانی ناپدید شود:\nهرگز: شما همیشه ماوس را خواهید دید.\nغیرفعال: زمانی را برای ناپدید شدن بعد از غیرفعالی تعیین کنید.\nهمیشه: شما هرگز ماوس را نخواهید دید.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>زمانی را برای ناپدید شدن ماوس بعد از غیرفعالی تعیین کنید.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>رفتار دکمه برگشت:\nدکمه برگشت کنترلر را طوری تنظیم می کند که ضربه زدن روی موقعیت مشخص شده روی صفحه لمسی PS4 را شبیه سازی کند.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>نمایش داده‌های سازگاری:\nاطلاعات سازگاری بازی را به صورت جدول نمایش می‌دهد. برای دریافت اطلاعات به‌روز، گزینه "به‌روزرسانی سازگاری هنگام راه‌اندازی" را فعال کنید.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>به‌روزرسانی سازگاری هنگام راه‌اندازی:\nبه‌طور خودکار پایگاه داده سازگاری را هنگام راه‌اندازی ShadPS4 به‌روزرسانی می‌کند.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>به‌روزرسانی پایگاه داده سازگاری:\nپایگاه داده سازگاری را بلافاصله به‌روزرسانی می‌کند.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>هرگز</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>بیکار</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>همیشه</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>صفحه لمسی سمت چپ</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>صفحه لمسی سمت راست</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>مرکز صفحه لمسی</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>هیچ کدام</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>دستگاه گرافیکی:\nدر سیستم‌های با چندین پردازنده گرافیکی، از فهرست کشویی، پردازنده گرافیکی که شبیه‌ساز از آن استفاده می‌کند را انتخاب کنید، یا گزینه "انتخاب خودکار" را انتخاب کنید تا به طور خودکار تعیین شود.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>عرض/ارتفاع:\nاندازه پنجره شبیه‌ساز را در هنگام راه‌اندازی تنظیم می‌کند، که در حین بازی قابل تغییر اندازه است.\nاین با وضوح داخل بازی متفاوت است.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>تقسیم‌کننده Vblank:\nمیزان فریم ریت که شبیه‌ساز با آن به‌روزرسانی می‌شود، در این عدد ضرب می‌شود. تغییر این مقدار ممکن است تأثیرات منفی داشته باشد، مانند افزایش سرعت بازی یا خراب شدن عملکردهای حیاتی بازی که انتظار تغییر آن را ندارند!</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>فعال‌سازی ذخیره‌سازی شیدرها:\nبه‌منظور اشکال‌زدایی فنی، شیدرهای بازی را هنگام رندر شدن در یک پوشه ذخیره می‌کند.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Enable Null GPU:\nFor the sake of technical debugging, disables game rendering as if there were no graphics card.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>پوشه های بازی:\nلیست پوشه هایی که باید بازی های نصب شده را بررسی کنید.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>اضافه کردن:\nیک پوشه به لیست اضافه کنید.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>حذف:\nیک پوشه را از لیست حذف کنید.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>فعال‌سازی ذخیره‌سازی دیباگ:\nنمادهای import و export و اطلاعات هدر فایل برنامه در حال اجرای PS4 را در یک پوشه ذخیره می‌کند.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Enable Vulkan Validation Layers:\nEnables a system that validates the state of the Vulkan renderer and logs information about its internal state. This will reduce performance and likely change the behavior of emulation.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Enable Vulkan Synchronization Validation:\nEnables a system that validates the timing of Vulkan rendering tasks. This will reduce performance and likely change the behavior of emulation.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>Enable RenderDoc Debugging:\nIf enabled, the emulator will provide compatibility with Renderdoc to allow capture and analysis of the currently rendered frame.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation> چیت / پچ برای </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>defaultTextEdit_MSG</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>تصویری موجود نمی باشد</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>سریال: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>نسخه: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>حجم: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>فایل چیت را انتخاب کنید:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>:منبع</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>دانلود چیت ها</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>حذف فایل</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>فایلی انتخاب نشده.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don&apos;t want after downloading them.</source>
+			<translation>شما میتوانید بعد از دانلود چیت هایی که نمیخواهید را پاک کنید</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>آیا میخواهید فایل های انتخاب شده را پاک کنید؟ \n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>فایل پچ را انتخاب کنید</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>دانلود کردن پچ ها</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>ذخیره</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>چیت ها</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>پچ ها</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>ارور</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>هیچ پچ انتخاب نشده</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>.json مشکل در خواندن فایل</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>هیچ فایل پچ برای سریال بازی شما پیدا نشد.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>خطا در خواندن فایل</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>خطا در نوشتن فایل</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>انجام نشد XML تجزیه فایل:</translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>عملیات موفق بود</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation >تغییرات با موفقیت ذخیره شد✅</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>منبع نامعتبر❌</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>منبع انتخاب شده نامعتبر است</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>فایل وجود دارد</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>فایل از قبل وجود دارد. آیا می خواهید آن را جایگزین کنید؟</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>ذخیره فایل موفقیت آمیز نبود:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>خطا در دانلود فایل:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>چیت یافت نشد</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>متاسفانه هیچ چیتی از منبع انتخاب شده پیدا نشد! شما میتوانید منابع دیگری را برای دانلود انتخاب و یا چیت های خود را به صورت دستی واردکنید.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>دانلود چیت ها موفقیت آمیز بود✅</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>تمامی چیت های موجود برای این بازی از منبع انتخاب شده دانلود شد! شما همچنان میتوانید چیت های دیگری را ازمنابع مختلف دانلود کنید و درصورت موجود بودن از آنها استفاده کنید.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>خطا در ذخیره اطلاعات:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>خطا در دانلود❌</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>دانلود کامل شد</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>پچ ها با موفقیت بارگیری شدند! تمام وصله های موجود برای همه بازی ها دانلود شده اند، نیازی به دانلود جداگانه آنها برای هر بازی نیست، همانطور که در Cheats اتفاق می افتد. اگر پچ ظاهر نشد، ممکن است برای سریال و نسخه خاصی از بازی وجود نداشته باشد.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>HTML از JSON خطا در تجزیه اطلاعات.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>HTML خطا دربازیابی صفحه</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>بازی در نسخه: %1 است</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>وصله دانلود شده فقط در نسخه: %1 کار می کند</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>شاید لازم باشد بازی خود را به روز کنید.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>اطلاعیه عدم سازگاری</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>خطا در اجرای فایل:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>XML ERROR:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>.json خطا در نوشتن فایل</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>تولید کننده: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>پوشه وجود ندارد:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>.json خطا در خواندن فایل</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>نام:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>قبل از شروع بازی نمی توانید تقلب ها را اعمال کنید.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>آیکون</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>نام</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>سریال</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>سازگاری</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>منطقه</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>فریم‌ور</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>اندازه</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>نسخه</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>مسیر</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>زمان بازی</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>هرگز بازی نشده</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>سازگاری تست نشده است</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>بازی به درستی راه‌اندازی نمی‌شود / شبیه‌ساز کرش می‌کند</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>بازی اجرا می‌شود، اما فقط یک صفحه خالی نمایش داده می‌شود</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>بازی تصویری نمایش می‌دهد، اما از منو فراتر نمی‌رود</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>بازی دارای اشکالات بحرانی یا عملکرد غیرقابل بازی است</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>بازی با عملکرد قابل قبول و بدون اشکالات عمده قابل بازی است.</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>به‌روزرسانی خودکار</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>خطا</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>خطای شبکه:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>خطا در تجزیه اطلاعات بهروزرسانی.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>هیچ پیش انتشاری یافت نشد.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>داده های نسخه نامعتبر است.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>هیچ URL دانلودی برای دارایی مشخص شده پیدا نشد.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>نسخه شما اکنون به روز شده است!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>به روز رسانی موجود است</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>کانال به‌روزرسانی</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>نسخه فعلی</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>جدیدترین نسخه</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>آیا می خواهید به روز رسانی کنید؟</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>نمایش تغییرات</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>بررسی به‌روزرسانی هنگام شروع</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>به روز رسانی</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>خیر</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>مخفی کردن تغییرات</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>تغییرات</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>در حین تلاش برای دسترسی به URL خطای شبکه رخ داد</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>دانلود کامل شد</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>به روز رسانی دانلود شده است، برای نصب OK را فشار دهید.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>فایل به روز رسانی ذخیره نشد</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>شروع به روز رسانی...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>فایل اسکریپت به روز رسانی ایجاد نشد</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/fi.ts
+++ b/src/qt_gui/translations/fi.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>Tietoa shadPS4:sta</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 on kokeellinen avoimen lähdekoodin PlayStation 4 emulaattori.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>Tätä ohjelmistoa ei saa käyttää pelien pelaamiseen, joita et ole hankkinut laillisesti.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Avaa Hakemisto</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Ole hyvä ja odota, ladataan pelilistaa :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>Peruuta</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Ladataan...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Valitse hakemisto</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Valitse, mihin hakemistoon haluat asentaa.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Valitse hakemisto</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Pelien asennushakemisto</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Selaa</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Virhe</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>Peliasennushakemiston sijainti on virheellinen.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>Luo Pikakuvake</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>Huijaukset / Korjaukset</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>SFO Selain</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophy Selain</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>Avaa Hakemisto...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>Avaa Pelihakemisto</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>Avaa Tallennustiedostohakemisto</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>Avaa Lokihakemisto</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>Kopioi tietoja...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>Kopioi Nimi</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>Kopioi Sarjanumero</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>Kopioi kaikki</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Poista...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Poista Peli</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Poista Päivitys</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Poista Lisäsisältö</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Yhteensopivuus...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Päivitä tietokanta</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>Näytä raportti</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Tee raportti</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>Pikakuvakkeen luonti</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>Pikakuvake luotu onnistuneesti!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>Virhe</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>Virhe pikakuvakkeen luonnissa!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>Asenna PKG</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Peli</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>Tämä ominaisuus vaatii, että 'Ota käyttöön erillinen päivityshakemisto' -asetus on päällä. Jos haluat käyttää tätä ominaisuutta, laita se asetus päälle.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>Tällä pelillä ei ole poistettavaa päivitystä!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Päivitä</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>Tällä pelillä ei ole poistettavaa lisäsisältöä!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>Lisäsisältö</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Poista %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Haluatko varmasti poistaa %1n %2hakemiston?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Avaa/Lisää Elf Hakemisto</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>Asenna Paketteja (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Käynnistä Peli</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>Tarkista Päivitykset</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>Tietoa shadPS4:sta</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Asetukset...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>Asenna sovellus .pkg tiedostosta</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Viimeisimmät Pelit</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Sulje</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>Sulje shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Sulje sovellus.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Avaa pelilista</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Päivitä pelilista</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Hyvin pieni</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Pieni</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Keskikokoinen</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Suuri</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>Listanäkymä</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Ruudukkonäkymä</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Elf Selain</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Peliasennushakemisto</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>Lataa Huijaukset / Korjaukset</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Kirjoita Pelilista Tiedostoon</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>PKG Selain</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Hae...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>Tiedosto</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>Näkymä</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Pelilistan Ikonit</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Pelilistamuoto</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Asetukset</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Työkalut</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Teemat</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>Apua</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Tumma</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Vaalea</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Vihreä</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Sininen</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Violetti</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>Työkalupalkki</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>Pelilista</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * Ei Tuettu Vulkan-versio</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>Lataa Huijaukset Kaikille Asennetuille Peleille</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>Lataa Paikkaukset Kaikille Peleille</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Lataus Valmis</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>Olet ladannut huijaukset kaikkiin asennettuihin peleihin.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>Paikkaukset Ladattu Onnistuneesti!</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>Kaikki saatavilla olevat Paikkaukset kaikille peleille on ladattu.</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>Pelit: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>PKG-tiedosto (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>ELF-tiedostot (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>Pelin Käynnistys</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>Vain yksi tiedosto voi olla valittuna!</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>PKG:n purku</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>Päivitys havaittu!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>PKG- ja peliversiot vastaavat: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>Haluatko korvata?</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>PKG-versio %1 on vanhempi kuin asennettu versio: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>Peli on asennettu: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>Haluatko asentaa päivityksen: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>Lisäsisällön asennus</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>Haluatko asentaa lisäsisällön: %1?</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>Lisäsisältö on jo asennettu:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>Peli on jo asennettu</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>PKG on päivitys, asenna peli ensin!</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>PKG VIRHE</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>Purkaminen PKG %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>Purku valmis</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>Peli asennettu onnistuneesti kohtaan %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>Tiedosto ei vaikuta olevan kelvollinen PKG-tiedosto</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Avaa Hakemisto</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophy Selain</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Asetukset</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>Yleinen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>Järjestelmä</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>Konsolin Kieli</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Emulaattorin Kieli</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Emulaattori</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Ota Käyttöön Koko Ruudun Tila</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Ota Käyttöön Erillinen Päivityshakemisto</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Näytä Aloitusnäyttö</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>On PS4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Ota käyttöön Discord Rich Presence</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Käyttäjänimi</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Avain</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Lokinkerääjä</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Lokin Tyyppi</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Lokisuodatin</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>Syöttö</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>Kursori</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>Piilota Kursori</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>Inaktiivisuuden Aikaraja Kursorin Piilottamiseen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>Ohjain</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>Takaisin-painikkeen Käyttäytyminen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Grafiikka</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Näytönohjain</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Leveys</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Korkeus</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Vblank jakaja</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Lisäasetukset</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Ota Käyttöön Varjostinvedokset</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>Ota Käyttöön NULL GPU</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>Polut</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>Pelihakemistot</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
-				<translation>Lisää...</translation>
+			<translation>Lisää...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>Poista</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Virheenkorjaus</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Ota Käyttöön Virheenkorjausvedokset</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Ota Käyttöön Vulkan-validointikerrokset</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Ota Käyttöön Vulkan-synkronointivalidointi</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>Ota Käyttöön RenderDoc Virheenkorjaus</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>Päivitys</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Tarkista Päivitykset Käynnistäessä</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>Päivityskanava</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>Tarkista Päivitykset</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>GUI-asetukset</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Poista Trophy Pop-upit Käytöstä</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>Soita Otsikkomusiikkia</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Päivitä Yhteensopivuustietokanta Käynnistäessä</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Peliyhteensopivuus</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Näytä Yhteensopivuustiedot</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Päivitä Yhteensopivuustietokanta</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>Äänenvoimakkuus</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Äänijärjestelmä</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>Pelilista</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * Ei Tuettu Vulkan-versio</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>Lataa Huijaukset Kaikille Asennetuille Peleille</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>Lataa Paikkaukset Kaikille Peleille</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>Lataus Valmis</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>Olet ladannut huijaukset kaikkiin asennettuihin peleihin.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>Paikkaukset Ladattu Onnistuneesti!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>Kaikki saatavilla olevat Paikkaukset kaikille peleille on ladattu.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>Pelit: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>PKG-tiedosto (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>ELF-tiedostot (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>Pelin Käynnistys</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>Vain yksi tiedosto voi olla valittuna!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>PKG:n purku</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>Päivitys havaittu!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>PKG- ja peliversiot vastaavat: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>Haluatko korvata?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>PKG-versio %1 on vanhempi kuin asennettu versio: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>Peli on asennettu: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>Haluatko asentaa Päivityksen: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>Lisäsisällön asennus</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>Haluatko asentaa lisäsisällön: %1?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>Lisäsisältö on jo asennettu:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>Peli on jo asennettu</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>PKG on päivitys, asenna peli ensin!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>PKG VIRHE</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>Purkaminen PKG %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>Purku Valmis</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>Peli asennettu onnistuneesti kohtaan %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>Tiedosto ei vaikuta olevan kelvollinen PKG-tiedosto</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Huijaukset / Paikkaukset pelille </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>Huijaukset/Paikkaukset ovat kokeellisia.\nKäytä varoen.\n\nLataa huijaukset yksitellen valitsemalla repositorion ja napsauttamalla latauspainiketta.\nPaikkaukset-välilehdessä voit ladata kaikki paikkaukset kerralla, valita, mitä haluat käyttää ja tallentaa valinnan.\n\nKoska me emme kehitä Huijauksia/Paikkauksia,\nole hyvä ja ilmoita ongelmista huijauksen tekijälle.\n\nLoitko uuden huijauksen? Käy osoitteessa:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>Kuvaa ei saatavilla</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>Sarjanumero: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>Versio: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>Koko: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>Valitse Huijaustiedosto:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>Repositorio:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>Lataa Huijaukset</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>Poista Tiedosto</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>Tiedostoja ei ole valittuna.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>Voit poistaa ei-toivomasi huijaukset lataamisen jälkeen.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>Haluatko poistaa valitun tiedoston?\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>Valitse Paikkaustiedosto:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>Lataa Paikkaukset</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>Tallenna</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>Huijaukset</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>Paikkaukset</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>Virhe</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>Paikkausta ei ole valittuna.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>Tiedostoa files.json ei voitu avata lukemista varten.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>Nykyiselle sarjanumerolle ei löytynyt paikkaustiedostoa.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>Tiedostoa ei voitu avata lukemista varten.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>Tiedostoa ei voitu avata kirjoittamista varten.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>XML:n jäsentäminen epäonnistui: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>Onnistuminen</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>Vaihtoehdot tallennettu onnistuneesti.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>Virheellinen Lähde</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>Valittu lähde on virheellinen.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>Olemassaoleva Tiedosto</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>Tiedosto on jo olemassa. Haluatko korvata sen?</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>Tiedoston tallentaminen epäonnistui:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>Tiedoston lataaminen epäonnistui:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>Huijauksia Ei Löytynyt</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>Huijauksia ei löytynyt tälle pelin versiolle valitusta repositoriosta. Kokeile toista repositoriota tai eri versiota pelistä.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>Huijaukset Ladattu Onnistuneesti</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>Olet ladannut huijaukset onnistuneesti valitusta repositoriosta tälle pelin versiolle. Voit yrittää ladata toisesta repositoriosta. Jos se on saatavilla, voit myös käyttää sitä valitsemalla tiedoston listasta.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>Tallentaminen epäonnistui:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>Lataus epäonnistui:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>Lataus valmis</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>Paikkaukset ladattu onnistuneesti! Kaikki saatavilla olevat paikkaukset kaikille peleille on ladattu, eikä niitä tarvitse ladata yksittäin jokaiselle pelille, kuten huijausten kohdalla. Jos paikkausta ei näy, saattaa olla, että sitä ei ole saatavilla kyseiselle sarjanumerolle ja peliversiolle.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>JSON-tietojen jäsentäminen HTML:stä epäonnistui.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>HTML-sivun hakeminen epäonnistui.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>Peli on versiossa: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>Ladattu paikkaus toimii vain versiossa: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>Sinun on ehkä päivitettävä pelisi.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>Yhteensopivuusilmoitus</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>Tiedoston avaaminen epäonnistui:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>XML VIRHE:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>Tiedostoa files.json ei voitu avata kirjoittamista varten</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>Tekijä: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>Hakemistoa ei ole olemassa:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>Tiedostoa files.json ei voitu avata lukemista varten.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>Nimi:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>Huijauksia ei voi käyttää ennen kuin peli on käynnissä.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>Tallenna</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
-			<translation>Ota Käyttöön</translation>
+			<translation>Ota käyttöön</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>Palauta Oletukset</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>Sulje</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>Siirrä hiiri vaihtoehdon päälle näyttääksesi sen kuvauksen.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Konsolin Kieli:\nAseta PS4-pelin käyttämä kieli.\nOn suositeltavaa asettaa tämä kieleksi, jota peli tukee, mikä vaihtelee alueittain.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>Emulaattorin Kieli:\nAsettaa emulaattorin käyttöliittymän kielen.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>Ota Koko Näytön Tila Käyttöön:\nAvaa pelin ikkunan automaattisesti koko näytön tilassa.\nTilaa voi vaihtaa painamalla F11-näppäintä.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Ota Käyttöön Erillinen Päivityskansio:\nOttaa käyttöön päivitysten asennuksen erilliseen kansioon helpottamaan niiden hallintaa.\nTämä on tehtävissä manuaalisesti lisäämällä puretun päivityksen pelikansioon "CUSA00000-UPDATE" nimellä, missä CUSA ID vastaa pelin ID:tä.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
-				<translation>Näytä Aloitusnäyttö:\nNäyttää pelin aloitusnäytön (erityinen kuva) pelin käynnistyessä.</translation>
+			<translation>Näytä Aloitusnäyttö:\nNäyttää pelin aloitusnäytön (erityinen kuva) pelin käynnistyessä.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>On PS4 Pro:\nAsettaa emulaattorin toimimaan PS4 PRO:na, mikä voi mahdollistaa erityisiä ominaisuuksia peleissä, jotka tukevat sitä.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>Ota käyttöön Discord Rich Presence:\nNäyttää emulaattorin kuvakkeen ja asiaankuuluvat tiedot Discord-profiilissasi.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>Käyttäjänimi:\nAsettaa PS4-tilin käyttäjänimen, joka voi näkyä joissain peleissä.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Avain:\nThrophyjen dekryptoinnissa käytetty avain. Pitää hankkia jailbreakatusta konsolista.\nSaa sisältää vain hex-merkkejä.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>Lokityyppi:\nAsettaa, synkronoidaanko loki-ikkunan ulostulo suorituskyvyn vuoksi. Tämä voi vaikuttaa haitallisesti emulointiin.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Lokisuodatin:\nSuodattaa lokia tulostamaan vain määrättyä tietoa.\nEsimerkkejä: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical"\nTasot: Trace, Debug, Info, Warning, Error, Critical - tässä järjestyksessä. Valittu taso vaientaa kaikki edeltävät tasot luettelossa ja kirjaa kaikki tasot sen jälkeen.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>Päivitys:\nRelease: Viralliset versiot, jotka julkaistaan kuukausittain ja saattavat olla hyvin vanhoja, mutta ovat luotettavampia ja testatumpia.\nNightly: Kehitysversiot, joissa on kaikki uusimmat ominaisuudet ja korjaukset, mutta ne saattavat sisältää virheitä ja ovat vähemmän vakaita.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Soita Otsikkomusiikkia:\nJos peli tukee sitä, ota käyttöön erityisen musiikin soittaminen pelin valinnan yhteydessä käyttöliittymässä.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Poista Trophy Pop-upit Käytöstä:\nPoista trophy ilmoitukset pelin aikana. Trophyjen edistystä voi silti seurata Trophy Selainta käyttämällä (klikkaa peliä hiiren oikealla emulaattorin pääikkunassa).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>Piilota kursori:\nValitse, milloin kursori häviää:\nEi koskaan: Näet hiiren aina.\nInaktiivinen: Aseta aika, jolloin se häviää oltuaan aktiivinen.\nAina: et koskaan näe hiirtä.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>Aseta aika, milloin hiiri häviää oltuaan aktiivinen.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>Takaisin-napin käyttäytyminen:\nAsettaa ohjaimen takaisin-napin jäljittelemään kosketusta PS4:n kosketuslevyn määritettyyn kohtaan.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Näytä Yhteensopivuustiedot:\nNäyttää pelien yhteensopivuustiedot listanäkymässä. Ota käyttöön "Päivitä Yhteensopivuustietokanta Käynnistäessä" saadaksesi ajantasaista tietoa.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Päivitä Yhteensopivuustiedot Käynnistäessä:\nPäivitä yhteensopivuustiedot automaattisesti shadPS4:n käynnistyessä.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Päivitä Yhteensopivuustietokanta:\nPäivitää yhteensopivuustietokannan heti.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>Ei koskaan</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>Inaktiivinen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>Aina</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>Kosketuslevyn Vasen Puoli</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>Kosketuslevyn Oikea Puoli</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>Kosketuslevyn Keskikohta</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>Ei mitään</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>Näytönohjain:\nUseamman näytönohjaimen järjestelmissä, valitse pudotusvalikosta, mitä näytönohjainta emulaattori käyttää,\n tai valitse "Auto Select" automaattiseen määritykseen.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Leveys/Korkeus:\nAsettaa käynnistetyn emulaattori-ikkunan koon, jota voidaan muuttaa pelin aikana.\nTämä on eri, kuin pelin sisäinen resoluutio.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Vblank Jakaja:\nEmulaattorin virkistystaajuus kerrotaan tällä numerolla. Tämän muuttaminen voi vaikuttaa haitallisesti, kuten lisätä pelin nopeutta tai rikkoa kriittisiä pelitoimintoja, jotka eivät odota tämän muuttuvan!</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>Ota Käyttöön Varjostinvedokset:\nTeknistä vianetsintää varten. Pelin varjostimia tallennetaan hakemistoon niiden renderöityessä.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Ota Null GPU käyttöön:\nTeknistä vianetsintää varten. Pelin renderöinti estetään, ikään kuin näytönohjainta ei olisi.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>Pelihakemistot:\nLista hakemistoista, joista pelejä haetaan.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>Lisää:\nLisää hakemisto listalle.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>Poista:\nPoista hakemisto listalta.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>Ota Käyttöön Virheenkorjausvedokset:\nTallentaa käynnissä olevan PS4-ohjelman tuonti- ja vientisymbolit ja tiedosto-otsikkotiedot hakemistoon.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Ota Käyttöön Vulkan-validointikerrokset:\nAktivoi järjestelmä, joka validoi Vulkan-renderöijän tilan ja kirjaa tietoa sen sisäisestä tilasta. Tämä heikentää suorituskykyä ja todennäköisesti muuttaa emulaation käyttäytymistä.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Ota Käyttöön Vulkan-synkronointivalidointi:\nAktivoi järjestelmä, joka validoi Vulkan-renderöinnin tehtävien aikataulutuksen. Tämä heikentää suorituskykyä ja todennäköisesti muuttaa emulaation käyttäytymistä.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>Ota Käyttöön RenderDoc Virheenkorjaus:\nJos käytössä, emulaattori tarjoaa Renderdoc-yhteensopivuuden, mikä mahdollistaa renderöidyn kehyksen tallennuksen ja analysoinnin.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Huijaukset / Paikkaukset pelille </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>Huijaukset/Paikkaukset ovat kokeellisia.\nKäytä varoen.\n\nLataa huijaukset yksitellen valitsemalla repositorion ja napsauttamalla latauspainiketta.\nPaikkaukset-välilehdessä voit ladata kaikki paikkaukset kerralla, valita, mitä haluat käyttää ja tallentaa valinnan.\n\nKoska me emme kehitä Huijauksia/Paikkauksia,\nole hyvä ja ilmoita ongelmista huijauksen tekijälle.\n\nLoitko uuden huijauksen? Käy osoitteessa:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>Kuvaa ei saatavilla</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>Sarjanumero: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>Versio: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>Koko: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>Valitse Huijaustiedosto:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>Repositorio:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>Lataa Huijaukset</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>Poista Tiedosto</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>Tiedostoja ei ole valittuna.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>Voit poistaa ei-toivomasi huijaukset lataamisen jälkeen.</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>Haluatko poistaa valitun tiedoston?\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>Valitse Paikkaustiedosto:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>Lataa Paikkaukset</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>Tallenna</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>Huijaukset</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>Paikkaukset</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Virhe</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>Paikkausta ei ole valittuna.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>Tiedostoa files.json ei voitu avata lukemista varten.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>Nykyiselle sarjanumerolle ei löytynyt paikkaustiedostoa.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>Tiedostoa ei voitu avata lukemista varten.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>Tiedostoa ei voitu avata kirjoittamista varten.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>XML:n jäsentäminen epäonnistui: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>Onnistuminen</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>Vaihtoehdot tallennettu onnistuneesti.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>Virheellinen Lähde</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>Valittu lähde on virheellinen.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>Olemassaoleva Tiedosto</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>Tiedosto on jo olemassa. Haluatko korvata sen?</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>Tiedoston tallentaminen epäonnistui:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>Tiedoston lataaminen epäonnistui:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>Huijauksia Ei Löytynyt</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>Huijauksia ei löytynyt tälle pelin versiolle valitusta repositoriosta. Kokeile toista repositoriota tai eri versiota pelistä.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>Huijaukset Ladattu Onnistuneesti</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>Olet ladannut huijaukset onnistuneesti valitusta repositoriosta tälle pelin versiolle. Voit yrittää ladata toisesta repositoriosta. Jos se on saatavilla, voit myös käyttää sitä valitsemalla tiedoston listasta.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>Tallentaminen epäonnistui:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>Lataus epäonnistui:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Lataus valmis</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>Paikkaukset ladattu onnistuneesti! Kaikki saatavilla olevat paikkaukset kaikille peleille on ladattu, eikä niitä tarvitse ladata yksittäin jokaiselle pelille, kuten huijausten kohdalla. Jos paikkausta ei näy, saattaa olla, että sitä ei ole saatavilla kyseiselle sarjanumerolle ja peliversiolle.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>JSON-tietojen jäsentäminen HTML:stä epäonnistui.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>HTML-sivun hakeminen epäonnistui.</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>Peli on versiossa: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>Ladattu paikkaus toimii vain versiossa: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>Sinun on ehkä päivitettävä pelisi.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>Yhteensopivuusilmoitus</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>Tiedoston avaaminen epäonnistui:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>XML VIRHE:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>Tiedostoa files.json ei voitu avata kirjoittamista varten</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>Tekijä: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>Hakemistoa ei ole olemassa:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>Tiedostoa files.json ei voitu avata lukemista varten.</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>Nimi:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>Huijauksia ei voi käyttää ennen kuin peli on käynnissä.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>Ikoni</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>Nimi</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>Sarjanumero</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>Alue</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>Ohjelmisto</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>Koko</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>Versio</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>Polku</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>Peliaika</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Pelaamaton</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Yhteensopivuutta ei ole testattu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
-            <translation>Peli ei alustaudu kunnolla / kaataa emulaattorin</translation>
+			<translation>Peli ei alustaudu kunnolla / kaataa emulaattorin</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Peli käynnistyy, mutta näyttää vain tyhjän ruudun</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Peli näyttää kuvan mutta ei mene valikosta eteenpäin</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Pelissä on pelikokemusta rikkovia häiriöitä tai kelvoton suorituskyky</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Pelillä on hyväksyttävä suorituskyky, eikä mitään suuria häiriöitä</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>Automaattinen Päivitys</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>Virhe</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>Verkkovirhe:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>Päivitystietojen jäsentäminen epäonnistui.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>Ennakkojulkaisuja ei löytynyt.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>Virheelliset julkaisutiedot.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>Lataus-URL:ia ei löytynyt määritetylle omaisuudelle.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>Versiosi on jo ajan tasalla!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>Päivitys Saatavilla</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>Päivityskanava</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>Nykyinen Versio</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>Uusin Versio</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>Haluatko päivittää?</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>Näytä Muutoshistoria</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Tarkista Päivitykset Käynnistettäessä</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>Päivitä</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>Ei</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>Piilota Muutoshistoria</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>Muutokset</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>URL-osoitteeseen yhdistettäessä tapahtui verkkovirhe</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>Lataus Valmis</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>Päivitys on ladattu, paina OK asentaaksesi.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>Päivitystiedoston tallentaminen epäonnistui sijaintiin</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>Aloitetaan päivitystä...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>Päivitysskripttitiedoston luominen epäonnistui</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/fr.ts
+++ b/src/qt_gui/translations/fr.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>À propos de shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 est un émulateur open-source expérimental de la PlayStation 4.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>Ce logiciel ne doit pas être utilisé pour jouer à des jeux que vous n'avez pas obtenus légalement.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Ouvrir un dossier</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Chargement de la liste de jeu, veuillez patienter...</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>Annuler</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Chargement...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Choisir un répertoire</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Sélectionnez le répertoire où vous souhaitez effectuer l'installation.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Choisir un répertoire</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Répertoire d'installation des jeux</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Parcourir</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Erreur</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>Le répertoire d'installation des jeux n'est pas valide.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>Créer un raccourci</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>Cheats/Patchs</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>Visionneuse SFO</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>Visionneuse de trophées</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>Ouvrir le Dossier...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>Ouvrir le Dossier du Jeu</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>Ouvrir le Dossier des Données de Sauvegarde</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>Ouvrir le Dossier des Logs</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>Copier infos...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>Copier le nom</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>Copier le N° de série</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>Copier tout</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Supprimer...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Supprimer jeu</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Supprimer MÀJ</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Supprimer DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>Création du raccourci</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>Raccourci créé avec succès !</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>Erreur</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>Erreur lors de la création du raccourci !</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>Installer un PKG</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Jeu</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>This feature requires the 'Enable Separate Update Folder' config option to work. If you want to use this feature, please enable it.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>Ce jeu n'a pas de mise à jour à supprimer!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Mise à jour</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>Ce jeu n'a pas de DLC à supprimer!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Supprime %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Êtes vous sûr de vouloir supprimer le répertoire %1 %2 ?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Ouvrir/Ajouter un dossier ELF</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>Installer des packages (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Démarrer un jeu</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>Vérifier les mises à jour</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>À propos de shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Configurer...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>Installer une application depuis un fichier .pkg</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Jeux récents</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Fermer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>Fermer shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Fermer l'application.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Afficher la liste de jeux</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Rafraîchir la liste de jeux</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Très Petit</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Petit</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Moyen</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Grand</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>Mode liste</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Mode grille</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Visionneuse ELF</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Répertoire des jeux</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>Télécharger Cheats/Patchs</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Dumper la liste des jeux</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>Visionneuse PKG</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Chercher...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>Fichier</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>Affichage</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Icônes des jeux</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Mode d'affichage</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Paramètres</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Utilitaires</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Thèmes</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>Aide</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Sombre</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Clair</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Vert</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Bleu</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Violet</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>Bare d'outils</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>Liste de jeux</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * Version de Vulkan non prise en charge</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>Télécharger les Cheats pour tous les jeux installés</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>Télécharger les patchs pour tous les jeux</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Téléchargement terminé</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>Vous avez téléchargé des Cheats pour tous les jeux installés.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>Patchs téléchargés avec succès !</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>Tous les patchs disponibles ont été téléchargés.</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>Jeux: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>Fichiers PKG (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>Fichiers ELF (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>Démarrer un jeu</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>Un seul fichier peut être sélectionné !</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>Extraction du PKG</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>Patch détecté !</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>Les versions PKG et jeu correspondent: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>Souhaitez-vous remplacer ?</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>La version PKG %1 est plus ancienne que la version installée: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>Jeu installé: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>Souhaitez-vous installer le patch: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>Installation du DLC</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>Souhaitez-vous installer le DLC: %1 ?</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC déjà installé:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>Jeu déjà installé</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>Le PKG est un patch, veuillez d'abord installer le jeu !</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>Erreur PKG</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>Extraction PKG %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>Extraction terminée</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>Jeu installé avec succès à %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>Le fichier ne semble pas être un PKG valide</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Ouvrir un dossier</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Visionneuse de trophées</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Paramètres</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>Général</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>Système</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>Langage de la console</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Langage de l'émulateur</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Émulateur</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Plein écran</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Dossier séparé pour les mises à jours</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Afficher l'image du jeu</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>Mode PS4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Activer la présence Discord</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Nom d'utilisateur</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Journalisation</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Type</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Filtre</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>Entrée</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>Curseur</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>Masquer le curseur</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>Délai d'inactivité pour masquer le curseur</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>Manette</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>Comportement du bouton retour</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Graphismes</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Carte graphique</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Largeur</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Hauteur</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Vblank</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Avancé</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Dumper les shaders</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>NULL GPU</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>Chemins</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>Dossiers de jeu</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>Ajouter...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>Supprimer</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Débogage</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Activer le débogage</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Activer la couche de validation Vulkan</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Activer la synchronisation de la validation Vulkan</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>Activer le débogage RenderDoc</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>Mise à jour</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Vérif. maj au démarrage</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>Canal de Mise à Jour</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>Vérifier les mises à jour</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>Paramètres de l'interface</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Disable Trophy Pop-ups</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>Lire la musique du titre</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Update Compatibility Database On Startup</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Game Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Display Compatibility Data</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Update Compatibility Database</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>Volume</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>Liste de jeux</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * Version de Vulkan non prise en charge</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>Télécharger les Cheats pour tous les jeux installés</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>Télécharger les patchs pour tous les jeux</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>Téléchargement terminé</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>Vous avez téléchargé des Cheats pour tous les jeux installés.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>Patchs téléchargés avec succès !</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>Tous les patchs disponibles ont été téléchargés.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>Jeux: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>Fichiers PKG (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>Fichiers ELF (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>Démarrer un jeu</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>Un seul fichier peut être sélectionné !</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>Extraction du PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>Patch détecté !</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>Les versions PKG et jeu correspondent: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>Souhaitez-vous remplacer ?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>La version PKG %1 est plus ancienne que la version installée: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>Jeu installé: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>Souhaitez-vous installer le patch: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>Installation du DLC</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>Souhaitez-vous installer le DLC: %1 ?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC déjà installé:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>Jeu déjà installé</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>Le PKG est un patch, veuillez d'abord installer le jeu !</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>Erreur PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>Extraction PKG %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>Extraction terminée</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>Jeu installé avec succès à %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>Le fichier ne semble pas être un PKG valide</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Cheats/Patchs pour </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>Les Cheats/Patchs sont expérimentaux.\nUtilisez-les avec précaution.\n\nTéléchargez les Cheats individuellement en sélectionnant le dépôt et en cliquant sur le bouton de téléchargement.\nDans l'onglet Patchs, vous pouvez télécharger tous les patchs en une seule fois, choisir lesquels vous souhaitez utiliser et enregistrer votre sélection.\n\nComme nous ne développons pas les Cheats/Patches,\nmerci de signaler les problèmes à l'auteur du Cheat.\n\nVous avez créé un nouveau cheat ? Visitez:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>Aucune image disponible</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>Série: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>Version: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>Taille: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>Sélectionner le fichier de Cheat:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>Dépôt:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>Télécharger les Cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>Supprimer le fichier</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>Aucun fichier sélectionné.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>Vous pouvez supprimer les Cheats que vous ne souhaitez pas après les avoir téléchargés.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>Voulez-vous supprimer le fichier sélectionné ?\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>Sélectionner le fichier de patch:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>Télécharger les patchs</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>Enregistrer</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>Cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>Patchs</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>Erreur</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>Aucun patch sélectionné.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>Impossible d'ouvrir files.json pour la lecture.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>Aucun fichier de patch trouvé pour la série actuelle.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>Impossible d'ouvrir le fichier pour la lecture.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>Impossible d'ouvrir le fichier pour l'écriture.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>Échec de l'analyse XML: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>Succès</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>Options enregistrées avec succès.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>Source invalide</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>La source sélectionnée est invalide.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>Le fichier existe</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>Le fichier existe déjà. Voulez-vous le remplacer ?</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>Échec de l'enregistrement du fichier:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>Échec du téléchargement du fichier:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>Cheats non trouvés</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>Aucun Cheat trouvé pour ce jeu dans cette version du dépôt sélectionné, essayez un autre dépôt ou une version différente du jeu.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>Cheats téléchargés avec succès</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>Vous avez téléchargé les cheats avec succès pour cette version du jeu depuis le dépôt sélectionné. Vous pouvez essayer de télécharger depuis un autre dépôt, si disponible, il sera également possible de l'utiliser en sélectionnant le fichier dans la liste.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>Échec de l'enregistrement:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>Échec du téléchargement:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>Téléchargement terminé</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>Patchs téléchargés avec succès ! Tous les patches disponibles pour tous les jeux ont été téléchargés, il n'est pas nécessaire de les télécharger individuellement pour chaque jeu comme c'est le cas pour les Cheats. Si le correctif n'apparaît pas, il se peut qu'il n'existe pas pour le numéro de série et la version spécifiques du jeu.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>Échec de l'analyse des données JSON à partir du HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>Échec de la récupération de la page HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>Le jeu est en version: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>Le patch téléchargé ne fonctionne que sur la version: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>Vous devrez peut-être mettre à jour votre jeu.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>Avis d'incompatibilité</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>Échec de l'ouverture du fichier:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>Erreur XML:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>Échec de l'ouverture de files.json pour l'écriture</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>Auteur: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>Répertoire n'existe pas:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>Échec de l'ouverture de files.json pour la lecture.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>Nom:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>Impossible d'appliquer les Cheats avant que le jeu ne commence.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>Enregistrer</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>Appliquer</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>Restaurer les paramètres par défaut</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>Fermer</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>Pointez votre souris sur une option pour afficher sa description.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Langue de la console:\nDéfinit la langue utilisée par le jeu PS4.\nIl est recommandé de le définir sur une langue que le jeu prend en charge, ce qui variera selon la région.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>Langue de l'émulateur:\nDéfinit la langue de l'interface utilisateur de l'émulateur.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>Activer le mode plein écran:\nMet automatiquement la fenêtre du jeu en mode plein écran.\nCela peut être activé en appuyant sur la touche F11.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Dossier séparé pour les mises à jours:\nInstalle les mises à jours des jeux dans un dossier séparé pour une gestion plus facile.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>Afficher l'écran de démarrage:\nAffiche l'écran de démarrage du jeu (une image spéciale) lors du démarrage du jeu.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>Mode PS4 Pro:\nFait en sorte que l'émulateur se comporte comme un PS4 PRO, ce qui peut activer des fonctionnalités spéciales dans les jeux qui le prennent en charge.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>Activer Discord Rich Presence:\nAffiche l'icône de l'émulateur et les informations pertinentes sur votre profil Discord.</translation>
 		</message>
 		<message>
-				<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>Nom d'utilisateur:\nDéfinit le nom d'utilisateur du compte PS4, qui peut être affiché par certains jeux.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>Type de journal:\nDétermine si la sortie de la fenêtre de journalisation est synchronisée pour des raisons de performance. Cela peut avoir un impact négatif sur l'émulation.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Filtre de journal:\n n'imprime que des informations spécifiques.\nExemples: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" Niveaux: Trace, Debug, Info, Avertissement, Erreur, Critique - dans cet ordre, un niveau particulier désactive tous les niveaux précédents de la liste et enregistre tous les niveaux suivants.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>Mise à jour:\nRelease: versions officielles publiées chaque mois qui peuvent être très anciennes, mais plus fiables et testées.\nNightly: versions de développement avec toutes les dernières fonctionnalités et correctifs, mais pouvant avoir des bogues et être moins stables.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Jouer de la musique de titre:\nSi le jeu le prend en charge, cela active la musique spéciale lorsque vous sélectionnez le jeu dans l'interface utilisateur.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Disable Trophy Pop-ups:\nDisable in-game trophy notifications. Trophy progress can still be tracked using the Trophy Viewer (right-click the game in the main window).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>Masquer le curseur:\nChoisissez quand le curseur disparaîtra:\nJamais: Vous verrez toujours la souris.\nInactif: Définissez un temps pour qu'il disparaisse après inactivité.\nToujours: vous ne verrez jamais la souris.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>Définissez un temps pour que la souris disparaisse après être inactif.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>Comportement du bouton retour:\nDéfinit le bouton de retour de la manette pour imiter le toucher de la position spécifiée sur le pavé tactile PS4.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Display Compatibility Data:\nDisplays game compatibility information in table view. Enable "Update Compatibility On Startup" to get up-to-date information.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Update Compatibility On Startup:\nAutomatically update the compatibility database when shadPS4 starts.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Update Compatibility Database:\nImmediately update the compatibility database.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>Jamais</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>Inactif</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>Toujours</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>Pavé Tactile Gauche</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>Pavé Tactile Droit</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>Centre du Pavé Tactile</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>Aucun</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>Adaptateur graphique:\nSélectionnez le GPU que l'émulateur utilisera dans les systèmes multi-GPU à partir de la liste déroulante,\nou choisissez "Auto Select" pour le déterminer automatiquement.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Largeur/Hauteur:\nDéfinit la taille de la fenêtre de l'émulateur au démarrage, qui peut être redimensionnée pendant le jeu.\nCela diffère de la résolution interne du jeu.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Diviseur Vblank:\nLe taux de rafraîchissement de l'émulateur est multiplié par ce nombre. Changer cela peut avoir des effets négatifs, tels qu'une augmentation de la vitesse du jeu ou la rupture de fonctionnalités critiques du jeu qui ne s'attendent pas à ce changement !</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>Activer l'exportation de shaders:\nPour le débogage technique, les shaders du jeu sont enregistrés dans un dossier lors du rendu.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Activer le GPU nul:\nPour le débogage technique, désactive le rendu du jeu comme s'il n'y avait pas de carte graphique.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>Dossiers de jeux:\nLa liste des dossiers à vérifier pour les jeux installés.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>Ajouter:\nAjouter un dossier à la liste.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>Supprimer:\nSupprimer un dossier de la liste.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>Activer l'exportation de débogage:\nEnregistre les symboles d'importation et d'exportation et les informations d'en-tête du fichier du programme PS4 actuel dans un répertoire.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Activer les couches de validation Vulkan:\nActive un système qui valide l'état du rendu Vulkan et enregistre des informations sur son état interne. Cela réduit les performances et peut changer le comportement de l'émulation.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Activer la validation de synchronisation Vulkan:\nActive un système qui valide la planification des tâches de rendu Vulkan. Cela réduit les performances et peut changer le comportement de l'émulation.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>Activer le débogage RenderDoc:\nS'il est activé, l'émulateur fournit une compatibilité avec Renderdoc, permettant d'enregistrer et d'analyser la trame rendue actuelle.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Cheats/Patchs pour </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>Les Cheats/Patchs sont expérimentaux.\nUtilisez-les avec précaution.\n\nTéléchargez les Cheats individuellement en sélectionnant le dépôt et en cliquant sur le bouton de téléchargement.\nDans l'onglet Patchs, vous pouvez télécharger tous les patchs en une seule fois, choisir lesquels vous souhaitez utiliser et enregistrer votre sélection.\n\nComme nous ne développons pas les Cheats/Patches,\nmerci de signaler les problèmes à l'auteur du Cheat.\n\nVous avez créé un nouveau cheat ? Visitez:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>Aucune image disponible</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>Série: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>Version: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>Taille: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>Sélectionner le fichier de Cheat:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>Dépôt:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>Télécharger les Cheats</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>Supprimer le fichier</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>Aucun fichier sélectionné.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>Vous pouvez supprimer les Cheats que vous ne souhaitez pas après les avoir téléchargés.</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>Voulez-vous supprimer le fichier sélectionné ?\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>Sélectionner le fichier de patch:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>Télécharger les patchs</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>Enregistrer</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>Cheats</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>Patchs</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Erreur</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>Aucun patch sélectionné.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>Impossible d'ouvrir files.json pour la lecture.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>Aucun fichier de patch trouvé pour la série actuelle.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>Impossible d'ouvrir le fichier pour la lecture.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>Impossible d'ouvrir le fichier pour l'écriture.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>Échec de l'analyse XML: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>Succès</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>Options enregistrées avec succès.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>Source invalide</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>La source sélectionnée est invalide.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>Le fichier existe</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>Le fichier existe déjà. Voulez-vous le remplacer ?</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>Échec de l'enregistrement du fichier:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>Échec du téléchargement du fichier:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>Cheats non trouvés</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>Aucun Cheat trouvé pour ce jeu dans cette version du dépôt sélectionné, essayez un autre dépôt ou une version différente du jeu.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>Cheats téléchargés avec succès</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>Vous avez téléchargé les cheats avec succès pour cette version du jeu depuis le dépôt sélectionné. Vous pouvez essayer de télécharger depuis un autre dépôt, si disponible, il sera également possible de l'utiliser en sélectionnant le fichier dans la liste.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>Échec de l'enregistrement:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>Échec du téléchargement:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Téléchargement terminé</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>Patchs téléchargés avec succès ! Tous les patches disponibles pour tous les jeux ont été téléchargés, il n'est pas nécessaire de les télécharger individuellement pour chaque jeu comme c'est le cas pour les Cheats. Si le correctif n'apparaît pas, il se peut qu'il n'existe pas pour le numéro de série et la version spécifiques du jeu.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>Échec de l'analyse des données JSON à partir du HTML.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>Échec de la récupération de la page HTML.</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>Le jeu est en version: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>Le patch téléchargé ne fonctionne que sur la version: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>Vous devrez peut-être mettre à jour votre jeu.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>Avis d'incompatibilité</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>Échec de l'ouverture du fichier:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>Erreur XML:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>Échec de l'ouverture de files.json pour l'écriture</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>Auteur: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>Répertoire n'existe pas:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>Échec de l'ouverture de files.json pour la lecture.</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>Nom:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>Impossible d'appliquer les Cheats avant que le jeu ne commence.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>Icône</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>Nom</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>Série</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>Région</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>Firmware</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>Taille</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>Version</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>Répertoire</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>Temps de jeu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Jamais joué</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Compatibility is untested</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Game does not initialize properly / crashes the emulator</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Game boots, but only displays a blank screen</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Game displays an image but does not go past the menu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Game has game-breaking glitches or unplayable performance</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>Mise à jour automatique</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>Erreur</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>Erreur réseau:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>Échec de l'analyse des informations de mise à jour.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>Aucune pré-version trouvée.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>Données de version invalides.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>Aucune URL de téléchargement trouvée pour l'élément spécifié.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>Votre version est déjà à jour !</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>Mise à jour disponible</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>Canal de Mise à Jour</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>Version actuelle</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>Dernière version</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>Voulez-vous mettre à jour ?</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>Afficher le journal des modifications</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Vérif. maj au démarrage</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>Mettre à jour</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>Non</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>Cacher le journal des modifications</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>Modifications</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>Une erreur réseau s'est produite en essayant d'accéder à l'URL</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>Téléchargement terminé</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>La mise à jour a été téléchargée, appuyez sur OK pour l'installer.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>Échec de la sauvegarde du fichier de mise à jour à</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>Démarrage de la mise à jour...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>Échec de la création du fichier de script de mise à jour</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/hu_HU.ts
+++ b/src/qt_gui/translations/hu_HU.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>A shadPS4-ről</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>A shadPS4 egy kezdetleges, open-source PlayStation 4 emulátor.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>Ne használja ezt a szoftvert olyan játékokkal, amelyeket nem legális módon szerzett be.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Mappa megnyitása</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Játék könyvtár betöltése, kérjük várjon :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>Megszakítás</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Betöltés..</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Mappa kiválasztása</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Válassza ki a mappát a játékok telepítésére.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Mappa kiválasztása</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Mappa a játékok telepítésére</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Böngészés</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Hiba</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>A játékok telepítéséhez megadott útvonal nem érvényes.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="39"/>
 			<source>Create Shortcut</source>
 			<translation>Parancsikon Létrehozása</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>Csalások / Javítások</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="41"/>
 			<source>SFO Viewer</source>
 			<translation>SFO Nézegető</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="42"/>
 			<source>Trophy Viewer</source>
 			<translation>Trófeák Megtekintése</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>Mappa megnyitása...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>Játék Mappa Megnyitása</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>Mentési adatok mappa megnyitása</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>Napló mappa megnyitása</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Copy info...</source>
 			<translation>Információ Másolása...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Copy Name</source>
 			<translation>Név Másolása</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Copy Serial</source>
 			<translation>Széria Másolása</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="53"/>
 			<source>Copy All</source>
 			<translation>Összes Másolása</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Törlés...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Játék törlése</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Frissítések törlése</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>DLC-k törlése</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="173"/>
 			<source>Shortcut creation</source>
 			<translation>Parancsikon létrehozása</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="174"/>
 			<source>Shortcut created successfully!</source>
 			<translation>Parancsikon sikeresen létrehozva!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="177"/>
 			<source>Error</source>
 			<translation>Hiba</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="178"/>
 			<source>Error creating shortcut!</source>
 			<translation>Hiba a parancsikon létrehozásával!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="253"/>
 			<source>Install PKG</source>
 			<translation>PKG telepítése</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Játék</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>Ehhez a funkcióhoz szükséges a 'Külön Frissítési Mappa Engedélyezése' opció, hogy működjön. Ha használni akarja, először engedélyezze azt.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>Ehhez a játékhoz nem tartozik törlendő frissítés!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Frissítés</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>Ehhez a játékhoz nem tartozik törlendő DLC!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Delete %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Biztosan törölni akarja a %1's %2 mappát?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>ELF Mappa Megnyitása/Hozzáadása</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>PKG-k Telepítése (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Játék Indítása</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>Frissítések keresése</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>A shadPS4-ről</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Konfigurálás...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>Program telepítése egy .pkg fájlból</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Legutóbbi Játékok</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Kilépés</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>Kilépés a shadPS4-ből</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Lépjen ki a programból.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Játék Könyvtár Megjelenítése</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Játék Könyvtár Újratöltése</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Apró</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Kicsi</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Közepes</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Nagy</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>Lista Nézet</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Rács Nézet</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Elf Nézegető</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Játék Telepítési Mappa</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>Csalások / Javítások letöltése</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Játéklista Dumpolása</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>PKG Nézegető</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Keresés...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>Fájl</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>Nézet</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Játékkönyvtár Ikonok</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Játékkönyvtár Nézet</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Beállítások</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Segédeszközök</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Témák</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>Segítség</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Sötét</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Világos</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Zöld</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Kék</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Ibolya</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>Eszköztár</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>Játéklista</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * Nem támogatott Vulkan verzió</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>Csalások letöltése minden telepített játékhoz</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>Javítások letöltése minden játékhoz</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Letöltés befejezve</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>Minden elérhető csalás letöltődött az összes telepített játékhoz.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>Javítások sikeresen letöltve!</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>Az összes játékhoz elérhető javítás letöltésre került.</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>Játékok: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>PKG fájl (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>ELF fájlok (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>Játék indító</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>Csak egy fájl választható ki!</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>PKG kicsomagolás</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>Frissítés észlelve!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>A PKG és a játék verziói egyeznek: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>Szeretné felülírni?</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>A(z) %1-es PKG verzió régebbi, mint a telepített verzió: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>A játék telepítve van: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>Szeretné telepíteni a frissítést: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>DLC Telepítés</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>Szeretné telepíteni a %1 DLC-t?</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC már telepítve:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>A játék már telepítve van</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>A PKG egy javítás, először telepítsd a játékot!</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>PKG HIBA</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>PKG kicsomagolása %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>Kicsomagolás befejezve</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>A játék sikeresen telepítve itt: %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>A fájl nem tűnik érvényes PKG fájlnak</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Mappa Megnyitása</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Trófeák Megtekintése</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Beállítások</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>Általános</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>Rendszer</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>A Konzol Nyelvezete</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Az Emulátor Nyelvezete</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Emulátor</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Teljes Képernyő Engedélyezése</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Külön Frissítési Mappa Engedélyezése</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Indítóképernyő Mutatása</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>PS4 Pro mód</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>A Discord Rich Presence engedélyezése</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Felhasználónév</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Naplózó</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Naplózási Típus</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Naplózási Filter</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>Bemenet</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>Kurzor</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>Kurzor elrejtése</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>Kurzor inaktivitási időtúllépés</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>Kontroller</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>Vissza gomb Viselkedése</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Grafika</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Grafikai Eszköz</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Szélesség</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Magasság</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Vblank Elosztó</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Haladó</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Shader Dumpolás Engedélyezése</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>NULL GPU Engedélyezése</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>Útvonalak</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>Játékmappák</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>Hozzáadás...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>Eltávolítás</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Debugolás</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Debug Dumpolás Engedélyezése</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Vulkan Validációs Rétegek Engedélyezése</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Vulkan Szinkronizálás Validáció</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>RenderDoc Debugolás Engedélyezése</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>Frissítés</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Frissítések keresése indításkor</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>Frissítési Csatorna</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>Frissítések keresése</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>GUI Beállítások</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Disable Trophy Pop-ups</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>Címzene lejátszása</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Update Compatibility Database On Startup</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Game Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Display Compatibility Data</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Update Compatibility Database</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>Hangerő</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>Játéklista</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * Nem támogatott Vulkan verzió</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>Csalások letöltése minden telepített játékhoz</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>Javítások letöltése minden játékhoz</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>Letöltés befejezve</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>Minden elérhető csalás letöltődött az összes telepített játékhoz.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>Javítások sikeresen letöltve!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>Az összes játékhoz elérhető javítás letöltésre került.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>Játékok: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>PKG fájl (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>ELF fájlok (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>Játék indító</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>Csak egy fájl választható ki!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>PKG kicsomagolás</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>Frissítés észlelve!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>A PKG és a játék verziói egyeznek: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>Szeretné felülírni?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>A(z) %1-es PKG verzió régebbi, mint a telepített verzió: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>A játék telepítve van: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>Szeretné telepíteni a frissítést: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>DLC Telepítés</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>Szeretné telepíteni a %1 DLC-t?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC már telepítve:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>A játék már telepítve van</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>A PKG egy javítás, először telepítsd a játékot!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>PKG HIBA</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>PKG kicsomagolása %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>Kicsomagolás befejezve</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>A játék sikeresen telepítve itt: %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>A fájl nem tűnik érvényes PKG fájlnak</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Cheats / Patches for </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>A csalások/javítások kísérleti jellegűek.\nHasználja őket óvatosan.\n\nTöltse le a csalásokat egyesével a tároló kiválasztásával és a letöltés gombra kattintással.\nA Javítások fül alatt egyszerre letöltheti az összes javítást, majd választhat, melyeket szeretné használni, és elmentheti a választását.\n\nMivel nem mi fejlesztjük a csalásokat/patch-eket,\nkérjük, jelentse a problémákat a csalás szerzőjének.\n\nKészített egy új csalást? Látogasson el ide:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>Nincs elérhető kép</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>Sorozatszám: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>Verzió: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>Méret: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>Válaszd ki a csalás fájlt:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>Tároló:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>Csalások letöltése</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>Fájl törlése</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>Nincsenek kiválasztott fájlok.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>Törölheted a nem kívánt csalásokat a letöltés után.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>Szeretnéd törölni a kiválasztott fájlt?\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>Válaszd ki a javítás fájlt:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>Javítások letöltése</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>Mentés</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>Csalások</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>Javítások</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>Hiba</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>Nincs kiválasztva javítás.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>Nem sikerült megnyitni a files.json fájlt olvasásra.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>Nincs található javítási fájl a jelenlegi sorozatszámhoz.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>Nem sikerült megnyitni a fájlt olvasásra.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>Nem sikerült megnyitni a fájlt írásra.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>XML elemzési hiba: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>Siker</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>A beállítások sikeresen elmentve.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>Érvénytelen forrás</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>A kiválasztott forrás érvénytelen.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>A fájl létezik</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>A fájl már létezik. Szeretnéd helyettesíteni?</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>Nem sikerült elmenteni a fájlt:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>Nem sikerült letölteni a fájlt:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>Csalások nem találhatóak</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>Nincs található csalás ezen a játékverzión ebben a kiválasztott tárolóban, próbálj meg egy másik tárolót vagy a játék egy másik verzióját.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>Csalások sikeresen letöltve</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>Sikeresen letöltötted a csalásokat ennek a játéknak a verziójához a kiválasztott tárolóból. Próbálhatsz letölteni egy másik tárolóból is, ha az elérhető, akkor a fájl kiválasztásával az is használható lesz.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>Nem sikerült menteni:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>Nem sikerült letölteni:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>Letöltés befejezve</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>Frissítések sikeresen letöltve! Minden elérhető frissítés letöltésre került, nem szükséges egyesével letölteni őket minden játékhoz, mint a csalások esetében. Ha a javítások nem jelennek meg, lehet, hogy nem léteznek a játék adott sorozatszámához és verziójához.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>Nem sikerült az JSON adatok elemzése HTML-ből.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>Nem sikerült HTML oldal lekérése.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>A játék verziója: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>A letöltött javításhoz a(z) %1 verzió működik</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>Lehet, hogy frissítened kell a játékodat.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>Inkompatibilitási értesítés</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>Nem sikerült megnyitni a fájlt:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>XML HIBA:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>Nem sikerült megnyitni a files.json fájlt írásra</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>Szerző: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>A mappa nem létezik:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>Nem sikerült megnyitni a files.json fájlt olvasásra.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>Név:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>Nem lehet csalásokat alkalmazni, mielőtt a játék elindul.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>Mentés</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>Alkalmaz</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>Alapértelmezett értékek visszaállítása</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>Bezárás</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>Helyezze az egérmutatót egy lehetőség fölé, hogy megjelenítse annak leírását.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Konzol nyelve:\nBeállítja a PS4 játék nyelvét.\nAjánlott a játék által támogatott nyelvre állítani, amely régiónként változhat.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>Emulátor nyelve:\nBeállítja az emulátor felhasználói felületének nyelvét.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>Teljes képernyő engedélyezése:\nAutomatikusan teljes képernyőre állítja a játék ablakát.\nEz a F11 billentyű megnyomásával kapcsolható ki/be.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Külön Frissítéi Mappa Engedélyezése:\nEngedélyezi a frissítések külön mappába helyezését, a könnyű kezelésük érdekében.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>Indítóképernyő megjelenítése:\nMegjeleníti a játék indítóképernyőjét (különleges képet) a játék elindításakor.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>PS4 Pro:\nAz emulátort PS4 PRO-ként kezeli, ami engedélyezhet speciális funkciókat olyan játékokban, amelyek támogatják azt.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>A Discord Rich Presence engedélyezése:\nMegjeleníti az emulator ikonját és a kapcsolódó információkat a Discord profilján.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>Felhasználónév:\nBeállítja a PS4 fiók felhasználónevét, amelyet egyes játékok megjeleníthetnek.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>Napló típusa:\nBeállítja, hogy szinkronizálja-e a naplóablak kimenetét a teljesítmény érdekében. Ennek kedvezőtlen hatásai lehetnek az emulációra.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Napló szűrő:\nCsak bizonyos információk megjelenítésére szűri a naplót.\nPéldák: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" Szintek: Trace, Debug, Info, Warning, Error, Critical - ebben a sorrendben, egy konkrét szint elnémítja az előtte lévő összes szintet, és naplózza az utána következő szinteket.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>Frissítés:\nRelease: Hivatalos verziók, amelyeket havonta adnak ki, és amelyek nagyon elavultak lehetnek, de megbízhatóbbak és teszteltek.\nNightly: Fejlesztési verziók, amelyek az összes legújabb funkciót és javítást tartalmazzák, de hibákat tartalmazhatnak és kevésbé stabilak.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Játék címzene lejátszása:\nHa a játék támogatja, engedélyezze egy speciális zene lejátszását, amikor a játékot kiválasztja a GUI-ban.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Disable Trophy Pop-ups:\nDisable in-game trophy notifications. Trophy progress can still be tracked using the Trophy Viewer (right-click the game in the main window).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>Kurzor elrejtése:\nVálassza ki, mikor tűnjön el az egérmutató:\nSoha: Az egér mindig látható.\nInaktív: Állítson be egy időt, amennyi idő mozdulatlanság után eltűnik.\nMindig: az egér mindig el lesz rejtve.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>Állítson be egy időt, ami után egér inaktív állapotban eltűnik.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>Vissza gomb viselkedés:\nBeállítja a vezérlő vissza gombját, hogy utánozza a PS4 érintőpadján megadott pozíció megérintését.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Display Compatibility Data:\nDisplays game compatibility information in table view. Enable "Update Compatibility On Startup" to get up-to-date information.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Update Compatibility On Startup:\nAutomatically update the compatibility database when shadPS4 starts.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Update Compatibility Database:\nImmediately update the compatibility database.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>Soha</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>Inaktív</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>Mindig</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>Érintőpad Bal</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>Érintőpad Jobb</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>Érintőpad Közép</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>Semmi</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>Grafikus eszköz:\nTöbb GPU-s rendszereken válassza ki, melyik GPU-t használja az emulátor a legördülő listából,\nvagy válassza az "Auto Select" lehetőséget, hogy automatikusan kiválassza azt.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Szélesség/Magasság:\nBeállítja az emulátor ablakának méretét induláskor, amely a játék során átméretezhető.\nEz különbözik a játékbeli felbontástól.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Vblank elosztó:\nAz emulátor frissítési sebessége e számot megszorozva működik. Ennek megváltoztatása kedvezőtlen hatásokat okozhat, például növelheti a játék sebességét, vagy megszakíthat kritikus játékfunkciókat, amelyek nem számítanak arra, hogy ez megváltozik!</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>Shader dumping engedélyezése:\nMűszaki hibaelhárítás céljából a játékok shaderjeit elmenti egy mappába, ahogy renderelődnek.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Null GPU engedélyezése:\nMűszaki hibaelhárítás céljából letiltja a játék renderelését, mintha nem lenne grafikus kártya.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>Játék mappák:\nA mappák listája, ahol telepített játékok vannak.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>Hozzáadás:\nHozzon létre egy mappát a listában.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>Eltávolítás:\nTávolítson el egy mappát a listából.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>Debug dumpolás engedélyezése:\nElmenti a futó PS4 program import- és exportszimbólumait, valamint a fájl fejlécinformációit egy könyvtárba.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Vulkan validációs rétegek engedélyezése:\nEngedélyezi a Vulkan renderelő állapotának validálását és információk naplózását annak belső állapotáról. Ez csökkenti a teljesítményt és valószínűleg megváltoztatja az emuláció viselkedését.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Vulkan szinkronizációs validáció engedélyezése:\nEngedélyezi a Vulkan renderelési feladatok időzítésének validálását. Ez csökkenti a teljesítményt és valószínűleg megváltoztatja az emuláció viselkedését.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>RenderDoc hibakeresés engedélyezése:\nHa engedélyezve van, az emulátor kompatibilitást biztosít a Renderdoc számára, hogy lehetővé tegye a jelenleg renderelt keret rögzítését és elemzését.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Cheats / Patches for </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>A csalások/javítások kísérleti jellegűek.\nHasználja őket óvatosan.\n\nTöltse le a csalásokat egyesével a tároló kiválasztásával és a letöltés gombra kattintással.\nA Javítások fül alatt egyszerre letöltheti az összes javítást, majd választhat, melyeket szeretné használni, és elmentheti a választását.\n\nMivel nem mi fejlesztjük a csalásokat/patch-eket,\nkérjük, jelentse a problémákat a csalás szerzőjének.\n\nKészített egy új csalást? Látogasson el ide:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>Nincs elérhető kép</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>Sorozatszám: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>Verzió: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>Méret: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>Válaszd ki a csalás fájlt:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>Tároló:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>Csalások letöltése</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>Fájl törlése</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>Nincsenek kiválasztott fájlok.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>Törölheted a nem kívánt csalásokat a letöltés után.</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>Szeretnéd törölni a kiválasztott fájlt?\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>Válaszd ki a javítás fájlt:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>Javítások letöltése</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>Mentés</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>Csalások</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>Javítások</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Hiba</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>Nincs kiválasztva javítás.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>Nem sikerült megnyitni a files.json fájlt olvasásra.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>Nincs található javítási fájl a jelenlegi sorozatszámhoz.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>Nem sikerült megnyitni a fájlt olvasásra.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>Nem sikerült megnyitni a fájlt írásra.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>XML elemzési hiba: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>Siker</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>A beállítások sikeresen elmentve.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>Érvénytelen forrás</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>A kiválasztott forrás érvénytelen.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>A fájl létezik</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>A fájl már létezik. Szeretnéd helyettesíteni?</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>Nem sikerült elmenteni a fájlt:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>Nem sikerült letölteni a fájlt:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>Csalások nem találhatóak</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>Nincs található csalás ezen a játékverzión ebben a kiválasztott tárolóban, próbálj meg egy másik tárolót vagy a játék egy másik verzióját.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>Csalások sikeresen letöltve</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>Sikeresen letöltötted a csalásokat ennek a játéknak a verziójához a kiválasztott tárolóból. Próbálhatsz letölteni egy másik tárolóból is, ha az elérhető, akkor a fájl kiválasztásával az is használható lesz.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>Nem sikerült menteni:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>Nem sikerült letölteni:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Letöltés befejezve</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>Frissítések sikeresen letöltve! Minden elérhető frissítés letöltésre került, nem szükséges egyesével letölteni őket minden játékhoz, mint a csalások esetében. Ha a javítások nem jelennek meg, lehet, hogy nem léteznek a játék adott sorozatszámához és verziójához.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>Nem sikerült az JSON adatok elemzése HTML-ből.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>Nem sikerült HTML oldal lekérése.</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>A játék verziója: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>A letöltött javításhoz a(z) %1 verzió működik</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>Lehet, hogy frissítened kell a játékodat.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>Inkompatibilitási értesítés</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>Nem sikerült megnyitni a fájlt:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>XML HIBA:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>Nem sikerült megnyitni a files.json fájlt írásra</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>Szerző: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>A mappa nem létezik:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>Nem sikerült megnyitni a files.json fájlt olvasásra.</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>Név:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>Nem lehet csalásokat alkalmazni, mielőtt a játék elindul.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>Ikon</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>Név</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>Sorozatszám</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>Régió</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>Firmware</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>Méret</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>Verzió</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>Útvonal</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>Játékidő</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Never Played</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Compatibility is untested</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Game does not initialize properly / crashes the emulator</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Game boots, but only displays a blank screen</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Game displays an image but does not go past the menu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Game has game-breaking glitches or unplayable performance</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>Automatikus frissítő</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>Hiba</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>Hálózati hiba:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>A frissítési információk elemzése sikertelen.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>Nem található előzetes kiadás.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>Érvénytelen kiadási adatok.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>Nincs letöltési URL a megadott eszközhöz.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>A verziód már naprakész!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>Frissítés elérhető</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>Frissítési Csatorna</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>Jelenlegi verzió</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>Új verzió</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>Szeretnéd frissíteni?</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>Változások megjelenítése</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Frissítések keresése indításkor</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>Frissítés</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>Mégse</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>Változások elrejtése</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>Változások</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>Hálózati hiba történt az URL elérésekor</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>Letöltés kész</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>A frissítés letöltődött, nyomja meg az OK gombot az telepítéshez.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>A frissítési fájl mentése nem sikerült a következő helyre</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>Frissítés indítása...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>A frissítési szkript fájl létrehozása nem sikerült</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/id.ts
+++ b/src/qt_gui/translations/id.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>About shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 is an experimental open-source emulator for the PlayStation 4.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>This software should not be used to play games you have not legally obtained.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Open Folder</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Loading game list, please wait :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>Cancel</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Loading...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Choose directory</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Select which directory you want to install to.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Choose directory</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Directory to install games</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Browse</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>The value for location to install games is not valid.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>Create Shortcut</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>Cheat / Patch</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>SFO Viewer</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophy Viewer</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>Buka Folder...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>Buka Folder Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>Buka Folder Data Simpanan</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>Buka Folder Log</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>Copy info...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>Copy Name</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>Copy Serial</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>Copy All</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Delete...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Delete Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Delete Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Delete DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>Shortcut creation</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>Shortcut created successfully!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>Error creating shortcut!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>Install PKG</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>This feature requires the 'Enable Separate Update Folder' config option to work. If you want to use this feature, please enable it.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>This game has no update to delete!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>This game has no DLC to delete!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Delete %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Are you sure you want to delete %1's %2 directory?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Open/Add Elf Folder</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>Install Packages (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Boot Game</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>Periksa pembaruan</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>About shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Configure...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>Install application from a .pkg file</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Recent Games</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Exit</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>Exit shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Exit the application.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Show Game List</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Game List Refresh</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Tiny</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Small</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Medium</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Large</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>List View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Grid View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Elf Viewer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Game Install Directory</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>Unduh Cheat / Patch</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Dump Game List</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>PKG Viewer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Search...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>File</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Game List Icons</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Game List Mode</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Settings</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Utils</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Themes</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>Bantuan</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Dark</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Light</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Green</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Blue</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Violet</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>toolBar</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>Daftar game</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * Versi Vulkan Tidak Didukung</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>Unduh Cheat Untuk Semua Game Yang Terpasang</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>Unduh Patch Untuk Semua Game</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Unduhan Selesai</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>Anda telah mengunduh cheat untuk semua game yang terpasang.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>Patch Berhasil Diunduh!</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>Semua Patch yang tersedia untuk semua game telah diunduh.</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>Game: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>File PKG (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>File ELF (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>Boot Game</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>Hanya satu file yang bisa dipilih!</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>Ekstraksi PKG</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>Patch terdeteksi!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>Versi PKG dan Game cocok: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>Apakah Anda ingin menimpa?</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>Versi PKG %1 lebih lama dari versi yang terpasang: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>Game telah terpasang: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>Apakah Anda ingin menginstal patch: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>Instalasi DLC</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>Apakah Anda ingin menginstal DLC: %1?</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC sudah terpasang:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>Game sudah terpasang</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>PKG adalah patch, harap pasang game terlebih dahulu!</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>KESALAHAN PKG</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>Mengekstrak PKG %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>Ekstraksi Selesai</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>Game berhasil dipasang di %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>File tampaknya bukan file PKG yang valid</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Open Folder</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophy Viewer</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Settings</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>General</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>System</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>Console Language</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Emulator Language</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Emulator</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Enable Fullscreen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Show Splash</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>Is PS4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Aktifkan Discord Rich Presence</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Username</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Logger</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Log Type</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Log Filter</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>Masukan</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>Kursor</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>Sembunyikan kursor</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>Batas waktu sembunyikan kursor tidak aktif</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>Pengontrol</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>Perilaku tombol kembali</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Graphics</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Graphics Device</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Width</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Height</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Vblank Divider</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Advanced</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Enable Shaders Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>Enable NULL GPU</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>Jalur</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>Folder Permainan</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>Tambah...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>Hapus</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Debug</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Enable Debug Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Enable Vulkan Validation Layers</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Enable Vulkan Synchronization Validation</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>Enable RenderDoc Debugging</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>Pembaruan</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Periksa pembaruan saat mulai</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>Saluran Pembaruan</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>Periksa pembaruan</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>Pengaturan GUI</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Disable Trophy Pop-ups</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>Putar musik judul</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Update Compatibility Database On Startup</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Game Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Display Compatibility Data</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Update Compatibility Database</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>Volume</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>Daftar game</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * Versi Vulkan Tidak Didukung</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>Unduh Cheat Untuk Semua Game Yang Terpasang</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>Unduh Patch Untuk Semua Game</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>Unduhan Selesai</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>Anda telah mengunduh cheat untuk semua game yang terpasang.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>Patch Berhasil Diunduh!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>Semua Patch yang tersedia untuk semua game telah diunduh.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>Game: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>File PKG (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>File ELF (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>Boot Game</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>Hanya satu file yang bisa dipilih!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>Ekstraksi PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>Patch terdeteksi!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>Versi PKG dan Game cocok: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>Apakah Anda ingin menimpa?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>Versi PKG %1 lebih lama dari versi yang terpasang: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>Game telah terpasang: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>Apakah Anda ingin menginstal patch: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>Instalasi DLC</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>Apakah Anda ingin menginstal DLC: %1?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC sudah terpasang:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>Game sudah terpasang</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>PKG adalah patch, harap pasang game terlebih dahulu!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>KESALAHAN PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>Mengekstrak PKG %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>Ekstraksi Selesai</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>Game berhasil dipasang di %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>File tampaknya bukan file PKG yang valid</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Cheats / Patches for </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>Cheats/Patches bersifat eksperimental.\nGunakan dengan hati-hati.\n\nUnduh cheats satu per satu dengan memilih repositori dan mengklik tombol unduh.\nDi tab Patches, Anda dapat mengunduh semua patch sekaligus, memilih yang ingin digunakan, dan menyimpan pilihan Anda.\n\nKarena kami tidak mengembangkan Cheats/Patches,\nharap laporkan masalah kepada pembuat cheat.\n\nMembuat cheat baru? Kunjungi:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>Tidak Ada Gambar Tersedia</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>Serial: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>Versi: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>Ukuran: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>Pilih File Cheat:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>Repositori:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>Unduh Cheat</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>Hapus File</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>Tidak ada file yang dipilih.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>Anda dapat menghapus cheat yang tidak Anda inginkan setelah mengunduhnya.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>Apakah Anda ingin menghapus berkas yang dipilih?\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>Pilih File Patch:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>Unduh Patch</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>Simpan</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>Cheat</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>Patch</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>Kesalahan</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>Tidak ada patch yang dipilih.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>Tidak dapat membuka files.json untuk dibaca.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>Tidak ada file patch ditemukan untuk serial saat ini.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>Tidak dapat membuka file untuk dibaca.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>Tidak dapat membuka file untuk menulis.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>Gagal menganalisis XML: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>Sukses</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>Opsi berhasil disimpan.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>Sumber Tidak Valid</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>Sumber yang dipilih tidak valid.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>File Ada</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>File sudah ada. Apakah Anda ingin menggantinya?</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>Gagal menyimpan file:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>Gagal mengunduh file:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>Cheat Tidak Ditemukan</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>Cheat tidak ditemukan untuk game ini dalam versi repositori yang dipilih,cobalah repositori lain atau versi game yang berbeda.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>Cheat Berhasil Diunduh</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>Anda telah berhasil mengunduh cheat untuk versi game ini dari repositori yang dipilih. Anda bisa mencoba mengunduh dari repositori lain, jika tersedia akan juga memungkinkan untuk menggunakannya dengan memilih file dari daftar.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>Gagal menyimpan:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>Gagal mengunduh:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>Unduhan Selesai</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>Patch Berhasil Diunduh! Semua Patch yang tersedia untuk semua game telah diunduh, tidak perlu mengunduhnya satu per satu seperti yang terjadi pada Cheat. Jika patch tidak muncul, mungkin patch tersebut tidak ada untuk nomor seri dan versi game yang spesifik.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>Gagal menganalisis data JSON dari HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>Gagal mengambil halaman HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>Permainan berada di versi: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>Patch yang diunduh hanya berfungsi pada versi: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>Anda mungkin perlu memperbarui permainan Anda.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>Pemberitahuan Ketidakcocokan</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>Gagal membuka file:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>KESALAHAN XML:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>Gagal membuka files.json untuk menulis</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>Penulis: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>Direktori tidak ada:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>Gagal membuka files.json untuk dibaca.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>Nama:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>Tidak bisa menerapkan cheat sebelum permainan dimulai.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>Simpan</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>Terapkan</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>Kembalikan Pengaturan Default</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>Tutup</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>Arahkan mouse Anda pada opsi untuk menampilkan deskripsinya.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Bahasa Konsol:\nMenetapkan bahasa yang digunakan oleh permainan PS4.\nDisarankan untuk mengatur ini ke bahasa yang didukung oleh permainan, yang dapat bervariasi berdasarkan wilayah.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>Bahasa Emulator:\nMenetapkan bahasa antarmuka pengguna emulator.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>Aktifkan Mode Layar Penuh:\nSecara otomatis menempatkan jendela permainan dalam mode layar penuh.\nIni dapat dinonaktifkan dengan menekan tombol F11.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Enable Separate Update Folder:\nEnables installing game updates into a separate folder for easy management.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>Tampilkan Layar Pembuka:\nMenampilkan layar pembuka permainan (gambar khusus) saat permainan dimulai.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>Adalah PS4 Pro:\nMembuat emulator berfungsi sebagai PS4 PRO, yang mungkin mengaktifkan fitur khusus dalam permainan yang mendukungnya.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>Aktifkan Discord Rich Presence:\nMenampilkan ikon emulator dan informasi relevan di profil Discord Anda.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>Nama Pengguna:\nMenetapkan nama pengguna akun PS4, yang mungkin ditampilkan oleh beberapa permainan.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>Jenis Log:\nMenetapkan apakah untuk menyinkronkan output jendela log untuk kinerja. Dapat memiliki efek buruk pada emulasi.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Filter Log:\nMenyaring log untuk hanya mencetak informasi tertentu.\nContoh: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" Tingkatan: Trace, Debug, Info, Warning, Error, Critical - dalam urutan ini, tingkat tertentu membungkam semua tingkat sebelumnya dalam daftar dan mencatat setiap tingkat setelahnya.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>Pembaruan:\nRelease: Versi resmi yang dirilis setiap bulan yang mungkin sangat ketinggalan zaman, tetapi lebih dapat diandalkan dan teruji.\nNightly: Versi pengembangan yang memiliki semua fitur dan perbaikan terbaru, tetapi mungkin mengandung bug dan kurang stabil.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Putar Musik Judul Permainan:\nJika permainan mendukungnya, aktifkan pemutaran musik khusus saat memilih permainan di GUI.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Disable Trophy Pop-ups:\nDisable in-game trophy notifications. Trophy progress can still be tracked using the Trophy Viewer (right-click the game in the main window).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>Sembunyikan Kursor:\nPilih kapan kursor akan menghilang:\nTidak Pernah: Anda akan selalu melihat mouse.\nTidak Aktif: Tetapkan waktu untuk menghilang setelah tidak aktif.\nSelalu: Anda tidak akan pernah melihat mouse.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>Tetapkan waktu untuk mouse menghilang setelah tidak aktif.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>Perilaku Tombol Kembali:\nMengatur tombol kembali pada pengontrol untuk meniru ketukan di posisi yang ditentukan di touchpad PS4.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Display Compatibility Data:\nDisplays game compatibility information in table view. Enable "Update Compatibility On Startup" to get up-to-date information.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Update Compatibility On Startup:\nAutomatically update the compatibility database when shadPS4 starts.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Update Compatibility Database:\nImmediately update the compatibility database.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>Tidak Pernah</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>Diam</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>Selalu</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>Touchpad Kiri</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>Touchpad Kanan</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>Pusat Touchpad</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>Tidak Ada</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>Perangkat Grafis:\nPada sistem GPU ganda, pilih GPU yang akan digunakan emulator dari daftar dropdown,\natau pilih "Auto Select" untuk menentukan secara otomatis.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Lebar/Tinggi:\nMenetapkan ukuran jendela emulator saat diluncurkan, yang dapat diubah ukurannya selama permainan.\nIni berbeda dari resolusi dalam permainan.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Pembagi Vblank:\nKecepatan bingkai di mana emulator menyegarkan dikalikan dengan angka ini. Mengubah ini dapat memiliki efek buruk, seperti meningkatkan kecepatan permainan, atau merusak fungsi kritis permainan yang tidak mengharapkan ini berubah!</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>Aktifkan Pembuangan Shader:\nUntuk tujuan debugging teknis, menyimpan shader permainan ke folder saat mereka dirender.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Aktifkan GPU Null:\nUntuk tujuan debugging teknis, menonaktifkan rendering permainan seolah-olah tidak ada kartu grafis.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>Folder Permainan:\nDaftar folder untuk memeriksa permainan yang diinstal.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>Tambah:\nTambahkan folder ke daftar.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>Hapus:\nHapus folder dari daftar.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>Aktifkan Pembuangan Debug:\nMenyimpan simbol impor dan ekspor serta informasi header file dari program PS4 yang sedang berjalan ke direktori.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Aktifkan Vulkan Validation Layers:\nMengaktifkan sistem yang memvalidasi status penggambaran Vulkan dan mencatat informasi tentang status internalnya. Ini akan mengurangi kinerja dan kemungkinan mengubah perilaku emulasi.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Aktifkan Vulkan Synchronization Validation:\nMengaktifkan sistem yang memvalidasi waktu tugas penggambaran Vulkan. Ini akan mengurangi kinerja dan kemungkinan mengubah perilaku emulasi.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>Aktifkan Debugging RenderDoc:\nJika diaktifkan, emulator akan menyediakan kompatibilitas dengan Renderdoc untuk memungkinkan pengambilan dan analisis bingkai yang sedang dirender.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Cheats / Patches for </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>Cheats/Patches bersifat eksperimental.\nGunakan dengan hati-hati.\n\nUnduh cheats satu per satu dengan memilih repositori dan mengklik tombol unduh.\nDi tab Patches, Anda dapat mengunduh semua patch sekaligus, memilih yang ingin digunakan, dan menyimpan pilihan Anda.\n\nKarena kami tidak mengembangkan Cheats/Patches,\nharap laporkan masalah kepada pembuat cheat.\n\nMembuat cheat baru? Kunjungi:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>Tidak Ada Gambar Tersedia</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>Serial: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>Versi: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>Ukuran: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>Pilih File Cheat:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>Repositori:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>Unduh Cheat</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>Hapus File</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>Tidak ada file yang dipilih.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>Anda dapat menghapus cheat yang tidak Anda inginkan setelah mengunduhnya.</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>Apakah Anda ingin menghapus berkas yang dipilih?\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>Pilih File Patch:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>Unduh Patch</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>Simpan</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>Cheat</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>Patch</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Kesalahan</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>Tidak ada patch yang dipilih.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>Tidak dapat membuka files.json untuk dibaca.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>Tidak ada file patch ditemukan untuk serial saat ini.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>Tidak dapat membuka file untuk dibaca.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>Tidak dapat membuka file untuk menulis.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>Gagal menganalisis XML: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>Sukses</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>Opsi berhasil disimpan.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>Sumber Tidak Valid</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>Sumber yang dipilih tidak valid.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>File Ada</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>File sudah ada. Apakah Anda ingin menggantinya?</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>Gagal menyimpan file:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>Gagal mengunduh file:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>Cheat Tidak Ditemukan</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>Cheat tidak ditemukan untuk game ini dalam versi repositori yang dipilih,cobalah repositori lain atau versi game yang berbeda.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>Cheat Berhasil Diunduh</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>Anda telah berhasil mengunduh cheat untuk versi game ini dari repositori yang dipilih. Anda bisa mencoba mengunduh dari repositori lain, jika tersedia akan juga memungkinkan untuk menggunakannya dengan memilih file dari daftar.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>Gagal menyimpan:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>Gagal mengunduh:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Unduhan Selesai</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>Patch Berhasil Diunduh! Semua Patch yang tersedia untuk semua game telah diunduh, tidak perlu mengunduhnya satu per satu seperti yang terjadi pada Cheat. Jika patch tidak muncul, mungkin patch tersebut tidak ada untuk nomor seri dan versi game yang spesifik.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>Gagal menganalisis data JSON dari HTML.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>Gagal mengambil halaman HTML.</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>Permainan berada di versi: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>Patch yang diunduh hanya berfungsi pada versi: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>Anda mungkin perlu memperbarui permainan Anda.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>Pemberitahuan Ketidakcocokan</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>Gagal membuka file:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>KESALAHAN XML:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>Gagal membuka files.json untuk menulis</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>Penulis: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>Direktori tidak ada:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>Gagal membuka files.json untuk dibaca.</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>Nama:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>Tidak bisa menerapkan cheat sebelum permainan dimulai.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>Ikon</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>Nama</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>Serial</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>Wilayah</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>Firmware</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>Ukuran</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>Versi</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>Jalur</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>Waktu Bermain</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Never Played</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Compatibility is untested</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Game does not initialize properly / crashes the emulator</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Game boots, but only displays a blank screen</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Game displays an image but does not go past the menu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Game has game-breaking glitches or unplayable performance</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>Pembaruan Otomatis</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>Kesalahan</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>Kesalahan jaringan:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>Gagal memparse informasi pembaruan.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>Tidak ada pra-rilis yang ditemukan.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>Data rilis tidak valid.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>Tidak ada URL unduhan ditemukan untuk aset yang ditentukan.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>Versi Anda sudah terbaru!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>Pembaruan Tersedia</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>Saluran Pembaruan</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>Versi Saat Ini</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>Versi Terbaru</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>Apakah Anda ingin memperbarui?</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>Tampilkan Catatan Perubahan</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Periksa pembaruan saat mulai</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>Perbarui</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>Tidak</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>Sembunyikan Catatan Perubahan</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>Perubahan</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>Kesalahan jaringan terjadi saat mencoba mengakses URL</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>Unduhan Selesai</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>Pembaruan telah diunduh, tekan OK untuk menginstal.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>Gagal menyimpan file pembaruan di</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>Memulai Pembaruan...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>Gagal membuat file skrip pembaruan</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/it.ts
+++ b/src/qt_gui/translations/it.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>Riguardo shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 è un emulatore sperimentale open-source per PlayStation 4.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>Questo programma non dovrebbe essere utilizzato per riprodurre giochi che non vengono ottenuti legalmente.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Apri Cartella</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Caricamento lista giochi, attendere :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>Annulla</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Caricamento...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Scegli cartella</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Seleziona in quale cartella vuoi effettuare l'installazione.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Scegli cartella</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Cartella di installazione dei giochi</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Sfoglia</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Errore</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>Il valore del percorso di installazione dei giochi non è valido.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>Crea scorciatoia</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>Trucchi / Patch</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>Visualizzatore SFO</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>Visualizzatore Trofei</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>Apri Cartella...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>Apri Cartella del Gioco</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>Apri Cartella dei Dati di Salvataggio</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>Apri Cartella dei Log</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>Copia informazioni...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>Copia Nome</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>Copia Seriale</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>Copia Tutto</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Elimina...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Elimina Gioco</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Elimina Aggiornamento</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Elimina DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>Creazione scorciatoia</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>Scorciatoia creata con successo!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>Errore</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>Errore nella creazione della scorciatoia!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>Installa PKG</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Gioco</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>Questa feature richiede che venga attivata l'opzione "Abilita Cartella Aggiornamenti Separata" per poter funzionare, per favore abilitala.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>Questo gioco non ha alcun aggiornamento da eliminare!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>Questo gioco non ha alcun DLC da eliminare!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Elimina %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Sei sicuro di eliminale la cartella %2 di %1?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Apri/Aggiungi cartella Elf</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>Installa Pacchetti (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Avvia Gioco</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>Controlla aggiornamenti</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>Riguardo a shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Configura...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>Installa applicazione da un file .pkg</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Giochi Recenti</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Uscita</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>Esci da shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Esci dall'applicazione.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Mostra Lista Giochi</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Aggiorna Lista Giochi</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Minuscolo</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Piccolo</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Medio</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Grande</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>Visualizzazione Lista</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Visualizzazione Griglia</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Visualizzatore Elf</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Cartella Installazione Giochi</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>Scarica Trucchi/Patch</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Scarica Lista Giochi</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>Visualizzatore PKG</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Cerca...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>File</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>Visualizza</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Icone Lista Giochi</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Modalità Lista Giochi</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Impostazioni</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Utilità</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Temi</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>Aiuto</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Scuro</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Chiaro</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Verde</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Blu</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Viola</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>Barra strumenti</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>Elenco giochi</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * Versione Vulkan non supportata</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>Scarica Trucchi per tutti i giochi installati</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>Scarica Patch per tutti i giochi</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Download completato</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>Hai scaricato trucchi per tutti i giochi installati.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>Patch scaricate con successo!</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>Tutte le patch disponibili per tutti i giochi sono state scaricate.</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>Giochi: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>File PKG (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>File ELF (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>Avvia Gioco</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>Si può selezionare solo un file!</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>Estrazione file PKG</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>Patch rilevata!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>Le versioni di PKG e del Gioco corrispondono: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>Vuoi sovrascrivere?</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>La versione PKG %1 è più vecchia rispetto alla versione installata: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>Gioco installato: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>Vuoi installare la patch: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>Installazione DLC</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>Vuoi installare il DLC: %1?</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC già installato:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>Gioco già installato</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>Questo file PKG contiene una patch. Per favore, installa prima il gioco!</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>ERRORE PKG</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>Estrazione file PKG %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>Estrazione Completata</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>Gioco installato correttamente in %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>Il file sembra non essere un file PKG valido</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Apri Cartella</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Visualizzatore Trofei</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Impostazioni</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>Generale</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>Sistema</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>Lingua della console</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Lingua dell'emulatore</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Emulatore</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Abilita Schermo Intero</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Abilita Cartella Aggiornamenti Separata</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Mostra Schermata Iniziale</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>Modalità Ps4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Abilita Discord Rich Presence</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Nome Utente</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Logger</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Tipo di Log</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Filtro Log</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>Input</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>Cursore</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>Nascondi Cursore</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>Timeout inattività per nascondere il cursore</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>Controller</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>Comportamento del pulsante Indietro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Grafica</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Scheda Grafica</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Larghezza</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Altezza</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Divisore Vblank</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Avanzate</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Abilita Dump Shader</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>Abilita NULL GPU</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>Percorsi</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>Cartelle di gioco</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
-				<translation>Aggiungi...</translation>
+			<translation>Aggiungi...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>Rimuovi</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Debug</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable</source>
 			<translation>Abilita Debug Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Abilita Vulkan Validation Layers</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Abilita Vulkan Synchronization Validation</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>Abilita RenderDoc Debugging</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>Aggiornamento</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Verifica aggiornamenti all’avvio</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>Canale di Aggiornamento</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>Controlla aggiornamenti</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>Impostazioni GUI</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Disabilita Notifica Trofei</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>Riproduci musica del titolo</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Aggiorna Database Compatibilità all'Avvio</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Compatibilità Gioco</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Mostra Dati Compatibilità</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Aggiorna Database Compatibilità</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>Volume</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>Elenco giochi</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * Versione Vulkan non supportata</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>Scarica Trucchi per tutti i giochi installati</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>Scarica Patch per tutti i giochi</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>Download completato</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>Hai scaricato trucchi per tutti i giochi installati.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>Patch scaricate con successo!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>Tutte le patch disponibili per tutti i giochi sono state scaricate.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>Giochi: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>File PKG (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>File ELF (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>Avvia Gioco</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>Si può selezionare solo un file!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>Estrazione file PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>Patch rilevata!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>Le versioni di PKG e del Gioco corrispondono: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>Vuoi sovrascrivere?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>La versione PKG %1 è più vecchia rispetto alla versione installata: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>Gioco installato: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>Vuoi installare la patch: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>Installazione DLC</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>Vuoi installare il DLC: %1?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC già installato:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>Gioco già installato</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>Questo file PKG contiene una patch. Per favore, installa prima il gioco!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>ERRORE PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>Estrazione file PKG %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>Estrazione Completata</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>Gioco installato correttamente in %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>Il file sembra non essere un file PKG valido</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Cheats / Patches for </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>I trucchi e le patch sono sperimentali.\nUtilizzali con cautela.\n\nScarica i trucchi singolarmente selezionando l'archivio e cliccando sul pulsante di download.\nNella scheda Patch, puoi scaricare tutte le patch in una volta sola, scegliere quali vuoi utilizzare e salvare la tua selezione.\n\nPoiché non sviluppiamo i trucchi e le patch,\nper favore segnala i problemi all'autore dei trucchi.\n\nHai creato un nuovo trucco? Visita:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>Nessuna immagine disponibile</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>Seriale: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>Versione: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>Dimensione: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>Seleziona File Trucchi:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>Archivio:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>Scarica trucchi</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>Cancella File</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>Nessun file selezionato.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>Puoi cancellare i trucchi che non vuoi utilizzare dopo averli scaricati.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>Vuoi cancellare il file selezionato?\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>Seleziona File Patch:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>Scarica Patch</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>Salva</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>Trucchi</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>Patch</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>Errore</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>Nessuna patch selezionata.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>Impossibile aprire il file .json per la lettura.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>Nessun file patch trovato per il seriale selezionato.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>Impossibile aprire il file per la lettura.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>Impossibile aprire il file per la scrittura.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>Analisi XML fallita: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>Successo</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>Opzioni salvate con successo.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>Fonte non valida</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>La fonte selezionata non è valida.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>Il file è presente</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>Il file è già presente. Vuoi sostituirlo?</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>Salvataggio file fallito:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>Scaricamento file fallito:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>Trucchi non trovati</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>Non sono stati trovati trucchi per questa versione del gioco nell'archivio selezionato, prova un altro archivio o una versione diversa del gioco.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>Trucchi scaricati con successo!</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>Hai scaricato con successo i trucchi per questa versione del gioco dall'archivio selezionato. Puoi provare a scaricare da un altro archivio, se disponibile, puoi anche utilizzarlo selezionando il file dall'elenco.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>Salvataggio fallito:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>Impossibile scaricare:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>Scaricamento completo</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>Patch scaricata con successo! Vengono scaricate tutte le patch disponibili per tutti i giochi, non è necessario scaricarle singolarmente per ogni gioco come nel caso dei trucchi. Se la patch non appare, potrebbe essere che non esista per il numero di serie e la versione specifica del gioco.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>Impossibile analizzare i dati JSON dall'HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>Impossibile recuperare la pagina HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>Il gioco è nella versione: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>La patch scaricata funziona solo sulla versione: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>Potresti aver bisogno di aggiornare il tuo gioco.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>Avviso di incompatibilità</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>Impossibile aprire file:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>ERRORE XML:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>Impossibile aprire i file .json per la scrittura</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>Autore: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>La cartella non esiste:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>Impossibile aprire i file .json per la lettura.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>Nome:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>Non è possibile applicare i trucchi prima dell'inizio del gioco.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>Salva</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>Applica</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>Ripristina Impostazioni Predefinite</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>Chiudi</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>Sposta il mouse su un'opzione per visualizzarne la descrizione.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Lingua della Console:\nImposta la lingua utilizzata dal gioco PS4.\nÈ consigliabile impostare questa su una lingua supportata dal gioco, che può variare a seconda della regione.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>Lingua dell'Emulatore:\nImposta la lingua dell'interfaccia utente dell'emulatore.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>Abilita Schermo Intero:\nMetti automaticamente la finestra di gioco in modalità schermo intero.\nQuesto può essere disattivato premendo il tasto F11.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Abilita Cartella Aggiornamenti Separata:\nAbilita l'installazione degli aggiornamenti in una cartella separata per una più facile gestione.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>Mostra Schermata di Avvio:\nMostra la schermata di avvio del gioco (un'immagine speciale) mentre il gioco si sta avviando.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>È PS4 Pro:\nFa sì che l'emulatore si comporti come una PS4 PRO, il che può abilitare funzionalità speciali in giochi che la supportano.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>Abilita Discord Rich Presence:\nMostra l'icona dell'emulatore e informazioni pertinenti sul tuo profilo Discord.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>Nome Utente:\nImposta il nome utente dell'account PS4, che potrebbe essere visualizzato da alcuni giochi.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>Tipo di Log:\nImposta se sincronizzare l'output della finestra di log per le prestazioni. Potrebbe avere effetti avversi sull'emulazione.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Filtro Log:\nFiltra il log per stampare solo informazioni specifiche.\nEsempi: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" Livelli: Trace, Debug, Info, Warning, Error, Critical - in questo ordine, un livello specifico silenzia tutti i livelli precedenti nell'elenco e registra ogni livello successivo.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>Aggiornamento:\nRelease: Versioni ufficiali rilasciate ogni mese che potrebbero essere molto datate, ma sono più affidabili e testate.\nNightly: Versioni di sviluppo che hanno tutte le ultime funzionalità e correzioni, ma potrebbero contenere bug e sono meno stabili.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Riproduci Musica del Titolo:\nSe un gioco lo supporta, attiva la riproduzione di musica speciale quando selezioni il gioco nell'interfaccia grafica.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Disable Trophy Pop-ups:\nDisable in-game trophy notifications. Trophy progress can still be tracked using the Trophy Viewer (right-click the game in the main window).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>Nascondi cursore:\nScegli quando il cursore scomparirà:\nMai: Vedrai sempre il mouse.\nInattivo: Imposta un tempo per farlo scomparire dopo essere stato inattivo.\nSempre: non vedrai mai il mouse.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
-				<source>idleTimeoutGroupBox</source>
+			<source>idleTimeoutGroupBox</source>
 			<translation>Imposta un tempo affinché il mouse scompaia dopo essere stato inattivo.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>Comportamento del pulsante Indietro:\nImposta il pulsante Indietro del controller per emulare il tocco sulla posizione specificata sul touchpad PS4.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Mostra Dati Compatibilità:\nMostra informazioni sulla compatibilità del gioco nella visualizzazione lista. Abilita "Aggiorna Compatiblità all'Avvio" per ottenere informazioni aggiornate.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Aggiorna Compatibilità all'Avvio:\nAggiorna automaticamente il database della compatibilità quando si avvia shadps4.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Aggiorna Database Compatibilità:\nAggiorna immediatamente il database di compatibilità.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>Mai</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>Inattivo</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>Sempre</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>Touchpad Sinistra</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>Touchpad Destra</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>Centro del Touchpad</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>Nessuno</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>Dispositivo Grafico:\nIn sistemi con più GPU, seleziona la GPU che l'emulatore utilizzerà dall'elenco a discesa,\no seleziona "Auto Select" per determinarlo automaticamente.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Larghezza/Altezza:\nImposta la dimensione della finestra dell'emulatore all'avvio, che può essere ridimensionata durante il gioco.\nQuesto è diverso dalla risoluzione in gioco.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Divisore Vblank:\nIl frame rate con cui l'emulatore si aggiorna viene moltiplicato per questo numero. Cambiare questo potrebbe avere effetti avversi, come aumentare la velocità del gioco o rompere funzionalità critiche del gioco che non si aspettano questa modifica!</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>Abilita Pompaggio Shader:\nPer scopi di debug tecnico, salva gli shader dei giochi in una cartella mentre vengono resi.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Abilita GPU Null:\nPer scopi di debug tecnico, disabilita il rendering del gioco come se non ci fosse alcuna scheda grafica.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>Cartelle di Gioco:\nL'elenco delle cartelle da controllare per i giochi installati.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>Aggiungi:\nAggiungi una cartella all'elenco.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>Rimuovi:\nRimuovi una cartella dall'elenco.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>Abilita Pompaggio di Debug:\nSalva i simboli di importazione ed esportazione e le informazioni sull'intestazione del file del programma PS4 attualmente in esecuzione in una directory.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Abilita Strati di Validazione Vulkan:\nAbilita un sistema che convalida lo stato del renderer Vulkan e registra informazioni sul suo stato interno. Ciò ridurrà le prestazioni e probabilmente cambierà il comportamento dell'emulazione.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Abilita Validazione della Sincronizzazione Vulkan:\nAbilita un sistema che convalida il timing delle attività di rendering Vulkan. Ciò ridurrà le prestazioni e probabilmente cambierà il comportamento dell'emulazione.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>Abilita Debugging RenderDoc:\nSe abilitato, l'emulatore fornirà compatibilità con Renderdoc per consentire la cattura e l'analisi del frame attualmente reso.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Cheats / Patches for </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>I trucchi e le patch sono sperimentali.\nUtilizzali con cautela.\n\nScarica i trucchi singolarmente selezionando l'archivio e cliccando sul pulsante di download.\nNella scheda Patch, puoi scaricare tutte le patch in una volta sola, scegliere quali vuoi utilizzare e salvare la tua selezione.\n\nPoiché non sviluppiamo i trucchi e le patch,\nper favore segnala i problemi all'autore dei trucchi.\n\nHai creato un nuovo trucco? Visita:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>Nessuna immagine disponibile</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>Seriale: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>Versione: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>Dimensione: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>Seleziona File Trucchi:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>Archivio:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>Scarica trucchi</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>Cancella File</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>Nessun file selezionato.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>Puoi cancellare i trucchi che non vuoi utilizzare dopo averli scaricati.</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>Vuoi cancellare il file selezionato?\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>Seleziona File Patch:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>Scarica Patch</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>Salva</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>Trucchi</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>Patch</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Errore</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>Nessuna patch selezionata.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>Impossibile aprire il file .json per la lettura.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>Nessun file patch trovato per il seriale selezionato.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>Impossibile aprire il file per la lettura.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>Impossibile aprire il file per la scrittura.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>Analisi XML fallita: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>Successo</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>Opzioni salvate con successo.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>Fonte non valida</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>La fonte selezionata non è valida.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>Il file è presente</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>Il file è già presente. Vuoi sostituirlo?</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>Salvataggio file fallito:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>Scaricamento file fallito:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>Trucchi non trovati</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>Non sono stati trovati trucchi per questa versione del gioco nell'archivio selezionato, prova un altro archivio o una versione diversa del gioco.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>Trucchi scaricati con successo!</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>Hai scaricato con successo i trucchi per questa versione del gioco dall'archivio selezionato. Puoi provare a scaricare da un altro archivio, se disponibile, puoi anche utilizzarlo selezionando il file dall'elenco.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>Salvataggio fallito:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>Impossibile scaricare:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Scaricamento completo</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>Patch scaricata con successo! Vengono scaricate tutte le patch disponibili per tutti i giochi, non è necessario scaricarle singolarmente per ogni gioco come nel caso dei trucchi. Se la patch non appare, potrebbe essere che non esista per il numero di serie e la versione specifica del gioco.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>Impossibile analizzare i dati JSON dall'HTML.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>Impossibile recuperare la pagina HTML.</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>Il gioco è nella versione: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>La patch scaricata funziona solo sulla versione: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>Potresti aver bisogno di aggiornare il tuo gioco.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>Avviso di incompatibilità</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>Impossibile aprire file:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>ERRORE XML:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>Impossibile aprire i file .json per la scrittura</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>Autore: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>La cartella non esiste:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>Impossibile aprire i file .json per la lettura.</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>Nome:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>Non è possibile applicare i trucchi prima dell'inizio del gioco.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>Icona</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>Nome</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>Seriale</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Compatibilità</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>Regione</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>Firmware</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>Dimensione</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>Versione</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>Percorso</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>Tempo di Gioco</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Mai Giocato</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Nessuna informazione sulla compatibilità</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Il gioco non si avvia in modo corretto / forza chiusura dell'emulatore</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Il gioco si avvia, ma mostra solo una schermata nera</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Il gioco mostra immagini ma non va oltre il menu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Il gioco ha problemi gravi di emulazione oppure framerate troppo basso</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Il gioco può essere completato con buone prestazioni e senza problemi gravi</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>Aggiornamento automatico</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>Errore</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>Errore di rete:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>Impossibile analizzare le informazioni di aggiornamento.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>Nessuna anteprima trovata.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>Dati della release non validi.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>Nessun URL di download trovato per l'asset specificato.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>La tua versione è già aggiornata!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>Aggiornamento disponibile</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>Canale di Aggiornamento</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>Versione attuale</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>Ultima versione</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>Vuoi aggiornare?</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>Mostra il Changelog</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Controlla aggiornamenti all’avvio</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>Aggiorna</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>No</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>Nascondi il Changelog</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>Modifiche</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>Si è verificato un errore di rete durante il tentativo di accesso all'URL</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>Download completato</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>L'aggiornamento è stato scaricato, premi OK per installare.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>Impossibile salvare il file di aggiornamento in</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>Inizio aggiornamento...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>Impossibile creare il file di script di aggiornamento</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/ja_JP.ts
+++ b/src/qt_gui/translations/ja_JP.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>shadPS4について</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4は、PlayStation 4の実験的なオープンソースエミュレーターです。</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>このソフトウェアは、合法的に入手していないゲームをプレイするために使用するものではありません。</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>フォルダを開く</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>ゲームリストを読み込み中です。お待ちください :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>キャンセル</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>読み込み中...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - ディレクトリを選択</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Select which directory you want to install to.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - ディレクトリを選択</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>ゲームをインストールするディレクトリ</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>参照</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>エラー</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>ゲームをインストールする場所が無効です。</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>ショートカットを作成</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>チート / パッチ</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>SFOビューワー</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>トロフィービューワー</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>フォルダを開く...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>ゲームフォルダを開く</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>セーブデータフォルダを開く</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>ログフォルダを開く</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>情報をコピー...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>名前をコピー</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>シリアルをコピー</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>すべてコピー</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Delete...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Delete Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Delete Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Delete DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>ショートカットの作成</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>ショートカットが正常に作成されました!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>エラー</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>ショートカットの作成に失敗しました!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>PKGをインストール</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>This feature requires the 'Enable Separate Update Folder' config option to work. If you want to use this feature, please enable it.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>This game has no update to delete!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>This game has no DLC to delete!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Delete %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Are you sure you want to delete %1's %2 directory?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Elfフォルダを開く/追加する</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>パッケージをインストール (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>ゲームを起動</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>更新を確認する</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>shadPS4について</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>設定...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>.pkgファイルからアプリケーションをインストールする</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>最近のゲーム</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>終了</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>shadPS4を終了</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>アプリケーションを終了します。</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>ゲームリストを表示</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>ゲームリストの更新</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>極小</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>小</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>中</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>大</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>リストビュー</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>グリッドビュー</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Elfビュワー</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>ゲームインストールディレクトリ</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>チート / パッチをダウンロード</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>ゲームリストをダンプ</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>PKGビューアー</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>検索...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>ファイル</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>表示</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>ゲームリストアイコン</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>ゲームリストモード</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>設定</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>ユーティリティ</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>テーマ</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>ヘルプ</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>ダーク</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>ライト</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>グリーン</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>ブルー</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>バイオレット</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>ツールバー</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>ゲームリスト</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * サポートされていないVulkanバージョン</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>すべてのインストール済みゲームのチートをダウンロード</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>すべてのゲームのパッチをダウンロード</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>ダウンロード完了</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>インストールしたすべてのゲームのチートをダウンロードしました。</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>パッチが正常にダウンロードされました！</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>すべてのゲームに利用可能なパッチがダウンロードされました。</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>ゲーム: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>PKGファイル (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>ELFファイル (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>ゲームブート</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>1つのファイルしか選択できません！</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>PKG抽出</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>パッチが検出されました！</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>PKGとゲームのバージョンが一致しています: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>上書きしてもよろしいですか？</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>PKGバージョン %1 はインストールされているバージョンよりも古いです: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>ゲームはインストール済みです: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>パッチをインストールしてもよろしいですか: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>DLCのインストール</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>DLCをインストールしてもよろしいですか: %1?</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLCはすでにインストールされています:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>ゲームはすでにインストールされています</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>PKGはパッチです。ゲームを先にインストールしてください！</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>PKGエラー</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>PKGを抽出中 %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>抽出完了</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>ゲームが %1 に正常にインストールされました</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>ファイルが有効なPKGファイルでないようです</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>フォルダーを開く</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>トロフィービューアー</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>設定</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>一般</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>システム</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>コンソール言語</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>エミュレーター言語</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>エミュレーター</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>フルスクリーンを有効にする</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>スプラッシュを表示する</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>PS4 Proモード</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Discord Rich Presenceを有効にする</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>ユーザー名</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>ロガー</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>ログタイプ</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>ログフィルター</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>入力</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>カーソル</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>カーソルを隠す</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>カーソル非アクティブタイムアウト</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>コントローラー</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>戻るボタンの動作</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>グラフィックス</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>グラフィックスデバイス</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>幅</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>高さ</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Vblankディバイダー</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>高度な設定</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>シェーダーのダンプを有効にする</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>NULL GPUを有効にする</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>パス</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>ゲームフォルダ</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>追加...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>削除</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>デバッグ</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>デバッグダンプを有効にする</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Vulkan検証レイヤーを有効にする</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Vulkan同期検証を有効にする</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>RenderDocデバッグを有効にする</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>更新</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>起動時に更新確認</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>アップデートチャネル</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>更新を確認</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>GUI設定</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Disable Trophy Pop-ups</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>タイトル音楽を再生する</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Update Compatibility Database On Startup</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Game Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Display Compatibility Data</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Update Compatibility Database</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>音量</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>ゲームリスト</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * サポートされていないVulkanバージョン</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>すべてのインストール済みゲームのチートをダウンロード</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>すべてのゲームのパッチをダウンロード</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>ダウンロード完了</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>インストールしたすべてのゲームのチートをダウンロードしました。</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>パッチが正常にダウンロードされました！</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>すべてのゲームに利用可能なパッチがダウンロードされました。</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>ゲーム: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>PKGファイル (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>ELFファイル (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>ゲームブート</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>1つのファイルしか選択できません！</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>PKG抽出</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>パッチが検出されました！</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>PKGとゲームのバージョンが一致しています: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>上書きしてもよろしいですか？</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>PKGバージョン %1 はインストールされているバージョンよりも古いです: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>ゲームはインストール済みです: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>パッチをインストールしてもよろしいですか: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>DLCのインストール</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>DLCをインストールしてもよろしいですか: %1?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLCはすでにインストールされています:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>ゲームはすでにインストールされています</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>PKGはパッチです。ゲームを先にインストールしてください！</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>PKGエラー</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>PKGを抽出中 %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>抽出完了</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>ゲームが %1 に正常にインストールされました</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>ファイルが有効なPKGファイルでないようです</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Cheats / Patches for </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>チート/パッチは実験的です。\n使用には注意してください。\n\nリポジトリを選択し、ダウンロードボタンをクリックしてチートを個別にダウンロードします。\n「Patches」タブでは、すべてのパッチを一度にダウンロードし、使用したいものを選択して選択を保存できます。\n\nチート/パッチを開発していないため、\n問題があればチートの作者に報告してください。\n\n新しいチートを作成しましたか？\nhttps://github.com/shadps4-emu/ps4_cheats を訪問してください。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>画像は利用できません</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>シリアル: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>バージョン: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>サイズ: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>チートファイルを選択:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>リポジトリ:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>チートをダウンロード</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>ファイルを削除</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>ファイルが選択されていません。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>ダウンロード後に不要なチートを削除できます。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>選択したファイルを削除しますか？\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>パッチファイルを選択:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>パッチをダウンロード</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>保存</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>チート</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>パッチ</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>エラー</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>パッチが選択されていません。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>files.jsonを読み込み用に開けません。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>現在のシリアルに対するパッチファイルが見つかりません。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>ファイルを読み込み用に開けません。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>ファイルを記録用に開けません。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>XMLの解析に失敗しました: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>成功</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>オプションが正常に保存されました。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>無効なソース</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>選択したソースは無効です。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>ファイルが存在します</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>ファイルはすでに存在します。置き換えますか？</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>ファイルの保存に失敗しました:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>ファイルのダウンロードに失敗しました:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>チートが見つかりません</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>このゲームのこのバージョンのチートが選択されたリポジトリに見つかりませんでした。別のリポジトリまたはゲームの別のバージョンを試してください。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>チートが正常にダウンロードされました</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>このゲームのこのバージョンのチートをリポジトリから正常にダウンロードしました。 別のリポジトリからのダウンロードも試せます。利用可能であれば、リストからファイルを選択して使用することも可能です。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>保存に失敗しました:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>ダウンロードに失敗しました:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>ダウンロード完了</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>パッチが正常にダウンロードされました！ すべてのゲームに利用可能なパッチがダウンロードされました。チートとは異なり、各ゲームごとに個別にダウンロードする必要はありません。 パッチが表示されない場合、特定のシリアル番号とバージョンのゲームには存在しない可能性があります。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>HTMLからJSONデータの解析に失敗しました。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>HTMLページの取得に失敗しました。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>ゲームのバージョン: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>ダウンロードしたパッチはバージョン: %1 のみ機能します</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>ゲームを更新する必要があるかもしれません。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>互換性のない通知</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>ファイルを開くのに失敗しました:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>XMLエラー:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>files.jsonを記録用に開けません</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>著者: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>ディレクトリが存在しません:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>files.jsonを読み込み用に開けません。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>名前:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>ゲームが開始される前にチートを適用することはできません。</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>保存</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>適用</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>デフォルトに戻す</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>閉じる</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>オプションにマウスをポイントすると、その説明が表示されます。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>コンソール言語:\nPS4ゲームが使用する言語を設定します。\nこれはゲームがサポートする言語に設定することをお勧めしますが、地域によって異なる場合があります。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>エミュレーター言語:\nエミュレーターのユーザーインターフェースの言語を設定します。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>全画面モードを有効にする:\nゲームウィンドウを自動的に全画面モードにします。\nF11キーを押すことで切り替えることができます。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Enable Separate Update Folder:\nEnables installing game updates into a separate folder for easy management.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>スプラッシュスクリーンを表示:\nゲーム起動中にゲームのスプラッシュスクリーン（特別な画像）を表示します。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>PS4 Proです:\nエミュレーターがPS4 PROとして動作するようにし、これをサポートするゲームで特別な機能を有効にする場合があります。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>Discord Rich Presenceを有効にする:\nエミュレーターのアイコンと関連情報をDiscordプロフィールに表示します。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>ユーザー名:\nPS4のアカウントユーザー名を設定します。これは、一部のゲームで表示される場合があります。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>ログタイプ:\nパフォーマンスのためにログウィンドウの出力を同期させるかどうかを設定します。エミュレーションに悪影響を及ぼす可能性があります。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>ログフィルター:\n特定の情報のみを印刷するようにログをフィルタリングします。\n例: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" レベル: Trace, Debug, Info, Warning, Error, Critical - この順序で、特定のレベルはリスト内のすべての前のレベルをサイレンスし、その後のすべてのレベルをログに記録します。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>更新:\nRelease: 非常に古いかもしれないが、より信頼性が高くテスト済みの公式バージョンを毎月リリースします。\nNightly: 最新の機能と修正がすべて含まれていますが、バグが含まれている可能性があり、安定性は低いです。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>タイトルミュージックを再生:\nゲームがそれをサポートしている場合、GUIでゲームを選択したときに特別な音楽を再生することを有効にします。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Disable Trophy Pop-ups:\nDisable in-game trophy notifications. Trophy progress can still be tracked using the Trophy Viewer (right-click the game in the main window).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>カーソルを隠す:\nカーソルが消えるタイミングを選択してください:\n決して: いつでもマウスが見えます。\nアイドル: アイダルの後に消えるまでの時間を設定します。\n常に: マウスは決して見えません。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>アイドル後にマウスが消えるまでの時間を設定します。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>戻るボタンの動作:\nコントローラーの戻るボタンを、PS4のタッチパッドの指定された位置をタッチするように設定します。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Display Compatibility Data:\nDisplays game compatibility information in table view. Enable "Update Compatibility On Startup" to get up-to-date information.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Update Compatibility On Startup:\nAutomatically update the compatibility database when shadPS4 starts.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Update Compatibility Database:\nImmediately update the compatibility database.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>決して</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>アイドル</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>常に</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>タッチパッド左</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>タッチパッド右</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>タッチパッド中央</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>なし</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>グラフィックデバイス:\n複数のGPUシステムで、ドロップダウンリストからエミュレーターで使用するGPUを選択するか、\n「自動選択」を選択して自動的に決定します。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>幅/高さ:\n起動時にエミュレーターウィンドウのサイズを設定します。ゲーム中にサイズ変更できます。\nこれはゲーム内の解像度とは異なります。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Vblankディバイダー:\nエミュレーターが更新されるフレームレートにこの数を掛けます。これを変更すると、ゲームの速度が上がったり、想定外の変更がある場合、ゲームの重要な機能が壊れる可能性があります！</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>シェーダーダンプを有効にする:\n技術的なデバッグの目的で、レンダリング中にゲームのシェーダーをフォルダーに保存します。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Null GPUを有効にする:\n技術的なデバッグの目的で、グラフィックスカードがないかのようにゲームのレンダリングを無効にします。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>ゲームフォルダ:\nインストールされたゲームを確認するためのフォルダのリスト。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>追加:\nリストにフォルダを追加します。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>削除:\nリストからフォルダを削除します。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>デバッグダンプを有効にする:\n現在実行中のPS4プログラムのインポートおよびエクスポートシンボルとファイルヘッダー情報をディレクトリに保存します。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Vulkanバリデーションレイヤーを有効にする:\nVulkanのレンダリングステータスを検証し、内部状態に関する情報をログに記録するシステムを有効にします。これによりパフォーマンスが低下し、エミュレーションの動作が変わる可能性があります。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Vulkan同期バリデーションを有効にする:\nVulkanのレンダリングタスクのタイミングを検証するシステムを有効にします。これによりパフォーマンスが低下し、エミュレーションの動作が変わる可能性があります。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>RenderDocデバッグを有効にする:\n有効にすると、エミュレーターはRenderdocとの互換性を提供し、現在レンダリング中のフレームのキャプチャと分析を可能にします。</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Cheats / Patches for </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>チート/パッチは実験的です。\n使用には注意してください。\n\nリポジトリを選択し、ダウンロードボタンをクリックしてチートを個別にダウンロードします。\n「Patches」タブでは、すべてのパッチを一度にダウンロードし、使用したいものを選択して選択を保存できます。\n\nチート/パッチを開発していないため、\n問題があればチートの作者に報告してください。\n\n新しいチートを作成しましたか？\nhttps://github.com/shadps4-emu/ps4_cheats を訪問してください。</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>画像は利用できません</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>シリアル: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>バージョン: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>サイズ: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>チートファイルを選択:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>リポジトリ:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>チートをダウンロード</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>ファイルを削除</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>ファイルが選択されていません。</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>ダウンロード後に不要なチートを削除できます。</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>選択したファイルを削除しますか？\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>パッチファイルを選択:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>パッチをダウンロード</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>保存</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>チート</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>パッチ</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>エラー</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>パッチが選択されていません。</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>files.jsonを読み込み用に開けません。</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>現在のシリアルに対するパッチファイルが見つかりません。</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>ファイルを読み込み用に開けません。</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>ファイルを記録用に開けません。</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>XMLの解析に失敗しました: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>成功</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>オプションが正常に保存されました。</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>無効なソース</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>選択したソースは無効です。</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>ファイルが存在します</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>ファイルはすでに存在します。置き換えますか？</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>ファイルの保存に失敗しました:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>ファイルのダウンロードに失敗しました:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>チートが見つかりません</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>このゲームのこのバージョンのチートが選択されたリポジトリに見つかりませんでした。別のリポジトリまたはゲームの別のバージョンを試してください。</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>チートが正常にダウンロードされました</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>このゲームのこのバージョンのチートをリポジトリから正常にダウンロードしました。 別のリポジトリからのダウンロードも試せます。利用可能であれば、リストからファイルを選択して使用することも可能です。</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>保存に失敗しました:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>ダウンロードに失敗しました:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>ダウンロード完了</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>パッチが正常にダウンロードされました！ すべてのゲームに利用可能なパッチがダウンロードされました。チートとは異なり、各ゲームごとに個別にダウンロードする必要はありません。 パッチが表示されない場合、特定のシリアル番号とバージョンのゲームには存在しない可能性があります。</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>HTMLからJSONデータの解析に失敗しました。</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>HTMLページの取得に失敗しました。</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>ゲームのバージョン: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>ダウンロードしたパッチはバージョン: %1 のみ機能します</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>ゲームを更新する必要があるかもしれません。</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>互換性のない通知</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>ファイルを開くのに失敗しました:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>XMLエラー:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>files.jsonを記録用に開けません</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>著者: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>ディレクトリが存在しません:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>files.jsonを読み込み用に開けません。</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>名前:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>ゲームが開始される前にチートを適用することはできません。</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>アイコン</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>名前</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>シリアル</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>地域</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>ファームウェア</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>サイズ</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>バージョン</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>パス</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>プレイ時間</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Never Played</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Compatibility is untested</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Game does not initialize properly / crashes the emulator</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Game boots, but only displays a blank screen</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Game displays an image but does not go past the menu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Game has game-breaking glitches or unplayable performance</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>自動アップデーター</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>エラー</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>ネットワークエラー:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>アップデート情報の解析に失敗しました。</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>プレリリースは見つかりませんでした。</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>リリースデータが無効です。</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>指定されたアセットのダウンロードURLが見つかりませんでした。</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>あなたのバージョンはすでに最新です！</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>アップデートがあります</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>アップデートチャネル</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>現在のバージョン</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>最新バージョン</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>アップデートしますか？</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>変更ログを表示</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>起動時に更新確認</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>アップデート</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>いいえ</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>変更ログを隠す</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>変更点</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>URLにアクセス中にネットワークエラーが発生しました</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>ダウンロード完了</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>アップデートがダウンロードされました。インストールするにはOKを押してください。</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>更新ファイルの保存に失敗しました</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>アップデートを開始しています...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>アップデートスクリプトファイルの作成に失敗しました</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/ko_KR.ts
+++ b/src/qt_gui/translations/ko_KR.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>About shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 is an experimental open-source emulator for the PlayStation 4.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>This software should not be used to play games you have not legally obtained.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Open Folder</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Loading game list, please wait :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>Cancel</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Loading...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Choose directory</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Select which directory you want to install to.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Choose directory</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Directory to install games</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Browse</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>The value for location to install games is not valid.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>Create Shortcut</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>치트 / 패치</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>SFO Viewer</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophy Viewer</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>Open Folder...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>Open Game Folder</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>Open Save Data Folder</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>Open Log Folder</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>Copy info...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>Copy Name</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>Copy Serial</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>Copy All</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Delete...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Delete Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Delete Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Delete DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>Shortcut creation</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>Shortcut created successfully!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>Error creating shortcut!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>Install PKG</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>This feature requires the 'Enable Separate Update Folder' config option to work. If you want to use this feature, please enable it.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>This game has no update to delete!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>This game has no DLC to delete!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Delete %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Are you sure you want to delete %1's %2 directory?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Open/Add Elf Folder</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>Install Packages (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Boot Game</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>Check for Updates</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>About shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Configure...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>Install application from a .pkg file</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Recent Games</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Exit</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>Exit shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Exit the application.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Show Game List</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Game List Refresh</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Tiny</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Small</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Medium</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Large</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>List View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Grid View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Elf Viewer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Game Install Directory</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>치트 / 패치 다운로드</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Dump Game List</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>PKG Viewer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Search...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>File</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Game List Icons</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Game List Mode</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Settings</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Utils</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Themes</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>Help</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Dark</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Light</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Green</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Blue</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Violet</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>toolBar</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>Game List</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * Unsupported Vulkan Version</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>Download Cheats For All Installed Games</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>Download Patches For All Games</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Download Complete</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>You have downloaded cheats for all the games you have installed.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>Patches Downloaded Successfully!</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>All Patches available for all games have been downloaded.</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>Games: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>PKG File (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>ELF files (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>Game Boot</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>Only one file can be selected!</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>PKG Extraction</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>Patch detected!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>PKG and Game versions match: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>Would you like to overwrite?</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>PKG Version %1 is older than installed version: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>Game is installed: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>Would you like to install Patch: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>DLC Installation</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>Would you like to install DLC: %1?</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC already installed:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>Game already installed</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>PKG is a patch, please install the game first!</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>PKG ERROR</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>Extracting PKG %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>Extraction Finished</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>Game successfully installed at %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>File doesn't appear to be a valid PKG file</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Open Folder</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophy Viewer</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Settings</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>General</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>System</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>Console Language</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Emulator Language</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Emulator</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Enable Fullscreen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Show Splash</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>Is PS4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Enable Discord Rich Presence</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Username</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Logger</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Log Type</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Log Filter</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>Input</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>Cursor</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>Hide Cursor</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>Hide Cursor Idle Timeout</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>Controller</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>Back Button Behavior</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Graphics</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Graphics Device</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Width</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Height</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Vblank Divider</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Advanced</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Enable Shaders Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>Enable NULL GPU</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>Paths</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>Game Folders</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>Add...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>Remove</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Debug</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Enable Debug Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Enable Vulkan Validation Layers</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Enable Vulkan Synchronization Validation</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>Enable RenderDoc Debugging</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>Update</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Check for Updates at Startup</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>Update Channel</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>Check for Updates</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>GUI Settings</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Disable Trophy Pop-ups</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>Play title music</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Update Compatibility Database On Startup</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Game Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Display Compatibility Data</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Update Compatibility Database</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>음량</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>Game List</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * Unsupported Vulkan Version</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>Download Cheats For All Installed Games</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>Download Patches For All Games</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>Download Complete</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>You have downloaded cheats for all the games you have installed.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>Patches Downloaded Successfully!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>All Patches available for all games have been downloaded.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>Games: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>PKG File (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>ELF files (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>Game Boot</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>Only one file can be selected!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>PKG Extraction</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>Patch detected!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>PKG and Game versions match: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>Would you like to overwrite?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>PKG Version %1 is older than installed version: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>Game is installed: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>Would you like to install Patch: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>DLC Installation</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>Would you like to install DLC: %1?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC already installed:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>Game already installed</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>PKG is a patch, please install the game first!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>PKG ERROR</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>Extracting PKG %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>Extraction Finished</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>Game successfully installed at %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>File doesn't appear to be a valid PKG file</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Cheats / Patches for </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>Cheats/Patches are experimental.\nUse with caution.\n\nDownload cheats individually by selecting the repository and clicking the download button.\nIn the Patches tab, you can download all patches at once, choose which ones you want to use, and save your selection.\n\nSince we do not develop the Cheats/Patches,\nplease report issues to the cheat author.\n\nCreated a new cheat? Visit:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>No Image Available</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>Serial: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>Version: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>Size: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>Select Cheat File:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>Repository:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>Download Cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>Delete File</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>No files selected.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>You can delete the cheats you don't want after downloading them.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>Do you want to delete the selected file?\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>Select Patch File:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>Download Patches</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>Save</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>Cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>Patches</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>Error</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>No patch selected.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>Unable to open files.json for reading.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>No patch file found for the current serial.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>Unable to open the file for reading.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>Unable to open the file for writing.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>Failed to parse XML: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>Success</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>Options saved successfully.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>Invalid Source</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>The selected source is invalid.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>File Exists</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>File already exists. Do you want to replace it?</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>Failed to save file:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>Failed to download file:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>Cheats Not Found</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>No Cheats found for this game in this version of the selected repository,try another repository or a different version of the game.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>Cheats Downloaded Successfully</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>You have successfully downloaded the cheats for this version of the game from the selected repository. You can try downloading from another repository, if it is available it will also be possible to use it by selecting the file from the list.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>Failed to save:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>Failed to download:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>Download Complete</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>Patches Downloaded Successfully! All Patches available for all games have been downloaded, there is no need to download them individually for each game as happens in Cheats. If the patch does not appear, it may be that it does not exist for the specific serial and version of the game.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>Failed to parse JSON data from HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>Failed to retrieve HTML page.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>The game is in version: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>The downloaded patch only works on version: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>You may need to update your game.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>Incompatibility Notice</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>Failed to open file:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>XML ERROR:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>Failed to open files.json for writing</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>Author: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>Directory does not exist:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>Failed to open files.json for reading.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>Name:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>Can't apply cheats before the game is started.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>Save</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>Apply</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>Restore Defaults</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>Close</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>Point your mouse at an option to display its description.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Console Language:\nSets the language that the PS4 game uses.\nIt's recommended to set this to a language the game supports, which will vary by region.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>Emulator Language:\nSets the language of the emulator's user interface.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>Enable Full Screen:\nAutomatically puts the game window into full-screen mode.\nThis can be toggled by pressing the F11 key.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Enable Separate Update Folder:\nEnables installing game updates into a separate folder for easy management.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>Show Splash Screen:\nShows the game's splash screen (a special image) while the game is starting.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>Is PS4 Pro:\nMakes the emulator act as a PS4 PRO, which may enable special features in games that support it.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>Discord Rich Presence 활성화:\nDiscord 프로필에 에뮬레이터 아이콘과 관련 정보를 표시합니다.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>Username:\nSets the PS4's account username, which may be displayed by some games.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>Log Type:\nSets whether to synchronize the output of the log window for performance. May have adverse effects on emulation.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Log Filter:\nFilters the log to only print specific information.\nExamples: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" Levels: Trace, Debug, Info, Warning, Error, Critical - in this order, a specific level silences all levels preceding it in the list and logs every level after it.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>Update:\nRelease: Official versions released every month that may be very outdated, but are more reliable and tested.\nNightly: Development versions that have all the latest features and fixes, but may contain bugs and are less stable.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Play Title Music:\nIf a game supports it, enable playing special music when selecting the game in the GUI.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Disable Trophy Pop-ups:\nDisable in-game trophy notifications. Trophy progress can still be tracked using the Trophy Viewer (right-click the game in the main window).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>Hide Cursor:\nChoose when the cursor will disappear:\nNever: You will always see the mouse.\nidle: Set a time for it to disappear after being idle.\nAlways: you will never see the mouse.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>Set a time for the mouse to disappear after being after being idle.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>Back Button Behavior:\nSets the controller's back button to emulate tapping the specified position on the PS4 touchpad.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Display Compatibility Data:\nDisplays game compatibility information in table view. Enable "Update Compatibility On Startup" to get up-to-date information.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Update Compatibility On Startup:\nAutomatically update the compatibility database when shadPS4 starts.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Update Compatibility Database:\nImmediately update the compatibility database.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>Never</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>Idle</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>Always</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>Touchpad Left</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>Touchpad Right</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>Touchpad Center</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>None</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>Graphics Device:\nOn multiple GPU systems, select the GPU the emulator will use from the drop down list,\nor select "Auto Select" to automatically determine it.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Width/Height:\nSets the size of the emulator window at launch, which can be resized during gameplay.\nThis is different from the in-game resolution.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Vblank Divider:\nThe frame rate at which the emulator refreshes at is multiplied by this number. Changing this may have adverse effects, such as increasing the game speed, or breaking critical game functionality that does not expect this to change!</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>Enable Shaders Dumping:\nFor the sake of technical debugging, saves the games shaders to a folder as they render.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Enable Null GPU:\nFor the sake of technical debugging, disables game rendering as if there were no graphics card.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>Game Folders:\nThe list of folders to check for installed games.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>Add:\nAdd a folder to the list.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>Remove:\nRemove a folder from the list.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>Enable Debug Dumping:\nSaves the import and export symbols and file header information of the currently running PS4 program to a directory.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Enable Vulkan Validation Layers:\nEnables a system that validates the state of the Vulkan renderer and logs information about its internal state. This will reduce performance and likely change the behavior of emulation.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Enable Vulkan Synchronization Validation:\nEnables a system that validates the timing of Vulkan rendering tasks. This will reduce performance and likely change the behavior of emulation.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>Enable RenderDoc Debugging:\nIf enabled, the emulator will provide compatibility with Renderdoc to allow capture and analysis of the currently rendered frame.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Cheats / Patches for </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>Cheats/Patches are experimental.\nUse with caution.\n\nDownload cheats individually by selecting the repository and clicking the download button.\nIn the Patches tab, you can download all patches at once, choose which ones you want to use, and save your selection.\n\nSince we do not develop the Cheats/Patches,\nplease report issues to the cheat author.\n\nCreated a new cheat? Visit:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>No Image Available</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>Serial: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>Version: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>Size: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>Select Cheat File:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>Repository:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>Download Cheats</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>Delete File</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>No files selected.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>You can delete the cheats you don't want after downloading them.</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>Do you want to delete the selected file?\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>Select Patch File:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>Download Patches</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>Save</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>Cheats</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>Patches</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Error</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>No patch selected.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>Unable to open files.json for reading.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>No patch file found for the current serial.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>Unable to open the file for reading.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>Unable to open the file for writing.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>Failed to parse XML: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>Success</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>Options saved successfully.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>Invalid Source</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>The selected source is invalid.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>File Exists</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>File already exists. Do you want to replace it?</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>Failed to save file:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>Failed to download file:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>Cheats Not Found</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>No Cheats found for this game in this version of the selected repository,try another repository or a different version of the game.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>Cheats Downloaded Successfully</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>You have successfully downloaded the cheats for this version of the game from the selected repository. You can try downloading from another repository, if it is available it will also be possible to use it by selecting the file from the list.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>Failed to save:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>Failed to download:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Download Complete</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>Patches Downloaded Successfully! All Patches available for all games have been downloaded, there is no need to download them individually for each game as happens in Cheats. If the patch does not appear, it may be that it does not exist for the specific serial and version of the game.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>Failed to parse JSON data from HTML.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>Failed to retrieve HTML page.</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>The game is in version: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>The downloaded patch only works on version: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>You may need to update your game.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>Incompatibility Notice</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>Failed to open file:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>XML ERROR:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>Failed to open files.json for writing</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>Author: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>Directory does not exist:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>Failed to open files.json for reading.</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>Name:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>Can't apply cheats before the game is started.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>Icon</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>Name</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>Serial</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>Region</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>Firmware</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>Size</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>Version</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>Path</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>Play Time</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Never Played</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Compatibility is untested</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Game does not initialize properly / crashes the emulator</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Game boots, but only displays a blank screen</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Game displays an image but does not go past the menu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Game has game-breaking glitches or unplayable performance</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>Auto Updater</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>Network error:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>Failed to parse update information.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>No pre-releases found.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>Invalid release data.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>No download URL found for the specified asset.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>Your version is already up to date!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>Update Available</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>Update Channel</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>Current Version</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>Latest Version</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>Do you want to update?</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>Show Changelog</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Check for Updates at Startup</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>Update</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>No</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>Hide Changelog</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>Changes</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>Network error occurred while trying to access the URL</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>Download Complete</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>The update has been downloaded, press OK to install.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>Failed to save the update file at</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>Starting Update...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>Failed to create the update script file</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/lt_LT.ts
+++ b/src/qt_gui/translations/lt_LT.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>About shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 is an experimental open-source emulator for the PlayStation 4.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>This software should not be used to play games you have not legally obtained.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Open Folder</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Loading game list, please wait :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>Cancel</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Loading...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Choose directory</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Select which directory you want to install to.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Choose directory</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Directory to install games</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Browse</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>The value for location to install games is not valid.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>Create Shortcut</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Apgaulės / Pleistrai</source>
 			<translation>Cheats / Patches</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>SFO Viewer</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophy Viewer</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>Atidaryti Katalogą...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>Atidaryti Žaidimo Katalogą</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>Atidaryti Išsaugotų Duomenų Katalogą</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>Atidaryti Žurnalų Katalogą</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>Copy info...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>Copy Name</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>Copy Serial</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>Copy All</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Delete...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Delete Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Delete Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Delete DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>Shortcut creation</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>Shortcut created successfully!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>Error creating shortcut!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>Install PKG</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>This feature requires the 'Enable Separate Update Folder' config option to work. If you want to use this feature, please enable it.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>This game has no update to delete!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>This game has no DLC to delete!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Delete %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Are you sure you want to delete %1's %2 directory?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Open/Add Elf Folder</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>Install Packages (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Boot Game</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>Patikrinti atnaujinimus</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>About shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Configure...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>Install application from a .pkg file</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Recent Games</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Exit</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>Exit shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Exit the application.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Show Game List</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Game List Refresh</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Tiny</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Small</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Medium</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Large</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>List View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Grid View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Elf Viewer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Game Install Directory</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>Atsisiųsti Apgaules / Pleistrus</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Dump Game List</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>PKG Viewer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Search...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>File</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Game List Icons</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Game List Mode</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Settings</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Utils</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Themes</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>Pagalba</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Dark</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Light</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Green</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Blue</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Violet</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>toolBar</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>Žaidimų sąrašas</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * Nepalaikoma Vulkan versija</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>Atsisiųsti sukčiavimus visiems įdiegtiems žaidimams</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>Atsisiųsti pataisas visiems žaidimams</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Atsisiuntimas baigtas</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>Jūs atsisiuntėte sukčiavimus visiems jūsų įdiegtiesiems žaidimams.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>Pataisos sėkmingai atsisiųstos!</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>Visos pataisos visiems žaidimams buvo atsisiųstos.</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>Žaidimai: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>PKG failas (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>ELF failai (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>Žaidimo paleidimas</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>Galite pasirinkti tik vieną failą!</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>PKG ištraukimas</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>Rasta atnaujinimą!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>PKG ir žaidimo versijos sutampa: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>Ar norite perrašyti?</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>PKG versija %1 yra senesnė nei įdiegta versija: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>Žaidimas įdiegtas: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>Ar norite įdiegti atnaujinimą: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>DLC diegimas</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>Ar norite įdiegti DLC: %1?</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC jau įdiegtas:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>Žaidimas jau įdiegtas</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>PKG yra pataisa, prašome pirmiausia įdiegti žaidimą!</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>PKG KLAIDA</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>Ekstrakcinis PKG %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>Ekstrakcija baigta</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>Žaidimas sėkmingai įdiegtas %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>Failas atrodo, kad nėra galiojantis PKG failas</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Open Folder</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophy Viewer</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Settings</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>General</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>System</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>Console Language</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Emulator Language</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Emulator</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Enable Fullscreen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Show Splash</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>Is PS4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Įjungti Discord Rich Presence</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Username</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Logger</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Log Type</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Log Filter</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>Įvestis</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>Žymeklis</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>Slėpti žymeklį</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>Žymeklio paslėpimo neveikimo laikas</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>Valdiklis</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>Atgal mygtuko elgsena</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Graphics</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Graphics Device</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Width</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Height</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Vblank Divider</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Advanced</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Enable Shaders Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>Enable NULL GPU</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>Keliai</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>Žaidimų aplankai</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>Pridėti...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>Pašalinti</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Debug</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Enable Debug Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Enable Vulkan Validation Layers</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Enable Vulkan Synchronization Validation</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>Enable RenderDoc Debugging</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>Atnaujinimas</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Tikrinti naujinimus paleidus</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>Atnaujinimo Kanalas</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>Patikrinkite atnaujinimus</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>GUI Nustatymai</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Disable Trophy Pop-ups</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>Groti antraštės muziką</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Update Compatibility Database On Startup</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Game Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Display Compatibility Data</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Update Compatibility Database</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>Garsumas</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>Žaidimų sąrašas</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * Nepalaikoma Vulkan versija</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>Atsisiųsti sukčiavimus visiems įdiegtiems žaidimams</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>Atsisiųsti pataisas visiems žaidimams</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>Atsisiuntimas baigtas</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>Jūs atsisiuntėte sukčiavimus visiems jūsų įdiegtiesiems žaidimams.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>Pataisos sėkmingai atsisiųstos!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>Visos pataisos visiems žaidimams buvo atsisiųstos.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>Žaidimai: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>PKG failas (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>ELF failai (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>Žaidimo paleidimas</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>Galite pasirinkti tik vieną failą!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>PKG ištraukimas</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>Rasta atnaujinimą!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>PKG ir žaidimo versijos sutampa: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>Ar norite perrašyti?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>PKG versija %1 yra senesnė nei įdiegta versija: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>Žaidimas įdiegtas: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>Ar norite įdiegti atnaujinimą: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>DLC diegimas</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>Ar norite įdiegti DLC: %1?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC jau įdiegtas:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>Žaidimas jau įdiegtas</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>PKG yra pataisa, prašome pirmiausia įdiegti žaidimą!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>PKG KLAIDA</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>Ekstrakcinis PKG %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>Ekstrakcija baigta</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>Žaidimas sėkmingai įdiegtas %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>Failas atrodo, kad nėra galiojantis PKG failas</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Cheats / Patches for </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>Cheats/Patches yra eksperimentiniai.\nNaudokite atsargiai.\n\nAtsisiųskite cheats atskirai pasirinkdami saugyklą ir paspausdami atsisiuntimo mygtuką.\nPatches skirtuke galite atsisiųsti visus patch’us vienu metu, pasirinkti, kuriuos norite naudoti, ir išsaugoti pasirinkimą.\n\nKadangi mes nekurime Cheats/Patches,\npraneškite problemas cheat autoriui.\n\nSukūrėte naują cheat? Apsilankykite:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>Nuotrauka neprieinama</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>Seriinis numeris: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>Versija: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>Dydis: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>Pasirinkite sukčiavimo failą:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>Saugykla:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>Atsisiųsti sukčiavimus</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>Pašalinti failą</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>Failai nepasirinkti.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>Galite pašalinti sukčiavimus, kurių nenorite, juos atsisiuntę.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>Ar norite ištrinti pasirinktą failą?\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>Pasirinkite pataisos failą:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>Atsisiųsti pataisas</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>Įrašyti</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>Sukčiavimai</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>Pataisos</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>Klaida</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>Nieko nepataisyta.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>Neįmanoma atidaryti files.json skaitymui.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>Nepavyko rasti pataisos failo dabartiniam serijiniam numeriui.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>Neįmanoma atidaryti failo skaitymui.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>Neįmanoma atidaryti failo rašymui.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>Nepavyko išanalizuoti XML: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>Sėkmė</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>Nustatymai sėkmingai išsaugoti.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>Netinkamas šaltinis</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>Pasirinktas šaltinis yra netinkamas.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>Failas egzistuoja</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>Failas jau egzistuoja. Ar norite jį pakeisti?</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>Nepavyko išsaugoti failo:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>Nepavyko atsisiųsti failo:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>Sukčiavimai nerasti</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>Nerasta sukčiavimų šiam žaidimui šioje pasirinktos saugyklos versijoje,bandykite kitą saugyklą arba skirtingą žaidimo versiją.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>Sukčiavimai sėkmingai atsisiųsti</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>Sėkmingai atsisiuntėte sukčiavimus šios žaidimo versijos iš pasirinktos saugyklos. Galite pabandyti atsisiųsti iš kitos saugyklos, jei ji yra prieinama, taip pat bus galima ją naudoti pasirinkus failą iš sąrašo.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>Nepavyko išsaugoti:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>Nepavyko atsisiųsti:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>Atsisiuntimas baigtas</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>Pataisos sėkmingai atsisiųstos! Visos pataisos visiems žaidimams buvo atsisiųstos, nebėra reikalo jas atsisiųsti atskirai kiekvienam žaidimui, kaip tai vyksta su sukčiavimais. Jei pleistras nepasirodo, gali būti, kad jo nėra tam tikram žaidimo serijos numeriui ir versijai.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>Nepavyko išanalizuoti JSON duomenų iš HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>Nepavyko gauti HTML puslapio.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>Žaidimas yra versijoje: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>Parsisiųstas pataisas veikia tik versijoje: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>Gali tekti atnaujinti savo žaidimą.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>Suderinamumo pranešimas</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>Nepavyko atidaryti failo:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>XML KLAIDA:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>Nepavyko atidaryti files.json rašymui</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>Autorius: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>Katalogas neegzistuoja:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>Nepavyko atidaryti files.json skaitymui.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>Pavadinimas:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>Negalima taikyti sukčiavimų prieš pradedant žaidimą.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>Įrašyti</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>Taikyti</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>Atkurti numatytuosius nustatymus</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>Uždaryti</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>Žymeklį nukreipkite ant pasirinkimo, kad pamatytumėte jo aprašymą.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Konsole kalba:\nNustato kalbą, kurią naudoja PS4 žaidimai.\nRekomenduojama nustatyti kalbą, kurią palaiko žaidimas, priklausomai nuo regiono.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>Emuliatoriaus kalba:\nNustato emuliatoriaus vartotojo sąsajos kalbą.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>Įjungti visą ekraną:\nAutomatiškai perjungia žaidimo langą į viso ekrano režimą.\nTai galima išjungti paspaudus F11 klavišą.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Enable Separate Update Folder:\nEnables installing game updates into a separate folder for easy management.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>Rodyti paleidimo ekraną:\nPaleidimo metu rodo žaidimo paleidimo ekraną (ypatingą vaizdą).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>Ar PS4 Pro:\nPadaro, kad emuliatorius veiktų kaip PS4 PRO, kas gali įjungti specialias funkcijas žaidimuose, kurie tai palaiko.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>Įjungti Discord Rich Presence:\nRodo emuliatoriaus ikoną ir susijusią informaciją jūsų Discord profilyje.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>Vartotojo vardas:\nNustato PS4 paskyros vartotojo vardą, kuris gali būti rodomas kai kuriuose žaidimuose.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>Žurnalo tipas:\nNustato, ar sinchronizuoti žurnalo lango išvestį našumui. Tai gali turėti neigiamą poveikį emuliacijai.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Žurnalo filtras:\nFiltruojamas žurnalas, kad būtų spausdinama tik konkreti informacija.\nPavyzdžiai: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" Lygiai: Trace, Debug, Info, Warning, Error, Critical - šia tvarka, konkretus lygis nutildo visus ankstesnius lygius sąraše ir registruoja visus vėlesnius.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>Atnaujinti:\nRelease: Oficialios versijos, išleidžiamos kiekvieną mėnesį, kurios gali būti labai pasenusios, tačiau yra patikimos ir išbandytos.\nNightly: Vystymo versijos, kuriose yra visos naujausios funkcijos ir taisymai, tačiau gali turėti klaidų ir būti mažiau stabilios.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Groti antraščių muziką:\nJei žaidimas tai palaiko, įjungia specialios muzikos grojimą, kai pasirinkite žaidimą GUI.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Disable Trophy Pop-ups:\nDisable in-game trophy notifications. Trophy progress can still be tracked using the Trophy Viewer (right-click the game in the main window).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>Slėpti žymeklį:\nPasirinkite, kada žymeklis dings:\nNiekuomet: Visada matysite pelę.\nNeaktyvus: Nustatykite laiką, po kurio ji dings, kai bus neaktyvi.\nVisada: niekada nematysite pelės.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>Nustatykite laiką, po kurio pelė dings, kai bus neaktyvi.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>Atgal mygtuko elgesys:\nNustato valdiklio atgal mygtuką imituoti paspaudimą nurodytoje vietoje PS4 jutiklinėje plokštėje.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Display Compatibility Data:\nDisplays game compatibility information in table view. Enable "Update Compatibility On Startup" to get up-to-date information.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Update Compatibility On Startup:\nAutomatically update the compatibility database when shadPS4 starts.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Update Compatibility Database:\nImmediately update the compatibility database.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>Niekada</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>Neaktyvus</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>Visada</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>Jutiklinis Paviršius Kairėje</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>Jutiklinis Paviršius Dešinėje</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>Jutiklinis Paviršius Centre</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>Nieko</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>Grafikos įrenginys:\nDaugiagrafikėse sistemose pasirinkite GPU, kurį emuliatorius naudos iš išskleidžiamojo sąrašo,\n arba pasirinkite "Auto Select", kad jis būtų nustatytas automatiškai.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Plotis/Aukštis:\nNustato emuliatoriaus lango dydį paleidimo metu, kurį galima keisti žaidimo metu.\nTai skiriasi nuo žaidimo rezoliucijos.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Vblank daliklis:\nKadrų dažnis, kuriuo emuliatorius atnaujinamas, dauginamas iš šio skaičiaus. Pakeitus tai gali turėti neigiamą poveikį, pvz., padidinti žaidimo greitį arba sukelti kritinių žaidimo funkcijų sugadinimą, kurios to nesitikėjo!</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>Įjungti šešėlių išmetimą:\nTechninio derinimo tikslais saugo žaidimo šešėlius į aplanką juos renderuojant.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Įjungti tuščią GPU:\nTechninio derinimo tikslais išjungia žaidimo renderiavimą, tarsi nebūtų grafikos plokštės.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>Žaidimų aplankai:\nAplankų sąrašas, kurį reikia patikrinti, ar yra įdiegtų žaidimų.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>Pridėti:\nPridėti aplanką į sąrašą.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>Pašalinti:\nPašalinti aplanką iš sąrašo.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>Įjungti derinimo išmetimą:\nIšsaugo importo ir eksporto simbolius bei failo antraštės informaciją apie šiuo metu vykdomą PS4 programą į katalogą.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Įjungti Vulkan patvirtinimo sluoksnius:\nĮjungia sistemą, kuri patvirtina Vulkan renderio būseną ir registruoja informaciją apie jo vidinę būseną. Tai sumažins našumą ir tikriausiai pakeis emuliacijos elgesį.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Įjungti Vulkan sinchronizacijos patvirtinimą:\nĮjungia sistemą, kuri patvirtina Vulkan renderavimo užduočių laiką. Tai sumažins našumą ir tikriausiai pakeis emuliacijos elgesį.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>Įjungti RenderDoc derinimą:\nJei įjungta, emuliatorius suteiks suderinamumą su Renderdoc, kad būtų galima užfiksuoti ir analizuoti šiuo metu renderuojamą kadrą.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Cheats / Patches for </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>Cheats/Patches yra eksperimentiniai.\nNaudokite atsargiai.\n\nAtsisiųskite cheats atskirai pasirinkdami saugyklą ir paspausdami atsisiuntimo mygtuką.\nPatches skirtuke galite atsisiųsti visus patch’us vienu metu, pasirinkti, kuriuos norite naudoti, ir išsaugoti pasirinkimą.\n\nKadangi mes nekurime Cheats/Patches,\npraneškite problemas cheat autoriui.\n\nSukūrėte naują cheat? Apsilankykite:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>Nuotrauka neprieinama</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>Seriinis numeris: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>Versija: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>Dydis: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>Pasirinkite sukčiavimo failą:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>Saugykla:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>Atsisiųsti sukčiavimus</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>Pašalinti failą</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>Failai nepasirinkti.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>Galite pašalinti sukčiavimus, kurių nenorite, juos atsisiuntę.</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>Ar norite ištrinti pasirinktą failą?\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>Pasirinkite pataisos failą:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>Atsisiųsti pataisas</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>Įrašyti</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>Sukčiavimai</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>Pataisos</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Klaida</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>Nieko nepataisyta.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>Neįmanoma atidaryti files.json skaitymui.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>Nepavyko rasti pataisos failo dabartiniam serijiniam numeriui.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>Neįmanoma atidaryti failo skaitymui.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>Neįmanoma atidaryti failo rašymui.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>Nepavyko išanalizuoti XML: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>Sėkmė</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>Nustatymai sėkmingai išsaugoti.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>Netinkamas šaltinis</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>Pasirinktas šaltinis yra netinkamas.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>Failas egzistuoja</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>Failas jau egzistuoja. Ar norite jį pakeisti?</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>Nepavyko išsaugoti failo:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>Nepavyko atsisiųsti failo:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>Sukčiavimai nerasti</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>Nerasta sukčiavimų šiam žaidimui šioje pasirinktos saugyklos versijoje,bandykite kitą saugyklą arba skirtingą žaidimo versiją.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>Sukčiavimai sėkmingai atsisiųsti</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>Sėkmingai atsisiuntėte sukčiavimus šios žaidimo versijos iš pasirinktos saugyklos. Galite pabandyti atsisiųsti iš kitos saugyklos, jei ji yra prieinama, taip pat bus galima ją naudoti pasirinkus failą iš sąrašo.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>Nepavyko išsaugoti:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>Nepavyko atsisiųsti:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Atsisiuntimas baigtas</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>Pataisos sėkmingai atsisiųstos! Visos pataisos visiems žaidimams buvo atsisiųstos, nebėra reikalo jas atsisiųsti atskirai kiekvienam žaidimui, kaip tai vyksta su sukčiavimais. Jei pleistras nepasirodo, gali būti, kad jo nėra tam tikram žaidimo serijos numeriui ir versijai.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>Nepavyko išanalizuoti JSON duomenų iš HTML.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>Nepavyko gauti HTML puslapio.</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>Žaidimas yra versijoje: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>Parsisiųstas pataisas veikia tik versijoje: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>Gali tekti atnaujinti savo žaidimą.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>Suderinamumo pranešimas</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>Nepavyko atidaryti failo:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>XML KLAIDA:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>Nepavyko atidaryti files.json rašymui</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>Autorius: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>Katalogas neegzistuoja:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>Nepavyko atidaryti files.json skaitymui.</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>Pavadinimas:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>Negalima taikyti sukčiavimų prieš pradedant žaidimą.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>Ikona</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>Vardas</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>Serijinis numeris</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>Regionas</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>Firmvare</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>Dydis</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>Versija</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>Kelias</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>Žaidimo laikas</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Never Played</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Compatibility is untested</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Game does not initialize properly / crashes the emulator</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Game boots, but only displays a blank screen</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Game displays an image but does not go past the menu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Game has game-breaking glitches or unplayable performance</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>Automatinis atnaujinimas</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>Klaida</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>Tinklo klaida:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>Nepavyko išanalizuoti atnaujinimo informacijos.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>Išankstinių leidimų nerasta.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>Neteisingi leidimo duomenys.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>Nerasta atsisiuntimo URL nurodytam turtui.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>Jūsų versija jau atnaujinta!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>Prieinama atnaujinimas</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>Atnaujinimo Kanalas</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>Esama versija</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>Paskutinė versija</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>Ar norite atnaujinti?</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>Rodyti pakeitimų sąrašą</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Tikrinti naujinimus paleidus</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>Atnaujinti</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>Ne</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>Slėpti pakeitimų sąrašą</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>Pokyčiai</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>Tinklo klaida bandant pasiekti URL</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>Atsisiuntimas baigtas</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>Atnaujinimas buvo atsisiųstas, paspauskite OK, kad įdiegtumėte.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>Nepavyko išsaugoti atnaujinimo failo</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>Pradedama atnaujinimas...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>Nepavyko sukurti atnaujinimo scenarijaus failo</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/nb.ts
+++ b/src/qt_gui/translations/nb.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>Om shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 er en eksperimentell åpen kildekode-etterligner for PlayStation 4.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>Denne programvaren skal ikke brukes til å spille spill du ikke har fått lovlig.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Åpne mappe</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Laster spill-liste, vennligst vent :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>Avbryt</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Laster...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Velg mappe</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Velg hvilken mappe du vil installere til.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Velg mappe</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Mappe for å installere spill</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Bla gjennom</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Feil</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>Stien for å installere spillet er ikke gyldig.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>Lag snarvei</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>Juks / Programrettelse</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>SFO viser</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>Trofé viser</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>Åpne mappen...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>Åpne spillmappen</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>Åpne lagrede datamappen</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>Åpne loggmappen</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>Kopier info...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>Kopier navn</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>Kopier serienummer</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>Kopier alle</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Slett...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Slett spill</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Slett oppdatering</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Slett DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>Snarvei opprettelse</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>Snarvei opprettet!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>Feil</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>Feil ved opprettelse av snarvei!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>Installer PKG</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Spill</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>Denne funksjonen krever 'Aktiver seperat oppdateringsmappe' konfigurasjonsalternativet. Hvis du vil bruke denne funksjonen, må du aktiver den.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>Dette spillet har ingen oppdatering å slette!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Oppdater</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>Dette spillet har ingen DLC å slette!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Slett %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Er du sikker på at du vil slette %1's %2 directory?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Åpne/Legg til Elf-mappe</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>Installer pakker (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Start spill</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>Se etter oppdateringer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>Om shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Konfigurer...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>Installer fra en .pkg fil</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Nylige spill</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Avslutt</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>Avslutt shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Avslutt programmet.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Vis spill-listen</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Oppdater spill-listen</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Bitteliten</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Liten</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Medium</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Stor</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>Liste-visning</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Rute-visning</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Elf-visning</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Spillinstallasjons-mappe</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>Last ned juks/programrettelse</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Dump spill-liste</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>PKG viser</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Søk...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>Fil</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>Oversikt</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Spill-liste ikoner</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Spill-liste modus</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Innstillinger</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Verktøy</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Tema</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>Hjelp</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Mørk</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Lys</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Grønn</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Blå</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Lilla</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>Verktøylinje</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>Spill-liste</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * Ustøttet Vulkan-versjon</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>Last ned juks for alle installerte spill</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>Last ned programrettelser for alle spill</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Nedlasting fullført</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>Du har lastet ned juks for alle spillene du har installert.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>Programrettelser ble lastet ned!</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>Programrettelser tilgjengelige for alle spill har blitt lastet ned.</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>Spill: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>PKG-fil (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>ELF-filer (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>Spilloppstart</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>Kun én fil kan velges!</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>PKG-utpakking</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>Programrettelse oppdaget!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>PKG og spillversjoner stemmer overens: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>Ønsker du å overskrive?</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>PKG-versjon %1 er eldre enn installert versjon: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>Spillet er installert: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>Ønsker du å installere programrettelsen: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>DLC installasjon</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>Ønsker du å installere DLC: %1?</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC allerede installert:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>Spillet er allerede installert</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>PKG er en programrettelse, vennligst installer spillet først!</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>PKG FEIL</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>Pakker ut PKG %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>Utpakking fullført</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>Spillet ble installert i %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>Filen ser ikke ut til å være en gyldig PKG-fil</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Åpne mappe</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Trofé viser</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Innstillinger</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>Generell</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>System</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>Konsollspråk</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Etterlignerspråk</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Etterligner</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Aktiver fullskjerm</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Aktiver seperat oppdateringsmappe</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Vis velkomstbilde</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>Er PS4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Aktiver Discord Rich Presence</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Brukernavn</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Logger</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Logg type</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Logg filter</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>Inndata</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>Musepeker</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>Skjul musepeker</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>Skjul musepeker ved inaktivitet</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>Kontroller</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>Tilbakeknapp atferd</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Grafikk</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Grafikkenhet</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Bredde</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Høyde</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Vblank skillelinje</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Avansert</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Aktiver dumping av skyggelegger</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>Aktiver NULL GPU</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>Stier</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>Spillmapper</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>Legg til...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>Fjern</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Feilretting</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Aktiver dumping av feilretting</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Aktiver Vulkan valideringslag</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Aktiver Vulkan synkroniseringslag</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>Aktiver RenderDoc feilretting</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>Oppdatering</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Se etter oppdateringer ved oppstart</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>Oppdateringskanal</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>Se etter oppdateringer</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>GUI-innstillinger</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Deaktiver trofé hurtigmeny</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>Spill tittelmusikk</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Oppdater kompatibilitets-database ved oppstart</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Spill kompatibilitet</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Vis kompatibilitets-data</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Oppdater kompatibilitets-database</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>Volum</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>Spill-liste</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * Ustøttet Vulkan-versjon</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>Last ned juks for alle installerte spill</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>Last ned programrettelser for alle spill</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>Nedlasting fullført</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>Du har lastet ned juks for alle spillene du har installert.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>Programrettelser ble lastet ned!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>Programrettelser tilgjengelige for alle spill har blitt lastet ned.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>Spill: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>PKG-fil (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>ELF-filer (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>Spilloppstart</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>Kun én fil kan velges!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>PKG-utpakking</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>Programrettelse oppdaget!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>PKG og spillversjoner stemmer overens: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>Ønsker du å overskrive?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>PKG-versjon %1 er eldre enn installert versjon: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>Spillet er installert: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>Ønsker du å installere programrettelsen: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>DLC installasjon</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>Ønsker du å installere DLC: %1?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC allerede installert:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>Spillet er allerede installert</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>PKG er en programrettelse, vennligst installer spillet først!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>PKG FEIL</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>Pakker ut PKG %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>Utpakking fullført</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>Spillet ble installert i %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>Filen ser ikke ut til å være en gyldig PKG-fil</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Juks / Programrettelser for </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>Juks/programrettelse er eksperimentelle.\nBruk med forsiktighet.\n\nLast ned juks individuelt ved å velge pakkebrønn og klikke på nedlastingsknappen.\nPå fanen programrettelse kan du laste ned alle programrettelser samtidig, velge hvilke du ønsker å bruke, og lagre valget ditt.\n\nSiden vi ikke utvikler Juks/Programrettelse,\nvær vennlig å rapportere problemer til juks/programrettelse utvikleren.\n\nHar du laget en ny juks? Besøk:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>Ingen bilde tilgjengelig</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>Serienummer: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>Versjon: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>Størrelse: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>Velg juksefil:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>Pakkebrønn:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>Last ned juks</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>Slett fil</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>Ingen filer valgt.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>Du kan slette juks du ikke ønsker etter å ha lastet dem ned.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>Ønsker du å slette den valgte filen?\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>Velg programrettelse-filen:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>Last ned programrettelser</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>Lagre</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>Juks</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>Programrettelse</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>Feil</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>Ingen programrettelse valgt.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>Kan ikke åpne files.json for lesing.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>Ingen programrettelse-fil funnet for det aktuelle serienummeret.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>Kan ikke åpne filen for lesing.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>Kan ikke åpne filen for skriving.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>Feil ved tolkning av XML: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>Vellykket</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>Alternativer ble lagret.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>Ugyldig kilde</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>Den valgte kilden er ugyldig.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>Filen eksisterer</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>Filen eksisterer allerede. Ønsker du å erstatte den?</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>Kunne ikke lagre filen:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>Kunne ikke laste ned filen:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>Fant ikke juks</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>Ingen juks funnet for dette spillet i denne versjonen av den valgte pakkebrønnen,prøv en annen pakkebrønn eller en annen versjon av spillet.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>Juks ble lastet ned</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>Du har lastet ned juks for denne versjonen av spillet fra den valgte pakkebrønnen. Du kan prøve å laste ned fra en annen pakkebrønn, hvis det er tilgjengelig, vil det også være mulig å bruke det ved å velge filen fra listen.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>Kunne ikke lagre:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>Kunne ikke laste ned:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>Nedlasting fullført</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>Programrettelser ble lastet ned! Alle programrettelsene tilgjengelige for alle spill har blitt lastet ned, det er ikke nødvendig å laste dem ned individuelt for hvert spill som skjer med juks. Hvis programrettelsen ikke vises, kan det hende at den ikke finnes for den spesifikke serienummeret og versjonen av spillet.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>Kunne ikke analysere JSON-data fra HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>Kunne ikke hente HTML-side.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>Spillet er i versjon: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>Den nedlastede programrettelsen fungerer bare på versjon: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>Du må kanskje oppdatere spillet ditt.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>Inkompatibilitets-varsel</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>Kunne ikke åpne filen:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>XML FEIL:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>Kunne ikke åpne files.json for skriving</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>Forfatter: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>Mappen eksisterer ikke:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>Kunne ikke åpne files.json for lesing.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>Navn:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>Kan ikke bruke juks før spillet er startet.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>Lagre</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>Bruk</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>Gjenopprett standardinnstillinger</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>Lukk</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>Pek musen over et alternativ for å vise beskrivelsen.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Konsollspråk:\nAngir språket som PS4-spillet bruker.\nDet anbefales å sette dette til et språk som spillet støtter, noe som kan variere avhengig av region.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>Etterlignerspråket:\nAngir språket for etterlignerens brukergrensesnitt.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>Aktiver fullskjerm:\nSetter spillvinduet automatisk i fullskjermmodus.\nDette kan slås av ved å trykke på F11-tasten.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Aktiver separat oppdateringsmappe:\nAktiverer installering av spill i en egen mappe for enkel administrasjon.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>Vis velkomstbilde:\nViser spillets velkomstbilde (et spesialbilde) når spillet starter.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>Er PS4 Pro:\nFår etterligneren til å fungere som en PS4 PRO, noe som kan aktivere spesielle funksjoner i spill som støtter dette.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>Aktiver Discord Rich Presence:\nViser etterlignerikonet og relevant informasjon på Discord-profilen din.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>Brukernavn:\nAngir brukernavnet for PS4-kontoen, som kan vises av enkelte spill.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>Logg type:\nAngir om loggvinduets utdata skal synkroniseres for ytelse. Kan ha negative effekter for etterligneren.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Logg filter:\nFiltrerer loggen for å kun skrive ut spesifikk informasjon.\nEksempler: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" Nivåer: Trace, Debug, Info, Warning, Error, Critical - i denne rekkefølgen, et spesifikt nivå demper alle tidligere nivåer i listen og logger alle nivåer etter det.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>Oppdatering:\nRelease: Offisielle versjoner utgitt hver måned som kan være veldig utdaterte, men er mer pålitelige og testet.\nNightly: Utviklingsversjoner som har alle de nyeste funksjonene og feilrettingene, men som kan inneholde feil og er mindre stabile.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Spille tittelmusikk:\nHvis et spill støtter det, så aktiveres det spesiell musikk når du velger spillet i menyen.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Deaktiver trofé hurtigmeny:\nDeaktiver trofévarsler i spillet. Trofé-fremgang kan fortsatt ved help av troféviseren (høyreklikk på spillet i hovedvinduet).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>Skjul musepeker:\nVelg når musepekeren skal forsvinne:\nAldri: Du vil alltid se musepekeren.\nInaktiv: Sett en tid for at den skal forsvinne etter å ha vært inaktiv.\nAlltid: du vil aldri se musepekeren.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>Sett en tid for når musepekeren forsvinner etter å ha vært inaktiv.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>Atferd for tilbaketasten:\nSetter tilbaketasten på kontrolleren til å imitere et trykk på den angitte posisjonen på PS4s berøringsplate.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Vis kompatibilitets-data:\nViser informasjon om spillkompatibilitet i tabellvisning. Aktiver "Oppdater kompatibilitets-data ved oppstart" for oppdatert informasjon.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Oppdater kompatibilitets-data ved oppstart:\nOppdaterer kompatibilitets-databasen automatisk når shadPS4 starter.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Oppdater kompatibilitets-database:\nOppdater kompatibilitets-databasen nå.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>Aldri</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>Inaktiv</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>Alltid</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>Berøringsplate Venstre</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>Berøringsplate Høyre</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>Berøringsplate Midt</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>Ingen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>Grafikkenhet:\nI systemer med flere GPU-er, velg GPU-en etterligneren skal bruke fra rullegardinlisten,\neller velg "Auto Select" for å velge automatisk.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Bredde/Høyde:\nAngir størrelsen på etterlignerkvinduet ved oppstart, som kan endres under spillingen.\nDette er forskjellig fra oppløsningen i spillet.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Vblank skillelinje:\nBildehastigheten som etterligneren oppdaterer ved, multipliseres med dette tallet. Endring av dette kan ha negative effekter, som å øke hastigheten av spillet, eller ødelegge kritisk spillfunksjonalitet som ikke forventer at dette endres!</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>Aktiver dumping av skyggelegger:\nFor teknisk feilsøking lagrer skyggeleggerne fra spillet i en mappe mens de gjengis.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Aktiver Null GPU:\nFor teknisk feilsøking deaktiverer spillets-gjengivelse som om det ikke var noe grafikkort.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>Spillmapper:\nListen over mapper som brukes for å se etter installerte spill.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>Legg til:\nLegg til en mappe til listen.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>Fjern:\nFjern en mappe fra listen.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>Aktiver dumping av feilsøking:\nLagrer import- og eksport-symbolene og filoverskriftsinformasjonen til det nåværende kjørende PS4-programmet i en katalog.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Aktiver Vulkan valideringslag:\nAktiverer et system som validerer tilstanden til Vulkan-gjengiveren og logger informasjon om dens indre tilstand. Dette vil redusere ytelsen og sannsynligvis endre etterlignerens atferd.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Aktiver Vulkan synkronisering validering:\nAktiverer et system som validerer frekvens tiden av Vulkan-gjengivelsensoppgaver. Dette vil redusere ytelsen og sannsynligvis endre etterlignerens atferd.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>Aktiver RenderDoc feilsøking:\nHvis aktivert, vil etterligneren gi kompatibilitet med Renderdoc for å tillate opptak og analyse av det nåværende gjengitte bildet.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Juks / Programrettelser for </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>Juks/programrettelse er eksperimentelle.\nBruk med forsiktighet.\n\nLast ned juks individuelt ved å velge pakkebrønn og klikke på nedlastingsknappen.\nPå fanen programrettelse kan du laste ned alle programrettelser samtidig, velge hvilke du ønsker å bruke, og lagre valget ditt.\n\nSiden vi ikke utvikler Juks/Programrettelse,\nvær vennlig å rapportere problemer til juks/programrettelse utvikleren.\n\nHar du laget en ny juks? Besøk:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>Ingen bilde tilgjengelig</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>Serienummer: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>Versjon: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>Størrelse: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>Velg juksefil:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>Pakkebrønn:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>Last ned juks</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>Slett fil</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>Ingen filer valgt.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>Du kan slette juks du ikke ønsker etter å ha lastet dem ned.</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>Ønsker du å slette den valgte filen?\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>Velg programrettelse-filen:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>Last ned programrettelser</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>Lagre</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>Juks</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>Programrettelse</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Feil</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>Ingen programrettelse valgt.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>Kan ikke åpne files.json for lesing.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>Ingen programrettelse-fil funnet for det aktuelle serienummeret.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>Kan ikke åpne filen for lesing.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>Kan ikke åpne filen for skriving.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>Feil ved tolkning av XML: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>Vellykket</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>Alternativer ble lagret.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>Ugyldig kilde</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>Den valgte kilden er ugyldig.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>Filen eksisterer</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>Filen eksisterer allerede. Ønsker du å erstatte den?</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>Kunne ikke lagre filen:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>Kunne ikke laste ned filen:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>Fant ikke juks</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>Ingen juks funnet for dette spillet i denne versjonen av den valgte pakkebrønnen,prøv en annen pakkebrønn eller en annen versjon av spillet.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>Juks ble lastet ned</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>Du har lastet ned juks for denne versjonen av spillet fra den valgte pakkebrønnen. Du kan prøve å laste ned fra en annen pakkebrønn, hvis det er tilgjengelig, vil det også være mulig å bruke det ved å velge filen fra listen.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>Kunne ikke lagre:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>Kunne ikke laste ned:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Nedlasting fullført</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>Programrettelser ble lastet ned! Alle programrettelsene tilgjengelige for alle spill har blitt lastet ned, det er ikke nødvendig å laste dem ned individuelt for hvert spill som skjer med juks. Hvis programrettelsen ikke vises, kan det hende at den ikke finnes for den spesifikke serienummeret og versjonen av spillet.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>Kunne ikke analysere JSON-data fra HTML.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>Kunne ikke hente HTML-side.</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>Spillet er i versjon: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>Den nedlastede programrettelsen fungerer bare på versjon: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>Du må kanskje oppdatere spillet ditt.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>Inkompatibilitets-varsel</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>Kunne ikke åpne filen:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>XML FEIL:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>Kunne ikke åpne files.json for skriving</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>Forfatter: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>Mappen eksisterer ikke:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>Kunne ikke åpne files.json for lesing.</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>Navn:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>Kan ikke bruke juks før spillet er startet.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>Ikon</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>Navn</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>Serienummer</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Kompatibilitet</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>Region</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>Fastvare</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>Størrelse</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>Versjon</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>Sti</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>Spilletid</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Aldri spilt</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>kompatibilitet er utestet</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Spillet initialiseres ikke riktig / krasjer etterligneren</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Spillet starter, men viser bare en tom skjerm</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Spillet viser et bilde, men går ikke forbi menyen</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Spillet har spillbrytende feil eller uspillbar ytelse</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Spillet kan fullføres med spillbar ytelse og ingen store feil</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>Automatisk oppdatering</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>Feil</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>Nettverksfeil:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>Kunne ikke analysere oppdaterings-informasjonen.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>Fant ingen forhåndsutgivelser.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>Ugyldige utgivelsesdata.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>Ingen nedlastings-URL funnet for den spesifiserte ressursen.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>Din versjon er allerede oppdatert!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>Oppdatering tilgjengelig</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>Oppdateringskanal</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>Gjeldende versjon</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>Nyeste versjon</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>Vil du oppdatere?</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>Vis endringslogg</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Se etter oppdateringer ved oppstart</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>Oppdater</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>Nei</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>Skjul endringslogg</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>Endringer</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>Nettverksfeil oppstod mens vi prøvde å få tilgang til URL</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>Nedlasting fullført</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>Oppdateringen har blitt lastet ned, trykk OK for å installere.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>Kunne ikke lagre oppdateringsfilen på</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>Starter oppdatering...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>Kunne ikke opprette oppdateringsskriptfilen</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/nl.ts
+++ b/src/qt_gui/translations/nl.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>About shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 is an experimental open-source emulator for the PlayStation 4.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>This software should not be used to play games you have not legally obtained.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Open Folder</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Loading game list, please wait :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>Cancel</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Loading...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Choose directory</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Select which directory you want to install to.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Choose directory</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Directory to install games</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Browse</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>The value for location to install games is not valid.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>Create Shortcut</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>Cheats / Patches</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>SFO Viewer</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophy Viewer</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>Map openen...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>Open Spelmap</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>Open Map voor Opslagdata</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>Open Logmap</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>Copy info...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>Copy Name</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>Copy Serial</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>Copy All</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Delete...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Delete Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Delete Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Delete DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>Shortcut creation</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>Shortcut created successfully!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>Error creating shortcut!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>Install PKG</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>This feature requires the 'Enable Separate Update Folder' config option to work. If you want to use this feature, please enable it.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>This game has no update to delete!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>This game has no DLC to delete!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Delete %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Are you sure you want to delete %1's %2 directory?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Open/Add Elf Folder</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>Install Packages (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Boot Game</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>Controleren op updates</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>About shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Configure...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>Install application from a .pkg file</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Recent Games</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Exit</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>Exit shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Exit the application.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Show Game List</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Game List Refresh</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Tiny</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Small</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Medium</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Large</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>List View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Grid View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Elf Viewer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Game Install Directory</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>Download Cheats/Patches</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Dump Game List</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>PKG Viewer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Search...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>File</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Game List Icons</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Game List Mode</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Settings</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Utils</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Themes</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>Help</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Dark</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Light</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Green</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Blue</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Violet</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>toolBar</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>Lijst met spellen</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * Niet ondersteunde Vulkan-versie</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>Download cheats voor alle geïnstalleerde spellen</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>Download patches voor alle spellen</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Download voltooid</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>Je hebt cheats gedownload voor alle spellen die je hebt geïnstalleerd.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>Patches succesvol gedownload!</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>Alle patches voor alle spellen zijn gedownload.</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>Spellen: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>PKG-bestand (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>ELF-bestanden (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>Spelopstart</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>Je kunt slechts één bestand selecteren!</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>PKG-extractie</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>Patch gedetecteerd!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>PKG- en gameversies komen overeen: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>Wilt u overschrijven?</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>PKG-versie %1 is ouder dan de geïnstalleerde versie: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>Game is geïnstalleerd: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>Wilt u de patch installeren: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>DLC-installatie</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>Wilt u DLC installeren: %1?</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC al geïnstalleerd:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>Game al geïnstalleerd</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>PKG is een patch, installeer eerst het spel!</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>PKG FOUT</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>PKG %1/%2 aan het extraheren</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>Extractie voltooid</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>Spel succesvol geïnstalleerd op %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>Het bestand lijkt geen geldig PKG-bestand te zijn</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Open Folder</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophy Viewer</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Settings</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>General</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>System</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>Console Language</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Emulator Language</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Emulator</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Enable Fullscreen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Show Splash</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>Is PS4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Discord Rich Presence inschakelen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Username</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Logger</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Log Type</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Log Filter</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>Invoer</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>Cursor</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>Cursor verbergen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>Inactiviteit timeout voor het verbergen van de cursor</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>Controller</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>Achterknop gedrag</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Graphics</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Graphics Device</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Width</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Height</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Vblank Divider</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Advanced</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Enable Shaders Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>Enable NULL GPU</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>Pad</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>Spelmappen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>Toevoegen...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>Verwijderen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Debug</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Enable Debug Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Enable Vulkan Validation Layers</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Enable Vulkan Synchronization Validation</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>Enable RenderDoc Debugging</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>Bijwerken</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Bij opstart op updates controleren</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>Updatekanaal</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>Controleren op updates</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>GUI-Instellingen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Disable Trophy Pop-ups</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>Titelmuziek afspelen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Update Compatibility Database On Startup</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Game Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Display Compatibility Data</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Update Compatibility Database</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>Volume</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>Lijst met spellen</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * Niet ondersteunde Vulkan-versie</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>Download cheats voor alle geïnstalleerde spellen</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>Download patches voor alle spellen</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>Download voltooid</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>Je hebt cheats gedownload voor alle spellen die je hebt geïnstalleerd.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>Patches succesvol gedownload!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>Alle patches voor alle spellen zijn gedownload.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>Spellen: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>PKG-bestand (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>ELF-bestanden (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>Spelopstart</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>Je kunt slechts één bestand selecteren!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>PKG-extractie</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>Patch gedetecteerd!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>PKG- en gameversies komen overeen: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>Wilt u overschrijven?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>PKG-versie %1 is ouder dan de geïnstalleerde versie: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>Game is geïnstalleerd: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>Wilt u de patch installeren: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>DLC-installatie</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>Wilt u DLC installeren: %1?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC al geïnstalleerd:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>Game al geïnstalleerd</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>PKG is een patch, installeer eerst het spel!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>PKG FOUT</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>PKG %1/%2 aan het extraheren</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>Extractie voltooid</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>Spel succesvol geïnstalleerd op %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>Het bestand lijkt geen geldig PKG-bestand te zijn</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Cheats / Patches for </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>Cheats/Patches zijn experimenteel.\nGebruik met voorzichtigheid.\n\nDownload cheats afzonderlijk door het repository te selecteren en op de downloadknop te klikken.\nOp het tabblad Patches kun je alle patches tegelijk downloaden, kiezen welke je wilt gebruiken en je selectie opslaan.\n\nAangezien wij de Cheats/Patches niet ontwikkelen,\nmeld problemen bij de auteur van de cheat.\n\nHeb je een nieuwe cheat gemaakt? Bezoek:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>Geen afbeelding beschikbaar</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>Serie: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>Versie: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>Grootte: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>Selecteer cheatbestand:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>Repository:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>Download cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>Bestand verwijderen</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>Geen bestanden geselecteerd.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>Je kunt de cheats die je niet wilt verwijderen nadat je ze hebt gedownload.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>Wil je het geselecteerde bestand verwijderen?\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>Selecteer patchbestand:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>Download patches</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>Opslaan</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>Cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>Patches</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>Fout</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>Geen patch geselecteerd.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>Kan files.json niet openen voor lezen.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>Geen patchbestand gevonden voor het huidige serienummer.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>Kan het bestand niet openen voor lezen.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>Kan het bestand niet openen voor schrijven.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>XML parsing mislukt: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>Succes</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>Opties succesvol opgeslagen.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>Ongeldige bron</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>De geselecteerde bron is ongeldig.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>Bestand bestaat</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>Bestand bestaat al. Wil je het vervangen?</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>Kan bestand niet opslaan:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>Kan bestand niet downloaden:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>Cheats niet gevonden</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>Geen cheats gevonden voor deze game in deze versie van de geselecteerde repository.Probeer een andere repository of een andere versie van het spel.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>Cheats succesvol gedownload</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>Je hebt cheats succesvol gedownload voor deze versie van het spel uit de geselecteerde repository. Je kunt proberen te downloaden van een andere repository. Als deze beschikbaar is, kan het ook worden gebruikt door het bestand uit de lijst te selecteren.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>Opslaan mislukt:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>Downloaden mislukt:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>Download voltooid</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>Patches succesvol gedownload! Alle beschikbare patches voor alle spellen zijn gedownload. Het is niet nodig om ze afzonderlijk te downloaden voor elk spel dat cheats heeft. Als de patch niet verschijnt, kan het zijn dat deze niet bestaat voor het specifieke serienummer en de versie van het spel.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>Kan JSON-gegevens uit HTML niet parseren.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>Kan HTML-pagina niet ophalen.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>Het spel is in versie: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>De gedownloade patch werkt alleen op versie: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>Misschien moet je je spel bijwerken.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>Incompatibiliteitsmelding</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>Kan bestand niet openen:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>XML FOUT:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>Kan files.json niet openen voor schrijven</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>Auteur: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>Map bestaat niet:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>Kan files.json niet openen voor lezen.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>Naam:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>Je kunt geen cheats toepassen voordat het spel is gestart.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>Opslaan</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>Toepassen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>Standaardinstellingen herstellen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>Sluiten</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>Wijzig de muisaanwijzer naar een optie om de beschrijving weer te geven.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Console Taal:\nStelt de taal in die het PS4-spel gebruikt.\nHet wordt aanbevolen om dit in te stellen op een taal die het spel ondersteunt, wat kan variëren per regio.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>Emulator Taal:\nStelt de taal van de gebruikersinterface van de emulator in.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>Volledig scherm inschakelen:\nZet het gamevenster automatisch in de volledig scherm modus.\nDit kan worden omgeschakeld door op de F11-toets te drukken.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Enable Separate Update Folder:\nEnables installing game updates into a separate folder for easy management.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>Opstartscherm weergeven:\nToont het opstartscherm van het spel (een speciale afbeelding) tijdens het starten van het spel.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>Is PS4 Pro:\nLaat de emulator zich gedragen als een PS4 PRO, wat speciale functies kan inschakelen in games die dit ondersteunen.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>Discord Rich Presence inschakelen:\nToont het emulatoricoon en relevante informatie op je Discord-profiel.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>Gebruikersnaam:\nStelt de gebruikersnaam van het PS4-account in, die door sommige games kan worden weergegeven.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>Logtype:\nStelt in of de uitvoer van het logvenster moet worden gesynchroniseerd voor prestaties. Kan nadelige effecten hebben op emulatie.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Logfilter:\nFiltert het logboek om alleen specifieke informatie af te drukken.\nVoorbeelden: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" Niveaus: Trace, Debug, Info, Waarschuwing, Fout, Kritiek - in deze volgorde, een specifiek niveau dempt alle voorgaande niveaus in de lijst en logt alle niveaus daarna.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>Updateren:\nRelease: Officiële versies die elke maand worden uitgebracht, die zeer verouderd kunnen zijn, maar betrouwbaar en getest zijn.\nNightly: Ontwikkelingsversies die alle nieuwste functies en bugfixes bevatten, maar mogelijk bugs bevatten en minder stabiel zijn.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Speel titelsong:\nAls een game dit ondersteunt, wordt speciale muziek afgespeeld wanneer je het spel in de GUI selecteert.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Disable Trophy Pop-ups:\nDisable in-game trophy notifications. Trophy progress can still be tracked using the Trophy Viewer (right-click the game in the main window).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>Verberg cursor:\nKies wanneer de cursor verdwijnt:\nNooit: Je ziet altijd de muis.\nInactief: Stel een tijd in waarna deze verdwijnt na inactiviteit.\nAltijd: je ziet de muis nooit.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>Stel een tijd in voor wanneer de muis verdwijnt na inactiviteit.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>Gedrag van de terugknop:\nStelt de terugknop van de controller in om een aanraking op de opgegeven positie op de PS4-touchpad na te bootsen.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Display Compatibility Data:\nDisplays game compatibility information in table view. Enable "Update Compatibility On Startup" to get up-to-date information.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Update Compatibility On Startup:\nAutomatically update the compatibility database when shadPS4 starts.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Update Compatibility Database:\nImmediately update the compatibility database.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>Nooit</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>Inactief</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>Altijd</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>Touchpad Links</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>Touchpad Rechts</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>Touchpad Midden</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>Geen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>Grafische adapter:\nIn systemen met meerdere GPU's, kies de GPU die de emulator uit de vervolgkeuzelijst moet gebruiken,\nof kies "Auto Select" om dit automatisch in te stellen.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Breedte/Hoogte:\nStelt de grootte van het emulatorvenster bij het opstarten in, wat tijdens het spelen kan worden gewijzigd.\nDit is anders dan de resolutie in de game.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Vblank deler:\nDe frame-rate waartegen de emulator wordt vernieuwd, vermenigvuldigd met dit getal. Dit veranderen kan nadelige effecten hebben, zoals het versnellen van het spel of het verpesten van kritieke gamefunctionaliteiten die niet verwachtten dat dit zou veranderen!</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>Shaderdump inschakelen:\nVoor technische foutopsporing slaat het de shaders van de game op in een map terwijl ze worden gerenderd.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Null GPU inschakelen:\nVoor technische foutopsporing schakelt de game-rendering uit alsof er geen grafische kaart is.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>Spelmap:\nDe lijst met mappen om te controleren op geïnstalleerde spellen.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>Toevoegen:\nVoeg een map toe aan de lijst.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>Verwijderen:\nVerwijder een map uit de lijst.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>Foutopsporing dump inschakelen:\nSlaat de import- en export-symbolen en de bestandsheaderinformatie van de momenteel draaiende PS4-toepassing op in een map.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Vulkan validatielaag inschakelen:\nSchakelt een systeem in dat de status van de Vulkan-renderer valideert en informatie over de interne status ervan logt. Dit zal de prestaties verlagen en waarschijnlijk het emulatiegedrag veranderen.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Vulkan synchronisatievalidatie inschakelen:\nSchakelt een systeem in dat de timing van Vulkan-renderingtaken valideert. Dit zal de prestaties verlagen en waarschijnlijk het emulatiegedrag veranderen.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>RenderDoc foutopsporing inschakelen:\nAls ingeschakeld, biedt de emulator compatibiliteit met Renderdoc om de momenteel gerenderde frame vast te leggen en te analyseren.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Cheats / Patches for </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>Cheats/Patches zijn experimenteel.\nGebruik met voorzichtigheid.\n\nDownload cheats afzonderlijk door het repository te selecteren en op de downloadknop te klikken.\nOp het tabblad Patches kun je alle patches tegelijk downloaden, kiezen welke je wilt gebruiken en je selectie opslaan.\n\nAangezien wij de Cheats/Patches niet ontwikkelen,\nmeld problemen bij de auteur van de cheat.\n\nHeb je een nieuwe cheat gemaakt? Bezoek:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>Geen afbeelding beschikbaar</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>Serie: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>Versie: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>Grootte: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>Selecteer cheatbestand:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>Repository:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>Download cheats</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>Bestand verwijderen</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>Geen bestanden geselecteerd.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>Je kunt de cheats die je niet wilt verwijderen nadat je ze hebt gedownload.</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>Wil je het geselecteerde bestand verwijderen?\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>Selecteer patchbestand:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>Download patches</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>Opslaan</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>Cheats</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>Patches</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Fout</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>Geen patch geselecteerd.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>Kan files.json niet openen voor lezen.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>Geen patchbestand gevonden voor het huidige serienummer.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>Kan het bestand niet openen voor lezen.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>Kan het bestand niet openen voor schrijven.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>XML parsing mislukt: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>Succes</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>Opties succesvol opgeslagen.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>Ongeldige bron</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>De geselecteerde bron is ongeldig.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>Bestand bestaat</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>Bestand bestaat al. Wil je het vervangen?</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>Kan bestand niet opslaan:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>Kan bestand niet downloaden:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>Cheats niet gevonden</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>Geen cheats gevonden voor deze game in deze versie van de geselecteerde repository.Probeer een andere repository of een andere versie van het spel.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>Cheats succesvol gedownload</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>Je hebt cheats succesvol gedownload voor deze versie van het spel uit de geselecteerde repository. Je kunt proberen te downloaden van een andere repository. Als deze beschikbaar is, kan het ook worden gebruikt door het bestand uit de lijst te selecteren.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>Opslaan mislukt:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>Downloaden mislukt:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Download voltooid</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>Patches succesvol gedownload! Alle beschikbare patches voor alle spellen zijn gedownload. Het is niet nodig om ze afzonderlijk te downloaden voor elk spel dat cheats heeft. Als de patch niet verschijnt, kan het zijn dat deze niet bestaat voor het specifieke serienummer en de versie van het spel.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>Kan JSON-gegevens uit HTML niet parseren.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>Kan HTML-pagina niet ophalen.</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>Het spel is in versie: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>De gedownloade patch werkt alleen op versie: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>Misschien moet je je spel bijwerken.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>Incompatibiliteitsmelding</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>Kan bestand niet openen:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>XML FOUT:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>Kan files.json niet openen voor schrijven</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>Auteur: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>Map bestaat niet:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>Kan files.json niet openen voor lezen.</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>Naam:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>Je kunt geen cheats toepassen voordat het spel is gestart.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>Pictogram</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>Naam</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>Serienummer</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>Regio</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>Firmware</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>Grootte</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>Versie</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>Pad</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>Speeltijd</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Never Played</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Compatibility is untested</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Game does not initialize properly / crashes the emulator</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Game boots, but only displays a blank screen</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Game displays an image but does not go past the menu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Game has game-breaking glitches or unplayable performance</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>Automatische updater</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>Fout</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>Netwerkfout:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>Kon update-informatie niet parseren.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>Geen pre-releases gevonden.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>Ongeldige releasegegevens.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>Geen download-URL gevonden voor het opgegeven bestand.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>Uw versie is al up-to-date!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>Update beschikbaar</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>Updatekanaal</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>Huidige versie</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>Laatste versie</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>Wilt u updaten?</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>Toon changelog</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Bij opstart op updates controleren</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>Bijwerken</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>Nee</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>Verberg changelog</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>Wijzigingen</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>Netwerkfout opgetreden tijdens toegang tot de URL</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>Download compleet</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>De update is gedownload, druk op OK om te installeren.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>Kon het updatebestand niet opslaan op</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>Starten van update...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>Kon het update-scriptbestand niet maken</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/pl_PL.ts
+++ b/src/qt_gui/translations/pl_PL.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>O programie</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 to eksperymentalny otwartoźródłowy emulator konsoli PlayStation 4.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>To oprogramowanie nie służy do grania w gry pochodzące z nielegalnego źródła.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Otwórz folder</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Ładowanie listy gier, proszę poczekaj :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>Anuluj</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Ładowanie...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Wybierz katalog</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Select which directory you want to install to.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Wybierz katalog</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Katalog do instalacji gier</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Przeglądaj</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Błąd</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>Podana ścieżka do instalacji gier nie jest prawidłowa.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>Utwórz skrót</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>Kody / poprawki</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>Menedżer plików SFO</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>Menedżer trofeów</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>Otwórz Folder...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>Otwórz Katalog Gry</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>Otwórz Folder Danych Zapisów</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>Otwórz Folder Dziennika</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>Kopiuj informacje...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>Kopiuj nazwę</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>Kopiuj numer seryjny</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>Kopiuj wszystko</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Delete...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Delete Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Delete Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Delete DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>Tworzenie skrótu</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>Utworzenie skrótu zakończone pomyślnie!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>Błąd</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>Utworzenie skrótu zakończone niepowodzeniem!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>Zainstaluj PKG</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>This feature requires the 'Enable Separate Update Folder' config option to work. If you want to use this feature, please enable it.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>This game has no update to delete!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>This game has no DLC to delete!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Delete %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Are you sure you want to delete %1's %2 directory?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Otwórz/Dodaj folder Elf</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>Zainstaluj paczkę (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Uruchom grę</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>Sprawdź aktualizacje</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>O programie</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Konfiguruj...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>Zainstaluj aplikacje z pliku .pkg</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Ostatnie gry</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Wyjdź</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>Wyjdź z shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Wyjdź z aplikacji.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Pokaż listę gier</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Odśwież listę gier</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Malutkie</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Małe</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Średnie</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Wielkie</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>Widok listy</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Widok siatki</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Menedżer plików ELF</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Katalog zainstalowanych gier</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>Pobierz kody / poprawki</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Zgraj listę gier</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>Menedżer plików PKG</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Szukaj...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>Plik</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>Widok</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Ikony w widoku listy</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Tryb listy gier</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Ustawienia</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Narzędzia</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Motywy</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>Pomoc</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Ciemny</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Jasny</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Zielony</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Niebieski</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Fioletowy</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>Pasek narzędzi</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>Lista gier</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * Nieobsługiwana wersja Vulkan</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>Pobierz kody do wszystkich zainstalowanych gier</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>Pobierz poprawki do wszystkich gier</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Pobieranie zakończone</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>Pobrałeś kody do wszystkich zainstalowanych gier.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>Poprawki pobrane pomyślnie!</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>Wszystkie poprawki dostępne dla wszystkich gier zostały pobrane.</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>Gry: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>Plik PKG (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>Pliki ELF (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>Uruchomienie gry</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>Można wybrać tylko jeden plik!</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>Wypakowywanie PKG</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>Wykryto łatkę!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>Wersje PKG i gry są zgodne: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>Czy chcesz nadpisać?</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>Wersja PKG %1 jest starsza niż zainstalowana wersja: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>Gra jest zainstalowana: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>Czy chcesz zainstalować łatkę: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>Instalacja DLC</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>Czy chcesz zainstalować DLC: %1?</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC już zainstalowane:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>Gra już zainstalowana</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>PKG jest poprawką, proszę najpierw zainstalować grę!</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>BŁĄD PKG</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>Wypakowywanie PKG %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>Wypakowywanie zakończone</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>Gra pomyślnie zainstalowana w %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>Plik nie wydaje się być prawidłowym plikiem PKG</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Otwórz folder</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Menedżer trofeów</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Ustawienia</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>Ogólne</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>System</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>Język konsoli</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Język emulatora</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Emulator</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Włącz pełny ekran</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Pokaż ekran powitania</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>Emulacja PS4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Włącz Discord Rich Presence</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Nazwa użytkownika</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Dziennik zdarzeń</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Typ dziennika</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Filtrowanie dziennika</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>Wejście</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>Kursor</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>Ukryj kursor</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>Czas oczekiwania na ukrycie kursora przy bezczynności</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>Kontroler</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>Zachowanie przycisku wstecz</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Grafika</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Karta graficzna</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Szerokość</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Wysokość</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Dzielnik przerwy pionowej (Vblank)</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Zaawansowane</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Włącz zgrywanie cieni</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>Wyłącz kartę graficzną</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>Ścieżki</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>Foldery gier</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>Dodaj...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>Usuń</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Debugowanie</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Włącz zgrywanie debugowania</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Włącz warstwy walidacji Vulkan</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Włącz walidację synchronizacji Vulkan</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>Włącz debugowanie RenderDoc</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>Aktualizacja</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Sprawdź aktualizacje przy starcie</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>Kanał Aktualizacji</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>Sprawdź aktualizacje</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>Ustawienia Interfejsu</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Disable Trophy Pop-ups</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>Odtwórz muzykę tytułową</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Update Compatibility Database On Startup</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Game Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Display Compatibility Data</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Update Compatibility Database</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>Głośność</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>Lista gier</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * Nieobsługiwana wersja Vulkan</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>Pobierz kody do wszystkich zainstalowanych gier</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>Pobierz poprawki do wszystkich gier</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>Pobieranie zakończone</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>Pobrałeś kody do wszystkich zainstalowanych gier.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>Poprawki pobrane pomyślnie!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>Wszystkie poprawki dostępne dla wszystkich gier zostały pobrane.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>Gry: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>Plik PKG (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>Pliki ELF (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>Uruchomienie gry</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>Można wybrać tylko jeden plik!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>Wypakowywanie PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>Wykryto łatkę!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>Wersje PKG i gry są zgodne: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>Czy chcesz nadpisać?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>Wersja PKG %1 jest starsza niż zainstalowana wersja: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>Gra jest zainstalowana: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>Czy chcesz zainstalować łatkę: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>Instalacja DLC</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>Czy chcesz zainstalować DLC: %1?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC już zainstalowane:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>Gra już zainstalowana</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>PKG jest poprawką, proszę najpierw zainstalować grę!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>BŁĄD PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>Wypakowywanie PKG %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>Wypakowywanie zakończone</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>Gra pomyślnie zainstalowana w %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>Plik nie wydaje się być prawidłowym plikiem PKG</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Cheats / Patches for </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>Cheaty/Patche są eksperymentalne.\nUżywaj ich ostrożnie.\n\nPobierz cheaty pojedynczo, wybierając repozytorium i klikając przycisk pobierania.\nNa zakładce Patches możesz pobrać wszystkie patche jednocześnie, wybrać, które chcesz używać, i zapisać wybór.\n\nPonieważ nie rozwijamy Cheats/Patches,\nproszę zgłosić problemy do autora cheatu.\n\nStworzyłeś nowy cheat? Odwiedź:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>Brak dostępnego obrazu</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>Numer seryjny: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>Wersja: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>Rozmiar: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>Wybierz plik kodu:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>Repozytorium:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>Pobierz kody</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="162"/>
-			<source>Remove Old Files</source>
-			<translation>Usuń stare pliki</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="168"/>
-			<source>Do you want to delete the files after downloading them?</source>
-			<translation>Czy chcesz usunąć pliki po ich pobraniu?</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="174"/>
-			<source>Do you want to delete the files after downloading them?\n%1</source>
-			<translation>Czy chcesz usunąć pliki po ich pobraniu?\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>Czy chcesz usunąć wybrany plik?\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>Wybierz plik poprawki:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>Pobierz poprawki</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>Zapisz</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>Kody</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>Poprawki</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>Błąd</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>Nie wybrano poprawki.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>Nie można otworzyć pliku files.json do odczytu.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>Nie znaleziono pliku poprawki dla bieżącego numeru seryjnego.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>Nie można otworzyć pliku do odczytu.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>Nie można otworzyć pliku do zapisu.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>Nie udało się przeanalizować XML: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>Sukces</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>Opcje zostały pomyślnie zapisane.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>Nieprawidłowe źródło</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>Wybrane źródło jest nieprawidłowe.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>Plik istnieje</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>Plik już istnieje. Czy chcesz go zastąpić?</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>Nie udało się zapisać pliku:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>Nie udało się pobrać pliku:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>Nie znaleziono kodów</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>Nie znaleziono kodów do tej gry w tej wersji wybranego repozytorium. Spróbuj innego repozytorium lub innej wersji gry.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>Kody pobrane pomyślnie</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>Pomyślnie pobrano kody dla tej wersji gry z wybranego repozytorium. Możesz spróbować pobrać z innego repozytorium. Jeśli jest dostępne, możesz również użyć go, wybierając plik z listy.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>Nie udało się zapisać:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>Nie udało się pobrać:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>Pobieranie zakończone</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>Poprawki zostały pomyślnie pobrane! Wszystkie dostępne poprawki dla wszystkich gier zostały pobrane. Nie ma potrzeby pobierania ich osobno dla każdej gry, która ma kody. Jeśli poprawka się nie pojawia, możliwe, że nie istnieje dla konkretnego numeru seryjnego i wersji gry.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>Nie udało się przeanalizować danych JSON z HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>Nie udało się pobrać strony HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>Gra jest w wersji: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>Pobrana łatka działa tylko w wersji: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>Możesz potrzebować zaktualizować swoją grę.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>Powiadomienie o niezgodności</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>Nie udało się otworzyć pliku:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>BŁĄD XML:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>Nie udało się otworzyć pliku files.json do zapisu</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>Autor: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>Katalog nie istnieje:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="999"/>
-			<source>Directory does not exist: %1</source>
-			<translation>Katalog nie istnieje: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1052"/>
-			<source>Failed to parse JSON:</source>
-			<translation>Nie udało się przeanlizować JSON:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>Nie można zastosować kodów przed uruchomieniem gry.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>Zapisz</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>Zastosuj</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>Przywróć ustawienia domyślne</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>Zamknij</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>Najedź kursorem na opcję, aby wyświetlić jej opis.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Język konsoli:\nUstala język, który używa gra PS4.\nZaleca się ustawienie tego na język, który obsługuje gra, co może się różnić w zależności od regionu.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>Język emulatora:\nUstala język interfejsu użytkownika emulatora.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>Włącz tryb pełnoekranowy:\nAutomatycznie przełącza okno gry w tryb pełnoekranowy.\nMożna to wyłączyć naciskając klawisz F11.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Enable Separate Update Folder:\nEnables installing game updates into a separate folder for easy management.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>Wyświetl ekran powitalny:\nPodczas uruchamiania gry wyświetla ekran powitalny (specjalny obraz).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>Czy PS4 Pro:\nSprawia, że emulator działa jak PS4 PRO, co może aktywować specjalne funkcje w grach, które to obsługują.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>Włącz Discord Rich Presence:\nWyświetla ikonę emuladora i odpowiednie informacje na twoim profilu Discord.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>Nazwa użytkownika:\nUstala nazwę użytkownika konta PS4, która może być wyświetlana w niektórych grach.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>Typ logu:\nUstala, czy synchronizować wyjście okna dziennika dla wydajności. Może to mieć negatywny wpływ na emulację.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Filtr logu:\nFiltruje dziennik, aby drukować tylko określone informacje.\nPrzykłady: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" Poziomy: Trace, Debug, Info, Warning, Error, Critical - w tej kolejności, konkretny poziom wycisza wszystkie wcześniejsze poziomy w liście i rejestruje wszystkie poziomy później.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>Aktualizator:\nRelease: Oficjalne wersje wydawane co miesiąc, które mogą być bardzo przestarzałe, ale są niezawodne i przetestowane.\nNightly: Wersje rozwojowe, które zawierają wszystkie najnowsze funkcje i poprawki błędów, ale mogą mieć błędy i być mniej stabilne.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Odtwórz muzykę tytułową:\nJeśli gra to obsługuje, aktywuje odtwarzanie specjalnej muzyki podczas wybierania gry w GUI.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Disable Trophy Pop-ups:\nDisable in-game trophy notifications. Trophy progress can still be tracked using the Trophy Viewer (right-click the game in the main window).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>Ukryj kursor:\nWybierz, kiedy kursor zniknie:\nNigdy: Zawsze będziesz widział myszkę.\nNieaktywny: Ustaw czas, po którym zniknie po bezczynności.\nZawsze: nigdy nie zobaczysz myszki.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>Ustaw czas, po którym mysz zniknie po bezczynności.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>Zachowanie przycisku Wstecz:\nUstawia przycisk Wstecz kontrolera tak, aby emulował dotknięcie określonego miejsca na panelu dotykowym PS4.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Display Compatibility Data:\nDisplays game compatibility information in table view. Enable "Update Compatibility On Startup" to get up-to-date information.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Update Compatibility On Startup:\nAutomatically update the compatibility database when shadPS4 starts.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Update Compatibility Database:\nImmediately update the compatibility database.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>Nigdy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>Bezczynny</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>Zawsze</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>Touchpad Lewy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>Touchpad Prawy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>Touchpad Środkowy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>Brak</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>Urządzenie graficzne:\nW systemach z wieloma GPU, wybierz GPU, który emulator ma używać z rozwijanego menu,\n lub wybierz "Auto Select", aby ustawić go automatycznie.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Szerokość/Wysokość:\nUstala rozmiar okna emulatora podczas uruchamiania, który może być zmieniany w trakcie gry.\nTo różni się od rozdzielczości w grze.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Dzielnik Vblank:\nWskaźnik klatek, z jakim emulator jest odświeżany, pomnożony przez tę liczbę. Zmiana tego może mieć negatywne skutki, takie jak przyspieszenie gry lub zniszczenie krytycznej funkcjonalności gry, która nie spodziewa się, że to zostanie zmienione!</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>Włącz zrzucanie shaderów:\nDla technicznego debugowania zapisuje shadery z gry w folderze podczas renderowania.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Włącz Null GPU:\nDla technicznego debugowania dezaktywuje renderowanie gry tak, jakby nie było karty graficznej.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>Foldery gier:\nLista folderów do sprawdzenia zainstalowanych gier.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>Dodaj:\nDodaj folder do listy.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>Usuń:\nUsuń folder z listy.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>Włącz zrzut debugowania:\nZapisuje symbole importu i eksportu oraz informacje nagłówkowe pliku dla aktualnie działającej aplikacji PS4 w katalogu.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Włącz warstwę walidacji Vulkan:\nWłącza system, który waliduje stan renderera Vulkan i loguje informacje o jego wewnętrznym stanie. Zmniejszy to wydajność i prawdopodobnie zmieni zachowanie emulacji.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Włącz walidację synchronizacji Vulkan:\nWłącza system, który waliduje timing zadań renderowania Vulkan. Zmniejszy to wydajność i prawdopodobnie zmieni zachowanie emulacji.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>Włącz debugowanie RenderDoc:\nJeśli włączone, emulator zapewnia kompatybilność z Renderdoc, aby umożliwić nagrywanie i analizowanie aktualnie renderowanej klatki.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Cheats / Patches for </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>Cheaty/Patche są eksperymentalne.\nUżywaj ich ostrożnie.\n\nPobierz cheaty pojedynczo, wybierając repozytorium i klikając przycisk pobierania.\nNa zakładce Patches możesz pobrać wszystkie patche jednocześnie, wybrać, które chcesz używać, i zapisać wybór.\n\nPonieważ nie rozwijamy Cheats/Patches,\nproszę zgłosić problemy do autora cheatu.\n\nStworzyłeś nowy cheat? Odwiedź:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>Brak dostępnego obrazu</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>Numer seryjny: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>Wersja: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>Rozmiar: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>Wybierz plik kodu:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>Repozytorium:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>Pobierz kody</translation>
+		</message>
+		<message>
+			<source>Remove Old Files</source>
+			<translation>Usuń stare pliki</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the files after downloading them?</source>
+			<translation>Czy chcesz usunąć pliki po ich pobraniu?</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the files after downloading them?\n%1</source>
+			<translation>Czy chcesz usunąć pliki po ich pobraniu?\n%1</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>Czy chcesz usunąć wybrany plik?\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>Wybierz plik poprawki:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>Pobierz poprawki</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>Zapisz</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>Kody</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>Poprawki</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Błąd</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>Nie wybrano poprawki.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>Nie można otworzyć pliku files.json do odczytu.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>Nie znaleziono pliku poprawki dla bieżącego numeru seryjnego.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>Nie można otworzyć pliku do odczytu.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>Nie można otworzyć pliku do zapisu.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>Nie udało się przeanalizować XML: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>Sukces</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>Opcje zostały pomyślnie zapisane.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>Nieprawidłowe źródło</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>Wybrane źródło jest nieprawidłowe.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>Plik istnieje</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>Plik już istnieje. Czy chcesz go zastąpić?</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>Nie udało się zapisać pliku:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>Nie udało się pobrać pliku:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>Nie znaleziono kodów</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>Nie znaleziono kodów do tej gry w tej wersji wybranego repozytorium. Spróbuj innego repozytorium lub innej wersji gry.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>Kody pobrane pomyślnie</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>Pomyślnie pobrano kody dla tej wersji gry z wybranego repozytorium. Możesz spróbować pobrać z innego repozytorium. Jeśli jest dostępne, możesz również użyć go, wybierając plik z listy.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>Nie udało się zapisać:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>Nie udało się pobrać:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Pobieranie zakończone</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>Poprawki zostały pomyślnie pobrane! Wszystkie dostępne poprawki dla wszystkich gier zostały pobrane. Nie ma potrzeby pobierania ich osobno dla każdej gry, która ma kody. Jeśli poprawka się nie pojawia, możliwe, że nie istnieje dla konkretnego numeru seryjnego i wersji gry.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>Nie udało się przeanalizować danych JSON z HTML.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>Nie udało się pobrać strony HTML.</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>Gra jest w wersji: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>Pobrana łatka działa tylko w wersji: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>Możesz potrzebować zaktualizować swoją grę.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>Powiadomienie o niezgodności</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>Nie udało się otworzyć pliku:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>BŁĄD XML:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>Nie udało się otworzyć pliku files.json do zapisu</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>Autor: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>Katalog nie istnieje:</translation>
+		</message>
+		<message>
+			<source>Directory does not exist: %1</source>
+			<translation>Katalog nie istnieje: %1</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON:</source>
+			<translation>Nie udało się przeanlizować JSON:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>Nie można zastosować kodów przed uruchomieniem gry.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>Ikona</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>Nazwa</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>Numer seryjny</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>Region</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>Oprogramowanie</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>Rozmiar</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>Wersja</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>Ścieżka</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>Czas gry</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Never Played</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Compatibility is untested</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Game does not initialize properly / crashes the emulator</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Game boots, but only displays a blank screen</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Game displays an image but does not go past the menu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Game has game-breaking glitches or unplayable performance</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>Automatyczne aktualizacje</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>Błąd</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>Błąd sieci:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>Nie udało się sparsować informacji o aktualizacji.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>Nie znaleziono wersji przedpremierowych.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>Nieprawidłowe dane wydania.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>Nie znaleziono adresu URL do pobrania dla określonego zasobu.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>Twoja wersja jest już aktualna!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>Dostępna aktualizacja</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>Kanał Aktualizacji</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>Aktualna wersja</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>Ostatnia wersja</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>Czy chcesz zaktualizować?</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>Pokaż zmiany</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Sprawdź aktualizacje przy starcie</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>Aktualizuj</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>Nie</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>Ukryj zmiany</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>Zmiany</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>Błąd sieci wystąpił podczas próby uzyskania dostępu do URL</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>Pobieranie zakończone</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>Aktualizacja została pobrana, naciśnij OK, aby zainstalować.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>Nie udało się zapisać pliku aktualizacji w</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>Rozpoczynanie aktualizacji...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>Nie udało się utworzyć pliku skryptu aktualizacji</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/pt_BR.ts
+++ b/src/qt_gui/translations/pt_BR.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>Sobre o shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 é um emulador experimental de código-fonte aberto para o PlayStation 4.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>Este software não deve ser usado para jogar jogos piratas.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Abrir Pasta</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Carregando a lista de jogos, por favor aguarde :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>Cancelar</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Carregando...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Escolha o diretório</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Selecione o diretório em que você deseja instalar.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Escolha o diretório</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Diretório para instalar jogos</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Procurar</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Erro</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>O diretório da instalação dos jogos não é válido.</translation>
 		</message>
@@ -96,373 +81,420 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>Criar Atalho</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>Cheats / Patches</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>Visualizador de SFO</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>Visualizador de Troféu</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>Abrir Pasta...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>Abrir Pasta do Jogo</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>Abrir Pasta de Save</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>Abrir Pasta de Log</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>Copiar informação...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>Copiar Nome</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>Copiar Serial</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>Copiar Tudo</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Deletar...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Deletar Jogo</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Deletar Atualização</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Deletar DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibilidade...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Atualizar banco de dados</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>Ver status</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Enviar status</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>Criação de atalho</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>Atalho criado com sucesso!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>Erro</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>Erro ao criar atalho!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>Instalar PKG</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Jogo</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>Este recurso requer a opção de configuração 'Habilitar Pasta de Atualização Separada' para funcionar. Se você quiser usar este recurso, habilite-o.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>Este jogo não tem atualização para excluir!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Atualização</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>Este jogo não tem DLC para excluir!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Deletar %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Tem certeza de que deseja excluir o diretório %2 de %1 ?</translation>
-		</message>		
+		</message>
 	</context>
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Abrir/Adicionar pasta Elf</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>Instalar Pacotes (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Iniciar Jogo</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>Verificar atualizações</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>Sobre o shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Configurar...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>Instalar aplicação de um arquivo .pkg</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Jogos Recentes</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Sair</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>Sair do shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Sair da aplicação.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Mostrar Lista de Jogos</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Atualizar Lista de Jogos</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Muito pequeno</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Pequeno</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Médio</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Grande</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>Visualizar em Lista</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Visualizar em Grade</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Visualizador de Elf</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Diretório de Instalação de Jogos</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>Baixar Cheats/Patches</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Dumpar Lista de Jogos</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>Visualizador de PKG</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Pesquisar...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>Arquivo</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>Ver</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Ícones da Lista de Jogos</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Modo da Lista de Jogos</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Configurações</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Utilitários</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Temas</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>Ajuda</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Escuro</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Claro</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Verde</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Azul</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Violeta</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>Barra de Ferramentas</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>Lista de Jogos</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * Versão Vulkan não suportada</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>Baixar Cheats para Todos os Jogos Instalados</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>Baixar Patches para Todos os Jogos</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Download Completo</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>Você baixou cheats para todos os jogos que instalou.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>Patches Baixados com Sucesso!</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>Todos os patches disponíveis para todos os jogos foram baixados.</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>Jogos: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>Arquivo PKG (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>Arquivos ELF (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>Inicialização do Jogo</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>Apenas um arquivo pode ser selecionado!</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>Extração de PKG</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>Atualização detectada!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>As versões do PKG e do Jogo são igual: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>Gostaria de substituir?</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>Versão do PKG %1 é mais antiga do que a versão instalada: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>Jogo instalado: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>Você gostaria de instalar a atualização: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>Instalação de DLC</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>Você gostaria de instalar o DLC: %1?</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC já instalada:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>O jogo já está instalado:</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>O PKG é um patch, por favor, instale o jogo primeiro!</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>ERRO de PKG</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>Extraindo PKG %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>Extração Concluída</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>Jogo instalado com sucesso em %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>O arquivo não parece ser um arquivo PKG válido</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Abrir Pasta</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Visualizador de Troféu</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Configurações</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>Geral</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>Sistema</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>Idioma do Console</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Idioma do Emulador</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Emulador</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Ativar Tela Cheia</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Habilitar pasta de atualização separada</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Mostrar Splash Inicial</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>Modo PS4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Ativar Discord Rich Presence</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Nome de usuário</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Troféus</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Registro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Tipo de Registro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Filtro do Registro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>Entradas</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>Cursor</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>Ocultar Cursor</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>Tempo de Inatividade para Ocultar Cursor</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>Controle</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>Comportamento do botão Voltar</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Gráficos</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Placa de Vídeo</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Largura</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Altura</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Divisor Vblank</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Avançado</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Ativar Dumping de Shaders</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>Ativar GPU NULA</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>Pastas</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>Pastas dos Jogos</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>Adicionar...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>Remover</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Depuração</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Ativar Depuração de Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Ativar Camadas de Validação do Vulkan</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Ativar Validação de Sincronização do Vulkan</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>Ativar Depuração por RenderDoc</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>Atualização</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Verificar Atualizações ao Iniciar</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>Canal de Atualização</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>Verificar atualizações</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>Configurações da Interface</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Desabilitar Pop-ups dos Troféus</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>Reproduzir música de abertura</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Atualizar Compatibilidade ao Inicializar</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Compatibilidade dos Jogos</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Exibir Dados de Compatibilidade</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Atualizar Lista de Compatibilidade</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>Volume</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Backend de Áudio</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>Lista de Jogos</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * Versão Vulkan não suportada</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>Baixar Cheats para Todos os Jogos Instalados</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>Baixar Patches para Todos os Jogos</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>Download Completo</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>Você baixou cheats para todos os jogos que instalou.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>Patches Baixados com Sucesso!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>Todos os patches disponíveis para todos os jogos foram baixados.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>Jogos: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>Arquivo PKG (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>Arquivos ELF (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>Inicialização do Jogo</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>Apenas um arquivo pode ser selecionado!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>Extração de PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>Atualização detectada!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>As versões do PKG e do Jogo são igual: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>Gostaria de substituir?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>Versão do PKG %1 é mais antiga do que a versão instalada: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>Jogo instalado: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>Você gostaria de instalar a atualização: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>Instalação de DLC</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>Você gostaria de instalar o DLC: %1?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC já instalada:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>O jogo já está instalado:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>O PKG é um patch, por favor, instale o jogo primeiro!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>ERRO de PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>Extraindo PKG %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>Extração Concluída</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>Jogo instalado com sucesso em %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>O arquivo não parece ser um arquivo PKG válido</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Cheats / Patches para </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>Cheats/Patches são experimentais.\nUse com cautela.\n\nBaixe os cheats individualmente selecionando o repositório e clicando no botão de download.\nNa aba Patches, você pode baixar todos os Patches de uma vez, escolha qual deseja usar e salve a opção.\n\nComo não desenvolvemos os Cheats/Patches,\npor favor, reporte problemas relacionados ao autor do cheat.\n\nCriou um novo cheat? Visite:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>Imagem Não Disponível</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>Serial: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>Versão: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>Tamanho: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>Selecione o Arquivo de Cheat:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>Repositório:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>Baixar Cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>Excluir Arquivo</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>Nenhum arquivo selecionado.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>Você pode excluir os cheats que não deseja após baixá-las.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>Deseja excluir o arquivo selecionado?\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>Selecione o Arquivo de Patch:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>Baixar Patches</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>Salvar</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>Cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>Patches</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>Erro</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>Nenhum patch selecionado.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>Não foi possível abrir files.json para leitura.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>Nenhum arquivo de patch encontrado para o serial atual.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>Não foi possível abrir o arquivo para leitura.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>Não foi possível abrir o arquivo para gravação.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>Falha ao analisar XML: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>Sucesso</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>Opções salvas com sucesso.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>Fonte Inválida</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>A fonte selecionada é inválida.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>Arquivo Existe</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>O arquivo já existe. Deseja substituí-lo?</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>Falha ao salvar o arquivo:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>Falha ao baixar o arquivo:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>Cheats Não Encontrados</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>Nenhum cheat encontrado para este jogo nesta versão do repositório selecionado, tente outro repositório ou uma versão diferente do jogo.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>Cheats Baixados com Sucesso</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>Você baixou os cheats com sucesso. Para esta versão do jogo a partir do repositório selecionado. Você pode tentar baixar de outro repositório, se estiver disponível, também será possível usá-lo selecionando o arquivo da lista.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>Falha ao salvar:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>Falha ao baixar:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>Download Completo</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>Patches Baixados com Sucesso! Todos os patches disponíveis para todos os jogos foram baixados, não é necessário baixá-los individualmente para cada jogo como acontece com os Cheats. Se o patch não aparecer, pode ser que ele não exista para o número de série e a versão específicos do jogo.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>Falha ao analisar dados JSON do HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>Falha ao recuperar a página HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>O jogo está na versão: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>O patch baixado só funciona na versão: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>Talvez você precise atualizar seu jogo.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>Aviso de incompatibilidade</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>Falha ao abrir o arquivo:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>ERRO de XML:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>Falha ao abrir files.json para gravação</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>Autor: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>O Diretório não existe:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>Falha ao abrir files.json para leitura.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>Nome:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>Não é possível aplicar cheats antes que o jogo comece.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>Salvar</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>Aplicar</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>Restaurar Padrões</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>Fechar</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>Passe o mouse sobre uma opção para exibir sua descrição.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Idioma do console:\nDefine o idioma usado pelo jogo no PS4.\nRecomenda-se configurá-lo para um idioma que o jogo suporte, o que pode variar conforme a região.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>Idioma do emulador:\nDefine o idioma da interface do emulador.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>Ativar Tela Cheia:\nMove automaticamente a janela do jogo para o modo tela cheia.\nIsso pode ser alterado pressionando a tecla F11.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Habilitar pasta de atualização separada:\nPermite instalar atualizações de jogos em uma pasta separada para fácil gerenciamento.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>Mostrar Splash Inicial:\nExibe a tela inicial do jogo (imagem especial) ao iniciar o jogo.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>Modo PS4 Pro:\nFaz o emulador agir como um PS4 PRO, o que pode ativar recursos especiais em jogos que o suportam.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>Ativar Discord Rich Presence:\nExibe o ícone do emulador e informações relevantes no seu perfil do Discord.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>Nome de usuário:\nDefine o nome de usuário da conta PS4 que pode ser exibido por alguns jogos.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>Tipo de Registro:\nDefine se a saída da janela de log deve ser sincronizada para melhorar o desempenho. Isso pode impactar negativamente a emulação.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Filtro de Registro:\nImprime apenas informações específicas.\nExemplos: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical"\nNíveis: Trace, Debug, Info, Warning, Error, Critical - assim, um nível específico desativa todos os níveis anteriores na lista e registra todos os níveis subsequentes.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>Atualizações:\nRelease: Versões oficiais que são lançadas todo mês e podem ser bastante antigas, mas são mais confiáveis e testadas.\nNightly: Versões de desenvolvimento que têm todos os novos recursos e correções, mas podem ter bugs e ser instáveis.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Reproduzir música de abertura:\nSe o jogo suportar, ativa a reprodução de uma música especial ao selecionar o jogo na interface do menu.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Desabilitar pop-ups dos troféus:\nDesabilite notificações de troféus no jogo. O progresso do troféu ainda pode ser rastreado usando o Trophy Viewer (clique com o botão direito do mouse no jogo na janela principal).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>Ocultar Cursor:\nEscolha quando o cursor desaparecerá:\nNunca: Você sempre verá o mouse.\nParado: Defina um tempo para ele desaparecer após ficar inativo.\nSempre: Você nunca verá o mouse.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>Defina um tempo em segundos para o mouse desaparecer após ficar inativo.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>Comportamento do botão Voltar:\nDefine o botão Voltar do controle para emular o toque na posição especificada no touchpad do PS4.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Exibir Dados de Compatibilidade:\nExibe informações de compatibilidade dos jogos na janela principal.\nHabilitar "Atualizar Compatibilidade ao Inicializar" para obter informações atualizadas.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Atualizar Compatibilidade ao inicializar:\nAtualiza automaticamente o banco de dados de compatibilidade quando o SHADPS4 é iniciado.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Atualizar Lista de Compatibilidade:\nAtualizar imediatamente o banco de dados de compatibilidade.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>Nunca</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>Parado</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>Sempre</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>Touchpad Esquerdo</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>Touchpad Direito</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>Touchpad Centro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>Nenhum</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>Placa de Vídeo:\nEm sistemas com múltiplas GPUs, escolha qual GPU o emulador usará da lista suspensa,\nou escolha "Auto Select" para que ele determine automaticamente.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Largura/Altura:\nDefine o tamanho da janela do emulador no momento da inicialização, que pode ser redimensionado durante o jogo.\nIsso é diferente da resolução dentro do jogo.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Divisor Vblank:\nA taxa de quadros que o emulador atualiza é multiplicada por este número. Mudar isso pode ter efeitos negativos, como aumentar a velocidade do jogo ou quebrar funções vitais do jogo que não esperam que isso mude!</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>Ativar Dumping de Shaders:\nArmazena os shaders do jogo em uma pasta durante a renderização para fins de depuração técnica.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Ativar GPU NULA:\nDesativa a renderização do jogo para fins de depuração técnica, como se não houvesse nenhuma placa gráfica.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>Pastas dos jogos:\nA lista de pastas para verificar se há jogos instalados.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>Adicionar:\nAdicione uma pasta à lista.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>Remover:\nRemove uma pasta da lista.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>Ativar Depuração de Dumping:\nArmazena os símbolos de importação e exportação e as informações do cabeçalho do arquivo do programa PS4 atual em um diretório.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Ativar Camadas de Validação do Vulkan:\nAtiva um sistema que valida o estado do renderizador Vulkan e registra informações sobre seu estado interno.\nIsso diminui o desempenho e pode alterar o comportamento da emulação.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Ativar Validação de Sincronização do Vulkan:\nAtiva um sistema que valida o agendamento de tarefas de renderização Vulkan.\nIsso diminui o desempenho e pode alterar o comportamento da emulação.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>Ativar depuração por RenderDoc:\nSe ativado, permite que o emulador tenha compatibilidade com RenderDoc para gravação e análise do quadro renderizado atual.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Cheats / Patches para </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>Cheats/Patches são experimentais.\nUse com cautela.\n\nBaixe os cheats individualmente selecionando o repositório e clicando no botão de download.\nNa aba Patches, você pode baixar todos os Patches de uma vez, escolha qual deseja usar e salve a opção.\n\nComo não desenvolvemos os Cheats/Patches,\npor favor, reporte problemas relacionados ao autor do cheat.\n\nCriou um novo cheat? Visite:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>Imagem Não Disponível</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>Serial: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>Versão: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>Tamanho: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>Selecione o Arquivo de Cheat:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>Repositório:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>Baixar Cheats</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>Excluir Arquivo</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>Nenhum arquivo selecionado.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>Você pode excluir os cheats que não deseja após baixá-las.</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>Deseja excluir o arquivo selecionado?\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>Selecione o Arquivo de Patch:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>Baixar Patches</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>Salvar</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>Cheats</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>Patches</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Erro</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>Nenhum patch selecionado.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>Não foi possível abrir files.json para leitura.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>Nenhum arquivo de patch encontrado para o serial atual.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>Não foi possível abrir o arquivo para leitura.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>Não foi possível abrir o arquivo para gravação.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>Falha ao analisar XML: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>Sucesso</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>Opções salvas com sucesso.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>Fonte Inválida</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>A fonte selecionada é inválida.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>Arquivo Existe</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>O arquivo já existe. Deseja substituí-lo?</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>Falha ao salvar o arquivo:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>Falha ao baixar o arquivo:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>Cheats Não Encontrados</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>Nenhum cheat encontrado para este jogo nesta versão do repositório selecionado, tente outro repositório ou uma versão diferente do jogo.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>Cheats Baixados com Sucesso</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>Você baixou os cheats com sucesso. Para esta versão do jogo a partir do repositório selecionado. Você pode tentar baixar de outro repositório, se estiver disponível, também será possível usá-lo selecionando o arquivo da lista.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>Falha ao salvar:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>Falha ao baixar:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Download Completo</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>Patches Baixados com Sucesso! Todos os patches disponíveis para todos os jogos foram baixados, não é necessário baixá-los individualmente para cada jogo como acontece com os Cheats. Se o patch não aparecer, pode ser que ele não exista para o número de série e a versão específicos do jogo.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>Falha ao analisar dados JSON do HTML.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>Falha ao recuperar a página HTML.</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>O jogo está na versão: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>O patch baixado só funciona na versão: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>Talvez você precise atualizar seu jogo.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>Aviso de incompatibilidade</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>Falha ao abrir o arquivo:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>ERRO de XML:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>Falha ao abrir files.json para gravação</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>Autor: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>O Diretório não existe:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>Falha ao abrir files.json para leitura.</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>Nome:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>Não é possível aplicar cheats antes que o jogo comece.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="33"/>
 			<source>Icon</source>
 			<translation>Icone</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>Nome</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Serial</source>
 			<translation>Serial</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Compatibilidade</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="36"/>
 			<source>Region</source>
 			<translation>Região</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>Firmware</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>Tamanho</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>Versão</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>Diretório</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>Tempo Jogado</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Nunca jogado</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Compatibilidade não testada</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Jogo não inicializa corretamente / trava o emulador</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>O jogo inicializa, mas exibe apenas uma tela vazia</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Jogo exibe imagem mas não passa do menu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>O jogo tem falhas que interrompem o jogo ou desempenho injogável</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>O jogo pode ser concluído com desempenho jogável e sem grandes falhas</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>Atualizador automático</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>Erro</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>Erro de rede:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>Falha ao analisar as informações de atualização.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>Nenhuma pre-release encontrada.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>Dados da release inválidos.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>Nenhuma URL de download encontrada para o asset especificado.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>Sua versão já está atualizada!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>Atualização disponível</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>Canal de Atualização</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>Versão atual</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>Última versão</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>Você quer atualizar?</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>Mostrar Changelog</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Verificar Atualizações ao Iniciar</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>Atualizar</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>Não</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>Ocultar Changelog</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>Alterações</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>Ocorreu um erro de rede ao tentar acessar o URL</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>Download Completo</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>A atualização foi baixada, pressione OK para instalar.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>Falha ao salvar o arquivo de atualização em</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>Iniciando atualização...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>Falha ao criar o arquivo de script de atualização</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/ro_RO.ts
+++ b/src/qt_gui/translations/ro_RO.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>About shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 is an experimental open-source emulator for the PlayStation 4.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>This software should not be used to play games you have not legally obtained.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Open Folder</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Loading game list, please wait :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>Cancel</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Loading...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Choose directory</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Select which directory you want to install to.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Choose directory</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Directory to install games</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Browse</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>The value for location to install games is not valid.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>Create Shortcut</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Trapaças / Patches</source>
 			<translation>Coduri / Patch-uri</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>SFO Viewer</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophy Viewer</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>Deschide Folder...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>Deschide Folder Joc</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>Deschide Folder Date Salvate</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>Deschide Folder Jurnal</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>Copy info...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>Copy Name</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>Copy Serial</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>Copy All</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Delete...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Delete Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Delete Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Delete DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>Shortcut creation</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>Shortcut created successfully!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>Error creating shortcut!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>Install PKG</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>This feature requires the 'Enable Separate Update Folder' config option to work. If you want to use this feature, please enable it.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>This game has no update to delete!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>This game has no DLC to delete!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Delete %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Are you sure you want to delete %1's %2 directory?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Open/Add Elf Folder</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>Install Packages (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Boot Game</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>Verifică actualizările</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>About shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Configure...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>Install application from a .pkg file</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Recent Games</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Exit</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>Exit shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Exit the application.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Show Game List</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Game List Refresh</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Tiny</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Small</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Medium</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Large</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>List View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Grid View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Elf Viewer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Game Install Directory</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>Descarcă Coduri / Patch-uri</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Dump Game List</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>PKG Viewer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Search...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>File</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Game List Icons</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Game List Mode</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Settings</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Utils</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Themes</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>Ajutor</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Dark</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Light</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Green</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Blue</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Violet</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>toolBar</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>Lista jocurilor</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * Versiune Vulkan nesuportată</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>Descarcă Cheats pentru toate jocurile instalate</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>Descarcă Patches pentru toate jocurile</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Descărcare completă</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>Ai descărcat cheats pentru toate jocurile instalate.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>Patches descărcate cu succes!</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>Toate Patches disponibile pentru toate jocurile au fost descărcate.</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>Jocuri: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>Fișier PKG (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>Fișiere ELF (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>Boot Joc</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>Numai un fișier poate fi selectat!</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>Extracție PKG</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>Patch detectat!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>Versiunile PKG și ale jocului sunt compatibile: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>Doriți să suprascrieți?</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>Versiunea PKG %1 este mai veche decât versiunea instalată: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>Jocul este instalat: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>Doriți să instalați patch-ul: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>Instalare DLC</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>Doriți să instalați DLC-ul: %1?</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC deja instalat:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>Jocul deja instalat</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>PKG este un patch, te rugăm să instalezi mai întâi jocul!</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>EROARE PKG</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>Extracție PKG %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>Extracție terminată</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>Jocul a fost instalat cu succes la %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>Fișierul nu pare să fie un fișier PKG valid</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Open Folder</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophy Viewer</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Settings</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>General</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>System</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>Console Language</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Emulator Language</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Emulator</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Enable Fullscreen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Show Splash</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>Is PS4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Activați Discord Rich Presence</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Username</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Logger</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Log Type</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Log Filter</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>Introducere</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>Cursor</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>Ascunde cursorul</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>Timeout pentru ascunderea cursorului inactiv</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>Controler</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>Comportament buton înapoi</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Graphics</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Graphics Device</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Width</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Height</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Vblank Divider</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Advanced</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Enable Shaders Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>Enable NULL GPU</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>Trasee</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>Dosare de joc</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>Adaugă...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>Eliminare</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Debug</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Enable Debug Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Enable Vulkan Validation Layers</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Enable Vulkan Synchronization Validation</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>Enable RenderDoc Debugging</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>Actualizare</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Verifică actualizări la pornire</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>Canal de Actualizare</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>Verifică actualizări</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>Setări GUI</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Disable Trophy Pop-ups</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>Redă muzica titlului</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Update Compatibility Database On Startup</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Game Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Display Compatibility Data</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Update Compatibility Database</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>Volum</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>Lista jocurilor</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * Versiune Vulkan nesuportată</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>Descarcă Cheats pentru toate jocurile instalate</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>Descarcă Patches pentru toate jocurile</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>Descărcare completă</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>Ai descărcat cheats pentru toate jocurile instalate.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>Patches descărcate cu succes!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>Toate Patches disponibile pentru toate jocurile au fost descărcate.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>Jocuri: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>Fișier PKG (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>Fișiere ELF (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>Boot Joc</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>Numai un fișier poate fi selectat!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>Extracție PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>Patch detectat!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>Versiunile PKG și ale jocului sunt compatibile: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>Doriți să suprascrieți?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>Versiunea PKG %1 este mai veche decât versiunea instalată: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>Jocul este instalat: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>Doriți să instalați patch-ul: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>Instalare DLC</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>Doriți să instalați DLC-ul: %1?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC deja instalat:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>Jocul deja instalat</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>PKG este un patch, te rugăm să instalezi mai întâi jocul!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>EROARE PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>Extracție PKG %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>Extracție terminată</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>Jocul a fost instalat cu succes la %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>Fișierul nu pare să fie un fișier PKG valid</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Cheats / Patches for </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>Cheats/Patches sunt experimentale.\nUtilizați cu prudență.\n\nDescărcați cheats individual prin selectarea depozitului și făcând clic pe butonul de descărcare.\nÎn fila Patches, puteți descărca toate patch-urile deodată, alege pe cele pe care doriți să le utilizați și salvați selecția.\n\nDeoarece nu dezvoltăm Cheats/Patches,\nte rugăm să raportezi problemele autorului cheat-ului.\n\nAi creat un nou cheat? Vizitează:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>Nu este disponibilă imaginea</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>Serial: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>Versiune: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>Dimensiune: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>Selectează fișierul Cheat:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>Repository:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>Descarcă Cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>Șterge Fișierul</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>Nu sunt fișiere selectate.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>Poti șterge cheats-urile pe care nu le dorești după ce le-ai descărcat.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>Vrei să ștergi fișierul selectat?\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>Selectează fișierul Patch:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>Descarcă Patches</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>Salvează</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>Cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>Patches</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>Eroare</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>Nu este selectat niciun patch.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>Imposibil de deschis files.json pentru citire.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>Nu s-a găsit niciun fișier patch pentru serialul curent.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>Imposibil de deschis fișierul pentru citire.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>Imposibil de deschis fișierul pentru scriere.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>Nu s-a reușit pararea XML: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>Succes</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>Opțiunile au fost salvate cu succes.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>Sursă invalidă</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>Sursa selectată este invalidă.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>Fișier existent</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>Fișierul există deja. Vrei să-l înlocuiești?</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>Nu s-a reușit salvarea fișierului:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>Nu s-a reușit descărcarea fișierului:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>Cheats Nu au fost găsite</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>Nu au fost găsite cheats pentru acest joc în această versiune a repository-ului selectat, încearcă un alt repository sau o versiune diferită a jocului.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>Cheats descărcate cu succes</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>Ai descărcat cu succes cheats-urile pentru această versiune a jocului din repository-ul selectat. Poți încerca descărcarea din alt repository; dacă este disponibil, va fi posibil să-l folosești selectând fișierul din listă.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>Nu s-a reușit salvarea:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>Nu s-a reușit descărcarea:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>Descărcare completă</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>Patches descărcate cu succes! Toate Patches disponibile pentru toate jocurile au fost descărcate; nu este nevoie să le descarci individual pentru fiecare joc, așa cum se întâmplă cu Cheats. Dacă patch-ul nu apare, este posibil să nu existe pentru seria și versiunea specifică a jocului.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>Nu s-a reușit pararea datelor JSON din HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>Nu s-a reușit obținerea paginii HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>Jocul este în versiunea: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>Patch-ul descărcat funcționează doar pe versiunea: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>Este posibil să trebuiască să actualizezi jocul tău.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>Avertizare de incompatibilitate</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>Nu s-a reușit deschiderea fișierului:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>EROARE XML:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>Nu s-a reușit deschiderea files.json pentru scriere</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>Autor: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>Directorul nu există:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>Nu s-a reușit deschiderea files.json pentru citire.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>Nume:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>Nu poți aplica cheats înainte ca jocul să înceapă.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>Salvează</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>Aplică</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>Restabilește Impozitivele</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>Închide</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>Indicați mouse-ul asupra unei opțiuni pentru a afișa descrierea acesteia.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Limba consolei:\nSetează limba pe care o folosește jocul PS4.\nSe recomandă să setezi această opțiune pe o limbă pe care jocul o suportă, ceea ce poate varia în funcție de regiune.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>Limba emulatorului:\nSetează limba interfeței utilizatorului a emulatorului.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>Activează modul pe ecran complet:\nPune automat fereastra jocului în modul pe ecran complet.\nAceasta poate fi dezactivată apăsând tasta F11.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Enable Separate Update Folder:\nEnables installing game updates into a separate folder for easy management.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>Afișează ecranul de încărcare:\nAfișează ecranul de încărcare al jocului (o imagine specială) în timp ce jocul pornește.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>Este PS4 Pro:\nFace ca emulatorul să se comporte ca un PS4 PRO, ceea ce poate activa funcții speciale în jocurile care o suportă.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>Activați Discord Rich Presence:\nAfișează pictograma emulatorului și informații relevante pe profilul dumneavoastră Discord.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>Nume utilizator:\nSetează numele de utilizator al contului PS4, care poate fi afișat de unele jocuri.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>Tip jurnal:\nSetează dacă să sincronizezi ieșirea ferestrei de jurnal pentru performanță. Aceasta poate avea efecte adverse asupra emulării.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Filtrul jurnalului:\nFiltrează jurnalul pentru a imprima doar informații specifice.\nExemple: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" Niveluri: Trace, Debug, Info, Warning, Error, Critical - în această ordine, un nivel specific reduce toate nivelurile anterioare din listă și înregistrează toate nivelurile ulterioare.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>Actualizare:\nRelease: Versiuni oficiale lansate în fiecare lună, care pot fi foarte învechite, dar sunt mai fiabile și testate.\nNightly: Versiuni de dezvoltare care conțin toate cele mai recente funcții și corecții, dar pot conține erori și sunt mai puțin stabile.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Redă muzica titlului:\nDacă un joc o suportă, activează redarea muzicii speciale când selectezi jocul în GUI.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Disable Trophy Pop-ups:\nDisable in-game trophy notifications. Trophy progress can still be tracked using the Trophy Viewer (right-click the game in the main window).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>Ascunde cursorul:\nAlegeți când va dispărea cursorul:\nNiciodată: Vei vedea întotdeauna mouse-ul.\nInactiv: Setează un timp pentru a dispărea după inactivitate.\nÎntotdeauna: nu vei vedea niciodată mouse-ul.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>Setați un timp pentru ca mouse-ul să dispară după ce a fost inactiv.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>Comportamentul butonului înapoi:\nSetează butonul înapoi al controlerului să imite atingerea poziției specificate pe touchpad-ul PS4.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Display Compatibility Data:\nDisplays game compatibility information in table view. Enable "Update Compatibility On Startup" to get up-to-date information.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Update Compatibility On Startup:\nAutomatically update the compatibility database when shadPS4 starts.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Update Compatibility Database:\nImmediately update the compatibility database.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>Niciodată</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>Inactiv</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>Întotdeauna</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>Touchpad Stânga</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>Touchpad Dreapta</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>Centru Touchpad</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>Niciunul</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>Dispozitiv grafic:\nPe sistemele cu mai multe GPU-uri, alege GPU-ul pe care emulatorul îl va folosi din lista derulantă,\nsau selectează "Auto Select" pentru a-l determina automat.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Lățime/Înălțime:\nSetează dimensiunea ferestrei emulatorului la lansare, care poate fi redimensionată în timpul jocului.\nAceasta este diferită de rezoluția din joc.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Împărțitor Vblank:\nRata de cadre cu care emulatorul se reîmprospătează este multiplicată cu acest număr. Schimbarea acestuia poate avea efecte adverse, cum ar fi creșterea vitezei jocului sau distrugerea funcționalității critice a jocului care nu se așteaptă ca aceasta să se schimbe!</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>Activează salvarea shaderelor:\nÎn scopuri de depanare tehnică, salvează shader-urile jocului într-un folder pe măsură ce sunt randate.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Activează GPU Null:\nÎn scopuri de depanare tehnică, dezactivează redarea jocului ca și cum nu ar exista o placă grafică.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>Folderele jocurilor:\nLista folderelor pentru a verifica jocurile instalate.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>Adăugați:\nAdăugați un folder la listă.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>Eliminați:\nÎndepărtați un folder din listă.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>Activează salvarea pentru depanare:\nSalvează simbolurile de import și export și informațiile din antetul fișierului pentru aplicația PS4 care rulează în prezent într-un director.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Activează straturile de validare Vulkan:\nActivează un sistem care validează starea renderer-ului Vulkan și înregistrează informații despre starea sa internă. Aceasta va reduce performanța și probabil va schimba comportamentul emulării.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Activează validarea sincronizării Vulkan:\nActivează un sistem care validează sincronizarea sarcinilor de redare Vulkan. Aceasta va reduce performanța și probabil va schimba comportamentul emulării.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>Activează depanarea RenderDoc:\nDacă este activat, emulatorul va oferi compatibilitate cu Renderdoc pentru a permite capturarea și analiza cadrului redat în prezent.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Cheats / Patches for </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>Cheats/Patches sunt experimentale.\nUtilizați cu prudență.\n\nDescărcați cheats individual prin selectarea depozitului și făcând clic pe butonul de descărcare.\nÎn fila Patches, puteți descărca toate patch-urile deodată, alege pe cele pe care doriți să le utilizați și salvați selecția.\n\nDeoarece nu dezvoltăm Cheats/Patches,\nte rugăm să raportezi problemele autorului cheat-ului.\n\nAi creat un nou cheat? Vizitează:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>Nu este disponibilă imaginea</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>Serial: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>Versiune: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>Dimensiune: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>Selectează fișierul Cheat:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>Repository:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>Descarcă Cheats</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>Șterge Fișierul</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>Nu sunt fișiere selectate.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>Poti șterge cheats-urile pe care nu le dorești după ce le-ai descărcat.</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>Vrei să ștergi fișierul selectat?\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>Selectează fișierul Patch:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>Descarcă Patches</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>Salvează</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>Cheats</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>Patches</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Eroare</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>Nu este selectat niciun patch.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>Imposibil de deschis files.json pentru citire.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>Nu s-a găsit niciun fișier patch pentru serialul curent.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>Imposibil de deschis fișierul pentru citire.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>Imposibil de deschis fișierul pentru scriere.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>Nu s-a reușit pararea XML: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>Succes</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>Opțiunile au fost salvate cu succes.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>Sursă invalidă</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>Sursa selectată este invalidă.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>Fișier existent</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>Fișierul există deja. Vrei să-l înlocuiești?</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>Nu s-a reușit salvarea fișierului:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>Nu s-a reușit descărcarea fișierului:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>Cheats Nu au fost găsite</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>Nu au fost găsite cheats pentru acest joc în această versiune a repository-ului selectat, încearcă un alt repository sau o versiune diferită a jocului.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>Cheats descărcate cu succes</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>Ai descărcat cu succes cheats-urile pentru această versiune a jocului din repository-ul selectat. Poți încerca descărcarea din alt repository; dacă este disponibil, va fi posibil să-l folosești selectând fișierul din listă.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>Nu s-a reușit salvarea:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>Nu s-a reușit descărcarea:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Descărcare completă</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>Patches descărcate cu succes! Toate Patches disponibile pentru toate jocurile au fost descărcate; nu este nevoie să le descarci individual pentru fiecare joc, așa cum se întâmplă cu Cheats. Dacă patch-ul nu apare, este posibil să nu existe pentru seria și versiunea specifică a jocului.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>Nu s-a reușit pararea datelor JSON din HTML.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>Nu s-a reușit obținerea paginii HTML.</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>Jocul este în versiunea: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>Patch-ul descărcat funcționează doar pe versiunea: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>Este posibil să trebuiască să actualizezi jocul tău.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>Avertizare de incompatibilitate</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>Nu s-a reușit deschiderea fișierului:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>EROARE XML:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>Nu s-a reușit deschiderea files.json pentru scriere</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>Autor: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>Directorul nu există:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>Nu s-a reușit deschiderea files.json pentru citire.</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>Nume:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>Nu poți aplica cheats înainte ca jocul să înceapă.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>Icon</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>Nume</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>Serie</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>Regiune</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>Firmware</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>Dimensiune</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>Versiune</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>Drum</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>Timp de Joacă</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Never Played</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Compatibility is untested</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Game does not initialize properly / crashes the emulator</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Game boots, but only displays a blank screen</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Game displays an image but does not go past the menu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Game has game-breaking glitches or unplayable performance</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>Actualizator automat</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>Eroare</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>Eroare de rețea:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>Nu s-au putut analiza informațiile de actualizare.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>Nu au fost găsite pre-lansări.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>Datele versiunii sunt invalide.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>Nu s-a găsit URL de descărcare pentru resursa specificată.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>Versiunea ta este deja actualizată!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>Actualizare disponibilă</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>Canal de Actualizare</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>Versiunea curentă</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>Ultima versiune</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>Doriți să actualizați?</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>Afișați jurnalul de modificări</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Verifică actualizări la pornire</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>Actualizare</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>Nu</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>Ascunde jurnalul de modificări</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>Modificări</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>A apărut o eroare de rețea în timpul încercării de a accesa URL-ul</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>Descărcare completă</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>Actualizarea a fost descărcată, apăsați OK pentru a instala.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>Nu s-a putut salva fișierul de actualizare la</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>Încep actualizarea...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>Nu s-a putut crea fișierul script de actualizare</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/ru_RU.ts
+++ b/src/qt_gui/translations/ru_RU.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>О shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 это экспериментальный эмулятор с открытым исходным кодом для PlayStation 4.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>Это програмное обеспечение не должно использоваться для запуска игр, которые вы получили нелегально.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Открыть папку</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Загрузка списка игр, пожалуйста подождите :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>Отмена</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Загрузка...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Выберите папку</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Выберите папку, в которую вы хотите установить.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Выберите папку</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Папка для установки игр</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Обзор</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Ошибка</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>Недопустимое значение местоположения для установки игр.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>Создать ярлык</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>Читы и патчи</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>Просмотр SFO</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>Просмотр трофеев</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>Открыть папку...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>Открыть папку с игрой</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>Открыть папку сохранений</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>Открыть папку логов</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>Копировать информацию...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>Копировать имя</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>Копировать серийный номер</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>Копировать все</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Удаление...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Удалить игру</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Удалить обновление</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Удалить DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Совместимость...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Обновить базу данных</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>Посмотреть отчет</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Отправить отчет</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>Создание ярлыка</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>Ярлык создан успешно!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>Ошибка</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>Ошибка создания ярлыка!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>Установить PKG</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Игры</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>Эта функция требует включения настройки 'Отдельная папка обновлений'. Если вы хотите использовать эту функцию, пожалуйста включите её.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>У этой игры нет обновлений для удаления!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Обновления</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>У этой игры нет DLC для удаления!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Удалить %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Вы уверены, что хотите удалить папку %2 %1?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Открыть/Добавить папку Elf</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>Установить пакеты (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Запустить игру</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>Проверить обновления</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>О shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Настроить...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>Установить приложение из файла .pkg</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Недавние игры</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Выход</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>Выйти из shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Выйти из приложения.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Показать список игр</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Обновить список игр</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Крошечный</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Маленький</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Средний</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Большой</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>Список</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Сетка</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Elf</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Каталог установки игры</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>Скачать читы или патчи</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Дамп списка игр</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>Просмотр PKG</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Поиск...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>Файл</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>Вид</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Размер иконок списка игр</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Вид списка игр</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Настройки</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Утилиты</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Темы</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>Помощь</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Темная</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Светлая</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Зеленая</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Синяя</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Фиолетовая</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>Панель инструментов</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>Список игр</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * Неподдерживаемая версия Vulkan</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>Скачать читы для всех установленных игр</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>Скачать патчи для всех игр</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Скачивание завершено</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>Вы скачали читы для всех установленных игр.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>Патчи успешно скачаны!</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>Все доступные патчи для всех игр были скачаны.</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>Игры: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>Файл PKG (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>Файлы ELF (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>Запуск игры</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>Можно выбрать только один файл!</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>Извлечение PKG</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>Обнаружен патч!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>Версии PKG и игры совпадают: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>Хотите перезаписать?</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>Версия PKG %1 старее установленной версии: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>Игра установлена: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>Хотите установить патч: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>Установка DLC</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>Вы хотите установить DLC: %1?</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC уже установлен:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>Игра уже установлена</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>PKG - это патч, сначала установите игру!</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>ОШИБКА PKG</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>Извлечение PKG %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>Извлечение завершено</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>Игра успешно установлена в %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>Файл не является допустимым файлом PKG</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Открыть папку</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Просмотр трофеев</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Настройки</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>Общее</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>Система</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>Язык консоли</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Язык эмулятора</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Эмулятор</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Полноэкранный режим</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Отдельная папка обновлений</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Показывать заставку</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>Режим PS4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Включить Discord Rich Presence</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Имя пользователя</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Логирование</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Тип логов</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Фильтр логов</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>Ввод</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>Курсор мыши</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>Скрывать курсор</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>Время скрытия курсора при бездействии</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>сек</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>Контроллер</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>Поведение кнопки назад</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Графика</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Графическое устройство</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Ширина</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Высота</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Делитель Vblank</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Продвинутые</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Включить дамп шейдеров</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>Включить NULL GPU</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>Пути</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>Игровые папки</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>Добавить...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>Удалить</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Отладка</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Включить отладочные дампы</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Включить слои валидации Vulkan</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Включить валидацию синхронизации Vulkan</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>Включить отладку RenderDoc</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>Обновление</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Проверка при запуске</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>Канал обновления</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>Проверить обновления</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>Интерфейс</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Отключить уведомления о трофеях</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>Играть заглавную музыку</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Обновлять базу совместимости при запуске</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Совместимость игр</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Показывать данные совместимости</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Обновить базу совместимости</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>Громкость</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Звуковая Подсистема</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>Список игр</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * Неподдерживаемая версия Vulkan</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>Скачать читы для всех установленных игр</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>Скачать патчи для всех игр</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>Скачивание завершено</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>Вы скачали читы для всех установленных игр.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>Патчи успешно скачаны!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>Все доступные патчи для всех игр были скачаны.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>Игры: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>Файл PKG (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>Файлы ELF (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>Запуск игры</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>Можно выбрать только один файл!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>Извлечение PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>Обнаружен патч!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>Версии PKG и игры совпадают: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>Хотите перезаписать?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>Версия PKG %1 старее установленной версии: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>Игра установлена: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>Хотите установить патч: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>Установка DLC</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>Вы хотите установить DLC: %1?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC уже установлен:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>Игра уже установлена</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>PKG - это патч, сначала установите игру!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>ОШИБКА PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>Извлечение PKG %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>Извлечение завершено</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>Игра успешно установлена в %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>Файл не является допустимым файлом PKG</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Читы и патчи для </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>Читы и патчи экспериментальны.\nИспользуйте с осторожностью.\n\nСкачивайте читы, выбрав репозиторий и нажав на кнопку загрузки.\nВо вкладке "Патчи" вы можете скачать все патчи сразу, выбирать какие вы хотите использовать, и сохранять выбор.\n\nПоскольку мы не разрабатываем читы/патчи,\nпожалуйста сообщайте о проблемах автору чита/патча.\n\nСоздали новый чит? Посетите:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>Изображение недоступно</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>Серийный номер: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>Версия: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>Размер: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>Выберите файл чита:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>Репозиторий:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>Скачать читы</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>Удалить файл</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>Файлы не выбраны.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>Вы можете удалить ненужные читы после их скачивания.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>Вы хотите удалить выбранный файл?\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>Выберите файл патча:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>Скачать патчи</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>Сохранить</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>Читы</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>Патчи</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>Ошибка</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>Патч не выбран.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>Не удалось открыть файл files.json для чтения.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>Не найден файл патча для текущего серийного номера.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>Не удалось открыть файл для чтения.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>Не удалось открыть файл для записи.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>Не удалось разобрать XML: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>Успех</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>Опции успешно сохранены.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>Неверный источник</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>Выбранный источник недействителен.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>Файл существует</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>Файл уже существует. Хотите заменить его?</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>Не удалось сохранить файл:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>Не удалось скачать файл:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>Читы не найдены</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>Читы не найдены для этой игры в выбранном репозитории. Попробуйте другой репозиторий или другую версию игры.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>Читы успешно скачаны</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>Вы успешно скачали читы для этой версии игры из выбранного репозитория. Вы можете попробовать скачать из другого репозитория. Если он доступен, его также можно будет использовать, выбрав файл из списка.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>Не удалось сохранить:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>Не удалось скачать:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>Скачивание завершено</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>Патчи успешно скачаны! Все доступные патчи для всех игр были скачаны, нет необходимости скачивать их по отдельности для каждой игры, как это происходит с читами. Если патч не появляется, возможно, его не существует для конкретного серийного номера и версии игры.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>Не удалось разобрать данные JSON из HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>Не удалось получить HTML-страницу.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>Игра в версии: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>Скачанный патч работает только на версии: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>Вам может понадобиться обновить игру.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>Уведомление о несовместимости</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>Не удалось открыть файл:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>ОШИБКА XML:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>Не удалось открыть файл files.json для записи</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>Автор: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>Каталог не существует:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>Не удалось открыть файл files.json для чтения.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>Имя:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>Невозможно применить читы до начала игры</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>Сохранить</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>Применить</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>По умолчанию</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>Закрыть</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>Наведите указатель мыши на опцию, чтобы отобразить ее описание.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Язык консоли:\nУстановите язык, который будет использоваться в играх PS4.\nРекомендуется устанавливать язык который поддерживается игрой, так как он может отличаться в зависимости от региона.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>Язык эмулятора:\nУстановите язык пользовательского интерфейса эмулятора.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>Полноэкранный режим:\nАвтоматически переводит игровое окно в полноэкранный режим.\nВы можете отключить это, нажав клавишу F11.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Отдельная папка обновлений:\nПозволяет устанавливать обновления игры в отдельную папку для удобства.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>Показывать заставку:\nОтображает заставку игры (специальное изображение) во время запуска.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>Режим PS4 Pro:\nЗаставляет эмулятор работать как PS4 Pro, что может включить специальные функции в играх, поддерживающих это.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>Включить Discord Rich Presence:\nОтображает значок эмулятора и соответствующую информацию в вашем профиле Discord.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>Имя пользователя:\nУстановите имя пользователя аккаунта PS4. Это может отображаться в некоторых играх.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>Тип логов:\nУстановите, синхронизировать ли вывод окна логов ради производительности. Это может негативно сказаться на эмуляции.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Фильтр логов:\nФильтрует логи, чтобы показывать только определенную информацию.\nПримеры: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" Уровни: Trace, Debug, Info, Warning, Error, Critical - в этом порядке, конкретный уровень глушит все предыдущие уровни в списке и показывает все последующие уровни.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>Обновление:\nRelease: Официальные версии, которые выпускаются каждый месяц и могут быть очень старыми, но они более надежные и проверенные.\nNightly: Версии разработки, которые содержат все последние функции и исправления, но могут содержать ошибки и менее стабильны.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Играть заглавную музыку:\nВключает воспроизведение специальной музыки при выборе игры в списке, если она это поддерживает.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Отключить уведомления о трофеях:\nОтключает внутриигровые уведомления о трофеях. Прогресс трофеев по прежнему можно отслеживать в меню Просмотр трофеев (правая кнопка мыши по игре в главном окне).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>Скрывать курсор:\nВыберите, когда курсор будет скрыт:\nНикогда: Вы всегда будете видеть курсор.\nПри бездействии: Установите время, через которое курсор будет скрыт при бездействии.\nВсегда: Курсор всегда будет скрыт.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>Установите время, через которое курсор исчезнет при бездействии.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>Поведение кнопки «Назад»:\nНастраивает кнопку «Назад» контроллера на эмуляцию нажатия на указанную область на сенсорной панели контроллера PS4.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Показывать данные совместимости:\nПоказывает информацию о совместимости игр в таблице. Включите «Обновлять базу совместимости при запуске» для получения актуальной информации.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Обновлять базу совместимости при запуске:\nАвтоматически обновлять базу данных совместимости при запуске shadPS4.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Обновить базу совместимости:\nНемедленно обновить базу данных совместимости.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>Никогда</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>При бездействии</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>Всегда</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>Тачпад слева</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>Тачпад справа</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>Центр тачпада</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>Нет</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>Графическое устройство:\nВ системах с несколькими GPU выберите GPU, который будет использовать эмулятор.\nВыберите "Auto Select", чтобы определить его автоматически.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Ширина/Высота:\nУстановите размер окна эмулятора при запуске, который может быть изменен во время игры.\nЭто отличается от разрешения в игре.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Делитель Vblank:\nЧастота кадров, с которой обновляется эмулятор, умножается на это число. Изменение этого параметра может иметь негативные последствия, такие как увеличение скорости игры или нарушение критических функций игры, которые этого не ожидают!</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>Включить дамп шейдеров:\nДля технической отладки сохраняет шейдеры игр в папку во время рендеринга.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Включить NULL GPU:\nДля технической отладки отключает рендеринг игры так, как будто графической карты нет.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>Игровые папки:\nСписок папок для проверки установленных игр.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>Добавить:\nДобавить папку в список.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>Удалить:\nУдалить папку из списка.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>Включить отладочные дампы:\nСохраняет символы импорта, экспорта и информацию о заголовке файла текущей исполняемой программы PS4 в папку.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Включить слои валидации Vulkan:\nВключает систему, которая проверяет состояние рендерера Vulkan и логирует информацию о его внутреннем состоянии. Это снизит производительность и, вероятно, изменит поведение эмуляции.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Включить валидацию синхронизации Vulkan:\nВключает систему, которая проверяет тайминг задач рендеринга Vulkan. Это снизит производительность и, вероятно, изменит поведение эмуляции.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>Включить отладку RenderDoc:\nЕсли включено, эмулятор обеспечит совместимость с Renderdoc, позволяя захватывать и анализировать текущие кадры во время рендеринга.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Читы и патчи для </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>Читы и патчи экспериментальны.\nИспользуйте с осторожностью.\n\nСкачивайте читы, выбрав репозиторий и нажав на кнопку загрузки.\nВо вкладке "Патчи" вы можете скачать все патчи сразу, выбирать какие вы хотите использовать, и сохранять выбор.\n\nПоскольку мы не разрабатываем читы/патчи,\nпожалуйста сообщайте о проблемах автору чита/патча.\n\nСоздали новый чит? Посетите:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>Изображение недоступно</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>Серийный номер: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>Версия: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>Размер: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>Выберите файл чита:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>Репозиторий:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>Скачать читы</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>Удалить файл</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>Файлы не выбраны.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>Вы можете удалить ненужные читы после их скачивания.</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>Вы хотите удалить выбранный файл?\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>Выберите файл патча:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>Скачать патчи</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>Сохранить</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>Читы</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>Патчи</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Ошибка</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>Патч не выбран.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>Не удалось открыть файл files.json для чтения.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>Не найден файл патча для текущего серийного номера.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>Не удалось открыть файл для чтения.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>Не удалось открыть файл для записи.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>Не удалось разобрать XML: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>Успех</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>Опции успешно сохранены.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>Неверный источник</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>Выбранный источник недействителен.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>Файл существует</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>Файл уже существует. Хотите заменить его?</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>Не удалось сохранить файл:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>Не удалось скачать файл:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>Читы не найдены</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>Читы не найдены для этой игры в выбранном репозитории. Попробуйте другой репозиторий или другую версию игры.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>Читы успешно скачаны</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>Вы успешно скачали читы для этой версии игры из выбранного репозитория. Вы можете попробовать скачать из другого репозитория. Если он доступен, его также можно будет использовать, выбрав файл из списка.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>Не удалось сохранить:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>Не удалось скачать:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Скачивание завершено</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>Патчи успешно скачаны! Все доступные патчи для всех игр были скачаны, нет необходимости скачивать их по отдельности для каждой игры, как это происходит с читами. Если патч не появляется, возможно, его не существует для конкретного серийного номера и версии игры.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>Не удалось разобрать данные JSON из HTML.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>Не удалось получить HTML-страницу.</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>Игра в версии: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>Скачанный патч работает только на версии: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>Вам может понадобиться обновить игру.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>Уведомление о несовместимости</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>Не удалось открыть файл:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>ОШИБКА XML:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>Не удалось открыть файл files.json для записи</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>Автор: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>Каталог не существует:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>Не удалось открыть файл files.json для чтения.</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>Имя:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>Невозможно применить читы до начала игры</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>Иконка</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>Название</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>Серийный номер</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Совместимость</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>Регион</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>Прошивка</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>Размер</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>Версия</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>Путь</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>Времени в игре</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Вы не играли</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>ч</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>м</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>с</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Совместимость не проверена</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Игра не иницализируется правильно / крашит эмулятор</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Игра запускается, но показывает только пустой экран</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Игра показывает картинку, но не проходит дальше меню</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Игра имеет ломающие игру глюки или плохую производительность</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Игра может быть пройдена с хорошей производительностью и без серьезных сбоев</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>Автообновление</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>Ошибка</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>Сетевая ошибка:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>Не удалось разобрать информацию об обновлении.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>Предварительных версий не найдено.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>Недопустимые данные релиза.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>Не найден URL для загрузки указанного ресурса.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>Ваша версия уже обновлена!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>Доступно обновление</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>Канал обновления</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>Текущая версия</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>Последняя версия</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>Вы хотите обновиться?</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>Показать журнал изменений</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Проверка при запуске</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>Обновить</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>Нет</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>Скрыть журнал изменений</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>Журнал изменений</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>Произошла сетевая ошибка при попытке доступа к URL</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>Скачивание завершено</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>Обновление загружено, нажмите OK для установки.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>Не удалось сохранить файл обновления в</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>Начало обновления...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>Не удалось создать файл скрипта обновления</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>Б</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>КБ</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>МБ</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>ГБ</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>ТБ</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/sq.ts
+++ b/src/qt_gui/translations/sq.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>Rreth shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 është një emulator eksperimental me burim të hapur për PlayStation 4.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>Ky program nuk duhet përdorur për të luajtur lojëra që nuk ke marrë ligjërisht.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Hap Dosjen</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Po ngarkohet lista e lojërave, të lutem prit :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>Anulo</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Duke ngarkuar...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Përzgjidh dosjen</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Përzgjidh në cilën dosje do që të instalosh.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Përzgjidh dosjen</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Dosja ku do instalohen lojërat</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Shfleto</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Gabim</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>Vlera për vendndodhjen e instalimit të lojërave nuk është e vlefshme.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>Krijo Shkurtore</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>Mashtrime / Arna</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>Shikuesi i SFO</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>Shikuesi i Trofeve</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>Hap Dosjen...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>Hap Dosjen e Lojës</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>Hap Dosjen e të Dhënave të Ruajtura</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>Hap Dosjen e Ditarit</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>Kopjo informacionin...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>Kopjo Emrin</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>Kopjo Serikun</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>Kopjo të Gjitha</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Fshi...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Fshi lojën</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Fshi përditësimin</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Fshi DLC-në</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>Krijimi i shkurtores</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>Shkurtorja u krijua me sukses!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>Gabim</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>Gabim në krijimin e shkurtores!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>Instalo PKG</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Loja</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>Kjo veçori kërkon cilësimin 'Aktivizo dosjen e ndarë të përditësimit' për të punuar. Në qoftë se do ta përdorësh këtë veçori, të lutem aktivizoje.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>Kjo lojë nuk ka përditësim për të fshirë!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Përditësim</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>Kjo lojë nuk ka DLC për të fshirë!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Fshi %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Je i sigurt që do të fsish dosjen %2 të %1?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Hap/Shto Dosje ELF</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>Instalo Paketat (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Nis Lojën</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>Kontrollo për përditësime</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>Rreth shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Konfiguro...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>Instalo aplikacionin nga një skedar .pkg</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Lojërat e fundit</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Dil</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>Dil nga shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Dil nga aplikacioni.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Shfaq Listën e Lojërave</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Rifresko Listën e Lojërave</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Të vockla</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Të vogla</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Të mesme</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Të mëdha</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>Pamja e Listës</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Pamja e Rrjetës</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Shikuesi i Elf</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Dosja e Instalimit të Lojës</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>Shkarko Mashtrime/Arna</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Zbraz Listën e Lojërave</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>Shikuesi i PKG</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Kërko...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>Skedari</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>Pamja</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Ikonat e Listës së Lojërave</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Mënyra e Listës së Lojërave</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Cilësimet</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Shërbimet</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Motivet</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>Ndihmë</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>E errët</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>E çelët</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>E gjelbër</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>E kaltër</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Vjollcë</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>Shiriti i veglave</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>Lista e lojërave</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * Version i pambështetur i Vulkan</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>Shkarko Mashtrime Për Të Gjitha Lojërat e Instaluara</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>Shkarko Arna Për Të Gjitha Lojërat e Instaluara</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Shkarkimi Përfundoi</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>Ke shkarkuar mashtrimet për të gjitha lojërat që ke instaluar.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>Arnat u shkarkuan me sukses!</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>Të gjitha arnat e ofruara për të gjitha lojërat janë shkarkuar.</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>Lojërat: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>Skedar PKG (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>Skedarë ELF (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>Nis Lojën</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>Mund të përzgjidhet vetëm një skedar!</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>Nxjerrja e PKG-së</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>U zbulua një arnë!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>PKG-ja dhe versioni i Lojës përputhen: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>Dëshiron të mbishkruash?</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>Versioni %1 i PKG-së është më i vjetër se versioni i instaluar: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>Loja është instaluar: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>Dëshiron të instalosh Arnën: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>Instalimi i DLC-ve</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>Dëshiron të instalosh DLC-në: %1?</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC-ja është instaluar tashmë:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>Loja është instaluar tashmë</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>PKG-ja është një arnë, të lutem instalo lojën fillimisht!</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>GABIM PKG</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>Po nxirret PKG-ja %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>Nxjerrja Përfundoi</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>Loja u instalua me sukses në %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>Skedari nuk duket si skedar PKG i vlefshëm</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Hap Dosjen</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Shikuesi i Trofeve</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Cilësimet</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>Të përgjithshme</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>Sistemi</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>Gjuha e Konsolës</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Gjuha e emulatorit</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Emulatori</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Aktivizo Ekranin e plotë</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Aktivizo dosjen e ndarë të përditësimit</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Shfaq Pamjen e nisjes</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>Mënyra PS4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Aktivizo Discord Rich Presence</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Përdoruesi</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Regjistruesi i ditarit</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Lloji i Ditarit</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Filtri i Ditarit</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>Hyrja</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>Kursori</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>Fshih kursorin</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>Koha për fshehjen e kursorit joaktiv</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>Dorezë</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>Sjellja e butonit mbrapa</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Grafika</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Pajisja e Grafikës</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Gjerësia</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Lartësia</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Ndarës Vblank</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Të përparuara</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Aktivizo Zbrazjen e Shaders-ave</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>Aktivizo GPU-në NULL</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>Shtigjet</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>Dosjet e lojës</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>Shto...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>Hiq</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Korrigjim</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Aktivizo Zbrazjen për Korrigjim</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Aktivizo Shtresat e Vlefshmërisë Vulkan</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Aktivizo Vërtetimin e Sinkronizimit Vulkan</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>Aktivizo Korrigjimin RenderDoc</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>Përditëso</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Kontrollo për përditësime në nisje</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>Kanali i përditësimit</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>Kontrollo për përditësime</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>Cilësimet e GUI</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Çaktivizo njoftimet për Trofetë</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>Luaj muzikën e titullit</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Përditëso bazën e të dhënave të përputhshmërisë gjatë nisjes</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Përputhshmëria e lojës</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Shfaq të dhënat e përputhshmërisë</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Përditëso bazën e të dhënave të përputhshmërisë</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>Vëllimi i zërit</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>Lista e lojërave</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * Version i pambështetur i Vulkan</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>Shkarko Mashtrime Për Të Gjitha Lojërat e Instaluara</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>Shkarko Arna Për Të Gjitha Lojërat e Instaluara</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>Shkarkimi Përfundoi</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>Ke shkarkuar mashtrimet për të gjitha lojërat që ke instaluar.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>Arnat u shkarkuan me sukses!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>Të gjitha arnat e ofruara për të gjitha lojërat janë shkarkuar.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>Lojërat: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>Skedar PKG (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>Skedarë ELF (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>Nis Lojën</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>Mund të përzgjidhet vetëm një skedar!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>Nxjerrja e PKG-së</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>U zbulua një arnë!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>PKG-ja dhe versioni i Lojës përputhen: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>Dëshiron të mbishkruash?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>Versioni %1 i PKG-së është më i vjetër se versioni i instaluar: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>Loja është instaluar: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>Dëshiron të instalosh Arnën: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>Instalimi i DLC-ve</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>Dëshiron të instalosh DLC-në: %1?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC-ja është instaluar tashmë:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>Loja është instaluar tashmë</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>PKG-ja është një arnë, të lutem instalo lojën fillimisht!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>GABIM PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>Po nxirret PKG-ja %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>Nxjerrja Përfundoi</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>Loja u instalua me sukses në %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>Skedari nuk duket si skedar PKG i vlefshëm</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Mashtrime / Arna për </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>Mashtrimet/Arnat janë eksperimentale.\nPërdori me kujdes.\n\nShkarko mashtrimet individualisht duke zgjedhur depon dhe duke klikuar butonin e shkarkimit.\nNë skedën Arna, mund t'i shkarkosh të gjitha arnat menjëherë, të zgjidhësh cilat dëshiron të përdorësh dhe të ruash zgjedhjen tënde.\n\nMeqenëse ne nuk zhvillojmë Mashtrimet/Arnat,\ntë lutem raporto problemet te autori i mashtrimit.\n\nKe krijuar një mashtrim të ri? Vizito:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>Nuk ofrohet asnjë imazh</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>Seriku: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>Versioni: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>Madhësia: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>Përzgjidh Skedarin e Mashtrimit:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>Depo:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>Shkarko Mashtrimet</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>Fshi Skedarin</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>Nuk u zgjodh asnjë skedar.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>Mund t'i fshish mashtrimet që nuk dëshiron pasi t'i kesh shkarkuar.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>Dëshiron të fshish skedarin e përzgjedhur?\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>Përzgjidh Skedarin e Arnës:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>Shkarko Arnat</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>Ruaj</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>Mashtrime</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>Arna</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>Gabim</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>Asnjë arnë e përzgjedhur.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>files.json nuk mund të hapet për lexim.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>Nuk u gjet asnjë skedar patch për serikun aktual.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>Skedari nuk mund të hapet për lexim.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>Skedari nuk mund të hapet për shkrim.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>Analiza e XML-së dështoi: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>Sukses</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>Rregullimet u ruajtën me sukses.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>Burim i pavlefshëm</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>Burimi i përzgjedhur është i pavlefshëm.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>Skedari Ekziston</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>Skedari ekziston tashmë. Dëshiron ta zëvendësosh?</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>Ruajtja e skedarit dështoi:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>Shkarkimi i skedarit dështoi:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>Mashtrimet nuk u gjetën</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>Nuk u gjetën mashtrime për këtë lojë në këtë version të depove të përzgjedhura, provo një depo tjetër ose një version tjetër të lojës.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>Mashtrimet u shkarkuan me sukses</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>Ke shkarkuar me sukses mashtrimet për këtë version të lojës nga depoja e përzgjedhur. Mund të provosh të shkarkosh nga një depo tjetër, nëse ofrohet do të jetë e mundur gjithashtu ta përdorësh duke përzgjedhur skedarin nga lista.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>Ruajtja dështoi:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>Shkarkimi dështoi:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>Shkarkimi përfundoi</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>Arnat u shkarkuan me sukses! Të gjitha arnat e ofruara për të gjitha lojërat janë shkarkuar, nuk ka nevojë t'i shkarkosh ato individualisht për secilën lojë siç ndodh me Mashtrimet. Nëse arna nuk shfaqet, mund të mos ekzistojë për numrin e serikut dhe versionin specifik të lojës.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>Analiza e të dhënave JSON nga HTML dështoi.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>Gjetja e faqes HTML dështoi.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>Loja është në versionin: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>Arna e shkarkuar funksionon vetëm në versionin: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>Mund të duhet të përditësosh lojën tënde.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>Njoftim për papajtueshmëri</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>Hapja e skedarit dështoi:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>GABIM XML:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>Hapja e files.json për shkrim dështoi</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>Autori: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>Dosja nuk ekziston:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>Hapja e files.json për lexim dështoi.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>Emri:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>Nuk mund të zbatohen mashtrime para fillimit të lojës.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>Ruaj</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>Zbato</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>Rikthe paracaktimet</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>Mbyll</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>Vendos miun mbi një rregullim për të shfaqur përshkrimin e tij.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Gjuha e konsolës:\nPërcakton gjuhën që përdor loja PS4.\nKëshillohet të caktosh një gjuhë që loja mbështet, e cila do të ndryshojë sipas rajonit.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>Gjuha e emulatorit:\nPërcakton gjuhën e ndërfaqes së përdoruesit të emulatorit.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>Aktivizo ekranin e plotë:\nVendos automatikisht dritaren e lojës në mënyrën e ekranit të plotë.\nKjo mund të aktivizohet duke shtypur tastin F11.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Aktivizo dosjen e ndarë të përditësimit:\nAktivizon instalimin e përditësimeve të lojërave në dosje të veçanta për menaxhim më të lehtë.\nKjo mund të krijohet manualisht duke shtuar përditësimin e shpaketuar në dosjen e lojës me emrin "CUSA00000-UPDATE" ku ID-ja CUSA përputhet me ID-në e lojës.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>Shfaq ekranin e ngarkesës:\nShfaq ekranin e ngarkesës së lojës (një pamje e veçantë) gjatë fillimit të lojës.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>Është PS4 Pro:\nBën që emulatori të veprojë si një PS4 PRO, gjë që mund të aktivizojë veçori të veçanta në lojrat që e mbështesin.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>Aktivizo Discord Rich Presence:\nShfaq ikonën e emulatorit dhe informacionin përkatës në profilin tënd në Discord.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>Përdoruesi:\nPërcakton emrin e përdoruesit të llogarisë PS4, i cili mund të shfaqet nga disa lojra.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>Lloji i ditarit:\nPërcakton nëse të sinkronizohet dalja e dritares së ditarit për performancë. Mund të ketë efekte të këqija në emulim.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Filtri i ditarit:\nFiltron ditarin për të shfaqur vetëm informacione specifike.\nShembuj: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" Nivelet: Trace, Debug, Info, Warning, Error, Critical - në këtë rend, një nivel specifik hesht të gjitha nivelet përpara në listë dhe regjistron çdo nivel pas atij.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>Përditësimi:\nRelease: Versionet zyrtare të lëshuara çdo muaj që mund të jenë shumë të vjetra, por janë më të besueshme dhe të provuara.\nNightly: Versionet e zhvillimit që kanë të gjitha veçoritë dhe rregullimet më të fundit, por mund të përmbajnë gabime dhe janë më pak të qëndrueshme.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Luaj muzikën e titullit:\nNëse një lojë e mbështet, aktivizohet luajtja e muzikës të veçantë kur të zgjidhësh lojën në GUI.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Çaktivizo njoftimet për Trofetë:\nÇaktivizo njoftimet për trofetë gjatë lojës. Përparimi i trofeve mund të ndiqet duke përdorur Shikuesin e Trofeve (kliko me të djathtën mbi lojën në dritaren kryesore).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>Fsheh kursorin:\nZgjidh kur do të fshihet kursori:\nKurrë: Do ta shohësh gjithmonë miun.\nInaktiv: Vendos një kohë për ta fshehur pas mosveprimit.\nGjithmonë: nuk do ta shohësh kurrë miun.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>Koha për fshehjen e kursorit joaktiv:\nKohëzgjatja (në sekonda) pas së cilës kursori që nuk ka qënë në veprim fshihet.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>Sjellja e butonit mbrapa:\nLejon të përcaktohet se në cilën pjesë të tastierës prekëse do të imitojë një prekje butoni mprapa.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Shfaq të dhënat e përputhshmërisë:\nShfaq informacionin e përputhshmërisë së lojës në formë tabele. Aktivizo 'Përditëso përputhshmërinë gjatë nisjes' për të marrë informacion të përditësuar.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Përditëso përputhshmërinë gjatë nisjes:\nPërditëson automatikisht bazën e të dhënave të përputhshmërisë kur shadPS4 niset.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Përditëso bazën e të dhënave të përputhshmërisë:\nPërditëso menjëherë bazën e të dhënave të përputhshmërisë.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>Kurrë</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>Joaktiv</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>Gjithmonë</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>Tastiera prekëse majtas</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>Tastiera prekëse djathtas</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>Tastiera prekëse në qendër</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>Asnjë</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>Pajisja grafike:\nNë sistemet me GPU të shumëfishta, zgjidh GPU-në që do të përdorë emulatori nga lista rënëse,\nose zgjidh "Auto Select" për ta përcaktuar automatikisht.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Gjerësia/Lartësia:\nPërcakton madhësinë e dritares së emulatorit në nisje, e cila mund të rregullohet gjatë lojës.\nKjo është ndryshe nga rezolucioni në lojë.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Ndarësi Vblank:\nFrekuenca pamore me të cilën rifreskohet emulatori shumëzohet me këtë numër. Ndryshimi i këtij mund të ketë efekte të këqija, si rritja e shpejtësisë së lojës ose prishja e punimit thelbësor të lojës që nuk e pret këtë ndryshim!</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>Aktivizo zbrazjen e shaders-ave:\nPër qëllime të korrigjimit teknik, ruan shaders-at e lojës në një dosje ndërsa ato pasqyrohen.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Aktivizo GPU-në Null:\nPër qëllime të korrigjimit teknik, çaktivizon pasqyrimin e lojës sikur nuk ka një kartë grafike.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>Dosjet e lojërave:\nLista e dosjeve për të kontrolluar lojërat e instaluara.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>Shto:\nShto një dosje në listë.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>Hiq:\nHiq një dosje nga lista.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>Aktivizo zbrazjen për korrigjim:\nRuan simbolet e importit dhe eksportit dhe informacionin e kreut të skedarit për aplikacionin PS4 që po ekzekutohet në një dosje.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Aktivizo shtresat e vlefshmërisë Vulkan:\nAktivizon një sistem që vërteton gjendjen e pasqyruesit Vulkan dhe regjistron informacionin në lidhje me gjendjen e tij të brendshme. Kjo do të ul performancën dhe ndoshta do të ndryshojë sjelljen e emulimit.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Aktivizo vërtetimin e sinkronizimit Vulkan:\nAktivizon një sistem që vërteton kohën e detyrave të pasqyrimit Vulkan. Kjo do të ul performancën dhe ndoshta do të ndryshojë sjelljen e emulimit.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>Aktivizo korrigjimin RenderDoc:\nNëse aktivizohet, emulatori do të ofrojë pajtueshmëri me Renderdoc për të lejuar kapjen dhe analizën e pamjes të pasqyruar në moment.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Mashtrime / Arna për </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>Mashtrimet/Arnat janë eksperimentale.\nPërdori me kujdes.\n\nShkarko mashtrimet individualisht duke zgjedhur depon dhe duke klikuar butonin e shkarkimit.\nNë skedën Arna, mund t'i shkarkosh të gjitha arnat menjëherë, të zgjidhësh cilat dëshiron të përdorësh dhe të ruash zgjedhjen tënde.\n\nMeqenëse ne nuk zhvillojmë Mashtrimet/Arnat,\ntë lutem raporto problemet te autori i mashtrimit.\n\nKe krijuar një mashtrim të ri? Vizito:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>Nuk ofrohet asnjë imazh</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>Seriku: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>Versioni: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>Madhësia: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>Përzgjidh Skedarin e Mashtrimit:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>Depo:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>Shkarko Mashtrimet</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>Fshi Skedarin</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>Nuk u zgjodh asnjë skedar.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>Mund t'i fshish mashtrimet që nuk dëshiron pasi t'i kesh shkarkuar.</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>Dëshiron të fshish skedarin e përzgjedhur?\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>Përzgjidh Skedarin e Arnës:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>Shkarko Arnat</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>Ruaj</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>Mashtrime</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>Arna</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Gabim</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>Asnjë arnë e përzgjedhur.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>files.json nuk mund të hapet për lexim.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>Nuk u gjet asnjë skedar patch për serikun aktual.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>Skedari nuk mund të hapet për lexim.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>Skedari nuk mund të hapet për shkrim.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>Analiza e XML-së dështoi: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>Sukses</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>Rregullimet u ruajtën me sukses.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>Burim i pavlefshëm</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>Burimi i përzgjedhur është i pavlefshëm.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>Skedari Ekziston</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>Skedari ekziston tashmë. Dëshiron ta zëvendësosh?</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>Ruajtja e skedarit dështoi:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>Shkarkimi i skedarit dështoi:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>Mashtrimet nuk u gjetën</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>Nuk u gjetën mashtrime për këtë lojë në këtë version të depove të përzgjedhura, provo një depo tjetër ose një version tjetër të lojës.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>Mashtrimet u shkarkuan me sukses</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>Ke shkarkuar me sukses mashtrimet për këtë version të lojës nga depoja e përzgjedhur. Mund të provosh të shkarkosh nga një depo tjetër, nëse ofrohet do të jetë e mundur gjithashtu ta përdorësh duke përzgjedhur skedarin nga lista.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>Ruajtja dështoi:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>Shkarkimi dështoi:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Shkarkimi përfundoi</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>Arnat u shkarkuan me sukses! Të gjitha arnat e ofruara për të gjitha lojërat janë shkarkuar, nuk ka nevojë t'i shkarkosh ato individualisht për secilën lojë siç ndodh me Mashtrimet. Nëse arna nuk shfaqet, mund të mos ekzistojë për numrin e serikut dhe versionin specifik të lojës.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>Analiza e të dhënave JSON nga HTML dështoi.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>Gjetja e faqes HTML dështoi.</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>Loja është në versionin: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>Arna e shkarkuar funksionon vetëm në versionin: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>Mund të duhet të përditësosh lojën tënde.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>Njoftim për papajtueshmëri</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>Hapja e skedarit dështoi:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>GABIM XML:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>Hapja e files.json për shkrim dështoi</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>Autori: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>Dosja nuk ekziston:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>Hapja e files.json për lexim dështoi.</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>Emri:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>Nuk mund të zbatohen mashtrime para fillimit të lojës.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>Ikona</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>Emri</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>Seriku</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Përputhshmëria</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>Rajoni</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>Firmueri</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>Madhësia</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>Versioni</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>Shtegu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>Koha e luajtjes</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Nuk është luajtur kurrë</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Përputhshmëria nuk është e testuar</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Loja nuk niset siç duhet / rrëzon emulatorin</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Loja niset, por shfaq vetëm një ekran të zbrazët</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Loja shfaq një imazh, por nuk kalon përtej menysë</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Loja ka probleme kritike ose performancë të papërshtatshme për lojë</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Loja mund të përfundohet me performancë të luajtshme dhe pa probleme të mëdha</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>Përditësues automatik</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>Gabim</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>Gabim rrjeti:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>Analizimi i informacionit të përditësimit deshtoi.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>Nuk u gjetën botime paraprake.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>Të dhënat e lëshimit janë të pavlefshme.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>Nuk u gjet URL-ja e shkarkimit për burimin e specifikuar.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>Versioni jotë është i përditësuar tashmë!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>Ofrohet një përditësim</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>Kanali i përditësimit</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>Versioni i tanishëm</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>Versioni më i fundit</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>Do të përditësosh?</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>Trego ndryshimet</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Kontrollo për përditësime në nisje</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>Përditëso</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>Jo</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>Fshih ndryshimet</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>Ndryshimet</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>Ka ndodhur një gabim rrjeti gjatë përpjekjes për të qasur në URL-në</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>Shkarkimi përfundoi</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>Përditësimi është shkarkuar, shtyp OK për ta instaluar.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>Dështoi ruajtja e skedarit të përditësimit në</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>Po fillon përditësimi...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>Krijimi i skedarit skript të përditësimit dështoi</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/tr_TR.ts
+++ b/src/qt_gui/translations/tr_TR.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>shadPS4 Hakkında</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4, PlayStation 4 için deneysel bir açık kaynak kodlu emülatördür.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>Bu yazılım, yasal olarak edinmediğiniz oyunları oynamak için kullanılmamalıdır.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Klasörü Aç</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Oyun listesi yükleniyor, lütfen bekleyin :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>İptal</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Yükleniyor...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Klasörü Seç</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Select which directory you want to install to.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Klasörü Seç</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Oyunların yükleneceği klasör</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Gözat</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Hata</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>Oyunların yükleneceği konum için girilen klasör geçerli değil.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>Kısayol Oluştur</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>Hileler / Yamanlar</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>SFO Görüntüleyici</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>Kupa Görüntüleyici</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>Klasörü Aç...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>Oyun Klasörünü Aç</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>Kaydetme Verileri Klasörünü Aç</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>Log Klasörünü Aç</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>Bilgiyi Kopyala...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>Adı Kopyala</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>Seri Numarasını Kopyala</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>Tümünü Kopyala</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Delete...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Delete Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Delete Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Delete DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>Kısayol oluşturma</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>Kısayol başarıyla oluşturuldu!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>Hata</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>Kısayol oluşturulurken hata oluştu!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>PKG Yükle</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>This feature requires the 'Enable Separate Update Folder' config option to work. If you want to use this feature, please enable it.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>This game has no update to delete!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>This game has no DLC to delete!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Delete %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Are you sure you want to delete %1's %2 directory?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Elf Klasörünü Aç/Ekle</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>Paketleri Kur (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Oyunu Başlat</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>Güncellemeleri kontrol et</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>shadPS4 Hakkında</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Yapılandır...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>.pkg dosyasından uygulama yükle</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Son Oyunlar</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Çıkış</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>shadPS4'ten Çık</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Uygulamadan çık.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Oyun Listesini Göster</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Oyun Listesini Yenile</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Küçük</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Ufak</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Orta</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Büyük</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>Liste Görünümü</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Izgara Görünümü</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Elf Görüntüleyici</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Oyun Kurulum Klasörü</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>Hileleri/Yamaları İndir</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Oyun Listesini Kaydet</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>PKG Görüntüleyici</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Ara...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>Dosya</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>Görünüm</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Oyun Listesi Simgeleri</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Oyun Listesi Modu</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Ayarlar</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Yardımcı Araçlar</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Temalar</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>Yardım</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Koyu</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Açık</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Yeşil</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Mavi</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Mor</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>Araç Çubuğu</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>Oyun Listesi</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * Desteklenmeyen Vulkan Sürümü</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>Tüm Yüklenmiş Oyunlar İçin Hileleri İndir</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>Tüm Oyunlar İçin Yamaları İndir</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>İndirme Tamamlandı</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>Yüklediğiniz tüm oyunlar için hileleri indirdiniz.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>Yamalar Başarıyla İndirildi!</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>Tüm oyunlar için mevcut tüm yamalar indirildi.</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>Oyunlar: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>PKG Dosyası (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>ELF Dosyaları (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>Oyun Başlatma</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>Sadece bir dosya seçilebilir!</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>PKG Çıkartma</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>Yama tespit edildi!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>PKG ve oyun sürümleri uyumlu: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>Üzerine yazmak ister misiniz?</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>PKG Sürümü %1, kurulu sürümden daha eski: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>Oyun yüklendi: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>Yamanın yüklenmesini ister misiniz: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>DLC Yükleme</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>DLC'yi yüklemek ister misiniz: %1?</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC zaten yüklü:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>Oyun zaten yüklü</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>PKG bir yama, lütfen önce oyunu yükleyin!</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>PKG HATASI</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>PKG Çıkarılıyor %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>Çıkarma Tamamlandı</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>Oyun başarıyla %1 konumuna yüklendi</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>Dosya geçerli bir PKG dosyası gibi görünmüyor</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Klasörü Aç</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Kupa Görüntüleyici</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Ayarlar</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>Genel</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>Sistem</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>Konsol Dili</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Emülatör Dili</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Emülatör</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Tam Ekranı Etkinleştir</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Başlangıç Ekranını Göster</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>PS4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Discord Rich Presence'i etkinleştir</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Kullanıcı Adı</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Kayıt Tutucu</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Kayıt Türü</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Kayıt Filtresi</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>Girdi</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>İmleç</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>İmleci Gizle</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>İmleç İçin Hareketsizlik Zaman Aşımı</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>Kontrolcü</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>Geri Dön Butonu Davranışı</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Grafikler</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Grafik Cihazı</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Genişlik</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Yükseklik</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Vblank Bölücü</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Gelişmiş</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Shader Kaydını Etkinleştir</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>NULL GPU'yu Etkinleştir</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>Yollar</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>Oyun Klasörleri</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>Ekle...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>Kaldır</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Hata Ayıklama</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Hata Ayıklama Dökümü Etkinleştir</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Vulkan Doğrulama Katmanlarını Etkinleştir</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Vulkan Senkronizasyon Doğrulamasını Etkinleştir</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>RenderDoc Hata Ayıklamayı Etkinleştir</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>Güncelle</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Başlangıçta güncellemeleri kontrol et</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>Güncelleme Kanalı</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>Güncellemeleri Kontrol Et</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>GUI Ayarları</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Disable Trophy Pop-ups</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>Başlık müziğini çal</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Update Compatibility Database On Startup</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Game Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Display Compatibility Data</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Update Compatibility Database</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>Ses seviyesi</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>Oyun Listesi</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * Desteklenmeyen Vulkan Sürümü</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>Tüm Yüklenmiş Oyunlar İçin Hileleri İndir</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>Tüm Oyunlar İçin Yamaları İndir</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>İndirme Tamamlandı</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>Yüklediğiniz tüm oyunlar için hileleri indirdiniz.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>Yamalar Başarıyla İndirildi!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>Tüm oyunlar için mevcut tüm yamalar indirildi.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>Oyunlar: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>PKG Dosyası (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>ELF Dosyaları (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>Oyun Başlatma</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>Sadece bir dosya seçilebilir!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>PKG Çıkartma</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>Yama tespit edildi!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>PKG ve oyun sürümleri uyumlu: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>Üzerine yazmak ister misiniz?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>PKG Sürümü %1, kurulu sürümden daha eski: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>Oyun yüklendi: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>Yamanın yüklenmesini ister misiniz: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>DLC Yükleme</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>DLC'yi yüklemek ister misiniz: %1?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC zaten yüklü:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>Oyun zaten yüklü</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>PKG bir yama, lütfen önce oyunu yükleyin!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>PKG HATASI</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>PKG Çıkarılıyor %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>Çıkarma Tamamlandı</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>Oyun başarıyla %1 konumuna yüklendi</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>Dosya geçerli bir PKG dosyası gibi görünmüyor</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Cheats / Patches for </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>Cheats/Patches deneysel niteliktedir.\nDikkatli kullanın.\n\nCheat'leri ayrı ayrı indirerek, depo seçerek ve indirme düğmesine tıklayarak indirin.\nPatches sekmesinde tüm patch'leri bir kerede indirebilir, hangi patch'leri kullanmak istediğinizi seçebilir ve seçiminizi kaydedebilirsiniz.\n\nCheats/Patches'i geliştirmediğimiz için,\nproblemleri cheat yazarına bildirin.\n\nYeni bir cheat mi oluşturduğunuz? Şu adresi ziyaret edin:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>Görüntü Mevcut Değil</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>Seri Numarası: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>Sürüm: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>Boyut: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>Hile Dosyasını Seçin:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>Depo:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>Hileleri İndir</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>Dosyayı Sil</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>Hiçbir dosya seçilmedi.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>İndirdikten sonra istemediğiniz hileleri silebilirsiniz.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>Seçilen dosyayı silmek istiyor musunuz?\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>Yama Dosyasını Seçin:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>Yamaları İndir</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>Kaydet</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>Hileler</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>Yamalar</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>Hata</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>Hiç yama seçilmedi.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>files.json dosyası okumak için açılamadı.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>Mevcut seri numarası için hiç yama dosyası bulunamadı.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>Dosya okumak için açılamadı.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>Dosya yazmak için açılamadı.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>XML ayrıştırılamadı: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>Başarı</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>Ayarlar başarıyla kaydedildi.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>Geçersiz Kaynak</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>Seçilen kaynak geçersiz.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>Dosya Var</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>Dosya zaten var. Üzerine yazmak ister misiniz?</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>Dosya kaydedilemedi:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>Dosya indirilemedi:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>Hileler Bulunamadı</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>Bu oyun için seçilen depoda hile bulunamadı.Başka bir depo veya oyun sürümü deneyin.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>Hileler Başarıyla İndirildi</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>Bu oyun sürümü için hileleri başarıyla indirdiniz. Başka bir depodan indirmeyi deneyebilirsiniz. Eğer mevcutsa, listeden dosyayı seçerek de kullanılabilir.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>Kaydedilemedi:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>İndirilemedi:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>İndirme Tamamlandı</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>Yamalar başarıyla indirildi! Tüm oyunlar için mevcut tüm yamalar indirildi, her oyun için ayrı ayrı indirme yapmanız gerekmez, hilelerle olduğu gibi. Yamanın görünmemesi durumunda, belirli seri numarası ve oyun sürümü için mevcut olmayabilir.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>HTML'den JSON verileri ayrıştırılamadı.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>HTML sayfası alınamadı.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>Oyun sürümde: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>İndirilen yamanın sadece sürümde çalışıyor: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>Oyunuzu güncellemeniz gerekebilir.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>Uyumsuzluk Bildirimi</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>Dosya açılamadı:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>XML HATASI:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>files.json dosyası yazmak için açılamadı</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>Yazar: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>Klasör mevcut değil:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>files.json dosyası okumak için açılamadı.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>İsim:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>Hileleri oyuna başlamadan önce uygulayamazsınız.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>Kaydet</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>Uygula</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>Varsayılanları Geri Yükle</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>Kapat</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>Seçenek üzerinde farenizi tutarak açıklamasını görüntüleyin.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Konsol Dili:\nPS4 oyununun kullandığı dili ayarlar.\nBu seçeneği, oyunun desteklediği bir dilde ayarlamanız önerilir; bu durum bölgeye göre değişebilir.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>Emülatör Dili:\nEmülatörün kullanıcı arayüzünün dilini ayarlar.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>Tam Ekranı Etkinleştir:\nOyun penceresini otomatik olarak tam ekran moduna alır.\nBu, F11 tuşuna basarak geçiş yapılabilir.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Enable Separate Update Folder:\nEnables installing game updates into a separate folder for easy management.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>Açılış Ekranını Göster:\nOyun açılırken (özel bir görüntü) açılış ekranını gösterir.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>PS4 Pro:\nEmülatörü bir PS4 PRO gibi çalıştırır; bu, bunu destekleyen oyunlarda özel özellikleri etkinleştirebilir.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>Discord Rich Presence'i etkinleştir:\nEmülatör simgesini ve Discord profilinizdeki ilgili bilgileri gösterir.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>Kullanıcı Adı:\nBazı oyunlar tarafından gösterilebilen PS4 hesabının kullanıcı adını ayarlar.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>Günlük Türü:\nPerformans için günlük penceresi çıkışını senkronize etme durumunu ayarlar. Bu, emülasyonda olumsuz etkilere yol açabilir.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Günlük Filtre:\nSadece belirli bilgileri yazdırmak için günlüğü filtreler.\nÖrnekler: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" Düzeyler: Trace, Debug, Info, Warning, Error, Critical - bu sırada, belirli bir seviye listede önceki tüm seviyeleri susturur ve sonraki tüm seviyeleri kaydeder.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>Güncelleme:\nRelease: Her ay yayınlanan resmi sürümler; çok eski olabilirler, ancak daha güvenilirdir ve test edilmiştir.\nNightly: Tüm en son özellikler ve düzeltmeler ile birlikte geliştirme sürümleri; hatalar içerebilir ve daha az kararlıdırlar.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Başlık Müziklerini Çal:\nEğer bir oyun bunu destekliyorsa, GUI'de oyunu seçtiğinizde özel müziklerin çalmasını etkinleştirir.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Disable Trophy Pop-ups:\nDisable in-game trophy notifications. Trophy progress can still be tracked using the Trophy Viewer (right-click the game in the main window).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>İmleci gizle:\nİmlecin ne zaman kaybolacağını seçin:\nAsla: Fareyi her zaman göreceksiniz.\nPasif: Hareketsiz kaldıktan sonra kaybolması için bir süre belirleyin.\nHer zaman: fareyi asla göremeyeceksiniz.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>Hareket etmeden sonra imlecin kaybolacağı süreyi ayarlayın.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>Geri düğmesi davranışı:\nKontrol cihazındaki geri düğmesini, PS4'ün dokunmatik panelindeki belirlenen noktaya dokunmak için ayarlar.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Display Compatibility Data:\nDisplays game compatibility information in table view. Enable "Update Compatibility On Startup" to get up-to-date information.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Update Compatibility On Startup:\nAutomatically update the compatibility database when shadPS4 starts.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Update Compatibility Database:\nImmediately update the compatibility database.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>Asla</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>Boşta</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>Her zaman</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>Dokunmatik Yüzey Sol</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>Dokunmatik Yüzey Sağ</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>Dokunmatik Yüzey Orta</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>Yok</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>Grafik Aygıtı:\nBirden fazla GPU'ya sahip sistemlerde, emülatörün kullanacağı GPU'yu açılır listeden seçin,\nor "Auto Select" seçeneğini seçerek otomatik olarak belirlenmesini sağlayın.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Genişlik/Yükseklik:\nEmülatör penceresinin açılışta boyutunu ayarlar; bu, oyun sırasında yeniden boyutlandırılabilir.\nBu, oyundaki çözünürlükten farklıdır.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Vblank Bölücü:\nEmülatörün yenileme hızı bu sayı ile çarpılır. Bu değerin değiştirilmesi olumsuz etkilere yol açabilir; oyun hızını artırabilir veya oyunun beklemediği kritik işlevselliği bozabilir!</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>Shader'ları Dışa Aktarmayı Etkinleştir:\nTeknik hata ayıklama amacıyla, shader'ları render edildikçe bir klasöre kaydeder.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Null GPU'yu Etkinleştir:\nTeknik hata ayıklama amacıyla, oyunun render edilmesini grafik kartı yokmuş gibi devre dışı bırakır.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>Oyun klasörleri:\nYüklenmiş oyunları kontrol etmek için klasörlerin listesi.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>Ekle:\nListeye bir klasör ekle.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>Kaldır:\nListeden bir klasörü kaldır.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>Hata Ayıklama için Dışa Aktarmayı Etkinleştir:\nŞu anda çalışan PS4 uygulaması için içe aktarılan ve dışa aktarılan sembolleri ve dosya başlık bilgilerini bir dizine kaydedin.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Vulkan Doğrulama Katmanlarını Etkinleştir:\nVulkan renderlayıcısının durumunu doğrulayan ve iç durum hakkında bilgi kaydeden bir sistemi etkinleştirir. Bu, performansı düşürür ve muhtemelen emülasyon davranışını değiştirir.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Vulkan Senkronizasyon Doğrulamasını Etkinleştir:\nVulkan renderlama görevlerinin senkronizasyonunu doğrulayan bir sistemi etkinleştirir. Bu, performansı düşürür ve muhtemelen emülasyon davranışını değiştirir.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>RenderDoc Hata Ayıklamayı Etkinleştir:\nEğer etkinleştirilirse, emülatör mevcut render edilmiş çerçeveyi yakalamak ve analiz etmek için Renderdoc ile uyumluluk sunar.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Cheats / Patches for </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>Cheats/Patches deneysel niteliktedir.\nDikkatli kullanın.\n\nCheat'leri ayrı ayrı indirerek, depo seçerek ve indirme düğmesine tıklayarak indirin.\nPatches sekmesinde tüm patch'leri bir kerede indirebilir, hangi patch'leri kullanmak istediğinizi seçebilir ve seçiminizi kaydedebilirsiniz.\n\nCheats/Patches'i geliştirmediğimiz için,\nproblemleri cheat yazarına bildirin.\n\nYeni bir cheat mi oluşturduğunuz? Şu adresi ziyaret edin:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>Görüntü Mevcut Değil</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>Seri Numarası: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>Sürüm: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>Boyut: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>Hile Dosyasını Seçin:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>Depo:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>Hileleri İndir</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>Dosyayı Sil</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>Hiçbir dosya seçilmedi.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>İndirdikten sonra istemediğiniz hileleri silebilirsiniz.</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>Seçilen dosyayı silmek istiyor musunuz?\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>Yama Dosyasını Seçin:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>Yamaları İndir</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>Kaydet</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>Hileler</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>Yamalar</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Hata</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>Hiç yama seçilmedi.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>files.json dosyası okumak için açılamadı.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>Mevcut seri numarası için hiç yama dosyası bulunamadı.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>Dosya okumak için açılamadı.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>Dosya yazmak için açılamadı.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>XML ayrıştırılamadı: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>Başarı</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>Ayarlar başarıyla kaydedildi.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>Geçersiz Kaynak</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>Seçilen kaynak geçersiz.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>Dosya Var</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>Dosya zaten var. Üzerine yazmak ister misiniz?</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>Dosya kaydedilemedi:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>Dosya indirilemedi:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>Hileler Bulunamadı</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>Bu oyun için seçilen depoda hile bulunamadı.Başka bir depo veya oyun sürümü deneyin.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>Hileler Başarıyla İndirildi</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>Bu oyun sürümü için hileleri başarıyla indirdiniz. Başka bir depodan indirmeyi deneyebilirsiniz. Eğer mevcutsa, listeden dosyayı seçerek de kullanılabilir.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>Kaydedilemedi:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>İndirilemedi:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>İndirme Tamamlandı</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>Yamalar başarıyla indirildi! Tüm oyunlar için mevcut tüm yamalar indirildi, her oyun için ayrı ayrı indirme yapmanız gerekmez, hilelerle olduğu gibi. Yamanın görünmemesi durumunda, belirli seri numarası ve oyun sürümü için mevcut olmayabilir.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>HTML'den JSON verileri ayrıştırılamadı.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>HTML sayfası alınamadı.</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>Oyun sürümde: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>İndirilen yamanın sadece sürümde çalışıyor: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>Oyunuzu güncellemeniz gerekebilir.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>Uyumsuzluk Bildirimi</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>Dosya açılamadı:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>XML HATASI:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>files.json dosyası yazmak için açılamadı</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>Yazar: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>Klasör mevcut değil:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>files.json dosyası okumak için açılamadı.</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>İsim:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>Hileleri oyuna başlamadan önce uygulayamazsınız.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>Simge</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>Ad</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>Seri Numarası</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>Bölge</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>Yazılım</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>Boyut</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>Sürüm</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>Yol</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>Oynama Süresi</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Never Played</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Compatibility is untested</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Game does not initialize properly / crashes the emulator</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Game boots, but only displays a blank screen</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Game displays an image but does not go past the menu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Game has game-breaking glitches or unplayable performance</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>Otomatik Güncelleyici</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>Hata</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>Ağ hatası:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>Güncelleme bilgilerini ayrıştırma başarısız oldu.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>Ön sürüm bulunamadı.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>Geçersiz sürüm verisi.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>Belirtilen varlık için hiçbir indirme URL'si bulunamadı.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>Versiyonunuz zaten güncel!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>Güncelleme Mevcut</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>Güncelleme Kanalı</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>Mevcut Versiyon</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>Son Versiyon</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>Güncellemek istiyor musunuz?</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>Değişiklik Günlüğünü Göster</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Başlangıçta güncellemeleri kontrol et</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>Güncelle</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>Hayır</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>Değişiklik Günlüğünü Gizle</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>Değişiklikler</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>URL'ye erişmeye çalışırken bir ağ hatası oluştu</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>İndirme Tamamlandı</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>Güncelleme indirildi, yüklemek için Tamam'a basın.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>Güncelleme dosyası kaydedilemedi</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>Güncelleme Başlatılıyor...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>Güncelleme betiği dosyası oluşturulamadı</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/uk_UA.ts
+++ b/src/qt_gui/translations/uk_UA.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>Про shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 - це експериментальний емулятор з відкритим вихідним кодом для PlayStation 4.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>Це програмне забезпечення не повинно використовуватися для запуску ігор, котрі ви отримали не легально.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Відкрити папку</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Завантажуємо список ігор, будь ласка, зачекайте :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>Відмінити</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Завантаження...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Виберіть папку</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Виберіть папку, до якої ви хочете встановити.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Виберіть папку</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Папка для встановлення ігор</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Обрати</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Помилка</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>Не коректне значення розташування для встановлення ігор.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>Створити Ярлик</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>Чити та Патчі</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>Перегляд SFO</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>Перегляд трофеїв</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>Відкрити Папку...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>Відкрити папку з грою</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>Відкрити Папку Збережених Даних</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>Відкрити Папку Логів</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>Копіювати інформацію...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>Копіювати Ім’я</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>Копіювати серійний номер</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>Копіювати все</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Видалення...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Видалити гру</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Видалити оновлення</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Видалити DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>Створення ярлика</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>Ярлик створений успішно!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>Помилка</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>Помилка при створенні ярлика!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>Встановити PKG</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Ігри</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>Ця функція потребує увімкнути опцію 'Окрема папка оновлень'. Якщо ви хочете використовувати цю функцію, будь ласка, увімкніть її.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>Ця гра не має оновлень для видалення!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Оновлення</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>Ця гра не має DLC для видалення!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Видалити %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Ви впевнені, що хочете видалити папку %1 з папки %2??</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Відкрити/Додати папку Elf</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>Встановити пакети (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Запустити гру</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>Перевити наявність оновлень</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>Про shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Налаштувати...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>Встановити додаток з файлу .pkg</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Нещодавні ігри</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Вихід</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>Вийти з shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Вийти з додатку.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Показати список ігор</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Оновити список ігор</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Крихітний</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Маленький</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Середній</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Великий</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>Список</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Сітка</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Elf</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Каталог встановлення гри</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>Завантажити Чити або Патчі</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Дамп списку ігор</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>Перегляд PKG</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Пошук...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>Файл</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>Вид</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Розмір значків списку игр</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Вид списку ігор</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Налаштування</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Утиліти</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Теми</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>Допомога</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Темна</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Світла</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Зелена</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Синя</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Фіолетова</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>Панель інструментів</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>Список ігор</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * Непідтримувана версія Vulkan</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>Завантажити чити для всіх встановлених ігор</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>Завантажити патчі для всіх ігор</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Завантаження завершено</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>Ви завантажили чити для всіх встановлених ігор.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>Патчі успішно завантажено!</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>Завантажено всі доступні патчі для всіх ігор.</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>Ігри: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>Файл PKG (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>Файл ELF (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>Запуск гри</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>Можна вибрати лише один файл!</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>Видобуток PKG</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>Виявлено патч!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>Версії PKG та гри збігаються: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>Бажаєте перезаписати?</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>Версія PKG %1 старіша за встановлену версію: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>Гра встановлена: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>Бажаєте встановити патч: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>Встановлення DLC</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>Ви бажаєте встановити DLC: %1??</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC вже встановлено:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>Гра вже встановлена</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>PKG - це патч, будь ласка, спочатку встановіть гру!</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>ПОМИЛКА PKG</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>Вилучення PKG %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>Вилучення завершено</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>Гру успішно встановлено у %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>Файл не є дійсним PKG-файлом</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Відкрити папку</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Трофеї</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Налаштування</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>Загальні</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>Система</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>Мова консолі</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Мова емулятора</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Емулятор</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Увімкнути повноекранний режим</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Увімкнути окрему папку оновлень</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Показувати заставку</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>Режим PS4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Увімкнути Discord Rich Presence</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Ім'я користувача</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Логування</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Тип логів</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Фільтр логів</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>Введення</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>Курсор миші</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>Приховати курсор</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>Тайм-аут приховування курсора при бездіяльності</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>Контролер</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>Поведінка кнопки назад</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Графіка</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Графічний пристрій</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Ширина</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Висота</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Розділювач Vblank</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Розширені</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Увімкнути дамп шейдерів</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>Увімкнути NULL GPU</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>Шляхи</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>Ігрові папки</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>Додати...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>Видалити</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Налагодження</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Увімкнути налагоджувальні дампи</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Увімкнути шари валідації Vulkan</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Увімкнути валідацію синхронізації Vulkan</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>Увімкнути налагодження RenderDoc</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>Оновлення</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Перевірка оновлень під час запуску</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>Канал оновлення</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>Перевірити оновлення</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>Інтерфейс</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Disable Trophy Pop-ups</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>Програвати заголовну музику</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Update Compatibility Database On Startup</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Game Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Display Compatibility Data</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Update Compatibility Database</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>Гучність</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>Список ігор</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * Непідтримувана версія Vulkan</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>Завантажити чити для всіх встановлених ігор</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>Завантажити патчі для всіх ігор</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>Завантаження завершено</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>Ви завантажили чити для всіх встановлених ігор.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>Патчі успішно завантажено!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>Завантажено всі доступні патчі для всіх ігор.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>Ігри: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>Файл PKG (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>Файл ELF (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>Запуск гри</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>Можна вибрати лише один файл!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>Видобуток PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>Виявлено патч!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>Версії PKG та гри збігаються: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>Бажаєте перезаписати?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>Версія PKG %1 старіша за встановлену версію: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>Гра встановлена: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>Бажаєте встановити патч: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>Встановлення DLC</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>Ви бажаєте встановити DLC: %1??</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC вже встановлено:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>Гра вже встановлена</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>PKG - це патч, будь ласка, спочатку встановіть гру!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>ПОМИЛКА PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>Вилучення PKG %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>Вилучення завершено</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>Гру успішно встановлено у %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>Файл не є дійсним PKG-файлом</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Cheats / Patches for </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>Чити та Патчі є експериментальними.\nВикористовуйте з обережністю.\n\nЗавантажуйте чити окремо, вибравши репозиторій і натиснувши кнопку завантаження.\nУ вкладці "Патчі" ви можете завантажити всі патчі відразу, вибрати, які з них ви хочете використовувати, і зберегти свій вибір.\n\nОскільки ми не займаємося розробкою читів/патчів,\nбудь ласка, повідомляйте про проблеми автору чита/патча.\n\nСтворили новий чит? Відвідайте:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>Зображення відсутнє</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>Серійний номер: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>Версія: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>Розмір: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>Виберіть файл читу:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>Репозиторій:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>Завантажити чити</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>Видалити файл</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>Файли не вибрані.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>Ви можете видалити непотрібні чити після їх завантаження.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>Ви хочете видалити вибраний файл?\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>Виберіть файл патчу:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>Завантажити патчі</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>Зберегти</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>Чити</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>Патчі</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>Помилка</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>Патч не вибрано.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>Не вдалось відкрити files.json для читання.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>Файл патча для поточного серійного номера не знайдено.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>Не вдалося відкрити файл для читання.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>Не вдалось відкрити файл для запису.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>Не вдалося розібрати XML: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>Успіх</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>Параметри успішно збережено.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>Неправильне джерело</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>Вибране джерело є недійсним.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>Файл існує</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>Файл вже існує. Ви хочете замінити його?</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>Не вдалося зберегти файл:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>Не вдалося завантажити файл:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>Читів не знайдено</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>У вибраному репозиторії не знайдено Читів для цієї гри, спробуйте інший репозиторій або іншу версію гри.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>Чити успішно завантажено</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>Ви успішно завантажили чити для цієї версії гри з обраного репозиторія. Ви можете спробувати завантажити з іншого репозиторія, якщо він буде доступним, ви також зможете скористатися ним, вибравши файл зі списку.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>Не вдалося зберегти:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>Не вдалося завантажити:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>Заватнаження завершено</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>Патчі успішно завантажено! Всі доступні патчі для усіх ігор, завантажено, немає необхідності завантажувати їх окремо для кожної гри, як це відбувається у випадку з читами. Якщо патч не з’являється, можливо, його не існує для конкретного серійного номера та версії гри. Можливо, необхідно оновити гру.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>Не вдалося розібрати JSON-дані з HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>Не вдалося отримати HTML-сторінку.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>Гра у версії: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>Завантажений патч працює лише на версії: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>Можливо, вам потрібно оновити гру.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>Повідомлення про несумісність</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>Не вдалося відкрити файл:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>ПОМИЛКА XML:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>Не вдалося відкрити files.json для запису</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>Автор: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>Каталогу не існує:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>Не вдалося відкрити files.json для читання.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>Ім'я:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>Неможливо застосовувати чити до початку гри.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>Зберегти</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>Застосувати</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>За замовчуванням</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>Закрити</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>Наведіть курсор миші на опцію, щоб відобразити її опис.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Мова консолі:\nВстановіть мову, яка буде використовуватись у іграх PS4.\nРекомендується встановити мову котра підтримується грою, оскільки вона може відрізнятися в залежності від регіону.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>Мова емулятора:\nВстановіть мову користувацького інтерфейсу емулятора.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>Повноекранний режим:\nАвтоматично переводить вікно гри у повноекранний режим.\nВи можете відключити це, натиснувши клавішу F11.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Окрема папка для оновлень:\nДає змогу встановлювати оновлення гри в окрему папку для зручності.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>Показувати заставку:\nВідображає заставку гри (спеціальне зображення) під час запуску гри.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>Режим PS4 Pro:\nЗмушує емулятор працювати як PS4 Pro, що може ввімкнути спеціальні функції в іграх, які підтримують це.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>Увімкнути Discord Rich Presence:\nВідображає значок емулятора та відповідну інформацію у вашому профілі Discord.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>Ім'я користувача:\nВстановіть ім'я користувача акаунта PS4. Це може відображатися в деяких іграх.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>Тип логів:\nВстановіть, чи синхронізувати виведення вікна логів заради продуктивності. Це може негативно вплинути на емуляцію.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Фільтр логів:\nФільтрує логи, щоб показувати тільки певну інформацію.\nПриклади: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" Рівні: Trace, Debug, Info, Warning, Error, Critical - у цьому порядку, конкретний рівень глушить усі попередні рівні у списку і показує всі наступні рівні.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>Оновлення:\nRelease: Офіційні версії, які випускаються щомісяця і можуть бути дуже старими, але вони більш надійні та перевірені.\nNightly: Версії для розробників, які мають усі найновіші функції та виправлення, але можуть містити помилки та є менш стабільними.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Грати заголовну музику:\nВмикає відтворення спеціальної музики під час вибору гри в списку, якщо вона це підтримує.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Disable Trophy Pop-ups:\nDisable in-game trophy notifications. Trophy progress can still be tracked using the Trophy Viewer (right-click the game in the main window).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>Приховувати курсор:\nВиберіть, коли курсор зникне:\nНіколи: Ви завжди будете бачити мишу.\nПри бездіяльності: Встановіть час, через який курсор зникне в разі бездіяльності.\nЗавжди: Ви ніколи не будете бачити мишу.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>Встановіть час, через який курсор зникне в разі бездіяльності.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>Поведінка кнопки «Назад»:\nНалаштовує кнопку «Назад» контролера на емуляцію натискання на зазначену область на сенсорній панелі контролера PS4.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Display Compatibility Data:\nDisplays game compatibility information in table view. Enable "Update Compatibility On Startup" to get up-to-date information.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Update Compatibility On Startup:\nAutomatically update the compatibility database when shadPS4 starts.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Update Compatibility Database:\nImmediately update the compatibility database.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>Ніколи</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>При бездіяльності</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>Завжди</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>Тачпад ліворуч</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>Тачпад праворуч</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>Тачпад по центру </translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>Ні</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>Графічний пристрій:\nУ системах із кількома GPU виберіть з випадаючого списку GPU, який буде використовувати емулятор,\nабо виберіть "Auto Select", щоб визначити його автоматично.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Ширина/Висота:\nВстановіть розмір вікна емулятора під час запуску, який може бути змінений під час гри.\nЦе відрізняється від роздільної здатності в грі.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Розділювач Vblank:\nЧастота кадрів, з якою оновлюється емулятор, множиться на це число. Зміна цього параметра може мати негативні наслідки, такі як збільшення швидкості гри або порушення критичних функцій гри, які цього не очікують!</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>Увімкнути дамп шейдерів:\nДля технічного налагодження зберігає шейдери ігор у папку під час рендерингу.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Увімкнути NULL GPU:\nДля технічного налагодження відключає рендеринг гри так, ніби графічної карти немає.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>Ігрові папки:\nСписок папок для перевірки встановлених ігор.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>Додати:\nДодати папку в список.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>Видалити:\nВидалити папку зі списку.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>Увімкнути налагоджувальні дампи:\nЗберігає символи імпорту, експорту та інформацію про заголовок файлу поточної виконуваної програми PS4 у папку.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Увімкнути шари валідації Vulkan:\nВключає систему, яка перевіряє стан рендерера Vulkan і логує інформацію про його внутрішній стан. Це знизить продуктивність і, ймовірно, змінить поведінку емуляції.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Увімкнути валідацію синхронізації Vulkan:\nВключає систему, яка перевіряє таймінг завдань рендерингу Vulkan. Це знизить продуктивність і, ймовірно, змінить поведінку емуляції.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>Увімкнути налагодження RenderDoc:\nЯкщо увімкнено, емулятор забезпечить сумісність із Renderdoc, даючи змогу захоплювати й аналізувати поточні кадри під час рендерингу.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Cheats / Patches for </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>Чити та Патчі є експериментальними.\nВикористовуйте з обережністю.\n\nЗавантажуйте чити окремо, вибравши репозиторій і натиснувши кнопку завантаження.\nУ вкладці "Патчі" ви можете завантажити всі патчі відразу, вибрати, які з них ви хочете використовувати, і зберегти свій вибір.\n\nОскільки ми не займаємося розробкою читів/патчів,\nбудь ласка, повідомляйте про проблеми автору чита/патча.\n\nСтворили новий чит? Відвідайте:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>Зображення відсутнє</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>Серійний номер: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>Версія: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>Розмір: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>Виберіть файл читу:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>Репозиторій:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>Завантажити чити</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>Видалити файл</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>Файли не вибрані.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>Ви можете видалити непотрібні чити після їх завантаження.</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>Ви хочете видалити вибраний файл?\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>Виберіть файл патчу:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>Завантажити патчі</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>Зберегти</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>Чити</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>Патчі</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Помилка</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>Патч не вибрано.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>Не вдалось відкрити files.json для читання.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>Файл патча для поточного серійного номера не знайдено.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>Не вдалося відкрити файл для читання.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>Не вдалось відкрити файл для запису.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>Не вдалося розібрати XML: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>Успіх</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>Параметри успішно збережено.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>Неправильне джерело</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>Вибране джерело є недійсним.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>Файл існує</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>Файл вже існує. Ви хочете замінити його?</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>Не вдалося зберегти файл:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>Не вдалося завантажити файл:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>Читів не знайдено</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>У вибраному репозиторії не знайдено Читів для цієї гри, спробуйте інший репозиторій або іншу версію гри.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>Чити успішно завантажено</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>Ви успішно завантажили чити для цієї версії гри з обраного репозиторія. Ви можете спробувати завантажити з іншого репозиторія, якщо він буде доступним, ви також зможете скористатися ним, вибравши файл зі списку.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>Не вдалося зберегти:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>Не вдалося завантажити:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Заватнаження завершено</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>Патчі успішно завантажено! Всі доступні патчі для усіх ігор, завантажено, немає необхідності завантажувати їх окремо для кожної гри, як це відбувається у випадку з читами. Якщо патч не з’являється, можливо, його не існує для конкретного серійного номера та версії гри. Можливо, необхідно оновити гру.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>Не вдалося розібрати JSON-дані з HTML.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>Не вдалося отримати HTML-сторінку.</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>Гра у версії: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>Завантажений патч працює лише на версії: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>Можливо, вам потрібно оновити гру.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>Повідомлення про несумісність</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>Не вдалося відкрити файл:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>ПОМИЛКА XML:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>Не вдалося відкрити files.json для запису</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>Автор: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>Каталогу не існує:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>Не вдалося відкрити files.json для читання.</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>Ім'я:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>Неможливо застосовувати чити до початку гри.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>Значок</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>Назва</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>Серійний номер</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>Регіон</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>Прошивка</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>Розмір</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>Версія</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>Шлях</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>Час у грі</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Never Played</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Compatibility is untested</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Game does not initialize properly / crashes the emulator</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Game boots, but only displays a blank screen</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Game displays an image but does not go past the menu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Game has game-breaking glitches or unplayable performance</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>Автооновлення</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>Помилка</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>Мережева помилка:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>Не вдалося розібрати інформацію про оновлення.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>Попередніх версій не знайдено.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>Неприпустимі дані релізу.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>Не знайдено URL для завантаження зазначеного ресурсу.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>Вашу версію вже оновлено!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>Доступне оновлення</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>Канал оновлення</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>Поточна версія</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>Остання версія</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>Ви хочете оновитися?</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>Показати журнал змін</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Перевірка оновлень під час запуску</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>Оновитись</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>Ні</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>Приховати журнал змін</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>Журнал змін</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>Сталася мережева помилка під час спроби доступу до URL</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>Завантаження завершено</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>Оновлення завантажено, натисніть OK для встановлення.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>Не вдалося зберегти файл оновлення в</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>Початок оновлення...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>Не вдалося створити файл скрипта оновлення</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/vi_VN.ts
+++ b/src/qt_gui/translations/vi_VN.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>About shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 is an experimental open-source emulator for the PlayStation 4.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>This software should not be used to play games you have not legally obtained.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Open Folder</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Loading game list, please wait :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>Cancel</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Loading...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Choose directory</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Select which directory you want to install to.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Choose directory</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Directory to install games</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Browse</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>The value for location to install games is not valid.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>Create Shortcut</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>Mẹo / Bản vá</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>SFO Viewer</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophy Viewer</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>Mở Thư Mục...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>Mở Thư Mục Trò Chơi</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>Mở Thư Mục Dữ Liệu Lưu</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>Mở Thư Mục Nhật Ký</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>Copy info...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>Copy Name</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>Copy Serial</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>Copy All</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Delete...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Delete Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Delete Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Delete DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>Shortcut creation</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>Shortcut created successfully!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>Error creating shortcut!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>Install PKG</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>This feature requires the 'Enable Separate Update Folder' config option to work. If you want to use this feature, please enable it.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>This game has no update to delete!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>This game has no DLC to delete!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Delete %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Are you sure you want to delete %1's %2 directory?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Open/Add Elf Folder</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>Install Packages (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Boot Game</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>Kiểm tra bản cập nhật</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>About shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Configure...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>Install application from a .pkg file</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Recent Games</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Exit</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>Exit shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Exit the application.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Show Game List</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Game List Refresh</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Tiny</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Small</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Medium</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Large</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>List View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Grid View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Elf Viewer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Game Install Directory</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>Tải Mẹo / Bản vá</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Dump Game List</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>PKG Viewer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Search...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>File</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Game List Icons</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Game List Mode</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Settings</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Utils</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Themes</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>Giúp đỡ</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Dark</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Light</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Green</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Blue</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Violet</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>toolBar</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>Danh sách trò chơi</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * Phiên bản Vulkan không được hỗ trợ</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>Tải xuống cheat cho tất cả các trò chơi đã cài đặt</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>Tải xuống bản vá cho tất cả các trò chơi</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Tải xuống hoàn tất</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>Bạn đã tải xuống cheat cho tất cả các trò chơi mà bạn đã cài đặt.</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>Bản vá đã tải xuống thành công!</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>Tất cả các bản vá có sẵn cho tất cả các trò chơi đã được tải xuống.</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>Trò chơi: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>Tệp PKG (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>Tệp ELF (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>Khởi động trò chơi</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>Chỉ có thể chọn một tệp duy nhất!</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>Giải nén PKG</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>Đã phát hiện bản vá!</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>Các phiên bản PKG và trò chơi khớp nhau: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>Bạn có muốn ghi đè không?</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>Phiên bản PKG %1 cũ hơn phiên bản đã cài đặt: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>Trò chơi đã được cài đặt: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>Bạn có muốn cài đặt bản vá: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>Cài đặt DLC</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>Bạn có muốn cài đặt DLC: %1?</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC đã được cài đặt:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>Trò chơi đã được cài đặt</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>PKG là bản vá, vui lòng cài đặt trò chơi trước!</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>LOI PKG</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>Đang giải nén PKG %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>Giải nén hoàn tất</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>Trò chơi đã được cài đặt thành công tại %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>Tệp không có vẻ là tệp PKG hợp lệ</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Open Folder</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophy Viewer</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Settings</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>General</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>System</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>Console Language</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Emulator Language</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Emulator</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Enable Fullscreen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Show Splash</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>Is PS4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>Bật Discord Rich Presence</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Username</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Logger</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Log Type</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Log Filter</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>Đầu vào</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>Con trỏ</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>Ẩn con trỏ</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>Thời gian chờ ẩn con trỏ</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>Điều khiển</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>Hành vi nút quay lại</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Graphics</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Graphics Device</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Width</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Height</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Vblank Divider</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Advanced</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Enable Shaders Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>Enable NULL GPU</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>Đường dẫn</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>Thư mục trò chơi</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>Thêm...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>Xóa</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Debug</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Enable Debug Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Enable Vulkan Validation Layers</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Enable Vulkan Synchronization Validation</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>Enable RenderDoc Debugging</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>Cập nhật</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Kiểm tra cập nhật khi khởi động</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>Kênh Cập Nhật</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>Kiểm tra cập nhật</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>Cài đặt GUI</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Disable Trophy Pop-ups</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>Phát nhạc tiêu đề</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Update Compatibility Database On Startup</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Game Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Display Compatibility Data</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Update Compatibility Database</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>Âm lượng</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>Danh sách trò chơi</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * Phiên bản Vulkan không được hỗ trợ</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>Tải xuống cheat cho tất cả các trò chơi đã cài đặt</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>Tải xuống bản vá cho tất cả các trò chơi</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>Tải xuống hoàn tất</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>Bạn đã tải xuống cheat cho tất cả các trò chơi mà bạn đã cài đặt.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>Bản vá đã tải xuống thành công!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>Tất cả các bản vá có sẵn cho tất cả các trò chơi đã được tải xuống.</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>Trò chơi: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>Tệp PKG (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>Tệp ELF (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>Khởi động trò chơi</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>Chỉ có thể chọn một tệp duy nhất!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>Giải nén PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>Đã phát hiện bản vá!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>Các phiên bản PKG và trò chơi khớp nhau: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>Bạn có muốn ghi đè không?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>Phiên bản PKG %1 cũ hơn phiên bản đã cài đặt: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>Trò chơi đã được cài đặt: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>Bạn có muốn cài đặt bản vá: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>Cài đặt DLC</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>Bạn có muốn cài đặt DLC: %1?</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC đã được cài đặt:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>Trò chơi đã được cài đặt</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>PKG là bản vá, vui lòng cài đặt trò chơi trước!</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>LOI PKG</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>Đang giải nén PKG %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>Giải nén hoàn tất</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>Trò chơi đã được cài đặt thành công tại %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>Tệp không có vẻ là tệp PKG hợp lệ</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Cheats / Patches for </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>Cheats/Patches là các tính năng thử nghiệm.\nHãy sử dụng cẩn thận.\n\nTải xuống các cheat riêng lẻ bằng cách chọn kho lưu trữ và nhấp vào nút tải xuống.\nTại tab Patches, bạn có thể tải xuống tất cả các patch cùng một lúc, chọn cái nào bạn muốn sử dụng và lưu lựa chọn của mình.\n\nVì chúng tôi không phát triển Cheats/Patches,\nxin vui lòng báo cáo các vấn đề cho tác giả cheat.\n\nBạn đã tạo ra một cheat mới? Truy cập:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>Không có hình ảnh</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>Số seri: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>Phiên bản: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>Kích thước: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>Chọn tệp Cheat:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>Kho lưu trữ:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>Tải xuống Cheat</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>Xóa tệp</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>Không có tệp nào được chọn.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>Bạn có thể xóa các cheat không muốn sau khi tải xuống.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>Bạn có muốn xóa tệp đã chọn?\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>Chọn tệp Bản vá:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>Tải xuống Bản vá</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>Lưu</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>Cheat</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>Bản vá</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>Lỗi</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>Không có bản vá nào được chọn.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>Không thể mở files.json để đọc.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>Không tìm thấy tệp bản vá cho số seri hiện tại.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>Không thể mở tệp để đọc.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>Không thể mở tệp để ghi.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>Không thể phân tích XML: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>Thành công</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>Các tùy chọn đã được lưu thành công.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>Nguồn không hợp lệ</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>Nguồn đã chọn không hợp lệ.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>Tệp đã tồn tại</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>Tệp đã tồn tại. Bạn có muốn thay thế nó không?</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>Không thể lưu tệp:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>Không thể tải xuống tệp:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>Không tìm thấy Cheat</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>Không tìm thấy Cheat cho trò chơi này trong phiên bản kho lưu trữ đã chọn,hãy thử kho lưu trữ khác hoặc phiên bản khác của trò chơi.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>Cheat đã tải xuống thành công</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>Bạn đã tải xuống các cheat thành công. Cho phiên bản trò chơi này từ kho lưu trữ đã chọn. Bạn có thể thử tải xuống từ kho lưu trữ khác, nếu có, bạn cũng có thể sử dụng bằng cách chọn tệp từ danh sách.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>Không thể lưu:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>Không thể tải xuống:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>Tải xuống hoàn tất</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>Bản vá đã tải xuống thành công! Tất cả các bản vá có sẵn cho tất cả các trò chơi đã được tải xuống, không cần tải xuống riêng lẻ cho mỗi trò chơi như trong Cheat. Nếu bản vá không xuất hiện, có thể là nó không tồn tại cho số seri và phiên bản cụ thể của trò chơi.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>Không thể phân tích dữ liệu JSON từ HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>Không thể lấy trang HTML.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>Trò chơi đang ở phiên bản: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>Patch đã tải về chỉ hoạt động trên phiên bản: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>Bạn có thể cần cập nhật trò chơi của mình.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>Thông báo không tương thích</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>Không thể mở tệp:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>LỖI XML:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>Không thể mở files.json để ghi</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>Tác giả: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>Thư mục không tồn tại:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>Không thể mở files.json để đọc.</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>Tên:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>Không thể áp dụng cheat trước khi trò chơi bắt đầu.</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>Lưu</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>Áp dụng</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>Khôi phục cài đặt mặc định</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>Đóng</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>Di chuyển chuột đến tùy chọn để hiển thị mô tả của nó.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>Ngôn ngữ console:\nChọn ngôn ngữ mà trò chơi PS4 sẽ sử dụng.\nKhuyên bạn nên đặt tùy chọn này thành một ngôn ngữ mà trò chơi hỗ trợ, có thể thay đổi tùy theo vùng.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>Ngôn ngữ của trình giả lập:\nChọn ngôn ngữ của giao diện người dùng của trình giả lập.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>Bật chế độ toàn màn hình:\nTự động đặt cửa sổ trò chơi ở chế độ toàn màn hình.\nĐiều này có thể bị vô hiệu hóa bằng cách nhấn phím F11.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Enable Separate Update Folder:\nEnables installing game updates into a separate folder for easy management.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>Hiển thị màn hình khởi động:\nHiển thị màn hình khởi động của trò chơi (một hình ảnh đặc biệt) trong khi trò chơi khởi động.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>Là PS4 Pro:\nKhiến trình giả lập hoạt động như một PS4 PRO, điều này có thể kích hoạt các tính năng đặc biệt trong các trò chơi hỗ trợ điều này.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>Bật Discord Rich Presence:\nHiển thị biểu tượng trình giả lập và thông tin liên quan trên hồ sơ Discord của bạn.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>Tên người dùng:\nChọn tên người dùng của tài khoản PS4, có thể được một số trò chơi hiển thị.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>Loại nhật ký:\nChọn xem có đồng bộ hóa đầu ra cửa sổ nhật ký cho hiệu suất hay không. Điều này có thể có tác động tiêu cực đến việc giả lập.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>Bộ lọc nhật ký:\nLọc nhật ký để in chỉ thông tin cụ thể.\nVí dụ: "Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" Các mức: Trace, Debug, Info, Warning, Error, Critical - theo thứ tự này, một mức cụ thể làm tắt tất cả các mức trước trong danh sách và ghi lại tất cả các mức sau đó.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>Cập nhật:\nRelease: Các phiên bản chính thức được phát hành hàng tháng; có thể khá cũ nhưng đáng tin cậy hơn và đã được thử nghiệm.\nNightly: Các phiên bản phát triển có tất cả các tính năng và sửa lỗi mới nhất; có thể có lỗi và ít ổn định hơn.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>Phát nhạc tiêu đề trò chơi:\nNếu một trò chơi hỗ trợ điều này, hãy kích hoạt phát nhạc đặc biệt khi bạn chọn trò chơi trong GUI.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Disable Trophy Pop-ups:\nDisable in-game trophy notifications. Trophy progress can still be tracked using the Trophy Viewer (right-click the game in the main window).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>Ẩn con trỏ:\nChọn khi nào con trỏ sẽ biến mất:\nKhông bao giờ: Bạn sẽ luôn thấy chuột.\nKhông hoạt động: Đặt một khoảng thời gian để nó biến mất sau khi không hoạt động.\nLuôn luôn: bạn sẽ không bao giờ thấy chuột.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>Đặt thời gian để chuột biến mất sau khi không hoạt động.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>Hành vi nút quay lại:\nĐặt nút quay lại của tay cầm để mô phỏng việc chạm vào vị trí đã chỉ định trên touchpad của PS4.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Display Compatibility Data:\nDisplays game compatibility information in table view. Enable "Update Compatibility On Startup" to get up-to-date information.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Update Compatibility On Startup:\nAutomatically update the compatibility database when shadPS4 starts.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Update Compatibility Database:\nImmediately update the compatibility database.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>Không bao giờ</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>Nhàn rỗi</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>Luôn luôn</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>Touchpad Trái</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>Touchpad Phải</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>Giữa Touchpad</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>Không có</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>Thiết bị đồ họa:\nTrên các hệ thống có GPU đa năng, hãy chọn GPU mà trình giả lập sẽ sử dụng từ danh sách thả xuống,\hoặc chọn "Auto Select" để tự động xác định.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>Chiều rộng/Cao:\nChọn kích thước cửa sổ của trình giả lập khi khởi động, có thể điều chỉnh trong quá trình chơi.\nĐiều này khác với độ phân giải trong trò chơi.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Bộ chia Vblank:\nTốc độ khung hình mà trình giả lập làm mới được nhân với số này. Thay đổi này có thể có tác động tiêu cực như tăng tốc độ trò chơi hoặc làm hỏng chức năng quan trọng mà trò chơi không mong đợi thay đổi điều này!</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>Bật xuất shader:\nĐể mục đích gỡ lỗi kỹ thuật, lưu shader của trò chơi vào một thư mục khi chúng được kết xuất.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>Bật GPU Null:\nĐể mục đích gỡ lỗi kỹ thuật, vô hiệu hóa việc kết xuất trò chơi như thể không có card đồ họa.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>Thư mục trò chơi:\nDanh sách các thư mục để kiểm tra các trò chơi đã cài đặt.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>Thêm:\nThêm một thư mục vào danh sách.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>Xóa:\nXóa một thư mục khỏi danh sách.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>Bật xuất gỡ lỗi:\nLưu biểu tượng nhập và xuất và thông tin tiêu đề tệp cho ứng dụng PS4 hiện đang chạy vào một thư mục.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>Bật lớp xác thực Vulkan:\nKích hoạt một hệ thống xác thực trạng thái của bộ kết xuất Vulkan và ghi lại thông tin về trạng thái nội bộ của nó. Điều này sẽ giảm hiệu suất và có thể thay đổi hành vi của việc giả lập.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>Bật xác thực đồng bộ Vulkan:\nKích hoạt một hệ thống xác thực thời gian của nhiệm vụ kết xuất Vulkan. Điều này sẽ giảm hiệu suất và có thể thay đổi hành vi của việc giả lập.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>Bật gỡ lỗi RenderDoc:\nNếu được kích hoạt, trình giả lập sẽ cung cấp tính tương thích với Renderdoc để cho phép bắt và phân tích khung hình hiện tại đang được kết xuất.</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Cheats / Patches for </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>Cheats/Patches là các tính năng thử nghiệm.\nHãy sử dụng cẩn thận.\n\nTải xuống các cheat riêng lẻ bằng cách chọn kho lưu trữ và nhấp vào nút tải xuống.\nTại tab Patches, bạn có thể tải xuống tất cả các patch cùng một lúc, chọn cái nào bạn muốn sử dụng và lưu lựa chọn của mình.\n\nVì chúng tôi không phát triển Cheats/Patches,\nxin vui lòng báo cáo các vấn đề cho tác giả cheat.\n\nBạn đã tạo ra một cheat mới? Truy cập:\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>Không có hình ảnh</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>Số seri: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>Phiên bản: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>Kích thước: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>Chọn tệp Cheat:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>Kho lưu trữ:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>Tải xuống Cheat</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>Xóa tệp</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>Không có tệp nào được chọn.</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>Bạn có thể xóa các cheat không muốn sau khi tải xuống.</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>Bạn có muốn xóa tệp đã chọn?\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>Chọn tệp Bản vá:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>Tải xuống Bản vá</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>Lưu</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>Cheat</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>Bản vá</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Lỗi</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>Không có bản vá nào được chọn.</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>Không thể mở files.json để đọc.</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>Không tìm thấy tệp bản vá cho số seri hiện tại.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>Không thể mở tệp để đọc.</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>Không thể mở tệp để ghi.</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>Không thể phân tích XML: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>Thành công</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>Các tùy chọn đã được lưu thành công.</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>Nguồn không hợp lệ</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>Nguồn đã chọn không hợp lệ.</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>Tệp đã tồn tại</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>Tệp đã tồn tại. Bạn có muốn thay thế nó không?</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>Không thể lưu tệp:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>Không thể tải xuống tệp:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>Không tìm thấy Cheat</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>Không tìm thấy Cheat cho trò chơi này trong phiên bản kho lưu trữ đã chọn,hãy thử kho lưu trữ khác hoặc phiên bản khác của trò chơi.</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>Cheat đã tải xuống thành công</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>Bạn đã tải xuống các cheat thành công. Cho phiên bản trò chơi này từ kho lưu trữ đã chọn. Bạn có thể thử tải xuống từ kho lưu trữ khác, nếu có, bạn cũng có thể sử dụng bằng cách chọn tệp từ danh sách.</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>Không thể lưu:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>Không thể tải xuống:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>Tải xuống hoàn tất</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>Bản vá đã tải xuống thành công! Tất cả các bản vá có sẵn cho tất cả các trò chơi đã được tải xuống, không cần tải xuống riêng lẻ cho mỗi trò chơi như trong Cheat. Nếu bản vá không xuất hiện, có thể là nó không tồn tại cho số seri và phiên bản cụ thể của trò chơi.</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>Không thể phân tích dữ liệu JSON từ HTML.</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>Không thể lấy trang HTML.</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>Trò chơi đang ở phiên bản: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>Patch đã tải về chỉ hoạt động trên phiên bản: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>Bạn có thể cần cập nhật trò chơi của mình.</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>Thông báo không tương thích</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>Không thể mở tệp:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>LỖI XML:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>Không thể mở files.json để ghi</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>Tác giả: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>Thư mục không tồn tại:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>Không thể mở files.json để đọc.</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>Tên:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>Không thể áp dụng cheat trước khi trò chơi bắt đầu.</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>Biểu tượng</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>Tên</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>Số seri</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>Khu vực</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>Phần mềm</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>Kích thước</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>Phiên bản</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>Đường dẫn</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>Thời gian chơi</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Never Played</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Compatibility is untested</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Game does not initialize properly / crashes the emulator</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Game boots, but only displays a blank screen</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Game displays an image but does not go past the menu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Game has game-breaking glitches or unplayable performance</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>Trình cập nhật tự động</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>Lỗi</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>Lỗi mạng:</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>Không thể phân tích thông tin cập nhật.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>Không tìm thấy bản phát hành trước.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>Dữ liệu bản phát hành không hợp lệ.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>Không tìm thấy URL tải xuống cho tài sản đã chỉ định.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>Phiên bản của bạn đã được cập nhật!</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>Có bản cập nhật</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>Kênh Cập Nhật</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>Phiên bản hiện tại</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>Phiên bản mới nhất</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>Bạn có muốn cập nhật không?</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>Hiện nhật ký thay đổi</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>Kiểm tra cập nhật khi khởi động</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>Cập nhật</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>Không</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>Ẩn nhật ký thay đổi</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>Thay đổi</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>Xảy ra lỗi mạng khi cố gắng truy cập URL</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>Tải xuống hoàn tất</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>Bản cập nhật đã được tải xuống, nhấn OK để cài đặt.</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>Không thể lưu tệp cập nhật tại</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>Đang bắt đầu cập nhật...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>Không thể tạo tệp kịch bản cập nhật</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/zh_CN.ts
+++ b/src/qt_gui/translations/zh_CN.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>关于 shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 是一款实验性质的开源 PlayStation 4 模拟器软件。</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>本软件不得用于运行未经合法授权而获得的游戏。</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>打开文件夹</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>加载游戏列表中, 请稍等 :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>取消</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>加载中...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - 选择文件目录</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>选择你想要安装到的目录。</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - 选择文件目录</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>要安装游戏的目录</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>浏览</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>错误</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>游戏安装位置无效。</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>创建快捷方式</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>作弊码/补丁</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>SFO 查看器</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>奖杯查看器</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>打开文件夹...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>打开游戏文件夹</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>打开存档数据文件夹</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>打开日志文件夹</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>复制信息...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>复制名称</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>复制序列号</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>复制全部</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>删除...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>删除游戏</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>删除更新</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>删除 DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>兼容性...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>更新数据库</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>查看报告</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>提交报告</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>创建快捷方式</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>创建快捷方式成功！</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>错误</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>创建快捷方式出错！</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>安装 PKG</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>游戏</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>这个功能需要“启用单独的更新目录”配置选项才能正常运行，如果你想要使用这个功能，请启用它。</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>这个游戏没有更新可以删除！</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>更新</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>这个游戏没有 DLC 可以删除！</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>删除 %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>你确定要删除 %1 的%2目录？</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>打开/添加 Elf 文件夹</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>安装 Packages (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>启动游戏</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>检查更新</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>关于 shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>设置...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>从 .pkg 文件安装应用程序</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>最近启动的游戏</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>退出</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>退出 shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>退出应用程序。</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>显示游戏列表</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>刷新游戏列表</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>微小</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>小</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>中</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>大</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>列表视图</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>表格视图</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Elf 查看器</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>游戏安装目录</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>下载作弊码/补丁</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>导出游戏列表</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>PKG 查看器</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>搜索...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>文件</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>显示</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>游戏列表图标</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>游戏列表模式</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>设置</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>工具</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>主题</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>帮助</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Dark</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Light</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Green</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Blue</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Violet</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>工具栏</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>游戏列表</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * 不支持的 Vulkan 版本</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>下载所有已安装游戏的作弊码</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>下载所有游戏的补丁</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>下载完成</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>您已下载了所有已安装游戏的作弊码。</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>补丁下载成功！</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>所有游戏的可用补丁都已下载。</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>游戏：</translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>PKG 文件 (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>ELF 文件 (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>启动游戏</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>只能选择一个文件！</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>PKG 解压</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>检测到补丁！</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>PKG 和游戏版本匹配：</translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>您想要覆盖吗？</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>PKG 版本 %1 比已安装版本更旧：</translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>游戏已安装：</translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>您想安装补丁吗：</translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>DLC 安装</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>您想安装 DLC：%1 吗？</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC 已经安装：</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>游戏已经安装</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>PKG 是一个补丁，请先安装游戏！</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>PKG 错误</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>正在解压 PKG %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>解压完成</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>游戏成功安装在 %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>文件似乎不是有效的 PKG 文件</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>打开文件夹</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>奖杯查看器</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>设置</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>常规</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>系统</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>主机语言</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>模拟器语言</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>模拟器</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>启用全屏</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>启用单独的更新目录</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>显示启动画面</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>模拟 PS4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>启用 Discord Rich Presence</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>用户名</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>日志</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>日志类型</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>日志过滤</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>输入</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>光标</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>隐藏光标</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>光标隐藏闲置时长</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>秒</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>手柄</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>返回按钮行为</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>图像</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>图形设备</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>宽度</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>高度</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Vblank Divider</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>高级</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>启用着色器转储</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>启用 NULL GPU</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>路径</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>游戏文件夹</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>添加...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>删除</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>调试</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>启用调试转储</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>启用 Vulkan 验证层</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>启用 Vulkan 同步验证</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>启用 RenderDoc 调试</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>更新</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>启动时检查更新</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>更新频道</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>检查更新</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>界面设置</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>禁止弹出奖杯</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>播放标题音乐</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>启动时更新兼容性数据库</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>游戏兼容性</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>显示兼容性数据</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>更新兼容性数据库</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>音量</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>音频后端</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>游戏列表</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * 不支持的 Vulkan 版本</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>下载所有已安装游戏的作弊码</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>下载所有游戏的补丁</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>下载完成</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>您已下载了所有已安装游戏的作弊码。</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>补丁下载成功！</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>所有游戏的可用补丁都已下载。</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>游戏：</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>PKG 文件 (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>ELF 文件 (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>启动游戏</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>只能选择一个文件！</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>PKG 解压</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>检测到补丁！</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>PKG 和游戏版本匹配：</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>您想要覆盖吗？</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>PKG 版本 %1 比已安装版本更旧：</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>游戏已安装：</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>您想安装补丁吗：</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>DLC 安装</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>您想安装 DLC：%1 吗？</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC 已经安装：</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>游戏已经安装</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>PKG 是一个补丁，请先安装游戏！</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>PKG 错误</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>正在解压 PKG %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>解压完成</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>游戏成功安装在 %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>文件似乎不是有效的 PKG 文件</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>作弊码/补丁：</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>作弊码/补丁是实验性的。\n请小心使用。\n\n通过选择存储库并点击下载按钮，下载该游戏的作弊码。\n在“补丁”选项卡中，您可以一次性下载所有补丁，选择要使用的补丁并保存选择。\n\n由于我们不开发作弊码/补丁，\n请将问题报告给作弊码/补丁的作者。\n\n创建了新的作弊码/补丁？欢迎提交到我们的仓库：\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>没有可用的图片</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>序列号：</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>版本：</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>大小：</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>选择作弊码文件：</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>存储库：</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>下载作弊码</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>删除文件</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>没有选择文件。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>您可以在下载后删除不想要的作弊码。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>您要删除选中的文件吗？\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>选择补丁文件：</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>下载补丁</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>保存</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>作弊码</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>补丁</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>错误</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>没有选择补丁。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>无法打开 files.json 进行读取。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>未找到当前序列号的补丁文件。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>无法打开文件进行读取。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>无法打开文件进行写入。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>解析 XML 失败：</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>成功</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>选项已成功保存。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>无效的来源</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>选择的来源无效。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>文件已存在</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>文件已存在，您要替换它吗？</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>保存文件失败：</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>下载文件失败：</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>未找到作弊码</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>在所选存储库的版本中找不到该游戏的作弊码，请尝试其他存储库或游戏版本。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>作弊码下载成功</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>您已从所选存储库中成功下载了该游戏版本的作弊码。您还可以尝试从其他存储库下载，或通过从列表中选择文件来使用它们。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>保存失败：</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>下载失败：</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>下载完成</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>补丁下载成功！所有可用的补丁已下载完成，无需像作弊码那样单独下载每个游戏的补丁。如果补丁没有出现，可能是该补丁不适用于当前游戏的序列号和版本。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>无法解析 HTML 中的 JSON 数据。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>无法获取 HTML 页面。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>游戏版本：%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>下载的补丁仅适用于版本：%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>您可能需要更新您的游戏。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>不兼容通知</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>无法打开文件：</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>XML 错误：</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>无法打开 files.json 进行写入</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>作者：</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>目录不存在：</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>无法打开 files.json 进行读取。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>名称：</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>在游戏启动之前无法应用作弊码。</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>保存</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>应用</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>恢复默认</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>关闭</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>将鼠标指针指向选项以显示其描述。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>主机语言：\n设置 PS4 游戏中使用的语言。\n建议设置为支持的语言，这将因地区而异。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>模拟器语言：\n设置模拟器用户界面的语言。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>启用全屏：\n以全屏模式启动游戏。\n您可以按 F11 键切换回窗口模式。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>启用单独的更新目录：\n启用安装游戏更新到一个单独的目录中以更便于管理。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>显示启动画面：\n在游戏启动时显示游戏的启动画面（特殊图像）。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>模拟 PS4 Pro:\n使模拟器作为 PS4 Pro 运行，可以在支持的游戏中激活特殊功能。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>启用 Discord Rich Presence：\n在您的 Discord 个人资料上显示模拟器图标和相关信息。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>用户名：\n设置 PS4 帐户的用户名，某些游戏中可能会显示此名称。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>日志类型：\n设置日志窗口输出的同步方式以提高性能。可能会对模拟产生不良影响。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>日志过滤器：\n过滤日志，仅打印特定信息。\n例如："Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" 级别: Trace, Debug, Info, Warning, Error, Critical - 按此顺序，特定级别将静默列表中所有先前的级别，并记录所有后续级别。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>更新：\nRelease：每月发布的官方版本可能非常过时，但更可靠且经过测试。\nNightly：包含所有最新功能和修复的开发版本，但可能包含错误且稳定性较低。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>播放标题音乐：\n如果游戏支持，在图形界面选择游戏时播放特殊音乐。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>禁止弹出奖杯：\n禁用游戏内奖杯通知。可以在奖杯查看器中继续跟踪奖杯进度（在主窗口中右键点击游戏）。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>隐藏光标：\n选择光标何时消失:\n从不: 始终显示光标。\闲置: 光标在闲置若干秒后消失。\n始终: 始终显示光标。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>光标隐藏闲置时长：\n光标自动隐藏之前的闲置时长。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>返回按钮行为：\n设置手柄的返回按钮模拟在 PS4 触控板上指定位置的点击。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>显示兼容性数据：\n在列表视图中显示游戏兼容性信息。启用“启动时更新兼容性数据库”以获取最新信息。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>启动时更新兼容性数据库：\n当 shadPS4 启动时自动更新兼容性数据库。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>更新兼容性数据库：\n立即更新兼容性数据库。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>从不</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>闲置</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>始终</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>触控板左侧</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>触控板右侧</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>触控板中间</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>无</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>图形设备：\n在具有多个 GPU 的系统中，从下拉列表中选择要使用的 GPU，\n或者选择“自动选择”由模拟器决定。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>宽度/高度：\n设置启动游戏时的窗口大小，游戏过程中可以调整。\n这与游戏内的分辨率不同。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Vblank Divider：\n模拟器刷新的帧率会乘以此数字。改变此项可能会导致游戏速度加快，或破坏游戏中不期望此变化的关键功能！</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>启用着色器转储：\n用于技术调试，在渲染期间将游戏着色器保存到文件夹中。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>启用 NULL GPU：\n用于技术调试，禁用游戏渲染，就像没有显卡一样。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>游戏文件夹：\n检查已安装游戏的文件夹列表。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>添加：\n将文件夹添加到列表。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>移除：\n从列表中移除文件夹。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>启用调试转储：\n将当前正在运行的 PS4 程序的导入和导出符号及文件头信息保存到目录中。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>启用 Vulkan 验证层：\n启用一个系统来验证 Vulkan 渲染器的状态并记录其内部状态的信息。\n这将降低性能并可能改变模拟的行为。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>启用 Vulkan 同步验证：\n启用一个系统来验证 Vulkan 渲染任务的时间。\n这将降低性能并可能改变模拟的行为。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>启用 RenderDoc 调试:\n启用后模拟器将提供与 Renderdoc 的兼容性，允许在渲染过程中捕获和分析当前渲染的帧。</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>作弊码/补丁：</translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>作弊码/补丁是实验性的。\n请小心使用。\n\n通过选择存储库并点击下载按钮，下载该游戏的作弊码。\n在“补丁”选项卡中，您可以一次性下载所有补丁，选择要使用的补丁并保存选择。\n\n由于我们不开发作弊码/补丁，\n请将问题报告给作弊码/补丁的作者。\n\n创建了新的作弊码/补丁？欢迎提交到我们的仓库：\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>没有可用的图片</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>序列号：</translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>版本：</translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>大小：</translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>选择作弊码文件：</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>存储库：</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>下载作弊码</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>删除文件</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>没有选择文件。</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>您可以在下载后删除不想要的作弊码。</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>您要删除选中的文件吗？\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>选择补丁文件：</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>下载补丁</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>保存</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>作弊码</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>补丁</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>错误</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>没有选择补丁。</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>无法打开 files.json 进行读取。</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>未找到当前序列号的补丁文件。</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>无法打开文件进行读取。</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>无法打开文件进行写入。</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>解析 XML 失败：</translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>成功</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>选项已成功保存。</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>无效的来源</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>选择的来源无效。</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>文件已存在</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>文件已存在，您要替换它吗？</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>保存文件失败：</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>下载文件失败：</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>未找到作弊码</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>在所选存储库的版本中找不到该游戏的作弊码，请尝试其他存储库或游戏版本。</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>作弊码下载成功</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>您已从所选存储库中成功下载了该游戏版本的作弊码。您还可以尝试从其他存储库下载，或通过从列表中选择文件来使用它们。</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>保存失败：</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>下载失败：</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>下载完成</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>补丁下载成功！所有可用的补丁已下载完成，无需像作弊码那样单独下载每个游戏的补丁。如果补丁没有出现，可能是该补丁不适用于当前游戏的序列号和版本。</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>无法解析 HTML 中的 JSON 数据。</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>无法获取 HTML 页面。</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>游戏版本：%1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>下载的补丁仅适用于版本：%1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>您可能需要更新您的游戏。</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>不兼容通知</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>无法打开文件：</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>XML 错误：</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>无法打开 files.json 进行写入</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>作者：</translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>目录不存在：</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>无法打开 files.json 进行读取。</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>名称：</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>在游戏启动之前无法应用作弊码。</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>图标</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>名称</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>序列号</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>兼容性</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>区域</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>固件</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>大小</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>版本</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>路径</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>游戏时间</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>未玩过</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>小时</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>分钟</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>秒</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>兼容性未经测试</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>游戏无法正确初始化/模拟器崩溃</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>游戏启动，但只显示白屏</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>游戏显示图像但无法通过菜单页面</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>游戏有严重的 Bug 或太卡无法游玩</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>游戏能在可玩的性能下完成且没有重大 Bug</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>自动更新程序</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>错误</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>网络错误：</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>无法解析更新信息。</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>未找到预发布版本。</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>无效的发布数据。</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>未找到指定资源的下载地址。</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>您的版本已经是最新的！</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>可用更新</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>更新频道</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>当前版本</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>最新版本</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>您想要更新吗？</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>显示更新日志</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>启动时检查更新</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>更新</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>否</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>隐藏更新日志</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>更新日志</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>尝试访问网址时发生网络错误</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>下载完成</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>更新已下载，请按 OK 安装。</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>无法保存更新文件到</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>正在开始更新...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>无法创建更新脚本文件</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/zh_TW.ts
+++ b/src/qt_gui/translations/zh_TW.ts
@@ -6,22 +6,18 @@
 	<context>
 		<name>AboutDialog</name>
 		<message>
-			<location filename="../about_dialog.ui" line="16"/>
 			<source>About shadPS4</source>
 			<translation>About shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="60"/>
 			<source>shadPS4</source>
 			<translation>shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="78"/>
 			<source>shadPS4 is an experimental open-source emulator for the PlayStation 4.</source>
 			<translation>shadPS4 is an experimental open-source emulator for the PlayStation 4.</translation>
 		</message>
 		<message>
-			<location filename="../about_dialog.ui" line="99"/>
 			<source>This software should not be used to play games you have not legally obtained.</source>
 			<translation>This software should not be used to play games you have not legally obtained.</translation>
 		</message>
@@ -29,7 +25,6 @@
 	<context>
 		<name>ElfViewer</name>
 		<message>
-			<location filename="../elf_viewer.cpp" line="45"/>
 			<source>Open Folder</source>
 			<translation>Open Folder</translation>
 		</message>
@@ -37,17 +32,14 @@
 	<context>
 		<name>GameInfoClass</name>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Loading game list, please wait :3</source>
 			<translation>Loading game list, please wait :3</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="26"/>
 			<source>Cancel</source>
 			<translation>Cancel</translation>
 		</message>
 		<message>
-			<location filename="../game_info.cpp" line="27"/>
 			<source>Loading...</source>
 			<translation>Loading...</translation>
 		</message>
@@ -55,12 +47,10 @@
 	<context>
 		<name>InstallDirSelect</name>
 		<message>
-			<location filename="../install_dir_select.cpp" line="30"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Choose directory</translation>
 		</message>
 		<message>
-			<location filename="../install_dir_select.cpp" line="37"/>
 			<source>Select which directory you want to install to.</source>
 			<translation>Select which directory you want to install to.</translation>
 		</message>
@@ -68,27 +58,22 @@
 	<context>
 		<name>GameInstallDialog</name>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="24"/>
 			<source>shadPS4 - Choose directory</source>
 			<translation>shadPS4 - Choose directory</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="31"/>
 			<source>Directory to install games</source>
 			<translation>Directory to install games</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="50"/>
 			<source>Browse</source>
 			<translation>Browse</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="74"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../game_install_dialog.cpp" line="75"/>
 			<source>The value for location to install games is not valid.</source>
 			<translation>The value for location to install games is not valid.</translation>
 		</message>
@@ -96,167 +81,134 @@
 	<context>
 		<name>GuiContextMenus</name>
 		<message>
-			<location filename="../gui_context_menus.h" line="46"/>
 			<source>Create Shortcut</source>
 			<translation>Create Shortcut</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="48"/>
 			<source>Cheats / Patches</source>
 			<translation>Zuòbì / Xiūbǔ chéngshì</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>SFO Viewer</source>
 			<translation>SFO Viewer</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophy Viewer</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="49"/>
 			<source>Open Folder...</source>
 			<translation>打開資料夾...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="50"/>
 			<source>Open Game Folder</source>
 			<translation>打開遊戲資料夾</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="51"/>
 			<source>Open Save Data Folder</source>
 			<translation>打開存檔資料夾</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="52"/>
 			<source>Open Log Folder</source>
 			<translation>打開日誌資料夾</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="59"/>
 			<source>Copy info...</source>
 			<translation>Copy info...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="60"/>
 			<source>Copy Name</source>
 			<translation>Copy Name</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="61"/>
 			<source>Copy Serial</source>
 			<translation>Copy Serial</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="62"/>
 			<source>Copy All</source>
 			<translation>Copy All</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="72"/>
 			<source>Delete...</source>
 			<translation>Delete...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="73"/>
 			<source>Delete Game</source>
 			<translation>Delete Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="74"/>
 			<source>Delete Update</source>
 			<translation>Delete Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="75"/>
 			<source>Delete DLC</source>
 			<translation>Delete DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="99"/>
 			<source>Compatibility...</source>
 			<translation>Compatibility...</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="100"/>
 			<source>Update database</source>
 			<translation>Update database</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="101"/>
 			<source>View report</source>
 			<translation>View report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="102"/>
 			<source>Submit a report</source>
 			<translation>Submit a report</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="195"/>
 			<source>Shortcut creation</source>
 			<translation>Shortcut creation</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="196"/>
 			<source>Shortcut created successfully!</source>
 			<translation>Shortcut created successfully!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="199"/>
 			<source>Error</source>
 			<translation>Error</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="200"/>
 			<source>Error creating shortcut!</source>
 			<translation>Error creating shortcut!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="275"/>
 			<source>Install PKG</source>
 			<translation>Install PKG</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="299"/>
 			<source>Game</source>
 			<translation>Game</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="305"/>
 			<source>requiresEnableSeparateUpdateFolder_MSG</source>
 			<translation>This feature requires the 'Enable Separate Update Folder' config option to work. If you want to use this feature, please enable it.</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="312"/>
 			<source>This game has no update to delete!</source>
 			<translation>This game has no update to delete!</translation>
 		</message>
-			<message>
-			<location filename="../gui_context_menus.h" line="316"/>
+		<message>
 			<source>Update</source>
 			<translation>Update</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="321"/>
 			<source>This game has no DLC to delete!</source>
 			<translation>This game has no DLC to delete!</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="325"/>
 			<source>DLC</source>
 			<translation>DLC</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="332"/>
 			<source>Delete %1</source>
 			<translation>Delete %1</translation>
 		</message>
 		<message>
-			<location filename="../gui_context_menus.h" line="333"/>
 			<source>Are you sure you want to delete %1's %2 directory?</source>
 			<translation>Are you sure you want to delete %1's %2 directory?</translation>
 		</message>
@@ -264,205 +216,285 @@
 	<context>
 		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window_ui.h" line="310"/>
 			<source>Open/Add Elf Folder</source>
 			<translation>Open/Add Elf Folder</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="312"/>
 			<source>Install Packages (PKG)</source>
 			<translation>Install Packages (PKG)</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="313"/>
 			<source>Boot Game</source>
 			<translation>Boot Game</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="308"/>
 			<source>Check for Updates</source>
 			<translation>檢查更新</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="314"/>
 			<source>About shadPS4</source>
 			<translation>About shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="315"/>
 			<source>Configure...</source>
 			<translation>Configure...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="318"/>
 			<source>Install application from a .pkg file</source>
 			<translation>Install application from a .pkg file</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="320"/>
 			<source>Recent Games</source>
 			<translation>Recent Games</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="321"/>
 			<source>Exit</source>
 			<translation>Exit</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="323"/>
 			<source>Exit shadPS4</source>
 			<translation>Exit shadPS4</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="327"/>
 			<source>Exit the application.</source>
 			<translation>Exit the application.</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="330"/>
 			<source>Show Game List</source>
 			<translation>Show Game List</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="332"/>
 			<source>Game List Refresh</source>
 			<translation>Game List Refresh</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="333"/>
 			<source>Tiny</source>
 			<translation>Tiny</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="334"/>
 			<source>Small</source>
 			<translation>Small</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="335"/>
 			<source>Medium</source>
 			<translation>Medium</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="336"/>
 			<source>Large</source>
 			<translation>Large</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="338"/>
 			<source>List View</source>
 			<translation>List View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="340"/>
 			<source>Grid View</source>
 			<translation>Grid View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="341"/>
 			<source>Elf Viewer</source>
 			<translation>Elf Viewer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Game Install Directory</source>
 			<translation>Game Install Directory</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="343"/>
 			<source>Download Cheats/Patches</source>
 			<translation>Xiàzài Zuòbì / Xiūbǔ chéngshì</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="345"/>
 			<source>Dump Game List</source>
 			<translation>Dump Game List</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="346"/>
 			<source>PKG Viewer</source>
 			<translation>PKG Viewer</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="348"/>
 			<source>Search...</source>
 			<translation>Search...</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="349"/>
 			<source>File</source>
 			<translation>File</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="350"/>
 			<source>View</source>
 			<translation>View</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="352"/>
 			<source>Game List Icons</source>
 			<translation>Game List Icons</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="354"/>
 			<source>Game List Mode</source>
 			<translation>Game List Mode</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="355"/>
 			<source>Settings</source>
 			<translation>Settings</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="356"/>
 			<source>Utils</source>
 			<translation>Utils</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="357"/>
 			<source>Themes</source>
 			<translation>Themes</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="358"/>
 			<source>Help</source>
 			<translation>幫助</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="359"/>
 			<source>Dark</source>
 			<translation>Dark</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="360"/>
 			<source>Light</source>
 			<translation>Light</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="361"/>
 			<source>Green</source>
 			<translation>Green</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="362"/>
 			<source>Blue</source>
 			<translation>Blue</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="363"/>
 			<source>Violet</source>
 			<translation>Violet</translation>
 		</message>
 		<message>
-			<location filename="../main_window_ui.h" line="364"/>
 			<source>toolBar</source>
 			<translation>toolBar</translation>
+		</message>
+		<message>
+			<source>Game List</source>
+			<translation>遊戲列表</translation>
+		</message>
+		<message>
+			<source> * Unsupported Vulkan Version</source>
+			<translation> * 不支援的 Vulkan 版本</translation>
+		</message>
+		<message>
+			<source>Download Cheats For All Installed Games</source>
+			<translation>下載所有已安裝遊戲的作弊碼</translation>
+		</message>
+		<message>
+			<source>Download Patches For All Games</source>
+			<translation>下載所有遊戲的修補檔</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>下載完成</translation>
+		</message>
+		<message>
+			<source>You have downloaded cheats for all the games you have installed.</source>
+			<translation>您已經下載了所有已安裝遊戲的作弊碼。</translation>
+		</message>
+		<message>
+			<source>Patches Downloaded Successfully!</source>
+			<translation>修補檔下載成功！</translation>
+		</message>
+		<message>
+			<source>All Patches available for all games have been downloaded.</source>
+			<translation>所有遊戲的修補檔已經下載完成。</translation>
+		</message>
+		<message>
+			<source>Games: </source>
+			<translation>遊戲: </translation>
+		</message>
+		<message>
+			<source>PKG File (*.PKG)</source>
+			<translation>PKG 檔案 (*.PKG)</translation>
+		</message>
+		<message>
+			<source>ELF files (*.bin *.elf *.oelf)</source>
+			<translation>ELF 檔案 (*.bin *.elf *.oelf)</translation>
+		</message>
+		<message>
+			<source>Game Boot</source>
+			<translation>遊戲啟動</translation>
+		</message>
+		<message>
+			<source>Only one file can be selected!</source>
+			<translation>只能選擇一個檔案！</translation>
+		</message>
+		<message>
+			<source>PKG Extraction</source>
+			<translation>PKG 解壓縮</translation>
+		</message>
+		<message>
+			<source>Patch detected!</source>
+			<translation>檢測到補丁！</translation>
+		</message>
+		<message>
+			<source>PKG and Game versions match: </source>
+			<translation>PKG 和遊戲版本匹配: </translation>
+		</message>
+		<message>
+			<source>Would you like to overwrite?</source>
+			<translation>您想要覆蓋嗎？</translation>
+		</message>
+		<message>
+			<source>PKG Version %1 is older than installed version: </source>
+			<translation>PKG 版本 %1 比已安裝版本更舊: </translation>
+		</message>
+		<message>
+			<source>Game is installed: </source>
+			<translation>遊戲已安裝: </translation>
+		</message>
+		<message>
+			<source>Would you like to install Patch: </source>
+			<translation>您想要安裝補丁嗎: </translation>
+		</message>
+		<message>
+			<source>DLC Installation</source>
+			<translation>DLC 安裝</translation>
+		</message>
+		<message>
+			<source>Would you like to install DLC: %1?</source>
+			<translation>您想要安裝 DLC: %1 嗎？</translation>
+		</message>
+		<message>
+			<source>DLC already installed:</source>
+			<translation>DLC 已經安裝:</translation>
+		</message>
+		<message>
+			<source>Game already installed</source>
+			<translation>遊戲已經安裝</translation>
+		</message>
+		<message>
+			<source>PKG is a patch, please install the game first!</source>
+			<translation>PKG 是修補檔，請先安裝遊戲！</translation>
+		</message>
+		<message>
+			<source>PKG ERROR</source>
+			<translation>PKG 錯誤</translation>
+		</message>
+		<message>
+			<source>Extracting PKG %1/%2</source>
+			<translation>正在解壓縮 PKG %1/%2</translation>
+		</message>
+		<message>
+			<source>Extraction Finished</source>
+			<translation>解壓縮完成</translation>
+		</message>
+		<message>
+			<source>Game successfully installed at %1</source>
+			<translation>遊戲成功安裝於 %1</translation>
+		</message>
+		<message>
+			<source>File doesn't appear to be a valid PKG file</source>
+			<translation>檔案似乎不是有效的 PKG 檔案</translation>
 		</message>
 	</context>
 	<context>
 		<name>PKGViewer</name>
 		<message>
-			<location filename="../pkg_viewer.cpp" line="32"/>
 			<source>Open Folder</source>
 			<translation>Open Folder</translation>
 		</message>
@@ -470,7 +502,6 @@
 	<context>
 		<name>TrophyViewer</name>
 		<message>
-			<location filename="../trophy_viewer.cpp" line="8"/>
 			<source>Trophy Viewer</source>
 			<translation>Trophy Viewer</translation>
 		</message>
@@ -478,1029 +509,700 @@
 	<context>
 		<name>SettingsDialog</name>
 		<message>
-			<location filename="../settings_dialog.ui" line="29"/>
 			<source>Settings</source>
 			<translation>Settings</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="67"/>
 			<source>General</source>
 			<translation>General</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="77"/>
 			<source>System</source>
 			<translation>System</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="83"/>
 			<source>Console Language</source>
 			<translation>Console Language</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="95"/>
 			<source>Emulator Language</source>
 			<translation>Emulator Language</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="114"/>
 			<source>Emulator</source>
 			<translation>Emulator</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="122"/>
 			<source>Enable Fullscreen</source>
 			<translation>Enable Fullscreen</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="140"/>
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="129"/>
 			<source>Show Splash</source>
 			<translation>Show Splash</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="136"/>
 			<source>Is PS4 Pro</source>
 			<translation>Is PS4 Pro</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="154"/>
 			<source>Enable Discord Rich Presence</source>
 			<translation>啟用 Discord Rich Presence</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="155"/>
 			<source>Username</source>
 			<translation>Username</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy Key</source>
 			<translation>Trophy Key</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Trophy</source>
 			<translation>Trophy</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="178"/>
 			<source>Logger</source>
 			<translation>Logger</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="199"/>
 			<source>Log Type</source>
 			<translation>Log Type</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="235"/>
 			<source>Log Filter</source>
 			<translation>Log Filter</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="595"/>
 			<source>Input</source>
 			<translation>輸入</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="611"/>
 			<source>Cursor</source>
 			<translation>游標</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="635"/>
 			<source>Hide Cursor</source>
 			<translation>隱藏游標</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="668"/>
 			<source>Hide Cursor Idle Timeout</source>
 			<translation>游標空閒超時隱藏</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="816"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="767"/>
 			<source>Controller</source>
 			<translation>控制器</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="797"/>
 			<source>Back Button Behavior</source>
 			<translation>返回按鈕行為</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="272"/>
 			<source>Graphics</source>
 			<translation>Graphics</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="282"/>
 			<source>Graphics Device</source>
 			<translation>Graphics Device</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="326"/>
 			<source>Width</source>
 			<translation>Width</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="357"/>
 			<source>Height</source>
 			<translation>Height</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="405"/>
 			<source>Vblank Divider</source>
 			<translation>Vblank Divider</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="453"/>
 			<source>Advanced</source>
 			<translation>Advanced</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="462"/>
 			<source>Enable Shaders Dumping</source>
 			<translation>Enable Shaders Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="469"/>
 			<source>Enable NULL GPU</source>
 			<translation>Enable NULL GPU</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1111"/>
 			<source>Paths</source>
 			<translation>路徑</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1119"/>
 			<source>Game Folders</source>
 			<translation>遊戲資料夾</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Add...</source>
 			<translation>添加...</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="1141"/>
 			<source>Remove</source>
 			<translation>刪除</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="517"/>
 			<source>Debug</source>
 			<translation>Debug</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="537"/>
 			<source>Enable Debug Dumping</source>
 			<translation>Enable Debug Dumping</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="560"/>
 			<source>Enable Vulkan Validation Layers</source>
 			<translation>Enable Vulkan Validation Layers</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="567"/>
 			<source>Enable Vulkan Synchronization Validation</source>
 			<translation>Enable Vulkan Synchronization Validation</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="574"/>
 			<source>Enable RenderDoc Debugging</source>
 			<translation>Enable RenderDoc Debugging</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="274"/>
 			<source>Update</source>
 			<translation>更新</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="286"/>
 			<source>Check for Updates at Startup</source>
 			<translation>啟動時檢查更新</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="313"/>
 			<source>Update Channel</source>
 			<translation>更新頻道</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="322"/>
 			<source>Check for Updates</source>
 			<translation>檢查更新</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="354"/>
 			<source>GUI Settings</source>
 			<translation>介面設置</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="475"/>
 			<source>Disable Trophy Pop-ups</source>
 			<translation>Disable Trophy Pop-ups</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="375"/>
 			<source>Play title music</source>
 			<translation>播放標題音樂</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database On Startup</source>
 			<translation>Update Compatibility Database On Startup</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Game Compatibility</source>
 			<translation>Game Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Display Compatibility Data</source>
 			<translation>Display Compatibility Data</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Update Compatibility Database</source>
 			<translation>Update Compatibility Database</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui" line="394"/>
 			<source>Volume</source>
 			<translation>音量</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.ui"/>
 			<source>Audio Backend</source>
 			<translation>Audio Backend</translation>
 		</message>
-	</context>
-	<context>
-		<name>MainWindow</name>
 		<message>
-			<location filename="../main_window.cpp" line="106"/>
-			<source>Game List</source>
-			<translation>遊戲列表</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="168"/>
-			<source> * Unsupported Vulkan Version</source>
-			<translation> * 不支援的 Vulkan 版本</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="326"/>
-			<source>Download Cheats For All Installed Games</source>
-			<translation>下載所有已安裝遊戲的作弊碼</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="328"/>
-			<source>Download Patches For All Games</source>
-			<translation>下載所有遊戲的修補檔</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="363"/>
-			<source>Download Complete</source>
-			<translation>下載完成</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="364"/>
-			<source>You have downloaded cheats for all the games you have installed.</source>
-			<translation>您已經下載了所有已安裝遊戲的作弊碼。</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="391"/>
-			<source>Patches Downloaded Successfully!</source>
-			<translation>修補檔下載成功！</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="392"/>
-			<source>All Patches available for all games have been downloaded.</source>
-			<translation>所有遊戲的修補檔已經下載完成。</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="549"/>
-			<source>Games: </source>
-			<translation>遊戲: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="575"/>
-			<source>PKG File (*.PKG)</source>
-			<translation>PKG 檔案 (*.PKG)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="594"/>
-			<source>ELF files (*.bin *.elf *.oelf)</source>
-			<translation>ELF 檔案 (*.bin *.elf *.oelf)</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Game Boot</source>
-			<translation>遊戲啟動</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="600"/>
-			<source>Only one file can be selected!</source>
-			<translation>只能選擇一個檔案！</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="623"/>
-			<source>PKG Extraction</source>
-			<translation>PKG 解壓縮</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>Patch detected!</source>
-			<translation>檢測到補丁！</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="646"/>
-			<source>PKG and Game versions match: </source>
-			<translation>PKG 和遊戲版本匹配: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="647"/>
-			<source>Would you like to overwrite?</source>
-			<translation>您想要覆蓋嗎？</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="639"/>
-			<source>PKG Version %1 is older than installed version: </source>
-			<translation>PKG 版本 %1 比已安裝版本更舊: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Game is installed: </source>
-			<translation>遊戲已安裝: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="660"/>
-			<source>Would you like to install Patch: </source>
-			<translation>您想要安裝補丁嗎: </translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="673"/>
-			<source>DLC Installation</source>
-			<translation>DLC 安裝</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>Would you like to install DLC: %1?</source>
-			<translation>您想要安裝 DLC: %1 嗎？</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="688"/>
-			<source>DLC already installed:</source>
-			<translation>DLC 已經安裝:</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="701"/>
-			<source>Game already installed</source>
-			<translation>遊戲已經安裝</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="674"/>
-			<source>PKG is a patch, please install the game first!</source>
-			<translation>PKG 是修補檔，請先安裝遊戲！</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="681"/>
-			<source>PKG ERROR</source>
-			<translation>PKG 錯誤</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="693"/>
-			<source>Extracting PKG %1/%2</source>
-			<translation>正在解壓縮 PKG %1/%2</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="703"/>
-			<source>Extraction Finished</source>
-			<translation>解壓縮完成</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="704"/>
-			<source>Game successfully installed at %1</source>
-			<translation>遊戲成功安裝於 %1</translation>
-		</message>
-		<message>
-			<location filename="../main_window.cpp" line="725"/>
-			<source>File doesn't appear to be a valid PKG file</source>
-			<translation>檔案似乎不是有效的 PKG 檔案</translation>
-		</message>
-	</context>
-	<context>
-		<name>CheatsPatches</name>
-		<message>
-			<location filename="../cheats_patches.cpp" line="44"/>
-			<source>Cheats / Patches for </source>
-			<translation>Cheats / Patches for </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="50"/>
-			<source>defaultTextEdit_MSG</source>
-			<translation>作弊/補丁為實驗性功能。\n請小心使用。\n\n透過選擇儲存庫並點擊下載按鈕來單獨下載作弊程式。\n在“補丁”標籤頁中，您可以一次下載所有補丁，選擇要使用的補丁並保存您的選擇。\n\n由於我們不開發作弊/補丁，\n請將問題報告給作弊程式的作者。\n\n創建了新的作弊程式？請訪問：\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="69"/>
-			<source>No Image Available</source>
-			<translation>沒有可用的圖片</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="79"/>
-			<source>Serial: </source>
-			<translation>序號: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="83"/>
-			<source>Version: </source>
-			<translation>版本: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="87"/>
-			<source>Size: </source>
-			<translation>大小: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="126"/>
-			<source>Select Cheat File:</source>
-			<translation>選擇作弊檔案:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="133"/>
-			<source>Repository:</source>
-			<translation>儲存庫:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="149"/>
-			<source>Download Cheats</source>
-			<translation>下載作弊碼</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="155"/>
-			<source>Delete File</source>
-			<translation>刪除檔案</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="169"/>
-			<source>No files selected.</source>
-			<translation>沒有選擇檔案。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="170"/>
-			<source>You can delete the cheats you don't want after downloading them.</source>
-			<translation>您可以在下載後刪除不需要的作弊碼。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="178"/>
-			<source>Do you want to delete the selected file?\n%1</source>
-			<translation>您是否要刪除選定的檔案？\n%1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="213"/>
-			<source>Select Patch File:</source>
-			<translation>選擇修補檔案:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="241"/>
-			<source>Download Patches</source>
-			<translation>下載修補檔</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="248"/>
 			<source>Save</source>
 			<translation>儲存</translation>
 		</message>
 		<message>
-			<location filename="../cheats_patches.cpp" line="256"/>
-			<source>Cheats</source>
-			<translation>作弊碼</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="257"/>
-			<source>Patches</source>
-			<translation>修補檔</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>Error</source>
-			<translation>錯誤</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="278"/>
-			<source>No patch selected.</source>
-			<translation>未選擇修補檔。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="292"/>
-			<source>Unable to open files.json for reading.</source>
-			<translation>無法打開 files.json 進行讀取。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="316"/>
-			<source>No patch file found for the current serial.</source>
-			<translation>找不到當前序號的修補檔。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="323"/>
-			<source>Unable to open the file for reading.</source>
-			<translation>無法打開檔案進行讀取。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="422"/>
-			<source>Unable to open the file for writing.</source>
-			<translation>無法打開檔案進行寫入。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="432"/>
-			<source>Failed to parse XML: </source>
-			<translation>解析 XML 失敗: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Success</source>
-			<translation>成功</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="434"/>
-			<source>Options saved successfully.</source>
-			<translation>選項已成功儲存。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="470"/>
-			<source>Invalid Source</source>
-			<translation>無效的來源</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="471"/>
-			<source>The selected source is invalid.</source>
-			<translation>選擇的來源無效。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="519"/>
-			<source>File Exists</source>
-			<translation>檔案已存在</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="520"/>
-			<source>File already exists. Do you want to replace it?</source>
-			<translation>檔案已存在。您是否希望替換它？</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="539"/>
-			<source>Failed to save file:</source>
-			<translation>無法儲存檔案:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="545"/>
-			<source>Failed to download file:</source>
-			<translation>無法下載檔案:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>Cheats Not Found</source>
-			<translation>未找到作弊碼</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="556"/>
-			<source>CheatsNotFound_MSG</source>
-			<translation>在此版本的儲存庫中未找到該遊戲的作弊碼，請嘗試另一個儲存庫或不同版本的遊戲。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="593"/>
-			<source>Cheats Downloaded Successfully</source>
-			<translation>作弊碼下載成功</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="594"/>
-			<source>CheatsDownloadedSuccessfully_MSG</source>
-			<translation>您已成功下載該遊戲版本的作弊碼 從選定的儲存庫中。 您可以嘗試從其他儲存庫下載，如果可用，您也可以選擇從列表中選擇檔案來使用它。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="747"/>
-			<source>Failed to save:</source>
-			<translation>儲存失敗:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="754"/>
-			<source>Failed to download:</source>
-			<translation>下載失敗:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="762"/>
-			<source>Download Complete</source>
-			<translation>下載完成</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="763"/>
-			<source>DownloadComplete_MSG</source>
-			<translation>修補檔下載成功！所有遊戲的修補檔已下載完成，無需像作弊碼那樣為每個遊戲單獨下載。如果補丁未顯示，可能是該補丁不適用於特定的序號和遊戲版本。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="773"/>
-			<source>Failed to parse JSON data from HTML.</source>
-			<translation>無法從 HTML 解析 JSON 數據。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="778"/>
-			<source>Failed to retrieve HTML page.</source>
-			<translation>無法檢索 HTML 頁面。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="850"/>
-			<source>The game is in version: %1</source>
-			<translation>遊戲版本: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="851"/>
-			<source>The downloaded patch only works on version: %1</source>
-			<translation>下載的補丁僅適用於版本: %1</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="856"/>
-			<source>You may need to update your game.</source>
-			<translation>您可能需要更新遊戲。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="860"/>
-			<source>Incompatibility Notice</source>
-			<translation>不相容通知</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="801"/>
-			<source>Failed to open file:</source>
-			<translation>無法打開檔案:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="819"/>
-			<source>XML ERROR:</source>
-			<translation>XML 錯誤:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="826"/>
-			<source>Failed to open files.json for writing</source>
-			<translation>無法打開 files.json 進行寫入</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="925"/>
-			<source>Author: </source>
-			<translation>作者: </translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="997"/>
-			<source>Directory does not exist:</source>
-			<translation>目錄不存在:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Failed to open files.json for reading.</source>
-			<translation>無法打開 files.json 進行讀取。</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1006"/>
-			<source>Name:</source>
-			<translation>名稱:</translation>
-		</message>
-		<message>
-			<location filename="../cheats_patches.cpp" line="1163"/>
-			<source>Can't apply cheats before the game is started</source>
-			<translation>在遊戲開始之前無法應用作弊。</translation>
-		</message>
-	</context>
-	<context>
-		<name>SettingsDialog</name>
-		<message>
-			<location filename="../settings_dialog.cpp" line="83"/>
-			<source>Save</source>
-			<translation>儲存</translation>
-		</message>
-		<message>
-			<location filename="../settings_dialog.cpp" line="84"/>
 			<source>Apply</source>
 			<translation>應用</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="85"/>
 			<source>Restore Defaults</source>
 			<translation>還原預設值</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="86"/>
 			<source>Close</source>
 			<translation>關閉</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Point your mouse at an option to display its description.</source>
 			<translation>將鼠標指向選項以顯示其描述。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="289"/>
 			<source>consoleLanguageGroupBox</source>
 			<translation>主機語言:\n設定PS4遊戲使用的語言。\n建議將其設置為遊戲支持的語言，這會因地區而異。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="291"/>
 			<source>emulatorLanguageGroupBox</source>
 			<translation>模擬器語言:\n設定模擬器的用戶介面的語言。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>fullscreenCheckBox</source>
 			<translation>啟用全螢幕:\n自動將遊戲視窗設置為全螢幕模式。\n可以按F11鍵進行切換。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="293"/>
 			<source>separateUpdatesCheckBox</source>
 			<translation>Enable Separate Update Folder:\nEnables installing game updates into a separate folder for easy management.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="295"/>
 			<source>showSplashCheckBox</source>
 			<translation>顯示啟動畫面:\n在遊戲啟動時顯示遊戲的啟動畫面（特殊圖片）。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="297"/>
 			<source>ps4proCheckBox</source>
 			<translation>為PS4 Pro:\n讓模擬器像PS4 PRO一樣運作，這可能啟用支持此功能的遊戲中的特殊功能。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="438"/>
 			<source>discordRPCCheckbox</source>
 			<translation>啟用 Discord Rich Presence:\n在您的 Discord 個人檔案上顯示模擬器圖標和相關信息。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="299"/>
 			<source>userName</source>
 			<translation>用戶名:\n設定PS4帳號的用戶名，某些遊戲中可能會顯示。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>TrophyKey</source>
 			<translation>Trophy Key:\nKey used to decrypt trophies. Must be obtained from your jailbroken console.\nMust contain only hex characters.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="301"/>
 			<source>logTypeGroupBox</source>
 			<translation>日誌類型:\n設定是否同步日誌窗口的輸出以提高性能。可能對模擬產生不良影響。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="303"/>
 			<source>logFilter</source>
 			<translation>日誌過濾器:\n過濾日誌以僅打印特定信息。\n範例："Core:Trace" "Lib.Pad:Debug Common.Filesystem:Error" "*:Critical" 等級: Trace, Debug, Info, Warning, Error, Critical - 以此順序，特定級別靜音所有前面的級別，並記錄其後的每個級別。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="305"/>
 			<source>updaterGroupBox</source>
 			<translation>更新:\nRelease: 每月發布的官方版本，可能非常舊，但更可靠且經過測試。\nNightly: 開發版本，擁有所有最新的功能和修復，但可能包含錯誤，穩定性較差。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="306"/>
 			<source>GUIgroupBox</source>
 			<translation>播放標題音樂:\n如果遊戲支持，啟用在GUI中選擇遊戲時播放特殊音樂。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="267"/>
 			<source>disableTrophycheckBox</source>
 			<translation>Disable Trophy Pop-ups:\nDisable in-game trophy notifications. Trophy progress can still be tracked using the Trophy Viewer (right-click the game in the main window).</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="450"/>
 			<source>hideCursorGroupBox</source>
 			<translation>隱藏游標:\n選擇游標何時消失:\n從不: 您將始終看到滑鼠。\n閒置: 設定在閒置後消失的時間。\n始終: 您將永遠看不到滑鼠。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="452"/>
 			<source>idleTimeoutGroupBox</source>
 			<translation>設定滑鼠在閒置後消失的時間。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="454"/>
 			<source>backButtonBehaviorGroupBox</source>
 			<translation>返回按鈕行為:\n設定控制器的返回按鈕模擬在 PS4 觸控板上指定位置的觸碰。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>enableCompatibilityCheckBox</source>
 			<translation>Display Compatibility Data:\nDisplays game compatibility information in table view. Enable "Update Compatibility On Startup" to get up-to-date information.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>checkCompatibilityOnStartupCheckBox</source>
 			<translation>Update Compatibility On Startup:\nAutomatically update the compatibility database when shadPS4 starts.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp"/>
 			<source>updateCompatibilityButton</source>
 			<translation>Update Compatibility Database:\nImmediately update the compatibility database.</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="70"/>
 			<source>Never</source>
 			<translation>從不</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="71"/>
 			<source>Idle</source>
 			<translation>閒置</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="72"/>
 			<source>Always</source>
 			<translation>始終</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="101"/>
 			<source>Touchpad Left</source>
 			<translation>觸控板左側</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="102"/>
 			<source>Touchpad Right</source>
 			<translation>觸控板右側</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="103"/>
 			<source>Touchpad Center</source>
 			<translation>觸控板中間</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="104"/>
 			<source>None</source>
 			<translation>無</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="312"/>
 			<source>graphicsAdapterGroupBox</source>
 			<translation>圖形設備:\n在多GPU系統中，從下拉列表中選擇模擬器將使用的GPU，\n或選擇「自動選擇」以自動確定。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="314"/>
 			<source>resolutionLayout</source>
 			<translation>寬度/高度:\n設定模擬器啟動時的窗口大小，可以在遊戲過程中調整。\n這與遊戲內解析度不同。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="318"/>
 			<source>heightDivider</source>
 			<translation>Vblank分隔符:\n模擬器的幀速率將乘以這個數字。更改此數字可能會有不良影響，例如增加遊戲速度，或破壞不預期此變化的關鍵遊戲功能！</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="320"/>
 			<source>dumpShadersCheckBox</source>
 			<translation>啟用著色器轉儲:\n為了技術調試，將遊戲的著色器在渲染時保存到文件夾中。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="322"/>
 			<source>nullGpuCheckBox</source>
 			<translation>啟用空GPU:\n為了技術調試，禁用遊戲渲染，彷彿沒有顯示卡。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>gameFoldersBox</source>
 			<translation>遊戲資料夾:\n檢查已安裝遊戲的資料夾列表。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>addFolderButton</source>
 			<translation>添加:\n將資料夾添加到列表。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="465"/>
 			<source>removeFolderButton</source>
 			<translation>移除:\n從列表中移除資料夾。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="329"/>
 			<source>debugDump</source>
 			<translation>啟用調試轉儲:\n將當前運行的PS4程序的輸入和輸出符號及文件頭信息保存到目錄中。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="331"/>
 			<source>vkValidationCheckBox</source>
 			<translation>啟用Vulkan驗證層:\n啟用一個系統來驗證Vulkan渲染器的狀態並記錄其內部狀態的信息。這將降低性能並可能改變模擬行為。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="333"/>
 			<source>vkSyncValidationCheckBox</source>
 			<translation>啟用Vulkan同步驗證:\n啟用一個系統來驗證Vulkan渲染任務的時間。這將降低性能並可能改變模擬行為。</translation>
 		</message>
 		<message>
-			<location filename="../settings_dialog.cpp" line="335"/>
 			<source>rdocCheckBox</source>
 			<translation>啟用RenderDoc調試:\n如果啟用，模擬器將提供與Renderdoc的兼容性，以允許捕獲和分析當前渲染的幀。</translation>
 		</message>
 	</context>
 	<context>
+		<name>CheatsPatches</name>
+		<message>
+			<source>Cheats / Patches for </source>
+			<translation>Cheats / Patches for </translation>
+		</message>
+		<message>
+			<source>defaultTextEdit_MSG</source>
+			<translation>作弊/補丁為實驗性功能。\n請小心使用。\n\n透過選擇儲存庫並點擊下載按鈕來單獨下載作弊程式。\n在“補丁”標籤頁中，您可以一次下載所有補丁，選擇要使用的補丁並保存您的選擇。\n\n由於我們不開發作弊/補丁，\n請將問題報告給作弊程式的作者。\n\n創建了新的作弊程式？請訪問：\nhttps://github.com/shadps4-emu/ps4_cheats</translation>
+		</message>
+		<message>
+			<source>No Image Available</source>
+			<translation>沒有可用的圖片</translation>
+		</message>
+		<message>
+			<source>Serial: </source>
+			<translation>序號: </translation>
+		</message>
+		<message>
+			<source>Version: </source>
+			<translation>版本: </translation>
+		</message>
+		<message>
+			<source>Size: </source>
+			<translation>大小: </translation>
+		</message>
+		<message>
+			<source>Select Cheat File:</source>
+			<translation>選擇作弊檔案:</translation>
+		</message>
+		<message>
+			<source>Repository:</source>
+			<translation>儲存庫:</translation>
+		</message>
+		<message>
+			<source>Download Cheats</source>
+			<translation>下載作弊碼</translation>
+		</message>
+		<message>
+			<source>Delete File</source>
+			<translation>刪除檔案</translation>
+		</message>
+		<message>
+			<source>No files selected.</source>
+			<translation>沒有選擇檔案。</translation>
+		</message>
+		<message>
+			<source>You can delete the cheats you don't want after downloading them.</source>
+			<translation>您可以在下載後刪除不需要的作弊碼。</translation>
+		</message>
+		<message>
+			<source>Do you want to delete the selected file?\n%1</source>
+			<translation>您是否要刪除選定的檔案？\n%1</translation>
+		</message>
+		<message>
+			<source>Select Patch File:</source>
+			<translation>選擇修補檔案:</translation>
+		</message>
+		<message>
+			<source>Download Patches</source>
+			<translation>下載修補檔</translation>
+		</message>
+		<message>
+			<source>Save</source>
+			<translation>儲存</translation>
+		</message>
+		<message>
+			<source>Cheats</source>
+			<translation>作弊碼</translation>
+		</message>
+		<message>
+			<source>Patches</source>
+			<translation>修補檔</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>錯誤</translation>
+		</message>
+		<message>
+			<source>No patch selected.</source>
+			<translation>未選擇修補檔。</translation>
+		</message>
+		<message>
+			<source>Unable to open files.json for reading.</source>
+			<translation>無法打開 files.json 進行讀取。</translation>
+		</message>
+		<message>
+			<source>No patch file found for the current serial.</source>
+			<translation>找不到當前序號的修補檔。</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for reading.</source>
+			<translation>無法打開檔案進行讀取。</translation>
+		</message>
+		<message>
+			<source>Unable to open the file for writing.</source>
+			<translation>無法打開檔案進行寫入。</translation>
+		</message>
+		<message>
+			<source>Failed to parse XML: </source>
+			<translation>解析 XML 失敗: </translation>
+		</message>
+		<message>
+			<source>Success</source>
+			<translation>成功</translation>
+		</message>
+		<message>
+			<source>Options saved successfully.</source>
+			<translation>選項已成功儲存。</translation>
+		</message>
+		<message>
+			<source>Invalid Source</source>
+			<translation>無效的來源</translation>
+		</message>
+		<message>
+			<source>The selected source is invalid.</source>
+			<translation>選擇的來源無效。</translation>
+		</message>
+		<message>
+			<source>File Exists</source>
+			<translation>檔案已存在</translation>
+		</message>
+		<message>
+			<source>File already exists. Do you want to replace it?</source>
+			<translation>檔案已存在。您是否希望替換它？</translation>
+		</message>
+		<message>
+			<source>Failed to save file:</source>
+			<translation>無法儲存檔案:</translation>
+		</message>
+		<message>
+			<source>Failed to download file:</source>
+			<translation>無法下載檔案:</translation>
+		</message>
+		<message>
+			<source>Cheats Not Found</source>
+			<translation>未找到作弊碼</translation>
+		</message>
+		<message>
+			<source>CheatsNotFound_MSG</source>
+			<translation>在此版本的儲存庫中未找到該遊戲的作弊碼，請嘗試另一個儲存庫或不同版本的遊戲。</translation>
+		</message>
+		<message>
+			<source>Cheats Downloaded Successfully</source>
+			<translation>作弊碼下載成功</translation>
+		</message>
+		<message>
+			<source>CheatsDownloadedSuccessfully_MSG</source>
+			<translation>您已成功下載該遊戲版本的作弊碼 從選定的儲存庫中。 您可以嘗試從其他儲存庫下載，如果可用，您也可以選擇從列表中選擇檔案來使用它。</translation>
+		</message>
+		<message>
+			<source>Failed to save:</source>
+			<translation>儲存失敗:</translation>
+		</message>
+		<message>
+			<source>Failed to download:</source>
+			<translation>下載失敗:</translation>
+		</message>
+		<message>
+			<source>Download Complete</source>
+			<translation>下載完成</translation>
+		</message>
+		<message>
+			<source>DownloadComplete_MSG</source>
+			<translation>修補檔下載成功！所有遊戲的修補檔已下載完成，無需像作弊碼那樣為每個遊戲單獨下載。如果補丁未顯示，可能是該補丁不適用於特定的序號和遊戲版本。</translation>
+		</message>
+		<message>
+			<source>Failed to parse JSON data from HTML.</source>
+			<translation>無法從 HTML 解析 JSON 數據。</translation>
+		</message>
+		<message>
+			<source>Failed to retrieve HTML page.</source>
+			<translation>無法檢索 HTML 頁面。</translation>
+		</message>
+		<message>
+			<source>The game is in version: %1</source>
+			<translation>遊戲版本: %1</translation>
+		</message>
+		<message>
+			<source>The downloaded patch only works on version: %1</source>
+			<translation>下載的補丁僅適用於版本: %1</translation>
+		</message>
+		<message>
+			<source>You may need to update your game.</source>
+			<translation>您可能需要更新遊戲。</translation>
+		</message>
+		<message>
+			<source>Incompatibility Notice</source>
+			<translation>不相容通知</translation>
+		</message>
+		<message>
+			<source>Failed to open file:</source>
+			<translation>無法打開檔案:</translation>
+		</message>
+		<message>
+			<source>XML ERROR:</source>
+			<translation>XML 錯誤:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for writing</source>
+			<translation>無法打開 files.json 進行寫入</translation>
+		</message>
+		<message>
+			<source>Author: </source>
+			<translation>作者: </translation>
+		</message>
+		<message>
+			<source>Directory does not exist:</source>
+			<translation>目錄不存在:</translation>
+		</message>
+		<message>
+			<source>Failed to open files.json for reading.</source>
+			<translation>無法打開 files.json 進行讀取。</translation>
+		</message>
+		<message>
+			<source>Name:</source>
+			<translation>名稱:</translation>
+		</message>
+		<message>
+			<source>Can't apply cheats before the game is started</source>
+			<translation>在遊戲開始之前無法應用作弊。</translation>
+		</message>
+	</context>
+	<context>
 		<name>GameListFrame</name>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Icon</source>
 			<translation>圖示</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Name</source>
 			<translation>名稱</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Serial</source>
 			<translation>序號</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility</source>
 			<translation>Compatibility</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Region</source>
 			<translation>區域</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="34"/>
 			<source>Firmware</source>
 			<translation>固件</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Size</source>
 			<translation>大小</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Version</source>
 			<translation>版本</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="35"/>
 			<source>Path</source>
 			<translation>路徑</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="38"/>
 			<source>Play Time</source>
 			<translation>遊玩時間</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp" line="108"/>
 			<source>Never Played</source>
 			<translation>Never Played</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>h</source>
 			<translation>h</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>m</source>
 			<translation>m</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>s</source>
 			<translation>s</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Compatibility is untested</source>
 			<translation>Compatibility is untested</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game does not initialize properly / crashes the emulator</source>
 			<translation>Game does not initialize properly / crashes the emulator</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game boots, but only displays a blank screen</source>
 			<translation>Game boots, but only displays a blank screen</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game displays an image but does not go past the menu</source>
 			<translation>Game displays an image but does not go past the menu</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game has game-breaking glitches or unplayable performance</source>
 			<translation>Game has game-breaking glitches or unplayable performance</translation>
 		</message>
 		<message>
-			<location filename="../game_list_frame.cpp"/>
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
@@ -1508,127 +1210,102 @@
 	<context>
 		<name>CheckUpdate</name>
 		<message>
-			<location filename="../check_update.cpp" line="34"/>
 			<source>Auto Updater</source>
 			<translation>自動更新程式</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="51"/>
 			<source>Error</source>
 			<translation>錯誤</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="64"/>
 			<source>Network error:</source>
 			<translation>網路錯誤：</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="73"/>
 			<source>Failed to parse update information.</source>
 			<translation>無法解析更新資訊。</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="89"/>
 			<source>No pre-releases found.</source>
 			<translation>未找到預發布版本。</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="102"/>
 			<source>Invalid release data.</source>
 			<translation>無效的發行數據。</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="142"/>
 			<source>No download URL found for the specified asset.</source>
 			<translation>未找到指定資產的下載 URL。</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="148"/>
 			<source>Your version is already up to date!</source>
 			<translation>您的版本已經是最新的！</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="172"/>
 			<source>Update Available</source>
 			<translation>可用更新</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="187"/>
 			<source>Update Channel</source>
 			<translation>更新頻道</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="177"/>
 			<source>Current Version</source>
 			<translation>當前版本</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="178"/>
 			<source>Latest Version</source>
 			<translation>最新版本</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="179"/>
 			<source>Do you want to update?</source>
 			<translation>您想要更新嗎？</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="193"/>
 			<source>Show Changelog</source>
 			<translation>顯示變更日誌</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="198"/>
 			<source>Check for Updates at Startup</source>
 			<translation>啟動時檢查更新</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="199"/>
 			<source>Update</source>
 			<translation>更新</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="200"/>
 			<source>No</source>
 			<translation>否</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="223"/>
 			<source>Hide Changelog</source>
 			<translation>隱藏變更日誌</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="296"/>
 			<source>Changes</source>
 			<translation>變更</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="310"/>
 			<source>Network error occurred while trying to access the URL</source>
 			<translation>嘗試訪問 URL 時發生網路錯誤</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="330"/>
 			<source>Download Complete</source>
 			<translation>下載完成</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="331"/>
 			<source>The update has been downloaded, press OK to install.</source>
 			<translation>更新已下載，按 OK 安裝。</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="336"/>
 			<source>Failed to save the update file at</source>
 			<translation>無法將更新文件保存到</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="545"/>
 			<source>Starting Update...</source>
 			<translation>正在開始更新...</translation>
 		</message>
 		<message>
-			<location filename="../check_update.cpp" line="619"/>
 			<source>Failed to create the update script file</source>
 			<translation>無法創建更新腳本文件</translation>
 		</message>
@@ -1636,29 +1313,24 @@
 	<context>
 		<name>GameListUtils</name>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>B</source>
 			<translation>B</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>KB</source>
 			<translation>KB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>MB</source>
 			<translation>MB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>GB</source>
 			<translation>GB</translation>
 		</message>
 		<message>
-			<location filename="../game_list_utils.h" line="34"/>
 			<source>TB</source>
 			<translation>TB</translation>
-		</message>		
+		</message>
 	</context>
 </TS>


### PR DESCRIPTION
Remove 'location' tag in translation files

As mentioned in [PR 2022](https://github.com/shadps4-emu/shadPS4/pull/2022) , the tag was more of a hindrance than a help, most of the line numbers were wrong, and it works without this tag, it will be simpler for anyone who translates.

now without the file reference, these 2 were unified:
context `MainWindow` was unified `main_window_ui.h` and `main_window.cpp`
context `SettingsDialog` was unified `settings_dialog.ui` and `settings_dialog.cpp`