### PR TITLE
Crash on sceKernelDebugRaiseExceptionOnReleaseMode

### DIFF
--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -153,6 +153,11 @@ int PS4_SYSV_ABI sceKernelDebugRaiseException() {
     return 0;
 }
 
+int PS4_SYSV_ABI sceKernelDebugRaiseExceptionOnReleaseMode() {
+    UNREACHABLE();
+    return 0;
+}
+
 void RegisterException(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("il03nluKfMk", "libkernel_unity", 1, "libkernel", 1, 1, sceKernelRaiseException);
     LIB_FUNCTION("WkwEd3N7w0Y", "libkernel_unity", 1, "libkernel", 1, 1,
@@ -160,6 +165,7 @@ void RegisterException(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("Qhv5ARAoOEc", "libkernel_unity", 1, "libkernel", 1, 1,
                  sceKernelRemoveExceptionHandler)
     LIB_FUNCTION("OMDRKKAZ8I4", "libkernel", 1, "libkernel", 1, 1, sceKernelDebugRaiseException);
+    LIB_FUNCTION("zE-wXIZjLoM", "libkernel", 1, "libkernel", 1, 1, sceKernelDebugRaiseExceptionOnReleaseMode);
 }
 
 } // namespace Libraries::Kernel

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -165,7 +165,8 @@ void RegisterException(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("Qhv5ARAoOEc", "libkernel_unity", 1, "libkernel", 1, 1,
                  sceKernelRemoveExceptionHandler)
     LIB_FUNCTION("OMDRKKAZ8I4", "libkernel", 1, "libkernel", 1, 1, sceKernelDebugRaiseException);
-    LIB_FUNCTION("zE-wXIZjLoM", "libkernel", 1, "libkernel", 1, 1, sceKernelDebugRaiseExceptionOnReleaseMode);
+    LIB_FUNCTION("zE-wXIZjLoM", "libkernel", 1, "libkernel", 1, 1,
+                 sceKernelDebugRaiseExceptionOnReleaseMode);
 }
 
 } // namespace Libraries::Kernel


### PR DESCRIPTION
Some games call sceKernelDebugRaiseExceptionOnReleaseMode instead of sceKernelDebugRaiseException. It will be easier to spot games crashing on this if we have an unreachable for it.

Spotted while debugging some older issues in Cyberpunk 2077 (CUSA16596)