### PR TITLE
vk_rasterizer: Keep viewport depth offset even without native depth clip control.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -1155,10 +1155,7 @@ void Rasterizer::UpdateViewportScissorState(const GraphicsPipeline& pipeline) {
 
     const auto& vp_ctl = regs.viewport_control;
     const float reduce_z =
-        instance.IsDepthClipControlSupported() &&
-                regs.clipper_control.clip_space == AmdGpu::Liverpool::ClipSpace::MinusWToW
-            ? 1.0f
-            : 0.0f;
+        regs.clipper_control.clip_space == AmdGpu::Liverpool::ClipSpace::MinusWToW ? 1.0f : 0.0f;
 
     if (regs.polygon_control.enable_window_offset) {
         LOG_ERROR(Render_Vulkan,


### PR DESCRIPTION
Got a more noticable example in CUSA14836 proving this is correct behavior; without it the title screen has incorrect depth blur due to wrong range.