### PR TITLE
Update README.md: Add note to keyboard mapping that some operating systems may require you to hold the Fn button

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ F11 | Fullscreen |
 F12 | Trigger RenderDoc Capture |
 
 > [!NOTE]
-> Xbox and Dual Shock controllers work right out of the box. On some operating systems because of its default settings, you may must press the fn button together with one of the above buttons to use its function. On MacOS, however, only the FPS counter works.
+> Xbox and Dual Shock controllers work right out of the box. On some operating systems because of their default settings, you may must press the fn button together with one of the above buttons to use its function. On MacOS, however, only the FPS counter works.
 
 | Controller button | Keyboard equivelant | Mac alternative |
 |-------------|-------------|--------------|

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ For more information on how to test, debug and report issues with the emulator o
 # Keyboard mapping
 
 > [!NOTE]
-> In some operating systems, the default settings require you to press the fn key together with one of the below keys in order to use their function. On MacOS, however, only the FPS counter works.
+> In some operating systems, the default settings require you to press the fn key together with one of the following keys in order to use their function. On MacOS, however, only the FPS counter works.
 
 | Button | Function |
 |-------------|-------------|

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ F11 | Fullscreen |
 F12 | Trigger RenderDoc Capture |
 
 > [!NOTE]
-> Xbox and DualShock controllers work right out of the box. In some operating systems, the default settings require you to press the fn key together with one of the above keys in order to use their function. On MacOS, however, only the FPS counter works.
+> In some operating systems, the default settings require you to press the fn key together with one of the above keys in order to use their function. On MacOS, however, only the FPS counter works. Xbox and DualShock controllers work right out of the box.
 
 | Controller button | Keyboard equivelant | Mac alternative |
 |-------------|-------------|--------------|

--- a/README.md
+++ b/README.md
@@ -84,8 +84,7 @@ F11 | Fullscreen |
 F12 | Trigger RenderDoc Capture |
 
 > [!NOTE]
-> Xbox and DualShock controllers work out of the box.
-> Some operating systems may require you on default to hold the fn button additionally to the ones listed above to use the said functions, on MacOS only the fps counter of the said functions works though.
+> Xbox and DualShock controllers work out of the box. Some operating systems may require you to hold down the fn key in addition to those listed above in order to use the above functions; however, under MacOS, only the fps counter of the above functions will work.
 
 | Controller button | Keyboard equivelant | Mac alternative |
 |-------------|-------------|--------------|

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ For more information on how to test, debug and report issues with the emulator o
 # Keyboard mapping
 
 > [!NOTE]
-> In some operating systems, the default settings require you to press the fn key together with one of the above keys in order to use their function. On MacOS, however, only the FPS counter works.
+> In some operating systems, the default settings require you to press the fn key together with one of the below keys in order to use their function. On MacOS, however, only the FPS counter works.
 
 | Button | Function |
 |-------------|-------------|

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ F12 | | Trigger RenderDoc Capture |
 
 > [!NOTE]
 > These functions are for the default keyboard mappings of the corresponding OS only.
-Xbox and DualShock controllers work out of the box.
+|Xbox and DualShock controllers work out of the box.
 
 | Controller button | Keyboard equivelant | Mac alternative |
 |-------------|-------------|--------------|

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ F12 | | Trigger RenderDoc Capture |
 
 > [!NOTE]
 > These functions are for the default keyboard mappings of the corresponding OS only.
+
 > Xbox and DualShock controllers work out of the box.
 
 | Controller button | Keyboard equivelant | Mac alternative |

--- a/README.md
+++ b/README.md
@@ -76,12 +76,12 @@ For more information on how to test, debug and report issues with the emulator o
 
 # Keyboard mapping
 
-| Button | Function | Mac alternative |
+| Button | Mac alternative | Function |
 |-------------|-------------|--------------|
-F10 | FPS Counter | fn+F10
-Ctrl+F10 | Video Debug Info |
-F11 | Fullscreen |
-F12 | Trigger RenderDoc Capture |
+F10 | fn+F10 | FPS Counter |
+Ctrl+F10 | | Video Debug Info |
+F11 | | Fullscreen |
+F12 | | Trigger RenderDoc Capture |
 
 > [!NOTE]
 > These functions are for the default keyboard mappings of the corresponding OS only.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ F11 | Fullscreen |
 F12 | Trigger RenderDoc Capture |
 
 > [!NOTE]
-> Xbox and DualShock controllers work right out of the box. On some operating systems because of their default settings, you may must press the fn button together with one of the above buttons to use its function. On MacOS, however, only the FPS counter works.
+> Xbox and DualShock controllers work right out of the box. In some operating systems, the default settings require you to press the fn key together with one of the above keys in order to use their function. On MacOS, however, only the FPS counter works.
 
 | Controller button | Keyboard equivelant | Mac alternative |
 |-------------|-------------|--------------|

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ F11 | Fullscreen |
 F12 | Trigger RenderDoc Capture |
 
 > [!NOTE]
-> Xbox and Dual Shock controllers work right out of the box. On some operating systems because of their default settings, you may must press the fn button together with one of the above buttons to use its function. On MacOS, however, only the FPS counter works.
+> Xbox and DualShock controllers work right out of the box. On some operating systems because of their default settings, you may must press the fn button together with one of the above buttons to use its function. On MacOS, however, only the FPS counter works.
 
 | Controller button | Keyboard equivelant | Mac alternative |
 |-------------|-------------|--------------|

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ F11 | Fullscreen |
 F12 | Trigger RenderDoc Capture |
 
 > [!NOTE]
-> Xbox and DualShock controllers work out of the box. Some operating systems may require you to hold down the fn key in addition to those listed above in order to use the above functions; however, under MacOS, only the fps counter of the above functions will work.
+> Xbox and Dual Shock controllers work right out of the box. On some operating systems, you must press the fn button together with one of the above buttons to use its function. On MacOS, however, only the FPS counter works.
 
 | Controller button | Keyboard equivelant | Mac alternative |
 |-------------|-------------|--------------|

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ F12 | Trigger RenderDoc Capture |
 
 > [!NOTE]
 > These functions are for the default keyboard mappings of the corresponding OS only.
-> > Xbox and DualShock controllers work out of the box.
+> Xbox and DualShock controllers work out of the box.
 
 | Controller button | Keyboard equivelant | Mac alternative |
 |-------------|-------------|--------------|

--- a/README.md
+++ b/README.md
@@ -85,8 +85,7 @@ F12 | | Trigger RenderDoc Capture |
 
 > [!NOTE]
 > These functions are for the default keyboard mappings of the corresponding OS only.
-
-> Xbox and DualShock controllers work out of the box.
+Xbox and DualShock controllers work out of the box.
 
 | Controller button | Keyboard equivelant | Mac alternative |
 |-------------|-------------|--------------|

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ For more information on how to test, debug and report issues with the emulator o
 # Keyboard mapping
 
 > [!NOTE]
-> In some operating systems, the default settings require you to press the fn key together with one of the following keys in order to use their function. On MacOS, however, only the FPS counter works.
+> Xbox and DualShock controllers work right out of the box.
 
 | Button | Function |
 |-------------|-------------|
@@ -87,7 +87,7 @@ F11 | Fullscreen |
 F12 | Trigger RenderDoc Capture |
 
 > [!NOTE]
->  Xbox and DualShock controllers work right out of the box.
+> In some operating systems, the default settings require you to press the fn key together with one of the following keys in order to use their function. On MacOS, however, only the FPS counter works.
 
 | Controller button | Keyboard equivelant | Mac alternative |
 |-------------|-------------|--------------|

--- a/README.md
+++ b/README.md
@@ -76,16 +76,16 @@ For more information on how to test, debug and report issues with the emulator o
 
 # Keyboard mapping
 
-| Button | Mac alternative | Function |
-|-------------|-------------|--------------|
-F10 | fn+F10 | FPS Counter |
-Ctrl+F10 | | Video Debug Info |
-F11 | | Fullscreen |
-F12 | | Trigger RenderDoc Capture |
+| Button | Function |
+|-------------|-------------|
+F10 | FPS Counter |
+Ctrl+F10 | Video Debug Info |
+F11 | Fullscreen |
+F12 | Trigger RenderDoc Capture |
 
 > [!NOTE]
-> These functions are for the default keyboard mappings of the corresponding OS only.
-Xbox and DualShock controllers work out of the box.
+> Xbox and DualShock controllers work out of the box.
+> Some operating systems may require you on default to hold the fn button additionally to the ones listed above to use the said functions, on MacOS only the fps counter of the said functions works though.
 
 | Controller button | Keyboard equivelant | Mac alternative |
 |-------------|-------------|--------------|

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ F11 | Fullscreen |
 F12 | Trigger RenderDoc Capture |
 
 > [!NOTE]
-> In some operating systems, the default settings require you to press the fn key together with one of the following keys in order to use their function. On MacOS, however, only the FPS counter works.
+> In some operating systems, the default settings require you to press the fn key together with one of the above keys in order to use their function. On MacOS, however, only the FPS counter works.
 
 | Controller button | Keyboard equivelant | Mac alternative |
 |-------------|-------------|--------------|

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ F11 | Fullscreen |
 F12 | Trigger RenderDoc Capture |
 
 > [!NOTE]
-> Xbox and Dual Shock controllers work right out of the box. On some operating systems, you must press the fn button together with one of the above buttons to use its function. On MacOS, however, only the FPS counter works.
+> Xbox and Dual Shock controllers work right out of the box. On some operating systems because of its default settings, you may must press the fn button together with one of the above buttons to use its function. On MacOS, however, only the FPS counter works.
 
 | Controller button | Keyboard equivelant | Mac alternative |
 |-------------|-------------|--------------|

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ For more information on how to test, debug and report issues with the emulator o
 
 # Keyboard mapping
 
+> [!NOTE]
+> In some operating systems, the default settings require you to press the fn key together with one of the above keys in order to use their function. On MacOS, however, only the FPS counter works.
+
 | Button | Function |
 |-------------|-------------|
 F10 | FPS Counter |
@@ -84,7 +87,7 @@ F11 | Fullscreen |
 F12 | Trigger RenderDoc Capture |
 
 > [!NOTE]
-> In some operating systems, the default settings require you to press the fn key together with one of the above keys in order to use their function. On MacOS, however, only the FPS counter works. Xbox and DualShock controllers work right out of the box.
+>  Xbox and DualShock controllers work right out of the box.
 
 | Controller button | Keyboard equivelant | Mac alternative |
 |-------------|-------------|--------------|

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ F12 | | Trigger RenderDoc Capture |
 
 > [!NOTE]
 > These functions are for the default keyboard mappings of the corresponding OS only.
-|Xbox and DualShock controllers work out of the box.
+Xbox and DualShock controllers work out of the box.
 
 | Controller button | Keyboard equivelant | Mac alternative |
 |-------------|-------------|--------------|

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ F11 | Fullscreen |
 F12 | Trigger RenderDoc Capture |
 
 > [!NOTE]
-> Xbox and DualShock controllers work out of the box.
+> These functions are for the default keyboard mappings of the corresponding OS only.
+> > Xbox and DualShock controllers work out of the box.
 
 | Controller button | Keyboard equivelant | Mac alternative |
 |-------------|-------------|--------------|

--- a/README.md
+++ b/README.md
@@ -76,12 +76,12 @@ For more information on how to test, debug and report issues with the emulator o
 
 # Keyboard mapping
 
-| Button | Function |
-|-------------|-------------|
-F10 | FPS Counter
-Ctrl+F10 | Video Debug Info
-F11 | Fullscreen
-F12 | Trigger RenderDoc Capture
+| Button | Function | Mac alternative |
+|-------------|-------------|--------------|
+F10 | FPS Counter | fn+F10
+Ctrl+F10 | Video Debug Info |
+F11 | Fullscreen |
+F12 | Trigger RenderDoc Capture |
 
 > [!NOTE]
 > Xbox and DualShock controllers work out of the box.


### PR DESCRIPTION
On macOS the fn button needs to be used to use the F-buttons like F10 for example because they are mapped to a different function on default, from my testing only the fps counter can be activated this way.