### PR TITLE
shader_recompiler: Add workaround for drivers with unexpected unorm rounding behavior.

### DIFF
--- a/src/shader_recompiler/frontend/translate/export.cpp
+++ b/src/shader_recompiler/frontend/translate/export.cpp
@@ -17,7 +17,11 @@ u32 SwizzleMrtComponent(const FragmentRuntimeInfo::PsColorBuffer& color_buffer, 
 
 void Translator::ExportMrtValue(IR::Attribute attribute, u32 comp, const IR::F32& value,
                                 const FragmentRuntimeInfo::PsColorBuffer& color_buffer) {
-    const auto converted = ApplyWriteNumberConversion(ir, value, color_buffer.num_conversion);
+    auto converted = ApplyWriteNumberConversion(ir, value, color_buffer.num_conversion);
+    if (color_buffer.needs_unorm_fixup) {
+        // FIXME: Fix-up for GPUs where float-to-unorm rounding is off from expected.
+        converted = ir.FPSub(converted, ir.Imm32(1.f / 127500.f));
+    }
     ir.SetAttribute(attribute, converted, comp);
 }
 

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -185,6 +185,7 @@ struct FragmentRuntimeInfo {
         AmdGpu::NumberConversion num_conversion;
         AmdGpu::CompMapping swizzle;
         AmdGpu::Liverpool::ShaderExportFormat export_format;
+        bool needs_unorm_fixup;
 
         auto operator<=>(const PsColorBuffer&) const noexcept = default;
     };


### PR DESCRIPTION
This is a bit of an ugly hack but it fixes some incorrect unorm rounding behavior seen in CUSA05637 on macOS. This workaround was discovered by reverse-engineering what Apple's D3DMetal does to solve the same issue for Direct3D games. So presumably this has to be done in order to get the correct results, at least for now. I'm still investigating why this is needed and whether it can/should be done at the driver level instead.