### PR TITLE
Revert "libkernel: handle special case in path for load module"

### DIFF
--- a/src/core/libraries/kernel/process.cpp
+++ b/src/core/libraries/kernel/process.cpp
@@ -41,13 +41,8 @@ s32 PS4_SYSV_ABI sceKernelLoadStartModule(const char* moduleFileName, size_t arg
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
 
-    std::string guest_path(moduleFileName);
-    if (moduleFileName[0] != '/') {
-        guest_path = "/app0/" + guest_path;
-    }
-
     auto* mnt = Common::Singleton<Core::FileSys::MntPoints>::Instance();
-    const auto path = mnt->GetHostPath(guest_path);
+    const auto path = mnt->GetHostPath(moduleFileName);
 
     // Load PRX module and relocate any modules that import it.
     auto* linker = Common::Singleton<Core::Linker>::Instance();


### PR DESCRIPTION
Reverts shadps4-emu/shadPS4#2269

red_prig mentioned that you should do multiple attempts to open the file by the path list . Your implementation will probably break some unity games