### PR TITLE
liverpool_to_vk: Add R32Uint depth promote.

### DIFF
--- a/src/video_core/renderer_vulkan/liverpool_to_vk.h
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.h
@@ -71,8 +71,35 @@ vk::ClearValue ColorBufferClearValue(const AmdGpu::Liverpool::ColorBuffer& color
 
 vk::SampleCountFlagBits NumSamples(u32 num_samples, vk::SampleCountFlags supported_flags);
 
+static inline bool IsFormatDepthCompatible(vk::Format fmt) {
+    switch (fmt) {
+    // 32-bit float compatible
+    case vk::Format::eD32Sfloat:
+    case vk::Format::eR32Sfloat:
+    case vk::Format::eR32Uint:
+    // 16-bit unorm compatible
+    case vk::Format::eD16Unorm:
+    case vk::Format::eR16Unorm:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static inline bool IsFormatStencilCompatible(vk::Format fmt) {
+    switch (fmt) {
+    // 8-bit uint compatible
+    case vk::Format::eS8Uint:
+    case vk::Format::eR8Uint:
+    case vk::Format::eR8Unorm:
+        return true;
+    default:
+        return false;
+    }
+}
+
 static inline vk::Format PromoteFormatToDepth(vk::Format fmt) {
-    if (fmt == vk::Format::eR32Sfloat) {
+    if (fmt == vk::Format::eR32Sfloat || fmt == vk::Format::eR32Uint) {
         return vk::Format::eD32Sfloat;
     } else if (fmt == vk::Format::eR16Unorm) {
         return vk::Format::eD16Unorm;

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -82,13 +82,12 @@ ImageView::ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info
     vk::Format format = info.format;
     vk::ImageAspectFlags aspect = image.aspect_mask;
     if (image.aspect_mask & vk::ImageAspectFlagBits::eDepth &&
-        (format == vk::Format::eR32Sfloat || format == vk::Format::eD32Sfloat ||
-         format == vk::Format::eR16Unorm || format == vk::Format::eD16Unorm)) {
+        Vulkan::LiverpoolToVK::IsFormatDepthCompatible(format)) {
         format = image.info.pixel_format;
         aspect = vk::ImageAspectFlagBits::eDepth;
     }
     if (image.aspect_mask & vk::ImageAspectFlagBits::eStencil &&
-        (format == vk::Format::eR8Uint || format == vk::Format::eR8Unorm)) {
+        Vulkan::LiverpoolToVK::IsFormatStencilCompatible(format)) {
         format = image.info.pixel_format;
         aspect = vk::ImageAspectFlagBits::eStencil;
     }


### PR DESCRIPTION
Spotted and confirmed in CUSA30446, `R32Uint` may be used to view 32-bit depth component. Added to depth promotions, and moved the format checks for image view with depth/stencil aspect to functions to make it easier to maintain.