### PR TITLE
vk_presenter: Fix splash issues.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_presenter.cpp
+++ b/src/video_core/renderer_vulkan/vk_presenter.cpp
@@ -476,7 +476,7 @@ bool Presenter::ShowSplash(Frame* frame /*= nullptr*/) {
     if (!frame) {
         if (!splash_img.has_value()) {
             VideoCore::ImageInfo info{};
-            info.pixel_format = vk::Format::eR8G8B8A8Srgb;
+            info.pixel_format = vk::Format::eR8G8B8A8Unorm;
             info.type = vk::ImageType::e2D;
             info.size =
                 VideoCore::Extent3D{splash->GetImageInfo().width, splash->GetImageInfo().height, 1};
@@ -487,6 +487,7 @@ bool Presenter::ShowSplash(Frame* frame /*= nullptr*/) {
                                           splash->GetImageInfo().width,
                                           splash->GetImageInfo().height, 0);
             splash_img.emplace(instance, present_scheduler, info);
+            splash_img->flags &= ~VideoCore::GpuDirty;
             texture_cache.RefreshImage(*splash_img);
 
             splash_img->Transit(vk::ImageLayout::eTransferSrcOptimal,


### PR DESCRIPTION
* Fix splash screen crash due to checking GPU memory tracking outside of possible bounds, since it is not actually a guest image. We should probably have a separate way to easily create non-guest images, but this will do for now to stop the crashing.
* Fix splash screen being too dark due to color format.