### PR TITLE
Fix game title sorting - List view

### DIFF
--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <algorithm> // std::transform
+#include <cctype>    // std::tolower
 #include <QToolTip>
 #include "common/config.h"
 #include "common/logging/log.h"
@@ -108,52 +110,73 @@ void GameListFrame::PopulateGameList() {
     this->setColumnHidden(2, !Config::getCompatibilityEnabled());
     this->setColumnHidden(6, !Config::GetLoadGameSizeEnabled());
 
+    // Update the row count in the table based on the number of games
     this->setRowCount(m_game_info->m_games.size());
     ResizeIcons(icon_size);
 
+    // Populate the columns with data for each game
     for (int i = 0; i < m_game_info->m_games.size(); i++) {
-        SetTableItem(i, 1, QString::fromStdString(m_game_info->m_games[i].name));
-        SetTableItem(i, 3, QString::fromStdString(m_game_info->m_games[i].serial));
-        SetRegionFlag(i, 4, QString::fromStdString(m_game_info->m_games[i].region));
-        SetTableItem(i, 5, QString::fromStdString(m_game_info->m_games[i].fw));
-        SetTableItem(i, 6, QString::fromStdString(m_game_info->m_games[i].size));
-        SetTableItem(i, 7, QString::fromStdString(m_game_info->m_games[i].version));
+        FillRowData(i);
+    }
 
-        m_game_info->m_games[i].compatibility =
-            m_compat_info->GetCompatibilityInfo(m_game_info->m_games[i].serial);
-        SetCompatibilityItem(i, 2, m_game_info->m_games[i].compatibility);
+    std::sort(
+        m_game_info->m_games.begin(), m_game_info->m_games.end(),
+        [this](const GameInfo& a, const GameInfo& b) { return CompareStringsAscending(a, b, 1); });
 
-        QString playTime = GetPlayTime(m_game_info->m_games[i].serial);
-        if (playTime.isEmpty()) {
-            m_game_info->m_games[i].play_time = "0:00:00";
-            SetTableItem(i, 8, tr("Never Played"));
-        } else {
-            QStringList timeParts = playTime.split(':');
-            int hours = timeParts[0].toInt();
-            int minutes = timeParts[1].toInt();
-            int seconds = timeParts[2].toInt();
+    ResizeIcons(icon_size);
 
-            QString formattedPlayTime;
-            if (hours > 0) {
-                formattedPlayTime += QString("%1").arg(hours) + tr("h");
-            }
-            if (minutes > 0) {
-                formattedPlayTime += QString("%1").arg(minutes) + tr("m");
-            }
+    // Update the table with the sorted data , Refill the row after sorting
+    for (int i = 0; i < m_game_info->m_games.size(); i++) {
+        FillRowData(i);
+    }
+}
 
-            formattedPlayTime = formattedPlayTime.trimmed();
-            m_game_info->m_games[i].play_time = playTime.toStdString();
-            if (formattedPlayTime.isEmpty()) {
-                SetTableItem(i, 8, QString("%1").arg(seconds) + tr("s"));
-            } else {
-                SetTableItem(i, 8, formattedPlayTime);
-            }
+void GameListFrame::FillRowData(int i) {
+    // Fill columns with game data
+    SetTableItem(i, 1, QString::fromStdString(m_game_info->m_games[i].name));
+    SetTableItem(i, 3, QString::fromStdString(m_game_info->m_games[i].serial));
+    SetRegionFlag(i, 4, QString::fromStdString(m_game_info->m_games[i].region));
+    SetTableItem(i, 5, QString::fromStdString(m_game_info->m_games[i].fw));
+    SetTableItem(i, 6, QString::fromStdString(m_game_info->m_games[i].size));
+    SetTableItem(i, 7, QString::fromStdString(m_game_info->m_games[i].version));
+
+    // Fill compatibility column
+    m_game_info->m_games[i].compatibility =
+        m_compat_info->GetCompatibilityInfo(m_game_info->m_games[i].serial);
+    SetCompatibilityItem(i, 2, m_game_info->m_games[i].compatibility);
+
+    // Fill playtime column
+    QString playTime = GetPlayTime(m_game_info->m_games[i].serial);
+    if (playTime.isEmpty()) {
+        m_game_info->m_games[i].play_time = "0:00:00";
+        SetTableItem(i, 8, tr("Never Played"));
+    } else {
+        QStringList timeParts = playTime.split(':');
+        int hours = timeParts[0].toInt();
+        int minutes = timeParts[1].toInt();
+        int seconds = timeParts[2].toInt();
+
+        QString formattedPlayTime;
+        if (hours > 0) {
+            formattedPlayTime += QString("%1").arg(hours) + tr("h");
+        }
+        if (minutes > 0) {
+            formattedPlayTime += QString("%1").arg(minutes) + tr("m");
         }
 
-        QString path;
-        Common::FS::PathToQString(path, m_game_info->m_games[i].path);
-        SetTableItem(i, 9, path);
+        formattedPlayTime = formattedPlayTime.trimmed();
+        m_game_info->m_games[i].play_time = playTime.toStdString();
+        if (formattedPlayTime.isEmpty()) {
+            SetTableItem(i, 8, QString("%1").arg(seconds) + tr("s"));
+        } else {
+            SetTableItem(i, 8, formattedPlayTime);
+        }
     }
+
+    // Fill path column
+    QString path;
+    Common::FS::PathToQString(path, m_game_info->m_games[i].path);
+    SetTableItem(i, 9, path);
 }
 
 void GameListFrame::SetListBackgroundImage(QTableWidgetItem* item) {

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -114,7 +114,7 @@ void GameListFrame::PopulateGameList(bool isInitialPopulation) {
     if (isInitialPopulation) {
         std::sort(m_game_info->m_games.begin(), m_game_info->m_games.end(),
                   [this](const GameInfo& a, const GameInfo& b) {
-                      return CompareStringsAscending(a, b, 1); // Column 1 = Nome
+                      return CompareStringsAscending(a, b, 1); // Column 1 = Name
                   });
         ResizeIcons(icon_size);
     }

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -112,10 +112,7 @@ void GameListFrame::PopulateGameList(bool isInitialPopulation) {
     ResizeIcons(icon_size);
 
     if (isInitialPopulation) {
-        std::sort(m_game_info->m_games.begin(), m_game_info->m_games.end(),
-                  [this](const GameInfo& a, const GameInfo& b) {
-                      return CompareStringsAscending(a, b, 1); // Column 1 = Name
-                  });
+        SortNameAscending(1); // Column 1 = Name
         ResizeIcons(icon_size);
     }
 

--- a/src/qt_gui/game_list_frame.h
+++ b/src/qt_gui/game_list_frame.h
@@ -47,6 +47,7 @@ private:
 
 public:
     void PopulateGameList();
+    void FillRowData(int i);
     void ResizeIcons(int iconSize);
 
     QImage backgroundImage;

--- a/src/qt_gui/game_list_frame.h
+++ b/src/qt_gui/game_list_frame.h
@@ -46,8 +46,7 @@ private:
     bool ListSortedAsc = true;
 
 public:
-    void PopulateGameList();
-    void FillRowData(int i);
+    void PopulateGameList(bool isInitialPopulation = true);
     void ResizeIcons(int iconSize);
 
     QImage backgroundImage;


### PR DESCRIPTION
PR https://github.com/shadps4-emu/shadPS4/pull/2284 corrects the sorting when clicking on the header, but the list was already disorganized.
Now it starts in the correct order.