### PR TITLE
Check thread param on posix_pthread_rename_np

### DIFF
--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -386,6 +386,9 @@ int PS4_SYSV_ABI posix_sched_get_priority_min() {
 }
 
 int PS4_SYSV_ABI posix_pthread_rename_np(PthreadT thread, const char* name) {
+    if (thread == nullptr) {
+        return POSIX_EINVAL;
+    }
     LOG_INFO(Kernel_Pthread, "name = {}", name);
     Common::SetThreadName(reinterpret_cast<void*>(thread->native_thr.GetHandle()), name);
     thread->name = name;


### PR DESCRIPTION
Monster Hunter: World throws several exceptions on startup because we don't properly check for this. Based on decompiling libkernel, a PS4 would return POSIX_EINVAL in this case.

Handling this properly fixes the current crash in Monster Hunter: World (CUSA07713)