### PR TITLE
Fix crash if remote is not set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,21 +106,27 @@ git_describe(GIT_DESC --always --long --dirty)
 git_branch_name(GIT_BRANCH)
 string(TIMESTAMP BUILD_DATE "%Y-%m-%d %H:%M:%S")
 
-# Get current remote name and branch
+# Try to get the upstream remote and branch
 execute_process(
   COMMAND git rev-parse --abbrev-ref --symbolic-full-name @{u}
   OUTPUT_VARIABLE GIT_REMOTE_NAME
   RESULT_VARIABLE GIT_BRANCH_RESULT
+  ERROR_QUIET
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-# Default to origin if branch is not set
+# Default to origin if there's no upstream set or if the command failed
 if (GIT_BRANCH_RESULT OR GIT_REMOTE_NAME STREQUAL "")
   set(GIT_REMOTE_NAME "origin")
 else()
-  # Extract remote name from full name
+  # Extract remote name if the output contains a remote/branch format
   string(FIND "${GIT_REMOTE_NAME}" "/" INDEX)
-  string(SUBSTRING "${GIT_REMOTE_NAME}" 0 "${INDEX}" GIT_REMOTE_NAME)
+  if (INDEX GREATER -1)
+    string(SUBSTRING "${GIT_REMOTE_NAME}" 0 "${INDEX}" GIT_REMOTE_NAME)
+  else()
+    # If no remote is present (only a branch name), default to origin
+    set(GIT_REMOTE_NAME "origin")
+  endif()
 endif()
 
 # Get remote link

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -201,7 +201,8 @@ void Emulator::Run(const std::filesystem::path& file, const std::vector<std::str
         window_title = fmt::format("shadPS4 v{} | {}", Common::VERSION, game_title);
     } else {
         std::string remote_url(Common::g_scm_remote_url);
-        if (remote_url == "https://github.com/shadps4-emu/shadPS4.git") {
+        if (remote_url == "https://github.com/shadps4-emu/shadPS4.git" ||
+            remote_url.length() == 0) {
             window_title = fmt::format("shadPS4 v{} {} {} | {}", Common::VERSION,
                                        Common::g_scm_branch, Common::g_scm_desc, game_title);
         } else {

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -58,7 +58,8 @@ bool MainWindow::Init() {
         window_title = fmt::format("shadPS4 v{}", Common::VERSION);
     } else {
         std::string remote_url(Common::g_scm_remote_url);
-        if (remote_url == "https://github.com/shadps4-emu/shadPS4.git") {
+        if (remote_url == "https://github.com/shadps4-emu/shadPS4.git" ||
+            remote_url.length() == 0) {
             window_title = fmt::format("shadPS4 v{} {} {}", Common::VERSION, Common::g_scm_branch,
                                        Common::g_scm_desc);
         } else {


### PR DESCRIPTION
Should fix some errors with local branches not having remotes set, and also add a fallback if an error occurs anyway so it doesn't crash on a null string