### PR TITLE
Remove releases.xml references

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1042,7 +1042,6 @@ install(TARGETS shadps4 BUNDLE DESTINATION .)
 
 if (ENABLE_QT_GUI AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
     install(FILES "dist/net.shadps4.shadPS4.desktop" DESTINATION "share/applications")
-    install(FILES "dist/net.shadps4.shadPS4.releases.xml" DESTINATION "share/metainfo/releases")
     install(FILES "dist/net.shadps4.shadPS4.metainfo.xml" DESTINATION "share/metainfo")
     install(FILES ".github/shadps4.png" DESTINATION "share/icons/hicolor/512x512/apps" RENAME "net.shadps4.shadPS4.png")
     install(FILES "src/images/net.shadps4.shadPS4.svg" DESTINATION "share/icons/hicolor/scalable/apps")

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -11,7 +11,6 @@ path = [
     "dist/net.shadps4.shadPS4.desktop",
     "dist/net.shadps4.shadPS4_metadata.pot",
     "dist/net.shadps4.shadPS4.metainfo.xml",
-    "dist/net.shadps4.shadPS4.releases.xml",
     "documents/changelog.md",
     "documents/Quickstart/2.png",
     "documents/Screenshots/*",


### PR DESCRIPTION
removes references to releases.xml that was removed in https://github.com/shadps4-emu/shadPS4/pull/2085

relates to https://github.com/flathub/flathub/pull/5997