### PR TITLE
vk_platform: Clean up unnecessary debug message filters.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_platform.cpp
+++ b/src/video_core/renderer_vulkan/vk_platform.cpp
@@ -31,17 +31,6 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL DebugUtilsCallback(
     VkDebugUtilsMessageSeverityFlagBitsEXT severity, VkDebugUtilsMessageTypeFlagsEXT type,
     const VkDebugUtilsMessengerCallbackDataEXT* callback_data, void* user_data) {
 
-    switch (static_cast<u32>(callback_data->messageIdNumber)) {
-    case 0x609a13b: // Vertex attribute at location not consumed by shader
-    case 0xc81ad50e:
-    case 0xb7c39078:
-    case 0x32868fde: // vkCreateBufferView(): pCreateInfo->range does not equal VK_WHOLE_SIZE
-    case 0x1012616b: // `VK_FORMAT_UNDEFINED` does not match fragment shader output type
-        return VK_FALSE;
-    default:
-        break;
-    }
-
     Common::Log::Level level{};
     switch (severity) {
     case VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT:


### PR DESCRIPTION
These validation errors are mostly fixed and I don't see them output by any of the games I've tested. Clean up the filters so that we aren't hiding validation issues and can fix them if they come back.