### PR TITLE
liverpool: Fix tiled check for color buffer.

### DIFF
--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -904,7 +904,7 @@ struct Liverpool {
         }
 
         bool IsTiled() const {
-            return !info.linear_general;
+            return GetTilingMode() != TilingMode::Display_Linear;
         }
 
         [[nodiscard]] DataFormat GetDataFmt() const {


### PR DESCRIPTION
Fix the `IsTiled()` check for color buffers. The `linear_general` flag overrides the array mode to linear general, but the tiling mode can also just be `Display_Linear` even if `linear_general` is not set. So instead of checking that flag, just delegate to `GetTilingMode()` and check if not `Display_Linear`.

In practice I don't think this changes much since we don't do much display tiling, but should stop some spam for unsupported tiling mode `Display_Linear`, which shouldn't be going through the detiling code at all.