### PR TITLE
sceAvPlayerAddSourceEx - error validation

### DIFF
--- a/src/core/libraries/avplayer/avplayer.cpp
+++ b/src/core/libraries/avplayer/avplayer.cpp
@@ -22,7 +22,7 @@ s32 PS4_SYSV_ABI sceAvPlayerAddSource(SceAvPlayerHandle handle, const char* file
 s32 PS4_SYSV_ABI sceAvPlayerAddSourceEx(SceAvPlayerHandle handle, SceAvPlayerUriType uriType,
                                         SceAvPlayerSourceDetails* sourceDetails) {
     LOG_ERROR(Lib_AvPlayer, "(STUBBED) called");
-    if (handle == nullptr) {
+    if (handle == nullptr || uriType != SceAvPlayerUriType::validAddSourceEx) {
         return ORBIS_AVPLAYER_ERROR_INVALID_PARAMS;
     }
     return ORBIS_OK;

--- a/src/core/libraries/avplayer/avplayer.h
+++ b/src/core/libraries/avplayer/avplayer.h
@@ -20,6 +20,7 @@ using SceAvPlayerHandle = AvPlayer*;
 
 enum class SceAvPlayerUriType : u32 {
     Source = 0,
+    validAddSourceEx = 99,
 };
 
 struct SceAvPlayerUri {


### PR DESCRIPTION
sceAvPlayerAddSourceEx looks quite complex, however this validation allows it to continue on 'CUSA23185 Biped'
as reverse engineering this seems to be necessary.
![image](https://github.com/user-attachments/assets/09ece931-1ccf-45f5-90a4-e550b8898519)

sceAvPlayerAddSourceEx seems similar to sceAvPlayerAddSource, perhaps using it in some way:
handle->AddSource(sourceDetails->uri.name);
as it contains the address of a local file, but in my tests it caused an error...

