### PR TITLE
Fix SurfaceFormat Format1_5_5_5

### DIFF
--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -612,7 +612,7 @@ std::span<const SurfaceFormatInfo> SurfaceFormats() {
                                 vk::Format::eB5G6R5UnormPack16),
         // 1_5_5_5
         CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format1_5_5_5, AmdGpu::NumberFormat::Unorm,
-                                vk::Format::eR5G5B5A1UnormPack16),
+                                vk::Format::eA1B5G5R5UnormPack16),
         // 5_5_5_1 - Remapped to 1_5_5_5.
         // 4_4_4_4
         CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format4_4_4_4, AmdGpu::NumberFormat::Unorm,


### PR DESCRIPTION
Fix `Castlevania: Symphony of the Night`

Format1_5_5_5
From:  eR5G5B5A1UnormPack16
To:       eA1B5G5R5UnormPack16

| Before | After |
|-------------|-------------|
![image](https://github.com/user-attachments/assets/1573587a-837a-4059-ad42-0463afc7d25a) | ![image](https://github.com/user-attachments/assets/9bbb1b6f-3a86-4415-8747-9b0d3079256f)

[Render.Vulkan] <Error> vk_platform.cpp:DebugUtilsCallback:52: VUID-VkImageViewCreateInfo-usage-08931: Validation Error: [ VUID-VkImageViewCreateInfo-usage-08931 ] Object 0: handle = 0x9675f10000000107, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0xca93720b | vkCreateImageView(): pCreateInfo->

format VK_FORMAT_R5G5B5A1_UNORM_PACK16 with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT.
(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT).
The Vulkan spec states: If usage contains VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT or VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV (https://vulkan.lunarg.com/doc/view/1.3.283.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-08931)