### PR TITLE
Translatable Compatibility Status

### DIFF
--- a/src/qt_gui/compatibility_info.cpp
+++ b/src/qt_gui/compatibility_info.cpp
@@ -260,3 +260,22 @@ void CompatibilityInfoClass::ExtractCompatibilityInfo(QByteArray response) {
 
     return;
 }
+
+const QString CompatibilityInfoClass::GetCompatStatusString(const CompatibilityStatus status) {
+    switch (status) {
+    case CompatibilityStatus::Unknown:
+        return tr("Unknown");
+    case CompatibilityStatus::Nothing:
+        return tr("Nothing");
+    case CompatibilityStatus::Boots:
+        return tr("Boots");
+    case CompatibilityStatus::Menus:
+        return tr("Menus");
+    case CompatibilityStatus::Ingame:
+        return tr("Ingame");
+    case CompatibilityStatus::Playable:
+        return tr("Playable");
+    default:
+        return tr("Unknown");
+    }
+}

--- a/src/qt_gui/compatibility_info.h
+++ b/src/qt_gui/compatibility_info.h
@@ -69,13 +69,6 @@ public:
         {QStringLiteral("os-windows"), OSType::Win32},
     };
 
-    inline static const std::unordered_map<CompatibilityStatus, QString> CompatStatusToString = {
-        {CompatibilityStatus::Unknown, QStringLiteral("Unknown")},
-        {CompatibilityStatus::Nothing, QStringLiteral("Nothing")},
-        {CompatibilityStatus::Boots, QStringLiteral("Boots")},
-        {CompatibilityStatus::Menus, QStringLiteral("Menus")},
-        {CompatibilityStatus::Ingame, QStringLiteral("Ingame")},
-        {CompatibilityStatus::Playable, QStringLiteral("Playable")}};
     inline static const std::unordered_map<OSType, QString> OSTypeToString = {
         {OSType::Linux, QStringLiteral("os-linux")},
         {OSType::macOS, QStringLiteral("os-macOS")},
@@ -87,6 +80,7 @@ public:
     void UpdateCompatibilityDatabase(QWidget* parent = nullptr, bool forced = false);
     bool LoadCompatibilityFile();
     CompatibilityEntry GetCompatibilityInfo(const std::string& serial);
+    const QString GetCompatStatusString(const CompatibilityStatus status);
     void ExtractCompatibilityInfo(QByteArray response);
     static bool WaitForReply(QNetworkReply* reply);
     QNetworkReply* FetchPage(int page_num);

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -289,7 +289,7 @@ void GameListFrame::SetCompatibilityItem(int row, int column, CompatibilityEntry
     QLabel* dotLabel = new QLabel("", widget);
     dotLabel->setPixmap(circle_pixmap);
 
-    QLabel* label = new QLabel(m_compat_info->CompatStatusToString.at(entry.status), widget);
+    QLabel* label = new QLabel(m_compat_info->GetCompatStatusString(entry.status), widget);
 
     label->setStyleSheet("color: white; font-size: 16px; font-weight: bold;");
 

--- a/src/qt_gui/translations/en.ts
+++ b/src/qt_gui/translations/en.ts
@@ -1414,4 +1414,31 @@
 			<translation>TB</translation>
 		</message>
 	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Unknown</source>
+			<translation>Unknown</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>Nothing</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>Boots</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>Menus</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>Ingame</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>Playable</translation>
+		</message>
+	</context>
 </TS>

--- a/src/qt_gui/translations/es_ES.ts
+++ b/src/qt_gui/translations/es_ES.ts
@@ -1405,4 +1405,31 @@
 			<translation>TB</translation>
 		</message>
 	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Unknown</source>
+			<translation>Desconocido</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>Nada</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>Inicia</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>Menús</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>En el juego</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>Jugable</translation>
+		</message>
+	</context>
 </TS>


### PR DESCRIPTION
This pr aims to fix this [issue](https://github.com/shadps4-emu/shadPS4/issues/2297) by making the compatibility status for games translatable.

I deleted the map that stored the Strings and just added a function with a switch statement, if the map is preferred I can change my implementation.

I also added a new translation class for the strings in the English translations and added Spanish translations for them.