### PR TITLE
video_core: Use adaptive mutex on Linux

### DIFF
--- a/src/common/adaptive_mutex.h
+++ b/src/common/adaptive_mutex.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#ifdef __linux__
+#include <pthread.h>
+#endif
+
+namespace Common {
+
+#ifdef PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP
+class AdaptiveMutex {
+public:
+    void lock() {
+        pthread_mutex_lock(&mutex);
+    }
+    void unlock() {
+        pthread_mutex_unlock(&mutex);
+    }
+
+private:
+    pthread_mutex_t mutex = PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP;
+};
+#endif // PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP
+
+} // namespace Common

--- a/src/video_core/buffer_cache/word_manager.h
+++ b/src/video_core/buffer_cache/word_manager.h
@@ -8,6 +8,9 @@
 #include <span>
 #include <utility>
 
+#ifdef __linux__
+#include "common/adaptive_mutex.h"
+#endif
 #include "common/spin_lock.h"
 #include "common/types.h"
 #include "video_core/page_manager.h"
@@ -272,7 +275,11 @@ private:
         }
     }
 
+#ifdef PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP
+    Common::AdaptiveMutex lock;
+#else
     Common::SpinLock lock;
+#endif
     PageManager* tracker;
     VAddr cpu_addr = 0;
     WordsArray cpu;

--- a/src/video_core/page_manager.h
+++ b/src/video_core/page_manager.h
@@ -5,6 +5,9 @@
 
 #include <memory>
 #include <boost/icl/interval_map.hpp>
+#ifdef __linux__
+#include "common/adaptive_mutex.h"
+#endif
 #include "common/spin_lock.h"
 #include "common/types.h"
 
@@ -36,7 +39,11 @@ private:
     std::unique_ptr<Impl> impl;
     Vulkan::Rasterizer* rasterizer;
     boost::icl::interval_map<VAddr, s32> cached_pages;
+#ifdef PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP
+    Common::AdaptiveMutex lock;
+#else
     Common::SpinLock lock;
+#endif
 };
 
 } // namespace VideoCore


### PR DESCRIPTION
Fix performance regression with #1973 on SteamDeck (https://github.com/shadps4-emu/shadPS4/issues/2048).

Tested with reduced resolution to reduce GPU load and vblank divider set to 2.

# SteamDeck

![main](https://github.com/user-attachments/assets/ebb4a200-5c55-4a05-a18c-1bb2d4d329a1)

![pm+wm](https://github.com/user-attachments/assets/d53609ad-c6f6-4a8f-87af-a552e03c1dfa)

# Laptop

https://github.com/user-attachments/assets/6bb79808-4dea-4c1e-b596-8d11d5a8652d

https://github.com/user-attachments/assets/ede4ebbf-bd15-4ed7-b024-7487cae36d05
