### PR TITLE
shader_recompiler: Fix image write swizzles.

### DIFF
--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -569,7 +569,7 @@ void PatchTextureBufferArgs(IR::Block& block, IR::Inst& inst, Info& info) {
     inst.SetArg(1, CalculateBufferAddress(ir, inst, info, buffer, 1U));
 
     if (inst.GetOpcode() == IR::Opcode::StoreBufferFormatF32) {
-        const auto swizzled = ApplySwizzle(ir, inst.Arg(2), buffer.DstSelect());
+        const auto swizzled = ApplySwizzle(ir, inst.Arg(2), buffer.DstSelect().Inverse());
         const auto converted =
             ApplyWriteNumberConversionVec4(ir, swizzled, buffer.GetNumberConversion());
         inst.SetArg(2, converted);
@@ -829,7 +829,7 @@ void PatchImageArgs(IR::Block& block, IR::Inst& inst, Info& info) {
             auto texel = inst.Arg(4);
             if (is_storage) {
                 // Storage image requires shader swizzle.
-                texel = ApplySwizzle(ir, texel, image.DstSelect());
+                texel = ApplySwizzle(ir, texel, image.DstSelect().Inverse());
             }
             const auto converted =
                 ApplyWriteNumberConversionVec4(ir, texel, image.GetNumberConversion());

--- a/src/video_core/amdgpu/types.h
+++ b/src/video_core/amdgpu/types.h
@@ -200,10 +200,10 @@ enum class NumberConversion : u32 {
 };
 
 struct CompMapping {
-    CompSwizzle r : 3;
-    CompSwizzle g : 3;
-    CompSwizzle b : 3;
-    CompSwizzle a : 3;
+    CompSwizzle r;
+    CompSwizzle g;
+    CompSwizzle b;
+    CompSwizzle a;
 
     auto operator<=>(const CompMapping& other) const = default;
 
@@ -215,6 +215,15 @@ struct CompMapping {
             ApplySingle(data, b),
             ApplySingle(data, a),
         };
+    }
+
+    [[nodiscard]] CompMapping Inverse() const {
+        CompMapping result{};
+        InverseSingle(result.r, CompSwizzle::Red);
+        InverseSingle(result.g, CompSwizzle::Green);
+        InverseSingle(result.b, CompSwizzle::Blue);
+        InverseSingle(result.a, CompSwizzle::Alpha);
+        return result;
     }
 
 private:
@@ -235,6 +244,20 @@ private:
             return data[3];
         default:
             UNREACHABLE();
+        }
+    }
+
+    void InverseSingle(CompSwizzle& dst, const CompSwizzle target) const {
+        if (r == target) {
+            dst = CompSwizzle::Red;
+        } else if (g == target) {
+            dst = CompSwizzle::Green;
+        } else if (b == target) {
+            dst = CompSwizzle::Blue;
+        } else if (a == target) {
+            dst = CompSwizzle::Alpha;
+        } else {
+            dst = CompSwizzle::Zero;
         }
     }
 };


### PR DESCRIPTION
Component mapping for swizzle needs to be inverted for image writes. For example, if the swizzle is [000R], it means that alpha should be written to red, not that red should be written to alpha.

Fixes videos in CUSA01047 intro. I believe this fixes baldness in CUSA00900 as well (https://github.com/shadps4-emu/shadPS4/issues/1858).