### PR TITLE
add 0.6.0 release to metainfo

### DIFF
--- a/dist/net.shadps4.shadPS4.metainfo.xml
+++ b/dist/net.shadps4.shadPS4.metainfo.xml
@@ -37,6 +37,9 @@
     <category translate="no">Game</category>
   </categories>
   <releases>
+    <release version="0.6.0" date="2025-01-31">
+      <url>https://github.com/shadps4-emu/shadPS4/releases/tag/v.0.6.0</url>
+    </release>
     <release version="0.5.0" date="2024-12-25">
       <url>https://github.com/shadps4-emu/shadPS4/releases/tag/v.0.5.0</url>
     </release>


### PR DESCRIPTION
add v0.6.0 to the metainfo file for usage with flathub