### PR TITLE
texture_cache: Prevent unregistered images from being tracked.

### DIFF
--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -643,6 +643,9 @@ void TextureCache::UnregisterImage(ImageId image_id) {
 
 void TextureCache::TrackImage(ImageId image_id) {
     auto& image = slot_images[image_id];
+    if (!(image.flags & ImageFlagBits::Registered)) {
+        return;
+    }
     const auto image_begin = image.info.guest_address;
     const auto image_end = image.info.guest_address + image.info.guest_size;
     if (image_begin == image.track_addr && image_end == image.track_addr_end) {
@@ -666,6 +669,9 @@ void TextureCache::TrackImage(ImageId image_id) {
 
 void TextureCache::TrackImageHead(ImageId image_id) {
     auto& image = slot_images[image_id];
+    if (!(image.flags & ImageFlagBits::Registered)) {
+        return;
+    }
     const auto image_begin = image.info.guest_address;
     if (image_begin == image.track_addr) {
         return;
@@ -678,6 +684,9 @@ void TextureCache::TrackImageHead(ImageId image_id) {
 
 void TextureCache::TrackImageTail(ImageId image_id) {
     auto& image = slot_images[image_id];
+    if (!(image.flags & ImageFlagBits::Registered)) {
+        return;
+    }
     const auto image_end = image.info.guest_address + image.info.guest_size;
     if (image_end == image.track_addr_end) {
         return;


### PR DESCRIPTION
Do not allow images that have been unregistered to be re-tracked. This could happen if an image is unregistered but not deleted until scheduler reaches tick, and then another piece of code updates the image ID before it is deleted. If this happens and the image then gets deleted from the image slots, it will leave dead page tracking ref-count and leave the page unable to be untracked for writes.

Fixes some loading stalls in CUSA28193