### PR TITLE
Fix showing debug menu bar / Devtools

### DIFF
--- a/src/core/debug_state.cpp
+++ b/src/core/debug_state.cpp
@@ -17,6 +17,8 @@ using namespace DebugStateType;
 
 DebugStateImpl& DebugState = *Common::Singleton<DebugStateImpl>::Instance();
 
+bool DebugStateType::showing_debug_menu_bar = false;
+
 static ThreadID ThisThreadID() {
 #ifdef _WIN32
     return GetCurrentThreadId();

--- a/src/core/debug_state.h
+++ b/src/core/debug_state.h
@@ -35,6 +35,8 @@ class ShaderList;
 
 namespace DebugStateType {
 
+static bool showing_debug_menu_bar = false;
+
 enum class QueueType {
     dcb = 0,
     ccb = 1,
@@ -130,8 +132,6 @@ class DebugStateImpl {
     friend class Core::Devtools::Layer;
     friend class Core::Devtools::Widget::FrameGraph;
     friend class Core::Devtools::Widget::ShaderList;
-
-    bool showing_debug_menu_bar = false;
 
     std::queue<std::string> debug_message_popup;
 

--- a/src/core/debug_state.h
+++ b/src/core/debug_state.h
@@ -35,7 +35,7 @@ class ShaderList;
 
 namespace DebugStateType {
 
-static bool showing_debug_menu_bar = false;
+extern bool showing_debug_menu_bar;
 
 enum class QueueType {
     dcb = 0,


### PR DESCRIPTION
After analyzing with @viniciuslrangel , we concluded that the issue occurs when the emulator crashes and the value of 'showing_debug_menu_bar' is saved incorrectly, causing the DevTools screen to appear the next time the game is started.