### PR TITLE
renderer_vulkan: Simplify debug marker settings.

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -61,9 +61,10 @@ static u32 vblankDivider = 1;
 static bool vkValidation = false;
 static bool vkValidationSync = false;
 static bool vkValidationGpu = false;
-static bool rdocEnable = false;
-static bool vkMarkers = false;
 static bool vkCrashDiagnostic = false;
+static bool vkHostMarkers = false;
+static bool vkGuestMarkers = false;
+static bool rdocEnable = false;
 static s16 cursorState = HideCursorState::Idle;
 static int cursorHideTimeout = 5; // 5 seconds (default)
 static bool separateupdatefolder = false;
@@ -227,10 +228,6 @@ bool isRdocEnabled() {
     return rdocEnable;
 }
 
-bool isMarkersEnabled() {
-    return vkMarkers;
-}
-
 u32 vblankDiv() {
     return vblankDivider;
 }
@@ -247,12 +244,18 @@ bool vkValidationGpuEnabled() {
     return vkValidationGpu;
 }
 
-bool vkMarkersEnabled() {
-    return vkMarkers || vkCrashDiagnostic; // Crash diagnostic forces markers on
-}
-
 bool vkCrashDiagnosticEnabled() {
     return vkCrashDiagnostic;
+}
+
+bool vkHostMarkersEnabled() {
+    // Forced on when crash diagnostic enabled.
+    return vkHostMarkers || vkCrashDiagnostic;
+}
+
+bool vkGuestMarkersEnabled() {
+    // Forced on when crash diagnostic enabled.
+    return vkGuestMarkers || vkCrashDiagnostic;
 }
 
 bool getSeparateUpdateEnabled() {
@@ -644,9 +647,10 @@ void load(const std::filesystem::path& path) {
         vkValidation = toml::find_or<bool>(vk, "validation", false);
         vkValidationSync = toml::find_or<bool>(vk, "validation_sync", false);
         vkValidationGpu = toml::find_or<bool>(vk, "validation_gpu", true);
-        rdocEnable = toml::find_or<bool>(vk, "rdocEnable", false);
-        vkMarkers = toml::find_or<bool>(vk, "rdocMarkersEnable", false);
         vkCrashDiagnostic = toml::find_or<bool>(vk, "crashDiagnostic", false);
+        vkHostMarkers = toml::find_or<bool>(vk, "hostMarkers", false);
+        vkGuestMarkers = toml::find_or<bool>(vk, "guestMarkers", false);
+        rdocEnable = toml::find_or<bool>(vk, "rdocEnable", false);
     }
 
     if (data.contains("Debug")) {
@@ -752,9 +756,10 @@ void save(const std::filesystem::path& path) {
     data["Vulkan"]["validation"] = vkValidation;
     data["Vulkan"]["validation_sync"] = vkValidationSync;
     data["Vulkan"]["validation_gpu"] = vkValidationGpu;
-    data["Vulkan"]["rdocEnable"] = rdocEnable;
-    data["Vulkan"]["rdocMarkersEnable"] = vkMarkers;
     data["Vulkan"]["crashDiagnostic"] = vkCrashDiagnostic;
+    data["Vulkan"]["hostMarkers"] = vkHostMarkers;
+    data["Vulkan"]["guestMarkers"] = vkGuestMarkers;
+    data["Vulkan"]["rdocEnable"] = rdocEnable;
     data["Debug"]["DebugDump"] = isDebugDump;
     data["Debug"]["CollectShader"] = isShaderDebug;
 
@@ -852,9 +857,10 @@ void setDefaultValues() {
     vkValidation = false;
     vkValidationSync = false;
     vkValidationGpu = false;
-    rdocEnable = false;
-    vkMarkers = false;
     vkCrashDiagnostic = false;
+    vkHostMarkers = false;
+    vkGuestMarkers = false;
+    rdocEnable = false;
     emulator_language = "en";
     m_language = 1;
     gpuId = -1;

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -100,8 +100,9 @@ void setRdocEnabled(bool enable);
 bool vkValidationEnabled();
 bool vkValidationSyncEnabled();
 bool vkValidationGpuEnabled();
-bool vkMarkersEnabled();
 bool vkCrashDiagnosticEnabled();
+bool vkHostMarkersEnabled();
+bool vkGuestMarkersEnabled();
 
 // Gui
 void setMainWindowGeometry(u32 x, u32 y, u32 w, u32 h);

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -66,9 +66,10 @@ Emulator::Emulator() {
     LOG_INFO(Config, "Vulkan vkValidation: {}", Config::vkValidationEnabled());
     LOG_INFO(Config, "Vulkan vkValidationSync: {}", Config::vkValidationSyncEnabled());
     LOG_INFO(Config, "Vulkan vkValidationGpu: {}", Config::vkValidationGpuEnabled());
-    LOG_INFO(Config, "Vulkan rdocEnable: {}", Config::isRdocEnabled());
-    LOG_INFO(Config, "Vulkan rdocMarkersEnable: {}", Config::vkMarkersEnabled());
     LOG_INFO(Config, "Vulkan crashDiagnostics: {}", Config::vkCrashDiagnosticEnabled());
+    LOG_INFO(Config, "Vulkan hostMarkers: {}", Config::vkHostMarkersEnabled());
+    LOG_INFO(Config, "Vulkan guestMarkers: {}", Config::vkGuestMarkersEnabled());
+    LOG_INFO(Config, "Vulkan rdocEnable: {}", Config::isRdocEnabled());
 
     // Create stdin/stdout/stderr
     Common::Singleton<FileSys::HandleTable>::Instance()->CreateStdHandles();

--- a/src/imgui/renderer/imgui_core.cpp
+++ b/src/imgui/renderer/imgui_core.cpp
@@ -199,7 +199,7 @@ void Render(const vk::CommandBuffer& cmdbuf, ::Vulkan::Frame* frame) {
         return;
     }
 
-    if (Config::vkMarkersEnabled()) {
+    if (Config::vkHostMarkersEnabled()) {
         cmdbuf.beginDebugUtilsLabelEXT(vk::DebugUtilsLabelEXT{
             .pLabelName = "ImGui Render",
         });
@@ -224,7 +224,7 @@ void Render(const vk::CommandBuffer& cmdbuf, ::Vulkan::Frame* frame) {
     cmdbuf.beginRendering(render_info);
     Vulkan::RenderDrawData(*draw_data, cmdbuf);
     cmdbuf.endRendering();
-    if (Config::vkMarkersEnabled()) {
+    if (Config::vkHostMarkersEnabled()) {
         cmdbuf.endDebugUtilsLabelEXT();
     }
 }

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -260,7 +260,7 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
                     const std::string_view label{reinterpret_cast<const char*>(&nop->data_block[1]),
                                                  marker_sz};
                     if (rasterizer) {
-                        rasterizer->ScopeMarkerBegin(label);
+                        rasterizer->ScopeMarkerBegin(label, true);
                     }
                     break;
                 }
@@ -271,13 +271,13 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
                     const u32 color = *reinterpret_cast<const u32*>(
                         reinterpret_cast<const u8*>(&nop->data_block[1]) + marker_sz);
                     if (rasterizer) {
-                        rasterizer->ScopedMarkerInsertColor(label, color);
+                        rasterizer->ScopedMarkerInsertColor(label, color, true);
                     }
                     break;
                 }
                 case PM4CmdNop::PayloadType::DebugMarkerPop: {
                     if (rasterizer) {
-                        rasterizer->ScopeMarkerEnd();
+                        rasterizer->ScopeMarkerEnd(true);
                     }
                     break;
                 }

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -225,7 +225,7 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
     }
 
     if (rasterizer) {
-        rasterizer->ScopeMarkerBegin("dcb");
+        rasterizer->ScopeMarkerBegin("gfx");
     }
 
     const auto base_addr = reinterpret_cast<uintptr_t>(dcb.data());
@@ -416,7 +416,7 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
                 }
                 if (rasterizer) {
                     const auto cmd_address = reinterpret_cast<const void*>(header);
-                    rasterizer->ScopeMarkerBegin(fmt::format("dcb:{}:DrawIndex2", cmd_address));
+                    rasterizer->ScopeMarkerBegin(fmt::format("{}:DrawIndex2", cmd_address));
                     rasterizer->Draw(true);
                     rasterizer->ScopeMarkerEnd();
                 }
@@ -433,8 +433,7 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
                 }
                 if (rasterizer) {
                     const auto cmd_address = reinterpret_cast<const void*>(header);
-                    rasterizer->ScopeMarkerBegin(
-                        fmt::format("dcb:{}:DrawIndexOffset2", cmd_address));
+                    rasterizer->ScopeMarkerBegin(fmt::format("{}:DrawIndexOffset2", cmd_address));
                     rasterizer->Draw(true, draw_index_off->index_offset);
                     rasterizer->ScopeMarkerEnd();
                 }
@@ -449,7 +448,7 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
                 }
                 if (rasterizer) {
                     const auto cmd_address = reinterpret_cast<const void*>(header);
-                    rasterizer->ScopeMarkerBegin(fmt::format("dcb:{}:DrawIndexAuto", cmd_address));
+                    rasterizer->ScopeMarkerBegin(fmt::format("{}:DrawIndexAuto", cmd_address));
                     rasterizer->Draw(false);
                     rasterizer->ScopeMarkerEnd();
                 }
@@ -464,7 +463,7 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
                 }
                 if (rasterizer) {
                     const auto cmd_address = reinterpret_cast<const void*>(header);
-                    rasterizer->ScopeMarkerBegin(fmt::format("dcb:{}:DrawIndirect", cmd_address));
+                    rasterizer->ScopeMarkerBegin(fmt::format("{}:DrawIndirect", cmd_address));
                     rasterizer->DrawIndirect(false, indirect_args_addr, offset, size, 1, 0);
                     rasterizer->ScopeMarkerEnd();
                 }
@@ -480,8 +479,7 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
                 }
                 if (rasterizer) {
                     const auto cmd_address = reinterpret_cast<const void*>(header);
-                    rasterizer->ScopeMarkerBegin(
-                        fmt::format("dcb:{}:DrawIndexIndirect", cmd_address));
+                    rasterizer->ScopeMarkerBegin(fmt::format("{}:DrawIndexIndirect", cmd_address));
                     rasterizer->DrawIndirect(true, indirect_args_addr, offset, size, 1, 0);
                     rasterizer->ScopeMarkerEnd();
                 }
@@ -497,7 +495,7 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
                 if (rasterizer) {
                     const auto cmd_address = reinterpret_cast<const void*>(header);
                     rasterizer->ScopeMarkerBegin(
-                        fmt::format("dcb:{}:DrawIndexIndirectCountMulti", cmd_address));
+                        fmt::format("{}:DrawIndexIndirectCountMulti", cmd_address));
                     rasterizer->DrawIndirect(
                         true, indirect_args_addr, offset, draw_index_indirect->stride,
                         draw_index_indirect->count, draw_index_indirect->countAddr);
@@ -518,7 +516,7 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
                 }
                 if (rasterizer && (cs_program.dispatch_initiator & 1)) {
                     const auto cmd_address = reinterpret_cast<const void*>(header);
-                    rasterizer->ScopeMarkerBegin(fmt::format("dcb:{}:Dispatch", cmd_address));
+                    rasterizer->ScopeMarkerBegin(fmt::format("{}:DispatchDirect", cmd_address));
                     rasterizer->DispatchDirect();
                     rasterizer->ScopeMarkerEnd();
                 }
@@ -536,8 +534,7 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
                 }
                 if (rasterizer && (cs_program.dispatch_initiator & 1)) {
                     const auto cmd_address = reinterpret_cast<const void*>(header);
-                    rasterizer->ScopeMarkerBegin(
-                        fmt::format("dcb:{}:DispatchIndirect", cmd_address));
+                    rasterizer->ScopeMarkerBegin(fmt::format("{}:DispatchIndirect", cmd_address));
                     rasterizer->DispatchIndirect(indirect_args_addr, offset, size);
                     rasterizer->ScopeMarkerEnd();
                 }
@@ -723,7 +720,7 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
     const auto& queue = asc_queues[{vqid}];
 
     if (rasterizer) {
-        rasterizer->ScopeMarkerBegin(fmt::format("acb[{}]", vqid));
+        rasterizer->ScopeMarkerBegin(fmt::format("asc[{}]", vqid));
     }
 
     auto base_addr = reinterpret_cast<uintptr_t>(acb.data());
@@ -823,8 +820,7 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
             }
             if (rasterizer && (cs_program.dispatch_initiator & 1)) {
                 const auto cmd_address = reinterpret_cast<const void*>(header);
-                rasterizer->ScopeMarkerBegin(
-                    fmt::format("acb[{}]:{}:DispatchIndirect", vqid, cmd_address));
+                rasterizer->ScopeMarkerBegin(fmt::format("{}:DispatchDirect", cmd_address));
                 rasterizer->DispatchDirect();
                 rasterizer->ScopeMarkerEnd();
             }
@@ -842,7 +838,7 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
             }
             if (rasterizer && (cs_program.dispatch_initiator & 1)) {
                 const auto cmd_address = reinterpret_cast<const void*>(header);
-                rasterizer->ScopeMarkerBegin(fmt::format("acb[{}]:{}:Dispatch", vqid, cmd_address));
+                rasterizer->ScopeMarkerBegin(fmt::format("{}:DispatchIndirect", cmd_address));
                 rasterizer->DispatchIndirect(ib_address, 0, size);
                 rasterizer->ScopeMarkerEnd();
             }

--- a/src/video_core/buffer_cache/buffer.cpp
+++ b/src/video_core/buffer_cache/buffer.cpp
@@ -131,6 +131,8 @@ vk::BufferView Buffer::View(u32 offset, u32 size, bool is_written, AmdGpu::DataF
                vk::to_string(view_result));
     scheduler->DeferOperation(
         [view, device = instance->GetDevice()] { device.destroyBufferView(view); });
+    Vulkan::SetObjectName(instance->GetDevice(), view, "BufferView {:#x}:{:#x}", cpu_addr + offset,
+                          size);
     return view;
 }
 

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -92,15 +92,13 @@ std::string GetReadableVersion(u32 version) {
 Instance::Instance(bool enable_validation, bool enable_crash_diagnostic)
     : instance{CreateInstance(Frontend::WindowSystemType::Headless, enable_validation,
                               enable_crash_diagnostic)},
-      physical_devices{EnumeratePhysicalDevices(instance)},
-      crash_diagnostic{enable_crash_diagnostic} {}
+      physical_devices{EnumeratePhysicalDevices(instance)} {}
 
 Instance::Instance(Frontend::WindowSDL& window, s32 physical_device_index,
                    bool enable_validation /*= false*/, bool enable_crash_diagnostic /*= false*/)
     : instance{CreateInstance(window.GetWindowInfo().type, enable_validation,
                               enable_crash_diagnostic)},
-      physical_devices{EnumeratePhysicalDevices(instance)},
-      crash_diagnostic{enable_crash_diagnostic} {
+      physical_devices{EnumeratePhysicalDevices(instance)} {
     if (enable_validation) {
         debug_callback = CreateDebugCallback(*instance);
     }
@@ -562,10 +560,7 @@ void Instance::CollectToolingInfo() {
         return;
     }
     for (const vk::PhysicalDeviceToolProperties& tool : tools) {
-        const std::string_view name = tool.name;
-        LOG_INFO(Render_Vulkan, "Attached debugging tool: {}", name);
-        has_renderdoc = has_renderdoc || name == "RenderDoc";
-        has_nsight_graphics = has_nsight_graphics || name == "NVIDIA Nsight Graphics";
+        LOG_INFO(Render_Vulkan, "Attached debugging tool: {}", tool.name);
     }
 }
 

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -79,11 +79,6 @@ public:
         return profiler_context;
     }
 
-    /// Returns true when a known debugging tool is attached.
-    bool HasDebuggingToolAttached() const {
-        return crash_diagnostic || has_renderdoc || has_nsight_graphics;
-    }
-
     /// Returns true if anisotropic filtering is supported
     bool IsAnisotropicFilteringSupported() const {
         return features.samplerAnisotropy;
@@ -340,13 +335,9 @@ private:
     bool legacy_vertex_attributes{};
     bool image_load_store_lod{};
     bool amd_gcn_shader{};
+    bool tooling_info{};
     u64 min_imported_host_pointer_alignment{};
     u32 subgroup_size{};
-    bool tooling_info{};
-    bool debug_utils_supported{};
-    bool crash_diagnostic{};
-    bool has_nsight_graphics{};
-    bool has_renderdoc{};
 };
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_platform.h
+++ b/src/video_core/renderer_vulkan/vk_platform.h
@@ -7,6 +7,7 @@
 #include <variant>
 #include <fmt/format.h>
 
+#include "common/config.h"
 #include "common/logging/log.h"
 #include "common/types.h"
 #include "video_core/renderer_vulkan/vk_common.h"
@@ -32,6 +33,9 @@ concept VulkanHandleType = vk::isVulkanHandleType<T>::value;
 
 template <VulkanHandleType HandleType>
 void SetObjectName(vk::Device device, const HandleType& handle, std::string_view debug_name) {
+    if (!Config::vkHostMarkersEnabled()) {
+        return;
+    }
     const vk::DebugUtilsObjectNameInfoEXT name_info = {
         .objectType = HandleType::objectType,
         .objectHandle = reinterpret_cast<u64>(static_cast<typename HandleType::NativeType>(handle)),
@@ -46,6 +50,9 @@ void SetObjectName(vk::Device device, const HandleType& handle, std::string_view
 template <VulkanHandleType HandleType, typename... Args>
 void SetObjectName(vk::Device device, const HandleType& handle, const char* format,
                    const Args&... args) {
+    if (!Config::vkHostMarkersEnabled()) {
+        return;
+    }
     const std::string debug_name = fmt::vformat(format, fmt::make_format_args(args...));
     SetObjectName(device, handle, debug_name);
 }

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -1195,42 +1195,43 @@ void Rasterizer::UpdateViewportScissorState() {
     cmdbuf.setScissorWithCountEXT(scissors);
 }
 
-void Rasterizer::ScopeMarkerBegin(const std::string_view& str) {
-    if (Config::nullGpu() || !Config::vkMarkersEnabled()) {
+void Rasterizer::ScopeMarkerBegin(const std::string_view& str, bool from_guest) {
+    if ((from_guest && !Config::vkGuestMarkersEnabled()) ||
+        (!from_guest && !Config::vkHostMarkersEnabled())) {
         return;
     }
-
     const auto cmdbuf = scheduler.CommandBuffer();
     cmdbuf.beginDebugUtilsLabelEXT(vk::DebugUtilsLabelEXT{
         .pLabelName = str.data(),
     });
 }
 
-void Rasterizer::ScopeMarkerEnd() {
-    if (Config::nullGpu() || !Config::vkMarkersEnabled()) {
+void Rasterizer::ScopeMarkerEnd(bool from_guest) {
+    if ((from_guest && !Config::vkGuestMarkersEnabled()) ||
+        (!from_guest && !Config::vkHostMarkersEnabled())) {
         return;
     }
-
     const auto cmdbuf = scheduler.CommandBuffer();
     cmdbuf.endDebugUtilsLabelEXT();
 }
 
-void Rasterizer::ScopedMarkerInsert(const std::string_view& str) {
-    if (Config::nullGpu() || !Config::vkMarkersEnabled()) {
+void Rasterizer::ScopedMarkerInsert(const std::string_view& str, bool from_guest) {
+    if ((from_guest && !Config::vkGuestMarkersEnabled()) ||
+        (!from_guest && !Config::vkHostMarkersEnabled())) {
         return;
     }
-
     const auto cmdbuf = scheduler.CommandBuffer();
     cmdbuf.insertDebugUtilsLabelEXT(vk::DebugUtilsLabelEXT{
         .pLabelName = str.data(),
     });
 }
 
-void Rasterizer::ScopedMarkerInsertColor(const std::string_view& str, const u32 color) {
-    if (Config::nullGpu() || !Config::vkMarkersEnabled()) {
+void Rasterizer::ScopedMarkerInsertColor(const std::string_view& str, const u32 color,
+                                         bool from_guest) {
+    if ((from_guest && !Config::vkGuestMarkersEnabled()) ||
+        (!from_guest && !Config::vkHostMarkersEnabled())) {
         return;
     }
-
     const auto cmdbuf = scheduler.CommandBuffer();
     cmdbuf.insertDebugUtilsLabelEXT(vk::DebugUtilsLabelEXT{
         .pLabelName = str.data(),

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -58,6 +58,7 @@ bool Rasterizer::FilterDraw() {
     if (regs.color_control.mode == Liverpool::ColorControl::OperationMode::FmaskDecompress) {
         // TODO: check for a valid MRT1 to promote the draw to the resolve pass.
         LOG_TRACE(Render_Vulkan, "FMask decompression pass skipped");
+        ScopedMarkerInsert("FmaskDecompress");
         return false;
     }
     if (regs.color_control.mode == Liverpool::ColorControl::OperationMode::Resolve) {
@@ -67,6 +68,7 @@ bool Rasterizer::FilterDraw() {
     }
     if (regs.primitive_type == AmdGpu::PrimitiveType::None) {
         LOG_TRACE(Render_Vulkan, "Primitive type 'None' skipped");
+        ScopedMarkerInsert("PrimitiveTypeNone");
         return false;
     }
 
@@ -244,10 +246,13 @@ void Rasterizer::EliminateFastClear() {
         .layerCount = col_buf.view.slice_max - col_buf.view.slice_start + 1,
     };
     scheduler.EndRendering();
+    ScopeMarkerBegin(fmt::format("EliminateFastClear:MRT={:#x}:M={:#x}", col_buf.Address(),
+                                 col_buf.CmaskAddress()));
     image.Transit(vk::ImageLayout::eTransferDstOptimal, vk::AccessFlagBits2::eTransferWrite, {});
     scheduler.CommandBuffer().clearColorImage(image.image, image.last_state.layout,
                                               LiverpoolToVK::ColorBufferClearValue(col_buf).color,
                                               range);
+    ScopeMarkerEnd();
 }
 
 void Rasterizer::Draw(bool is_indexed, u32 index_offset) {
@@ -842,8 +847,6 @@ void Rasterizer::BeginRendering(const GraphicsPipeline& pipeline, RenderState& s
 }
 
 void Rasterizer::Resolve() {
-    const auto cmdbuf = scheduler.CommandBuffer();
-
     // Read from MRT0, average all samples, and write to MRT1, which is one-sample
     const auto& mrt0_hint = liverpool->last_cb_extent[0];
     const auto& mrt1_hint = liverpool->last_cb_extent[1];
@@ -863,9 +866,12 @@ void Rasterizer::Resolve() {
     mrt1_range.base.layer = liverpool->regs.color_buffers[1].view.slice_start;
     mrt1_range.extent.layers = liverpool->regs.color_buffers[1].NumSlices() - mrt1_range.base.layer;
 
+    ScopeMarkerBegin(fmt::format("Resolve:MRT0={:#x}:MRT1={:#x}",
+                                 liverpool->regs.color_buffers[0].Address(),
+                                 liverpool->regs.color_buffers[1].Address()));
+
     mrt0_image.Transit(vk::ImageLayout::eTransferSrcOptimal, vk::AccessFlagBits2::eTransferRead,
                        mrt0_range);
-
     mrt1_image.Transit(vk::ImageLayout::eTransferDstOptimal, vk::AccessFlagBits2::eTransferWrite,
                        mrt1_range);
 
@@ -892,8 +898,9 @@ void Rasterizer::Resolve() {
             .dstOffset = {0, 0, 0},
             .extent = {mrt1_image.info.size.width, mrt1_image.info.size.height, 1},
         };
-        cmdbuf.copyImage(mrt0_image.image, vk::ImageLayout::eTransferSrcOptimal, mrt1_image.image,
-                         vk::ImageLayout::eTransferDstOptimal, region);
+        scheduler.CommandBuffer().copyImage(mrt0_image.image, vk::ImageLayout::eTransferSrcOptimal,
+                                            mrt1_image.image, vk::ImageLayout::eTransferDstOptimal,
+                                            region);
     } else {
         vk::ImageResolve region = {
             .srcSubresource =
@@ -914,9 +921,12 @@ void Rasterizer::Resolve() {
             .dstOffset = {0, 0, 0},
             .extent = {mrt1_image.info.size.width, mrt1_image.info.size.height, 1},
         };
-        cmdbuf.resolveImage(mrt0_image.image, vk::ImageLayout::eTransferSrcOptimal,
-                            mrt1_image.image, vk::ImageLayout::eTransferDstOptimal, region);
+        scheduler.CommandBuffer().resolveImage(
+            mrt0_image.image, vk::ImageLayout::eTransferSrcOptimal, mrt1_image.image,
+            vk::ImageLayout::eTransferDstOptimal, region);
     }
+
+    ScopeMarkerEnd();
 }
 
 void Rasterizer::DepthStencilCopy(bool is_depth, bool is_stencil) {
@@ -935,6 +945,11 @@ void Rasterizer::DepthStencilCopy(bool is_depth, bool is_stencil) {
     VideoCore::SubresourceRange sub_range;
     sub_range.base.layer = liverpool->regs.depth_view.slice_start;
     sub_range.extent.layers = liverpool->regs.depth_view.NumSlices() - sub_range.base.layer;
+
+    ScopeMarkerBegin(fmt::format(
+        "DepthStencilCopy:DR={:#x}:SR={:#x}:DW={:#x}:SW={:#x}", regs.depth_buffer.DepthAddress(),
+        regs.depth_buffer.StencilAddress(), regs.depth_buffer.DepthWriteAddress(),
+        regs.depth_buffer.StencilWriteAddress()));
 
     read_image.Transit(vk::ImageLayout::eTransferSrcOptimal, vk::AccessFlagBits2::eTransferRead,
                        sub_range);
@@ -967,9 +982,11 @@ void Rasterizer::DepthStencilCopy(bool is_depth, bool is_stencil) {
         .dstOffset = {0, 0, 0},
         .extent = {write_image.info.size.width, write_image.info.size.height, 1},
     };
-    const auto cmdbuf = scheduler.CommandBuffer();
-    cmdbuf.copyImage(read_image.image, vk::ImageLayout::eTransferSrcOptimal, write_image.image,
-                     vk::ImageLayout::eTransferDstOptimal, region);
+    scheduler.CommandBuffer().copyImage(read_image.image, vk::ImageLayout::eTransferSrcOptimal,
+                                        write_image.image, vk::ImageLayout::eTransferDstOptimal,
+                                        region);
+
+    ScopeMarkerEnd();
 }
 
 void Rasterizer::InlineData(VAddr address, const void* value, u32 num_bytes, bool is_gds) {

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -47,10 +47,11 @@ public:
     void DispatchDirect();
     void DispatchIndirect(VAddr address, u32 offset, u32 size);
 
-    void ScopeMarkerBegin(const std::string_view& str);
-    void ScopeMarkerEnd();
-    void ScopedMarkerInsert(const std::string_view& str);
-    void ScopedMarkerInsertColor(const std::string_view& str, const u32 color);
+    void ScopeMarkerBegin(const std::string_view& str, bool from_guest = false);
+    void ScopeMarkerEnd(bool from_guest = false);
+    void ScopedMarkerInsert(const std::string_view& str, bool from_guest = false);
+    void ScopedMarkerInsertColor(const std::string_view& str, const u32 color,
+                                 bool from_guest = false);
 
     void InlineData(VAddr address, const void* value, u32 num_bytes, bool is_gds);
     u32 ReadDataFromGds(u32 gsd_offset);

--- a/src/video_core/renderer_vulkan/vk_resource_pool.cpp
+++ b/src/video_core/renderer_vulkan/vk_resource_pool.cpp
@@ -73,9 +73,7 @@ CommandPool::CommandPool(const Instance& instance, MasterSemaphore* master_semap
     ASSERT_MSG(pool_result == vk::Result::eSuccess, "Failed to create command pool: {}",
                vk::to_string(pool_result));
     cmd_pool = std::move(pool);
-    if (instance.HasDebuggingToolAttached()) {
-        SetObjectName(device, *cmd_pool, "CommandPool");
-    }
+    SetObjectName(device, *cmd_pool, "CommandPool");
 }
 
 CommandPool::~CommandPool() = default;
@@ -94,10 +92,8 @@ void CommandPool::Allocate(std::size_t begin, std::size_t end) {
         device.allocateCommandBuffers(&buffer_alloc_info, cmd_buffers.data() + begin);
     ASSERT(result == vk::Result::eSuccess);
 
-    if (instance.HasDebuggingToolAttached()) {
-        for (std::size_t i = begin; i < end; ++i) {
-            SetObjectName(device, cmd_buffers[i], "CommandPool: Command Buffer {}", i);
-        }
+    for (std::size_t i = begin; i < end; ++i) {
+        SetObjectName(device, cmd_buffers[i], "CommandPool: Command Buffer {}", i);
     }
 }
 

--- a/src/video_core/renderer_vulkan/vk_swapchain.cpp
+++ b/src/video_core/renderer_vulkan/vk_swapchain.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <limits>
 #include "common/assert.h"
+#include "common/config.h"
 #include "common/logging/log.h"
 #include "sdl_window.h"
 #include "video_core/renderer_vulkan/vk_instance.h"
@@ -235,11 +236,9 @@ void Swapchain::RefreshSemaphores() {
         semaphore = sem;
     }
 
-    if (instance.HasDebuggingToolAttached()) {
-        for (u32 i = 0; i < image_count; ++i) {
-            SetObjectName(device, image_acquired[i], "Swapchain Semaphore: image_acquired {}", i);
-            SetObjectName(device, present_ready[i], "Swapchain Semaphore: present_ready {}", i);
-        }
+    for (u32 i = 0; i < image_count; ++i) {
+        SetObjectName(device, image_acquired[i], "Swapchain Semaphore: image_acquired {}", i);
+        SetObjectName(device, present_ready[i], "Swapchain Semaphore: present_ready {}", i);
     }
 }
 
@@ -251,10 +250,8 @@ void Swapchain::SetupImages() {
     images = std::move(imgs);
     image_count = static_cast<u32>(images.size());
 
-    if (instance.HasDebuggingToolAttached()) {
-        for (u32 i = 0; i < image_count; ++i) {
-            SetObjectName(device, images[i], "Swapchain Image {}", i);
-        }
+    for (u32 i = 0; i < image_count; ++i) {
+        SetObjectName(device, images[i], "Swapchain Image {}", i);
     }
 }
 

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -110,6 +110,13 @@ ImageView::ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info
     ASSERT_MSG(view_result == vk::Result::eSuccess, "Failed to create image view: {}",
                vk::to_string(view_result));
     image_view = std::move(view);
+
+    const auto view_aspect = aspect & vk::ImageAspectFlagBits::eDepth     ? "Depth"
+                             : aspect & vk::ImageAspectFlagBits::eStencil ? "Stencil"
+                                                                          : "Color";
+    Vulkan::SetObjectName(instance.GetDevice(), *image_view, "ImageView {}x{}x{} {:#x}:{:#x} ({})",
+                          image.info.size.width, image.info.size.height, image.info.size.depth,
+                          image.info.guest_address, image.info.guest_size, view_aspect);
 }
 
 ImageView::~ImageView() = default;


### PR DESCRIPTION
Currently emitting debug names/markers is gated behind a confusing mix of conditions like whether certain tools are attached, settings named after tools like RenderDoc that they actually have nothing to do with, etc.

This PR simplifies things down to just two settings with very clear purpose: a setting to enable host-provided debug markers, and a setting to enable guest-provided debug markers. When host markers are enabled, debug names and markers provided by the emulator will be emitted. When guest markers are enabled, debug markers provided by the guest in the command buffer will be emitted.

Both types of markers are forced on when crash diagnostics are enabled at the config level, similar to before. We can force them on based on other settings as well if we decide it is warranted.

This also adds debug names to image and buffer views, which are useful to me and part of the motivation for this change: putting names on every created view could be expensive, and I wanted clear settings to gate this behavior behind.