### PR TITLE
shader_recompiler: Remove AMD native CubeFaceCoord.

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
@@ -255,14 +255,6 @@ void EmitImageWrite(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id 
     ctx.OpImageWrite(image, coords, texel, operands.mask, operands.operands);
 }
 
-Id EmitCubeFaceCoord(EmitContext& ctx, IR::Inst* inst, Id cube_coords) {
-    if (ctx.profile.supports_native_cube_calc) {
-        return ctx.OpCubeFaceCoordAMD(ctx.F32[2], cube_coords);
-    } else {
-        UNREACHABLE_MSG("SPIR-V Instruction");
-    }
-}
-
 Id EmitCubeFaceIndex(EmitContext& ctx, IR::Inst* inst, Id cube_coords) {
     if (ctx.profile.supports_native_cube_calc) {
         return ctx.OpCubeFaceIndexAMD(ctx.F32[1], cube_coords);

--- a/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
@@ -439,7 +439,6 @@ Id EmitImageAtomicAnd32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords,
 Id EmitImageAtomicOr32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id value);
 Id EmitImageAtomicXor32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id value);
 Id EmitImageAtomicExchange32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id value);
-Id EmitCubeFaceCoord(EmitContext& ctx, IR::Inst* inst, Id cube_coords);
 Id EmitCubeFaceIndex(EmitContext& ctx, IR::Inst* inst, Id cube_coords);
 Id EmitLaneId(EmitContext& ctx);
 Id EmitWarpId(EmitContext& ctx);

--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -1083,19 +1083,13 @@ void Translator::V_CUBESC_F32(const GcnInst& inst) {
     const auto y = GetSrc<IR::F32>(inst.src[1]);
     const auto z = GetSrc<IR::F32>(inst.src[2]);
 
-    IR::F32 result;
-    if (profile.supports_native_cube_calc) {
-        const auto coords{ir.CubeFaceCoord(ir.CompositeConstruct(x, y, z))};
-        result = IR::F32{ir.CompositeExtract(coords, 0)};
-    } else {
-        const auto x_neg_cond{ir.FPLessThan(x, ir.Imm32(0.f))};
-        const auto z_neg_cond{ir.FPLessThan(z, ir.Imm32(0.f))};
-        const IR::F32 x_sc{ir.Select(x_neg_cond, z, ir.FPNeg(z))};
-        const IR::F32 y_sc{x};
-        const IR::F32 z_sc{ir.Select(z_neg_cond, ir.FPNeg(x), x)};
+    const auto x_neg_cond{ir.FPLessThan(x, ir.Imm32(0.f))};
+    const auto z_neg_cond{ir.FPLessThan(z, ir.Imm32(0.f))};
+    const IR::F32 x_sc{ir.Select(x_neg_cond, z, ir.FPNeg(z))};
+    const IR::F32 y_sc{x};
+    const IR::F32 z_sc{ir.Select(z_neg_cond, ir.FPNeg(x), x)};
 
-        result = SelectCubeResult(x, y, z, x_sc, y_sc, z_sc);
-    }
+    const auto result{SelectCubeResult(x, y, z, x_sc, y_sc, z_sc)};
     SetDst(inst.dst[0], result);
 }
 
@@ -1104,17 +1098,11 @@ void Translator::V_CUBETC_F32(const GcnInst& inst) {
     const auto y = GetSrc<IR::F32>(inst.src[1]);
     const auto z = GetSrc<IR::F32>(inst.src[2]);
 
-    IR::F32 result;
-    if (profile.supports_native_cube_calc) {
-        const auto coords{ir.CubeFaceCoord(ir.CompositeConstruct(x, y, z))};
-        result = IR::F32{ir.CompositeExtract(coords, 1)};
-    } else {
-        const auto y_neg_cond{ir.FPLessThan(y, ir.Imm32(0.f))};
-        const IR::F32 x_z_tc{ir.FPNeg(y)};
-        const IR::F32 y_tc{ir.Select(y_neg_cond, ir.FPNeg(z), z)};
+    const auto y_neg_cond{ir.FPLessThan(y, ir.Imm32(0.f))};
+    const IR::F32 x_z_tc{ir.FPNeg(y)};
+    const IR::F32 y_tc{ir.Select(y_neg_cond, ir.FPNeg(z), z)};
 
-        result = SelectCubeResult(x, y, z, x_z_tc, y_tc, x_z_tc);
-    }
+    const auto result{SelectCubeResult(x, y, z, x_z_tc, y_tc, x_z_tc)};
     SetDst(inst.dst[0], result);
 }
 

--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -1758,10 +1758,6 @@ void IREmitter::ImageWrite(const Value& handle, const Value& coords, const U32& 
     Inst(Opcode::ImageWrite, Flags{info}, handle, coords, lod, multisampling, color);
 }
 
-[[nodiscard]] Value IREmitter::CubeFaceCoord(const Value& cube_coords) {
-    return Inst(Opcode::CubeFaceCoord, cube_coords);
-}
-
 [[nodiscard]] F32 IREmitter::CubeFaceIndex(const Value& cube_coords) {
     return Inst<F32>(Opcode::CubeFaceIndex, cube_coords);
 }

--- a/src/shader_recompiler/ir/ir_emitter.h
+++ b/src/shader_recompiler/ir/ir_emitter.h
@@ -342,7 +342,6 @@ public:
     void ImageWrite(const Value& handle, const Value& coords, const U32& lod,
                     const U32& multisampling, const Value& color, TextureInstInfo info);
 
-    [[nodiscard]] Value CubeFaceCoord(const Value& cube_coords);
     [[nodiscard]] F32 CubeFaceIndex(const Value& cube_coords);
 
     void EmitVertex();

--- a/src/shader_recompiler/ir/opcodes.inc
+++ b/src/shader_recompiler/ir/opcodes.inc
@@ -375,7 +375,6 @@ OPCODE(ImageAtomicXor32,                                    U32,            Opaq
 OPCODE(ImageAtomicExchange32,                               U32,            Opaque,         Opaque,         U32,                                            )
 
 // Cube operations - optional, usable if profile.supports_native_cube_calc
-OPCODE(CubeFaceCoord,                                       F32x2,          F32x3,                                                                          )
 OPCODE(CubeFaceIndex,                                       F32,            F32x3,                                                                          )
 
 // Warp operations


### PR DESCRIPTION
AMD's SPIR-V `CubeFaceCoord` does not seem to be equivalent to `v_cubesc_f32`/`v_cubetc_f32`, rather it seems to include some of the additional transformations typically done on those instructions' outputs after. So we can't use it as a native implementation for those instructions.

Should fix some Bloodborne shadow issues in first area remaining on AMD GPUs, need someone with AMD to test and confirm.