### PR TITLE
Fix minor issue with 'Emulator' group box

### DIFF
--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -108,9 +108,6 @@
               <property name="title">
                <string>Emulator</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft</set>
-              </property>
               <property name="flat">
                <bool>false</bool>
               </property>


### PR DESCRIPTION
Removing 3 lines from settings_dialog.ui fixes an issue where the text for the group box "merges" with the group box:

![image-36](https://github.com/user-attachments/assets/56098501-0cc4-4a0d-933b-23d558909604)

This might have been introduced by #2254, I'm not sure.