### PR TITLE
Fork detection: Fix Windows naming + add a new check for fork detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,9 +115,20 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-# Default to origin if there's no upstream set or if the command failed
+# If there's no upstream set or the command failed, check remote.pushDefault
 if (GIT_BRANCH_RESULT OR GIT_REMOTE_NAME STREQUAL "")
-  set(GIT_REMOTE_NAME "origin")
+  execute_process(
+    COMMAND git config --get remote.pushDefault
+    OUTPUT_VARIABLE GIT_REMOTE_NAME
+    RESULT_VARIABLE GIT_PUSH_DEFAULT_RESULT
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  
+  # If remote.pushDefault is not set or fails, default to origin
+  if (GIT_PUSH_DEFAULT_RESULT OR GIT_REMOTE_NAME STREQUAL "")
+    set(GIT_REMOTE_NAME "origin")
+  endif()
 else()
   # Extract remote name if the output contains a remote/branch format
   string(FIND "${GIT_REMOTE_NAME}" "/" INDEX)

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -201,8 +201,13 @@ void Emulator::Run(const std::filesystem::path& file, const std::vector<std::str
         window_title = fmt::format("shadPS4 v{} | {}", Common::VERSION, game_title);
     } else {
         std::string remote_url(Common::g_scm_remote_url);
-        if (remote_url == "https://github.com/shadps4-emu/shadPS4.git" ||
-            remote_url.length() == 0) {
+        std::string remote_host;
+        try {
+            remote_host = remote_url.substr(19, remote_url.rfind('/') - 19);
+        } catch (...) {
+            remote_host = "unknown";
+        }
+        if (remote_host == "shadps4-emu" || remote_url.length() == 0) {
             window_title = fmt::format("shadPS4 v{} {} {} | {}", Common::VERSION,
                                        Common::g_scm_branch, Common::g_scm_desc, game_title);
         } else {

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -211,7 +211,6 @@ void Emulator::Run(const std::filesystem::path& file, const std::vector<std::str
             window_title = fmt::format("shadPS4 v{} {} {} | {}", Common::VERSION,
                                        Common::g_scm_branch, Common::g_scm_desc, game_title);
         } else {
-            std::string remote_host = remote_url.substr(19, remote_url.rfind('/') - 19);
             window_title = fmt::format("shadPS4 v{} {}/{} {} | {}", Common::VERSION, remote_host,
                                        Common::g_scm_branch, Common::g_scm_desc, game_title);
         }

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -62,8 +62,13 @@ bool MainWindow::Init() {
         window_title = fmt::format("shadPS4 v{}", Common::VERSION);
     } else {
         std::string remote_url(Common::g_scm_remote_url);
-        if (remote_url == "https://github.com/shadps4-emu/shadPS4.git" ||
-            remote_url.length() == 0) {
+        std::string remote_host;
+        try {
+            remote_host = remote_url.substr(19, remote_url.rfind('/') - 19);
+        } catch (...) {
+            remote_host = "unknown";
+        }
+        if (remote_host == "shadps4-emu" || remote_url.length() == 0) {
             window_title = fmt::format("shadPS4 v{} {} {}", Common::VERSION, Common::g_scm_branch,
                                        Common::g_scm_desc);
         } else {

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -72,7 +72,6 @@ bool MainWindow::Init() {
             window_title = fmt::format("shadPS4 v{} {} {}", Common::VERSION, Common::g_scm_branch,
                                        Common::g_scm_desc);
         } else {
-            std::string remote_host = remote_url.substr(19, remote_url.rfind('/') - 19);
             window_title = fmt::format("shadPS4 v{} {}/{} {}", Common::VERSION, remote_host,
                                        Common::g_scm_branch, Common::g_scm_desc);
         }


### PR DESCRIPTION
I saw some screenshots on Discord which had the shadps4-emu/main text instead of just main in the window title, and I think this might be due to Windows handling Git remote links slightly differently, so I changed the code to first extract the name, and then check only that, instead of the full link. I don't actually know if this will fix the issue, but I certainly hope it will.
![image](https://github.com/user-attachments/assets/da649e15-6e50-4cc1-a67e-0ca207482d7a)
I also found a possible reason as to why @StevenMiller123's local builds fail to find the remote link even though his push defaults were set, and it is now included as the second thing to check if the branch doesn't explicitly have a remote pair defined.