### PR TITLE
shader_recompiler: Fix V_CMP_U_F32

### DIFF
--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -904,7 +904,7 @@ void Translator::V_CMP_F32(ConditionOp op, bool set_exec, const GcnInst& inst) {
         case ConditionOp::GE:
             return ir.FPGreaterThanEqual(src0, src1);
         case ConditionOp::U:
-            return ir.LogicalNot(ir.LogicalAnd(ir.FPIsNan(src0), ir.FPIsNan(src1)));
+            return ir.LogicalOr(ir.FPIsNan(src0), ir.FPIsNan(src1));
         default:
             UNREACHABLE();
         }


### PR DESCRIPTION
Spotted this in CUSA28193, which has shader code like `V_CMP_U_F32(value, value) ? 0 : value`. There is a typo in the AMD ISA docs for GCN; `V_CMP_U_F32` is supposed to be`D.u = (isNaN(S0) || isNaN(S1))`, not `D.u = (!isNaN(S0) || !isNaN(S1))`. This is supported by checking LLVM and Mesa compilers instruction usage, as well as docs for future ISA revisions listing it as `D[threadId] = (isNan(S0) || isNan(S1))`.