### PR TITLE
fs: handle relative paths

### DIFF
--- a/src/core/file_sys/fs.cpp
+++ b/src/core/file_sys/fs.cpp
@@ -51,7 +51,7 @@ std::filesystem::path MntPoints::GetHostPath(std::string_view path, bool* is_rea
     }
 
     // Path is relative?
-    if(corrected_path.at(0) != '/') {
+    if (corrected_path.at(0) != '/') {
         corrected_path = "/app0/" + corrected_path;
     }
 

--- a/src/core/file_sys/fs.cpp
+++ b/src/core/file_sys/fs.cpp
@@ -50,6 +50,11 @@ std::filesystem::path MntPoints::GetHostPath(std::string_view path, bool* is_rea
         pos = corrected_path.find("//", pos + 1);
     }
 
+    // Path is relative?
+    if(corrected_path.at(0) != '/') {
+        corrected_path = "/app0/" + corrected_path;
+    }
+
     const MntPair* mount = GetMount(corrected_path);
     if (!mount) {
         return "";


### PR DESCRIPTION
Some games (like M2 Cave portings) uses relative paths for module loading. This PR introduce a simple way to handle these type of paths.