### PR TITLE
Remapping: Documentation and defaults update + add option to use a unified config

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -68,6 +68,7 @@ static bool vkGuestMarkers = false;
 static bool rdocEnable = false;
 static s16 cursorState = HideCursorState::Idle;
 static int cursorHideTimeout = 5; // 5 seconds (default)
+static bool useUnifiedInputConfig = true;
 static bool separateupdatefolder = false;
 static bool compatibilityData = false;
 static bool checkCompatibilityOnStartup = false;
@@ -97,6 +98,14 @@ std::string emulator_language = "en";
 
 // Language
 u32 m_language = 1; // english
+
+bool GetUseUnifiedInputConfig() {
+    return useUnifiedInputConfig;
+}
+
+void SetUseUnifiedInputConfig(bool use) {
+    useUnifiedInputConfig = use;
+}
 
 std::string getTrophyKey() {
     return trophyKey;
@@ -657,6 +666,7 @@ void load(const std::filesystem::path& path) {
         useSpecialPad = toml::find_or<bool>(input, "useSpecialPad", false);
         specialPadClass = toml::find_or<int>(input, "specialPadClass", 1);
         isMotionControlsEnabled = toml::find_or<bool>(input, "isMotionControlsEnabled", true);
+        useUnifiedInputConfig = toml::find_or<bool>(input, "useUnifiedInputConfig", true);
     }
 
     if (data.contains("GPU")) {
@@ -779,6 +789,7 @@ void save(const std::filesystem::path& path) {
     data["Input"]["useSpecialPad"] = useSpecialPad;
     data["Input"]["specialPadClass"] = specialPadClass;
     data["Input"]["isMotionControlsEnabled"] = isMotionControlsEnabled;
+    data["Input"]["useUnifiedInputConfig"] = useUnifiedInputConfig;
     data["GPU"]["screenWidth"] = screenWidth;
     data["GPU"]["screenHeight"] = screenHeight;
     data["GPU"]["nullGpu"] = isNullGpu;
@@ -969,9 +980,12 @@ touchpad = back
 
 axis_left_x = axis_left_x
 axis_left_y = axis_left_y
-
 axis_right_x = axis_right_x
 axis_right_y = axis_right_y
+
+# Range of deadzones: 1 (almost none) to 127 (max)
+analog_deadzone = leftjoystick, 2
+analog_deadzone = rightjoystick, 2
 )";
 }
 std::filesystem::path GetFoolproofKbmConfigFile(const std::string& game_id) {

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -43,6 +43,8 @@ std::string getBackButtonBehavior();
 bool getUseSpecialPad();
 int getSpecialPadClass();
 bool getIsMotionControlsEnabled();
+bool GetUseUnifiedInputConfig();
+void SetUseUnifiedInputConfig(bool use);
 
 u32 getScreenWidth();
 u32 getScreenHeight();

--- a/src/input/input_handler.cpp
+++ b/src/input/input_handler.cpp
@@ -198,8 +198,8 @@ InputBinding GetBindingFromString(std::string& line) {
 }
 
 void ParseInputConfig(const std::string game_id = "") {
-    std::string config_file = Config::GetUseUnifiedInputConfig() ? "default" : game_id;
-    const auto config_file = Config::GetFoolproofKbmConfigFile(config_file);
+    std::string config_type = Config::GetUseUnifiedInputConfig() ? "default" : game_id;
+    const auto config_file = Config::GetFoolproofKbmConfigFile(config_type);
 
     // we reset these here so in case the user fucks up or doesn't include some of these,
     // we can fall back to default

--- a/src/input/input_handler.cpp
+++ b/src/input/input_handler.cpp
@@ -198,11 +198,8 @@ InputBinding GetBindingFromString(std::string& line) {
 }
 
 void ParseInputConfig(const std::string game_id = "") {
-    const auto config_file = Config::GetFoolproofKbmConfigFile(game_id);
-
-    if (game_id == "") {
-        return;
-    }
+    std::string config_file = Config::GetUseUnifiedInputConfig() ? "default" : game_id;
+    const auto config_file = Config::GetFoolproofKbmConfigFile(config_file);
 
     // we reset these here so in case the user fucks up or doesn't include some of these,
     // we can fall back to default

--- a/src/qt_gui/kbm_config_dialog.cpp
+++ b/src/qt_gui/kbm_config_dialog.cpp
@@ -12,8 +12,8 @@
 #include "game_info.h"
 #include "src/sdl_window.h"
 
-#include <QCloseEvent>
 #include <QCheckBox>
+#include <QCloseEvent>
 #include <QComboBox>
 #include <QFile>
 #include <QHBoxLayout>

--- a/src/qt_gui/kbm_config_dialog.cpp
+++ b/src/qt_gui/kbm_config_dialog.cpp
@@ -13,6 +13,7 @@
 #include "src/sdl_window.h"
 
 #include <QCloseEvent>
+#include <QCheckBox>
 #include <QComboBox>
 #include <QFile>
 #include <QHBoxLayout>
@@ -50,7 +51,16 @@ EditorDialog::EditorDialog(QWidget* parent) : QDialog(parent) {
     // Load all installed games
     loadInstalledGames();
 
+    QCheckBox* unifiedInputCheckBox = new QCheckBox("Use Per-Game configs", this);
+    unifiedInputCheckBox->setChecked(!Config::GetUseUnifiedInputConfig());
+
+    // Connect checkbox signal
+    connect(unifiedInputCheckBox, &QCheckBox::toggled, this, [](bool checked) {
+        Config::SetUseUnifiedInputConfig(!checked);
+        Config::save(Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "config.toml");
+    });
     // Create Save, Cancel, and Help buttons
+    Config::SetUseUnifiedInputConfig(!Config::GetUseUnifiedInputConfig());
     QPushButton* saveButton = new QPushButton("Save", this);
     QPushButton* cancelButton = new QPushButton("Cancel", this);
     QPushButton* helpButton = new QPushButton("Help", this);
@@ -58,6 +68,7 @@ EditorDialog::EditorDialog(QWidget* parent) : QDialog(parent) {
 
     // Layout for the game selection and buttons
     QHBoxLayout* topLayout = new QHBoxLayout();
+    topLayout->addWidget(unifiedInputCheckBox);
     topLayout->addWidget(gameComboBox);
     topLayout->addStretch();
     topLayout->addWidget(saveButton);

--- a/src/qt_gui/kbm_help_dialog.h
+++ b/src/qt_gui/kbm_help_dialog.h
@@ -70,6 +70,12 @@ A: The code recognises the line as wrong, and skip it, so the rest of the file w
 
 Q: I want to bind <input> to <output>, but your code doesn't support <input>!
 A: Some keys are intentionally omitted, but if you read the bindings through, and you're sure it is not there and isn't one of the intentionally disabled ones, open an issue on https://github.com/shadps4-emu/shadPS4.
+
+Q: What does default.ini do?
+A: If you're using per-game configs, it's the base from which all new games generate their config file. If you use the unified config, then this is used for every game directly instead.
+
+Q: What does the use Per-game Config checkbox do?
+A: It controls whether the config is loaded from CUSAXXXXX.ini for a game, or from default.ini. This way, if you only want to manage one set of bindings, you can do so, but if you want to use a different setup for every game, that's possible as well.
 )";
     }
     QString syntax() {


### PR DESCRIPTION
Adds an example of deadzone configuration to the default config, and adds the ability to use only one config file (which will be default.ini if the option is set to true, which it is by default) instead of one config per every game. 