### PR TITLE
shader_recompiler: Maintain loss of precision when folding half-float unpack.

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_bitwise_conversion.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_bitwise_conversion.cpp
@@ -58,4 +58,8 @@ Id EmitUnpackHalf2x16(EmitContext& ctx, Id value) {
     return ctx.OpUnpackHalf2x16(ctx.F32[2], value);
 }
 
+Id EmitQuantizeHalf2x16(EmitContext& ctx, Id value) {
+    return ctx.OpQuantizeToF16(ctx.F32[2], value);
+}
+
 } // namespace Shader::Backend::SPIRV

--- a/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
@@ -197,6 +197,7 @@ Id EmitPackFloat2x16(EmitContext& ctx, Id value);
 Id EmitUnpackFloat2x16(EmitContext& ctx, Id value);
 Id EmitPackHalf2x16(EmitContext& ctx, Id value);
 Id EmitUnpackHalf2x16(EmitContext& ctx, Id value);
+Id EmitQuantizeHalf2x16(EmitContext& ctx, Id value);
 Id EmitFPAbs16(EmitContext& ctx, Id value);
 Id EmitFPAbs32(EmitContext& ctx, Id value);
 Id EmitFPAbs64(EmitContext& ctx, Id value);

--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -795,6 +795,10 @@ Value IREmitter::UnpackHalf2x16(const U32& value) {
     return Inst(Opcode::UnpackHalf2x16, value);
 }
 
+Value IREmitter::QuantizeHalf2x16(const Value& value) {
+    return Inst(Opcode::QuantizeHalf2x16, value);
+}
+
 F32F64 IREmitter::FPMul(const F32F64& a, const F32F64& b) {
     if (a.Type() != b.Type()) {
         UNREACHABLE_MSG("Mismatching types {} and {}", a.Type(), b.Type());

--- a/src/shader_recompiler/ir/ir_emitter.h
+++ b/src/shader_recompiler/ir/ir_emitter.h
@@ -175,6 +175,7 @@ public:
 
     [[nodiscard]] U32 PackHalf2x16(const Value& vector);
     [[nodiscard]] Value UnpackHalf2x16(const U32& value);
+    [[nodiscard]] Value QuantizeHalf2x16(const Value& value);
 
     [[nodiscard]] F32F64 FPAdd(const F32F64& a, const F32F64& b);
     [[nodiscard]] F32F64 FPSub(const F32F64& a, const F32F64& b);

--- a/src/shader_recompiler/ir/opcodes.inc
+++ b/src/shader_recompiler/ir/opcodes.inc
@@ -187,6 +187,7 @@ OPCODE(PackFloat2x16,                                       U32,            F16x
 OPCODE(UnpackFloat2x16,                                     F16x2,          U32,                                                                            )
 OPCODE(PackHalf2x16,                                        U32,            F32x2,                                                                          )
 OPCODE(UnpackHalf2x16,                                      F32x2,          U32,                                                                            )
+OPCODE(QuantizeHalf2x16,                                    F32x2,          F32x2,                                                                          )
 
 // Floating-point operations
 OPCODE(FPAbs32,                                             F32,            F32,                                                                            )


### PR DESCRIPTION
When folding a pair of half unpack and pack instructions, maintain the loss of precision that should have happened from converting to 16-bit float using a quantize op.

Fixes some missing lighting in CUSA05637. The game stores a set of control bits in the alpha channel during rendering in order to control lighting properties in later shaders. This involves dividing to convert it to a normalized float when writing, and multiplying to convert it back to an 8-bit integer when reading. When writing they compensate for the loss of precision when packing to 16-bit float on PS4 by adding a constant `0.5 / 255`, but without the loss in precision this ends up changing the bits when transformed back into an integer in the lighting shader.

The lighting components that are now visible in this game seem to have some color problems but those appear to be a separate issue from this.