### PR TITLE
resource_tracking_pass: Persist image resource atomic designation.

### DIFF
--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -164,6 +164,7 @@ public:
             return desc.sharp_idx == existing.sharp_idx && desc.is_array == existing.is_array;
         })};
         auto& image = image_resources[index];
+        image.is_atomic |= desc.is_atomic;
         image.is_written |= desc.is_written;
         return index;
     }


### PR DESCRIPTION
Make sure `is_atomic` is kept for de-duplicated image resources, as we need to know if any instruction uses it atomically.