### PR TITLE
texture_cache: Fix image mip overlap.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -791,8 +791,6 @@ void Rasterizer::BeginRendering(const GraphicsPipeline& pipeline, RenderState& s
             const auto mip = view.info.range.base.level;
             state.width = std::min<u32>(state.width, std::max(image.info.size.width >> mip, 1u));
             state.height = std::min<u32>(state.height, std::max(image.info.size.height >> mip, 1u));
-            ASSERT(old_img.info.size.width == state.width);
-            ASSERT(old_img.info.size.height == state.height);
         }
         auto& image = texture_cache.GetImage(image_id);
         if (image.binding.force_general) {

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -219,7 +219,7 @@ int ImageInfo::IsMipOf(const ImageInfo& info) const {
         return -1;
     }
 
-    if (IsTilingCompatible(info.tiling_idx, tiling_idx)) {
+    if (!IsTilingCompatible(info.tiling_idx, tiling_idx)) {
         return -1;
     }
 

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -114,9 +114,12 @@ ImageView::ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info
     const auto view_aspect = aspect & vk::ImageAspectFlagBits::eDepth     ? "Depth"
                              : aspect & vk::ImageAspectFlagBits::eStencil ? "Stencil"
                                                                           : "Color";
-    Vulkan::SetObjectName(instance.GetDevice(), *image_view, "ImageView {}x{}x{} {:#x}:{:#x} ({})",
-                          image.info.size.width, image.info.size.height, image.info.size.depth,
-                          image.info.guest_address, image.info.guest_size, view_aspect);
+    Vulkan::SetObjectName(
+        instance.GetDevice(), *image_view, "ImageView {}x{}x{} {:#x}:{:#x} {}:{} {}:{} ({})",
+        image.info.size.width, image.info.size.height, image.info.size.depth,
+        image.info.guest_address, image.info.guest_size, info.range.base.level,
+        info.range.base.level + info.range.extent.levels - 1, info.range.base.layer,
+        info.range.base.layer + info.range.extent.layers - 1, view_aspect);
 }
 
 ImageView::~ImageView() = default;


### PR DESCRIPTION
A check in `IsMipOf` was inverted to return a negative result if tiling is compatible, when it should return a negative result if tiling is not compatible. Additionally, an assert for rebinding color attachments seems to be invalid, as it is not necessarily true that the current state width/height will equal the old image size, if it was not previously the smallest bound attachment.

Additionally, I added level and layer info to image view debug names to help my debugging in this process.

Fixes passes in Hedgehog Engine 2 games where an image's base level would be used as a render target, and then subsequent levels would be rendered to from that base to generate mips.