### PR TITLE
texture_cache: Do not overwrite overlap hit with a miss.

### DIFF
--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -345,8 +345,13 @@ ImageId TextureCache::FindImage(BaseDesc& desc, FindFlags flags) {
             view_slice = -1;
 
             const auto& merged_info = image_id ? slot_images[image_id].info : info;
-            std::tie(image_id, view_mip, view_slice) =
+            auto [overlap_image_id, overlap_view_mip, overlap_view_slice] =
                 ResolveOverlap(merged_info, desc.type, cache_id, image_id);
+            if (overlap_image_id) {
+                image_id = overlap_image_id;
+                view_mip = overlap_view_mip;
+                view_slice = overlap_view_slice;
+            }
         }
     }
 


### PR DESCRIPTION
When resolving overlaps, don't overwrite an overlap hit with a miss.

Fixes fog effect in battles in CUSA16404 incorrectly covering the entire screen. The depth buffer was not being matched and instead a new, empty color image was being created.