### PR TITLE
Fix game title sorting bug from Issue #2260

### DIFF
--- a/src/qt_gui/game_list_frame.h
+++ b/src/qt_gui/game_list_frame.h
@@ -3,12 +3,14 @@
 
 #pragma once
 
+#include <algorithm>    // std::transform
+#include <cctype>   // std::tolower
+
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QPainter>
 #include <QScrollBar>
-#include <cctype>    // std::tolower
 
 #include "background_music_player.h"
 #include "compatibility_info.h"
@@ -66,8 +68,12 @@ public:
 
     static bool CompareStringsAscending(GameInfo a, GameInfo b, int columnIndex) {
         switch (columnIndex) {
-        case 1:
-            return std::tolower(a.name) < std::tolower(b.name);
+        case 1: {
+            std::string name_a = a.name, name_b = b.name;
+            std::transform(name_a.begin(), name_a.end(), name_a.begin(), ::tolower);
+            std::transform(name_b.begin(), name_b.end(), name_b.begin(), ::tolower);
+            return name_a < name_b;
+        }
         case 2:
             return a.compatibility.status < b.compatibility.status;
         case 3:
@@ -91,8 +97,12 @@ public:
 
     static bool CompareStringsDescending(GameInfo a, GameInfo b, int columnIndex) {
         switch (columnIndex) {
-        case 1:
-            return std::tolower(a.name) > std::tolower(b.name);
+        case 1: {
+            std::string name_a = a.name, name_b = b.name;
+            std::transform(name_a.begin(), name_a.end(), name_a.begin(), ::tolower);
+            std::transform(name_b.begin(), name_b.end(), name_b.begin(), ::tolower);
+            return name_a > name_b;
+        }
         case 2:
             return a.compatibility.status > b.compatibility.status;
         case 3:

--- a/src/qt_gui/game_list_frame.h
+++ b/src/qt_gui/game_list_frame.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <algorithm>    // std::transform
-#include <cctype>   // std::tolower
+#include <algorithm> // std::transform
+#include <cctype>    // std::tolower
 
 #include <QNetworkAccessManager>
 #include <QNetworkReply>

--- a/src/qt_gui/game_list_frame.h
+++ b/src/qt_gui/game_list_frame.h
@@ -8,6 +8,7 @@
 #include <QNetworkRequest>
 #include <QPainter>
 #include <QScrollBar>
+#include <cctype>    // std::tolower
 
 #include "background_music_player.h"
 #include "compatibility_info.h"
@@ -66,7 +67,7 @@ public:
     static bool CompareStringsAscending(GameInfo a, GameInfo b, int columnIndex) {
         switch (columnIndex) {
         case 1:
-            return a.name < b.name;
+            return std::tolower(a.name) < std::tolower(b.name);
         case 2:
             return a.compatibility.status < b.compatibility.status;
         case 3:
@@ -91,7 +92,7 @@ public:
     static bool CompareStringsDescending(GameInfo a, GameInfo b, int columnIndex) {
         switch (columnIndex) {
         case 1:
-            return a.name > b.name;
+            return std::tolower(a.name) > std::tolower(b.name);
         case 2:
             return a.compatibility.status > b.compatibility.status;
         case 3:


### PR DESCRIPTION
Game titles should now be sorted alphabetically regardless of case. From #2260

![image](https://github.com/user-attachments/assets/9d234c52-03f4-43f3-a354-ef03bfe595b7)