### PR TITLE
tile: Fix some tile thickness calculation errors.

### DIFF
--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -188,7 +188,7 @@ void ImageInfo::UpdateSize() {
         case AmdGpu::TilingMode::Display_MicroTiled:
         case AmdGpu::TilingMode::Texture_MicroTiled: {
             std::tie(mip_info.pitch, mip_info.size) =
-                ImageSizeMicroTiled(mip_w, mip_h, bpp, thickness, num_samples);
+                ImageSizeMicroTiled(mip_w, mip_h, thickness, bpp, num_samples);
             mip_info.height = std::max(mip_h, 8u);
             if (props.is_block) {
                 mip_info.pitch = std::max(mip_info.pitch * 4, 32u);

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -178,7 +178,6 @@ void ImageInfo::UpdateSize() {
         case AmdGpu::TilingMode::Display_Linear: {
             std::tie(mip_info.pitch, mip_info.size) =
                 ImageSizeLinearAligned(mip_w, mip_h, bpp, num_samples);
-            mip_info.height = mip_h;
             break;
         }
         case AmdGpu::TilingMode::Texture_Volume:
@@ -189,11 +188,6 @@ void ImageInfo::UpdateSize() {
         case AmdGpu::TilingMode::Texture_MicroTiled: {
             std::tie(mip_info.pitch, mip_info.size) =
                 ImageSizeMicroTiled(mip_w, mip_h, thickness, bpp, num_samples);
-            mip_info.height = std::max(mip_h, 8u);
-            if (props.is_block) {
-                mip_info.pitch = std::max(mip_info.pitch * 4, 32u);
-                mip_info.height = std::max(mip_info.height * 4, 32u);
-            }
             break;
         }
         case AmdGpu::TilingMode::Display_MacroTiled:
@@ -207,6 +201,11 @@ void ImageInfo::UpdateSize() {
         default: {
             UNREACHABLE();
         }
+        }
+        mip_info.height = mip_h;
+        if (props.is_block) {
+            mip_info.pitch = std::max(mip_info.pitch * 4, 32u);
+            mip_info.height = std::max(mip_info.height * 4, 32u);
         }
         mip_info.size *= mip_d;
         mip_info.offset = guest_size;

--- a/src/video_core/texture_cache/tile.h
+++ b/src/video_core/texture_cache/tile.h
@@ -313,8 +313,8 @@ constexpr std::pair<u32, size_t> ImageSizeMicroTiled(u32 pitch, u32 height, u32 
     const auto& [pitch_align, height_align] = micro_tile_extent;
     auto pitch_aligned = (pitch + pitch_align - 1) & ~(pitch_align - 1);
     const auto height_aligned = (height + height_align - 1) & ~(height_align - 1);
-    size_t log_sz = (pitch_aligned * height_aligned * bpp * num_samples * thickness + 7) / 8;
-    while (log_sz % 256) {
+    size_t log_sz = (pitch_aligned * height_aligned * bpp * num_samples + 7) / 8;
+    while ((log_sz * thickness) % 256) {
         pitch_aligned += pitch_align;
         log_sz = (pitch_aligned * height_aligned * bpp * num_samples + 7) / 8;
     }


### PR DESCRIPTION
Fix some mistakes from updates to tile calculations related to volume thickness:
* Typo in arg order to `ImageSizeMicroTiled` in `UpdateSize`.
* `ImageSizeMicroTiled` should not return size multiplied with thickness, only use it for pitch alignment padding condition. Returned value will be multiplied with full texture depth after.