### PR TITLE
renderer_vulkan: Handle depth-stencil copies through depth render overrides.

### DIFF
--- a/src/core/devtools/widget/reg_popup.cpp
+++ b/src/core/devtools/widget/reg_popup.cpp
@@ -105,7 +105,8 @@ void RegPopup::DrawDepthBuffer(const DepthBuffer& depth_data) {
             "DEPTH_SLICE.TILE_MAX",           depth_buffer.depth_slice.tile_max,
             "Pitch()",                        depth_buffer.Pitch(),
             "Height()",                       depth_buffer.Height(),
-            "Address()",                      depth_buffer.Address(),
+            "DepthAddress()",                 depth_buffer.DepthAddress(),
+            "StencilAddress()",               depth_buffer.StencilAddress(),
             "NumSamples()",                   depth_buffer.NumSamples(),
             "NumBits()",                      depth_buffer.NumBits(),
             "GetDepthSliceSize()",            depth_buffer.GetDepthSliceSize()

--- a/src/core/devtools/widget/reg_view.cpp
+++ b/src/core/devtools/widget/reg_view.cpp
@@ -155,7 +155,7 @@ void RegView::DrawGraphicsRegs() {
         TableNextColumn();
         TextUnformatted("Depth buffer");
         TableNextColumn();
-        if (regs.depth_buffer.Address() == 0 || !regs.depth_control.depth_enable) {
+        if (regs.depth_buffer.DepthAddress() == 0 || !regs.depth_control.depth_enable) {
             TextUnformatted("N/A");
         } else {
             const char* text = last_selected_cb == depth_id && default_reg_popup.open ? "x" : "->";
@@ -241,7 +241,7 @@ void RegView::SetData(DebugStateType::RegDump _data, const std::string& base_tit
             default_reg_popup.open = false;
             if (last_selected_cb == depth_id) {
                 const auto& has_depth =
-                    regs.depth_buffer.Address() != 0 && regs.depth_control.depth_enable;
+                    regs.depth_buffer.DepthAddress() != 0 && regs.depth_control.depth_enable;
                 if (has_depth) {
                     default_reg_popup.SetData(title, regs.depth_buffer, regs.depth_control);
                     default_reg_popup.open = true;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -71,6 +71,7 @@ private:
     RenderState PrepareRenderState(u32 mrt_mask);
     void BeginRendering(const GraphicsPipeline& pipeline, RenderState& state);
     void Resolve();
+    void DepthStencilCopy(bool is_depth, bool is_stencil);
     void EliminateFastClear();
 
     void UpdateDynamicState(const GraphicsPipeline& pipeline);

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -98,7 +98,8 @@ ImageInfo::ImageInfo(const AmdGpu::Liverpool::ColorBuffer& buffer,
 }
 
 ImageInfo::ImageInfo(const AmdGpu::Liverpool::DepthBuffer& buffer, u32 num_slices,
-                     VAddr htile_address, const AmdGpu::Liverpool::CbDbExtent& hint) noexcept {
+                     VAddr htile_address, const AmdGpu::Liverpool::CbDbExtent& hint,
+                     bool write_buffer) noexcept {
     props.is_tiled = false;
     pixel_format = LiverpoolToVK::DepthFormat(buffer.z_info.format, buffer.stencil_info.format);
     type = vk::ImageType::e2D;
@@ -111,10 +112,10 @@ ImageInfo::ImageInfo(const AmdGpu::Liverpool::DepthBuffer& buffer, u32 num_slice
     resources.layers = num_slices;
     meta_info.htile_addr = buffer.z_info.tile_surface_en ? htile_address : 0;
 
-    stencil_addr = buffer.StencilAddress();
+    stencil_addr = write_buffer ? buffer.StencilWriteAddress() : buffer.StencilAddress();
     stencil_size = pitch * size.height * sizeof(u8);
 
-    guest_address = buffer.Address();
+    guest_address = write_buffer ? buffer.DepthWriteAddress() : buffer.DepthAddress();
     const auto depth_slice_sz = buffer.GetDepthSliceSize();
     guest_size = depth_slice_sz * num_slices;
     mips_layout.emplace_back(depth_slice_sz, pitch, 0);

--- a/src/video_core/texture_cache/image_info.h
+++ b/src/video_core/texture_cache/image_info.h
@@ -19,7 +19,7 @@ struct ImageInfo {
     ImageInfo(const AmdGpu::Liverpool::ColorBuffer& buffer,
               const AmdGpu::Liverpool::CbDbExtent& hint = {}) noexcept;
     ImageInfo(const AmdGpu::Liverpool::DepthBuffer& buffer, u32 num_slices, VAddr htile_address,
-              const AmdGpu::Liverpool::CbDbExtent& hint = {}) noexcept;
+              const AmdGpu::Liverpool::CbDbExtent& hint = {}, bool write_buffer = false) noexcept;
     ImageInfo(const AmdGpu::Image& image, const Shader::ImageResource& desc) noexcept;
 
     bool IsTiled() const {

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -79,9 +79,9 @@ public:
         DepthTargetDesc(const AmdGpu::Liverpool::DepthBuffer& buffer,
                         const AmdGpu::Liverpool::DepthView& view,
                         const AmdGpu::Liverpool::DepthControl& ctl, VAddr htile_address,
-                        const AmdGpu::Liverpool::CbDbExtent& hint = {})
+                        const AmdGpu::Liverpool::CbDbExtent& hint = {}, bool write_buffer = false)
             : BaseDesc{BindingType::DepthTarget,
-                       ImageInfo{buffer, view.NumSlices(), htile_address, hint},
+                       ImageInfo{buffer, view.NumSlices(), htile_address, hint, write_buffer},
                        ImageViewInfo{buffer, view, ctl}} {}
     };
 


### PR DESCRIPTION
As noted in the AMD docs, `DB_RENDER_OVERRIDE` bits may be used to perform copies to alternate surfaces. Detect and implement this case by looking for these bits set along with a valid depth/stencil read/write base and disabled color buffer mode.

Fixes a lot of post-processing issues in Hedgehog Engine 2 games, such as persistent screen overlays (supposed to be an effect over objects far in the distance) and incorrect lighting effects (although there are still some other lighting problems remaining). Probably helps other games that do this as well.