### PR TITLE
Fix heap read after free in UnmapMemoryImpl

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -418,8 +418,9 @@ u64 MemoryManager::UnmapBytesFromEntry(VAddr virtual_addr, VirtualMemoryArea vma
     vma.phys_base = 0;
     vma.disallow_merge = false;
     vma.name = "";
-    MergeAdjacent(vma_map, new_it);
-    bool readonly_file = vma.prot == MemoryProt::CpuRead && type == VMAType::File;
+    const auto post_merge_it = MergeAdjacent(vma_map, new_it);
+    auto& post_merge_vma = post_merge_it->second;
+    bool readonly_file = post_merge_vma.prot == MemoryProt::CpuRead && type == VMAType::File;
     if (type != VMAType::Reserved && type != VMAType::PoolReserved) {
         // Unmap the memory region.
         impl.Unmap(vma_base_addr, vma_base_size, start_in_vma, start_in_vma + adjusted_size,


### PR DESCRIPTION
This doesn't fix any known behavior, but it fixes a read after free.

`new_it` can become invalidated in `MergeAdjacent`, and the known safe iterator is returned from the function. The old code was discarding that new iterator, and continuing to access memory of the (potentially merged and potentially deleted) data.

The read of `vma.prot` was hanging my debugger (w/ the aggressive debug assertion settings I had enabled in Application Verifier).

I'm not sure what significance the `readonly_file` variable/parameter has here, but it had a chance of being inaccurate before this change.