### PR TITLE
GUI: Speed up GUI loading by caching game sizes

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -72,6 +72,7 @@ static bool checkCompatibilityOnStartup = false;
 static std::string trophyKey;
 
 // Gui
+static bool load_game_size = true;
 std::vector<std::filesystem::path> settings_install_dirs = {};
 std::filesystem::path settings_addon_install_dir = {};
 u32 main_window_geometry_x = 400;
@@ -100,6 +101,14 @@ std::string getTrophyKey() {
 
 void setTrophyKey(std::string key) {
     trophyKey = key;
+}
+
+bool GetLoadGameSizeEnabled() {
+    return load_game_size;
+}
+
+void setLoadGameSizeEnabled(bool enable) {
+    load_game_size = enable;
 }
 
 bool isNeoModeConsole() {
@@ -650,6 +659,7 @@ void load(const std::filesystem::path& path) {
     if (data.contains("GUI")) {
         const toml::value& gui = data.at("GUI");
 
+        load_game_size = toml::find_or<bool>(gui, "loadGameSizeEnabled", true);
         m_icon_size = toml::find_or<int>(gui, "iconSize", 0);
         m_icon_size_grid = toml::find_or<int>(gui, "iconSizeGrid", 0);
         m_slider_pos = toml::find_or<int>(gui, "sliderPos", 0);
@@ -755,6 +765,7 @@ void save(const std::filesystem::path& path) {
         install_dirs.emplace_back(std::string{fmt::UTF(dirString.u8string()).data});
     }
     data["GUI"]["installDirs"] = install_dirs;
+    data["GUI"]["loadGameSizeEnabled"] = load_game_size;
 
     data["GUI"]["addonInstallDir"] =
         std::string{fmt::UTF(settings_addon_install_dir.u8string()).data};

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -17,6 +17,8 @@ void saveMainWindow(const std::filesystem::path& path);
 
 std::string getTrophyKey();
 void setTrophyKey(std::string key);
+bool GetLoadGameSizeEnabled();
+void setLoadGameSizeEnabled(bool enable);
 bool getIsFullscreen();
 std::string getFullscreenMode();
 bool isNeoModeConsole();

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -106,6 +106,8 @@ void GameListFrame::PlayBackgroundMusic(QTableWidgetItem* item) {
 void GameListFrame::PopulateGameList() {
     // Do not show status column if it is not enabled
     this->setColumnHidden(2, !Config::getCompatibilityEnabled());
+    this->setColumnHidden(6, !Config::GetLoadGameSizeEnabled());
+
     this->setRowCount(m_game_info->m_games.size());
     ResizeIcons(icon_size);
 

--- a/src/qt_gui/game_list_utils.h
+++ b/src/qt_gui/game_list_utils.h
@@ -62,6 +62,10 @@ public:
         QDir dir(dirPath);
         QDirIterator it(dir.absolutePath(), QDirIterator::Subdirectories);
         qint64 total = 0;
+        if (!Config::GetLoadGameSizeEnabled()) {
+            game.size = FormatSize(0).toStdString();
+            return;
+        }
         while (it.hasNext()) {
             it.next();
             total += it.fileInfo().size();

--- a/src/qt_gui/game_list_utils.h
+++ b/src/qt_gui/game_list_utils.h
@@ -62,15 +62,46 @@ public:
         QDir dir(dirPath);
         QDirIterator it(dir.absolutePath(), QDirIterator::Subdirectories);
         qint64 total = 0;
+
         if (!Config::GetLoadGameSizeEnabled()) {
             game.size = FormatSize(0).toStdString();
             return;
         }
+
+        // Cache path
+        QFile size_cache_file(Common::FS::GetUserPath(Common::FS::PathType::MetaDataDir) /
+                              game.serial / "size_cache.txt");
+        QFileInfo cacheInfo(size_cache_file);
+        QFileInfo dirInfo(dirPath);
+
+        // Check if cache file exists and is valid
+        if (size_cache_file.exists() && cacheInfo.lastModified() >= dirInfo.lastModified()) {
+            if (size_cache_file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+                QTextStream in(&size_cache_file);
+                QString cachedSize = in.readLine();
+                size_cache_file.close();
+
+                if (!cachedSize.isEmpty()) {
+                    game.size = cachedSize.toStdString();
+                    return;
+                }
+            }
+        }
+
+        // Cache is invalid or does not exist; calculate size
         while (it.hasNext()) {
             it.next();
             total += it.fileInfo().size();
         }
+
         game.size = FormatSize(total).toStdString();
+
+        // Save new cache
+        if (size_cache_file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+            QTextStream out(&size_cache_file);
+            out << QString::fromStdString(game.size) << "\n";
+            size_cache_file.close();
+        }
     }
 
     static QString GetRegion(char region) {

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -315,6 +315,7 @@ void SettingsDialog::LoadValuesFromConfig() {
         toml::find_or<std::string>(data, "General", "FullscreenMode", "Borderless")));
     ui->separateUpdatesCheckBox->setChecked(
         toml::find_or<bool>(data, "General", "separateUpdateEnabled", false));
+    ui->gameSizeCheckBox->setChecked(toml::find_or<bool>(data, "GUI", "loadGameSizeEnabled", true));
     ui->showSplashCheckBox->setChecked(toml::find_or<bool>(data, "General", "showSplash", false));
     ui->logTypeComboBox->setCurrentText(
         QString::fromStdString(toml::find_or<std::string>(data, "General", "logType", "async")));
@@ -568,6 +569,7 @@ void SettingsDialog::UpdateSettings() {
     Config::setDumpShaders(ui->dumpShadersCheckBox->isChecked());
     Config::setNullGpu(ui->nullGpuCheckBox->isChecked());
     Config::setSeparateUpdateEnabled(ui->separateUpdatesCheckBox->isChecked());
+    Config::setLoadGameSizeEnabled(ui->gameSizeCheckBox->isChecked());
     Config::setShowSplash(ui->showSplashCheckBox->isChecked());
     Config::setDebugDump(ui->debugDump->isChecked());
     Config::setVkValidation(ui->vkValidationCheckBox->isChecked());

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -171,6 +171,13 @@
                   </widget>
                  </item>
                  <item>
+                  <widget class="QCheckBox" name="gameSizeCheckBox">
+                   <property name="text">
+                    <string>Show Game Size In List</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
                   <widget class="QCheckBox" name="showSplashCheckBox">
                    <property name="text">
                     <string>Show Splash</string>

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -68,7 +68,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>536</height>
+         <height>586</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="generalTabVLayout" stretch="0">
@@ -134,7 +134,7 @@
                    </property>
                   </widget>
                  </item>
-				 <item>
+                 <item>
                   <widget class="QGroupBox" name="fullscreenModeGroupBox">
                    <property name="title">
                     <string>Fullscreen Mode</string>
@@ -167,13 +167,6 @@
                   <widget class="QCheckBox" name="separateUpdatesCheckBox">
                    <property name="text">
                     <string>Enable Separate Update Folder</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QCheckBox" name="gameSizeCheckBox">
-                   <property name="text">
-                    <string>Show Game Size In List</string>
                    </property>
                   </widget>
                  </item>
@@ -491,6 +484,13 @@
                 <number>11</number>
                </property>
                <item>
+                <widget class="QCheckBox" name="gameSizeCheckBox">
+                 <property name="text">
+                  <string>Show Game Size In List</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <widget class="QCheckBox" name="playBGMCheckBox">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -564,59 +564,59 @@
                    </property>
                   </widget>
                  </item>
+                </layout>
+               </item>
+               <item>
+                <layout class="QVBoxLayout" name="vLayoutTrophy">
+                 <property name="spacing">
+                  <number>6</number>
+                 </property>
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>50</number>
+                 </property>
                  <item>
-                  <layout class="QVBoxLayout" name="vLayoutTrophy">
-                   <property name="spacing">
-                    <number>6</number>
-                   </property>
-                   <property name="leftMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>80</number>
-                   </property>
+                  <layout class="QHBoxLayout" name="hLayoutTrophy">
                    <item>
-                    <layout class="QHBoxLayout" name="hLayoutTrophy">
-                     <item>
-                      <widget class="QGroupBox" name="trophyGroupBox">
-                       <property name="title">
-                        <string>Trophy</string>
-                       </property>
-                       <layout class="QVBoxLayout" name="userNameLayout">
-                        <item>
-                         <widget class="QCheckBox" name="disableTrophycheckBox">
-                          <property name="text">
-                           <string>Disable Trophy Pop-ups</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item>
-                         <widget class="QLabel" name="label_Trophy">
-                          <property name="text">
-                           <string>Trophy Key</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item>
-                         <widget class="QLineEdit" name="trophyKeyLineEdit">
-                          <property name="minimumSize">
-                           <size>
-                            <width>0</width>
-                            <height>0</height>
-                           </size>
-                          </property>
-                          <property name="font">
-                           <font>
-                            <pointsize>10</pointsize>
-                            <bold>false</bold>
-                           </font>
-                          </property>
-                         </widget>
-                        </item>
-                       </layout>
-                      </widget>
-                     </item>
-                    </layout>
+                    <widget class="QGroupBox" name="trophyGroupBox">
+                     <property name="title">
+                      <string>Trophy</string>
+                     </property>
+                     <layout class="QVBoxLayout" name="userNameLayout">
+                      <item>
+                       <widget class="QCheckBox" name="disableTrophycheckBox">
+                        <property name="text">
+                         <string>Disable Trophy Pop-ups</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QLabel" name="label_Trophy">
+                        <property name="text">
+                         <string>Trophy Key</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QLineEdit" name="trophyKeyLineEdit">
+                        <property name="minimumSize">
+                         <size>
+                          <width>0</width>
+                          <height>0</height>
+                         </size>
+                        </property>
+                        <property name="font">
+                         <font>
+                          <pointsize>10</pointsize>
+                          <bold>false</bold>
+                         </font>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
                    </item>
                   </layout>
                  </item>
@@ -644,8 +644,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>926</width>
-         <height>536</height>
+         <width>946</width>
+         <height>586</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="inputTabVLayout" stretch="0,0">
@@ -860,13 +860,13 @@
                  </layout>
                 </widget>
                </item>
-				  <item>
-					  <widget class="QCheckBox" name="motionControlsCheckBox"> 
-						  <property name="text">
-							  <string>Enable Motion Controls</string>
-						  </property>
-					  </widget>
-				  </item>
+               <item>
+                <widget class="QCheckBox" name="motionControlsCheckBox">
+                 <property name="text">
+                  <string>Enable Motion Controls</string>
+                 </property>
+                </widget>
+               </item>
                <item>
                 <widget class="QWidget" name="controllerWidgetSpacer" native="true">
                  <property name="enabled">
@@ -942,8 +942,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>926</width>
-         <height>536</height>
+         <width>946</width>
+         <height>586</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="graphicsTabVLayout" stretch="0,0">
@@ -1193,8 +1193,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>926</width>
-         <height>536</height>
+         <width>946</width>
+         <height>586</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="pathsTabLayout" stretch="0">
@@ -1266,8 +1266,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>926</width>
-         <height>536</height>
+         <width>946</width>
+         <height>586</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="debugTabVLayout" stretch="0,1">

--- a/src/qt_gui/translations/ar.ts
+++ b/src/qt_gui/translations/ar.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>عرض حجم اللعبة في القائمة</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>إظهار شاشة البداية</translation>

--- a/src/qt_gui/translations/da_DK.ts
+++ b/src/qt_gui/translations/da_DK.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>Vis vis spilstørrelse i listen</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>Show Splash</translation>

--- a/src/qt_gui/translations/de.ts
+++ b/src/qt_gui/translations/de.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>Zeigen Sie die Spielgröße in der Liste</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>Startbildschirm anzeigen</translation>

--- a/src/qt_gui/translations/el.ts
+++ b/src/qt_gui/translations/el.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>Εμφάνιση Μεγέθους Παιχνιδιού στη Λίστα</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>Show Splash</translation>

--- a/src/qt_gui/translations/en.ts
+++ b/src/qt_gui/translations/en.ts
@@ -541,6 +541,10 @@
 			<translation>Enable Separate Update Folder</translation>
 		</message>
 		<message>
+			<source>Show Game Size In List</source>
+			<translation>Show Game Size In List</translation>
+		</message>
+		<message>
 			<source>Show Splash</source>
 			<translation>Show Splash</translation>
 		</message>

--- a/src/qt_gui/translations/es_ES.ts
+++ b/src/qt_gui/translations/es_ES.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>Mostrar Tamaño del Juego en la Lista</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>Mostrar splash</translation>

--- a/src/qt_gui/translations/fa_IR.ts
+++ b/src/qt_gui/translations/fa_IR.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>فعال‌سازی پوشه جداگانه برای به‌روزرسانی</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>نمایش اندازه بازی در لیست</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>Splash نمایش</translation>

--- a/src/qt_gui/translations/fi.ts
+++ b/src/qt_gui/translations/fi.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Ota Käyttöön Erillinen Päivityshakemisto</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>Näytä pelin koko luettelossa</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>Näytä Aloitusnäyttö</translation>

--- a/src/qt_gui/translations/fr.ts
+++ b/src/qt_gui/translations/fr.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Dossier séparé pour les mises à jours</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>Afficher la taille du jeu dans la liste</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>Afficher l'image du jeu</translation>

--- a/src/qt_gui/translations/hu_HU.ts
+++ b/src/qt_gui/translations/hu_HU.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Külön Frissítési Mappa Engedélyezése</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>Játékméret megjelenítése a listában</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>Indítóképernyő Mutatása</translation>

--- a/src/qt_gui/translations/id.ts
+++ b/src/qt_gui/translations/id.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>Tampilkan Ukuran Game di Daftar</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>Show Splash</translation>

--- a/src/qt_gui/translations/it.ts
+++ b/src/qt_gui/translations/it.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Abilita Cartella Aggiornamenti Separata</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>Mostra la dimensione del gioco nell'elenco</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>Mostra Schermata Iniziale</translation>

--- a/src/qt_gui/translations/ja_JP.ts
+++ b/src/qt_gui/translations/ja_JP.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>ゲームサイズをリストに表示</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>スプラッシュを表示する</translation>

--- a/src/qt_gui/translations/ko_KR.ts
+++ b/src/qt_gui/translations/ko_KR.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>게임 크기를 목록에 표시</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>Show Splash</translation>

--- a/src/qt_gui/translations/lt_LT.ts
+++ b/src/qt_gui/translations/lt_LT.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>Rodyti žaidimo dydį sąraše</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>Show Splash</translation>

--- a/src/qt_gui/translations/nb.ts
+++ b/src/qt_gui/translations/nb.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Aktiver seperat oppdateringsmappe</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>Vis spillstørrelse i listen</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>Vis velkomstbilde</translation>

--- a/src/qt_gui/translations/nl.ts
+++ b/src/qt_gui/translations/nl.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>Toon grootte van het spel in de lijst</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>Show Splash</translation>

--- a/src/qt_gui/translations/pl_PL.ts
+++ b/src/qt_gui/translations/pl_PL.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>Pokaż rozmiar gry na liście</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>Pokaż ekran powitania</translation>

--- a/src/qt_gui/translations/pt_BR.ts
+++ b/src/qt_gui/translations/pt_BR.ts
@@ -541,6 +541,10 @@
 			<translation>Habilitar pasta de atualização separada</translation>
 		</message>
 		<message>
+			<source>Show Game Size In List</source>
+			<translation>Mostrar Tamanho do Jogo na Lista</translation>
+		</message>
+		<message>
 			<source>Show Splash</source>
 			<translation>Mostrar Splash Inicial</translation>
 		</message>

--- a/src/qt_gui/translations/ro_RO.ts
+++ b/src/qt_gui/translations/ro_RO.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>Afișează dimensiunea jocului în listă</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>Show Splash</translation>

--- a/src/qt_gui/translations/ru_RU.ts
+++ b/src/qt_gui/translations/ru_RU.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Отдельная папка обновлений</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>Показать размер игры в списке</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>Показывать заставку</translation>

--- a/src/qt_gui/translations/sq.ts
+++ b/src/qt_gui/translations/sq.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Aktivizo dosjen e ndarë të përditësimit</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>Shfaq madhësinë e lojës në listë</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>Shfaq Pamjen e nisjes</translation>

--- a/src/qt_gui/translations/sv.ts
+++ b/src/qt_gui/translations/sv.ts
@@ -1032,6 +1032,10 @@
         <source>Enable Separate Update Folder</source>
         <translation>Aktivera separat uppdateringsmapp</translation>
     </message>
+    <message> 
+        <source>Show Game Size In List</source>
+        <translation>Visa spelstorlek i listan</translation>
+    </message>
     <message>
         <source>Show Splash</source>
         <translation>Visa startskärm</translation>

--- a/src/qt_gui/translations/tr_TR.ts
+++ b/src/qt_gui/translations/tr_TR.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>Göster oyun boyutunu listede</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>Başlangıç Ekranını Göster</translation>

--- a/src/qt_gui/translations/uk_UA.ts
+++ b/src/qt_gui/translations/uk_UA.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Увімкнути окрему папку оновлень</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>Показати розмір гри в списку</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>Показувати заставку</translation>

--- a/src/qt_gui/translations/vi_VN.ts
+++ b/src/qt_gui/translations/vi_VN.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>Hiển thị Kích thước Game trong Danh sách</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>Show Splash</translation>

--- a/src/qt_gui/translations/zh_CN.ts
+++ b/src/qt_gui/translations/zh_CN.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>启用单独的更新目录</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>显示游戏大小在列表中</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>显示启动画面</translation>

--- a/src/qt_gui/translations/zh_TW.ts
+++ b/src/qt_gui/translations/zh_TW.ts
@@ -540,6 +540,10 @@
 			<source>Enable Separate Update Folder</source>
 			<translation>Enable Separate Update Folder</translation>
 		</message>
+		<message> 
+			<source>Show Game Size In List</source>
+			<translation>顯示遊戲大小在列表中</translation>
+		</message>
 		<message>
 			<source>Show Splash</source>
 			<translation>Show Splash</translation>


### PR DESCRIPTION
Are you tired of waiting for the emulator to go through tens, if not hundreds of gigabytes of your games for the nth time just to calculate how big each game is? Well, if you also want your loader to load everything in less than a second and don't really care how big your games are, then just turn the feature off!
When the option is disabled (it is on by default), the entire Size colunm is also hidden.