### PR TITLE
Display correct icon when running under Wayland on Linux

### DIFF
--- a/src/qt_gui/main.cpp
+++ b/src/qt_gui/main.cpp
@@ -26,6 +26,8 @@ int main(int argc, char* argv[]) {
 
     QApplication a(argc, argv);
 
+    QApplication::setDesktopFileName("net.shadps4.shadPS4");
+
     // Load configurations and initialize Qt application
     const auto user_dir = Common::FS::GetUserPath(Common::FS::PathType::UserDir);
     Config::load(user_dir / "config.toml");


### PR DESCRIPTION
**Before**

![Screenshot_20250131_230009](https://github.com/user-attachments/assets/c1e6b3e9-7012-4ebd-9190-dd1915c604f3)
![Screenshot_20250131_230023](https://github.com/user-attachments/assets/36293774-62f0-4139-bf15-3ba190f93851)

**After**

![Screenshot_20250131_230049](https://github.com/user-attachments/assets/d044ff8c-df7f-48f9-8eeb-afab68707d5a)
![Screenshot_20250131_230103](https://github.com/user-attachments/assets/ca2d3112-e468-4bdd-b443-fead89055b87)
