### PR TITLE
Implement IMAGE_ATOMIC_SWAP

### DIFF
--- a/src/shader_recompiler/frontend/format.cpp
+++ b/src/shader_recompiler/frontend/format.cpp
@@ -3420,8 +3420,8 @@ constexpr std::array<InstFormat, 112> InstructionFormatMIMG = {{
     {InstClass::VectorMemImgUt, InstCategory::VectorMemory, 4, 1, ScalarType::Uint32,
      ScalarType::Uint32},
     // 15 = IMAGE_ATOMIC_SWAP
-    {InstClass::VectorMemImgNoSmp, InstCategory::VectorMemory, 4, 1, ScalarType::Undefined,
-     ScalarType::Undefined},
+    {InstClass::VectorMemImgNoSmp, InstCategory::VectorMemory, 4, 1, ScalarType::Uint32,
+     ScalarType::Uint32},
     // 16 = IMAGE_ATOMIC_CMPSWAP
     {InstClass::VectorMemImgNoSmp, InstCategory::VectorMemory, 4, 1, ScalarType::Undefined,
      ScalarType::Undefined},

--- a/src/shader_recompiler/frontend/translate/vector_memory.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_memory.cpp
@@ -107,6 +107,8 @@ void Translator::EmitVectorMemory(const GcnInst& inst) {
         return IMAGE_GET_RESINFO(inst);
 
         // Image atomic operations
+    case Opcode::IMAGE_ATOMIC_SWAP:
+        return IMAGE_ATOMIC(AtomicOp::Swap, inst);
     case Opcode::IMAGE_ATOMIC_ADD:
         return IMAGE_ATOMIC(AtomicOp::Add, inst);
     case Opcode::IMAGE_ATOMIC_SMIN:


### PR DESCRIPTION
We already handle everything for this opcode in our IMAGE_ATOMIC function, so implementing this is fairly simple. 
This should improve Wipeout 3.