### PR TITLE
made compatible with latest boost versions

### DIFF
--- a/src/core/libraries/kernel/kernel.cpp
+++ b/src/core/libraries/kernel/kernel.cpp
@@ -59,7 +59,7 @@ static void KernelServiceThread(std::stop_token stoken) {
         }
 
         io_context.run();
-        io_context.reset();
+        io_context.restart();
 
         asio_requests = 0;
     }


### PR DESCRIPTION
In kernel.cpp, boost asio io_context.reset() is deprecated/discontinued.  Changed to io_context.restart() as recommended as otherwise does not build with latest versions of boost.