### PR TITLE
texture_cache: Lock when updating image.

### DIFF
--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -60,15 +60,13 @@ void TextureCache::MarkAsMaybeDirty(ImageId image_id, Image& image) {
 
 void TextureCache::InvalidateMemory(VAddr addr, size_t size) {
     std::scoped_lock lock{mutex};
-    const auto end = addr + size;
     const auto pages_start = PageManager::GetPageAddr(addr);
     const auto pages_end = PageManager::GetNextPageAddr(addr + size - 1);
     ForEachImageInRegion(pages_start, pages_end - pages_start, [&](ImageId image_id, Image& image) {
         const auto image_begin = image.info.guest_address;
         const auto image_end = image.info.guest_address + image.info.guest_size;
-        if (image_begin < end && addr < image_end) {
-            // Start or end of the modified region is in the image, or the image is entirely within
-            // the modified region, so the image was definitely accessed by this page fault.
+        if (image.Overlaps(addr, size)) {
+            // Modified region overlaps image, so the image was definitely accessed by this fault.
             // Untrack the image, so that the range is unprotected and the guest can write freely.
             image.flags |= ImageFlagBits::CpuDirty;
             UntrackImage(image_id);

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -118,6 +118,7 @@ public:
 
     /// Updates image contents if it was modified by CPU.
     void UpdateImage(ImageId image_id, Vulkan::Scheduler* custom_scheduler = nullptr) {
+        std::scoped_lock lock{mutex};
         Image& image = slot_images[image_id];
         TrackImage(image_id);
         RefreshImage(image, custom_scheduler);


### PR DESCRIPTION
`UpdateImage` need to acquire lock in order to prevent race conditions updating tracking status. Also fixed up the range check in `InvalidateMemory` to use the existing image overlap function.

Fixes possible crash due to tracking asserts. Texture cache will probably need a pass in the future to clean up/reduce locking.