### PR TITLE
shader_recompiler: Fix some image view type issues.

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
@@ -174,13 +174,12 @@ Id EmitImageQueryDimensions(EmitContext& ctx, IR::Inst* inst, u32 handle, Id lod
     const auto sharp = ctx.info.images[handle & 0xFFFF].GetSharp(ctx.info);
     const Id zero = ctx.u32_zero_value;
     const auto mips{[&] { return has_mips ? ctx.OpImageQueryLevels(ctx.U32[1], image) : zero; }};
-    const bool uses_lod{texture.bound_type != AmdGpu::ImageType::Color2DMsaa &&
-                        !texture.is_storage};
+    const bool uses_lod{texture.view_type != AmdGpu::ImageType::Color2DMsaa && !texture.is_storage};
     const auto query{[&](Id type) {
         return uses_lod ? ctx.OpImageQuerySizeLod(type, image, lod)
                         : ctx.OpImageQuerySize(type, image);
     }};
-    switch (texture.bound_type) {
+    switch (texture.view_type) {
     case AmdGpu::ImageType::Color1D:
         return ctx.OpCompositeConstruct(ctx.U32[4], query(ctx.U32[1]), zero, zero, mips());
     case AmdGpu::ImageType::Color1DArray:

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -773,7 +773,7 @@ spv::ImageFormat GetFormat(const AmdGpu::Image& image) {
 Id ImageType(EmitContext& ctx, const ImageResource& desc, Id sampled_type) {
     const auto image = desc.GetSharp(ctx.info);
     const auto format = desc.is_atomic ? GetFormat(image) : spv::ImageFormat::Unknown;
-    const auto type = image.GetBoundType(desc.is_array);
+    const auto type = image.GetViewType(desc.is_array);
     const u32 sampled = desc.is_written ? 2 : 1;
     switch (type) {
     case AmdGpu::ImageType::Color1D:
@@ -814,7 +814,7 @@ void EmitContext::DefineImagesAndSamplers() {
             .sampled_type = is_storage ? sampled_type : TypeSampledImage(image_type),
             .pointer_type = pointer_type,
             .image_type = image_type,
-            .bound_type = sharp.GetBoundType(image_desc.is_array),
+            .view_type = sharp.GetViewType(image_desc.is_array),
             .is_integer = is_integer,
             .is_storage = is_storage,
         });

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -222,7 +222,7 @@ public:
         Id sampled_type;
         Id pointer_type;
         Id image_type;
-        AmdGpu::ImageType bound_type;
+        AmdGpu::ImageType view_type;
         bool is_integer = false;
         bool is_storage = false;
     };

--- a/src/shader_recompiler/specialization.h
+++ b/src/shader_recompiler/specialization.h
@@ -113,7 +113,7 @@ struct StageSpecialization {
                      });
         ForEachSharp(binding, images, info->images,
                      [](auto& spec, const auto& desc, AmdGpu::Image sharp) {
-                         spec.type = sharp.GetBoundType(desc.is_array);
+                         spec.type = sharp.GetViewType(desc.is_array);
                          spec.is_integer = AmdGpu::IsInteger(sharp.GetNumberFmt());
                          spec.is_storage = desc.is_written;
                          if (spec.is_storage) {

--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -254,9 +254,12 @@ struct Image {
         return 1;
     }
 
+    bool IsCube() const noexcept {
+        return static_cast<ImageType>(type) == ImageType::Cube;
+    }
+
     ImageType GetType() const noexcept {
-        const auto img_type = static_cast<ImageType>(type);
-        return img_type == ImageType::Cube ? ImageType::Color2DArray : img_type;
+        return IsCube() ? ImageType::Color2DArray : static_cast<ImageType>(type);
     }
 
     DataFormat GetDataFmt() const noexcept {
@@ -288,8 +291,12 @@ struct Image {
                GetDataFmt() <= DataFormat::FormatFmask64_8;
     }
 
-    [[nodiscard]] ImageType GetBoundType(const bool is_array) const noexcept {
+    [[nodiscard]] ImageType GetViewType(const bool is_array) const noexcept {
         const auto base_type = GetType();
+        if (IsCube()) {
+            // Cube needs to remain array type regardless of instruction array specifier.
+            return base_type;
+        }
         if (base_type == ImageType::Color1DArray && !is_array) {
             return ImageType::Color1D;
         }
@@ -303,7 +310,7 @@ struct Image {
     }
 
     [[nodiscard]] u32 NumViewLevels(const bool is_array) const noexcept {
-        switch (GetBoundType(is_array)) {
+        switch (GetViewType(is_array)) {
         case ImageType::Color2DMsaa:
         case ImageType::Color2DMsaaArray:
             return 1;
@@ -313,7 +320,7 @@ struct Image {
     }
 
     [[nodiscard]] u32 NumViewLayers(const bool is_array) const noexcept {
-        switch (GetBoundType(is_array)) {
+        switch (GetViewType(is_array)) {
         case ImageType::Color1D:
         case ImageType::Color2D:
         case ImageType::Color2DMsaa:

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -45,7 +45,7 @@ ImageViewInfo::ImageViewInfo(const AmdGpu::Image& image, const Shader::ImageReso
     range.base.layer = image.base_array;
     range.extent.levels = image.NumViewLevels(desc.is_array);
     range.extent.layers = image.NumViewLayers(desc.is_array);
-    type = ConvertImageViewType(image.GetBoundType(desc.is_array));
+    type = ConvertImageViewType(image.GetViewType(desc.is_array));
 
     if (!is_storage) {
         mapping = Vulkan::LiverpoolToVK::ComponentMapping(image.DstSelect());


### PR DESCRIPTION
Few small fix-ups for new image type handling:
* Clarify naming by changing image `bound type` to `view type`.
* Fix cube non-array potentially being remapped to 2D texture via 2D array check.
* Fix image instruction parameter resolution considering base type instead of view type. Have confirmed now this is the correct way to handle it.