### PR TITLE
qt: Prevent interacting with empty grid cells.

### DIFF
--- a/src/qt_gui/game_grid_frame.cpp
+++ b/src/qt_gui/game_grid_frame.cpp
@@ -38,17 +38,18 @@ GameGridFrame::GameGridFrame(std::shared_ptr<GameInfoClass> game_info_get,
 
 void GameGridFrame::onCurrentCellChanged(int currentRow, int currentColumn, int previousRow,
                                          int previousColumn) {
-    cellClicked = true;
     crtRow = currentRow;
     crtColumn = currentColumn;
     columnCnt = this->columnCount();
 
     auto itemID = (crtRow * columnCnt) + currentColumn;
     if (itemID > m_game_info->m_games.count() - 1) {
+        cellClicked = false;
         validCellSelected = false;
         BackgroundMusicPlayer::getInstance().stopMusic();
         return;
     }
+    cellClicked = true;
     validCellSelected = true;
     SetGridBackgroundImage(crtRow, crtColumn);
     auto snd0Path = QString::fromStdString(m_game_info->m_games[itemID].snd0_path.string());

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -41,8 +41,8 @@ public:
             itemID = widget->currentRow() * widget->columnCount() + widget->currentColumn();
         }
 
-        // Do not show the menu if an item is selected
-        if (itemID == -1) {
+        // Do not show the menu if no item is selected
+        if (itemID < 0 || itemID >= m_games.size()) {
             return;
         }
 


### PR DESCRIPTION
Prevent interacting with empty cells in the game grid view, to prevent actions on out-of-bounds game list reads with potentially destructive results. Unfortunately I am not familiar enough with Qt to figure out how to disable selecting the empty cells that pad out rows to the number of grid columns, but this will at least prevent it from causing harm.

Should prevent https://github.com/shadps4-emu/shadPS4/issues/2242