### PR TITLE
libkernel: handle special case in path for load module

### DIFF
--- a/src/core/libraries/kernel/process.cpp
+++ b/src/core/libraries/kernel/process.cpp
@@ -41,8 +41,13 @@ s32 PS4_SYSV_ABI sceKernelLoadStartModule(const char* moduleFileName, size_t arg
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
 
+    std::string guest_path(moduleFileName);
+    if(moduleFileName[0] != '/') {
+        guest_path = "/app0/" + guest_path;
+    }
+
     auto* mnt = Common::Singleton<Core::FileSys::MntPoints>::Instance();
-    const auto path = mnt->GetHostPath(moduleFileName);
+    const auto path = mnt->GetHostPath(guest_path);
 
     // Load PRX module and relocate any modules that import it.
     auto* linker = Common::Singleton<Core::Linker>::Instance();

--- a/src/core/libraries/kernel/process.cpp
+++ b/src/core/libraries/kernel/process.cpp
@@ -42,7 +42,7 @@ s32 PS4_SYSV_ABI sceKernelLoadStartModule(const char* moduleFileName, size_t arg
     }
 
     std::string guest_path(moduleFileName);
-    if(moduleFileName[0] != '/') {
+    if (moduleFileName[0] != '/') {
         guest_path = "/app0/" + guest_path;
     }
 


### PR DESCRIPTION
This PR changes sceKernelLoadStartModule to load modules present in the same path as the executable. It's based on the comment on a previous MR https://github.com/shadps4-emu/shadPS4/pull/2246#issuecomment-2621075627

This also makes Battle Garegga (https://github.com/shadps4-emu/shadps4-game-compatibility/issues/398) continues its boot sequence.