### PR TITLE
shader_recompiler: Add another constant propagation pass near the end.

### DIFF
--- a/src/shader_recompiler/recompiler.cpp
+++ b/src/shader_recompiler/recompiler.cpp
@@ -90,6 +90,7 @@ IR::Program TranslateProgram(std::span<const u32> code, Pools& pools, Info& info
     Shader::Optimization::ResourceTrackingPass(program);
     Shader::Optimization::IdentityRemovalPass(program.blocks);
     Shader::Optimization::DeadCodeEliminationPass(program);
+    Shader::Optimization::ConstantPropagationPass(program.post_order_blocks);
     Shader::Optimization::CollectShaderInfoPass(program);
     Shader::Optimization::SharedMemoryBarrierPass(program, profile);
 


### PR DESCRIPTION
Should help fold some more constant expressions after other passes applying code like buffer addressing.