### PR TITLE
renderer_vulkan: Clear blank frame

### DIFF
--- a/src/video_core/renderer_vulkan/vk_presenter.cpp
+++ b/src/video_core/renderer_vulkan/vk_presenter.cpp
@@ -682,6 +682,28 @@ Frame* Presenter::PrepareFrameInternal(VideoCore::ImageId image_id, bool is_eop)
         cmdbuf.beginRendering(rendering_info);
         cmdbuf.draw(3, 1, 0, 0);
         cmdbuf.endRendering();
+    } else {
+        // Fix display of garbage images on startup on some drivers
+        const std::array attachments = {vk::RenderingAttachmentInfo{
+            .imageView = frame->image_view,
+            .imageLayout = vk::ImageLayout::eColorAttachmentOptimal,
+            .loadOp = vk::AttachmentLoadOp::eClear,
+            .storeOp = vk::AttachmentStoreOp::eStore,
+        }};
+
+        vk::RenderingInfo rendering_info{
+            .renderArea =
+                vk::Rect2D{
+                    .offset = {0, 0},
+                    .extent = {frame->width, frame->height},
+                },
+            .layerCount = 1,
+            .colorAttachmentCount = attachments.size(),
+            .pColorAttachments = attachments.data(),
+        };
+
+        cmdbuf.beginRendering(rendering_info);
+        cmdbuf.endRendering();
     }
 
     const auto post_barrier =

--- a/src/video_core/renderer_vulkan/vk_presenter.cpp
+++ b/src/video_core/renderer_vulkan/vk_presenter.cpp
@@ -602,6 +602,13 @@ Frame* Presenter::PrepareFrameInternal(VideoCore::ImageId image_id, bool is_eop)
         .pImageMemoryBarriers = &pre_barrier,
     });
 
+    const std::array attachments = {vk::RenderingAttachmentInfo{
+        .imageView = frame->image_view,
+        .imageLayout = vk::ImageLayout::eColorAttachmentOptimal,
+        .loadOp = vk::AttachmentLoadOp::eClear,
+        .storeOp = vk::AttachmentStoreOp::eStore,
+    }};
+
     if (image_id != VideoCore::NULL_IMAGE_ID) {
         auto& image = texture_cache.GetImage(image_id);
         image.Transit(vk::ImageLayout::eShaderReadOnlyOptimal, vk::AccessFlagBits2::eShaderRead, {},
@@ -662,13 +669,6 @@ Frame* Presenter::PrepareFrameInternal(VideoCore::ImageId image_id, bool is_eop)
         cmdbuf.pushConstants(*pp_pipeline_layout, vk::ShaderStageFlagBits::eFragment, 0,
                              sizeof(PostProcessSettings), &pp_settings);
 
-        const std::array attachments = {vk::RenderingAttachmentInfo{
-            .imageView = frame->image_view,
-            .imageLayout = vk::ImageLayout::eColorAttachmentOptimal,
-            .loadOp = vk::AttachmentLoadOp::eClear,
-            .storeOp = vk::AttachmentStoreOp::eStore,
-        }};
-
         vk::RenderingInfo rendering_info{
             .renderArea =
                 vk::Rect2D{
@@ -684,13 +684,6 @@ Frame* Presenter::PrepareFrameInternal(VideoCore::ImageId image_id, bool is_eop)
         cmdbuf.endRendering();
     } else {
         // Fix display of garbage images on startup on some drivers
-        const std::array attachments = {vk::RenderingAttachmentInfo{
-            .imageView = frame->image_view,
-            .imageLayout = vk::ImageLayout::eColorAttachmentOptimal,
-            .loadOp = vk::AttachmentLoadOp::eClear,
-            .storeOp = vk::AttachmentStoreOp::eStore,
-        }};
-
         vk::RenderingInfo rendering_info{
             .renderArea =
                 vk::Rect2D{
@@ -701,7 +694,6 @@ Frame* Presenter::PrepareFrameInternal(VideoCore::ImageId image_id, bool is_eop)
             .colorAttachmentCount = attachments.size(),
             .pColorAttachments = attachments.data(),
         };
-
         cmdbuf.beginRendering(rendering_info);
         cmdbuf.endRendering();
     }

--- a/src/video_core/renderer_vulkan/vk_presenter.cpp
+++ b/src/video_core/renderer_vulkan/vk_presenter.cpp
@@ -608,6 +608,16 @@ Frame* Presenter::PrepareFrameInternal(VideoCore::ImageId image_id, bool is_eop)
         .loadOp = vk::AttachmentLoadOp::eClear,
         .storeOp = vk::AttachmentStoreOp::eStore,
     }};
+    const vk::RenderingInfo rendering_info{
+        .renderArea =
+            vk::Rect2D{
+                .offset = {0, 0},
+                .extent = {frame->width, frame->height},
+            },
+        .layerCount = 1,
+        .colorAttachmentCount = attachments.size(),
+        .pColorAttachments = attachments.data(),
+    };
 
     if (image_id != VideoCore::NULL_IMAGE_ID) {
         auto& image = texture_cache.GetImage(image_id);
@@ -669,31 +679,11 @@ Frame* Presenter::PrepareFrameInternal(VideoCore::ImageId image_id, bool is_eop)
         cmdbuf.pushConstants(*pp_pipeline_layout, vk::ShaderStageFlagBits::eFragment, 0,
                              sizeof(PostProcessSettings), &pp_settings);
 
-        vk::RenderingInfo rendering_info{
-            .renderArea =
-                vk::Rect2D{
-                    .offset = {0, 0},
-                    .extent = {frame->width, frame->height},
-                },
-            .layerCount = 1,
-            .colorAttachmentCount = attachments.size(),
-            .pColorAttachments = attachments.data(),
-        };
         cmdbuf.beginRendering(rendering_info);
         cmdbuf.draw(3, 1, 0, 0);
         cmdbuf.endRendering();
     } else {
         // Fix display of garbage images on startup on some drivers
-        vk::RenderingInfo rendering_info{
-            .renderArea =
-                vk::Rect2D{
-                    .offset = {0, 0},
-                    .extent = {frame->width, frame->height},
-                },
-            .layerCount = 1,
-            .colorAttachmentCount = attachments.size(),
-            .pColorAttachments = attachments.data(),
-        };
         cmdbuf.beginRendering(rendering_info);
         cmdbuf.endRendering();
     }


### PR DESCRIPTION
Fix display of garbage images on startup on some drivers.

<details>
  <summary>Epilepsy warning</summary>
  

https://github.com/user-attachments/assets/7b2a8363-6fc5-4fc0-8d27-7c7ed9145d27


</details>