### PR TITLE
Add auto-generated libSceNpWebApi stubs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,6 +430,8 @@ set(NP_LIBS src/core/libraries/np_common/np_common.cpp
             src/core/libraries/np_trophy/trophy_ui.cpp
             src/core/libraries/np_trophy/trophy_ui.h
             src/core/libraries/np_trophy/np_trophy_error.h
+            src/core/libraries/np_web_api/np_web_api.cpp
+            src/core/libraries/np_web_api/np_web_api.h
 )
 
 set(MISC_LIBS  src/core/libraries/screenshot/screenshot.cpp

--- a/src/common/logging/filter.cpp
+++ b/src/common/logging/filter.cpp
@@ -104,6 +104,7 @@ bool ParseFilterRule(Filter& instance, Iterator begin, Iterator end) {
     SUB(Lib, NpManager)                                                                            \
     SUB(Lib, NpScore)                                                                              \
     SUB(Lib, NpTrophy)                                                                             \
+    SUB(Lib, NpWebApi)                                                                             \
     SUB(Lib, Screenshot)                                                                           \
     SUB(Lib, LibCInternal)                                                                         \
     SUB(Lib, AppContent)                                                                           \

--- a/src/common/logging/types.h
+++ b/src/common/logging/types.h
@@ -71,6 +71,7 @@ enum class Class : u8 {
     Lib_NpManager,         ///< The LibSceNpManager implementation
     Lib_NpScore,           ///< The LibSceNpScore implementation
     Lib_NpTrophy,          ///< The LibSceNpTrophy implementation
+    Lib_NpWebApi,          ///< The LibSceWebApi implementation
     Lib_Screenshot,        ///< The LibSceScreenshot implementation
     Lib_LibCInternal,      ///< The LibCInternal implementation.
     Lib_AppContent,        ///< The LibSceAppContent implementation.

--- a/src/core/libraries/libs.cpp
+++ b/src/core/libraries/libs.cpp
@@ -30,6 +30,7 @@
 #include "core/libraries/np_manager/np_manager.h"
 #include "core/libraries/np_score/np_score.h"
 #include "core/libraries/np_trophy/np_trophy.h"
+#include "core/libraries/np_web_api/np_web_api.h"
 #include "core/libraries/pad/pad.h"
 #include "core/libraries/playgo/playgo.h"
 #include "core/libraries/playgo/playgo_dialog.h"
@@ -81,6 +82,7 @@ void InitHLELibs(Core::Loader::SymbolsResolver* sym) {
     Libraries::NpManager::RegisterlibSceNpManager(sym);
     Libraries::NpScore::RegisterlibSceNpScore(sym);
     Libraries::NpTrophy::RegisterlibSceNpTrophy(sym);
+    Libraries::NpWebApi::RegisterlibSceNpWebApi(sym);
     Libraries::ScreenShot::RegisterlibSceScreenShot(sym);
     Libraries::AppContent::RegisterlibSceAppContent(sym);
     Libraries::PngDec::RegisterlibScePngDec(sym);

--- a/src/core/libraries/np_web_api/np_web_api.cpp
+++ b/src/core/libraries/np_web_api/np_web_api.cpp
@@ -1,0 +1,692 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "common/logging/log.h"
+#include "core/libraries/error_codes.h"
+#include "core/libraries/libs.h"
+#include "core/libraries/np_web_api/np_web_api.h"
+
+namespace Libraries::NpWebApi {
+
+s32 PS4_SYSV_ABI sceNpWebApiCreateContext() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiCreatePushEventFilter() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiCreateServicePushEventFilter() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiDeletePushEventFilter() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiDeleteServicePushEventFilter() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiRegisterExtdPushEventCallback() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiRegisterNotificationCallback() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiRegisterPushEventCallback() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiRegisterServicePushEventCallback() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiUnregisterNotificationCallback() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiUnregisterPushEventCallback() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiUnregisterServicePushEventCallback() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiAbortHandle() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiAbortRequest() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiAddHttpRequestHeader() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiAddMultipartPart() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiCheckTimeout() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiClearAllUnusedConnection() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiClearUnusedConnection() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiCreateContextA() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiCreateExtdPushEventFilter() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiCreateHandle() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiCreateMultipartRequest() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiCreateRequest() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiDeleteContext() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiDeleteExtdPushEventFilter() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiDeleteHandle() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiDeleteRequest() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiGetConnectionStats() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiGetErrorCode() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiGetHttpResponseHeaderValue() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiGetHttpResponseHeaderValueLength() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiGetHttpStatusCode() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiGetMemoryPoolStats() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiInitialize() {
+    LOG_ERROR(Lib_NpWebApi, "(DUMMY) called");
+    static s32 id = 0;
+    return ++id;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiInitializeForPresence() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiIntCreateCtxIndExtdPushEventFilter() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiIntCreateRequest() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiIntCreateServicePushEventFilter() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiIntInitialize() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiIntRegisterServicePushEventCallback() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiIntRegisterServicePushEventCallbackA() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiReadData() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiRegisterExtdPushEventCallbackA() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiSendMultipartRequest() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiSendMultipartRequest2() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiSendRequest() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiSendRequest2() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiSetHandleTimeout() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiSetMaxConnection() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiSetMultipartContentType() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiSetRequestTimeout() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiTerminate() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiUnregisterExtdPushEventCallback() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiUtilityParseNpId() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceNpWebApiVshInitialize() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_064C4ED1EDBEB9E8() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_0783955D4E9563DA() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_1A6D77F3FD8323A8() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_1E0693A26FE0F954() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_24A9B5F1D77000CF() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_24AAA6F50E4C2361() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_24D8853D6B47FC79() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_279B3E9C7C4A9DC5() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_28461E29E9F8D697() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_3C29624704FAB9E0() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_3F027804ED2EC11E() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_4066C94E782997CD() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_47C85356815DBE90() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_4FCE8065437E3B87() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_536280BE3DABB521() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_57A0E1BC724219F3() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_5819749C040B6637() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_6198D0C825E86319() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_61F2B9E8AB093743() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_6BC388E6113F0D44() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_7500F0C4F8DC2D16() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_75A03814C7E9039F() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_789D6026C521416E() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_7DED63D06399EFFF() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_7E55A2DCC03D395A() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_7E6C8F9FB86967F4() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_7F04B7D4A7D41E80() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_8E167252DFA5C957() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_95D0046E504E3B09() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_97284BFDA4F18FDF() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_99E32C1F4737EAB4() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_9CFF661EA0BCBF83() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_9EB0E1F467AC3B29() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_A2318FE6FBABFAA3() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_BA07A2E1BF7B3971() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_BD0803EEE0CC29A0() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_BE6F4E5524BB135F() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_C0D490EB481EA4D0() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_C175D392CA6D084A() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_CD0136AF165D2F2F() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_D1C0ADB7B52FEAB5() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_E324765D18EE4D12() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_E789F980D907B653() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_F9A32E8685627436() {
+    LOG_ERROR(Lib_NpWebApi, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+void RegisterlibSceNpWebApi(Core::Loader::SymbolsResolver* sym) {
+    LIB_FUNCTION("x1Y7yiYSk7c", "libSceNpWebApiCompat", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiCreateContext);
+    LIB_FUNCTION("y5Ta5JCzQHY", "libSceNpWebApiCompat", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiCreatePushEventFilter);
+    LIB_FUNCTION("sIFx734+xys", "libSceNpWebApiCompat", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiCreateServicePushEventFilter);
+    LIB_FUNCTION("zE+R6Rcx3W0", "libSceNpWebApiCompat", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiDeletePushEventFilter);
+    LIB_FUNCTION("PfQ+f6ws764", "libSceNpWebApiCompat", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiDeleteServicePushEventFilter);
+    LIB_FUNCTION("vrM02A5Gy1M", "libSceNpWebApiCompat", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiRegisterExtdPushEventCallback);
+    LIB_FUNCTION("HVgWmGIOKdk", "libSceNpWebApiCompat", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiRegisterNotificationCallback);
+    LIB_FUNCTION("PfSTDCgNMgc", "libSceNpWebApiCompat", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiRegisterPushEventCallback);
+    LIB_FUNCTION("kJQJE0uKm5w", "libSceNpWebApiCompat", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiRegisterServicePushEventCallback);
+    LIB_FUNCTION("wjYEvo4xbcA", "libSceNpWebApiCompat", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiUnregisterNotificationCallback);
+    LIB_FUNCTION("qK4o2656W4w", "libSceNpWebApiCompat", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiUnregisterPushEventCallback);
+    LIB_FUNCTION("2edrkr0c-wg", "libSceNpWebApiCompat", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiUnregisterServicePushEventCallback);
+    LIB_FUNCTION("WKcm4PeyJww", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiAbortHandle);
+    LIB_FUNCTION("JzhYTP2fG18", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiAbortRequest);
+    LIB_FUNCTION("joRjtRXTFoc", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiAddHttpRequestHeader);
+    LIB_FUNCTION("19KgfJXgM+U", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiAddMultipartPart);
+    LIB_FUNCTION("gVNNyxf-1Sg", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiCheckTimeout);
+    LIB_FUNCTION("KQIkDGf80PQ", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiClearAllUnusedConnection);
+    LIB_FUNCTION("f-pgaNSd1zc", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiClearUnusedConnection);
+    LIB_FUNCTION("x1Y7yiYSk7c", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiCreateContext);
+    LIB_FUNCTION("zk6c65xoyO0", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiCreateContextA);
+    LIB_FUNCTION("M2BUB+DNEGE", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiCreateExtdPushEventFilter);
+    LIB_FUNCTION("79M-JqvvGo0", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiCreateHandle);
+    LIB_FUNCTION("KBxgeNpoRIQ", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiCreateMultipartRequest);
+    LIB_FUNCTION("y5Ta5JCzQHY", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiCreatePushEventFilter);
+    LIB_FUNCTION("rdgs5Z1MyFw", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiCreateRequest);
+    LIB_FUNCTION("sIFx734+xys", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiCreateServicePushEventFilter);
+    LIB_FUNCTION("XUjdsSTTZ3U", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiDeleteContext);
+    LIB_FUNCTION("pfaJtb7SQ80", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiDeleteExtdPushEventFilter);
+    LIB_FUNCTION("5Mn7TYwpl30", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiDeleteHandle);
+    LIB_FUNCTION("zE+R6Rcx3W0", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiDeletePushEventFilter);
+    LIB_FUNCTION("noQgleu+KLE", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiDeleteRequest);
+    LIB_FUNCTION("PfQ+f6ws764", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiDeleteServicePushEventFilter);
+    LIB_FUNCTION("UJ8H+7kVQUE", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiGetConnectionStats);
+    LIB_FUNCTION("2qSZ0DgwTsc", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiGetErrorCode);
+    LIB_FUNCTION("VwJ5L0Higg0", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiGetHttpResponseHeaderValue);
+    LIB_FUNCTION("743ZzEBzlV8", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiGetHttpResponseHeaderValueLength);
+    LIB_FUNCTION("k210oKgP80Y", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiGetHttpStatusCode);
+    LIB_FUNCTION("3OnubUs02UM", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiGetMemoryPoolStats);
+    LIB_FUNCTION("G3AnLNdRBjE", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, sceNpWebApiInitialize);
+    LIB_FUNCTION("FkuwsD64zoQ", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiInitializeForPresence);
+    LIB_FUNCTION("c1pKoztonB8", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiIntCreateCtxIndExtdPushEventFilter);
+    LIB_FUNCTION("N2Jbx4tIaQ4", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiIntCreateRequest);
+    LIB_FUNCTION("TZSep4xB4EY", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiIntCreateServicePushEventFilter);
+    LIB_FUNCTION("8Vjplhyyc44", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiIntInitialize);
+    LIB_FUNCTION("VjVukb2EWPc", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiIntRegisterServicePushEventCallback);
+    LIB_FUNCTION("sfq23ZVHVEw", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiIntRegisterServicePushEventCallbackA);
+    LIB_FUNCTION("CQtPRSF6Ds8", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, sceNpWebApiReadData);
+    LIB_FUNCTION("vrM02A5Gy1M", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiRegisterExtdPushEventCallback);
+    LIB_FUNCTION("jhXKGQJ4egI", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiRegisterExtdPushEventCallbackA);
+    LIB_FUNCTION("HVgWmGIOKdk", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiRegisterNotificationCallback);
+    LIB_FUNCTION("PfSTDCgNMgc", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiRegisterPushEventCallback);
+    LIB_FUNCTION("kJQJE0uKm5w", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiRegisterServicePushEventCallback);
+    LIB_FUNCTION("KCItz6QkeGs", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiSendMultipartRequest);
+    LIB_FUNCTION("DsPOTEvSe7M", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiSendMultipartRequest2);
+    LIB_FUNCTION("kVbL4hL3K7w", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiSendRequest);
+    LIB_FUNCTION("KjNeZ-29ysQ", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiSendRequest2);
+    LIB_FUNCTION("6g6q-g1i4XU", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiSetHandleTimeout);
+    LIB_FUNCTION("gRiilVCvfAI", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiSetMaxConnection);
+    LIB_FUNCTION("i0dr6grIZyc", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiSetMultipartContentType);
+    LIB_FUNCTION("qWcbJkBj1Lg", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiSetRequestTimeout);
+    LIB_FUNCTION("asz3TtIqGF8", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, sceNpWebApiTerminate);
+    LIB_FUNCTION("PqCY25FMzPs", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiUnregisterExtdPushEventCallback);
+    LIB_FUNCTION("wjYEvo4xbcA", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiUnregisterNotificationCallback);
+    LIB_FUNCTION("qK4o2656W4w", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiUnregisterPushEventCallback);
+    LIB_FUNCTION("2edrkr0c-wg", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiUnregisterServicePushEventCallback);
+    LIB_FUNCTION("or0e885BlXo", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiUtilityParseNpId);
+    LIB_FUNCTION("uRsskUhAfnM", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1,
+                 sceNpWebApiVshInitialize);
+    LIB_FUNCTION("BkxO0e2+ueg", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_064C4ED1EDBEB9E8);
+    LIB_FUNCTION("B4OVXU6VY9o", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_0783955D4E9563DA);
+    LIB_FUNCTION("Gm138-2DI6g", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_1A6D77F3FD8323A8);
+    LIB_FUNCTION("HgaTom-g+VQ", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_1E0693A26FE0F954);
+    LIB_FUNCTION("JKm18ddwAM8", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_24A9B5F1D77000CF);
+    LIB_FUNCTION("JKqm9Q5MI2E", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_24AAA6F50E4C2361);
+    LIB_FUNCTION("JNiFPWtH-Hk", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_24D8853D6B47FC79);
+    LIB_FUNCTION("J5s+nHxKncU", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_279B3E9C7C4A9DC5);
+    LIB_FUNCTION("KEYeKen41pc", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_28461E29E9F8D697);
+    LIB_FUNCTION("PCliRwT6ueA", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_3C29624704FAB9E0);
+    LIB_FUNCTION("PwJ4BO0uwR4", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_3F027804ED2EC11E);
+    LIB_FUNCTION("QGbJTngpl80", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_4066C94E782997CD);
+    LIB_FUNCTION("R8hTVoFdvpA", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_47C85356815DBE90);
+    LIB_FUNCTION("T86AZUN+O4c", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_4FCE8065437E3B87);
+    LIB_FUNCTION("U2KAvj2rtSE", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_536280BE3DABB521);
+    LIB_FUNCTION("V6DhvHJCGfM", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_57A0E1BC724219F3);
+    LIB_FUNCTION("WBl0nAQLZjc", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_5819749C040B6637);
+    LIB_FUNCTION("YZjQyCXoYxk", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_6198D0C825E86319);
+    LIB_FUNCTION("YfK56KsJN0M", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_61F2B9E8AB093743);
+    LIB_FUNCTION("a8OI5hE-DUQ", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_6BC388E6113F0D44);
+    LIB_FUNCTION("dQDwxPjcLRY", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_7500F0C4F8DC2D16);
+    LIB_FUNCTION("daA4FMfpA58", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_75A03814C7E9039F);
+    LIB_FUNCTION("eJ1gJsUhQW4", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_789D6026C521416E);
+    LIB_FUNCTION("fe1j0GOZ7-8", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_7DED63D06399EFFF);
+    LIB_FUNCTION("flWi3MA9OVo", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_7E55A2DCC03D395A);
+    LIB_FUNCTION("fmyPn7hpZ-Q", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_7E6C8F9FB86967F4);
+    LIB_FUNCTION("fwS31KfUHoA", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_7F04B7D4A7D41E80);
+    LIB_FUNCTION("jhZyUt+lyVc", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_8E167252DFA5C957);
+    LIB_FUNCTION("ldAEblBOOwk", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_95D0046E504E3B09);
+    LIB_FUNCTION("lyhL-aTxj98", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_97284BFDA4F18FDF);
+    LIB_FUNCTION("meMsH0c36rQ", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_99E32C1F4737EAB4);
+    LIB_FUNCTION("nP9mHqC8v4M", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_9CFF661EA0BCBF83);
+    LIB_FUNCTION("nrDh9GesOyk", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_9EB0E1F467AC3B29);
+    LIB_FUNCTION("ojGP5vur+qM", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_A2318FE6FBABFAA3);
+    LIB_FUNCTION("ugei4b97OXE", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_BA07A2E1BF7B3971);
+    LIB_FUNCTION("vQgD7uDMKaA", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_BD0803EEE0CC29A0);
+    LIB_FUNCTION("vm9OVSS7E18", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_BE6F4E5524BB135F);
+    LIB_FUNCTION("wNSQ60gepNA", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_C0D490EB481EA4D0);
+    LIB_FUNCTION("wXXTksptCEo", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_C175D392CA6D084A);
+    LIB_FUNCTION("zQE2rxZdLy8", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_CD0136AF165D2F2F);
+    LIB_FUNCTION("0cCtt7Uv6rU", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_D1C0ADB7B52FEAB5);
+    LIB_FUNCTION("4yR2XRjuTRI", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_E324765D18EE4D12);
+    LIB_FUNCTION("54n5gNkHtlM", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_E789F980D907B653);
+    LIB_FUNCTION("+aMuhoVidDY", "libSceNpWebApi", 1, "libSceNpWebApi", 1, 1, Func_F9A32E8685627436);
+};
+
+} // namespace Libraries::NpWebApi

--- a/src/core/libraries/np_web_api/np_web_api.h
+++ b/src/core/libraries/np_web_api/np_web_api.h
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "common/types.h"
+
+namespace Core::Loader {
+class SymbolsResolver;
+}
+
+namespace Libraries::NpWebApi {
+
+s32 PS4_SYSV_ABI sceNpWebApiCreateContext();
+s32 PS4_SYSV_ABI sceNpWebApiCreatePushEventFilter();
+s32 PS4_SYSV_ABI sceNpWebApiCreateServicePushEventFilter();
+s32 PS4_SYSV_ABI sceNpWebApiDeletePushEventFilter();
+s32 PS4_SYSV_ABI sceNpWebApiDeleteServicePushEventFilter();
+s32 PS4_SYSV_ABI sceNpWebApiRegisterExtdPushEventCallback();
+s32 PS4_SYSV_ABI sceNpWebApiRegisterNotificationCallback();
+s32 PS4_SYSV_ABI sceNpWebApiRegisterPushEventCallback();
+s32 PS4_SYSV_ABI sceNpWebApiRegisterServicePushEventCallback();
+s32 PS4_SYSV_ABI sceNpWebApiUnregisterNotificationCallback();
+s32 PS4_SYSV_ABI sceNpWebApiUnregisterPushEventCallback();
+s32 PS4_SYSV_ABI sceNpWebApiUnregisterServicePushEventCallback();
+s32 PS4_SYSV_ABI sceNpWebApiAbortHandle();
+s32 PS4_SYSV_ABI sceNpWebApiAbortRequest();
+s32 PS4_SYSV_ABI sceNpWebApiAddHttpRequestHeader();
+s32 PS4_SYSV_ABI sceNpWebApiAddMultipartPart();
+s32 PS4_SYSV_ABI sceNpWebApiCheckTimeout();
+s32 PS4_SYSV_ABI sceNpWebApiClearAllUnusedConnection();
+s32 PS4_SYSV_ABI sceNpWebApiClearUnusedConnection();
+s32 PS4_SYSV_ABI sceNpWebApiCreateContextA();
+s32 PS4_SYSV_ABI sceNpWebApiCreateExtdPushEventFilter();
+s32 PS4_SYSV_ABI sceNpWebApiCreateHandle();
+s32 PS4_SYSV_ABI sceNpWebApiCreateMultipartRequest();
+s32 PS4_SYSV_ABI sceNpWebApiCreateRequest();
+s32 PS4_SYSV_ABI sceNpWebApiDeleteContext();
+s32 PS4_SYSV_ABI sceNpWebApiDeleteExtdPushEventFilter();
+s32 PS4_SYSV_ABI sceNpWebApiDeleteHandle();
+s32 PS4_SYSV_ABI sceNpWebApiDeleteRequest();
+s32 PS4_SYSV_ABI sceNpWebApiGetConnectionStats();
+s32 PS4_SYSV_ABI sceNpWebApiGetErrorCode();
+s32 PS4_SYSV_ABI sceNpWebApiGetHttpResponseHeaderValue();
+s32 PS4_SYSV_ABI sceNpWebApiGetHttpResponseHeaderValueLength();
+s32 PS4_SYSV_ABI sceNpWebApiGetHttpStatusCode();
+s32 PS4_SYSV_ABI sceNpWebApiGetMemoryPoolStats();
+s32 PS4_SYSV_ABI sceNpWebApiInitialize();
+s32 PS4_SYSV_ABI sceNpWebApiInitializeForPresence();
+s32 PS4_SYSV_ABI sceNpWebApiIntCreateCtxIndExtdPushEventFilter();
+s32 PS4_SYSV_ABI sceNpWebApiIntCreateRequest();
+s32 PS4_SYSV_ABI sceNpWebApiIntCreateServicePushEventFilter();
+s32 PS4_SYSV_ABI sceNpWebApiIntInitialize();
+s32 PS4_SYSV_ABI sceNpWebApiIntRegisterServicePushEventCallback();
+s32 PS4_SYSV_ABI sceNpWebApiIntRegisterServicePushEventCallbackA();
+s32 PS4_SYSV_ABI sceNpWebApiReadData();
+s32 PS4_SYSV_ABI sceNpWebApiRegisterExtdPushEventCallbackA();
+s32 PS4_SYSV_ABI sceNpWebApiSendMultipartRequest();
+s32 PS4_SYSV_ABI sceNpWebApiSendMultipartRequest2();
+s32 PS4_SYSV_ABI sceNpWebApiSendRequest();
+s32 PS4_SYSV_ABI sceNpWebApiSendRequest2();
+s32 PS4_SYSV_ABI sceNpWebApiSetHandleTimeout();
+s32 PS4_SYSV_ABI sceNpWebApiSetMaxConnection();
+s32 PS4_SYSV_ABI sceNpWebApiSetMultipartContentType();
+s32 PS4_SYSV_ABI sceNpWebApiSetRequestTimeout();
+s32 PS4_SYSV_ABI sceNpWebApiTerminate();
+s32 PS4_SYSV_ABI sceNpWebApiUnregisterExtdPushEventCallback();
+s32 PS4_SYSV_ABI sceNpWebApiUtilityParseNpId();
+s32 PS4_SYSV_ABI sceNpWebApiVshInitialize();
+s32 PS4_SYSV_ABI Func_064C4ED1EDBEB9E8();
+s32 PS4_SYSV_ABI Func_0783955D4E9563DA();
+s32 PS4_SYSV_ABI Func_1A6D77F3FD8323A8();
+s32 PS4_SYSV_ABI Func_1E0693A26FE0F954();
+s32 PS4_SYSV_ABI Func_24A9B5F1D77000CF();
+s32 PS4_SYSV_ABI Func_24AAA6F50E4C2361();
+s32 PS4_SYSV_ABI Func_24D8853D6B47FC79();
+s32 PS4_SYSV_ABI Func_279B3E9C7C4A9DC5();
+s32 PS4_SYSV_ABI Func_28461E29E9F8D697();
+s32 PS4_SYSV_ABI Func_3C29624704FAB9E0();
+s32 PS4_SYSV_ABI Func_3F027804ED2EC11E();
+s32 PS4_SYSV_ABI Func_4066C94E782997CD();
+s32 PS4_SYSV_ABI Func_47C85356815DBE90();
+s32 PS4_SYSV_ABI Func_4FCE8065437E3B87();
+s32 PS4_SYSV_ABI Func_536280BE3DABB521();
+s32 PS4_SYSV_ABI Func_57A0E1BC724219F3();
+s32 PS4_SYSV_ABI Func_5819749C040B6637();
+s32 PS4_SYSV_ABI Func_6198D0C825E86319();
+s32 PS4_SYSV_ABI Func_61F2B9E8AB093743();
+s32 PS4_SYSV_ABI Func_6BC388E6113F0D44();
+s32 PS4_SYSV_ABI Func_7500F0C4F8DC2D16();
+s32 PS4_SYSV_ABI Func_75A03814C7E9039F();
+s32 PS4_SYSV_ABI Func_789D6026C521416E();
+s32 PS4_SYSV_ABI Func_7DED63D06399EFFF();
+s32 PS4_SYSV_ABI Func_7E55A2DCC03D395A();
+s32 PS4_SYSV_ABI Func_7E6C8F9FB86967F4();
+s32 PS4_SYSV_ABI Func_7F04B7D4A7D41E80();
+s32 PS4_SYSV_ABI Func_8E167252DFA5C957();
+s32 PS4_SYSV_ABI Func_95D0046E504E3B09();
+s32 PS4_SYSV_ABI Func_97284BFDA4F18FDF();
+s32 PS4_SYSV_ABI Func_99E32C1F4737EAB4();
+s32 PS4_SYSV_ABI Func_9CFF661EA0BCBF83();
+s32 PS4_SYSV_ABI Func_9EB0E1F467AC3B29();
+s32 PS4_SYSV_ABI Func_A2318FE6FBABFAA3();
+s32 PS4_SYSV_ABI Func_BA07A2E1BF7B3971();
+s32 PS4_SYSV_ABI Func_BD0803EEE0CC29A0();
+s32 PS4_SYSV_ABI Func_BE6F4E5524BB135F();
+s32 PS4_SYSV_ABI Func_C0D490EB481EA4D0();
+s32 PS4_SYSV_ABI Func_C175D392CA6D084A();
+s32 PS4_SYSV_ABI Func_CD0136AF165D2F2F();
+s32 PS4_SYSV_ABI Func_D1C0ADB7B52FEAB5();
+s32 PS4_SYSV_ABI Func_E324765D18EE4D12();
+s32 PS4_SYSV_ABI Func_E789F980D907B653();
+s32 PS4_SYSV_ABI Func_F9A32E8685627436();
+
+void RegisterlibSceNpWebApi(Core::Loader::SymbolsResolver* sym);
+} // namespace Libraries::NpWebApi


### PR DESCRIPTION
This PR adds auto-generated stubs for the libSceNpWebApi library. This includes a dummy return for sceNpWebApiInitialize, to make it return a positive value.

This fixes an internal assert seen in updated versions of The Playroom (CUSA00001).