### PR TITLE
linker: handle relocation for exported modules

### DIFF
--- a/src/core/linker.h
+++ b/src/core/linker.h
@@ -109,10 +109,13 @@ public:
 
     void RelocateAnyImports(Module* m) {
         Relocate(m);
-        for (auto& module : m_modules) {
-            const auto imports = module->GetImportModules();
-            if (std::ranges::contains(imports, m->name, &ModuleInfo::name)) {
-                Relocate(module.get());
+        const auto exports = m->GetExportModules();
+        for (auto& export_mod : exports) {
+            for (auto& module : m_modules) {
+                const auto imports = module->GetImportModules();
+                if (std::ranges::contains(imports, export_mod.name, &ModuleInfo::name)) {
+                    Relocate(module.get());
+                }
             }
         }
     }


### PR DESCRIPTION
In some games the module filename and module exported name are not the same. This PR changes how we decide if there is the need for a symbol relocation based on the export module info.