### PR TITLE
renderer: handle disabled clipping

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_special.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_special.cpp
@@ -47,14 +47,14 @@ void ConvertPositionToClipSpace(EmitContext& ctx) {
                                           ctx.push_data_block,
                                           ctx.ConstU32(PushData::YScaleIndex))};
     const Id yscale{ctx.OpLoad(type, yscale_ptr)};
-    Id ndc_x = ctx.OpFMul(type, x, xscale);
-    ndc_x = ctx.OpFAdd(type, ndc_x, xoffset);
-    ndc_x = ctx.OpFDiv(type, ndc_x, ctx.Constant(type, float(8_KB)));
-    ndc_x = ctx.OpFSub(type, ndc_x, ctx.Constant(type, 1.f));
-    Id ndc_y = ctx.OpFMul(type, y, yscale);
-    ndc_y = ctx.OpFAdd(type, ndc_y, yoffset);
-    ndc_y = ctx.OpFDiv(type, ndc_y, ctx.Constant(type, float(8_KB)));
-    ndc_y = ctx.OpFSub(type, ndc_y, ctx.Constant(type, 1.f));
+    const Id vport_w =
+        ctx.Constant(type, float(std::min<u32>(ctx.profile.max_viewport_width / 2, 8_KB)));
+    const Id wnd_x = ctx.OpFAdd(type, ctx.OpFMul(type, x, xscale), xoffset);
+    const Id ndc_x = ctx.OpFSub(type, ctx.OpFDiv(type, wnd_x, vport_w), ctx.Constant(type, 1.f));
+    const Id vport_h =
+        ctx.Constant(type, float(std::min<u32>(ctx.profile.max_viewport_height / 2, 8_KB)));
+    const Id wnd_y = ctx.OpFAdd(type, ctx.OpFMul(type, y, yscale), yoffset);
+    const Id ndc_y = ctx.OpFSub(type, ctx.OpFDiv(type, wnd_y, vport_h), ctx.Constant(type, 1.f));
     const Id vector{ctx.OpCompositeConstruct(ctx.F32[4], std::array<Id, 4>({ndc_x, ndc_y, z, w}))};
     ctx.OpStore(ctx.output_position, vector);
 }

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -568,25 +568,34 @@ void EmitContext::DefineOutputs() {
 
 void EmitContext::DefinePushDataBlock() {
     // Create push constants block for instance steps rates
-    const Id struct_type{Name(
-        TypeStruct(U32[1], U32[1], U32[4], U32[4], U32[4], U32[4], U32[4], U32[4]), "AuxData")};
+    const Id struct_type{Name(TypeStruct(U32[1], U32[1], U32[4], U32[4], U32[4], U32[4], U32[4],
+                                         U32[4], F32[1], F32[1], F32[1], F32[1]),
+                              "AuxData")};
     Decorate(struct_type, spv::Decoration::Block);
     MemberName(struct_type, 0, "sr0");
     MemberName(struct_type, 1, "sr1");
-    MemberName(struct_type, 2, "buf_offsets0");
-    MemberName(struct_type, 3, "buf_offsets1");
-    MemberName(struct_type, 4, "ud_regs0");
-    MemberName(struct_type, 5, "ud_regs1");
-    MemberName(struct_type, 6, "ud_regs2");
-    MemberName(struct_type, 7, "ud_regs3");
+    MemberName(struct_type, Shader::PushData::BufOffsetIndex + 0, "buf_offsets0");
+    MemberName(struct_type, Shader::PushData::BufOffsetIndex + 1, "buf_offsets1");
+    MemberName(struct_type, Shader::PushData::UdRegsIndex + 0, "ud_regs0");
+    MemberName(struct_type, Shader::PushData::UdRegsIndex + 1, "ud_regs1");
+    MemberName(struct_type, Shader::PushData::UdRegsIndex + 2, "ud_regs2");
+    MemberName(struct_type, Shader::PushData::UdRegsIndex + 3, "ud_regs3");
+    MemberName(struct_type, Shader::PushData::XOffsetIndex, "xoffset");
+    MemberName(struct_type, Shader::PushData::YOffsetIndex, "yoffset");
+    MemberName(struct_type, Shader::PushData::XScaleIndex, "xscale");
+    MemberName(struct_type, Shader::PushData::YScaleIndex, "yscale");
     MemberDecorate(struct_type, 0, spv::Decoration::Offset, 0U);
     MemberDecorate(struct_type, 1, spv::Decoration::Offset, 4U);
-    MemberDecorate(struct_type, 2, spv::Decoration::Offset, 8U);
-    MemberDecorate(struct_type, 3, spv::Decoration::Offset, 24U);
-    MemberDecorate(struct_type, 4, spv::Decoration::Offset, 40U);
-    MemberDecorate(struct_type, 5, spv::Decoration::Offset, 56U);
-    MemberDecorate(struct_type, 6, spv::Decoration::Offset, 72U);
-    MemberDecorate(struct_type, 7, spv::Decoration::Offset, 88U);
+    MemberDecorate(struct_type, Shader::PushData::BufOffsetIndex + 0, spv::Decoration::Offset, 8U);
+    MemberDecorate(struct_type, Shader::PushData::BufOffsetIndex + 1, spv::Decoration::Offset, 24U);
+    MemberDecorate(struct_type, Shader::PushData::UdRegsIndex + 0, spv::Decoration::Offset, 40U);
+    MemberDecorate(struct_type, Shader::PushData::UdRegsIndex + 1, spv::Decoration::Offset, 56U);
+    MemberDecorate(struct_type, Shader::PushData::UdRegsIndex + 2, spv::Decoration::Offset, 72U);
+    MemberDecorate(struct_type, Shader::PushData::UdRegsIndex + 3, spv::Decoration::Offset, 88U);
+    MemberDecorate(struct_type, Shader::PushData::XOffsetIndex, spv::Decoration::Offset, 104U);
+    MemberDecorate(struct_type, Shader::PushData::YOffsetIndex, spv::Decoration::Offset, 108U);
+    MemberDecorate(struct_type, Shader::PushData::XScaleIndex, spv::Decoration::Offset, 112U);
+    MemberDecorate(struct_type, Shader::PushData::YScaleIndex, spv::Decoration::Offset, 116U);
     push_data_block = DefineVar(struct_type, spv::StorageClass::PushConstant);
     Name(push_data_block, "push_data");
     interfaces.push_back(push_data_block);

--- a/src/shader_recompiler/info.h
+++ b/src/shader_recompiler/info.h
@@ -96,11 +96,19 @@ using FMaskResourceList = boost::container::small_vector<FMaskResource, 16>;
 struct PushData {
     static constexpr u32 BufOffsetIndex = 2;
     static constexpr u32 UdRegsIndex = 4;
+    static constexpr u32 XOffsetIndex = 8;
+    static constexpr u32 YOffsetIndex = 9;
+    static constexpr u32 XScaleIndex = 10;
+    static constexpr u32 YScaleIndex = 11;
 
     u32 step0;
     u32 step1;
     std::array<u8, 32> buf_offsets;
     std::array<u32, NumUserDataRegs> ud_regs;
+    float xoffset;
+    float yoffset;
+    float xscale;
+    float yscale;
 
     void AddOffset(u32 binding, u32 offset) {
         ASSERT(offset < 256 && binding < buf_offsets.size());

--- a/src/shader_recompiler/profile.h
+++ b/src/shader_recompiler/profile.h
@@ -30,6 +30,8 @@ struct Profile {
     bool needs_manual_interpolation{};
     bool needs_lds_barriers{};
     u64 min_ssbo_alignment{};
+    u32 max_viewport_width{};
+    u32 max_viewport_height{};
 };
 
 } // namespace Shader

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -84,6 +84,7 @@ struct VertexRuntimeInfo {
     u32 num_outputs;
     std::array<VsOutputMap, 3> outputs;
     bool emulate_depth_negative_one_to_one{};
+    bool clip_disable{};
     // Domain
     AmdGpu::TessellationType tess_type;
     AmdGpu::TessellationTopology tess_topology;
@@ -92,7 +93,8 @@ struct VertexRuntimeInfo {
 
     bool operator==(const VertexRuntimeInfo& other) const noexcept {
         return emulate_depth_negative_one_to_one == other.emulate_depth_negative_one_to_one &&
-               tess_type == other.tess_type && tess_topology == other.tess_topology &&
+               clip_disable == other.clip_disable && tess_type == other.tess_type &&
+               tess_topology == other.tess_topology &&
                tess_partitioning == other.tess_partitioning &&
                hs_output_cp_stride == other.hs_output_cp_stride;
     }

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -42,13 +42,14 @@ struct GraphicsPipelineKey {
     vk::Format stencil_format;
 
     struct {
+        bool clip_disable : 1;
         bool depth_test_enable : 1;
         bool depth_write_enable : 1;
         bool depth_bounds_test_enable : 1;
         bool depth_bias_enable : 1;
         bool stencil_test_enable : 1;
         // Must be named to be zero-initialized.
-        u8 _unused : 3;
+        u8 _unused : 2;
     };
     vk::CompareOp depth_compare_op;
 
@@ -92,6 +93,10 @@ public:
 
     auto GetMrtMask() const {
         return key.mrt_mask;
+    }
+
+    auto IsClipDisabled() const {
+        return key.clip_disable;
     }
 
     [[nodiscard]] bool IsPrimitiveListTopology() const {

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -406,6 +406,7 @@ bool Instance::CreateDevice() {
         },
         vk::PhysicalDevicePrimitiveTopologyListRestartFeaturesEXT{
             .primitiveTopologyListRestart = true,
+            .primitiveTopologyPatchListRestart = true,
         },
         vk::PhysicalDeviceFragmentShaderBarycentricFeaturesKHR{
             .fragmentShaderBarycentric = true,

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -208,6 +208,7 @@ std::string Instance::GetDriverVersionName() {
 bool Instance::CreateDevice() {
     const vk::StructureChain feature_chain = physical_device.getFeatures2<
         vk::PhysicalDeviceFeatures2, vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT,
+        vk::PhysicalDevicePrimitiveTopologyListRestartFeaturesEXT,
         vk::PhysicalDeviceExtendedDynamicState2FeaturesEXT,
         vk::PhysicalDeviceExtendedDynamicState3FeaturesEXT,
         vk::PhysicalDeviceCustomBorderColorFeaturesEXT,
@@ -316,6 +317,9 @@ bool Instance::CreateDevice() {
         .pQueuePriorities = queue_priorities.data(),
     };
 
+    const auto topology_list_restart_features =
+        feature_chain.get<vk::PhysicalDevicePrimitiveTopologyListRestartFeaturesEXT>();
+
     const auto vk12_features = feature_chain.get<vk::PhysicalDeviceVulkan12Features>();
     vk::StructureChain device_chain = {
         vk::DeviceCreateInfo{
@@ -406,7 +410,8 @@ bool Instance::CreateDevice() {
         },
         vk::PhysicalDevicePrimitiveTopologyListRestartFeaturesEXT{
             .primitiveTopologyListRestart = true,
-            .primitiveTopologyPatchListRestart = true,
+            .primitiveTopologyPatchListRestart =
+                topology_list_restart_features.primitiveTopologyPatchListRestart,
         },
         vk::PhysicalDeviceFragmentShaderBarycentricFeaturesKHR{
             .fragmentShaderBarycentric = true,

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -274,6 +274,14 @@ public:
         return min_imported_host_pointer_alignment;
     }
 
+    u32 GetMaxViewportWidth() const {
+        return properties.limits.maxViewportDimensions[0];
+    }
+
+    u32 GetMaxViewportHeight() const {
+        return properties.limits.maxViewportDimensions[1];
+    }
+
     /// Returns the sample count flags supported by framebuffers.
     vk::SampleCountFlags GetFramebufferSampleCounts() const {
         return properties.limits.framebufferColorSampleCounts &

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -125,6 +125,7 @@ const Shader::RuntimeInfo& PipelineCache::BuildRuntimeInfo(Stage stage, LogicalS
         info.vs_info.emulate_depth_negative_one_to_one =
             !instance.IsDepthClipControlSupported() &&
             regs.clipper_control.clip_space == Liverpool::ClipSpace::MinusWToW;
+        info.vs_info.clip_disable = graphics_key.clip_disable;
         if (l_stage == LogicalStage::TessellationEval) {
             info.vs_info.tess_type = regs.tess_config.type;
             info.vs_info.tess_topology = regs.tess_config.topology;
@@ -261,6 +262,15 @@ bool PipelineCache::RefreshGraphicsKey() {
     auto& regs = liverpool->regs;
     auto& key = graphics_key;
 
+    const auto& vp_ctl = regs.viewport_control;
+
+    // TODO(roamic): the statement below needs verification with a sample on the real HW.
+    // If there is no defined transform to convert from clip space to screen space we assume that
+    // clipping is also disabled.
+    const bool viewport_disabled = !vp_ctl.xoffset_enable && !vp_ctl.xscale_enable &&
+                                   !vp_ctl.yoffset_enable && !vp_ctl.yscale_enable &&
+                                   !vp_ctl.zoffset_enable && !vp_ctl.zscale_enable;
+    key.clip_disable = regs.clipper_control.clip_disable || viewport_disabled;
     key.depth_test_enable = regs.depth_control.depth_enable;
     key.depth_write_enable =
         regs.depth_control.depth_write_enable && !regs.depth_render_control.depth_clear_enable;

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -210,6 +210,8 @@ PipelineCache::PipelineCache(const Instance& instance_, Scheduler& scheduler_,
                                       instance.GetDriverID() == vk::DriverId::eNvidiaProprietary,
         .needs_lds_barriers = instance.GetDriverID() == vk::DriverId::eNvidiaProprietary ||
                               instance.GetDriverID() == vk::DriverId::eMoltenvk,
+        .max_viewport_width = instance.GetMaxViewportWidth(),
+        .max_viewport_height = instance.GetMaxViewportHeight(),
     };
     auto [cache_result, cache] = instance.GetDevice().createPipelineCacheUnique({});
     ASSERT_MSG(cache_result == vk::Result::eSuccess, "Failed to create pipeline cache: {}",

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -262,15 +262,8 @@ bool PipelineCache::RefreshGraphicsKey() {
     auto& regs = liverpool->regs;
     auto& key = graphics_key;
 
-    const auto& vp_ctl = regs.viewport_control;
-
-    // TODO(roamic): the statement below needs verification with a sample on the real HW.
-    // If there is no defined transform to convert from clip space to screen space we assume that
-    // clipping is also disabled.
-    const bool viewport_disabled = !vp_ctl.xoffset_enable && !vp_ctl.xscale_enable &&
-                                   !vp_ctl.yoffset_enable && !vp_ctl.yscale_enable &&
-                                   !vp_ctl.zoffset_enable && !vp_ctl.zscale_enable;
-    key.clip_disable = regs.clipper_control.clip_disable || viewport_disabled;
+    key.clip_disable =
+        regs.clipper_control.clip_disable || regs.primitive_type == AmdGpu::PrimitiveType::RectList;
     key.depth_test_enable = regs.depth_control.depth_enable;
     key.depth_write_enable =
         regs.depth_control.depth_write_enable && !regs.depth_render_control.depth_clear_enable;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -504,6 +504,10 @@ bool Rasterizer::BindResources(const Pipeline* pipeline) {
         }
         push_data.step0 = regs.vgt_instance_step_rate_0;
         push_data.step1 = regs.vgt_instance_step_rate_1;
+        push_data.xoffset = regs.viewport_control.xoffset_enable ? regs.viewports[0].xoffset : 0.f;
+        push_data.xscale = regs.viewport_control.xscale_enable ? regs.viewports[0].xscale : 1.f;
+        push_data.yoffset = regs.viewport_control.yoffset_enable ? regs.viewports[0].yoffset : 0.f;
+        push_data.yscale = regs.viewport_control.yscale_enable ? regs.viewports[0].yscale : 1.f;
         stage->PushUd(binding, push_data);
 
         BindBuffers(*stage, binding, push_data, set_writes, buffer_barriers);

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -76,7 +76,7 @@ private:
     void EliminateFastClear();
 
     void UpdateDynamicState(const GraphicsPipeline& pipeline);
-    void UpdateViewportScissorState();
+    void UpdateViewportScissorState(const GraphicsPipeline& pipeline);
 
     bool FilterDraw();
 


### PR DESCRIPTION
Adds handling to the disabled clipping by creating a vertex shader permutation that converts vertex coordinates from clip space to screen space and fits them inside a huge (`[0..16383, 0..16383]`) viewport. One shortcoming of this method is that it does not support multiple different viewport transformations but nothing can be done about this without hardware and API support.

Also implicitly disables clipping for the `RECTLIST` primitive because this primitive should not be clipped, rather it should be culled.

Other minor changes:
* Added `primitiveTopologyPatchListRestart` if it is supported by the device to silence the validation errors.
* Changed empty viewport to one outside of the render space.