### PR TITLE
externals: Update discord-rpc.

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -213,9 +213,7 @@ endif()
 
 # Discord RPC
 if (ENABLE_DISCORD_RPC)
-    set(BUILD_EXAMPLES OFF)
     add_subdirectory(discord-rpc)
-    target_include_directories(discord-rpc INTERFACE discord-rpc/include)
 endif()
 
 # GCN Headers


### PR DESCRIPTION
Update discord-rpc with a GCC build fix. Some clean up also means some additional CMake lines are no longer needed.