### PR TITLE
sdl: Respect text input main thread requirements.

### DIFF
--- a/src/imgui/renderer/imgui_impl_sdl3.cpp
+++ b/src/imgui/renderer/imgui_impl_sdl3.cpp
@@ -11,7 +11,6 @@
 #include <SDL3/SDL.h>
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
-#include <dispatch/dispatch.h>
 #endif
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
@@ -72,33 +71,25 @@ static void PlatformSetImeData(ImGuiContext*, ImGuiViewport* viewport, ImGuiPlat
     auto window_id = (SDL_WindowID)(intptr_t)viewport->PlatformHandle;
     SDL_Window* window = SDL_GetWindowFromID(window_id);
     if ((!data->WantVisible || bd->ime_window != window) && bd->ime_window != nullptr) {
-        auto stop_input = [&bd] { SDL_StopTextInput(bd->ime_window); };
-#ifdef __APPLE__
-        dispatch_sync(dispatch_get_main_queue(), ^{
-          stop_input();
-        });
-#else
-        stop_input();
-#endif
+        SDL_RunOnMainThread(
+            [](void* userdata) { SDL_StopTextInput(static_cast<SDL_Window*>(userdata)); },
+            bd->ime_window, true);
         bd->ime_window = nullptr;
     }
     if (data->WantVisible) {
-        SDL_Rect r;
-        r.x = (int)data->InputPos.x;
-        r.y = (int)data->InputPos.y;
-        r.w = 1;
-        r.h = (int)data->InputLineHeight;
-        const auto start_input = [&window, &r] {
-            SDL_SetTextInputArea(window, &r, 0);
-            SDL_StartTextInput(window);
-        };
-#ifdef __APPLE__
-        dispatch_sync(dispatch_get_main_queue(), ^{
-          start_input();
-        });
-#else
-        start_input();
-#endif
+        std::pair<SDL_Window*, SDL_Rect> usr_data;
+        usr_data.first = window;
+        usr_data.second.x = (int)data->InputPos.x;
+        usr_data.second.y = (int)data->InputPos.y;
+        usr_data.second.w = 1;
+        usr_data.second.h = (int)data->InputLineHeight;
+        SDL_RunOnMainThread(
+            [](void* userdata) {
+                auto* params = static_cast<std::pair<SDL_Window*, SDL_Rect>*>(userdata);
+                SDL_SetTextInputArea(params->first, &params->second, 0);
+                SDL_StartTextInput(params->first);
+            },
+            &usr_data, true);
         bd->ime_window = window;
     }
 }

--- a/src/sdl_window.cpp
+++ b/src/sdl_window.cpp
@@ -205,7 +205,9 @@ void WindowSDL::InitTimers() {
 
 void WindowSDL::RequestKeyboard() {
     if (keyboard_grab == 0) {
-        SDL_StartTextInput(window);
+        SDL_RunOnMainThread(
+            [](void* userdata) { SDL_StartTextInput(static_cast<SDL_Window*>(userdata)); }, window,
+            true);
     }
     keyboard_grab++;
 }
@@ -214,7 +216,9 @@ void WindowSDL::ReleaseKeyboard() {
     ASSERT(keyboard_grab > 0);
     keyboard_grab--;
     if (keyboard_grab == 0) {
-        SDL_StopTextInput(window);
+        SDL_RunOnMainThread(
+            [](void* userdata) { SDL_StopTextInput(static_cast<SDL_Window*>(userdata)); }, window,
+            true);
     }
 }
 


### PR DESCRIPTION
Some SDL text input functions are documented to be required to run on the main SDL thread. Update SDL to the latest versioned release and use the new `SDL_RunOnMainThread` to respect this requirement.

Existing code for this in the ImGui SDL backend is also updated to use this instead of dispatches on macOS.