### PR TITLE
Optimize workflows by caching `apt install`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        submodules: recursive
 
     - name: Install
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,16 +3,7 @@
 
 name: Build and Release
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - ready_for_review
-      - synchronize
+on: [push, pull_request]
 
 concurrency:
   group: ci-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        submodules: recursive
 
     - name: Install
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -350,9 +350,6 @@ jobs:
       with:
         submodules: recursive
 
-    #- name: Install dependencies
-      #run: sudo apt-get update && sudo apt install -y libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 clang build-essential qt6-base-dev qt6-tools-dev qt6-multimedia-dev libasound2-dev libpulse-dev libopenal-dev libudev-dev
-
     - uses: awalsh128/cache-apt-pkgs-action@latest
       with: 
         packages: libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 clang build-essential qt6-base-dev qt6-tools-dev qt6-multimedia-dev libasound2-dev libpulse-dev libopenal-dev libudev-dev
@@ -402,9 +399,6 @@ jobs:
       with:
         submodules: recursive
 
-    #- name: Install dependencies
-      #run: sudo apt-get update && sudo apt install -y libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 gcc-14 build-essential libasound2-dev libpulse-dev libopenal-dev libudev-dev
-
     - uses: awalsh128/cache-apt-pkgs-action@latest
       with: 
         packages: libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 gcc-14 build-essential libasound2-dev libpulse-dev libopenal-dev libudev-dev
@@ -442,9 +436,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
-
-    #- name: Install dependencies
-      #run: sudo apt-get update && sudo apt install -y libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 gcc-14 build-essential qt6-base-dev qt6-tools-dev qt6-multimedia-dev libasound2-dev libpulse-dev libopenal-dev libudev-dev
 
     - uses: awalsh128/cache-apt-pkgs-action@latest
       with: 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,20 +24,27 @@ jobs:
     runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
+      
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+
     - name: Install
       run: |
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main'
-        sudo apt update
-        sudo apt install clang-format-18
+
+    - uses: awalsh128/cache-apt-pkgs-action@latest
+      with: 
+        packages: clang-format-18
+        version: 1.0
+
     - name: Build
       env:
         COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       run: ./.ci/clang-format.sh
-      
+
+
   get-info:
     runs-on: ubuntu-24.04
     outputs:
@@ -281,9 +288,6 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Install dependencies
-      run: sudo apt-get update && sudo apt install -y libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 clang build-essential libasound2-dev libpulse-dev libopenal-dev libudev-dev
-
     - name: Cache CMake Configuration
       uses: actions/cache@v4 
       env: 
@@ -337,8 +341,13 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Install dependencies
-      run: sudo apt-get update && sudo apt install -y libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 clang build-essential qt6-base-dev qt6-tools-dev qt6-multimedia-dev libasound2-dev libpulse-dev libopenal-dev libudev-dev
+    #- name: Install dependencies
+      #run: sudo apt-get update && sudo apt install -y libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 clang build-essential qt6-base-dev qt6-tools-dev qt6-multimedia-dev libasound2-dev libpulse-dev libopenal-dev libudev-dev
+
+    - uses: awalsh128/cache-apt-pkgs-action@latest
+      with: 
+        packages: libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 clang build-essential qt6-base-dev qt6-tools-dev qt6-multimedia-dev libasound2-dev libpulse-dev libopenal-dev libudev-dev
+        version: 1.0      
 
     - name: Cache CMake Configuration
       uses: actions/cache@v4 
@@ -384,8 +393,13 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Install dependencies
-      run: sudo apt-get update && sudo apt install -y libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 gcc-14 build-essential libasound2-dev libpulse-dev libopenal-dev libudev-dev
+    #- name: Install dependencies
+      #run: sudo apt-get update && sudo apt install -y libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 gcc-14 build-essential libasound2-dev libpulse-dev libopenal-dev libudev-dev
+
+    - uses: awalsh128/cache-apt-pkgs-action@latest
+      with: 
+        packages: libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 gcc-14 build-essential libasound2-dev libpulse-dev libopenal-dev libudev-dev
+        version: 1.0      
 
     - name: Cache CMake Configuration
       uses: actions/cache@v4 
@@ -420,8 +434,13 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Install dependencies
-      run: sudo apt-get update && sudo apt install -y libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 gcc-14 build-essential qt6-base-dev qt6-tools-dev qt6-multimedia-dev libasound2-dev libpulse-dev libopenal-dev libudev-dev
+    #- name: Install dependencies
+      #run: sudo apt-get update && sudo apt install -y libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 gcc-14 build-essential qt6-base-dev qt6-tools-dev qt6-multimedia-dev libasound2-dev libpulse-dev libopenal-dev libudev-dev
+
+    - uses: awalsh128/cache-apt-pkgs-action@latest
+      with: 
+        packages: libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 gcc-14 build-essential qt6-base-dev qt6-tools-dev qt6-multimedia-dev libasound2-dev libpulse-dev libopenal-dev libudev-dev
+        version: 1.0     
 
     - name: Cache CMake Configuration
       uses: actions/cache@v4 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,16 @@
 
 name: Build and Release
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
 
 concurrency:
   group: ci-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -352,11 +352,11 @@ jobs:
 
     - name: Install dependencies
       run: |
-            sudo apt install -y libfuse2
+            sudo apt install -y libfuse2 qt6-base-dev qt6-tools-dev qt6-multimedia-dev
 
     - uses: awalsh128/cache-apt-pkgs-action@latest
       with: 
-        packages: libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev clang build-essential qt6-base-dev qt6-tools-dev qt6-multimedia-dev libasound2-dev libpulse-dev libopenal-dev libudev-dev
+        packages: libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev clang build-essential libasound2-dev libpulse-dev libopenal-dev libudev-dev
         version: 1.0      
 
     - name: Cache CMake Configuration
@@ -447,12 +447,12 @@ jobs:
 
     - name: Install dependencies
       run: |
-            sudo apt install -y libfuse2
+            sudo apt install -y libfuse2 qt6-base-dev qt6-tools-dev qt6-multimedia-dev
 
     - uses: awalsh128/cache-apt-pkgs-action@latest
       with: 
-        packages: libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev gcc-14 build-essential qt6-base-dev qt6-tools-dev qt6-multimedia-dev libasound2-dev libpulse-dev libopenal-dev libudev-dev
-        version: 1.0     
+        packages: libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev gcc-14 build-essential libasound2-dev libpulse-dev libopenal-dev libudev-dev
+        version: 1.0 
 
     - name: Cache CMake Configuration
       uses: actions/cache@v4 
@@ -474,7 +474,8 @@ jobs:
         key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
 
     - name: Configure CMake
-      run: cmake --fresh -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE=ON -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DENABLE_QT_GUI=ON -DENABLE_UPDATER=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+      run: |
+            cmake --fresh -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE=ON -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DENABLE_QT_GUI=ON -DENABLE_UPDATER=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel $(nproc)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,6 +288,15 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Install dependencies
+      run: |
+            sudo apt install -y libfuse2
+
+    - uses: awalsh128/cache-apt-pkgs-action@latest
+      with: 
+        packages: libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev clang build-essential libasound2-dev libpulse-dev libopenal-dev libudev-dev
+        version: 1.0
+
     - name: Cache CMake Configuration
       uses: actions/cache@v4 
       env: 
@@ -341,9 +350,13 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Install dependencies
+      run: |
+            sudo apt install -y libfuse2
+
     - uses: awalsh128/cache-apt-pkgs-action@latest
       with: 
-        packages: libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 clang build-essential qt6-base-dev qt6-tools-dev qt6-multimedia-dev libasound2-dev libpulse-dev libopenal-dev libudev-dev
+        packages: libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev clang build-essential qt6-base-dev qt6-tools-dev qt6-multimedia-dev libasound2-dev libpulse-dev libopenal-dev libudev-dev
         version: 1.0      
 
     - name: Cache CMake Configuration
@@ -390,9 +403,13 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Install dependencies
+      run: |
+            sudo apt install -y libfuse2
+
     - uses: awalsh128/cache-apt-pkgs-action@latest
       with: 
-        packages: libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 gcc-14 build-essential libasound2-dev libpulse-dev libopenal-dev libudev-dev
+        packages: libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev gcc-14 build-essential libasound2-dev libpulse-dev libopenal-dev libudev-dev
         version: 1.0      
 
     - name: Cache CMake Configuration
@@ -428,9 +445,13 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Install dependencies
+      run: |
+            sudo apt install -y libfuse2
+
     - uses: awalsh128/cache-apt-pkgs-action@latest
       with: 
-        packages: libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 gcc-14 build-essential qt6-base-dev qt6-tools-dev qt6-multimedia-dev libasound2-dev libpulse-dev libopenal-dev libudev-dev
+        packages: libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev gcc-14 build-essential qt6-base-dev qt6-tools-dev qt6-multimedia-dev libasound2-dev libpulse-dev libopenal-dev libudev-dev
         version: 1.0     
 
     - name: Cache CMake Configuration


### PR DESCRIPTION
This PR:

- Attempts to gain a few seconds by using `awalsh128/cache-apt-pkgs-action` for caching apt installs on `linux` building workflows

It is not that much but at least half minute per job, after the first push, is gained