### PR TITLE
Devtools: Close Button ( X )

### DIFF
--- a/src/core/devtools/layer.cpp
+++ b/src/core/devtools/layer.cpp
@@ -93,6 +93,12 @@ void L::DrawMenuBar() {
             }
             ImGui::EndMenu();
         }
+
+        SameLine(ImGui::GetWindowWidth() - 30.0f);
+        if (Button("X", ImVec2(25, 25))) {
+            DebugState.IsShowingDebugMenuBar() = false;
+        }
+
         EndMainMenuBar();
     }
 


### PR DESCRIPTION
Some people have accidentally entered the magical world of Devtools and don't know how to close it.
It is still possible to use Ctrl+F10.
However, I added an X button to close it.

![image](https://github.com/user-attachments/assets/58a76ceb-1a97-4387-a766-ca827ec47621)

