### PR TITLE
qt: fix grid

### DIFF
--- a/src/qt_gui/game_grid_frame.cpp
+++ b/src/qt_gui/game_grid_frame.cpp
@@ -43,12 +43,17 @@ void GameGridFrame::onCurrentCellChanged(int currentRow, int currentColumn, int 
     columnCnt = this->columnCount();
 
     auto itemID = (crtRow * columnCnt) + currentColumn;
+    static QString originalStyle = this->styleSheet();
     if (itemID > m_game_info->m_games.count() - 1) {
         cellClicked = false;
         validCellSelected = false;
         BackgroundMusicPlayer::getInstance().stopMusic();
+        this->setStyleSheet(originalStyle +
+                            "QTableWidget {outline: auto;}"
+                            "QTableWidget::item:selected {background-color: transparent;}");
         return;
     }
+    this->setStyleSheet(originalStyle);
     cellClicked = true;
     validCellSelected = true;
     SetGridBackgroundImage(crtRow, crtColumn);


### PR DESCRIPTION
This fixes the problem presented in https://github.com/shadps4-emu/shadPS4/pull/2243, but causes another problem.
I'll leave it as a draft in the hope that someone can help to understand this better. 
I believe this cannot be merged because it becomes worse than before...

this should solve the selection of invisible grids:
![image](https://github.com/user-attachments/assets/dbc4b72b-69f7-47bb-8a41-22f6de86b558)

It's a bit complicated to describe the new problem, so it's easier to watch the video, but in short:
after selecting outside the grid, the background images do not load, only if I click again outside the games on the grid

https://github.com/user-attachments/assets/cf11e8a3-38e8-4b6a-84cb-150b10d7bbb8

