### PR TITLE
network: Remove firing Np callbacks from check stubs.

### DIFF
--- a/src/core/libraries/network/netctl.cpp
+++ b/src/core/libraries/network/netctl.cpp
@@ -93,7 +93,7 @@ int PS4_SYSV_ABI sceNetCtlUnregisterCallbackV6() {
 }
 
 int PS4_SYSV_ABI sceNetCtlCheckCallback() {
-    netctl.CheckCallback();
+    LOG_DEBUG(Lib_NetCtl, "(STUBBED) called");
     return ORBIS_OK;
 }
 
@@ -373,7 +373,7 @@ int PS4_SYSV_ABI Func_D8DCB6973537A3DC() {
 }
 
 int PS4_SYSV_ABI sceNetCtlCheckCallbackForNpToolkit() {
-    netctl.CheckNpToolkitCallback();
+    LOG_DEBUG(Lib_NetCtl, "(STUBBED) called");
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/np_manager/np_manager.cpp
+++ b/src/core/libraries/np_manager/np_manager.cpp
@@ -2509,7 +2509,7 @@ struct NpStateCallbackForNpToolkit {
 NpStateCallbackForNpToolkit NpStateCbForNp;
 
 int PS4_SYSV_ABI sceNpCheckCallbackForLib() {
-    Core::ExecuteGuest(NpStateCbForNp.func, 1, OrbisNpState::SignedOut, NpStateCbForNp.userdata);
+    LOG_DEBUG(Lib_NpManager, "(STUBBED) called");
     return ORBIS_OK;
 }
 


### PR DESCRIPTION
Np callbacks are intended to be called when an event occurs and probably should not be spammed every time the game requests checking for events. Removing the calls from these stubs seems to fix general instability I have where the thread `Toolkit::NP::MainThread` from `libSceNpToolkit2` would crash randomly in `sceLibcMspaceFree`.