### PR TITLE
sdl_window: Allow alternate face button keys on any system.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ F12 | Trigger RenderDoc Capture
 > [!NOTE]
 > Xbox and DualShock controllers work out of the box.
 
-| Controller button | Keyboard equivelant |
+| Controller button | Keyboard equivalent |
 |-------------|-------------|
 LEFT AXIS UP | W |
 LEFT AXIS DOWN | S |

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ For more information on how to test, debug and report issues with the emulator o
 
 # Keyboard mapping
 
+> [!NOTE]
+> Some keyboards may also require you to hold the Fn key to use the F\* keys. Mac users should use the Command key instead of Control, and need to use Command+F11 for full screen to avoid conflicting with system key bindings.
+
 | Button | Function |
 |-------------|-------------|
 F10 | FPS Counter
@@ -86,32 +89,32 @@ F12 | Trigger RenderDoc Capture
 > [!NOTE]
 > Xbox and DualShock controllers work out of the box.
 
-| Controller button | Keyboard equivelant | Mac alternative |
-|-------------|-------------|--------------|
-LEFT AXIS UP | W | |
-LEFT AXIS DOWN | S | |
-LEFT AXIS LEFT | A | |
-LEFT AXIS RIGHT | D | |
-RIGHT AXIS UP | I | |
-RIGHT AXIS DOWN | K | |
-RIGHT AXIS LEFT | J | |
-RIGHT AXIS RIGHT | L | |
-TRIANGLE | Numpad 8 | C |
-CIRCLE | Numpad 6 | B |
-CROSS | Numpad 2 | N |
-SQUARE | Numpad 4 | V |
-PAD UP | UP | |
-PAD DOWN | DOWN | |
-PAD LEFT | LEFT | |
-PAD RIGHT | RIGHT | |
-OPTIONS | RETURN | |
-BACK BUTTON / TOUCH PAD | SPACE | |
-L1 | Q | |
-R1 | U | |
-L2 | E | |
-R2 | O | |
-L3 | X | |
-R3 | M | |
+| Controller button | Keyboard equivelant |
+|-------------|-------------|
+LEFT AXIS UP | W |
+LEFT AXIS DOWN | S |
+LEFT AXIS LEFT | A |
+LEFT AXIS RIGHT | D |
+RIGHT AXIS UP | I |
+RIGHT AXIS DOWN | K |
+RIGHT AXIS LEFT | J |
+RIGHT AXIS RIGHT | L |
+TRIANGLE | Numpad 8 or C |
+CIRCLE | Numpad 6 or B |
+CROSS | Numpad 2 or N |
+SQUARE | Numpad 4 or V |
+PAD UP | UP |
+PAD DOWN | DOWN |
+PAD LEFT | LEFT |
+PAD RIGHT | RIGHT |
+OPTIONS | RETURN |
+BACK BUTTON / TOUCH PAD | SPACE |
+L1 | Q |
+R1 | U |
+L2 | E |
+R2 | O |
+L3 | X |
+R3 | M |
 
 # Main team
 

--- a/src/sdl_window.cpp
+++ b/src/sdl_window.cpp
@@ -382,20 +382,6 @@ void WindowSDL::OnResize() {
 }
 
 void WindowSDL::OnKeyPress(const SDL_Event* event) {
-#ifdef __APPLE__
-    // Use keys that are more friendly for keyboards without a keypad.
-    // Once there are key binding options this won't be necessary.
-    constexpr SDL_Keycode CrossKey = SDLK_N;
-    constexpr SDL_Keycode CircleKey = SDLK_B;
-    constexpr SDL_Keycode SquareKey = SDLK_V;
-    constexpr SDL_Keycode TriangleKey = SDLK_C;
-#else
-    constexpr SDL_Keycode CrossKey = SDLK_KP_2;
-    constexpr SDL_Keycode CircleKey = SDLK_KP_6;
-    constexpr SDL_Keycode SquareKey = SDLK_KP_4;
-    constexpr SDL_Keycode TriangleKey = SDLK_KP_8;
-#endif
-
     auto button = OrbisPadButtonDataOffset::None;
     Input::Axis axis = Input::Axis::AxisMax;
     int axisvalue = 0;
@@ -414,16 +400,21 @@ void WindowSDL::OnKeyPress(const SDL_Event* event) {
     case SDLK_RIGHT:
         button = OrbisPadButtonDataOffset::Right;
         break;
-    case TriangleKey:
+    // Provide alternatives for face buttons for users without a numpad.
+    case SDLK_KP_8:
+    case SDLK_C:
         button = OrbisPadButtonDataOffset::Triangle;
         break;
-    case CircleKey:
+    case SDLK_KP_6:
+    case SDLK_B:
         button = OrbisPadButtonDataOffset::Circle;
         break;
-    case CrossKey:
+    case SDLK_KP_2:
+    case SDLK_N:
         button = OrbisPadButtonDataOffset::Cross;
         break;
-    case SquareKey:
+    case SDLK_KP_4:
+    case SDLK_V:
         button = OrbisPadButtonDataOffset::Square;
         break;
     case SDLK_RETURN:


### PR DESCRIPTION
* Allows the alternate key bindings for face buttons to be used on any system, not just Mac. My test Windows system also has no numpad, so I keep having to use the on-screen keyboard without this. The numpad bindings are still available, either can be used.
* Updates the README section on keyboard bindings.