### PR TITLE
system_service: Add simple event queue and push an EntitlementUpdate event to it when app content is initialized

### DIFF
--- a/src/core/libraries/app_content/app_content.cpp
+++ b/src/core/libraries/app_content/app_content.cpp
@@ -12,6 +12,7 @@
 #include "core/file_sys/fs.h"
 #include "core/libraries/app_content/app_content_error.h"
 #include "core/libraries/libs.h"
+#include "core/libraries/system/systemservice.h"
 
 namespace Libraries::AppContent {
 
@@ -262,6 +263,15 @@ int PS4_SYSV_ABI sceAppContentInitialize(const OrbisAppContentInitParam* initPar
             entitlement_label.copy(info.entitlement_label, sizeof(info.entitlement_label));
         }
     }
+
+    if (addcont_count > 0) {
+        SystemService::OrbisSystemServiceEvent event{};
+        event.event_type = SystemService::OrbisSystemServiceEventType::EntitlementUpdate;
+        event.service_entitlement_update.user_id = 0;
+        event.service_entitlement_update.np_service_label = 0;
+        SystemService::PushSystemServiceEvent(event);
+    }
+
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/system/systemservice.h
+++ b/src/core/libraries/system/systemservice.h
@@ -4,6 +4,8 @@
 // https://github.com/OpenOrbis/OpenOrbis-PS4-Toolchain/blob/master/include/orbis/_types/sys_service.h
 #pragma once
 
+#include <mutex>
+#include <queue>
 #include "common/types.h"
 
 namespace Core::Loader {
@@ -602,6 +604,8 @@ int PS4_SYSV_ABI sceSystemServiceDisableVoiceRecognition();
 int PS4_SYSV_ABI sceSystemServiceReenableVoiceRecognition();
 int PS4_SYSV_ABI Func_6B1CDB955F0EBD65();
 int PS4_SYSV_ABI Func_CB5E885E225F69F0();
+
+void PushSystemServiceEvent(const OrbisSystemServiceEvent& event);
 
 void RegisterlibSceSystemService(Core::Loader::SymbolsResolver* sym);
 } // namespace Libraries::SystemService


### PR DESCRIPTION
Fist of the North Star: Lost Paradise expects an `EntitlementUpdate` system event to be fired before it checks if DLC is installed. It does call `sceAppContentInitialize` beforehand, so I added a simple queue to hold the events and pushed the `EntitlementUpdate` event to it when `sceAppContentInitialize` is called. This allows installed DLC to show up ingame now.

I'm not sure if this is 100% the correct behavior, but it made the most sense to me.

![image](https://github.com/user-attachments/assets/d6642a97-f1fe-490d-807a-78afa054c739)
