### PR TITLE
config: Restore previous keyboard mapping defaults.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,33 +92,34 @@ F12 | Trigger RenderDoc Capture
 > [!NOTE]
 > Xbox and DualShock controllers work out of the box.
 
-The default controls are inspired by the *Elden Ring* PC controls. Inputs support up to three keys per binding, mouse buttons, mouse movement mapped to joystick input, and more.
+| Controller button | Keyboard equivalent |
+|-------------|-------------|
+LEFT AXIS UP | W |
+LEFT AXIS DOWN | S |
+LEFT AXIS LEFT | A |
+LEFT AXIS RIGHT | D |
+RIGHT AXIS UP | I |
+RIGHT AXIS DOWN | K |
+RIGHT AXIS LEFT | J |
+RIGHT AXIS RIGHT | L |
+TRIANGLE | Numpad 8 or C |
+CIRCLE | Numpad 6 or B |
+CROSS | Numpad 2 or N |
+SQUARE | Numpad 4 or V |
+PAD UP | UP |
+PAD DOWN | DOWN |
+PAD LEFT | LEFT |
+PAD RIGHT | RIGHT |
+OPTIONS | RETURN |
+BACK BUTTON / TOUCH PAD | SPACE |
+L1 | Q |
+R1 | U |
+L2 | E |
+R2 | O |
+L3 | X |
+R3 | M |
 
-| Action      | Default Key(s)              |
-|-------------|-----------------------------|
-| Triangle    | F                           |
-| Circle      | Space                       |
-| Cross       | E                           |
-| Square      | R                           |
-| Pad Up      | W, LAlt / Mouse Wheel Up    |
-| Pad Down    | S, LAlt / Mouse Wheel Down  |
-| Pad Left    | A, LAlt / Mouse Wheel Left  |
-| Pad Right   | D, LAlt / Mouse Wheel Right |
-| L1          | Right Button, LShift        |
-| R1          | Left Button                 |
-| L2          | Right Button                |
-| R2          | Left Button, LShift         |
-| L3          | X                           |
-| R3          | Q / Middle Button           |
-| Options     | Escape                      |
-| Touchpad    | G                           |
-
-| Joystick           | Default Input  |
-|--------------------|----------------|
-| Left Joystick      | WASD           |
-| Right Joystick     | Mouse movement |
-
-Keyboard and mouse inputs can be customized in the settings menu by clicking the Controller button, and further details and help on controls are  also found there. Custom bindings are saved per-game.
+Keyboard and mouse inputs can be customized in the settings menu by clicking the Controller button, and further details and help on controls are  also found there. Custom bindings are saved per-game. Inputs support up to three keys per binding, mouse buttons, mouse movement mapped to joystick input, and more.
 
 
 # Main team

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -919,44 +919,44 @@ void setDefaultValues() {
 constexpr std::string_view GetDefaultKeyboardConfig() {
     return R"(#Feeling lost? Check out the Help section!
 
-#Keyboard bindings
+# Keyboard bindings
 
-triangle = f
-circle = space
-cross = e
-square = r
+triangle = kp8
+circle = kp6
+cross = kp2
+square = kp4
+# Alternatives for users without a keypad
+triangle = c
+circle = b
+cross = n
+square = v
 
-pad_up = w, lalt
-pad_up = mousewheelup
-pad_down = s, lalt
-pad_down = mousewheeldown
-pad_left = a, lalt
-pad_left = mousewheelleft
-pad_right = d, lalt
-pad_right = mousewheelright
-
-l1 = rightbutton, lshift
-r1 = leftbutton
-l2 = rightbutton
-r2 = leftbutton, lshift
+l1 = q
+r1 = u
+l2 = e
+r2 = o
 l3 = x
-r3 = q
-r3 = middlebutton
+r3 = m
 
-options = escape
-touchpad = g
+options = enter
+touchpad = space
 
-key_toggle = i, lalt
-mouse_to_joystick = right
-mouse_movement_params = 0.5, 1, 0.125
-leftjoystick_halfmode = lctrl
+pad_up = up
+pad_down = down
+pad_left = left
+pad_right = right
 
 axis_left_x_minus = a
 axis_left_x_plus = d
 axis_left_y_minus = w
 axis_left_y_plus = s
 
-#Controller bindings
+axis_right_x_minus = j
+axis_right_x_plus = l
+axis_right_y_minus = i
+axis_right_y_plus = k
+
+# Controller bindings
 
 triangle = triangle
 cross = cross
@@ -970,13 +970,13 @@ r1 = r1
 r2 = r2
 r3 = r3
 
+options = options
+touchpad = back
+
 pad_up = pad_up
 pad_down = pad_down
 pad_left = pad_left
 pad_right = pad_right
-
-options = options
-touchpad = back
 
 axis_left_x = axis_left_x
 axis_left_y = axis_left_y


### PR DESCRIPTION
Reverts to the previous set of default keyboard mappings. Users who want different mappings can still configure them as desired.