### PR TITLE
amdgpu: Handle 8-bit float format case for stencil.

### DIFF
--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -899,7 +899,8 @@ struct Liverpool {
             // There is a small difference between T# and CB number types, account for it.
             return RemapNumberFormat(info.number_type == NumberFormat::SnormNz
                                          ? NumberFormat::Srgb
-                                         : info.number_type.Value());
+                                         : info.number_type.Value(),
+                                     info.format);
         }
 
         [[nodiscard]] NumberConversion GetNumberConversion() const {

--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -54,7 +54,7 @@ struct Buffer {
     }
 
     NumberFormat GetNumberFmt() const noexcept {
-        return RemapNumberFormat(NumberFormat(num_format));
+        return RemapNumberFormat(NumberFormat(num_format), DataFormat(data_format));
     }
 
     DataFormat GetDataFmt() const noexcept {
@@ -265,7 +265,7 @@ struct Image {
     }
 
     NumberFormat GetNumberFmt() const noexcept {
-        return RemapNumberFormat(NumberFormat(num_format));
+        return RemapNumberFormat(NumberFormat(num_format), DataFormat(data_format));
     }
 
     NumberConversion GetNumberConversion() const noexcept {

--- a/src/video_core/amdgpu/types.h
+++ b/src/video_core/amdgpu/types.h
@@ -252,7 +252,7 @@ inline DataFormat RemapDataFormat(const DataFormat format) {
     }
 }
 
-inline NumberFormat RemapNumberFormat(const NumberFormat format) {
+inline NumberFormat RemapNumberFormat(const NumberFormat format, const DataFormat data_format) {
     switch (format) {
     case NumberFormat::Uscaled:
         return NumberFormat::Uint;
@@ -260,6 +260,14 @@ inline NumberFormat RemapNumberFormat(const NumberFormat format) {
         return NumberFormat::Sint;
     case NumberFormat::Ubnorm:
         return NumberFormat::Unorm;
+    case NumberFormat::Float:
+        if (data_format == DataFormat::Format8) {
+            // Games may ask for 8-bit float when they want to access the stencil component
+            // of a depth-stencil image. Change to unsigned int to match the stencil format.
+            // This is also the closest approximation to pass the bits through unconverted.
+            return NumberFormat::Uint;
+        }
+        [[fallthrough]];
     default:
         return format;
     }


### PR DESCRIPTION
8-bit float format is sometimes used for stencil views of a depth-stencil image. It's possible that because float formats don't do conversion this just happens to work on a real GPU even though 8-bit floats aren't supported; the shaders I've seen just read it as uint anyway. Handle this case by changing 8-bit float format to 8-bit unsigned integer automatically, to match stencil format.

Unfortunately we can't really know if this will end up being used for a stencil view of an existing depth-stencil image as we need the format change to happen earlier than that point, e.g. to use the right types in the shader resources and resolve the Vulkan format for the `ImageViewInfo`. Therefore, this just applies the conversion to all 8-bit float resources. If we do hit any non-stencil cases this *should* still work as it would on real hardware due to the lack of bit conversion for float formats.