### PR TITLE
ci: Don't use the same cache for clang and gcc on linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -390,7 +390,7 @@ jobs:
     - name: Cache CMake Configuration
       uses: actions/cache@v4 
       env: 
-          cache-name: ${{ runner.os }}-sdl-cache-cmake-configuration
+          cache-name: ${{ runner.os }}-sdl-gcc-cache-cmake-configuration
       with: 
           path: |  
             ${{github.workspace}}/build 
@@ -401,7 +401,7 @@ jobs:
     - name: Cache CMake Build
       uses: hendrikmuhs/ccache-action@v1.2.14
       env:
-          cache-name: ${{ runner.os }}-sdl-cache-cmake-build
+          cache-name: ${{ runner.os }}-sdl-gcc-cache-cmake-build
       with:
         append-timestamp: false
         key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
@@ -426,7 +426,7 @@ jobs:
     - name: Cache CMake Configuration
       uses: actions/cache@v4 
       env: 
-          cache-name: ${{ runner.os }}-qt-cache-cmake-configuration
+          cache-name: ${{ runner.os }}-qt-gcc-cache-cmake-configuration
       with: 
           path: |  
             ${{github.workspace}}/build 
@@ -437,7 +437,7 @@ jobs:
     - name: Cache CMake Build
       uses: hendrikmuhs/ccache-action@v1.2.14
       env:
-          cache-name: ${{ runner.os }}-qt-cache-cmake-build
+          cache-name: ${{ runner.os }}-qt-gcc-cache-cmake-build
       with:
         append-timestamp: false
         key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}


### PR DESCRIPTION
The workflow runs for `Linux-sdl` and `Linux-qt` are taking too much time, I think one of the reasons is that the new `linux-sdl/qt-gcc` (#2027) pipelines are using the same cache from the default ones, so by renaming the cache specifically for the `gcc` pipelines should shorten the time from the Workflow runs.