### PR TITLE
Unmap Fixes

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -395,12 +395,16 @@ s32 MemoryManager::UnmapMemoryImpl(VAddr virtual_addr, size_t size) {
     ASSERT_MSG(vma_base.Contains(virtual_addr, size),
                "Existing mapping does not contain requested unmap range");
 
+    const auto type = vma_base.type;
+    if (type == VMAType::Free) {
+        return ORBIS_OK;
+    }
+
     const auto vma_base_addr = vma_base.base;
     const auto vma_base_size = vma_base.size;
     const auto phys_base = vma_base.phys_base;
     const bool is_exec = vma_base.is_exec;
     const auto start_in_vma = virtual_addr - vma_base_addr;
-    const auto type = vma_base.type;
     const bool has_backing = type == VMAType::Direct || type == VMAType::File;
     if (type == VMAType::Direct) {
         rasterizer->UnmapMemory(virtual_addr, size);

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -422,8 +422,8 @@ s32 MemoryManager::UnmapMemoryImpl(VAddr virtual_addr, size_t size) {
 
     if (type != VMAType::Reserved) {
         // Unmap the memory region.
-        impl.Unmap(vma_base_addr, vma_base_size, start_in_vma, start_in_vma + size, phys_base, is_exec,
-                   has_backing, readonly_file);
+        impl.Unmap(vma_base_addr, vma_base_size, start_in_vma, start_in_vma + size, phys_base,
+                   is_exec, has_backing, readonly_file);
         TRACK_FREE(virtual_addr, "VMEM");
     }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -406,7 +406,7 @@ s32 MemoryManager::UnmapMemoryImpl(VAddr virtual_addr, size_t size) {
     const bool is_exec = vma_base.is_exec;
     const auto start_in_vma = virtual_addr - vma_base_addr;
     const bool has_backing = type == VMAType::Direct || type == VMAType::File;
-    if (type == VMAType::Direct) {
+    if (type == VMAType::Direct || type == VMAType::Pooled) {
         rasterizer->UnmapMemory(virtual_addr, size);
     }
     if (type == VMAType::Flexible) {
@@ -424,7 +424,7 @@ s32 MemoryManager::UnmapMemoryImpl(VAddr virtual_addr, size_t size) {
     MergeAdjacent(vma_map, new_it);
     bool readonly_file = vma.prot == MemoryProt::CpuRead && type == VMAType::File;
 
-    if (type != VMAType::Reserved) {
+    if (type != VMAType::Reserved && type != VMAType::PoolReserved) {
         // Unmap the memory region.
         impl.Unmap(vma_base_addr, vma_base_size, start_in_vma, start_in_vma + size, phys_base,
                    is_exec, has_backing, readonly_file);

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -418,10 +418,12 @@ s32 MemoryManager::UnmapMemoryImpl(VAddr virtual_addr, size_t size) {
     MergeAdjacent(vma_map, new_it);
     bool readonly_file = vma.prot == MemoryProt::CpuRead && type == VMAType::File;
 
-    // Unmap the memory region.
-    impl.Unmap(vma_base_addr, vma_base_size, start_in_vma, start_in_vma + size, phys_base, is_exec,
-               has_backing, readonly_file);
-    TRACK_FREE(virtual_addr, "VMEM");
+    if (type != VMAType::Reserved) {
+        // Unmap the memory region.
+        impl.Unmap(vma_base_addr, vma_base_size, start_in_vma, start_in_vma + size, phys_base, is_exec,
+                   has_backing, readonly_file);
+        TRACK_FREE(virtual_addr, "VMEM");
+    }
 
     return ORBIS_OK;
 }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -171,10 +171,11 @@ int MemoryManager::PoolReserve(void** out_addr, VAddr virtual_addr, size_t size,
 
     // Fixed mapping means the virtual address must exactly match the provided one.
     if (True(flags & MemoryMapFlags::Fixed)) {
-        const auto& vma = FindVMA(mapped_addr)->second;
+        auto& vma = FindVMA(mapped_addr)->second;
         // If the VMA is mapped, unmap the region first.
         if (vma.IsMapped()) {
             UnmapMemoryImpl(mapped_addr, size);
+            vma = FindVMA(mapped_addr)->second;
         }
         const size_t remaining_size = vma.base + vma.size - mapped_addr;
         ASSERT_MSG(vma.type == VMAType::Free && remaining_size >= size);
@@ -208,10 +209,11 @@ int MemoryManager::Reserve(void** out_addr, VAddr virtual_addr, size_t size, Mem
 
     // Fixed mapping means the virtual address must exactly match the provided one.
     if (True(flags & MemoryMapFlags::Fixed)) {
-        const auto& vma = FindVMA(mapped_addr)->second;
+        auto& vma = FindVMA(mapped_addr)->second;
         // If the VMA is mapped, unmap the region first.
         if (vma.IsMapped()) {
             UnmapMemoryImpl(mapped_addr, size);
+            vma = FindVMA(mapped_addr)->second;
         }
         const size_t remaining_size = vma.base + vma.size - mapped_addr;
         ASSERT_MSG(vma.type == VMAType::Free && remaining_size >= size);


### PR DESCRIPTION
This PR fixes several memory issues I've noticed.
1. When games try to unmap reserved memory, this would cause address_space asserts on Windows. This is because reserved memory was never mapped in address_space to begin with. My fix is to only unmap in address_space if the unmapped VMA had `type != VMAType::Reserved`.
2. Some games also attempt to unmap free memory. This causes address_space asserts on Windows, and also messes up later memory use calculations. My solution is adding an early return if the VMA to unmap has `type == VMAType::Free`.
3. `UnmapMemoryImpl` doesn't properly handle pooled memory. PoolReserved memory can either be reserved or decommitted memory, either case isn't mapped in address_space. Additionally, Pooled memory is GPU mapped. My solution is adding those relevant checks so we don't run into any strange Windows-specific issues.
4. When games overwrite memory with reserved pages, our check for `vma.type == VMAType::Free` would fail. This is because, while the `UnmapMemoryImpl` call modifies vma_map, the vma retrieved before that call is not modified. To fix this, I add an extra FindVMA call after the unmap.

This should fix cases of:
```
[Debug] <Critical> address_space.cpp:operator():268: Assertion Failed!
Invalid address/size given to unmap.
```
And some cases of:
```
[Debug] <Critical> memory.cpp:operator():217: Assertion Failed!
```

Credits to @red-prig for providing relevant information.