### PR TITLE
Fix SurfaceFormat Format1_5_5_5 - Format5_5_5_1

### DIFF
--- a/src/video_core/amdgpu/types.h
+++ b/src/video_core/amdgpu/types.h
@@ -292,6 +292,14 @@ inline CompMapping RemapSwizzle(const DataFormat format, const CompMapping swizz
         result.a = swizzle.r;
         return result;
     }
+    case DataFormat::Format1_5_5_5: {
+        CompMapping result;
+        result.r = swizzle.b;
+        result.g = swizzle.g;
+        result.b = swizzle.r;
+        result.a = swizzle.a;
+        return result;
+    }
     default:
         return swizzle;
     }

--- a/src/video_core/amdgpu/types.h
+++ b/src/video_core/amdgpu/types.h
@@ -283,8 +283,7 @@ inline CompMapping RemapSwizzle(const DataFormat format, const CompMapping swizz
         result.a = swizzle.a;
         return result;
     }
-    case DataFormat::Format10_10_10_2:
-    case DataFormat::Format5_5_5_1: {
+    case DataFormat::Format10_10_10_2: {
         CompMapping result;
         result.r = swizzle.a;
         result.g = swizzle.b;

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -613,7 +613,9 @@ std::span<const SurfaceFormatInfo> SurfaceFormats() {
         // 1_5_5_5
         CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format1_5_5_5, AmdGpu::NumberFormat::Unorm,
                                 vk::Format::eA1R5G5B5UnormPack16),
-        // 5_5_5_1 - Remapped to 1_5_5_5.
+        // 5_5_5_1
+        CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format5_5_5_1, AmdGpu::NumberFormat::Unorm,
+                                vk::Format::eR5G5B5A1UnormPack16),
         // 4_4_4_4
         CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format4_4_4_4, AmdGpu::NumberFormat::Unorm,
                                 vk::Format::eR4G4B4A4UnormPack16),

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -612,7 +612,7 @@ std::span<const SurfaceFormatInfo> SurfaceFormats() {
                                 vk::Format::eB5G6R5UnormPack16),
         // 1_5_5_5
         CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format1_5_5_5, AmdGpu::NumberFormat::Unorm,
-                                vk::Format::eA1B5G5R5UnormPack16),
+                                vk::Format::eA1R5G5B5UnormPack16),
         // 5_5_5_1 - Remapped to 1_5_5_5.
         // 4_4_4_4
         CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format4_4_4_4, AmdGpu::NumberFormat::Unorm,


### PR DESCRIPTION
As discussed in: https://github.com/shadps4-emu/shadPS4/pull/2188

Format1_5_5_5 was changed to eA1R5G5B5UnormPack16
and the r-b, b-r components swapped.
Because eA1B5G5R5UnormPack16 was only added with Vulkan 1.4

add a mapping for Format5_5_5_1 as eR5G5B5A1UnormPack1

*I was unable to use eR5G5B5A1UnormPack16, even changing the components to the correct order, the colors were bad.

In the end the result was the same/good:
![image](https://github.com/user-attachments/assets/caefe860-cfff-47b4-9d4a-d7cd512de68f)
