### PR TITLE
renderer_vulkan: Fix present related validation errors.

### DIFF
--- a/src/imgui/renderer/imgui_impl_vulkan.cpp
+++ b/src/imgui/renderer/imgui_impl_vulkan.cpp
@@ -687,8 +687,6 @@ void RenderDrawData(ImDrawData& draw_data, vk::CommandBuffer command_buffer,
                 vk::DescriptorSet desc_set[1]{pcmd->TextureId->descriptor_set};
                 command_buffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
                                                   bd->pipeline_layout, 0, {desc_set}, {});
-                command_buffer.setColorBlendEnableEXT(
-                    0, {pcmd->TextureId->disable_blend ? vk::False : vk::True});
 
                 // Draw
                 command_buffer.drawIndexed(pcmd->ElemCount, 1, pcmd->IdxOffset + global_idx_offset,
@@ -1058,10 +1056,9 @@ static void CreatePipeline(vk::Device device, const vk::AllocationCallbacks* all
         .pAttachments = color_attachment,
     };
 
-    vk::DynamicState dynamic_states[3]{
+    vk::DynamicState dynamic_states[2]{
         vk::DynamicState::eViewport,
         vk::DynamicState::eScissor,
-        vk::DynamicState::eColorBlendEnableEXT,
     };
     vk::PipelineDynamicStateCreateInfo dynamic_state{
         .dynamicStateCount = (uint32_t)IM_ARRAYSIZE(dynamic_states),

--- a/src/imgui/renderer/imgui_impl_vulkan.h
+++ b/src/imgui/renderer/imgui_impl_vulkan.h
@@ -13,7 +13,6 @@ struct ImDrawData;
 namespace ImGui {
 struct Texture {
     vk::DescriptorSet descriptor_set{nullptr};
-    bool disable_blend{false};
 };
 } // namespace ImGui
 

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -270,6 +270,7 @@ bool Instance::CreateDevice() {
     legacy_vertex_attributes = add_extension(VK_EXT_LEGACY_VERTEX_ATTRIBUTES_EXTENSION_NAME);
     image_load_store_lod = add_extension(VK_AMD_SHADER_IMAGE_LOAD_STORE_LOD_EXTENSION_NAME);
     amd_gcn_shader = add_extension(VK_AMD_GCN_SHADER_EXTENSION_NAME);
+    add_extension(VK_KHR_SWAPCHAIN_MUTABLE_FORMAT_EXTENSION_NAME);
 
     // These extensions are promoted by Vulkan 1.3, but for greater compatibility we use Vulkan 1.2
     // with extensions.
@@ -383,7 +384,6 @@ bool Instance::CreateDevice() {
             .extendedDynamicState = true,
         },
         vk::PhysicalDeviceExtendedDynamicState3FeaturesEXT{
-            .extendedDynamicState3ColorBlendEnable = true,
             .extendedDynamicState3ColorWriteMask = true,
         },
         vk::PhysicalDeviceDepthClipControlFeaturesEXT{

--- a/src/video_core/renderer_vulkan/vk_presenter.cpp
+++ b/src/video_core/renderer_vulkan/vk_presenter.cpp
@@ -380,7 +380,7 @@ void Presenter::RecreateFrame(Frame* frame, u32 width, u32 height) {
     const vk::ImageViewCreateInfo view_info = {
         .image = frame->image,
         .viewType = vk::ImageViewType::e2D,
-        .format = FormatToUnorm(format),
+        .format = swapchain.GetViewFormat(),
         .subresourceRange{
             .aspectMask = vk::ImageAspectFlagBits::eColor,
             .baseMipLevel = 0,
@@ -397,7 +397,6 @@ void Presenter::RecreateFrame(Frame* frame, u32 width, u32 height) {
     frame->height = height;
 
     frame->imgui_texture = ImGui::Vulkan::AddTexture(view, vk::ImageLayout::eShaderReadOnlyOptimal);
-    frame->imgui_texture->disable_blend = true;
 }
 
 Frame* Presenter::PrepareLastFrame() {
@@ -599,6 +598,13 @@ Frame* Presenter::PrepareFrameInternal(VideoCore::ImageId image_id, bool is_eop)
 
         VideoCore::ImageViewInfo info{};
         info.format = image.info.pixel_format;
+        // Exclude alpha from output frame to avoid blending with UI.
+        info.mapping = vk::ComponentMapping{
+            .r = vk::ComponentSwizzle::eIdentity,
+            .g = vk::ComponentSwizzle::eIdentity,
+            .b = vk::ComponentSwizzle::eIdentity,
+            .a = vk::ComponentSwizzle::eOne,
+        };
         if (auto view = image.FindView(info)) {
             image_info.imageView = *texture_cache.GetImageView(view).image_view;
         } else {

--- a/src/video_core/renderer_vulkan/vk_swapchain.h
+++ b/src/video_core/renderer_vulkan/vk_swapchain.h
@@ -61,6 +61,10 @@ public:
         return surface_format;
     }
 
+    vk::Format GetViewFormat() const {
+        return view_format;
+    }
+
     vk::SwapchainKHR GetHandle() const {
         return swapchain;
     }
@@ -114,6 +118,7 @@ private:
     vk::SwapchainKHR swapchain{};
     vk::SurfaceKHR surface{};
     vk::SurfaceFormatKHR surface_format;
+    vk::Format view_format;
     vk::Extent2D extent;
     vk::SurfaceTransformFlagBitsKHR transform;
     vk::CompositeAlphaFlagBitsKHR composite_alpha;


### PR DESCRIPTION
Fixes some validation errors from new ImGui present logic:
* `setColorBlendEnableEXT` is not always available, instead just swizzle alpha to one when blitting frame to disable alpha.
* Make swapchain image format mutable and provide correct format to ImGui, to properly use non-SRGB image view.

Does not resolve issue on some platforms where rendering is empty.