### PR TITLE
qt: Add more options to the "Copy info..." section + update en.ts/de.ts

### DIFF
--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -344,22 +344,22 @@ public:
         if (selected == copyName) {
             QClipboard* clipboard = QGuiApplication::clipboard();
             clipboard->setText(QString::fromStdString(m_games[itemID].name));
-            }
+        }
                 
         if (selected == copySerial) {
             QClipboard* clipboard = QGuiApplication::clipboard();
             clipboard->setText(QString::fromStdString(m_games[itemID].serial));
-            }
+        }
 
         if (selected == copyFirmware) {
             QClipboard* clipboard = QGuiApplication::clipboard();
             clipboard->setText(QString::fromStdString(m_games[itemID].version));
-            }
+        }
                 
         if (selected == copySize) {
             QClipboard* clipboard = QGuiApplication::clipboard();
             clipboard->setText(QString::fromStdString(m_games[itemID].size));
-            {
+        }
 
         if (selected == copyNameAll) {
             QClipboard* clipboard = QGuiApplication::clipboard();

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -77,13 +77,13 @@ public:
         QMenu* copyMenu = new QMenu(tr("Copy info..."), widget);
         QAction* copyName = new QAction(tr("Copy Name"), widget);
         QAction* copySerial = new QAction(tr("Copy Serial"), widget);
-        QAction* copyFirmware = new QAction(tr("Copy Firmware"), widget);
+        QAction* copyFirmware = new QAction(tr("Copy Version"), widget);
         QAction* copySize = new QAction(tr("Copy Size"), widget);
         QAction* copyNameAll = new QAction(tr("Copy All"), widget);
 
         copyMenu->addAction(copyName);
         copyMenu->addAction(copySerial);
-        copyMenu->addAction(copyFirmware);
+        copyMenu->addAction(copyVersion);
         copyMenu->addAction(copySize);
         copyMenu->addAction(copyNameAll);
 
@@ -351,7 +351,7 @@ public:
             clipboard->setText(QString::fromStdString(m_games[itemID].serial));
         }
 
-        if (selected == copyFirmware) {
+        if (selected == copyVersion) {
             QClipboard* clipboard = QGuiApplication::clipboard();
             clipboard->setText(QString::fromStdString(m_games[itemID].version));
         }

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -365,7 +365,7 @@ public:
             QString combinedText = QString("Name:%1 | Serial:%2 | Version:%3 | Size:%4")
                                        .arg(QString::fromStdString(m_games[itemID].name))
                                        .arg(QString::fromStdString(m_games[itemID].serial))
-                                       .arg(QString::fromStdString(m_games[itemID].version))        
+                                       .arg(QString::fromStdString(m_games[itemID].version))
                                        .arg(QString::fromStdString(m_games[itemID].size));
             clipboard->setText(combinedText);
         }

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -77,12 +77,14 @@ public:
         QMenu* copyMenu = new QMenu(tr("Copy info..."), widget);
         QAction* copyName = new QAction(tr("Copy Name"), widget);
         QAction* copySerial = new QAction(tr("Copy Serial"), widget);
-        QMenu* copyMenu = new QMenu(tr("Copy Firmware Version..."), widget);
+        QMenu* copyFirmware = new QMenu(tr("Copy Firmware..."), widget);
+        QMenu* copySize = new QMenu(tr("Copy Size..."), widget);
         QAction* copyNameAll = new QAction(tr("Copy All"), widget);
 
         copyMenu->addAction(copyName);
         copyMenu->addAction(copySerial);
-        openFolderMenu->addAction(copyFirmwareVersion);
+        copyMenu->addAction(copyFirmware);
+        copyMenu->addAction(copySize);
         copyMenu->addAction(copyNameAll);
 
         menu.addMenu(copyMenu);
@@ -348,9 +350,14 @@ public:
             clipboard->setText(QString::fromStdString(m_games[itemID].serial));
         }
 
-        if (selected == copyFirmwareVersion) {
+        if (selected == copyFirmware) {
             QClipboard* clipboard = QGuiApplication::clipboard();
-            clipboard->setText(QString::fromStdString(m_games[itemID].serial));
+            clipboard->setText(QString::fromStdString(m_games[itemID].version));
+        }
+        
+        if (selected == copySize) {
+            QClipboard* clipboard = QGuiApplication::clipboard();
+            clipboard->setText(QString::fromStdString(m_games[itemID].size));
         }
 
         if (selected == copyNameAll) {
@@ -358,7 +365,7 @@ public:
             QString combinedText = QString("Name:%1 | Serial:%2 | Version:%3 | Size:%4")
                                        .arg(QString::fromStdString(m_games[itemID].name))
                                        .arg(QString::fromStdString(m_games[itemID].serial))
-                                       .arg(QString::fromStdString(m_games[itemID].version))
+                                       .arg(QString::fromStdString(m_games[itemID].version))        
                                        .arg(QString::fromStdString(m_games[itemID].size));
             clipboard->setText(combinedText);
         }

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -77,7 +77,7 @@ public:
         QMenu* copyMenu = new QMenu(tr("Copy info..."), widget);
         QAction* copyName = new QAction(tr("Copy Name"), widget);
         QAction* copySerial = new QAction(tr("Copy Serial"), widget);
-        QAction* copyFirmware = new QAction(tr("Copy Version"), widget);
+        QAction* copyVersion = new QAction(tr("Copy Version"), widget);
         QAction* copySize = new QAction(tr("Copy Size"), widget);
         QAction* copyNameAll = new QAction(tr("Copy All"), widget);
 

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -345,7 +345,7 @@ public:
             QClipboard* clipboard = QGuiApplication::clipboard();
             clipboard->setText(QString::fromStdString(m_games[itemID].name));
         }
-                
+
         if (selected == copySerial) {
             QClipboard* clipboard = QGuiApplication::clipboard();
             clipboard->setText(QString::fromStdString(m_games[itemID].serial));
@@ -355,7 +355,7 @@ public:
             QClipboard* clipboard = QGuiApplication::clipboard();
             clipboard->setText(QString::fromStdString(m_games[itemID].version));
         }
-                
+   
         if (selected == copySize) {
             QClipboard* clipboard = QGuiApplication::clipboard();
             clipboard->setText(QString::fromStdString(m_games[itemID].size));

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -355,7 +355,7 @@ public:
             QClipboard* clipboard = QGuiApplication::clipboard();
             clipboard->setText(QString::fromStdString(m_games[itemID].version));
         }
-   
+
         if (selected == copySize) {
             QClipboard* clipboard = QGuiApplication::clipboard();
             clipboard->setText(QString::fromStdString(m_games[itemID].size));

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -77,8 +77,8 @@ public:
         QMenu* copyMenu = new QMenu(tr("Copy info..."), widget);
         QAction* copyName = new QAction(tr("Copy Name"), widget);
         QAction* copySerial = new QAction(tr("Copy Serial"), widget);
-        QAction* copyFirmware = new QMenu(tr("Copy Firmware..."), widget);
-        QAction* copySize = new QMenu(tr("Copy Size..."), widget);
+        QAction* copyFirmware = new QAction(tr("Copy Firmware..."), widget);
+        QAction* copySize = new QAction(tr("Copy Size..."), widget);
         QAction* copyNameAll = new QAction(tr("Copy All"), widget);
 
         copyMenu->addAction(copyName);

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -344,24 +344,23 @@ public:
         if (selected == copyName) {
             QClipboard* clipboard = QGuiApplication::clipboard();
             clipboard->setText(QString::fromStdString(m_games[itemID].name));
-        }
-
+            }
+                
         if (selected == copySerial) {
             QClipboard* clipboard = QGuiApplication::clipboard();
             clipboard->setText(QString::fromStdString(m_games[itemID].serial));
-        }
-        
+            }
+
         if (selected == copyFirmware) {
             QClipboard* clipboard = QGuiApplication::clipboard();
             clipboard->setText(QString::fromStdString(m_games[itemID].version));
-        }
+            }
                 
         if (selected == copySize) {
             QClipboard* clipboard = QGuiApplication::clipboard();
             clipboard->setText(QString::fromStdString(m_games[itemID].size));
-            
-        }        
-        
+            {
+
         if (selected == copyNameAll) {
             QClipboard* clipboard = QGuiApplication::clipboard();
             QString combinedText = QString("Name:%1 | Serial:%2 | Version:%3 | Size:%4")

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -77,8 +77,8 @@ public:
         QMenu* copyMenu = new QMenu(tr("Copy info..."), widget);
         QAction* copyName = new QAction(tr("Copy Name"), widget);
         QAction* copySerial = new QAction(tr("Copy Serial"), widget);
-        QAction* copyFirmware = new QAction(tr("Copy Firmware..."), widget);
-        QAction* copySize = new QAction(tr("Copy Size..."), widget);
+        QAction* copyFirmware = new QAction(tr("Copy Firmware"), widget);
+        QAction* copySize = new QAction(tr("Copy Size"), widget);
         QAction* copyNameAll = new QAction(tr("Copy All"), widget);
 
         copyMenu->addAction(copyName);

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -340,6 +340,7 @@ public:
         }
 
         // Handle the "Copy" actions
+
         if (selected == copyName) {
             QClipboard* clipboard = QGuiApplication::clipboard();
             clipboard->setText(QString::fromStdString(m_games[itemID].name));
@@ -349,17 +350,18 @@ public:
             QClipboard* clipboard = QGuiApplication::clipboard();
             clipboard->setText(QString::fromStdString(m_games[itemID].serial));
         }
-
+        
         if (selected == copyFirmware) {
             QClipboard* clipboard = QGuiApplication::clipboard();
             clipboard->setText(QString::fromStdString(m_games[itemID].version));
         }
-        
+                
         if (selected == copySize) {
             QClipboard* clipboard = QGuiApplication::clipboard();
             clipboard->setText(QString::fromStdString(m_games[itemID].size));
-        }
-
+            
+        }        
+        
         if (selected == copyNameAll) {
             QClipboard* clipboard = QGuiApplication::clipboard();
             QString combinedText = QString("Name:%1 | Serial:%2 | Version:%3 | Size:%4")

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -340,7 +340,6 @@ public:
         }
 
         // Handle the "Copy" actions
-
         if (selected == copyName) {
             QClipboard* clipboard = QGuiApplication::clipboard();
             clipboard->setText(QString::fromStdString(m_games[itemID].name));

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -77,10 +77,12 @@ public:
         QMenu* copyMenu = new QMenu(tr("Copy info..."), widget);
         QAction* copyName = new QAction(tr("Copy Name"), widget);
         QAction* copySerial = new QAction(tr("Copy Serial"), widget);
+        QMenu* copyMenu = new QMenu(tr("Copy Firmware Version..."), widget);
         QAction* copyNameAll = new QAction(tr("Copy All"), widget);
 
         copyMenu->addAction(copyName);
         copyMenu->addAction(copySerial);
+        openFolderMenu->addAction(copyFirmwareVersion);
         copyMenu->addAction(copyNameAll);
 
         menu.addMenu(copyMenu);
@@ -342,6 +344,11 @@ public:
         }
 
         if (selected == copySerial) {
+            QClipboard* clipboard = QGuiApplication::clipboard();
+            clipboard->setText(QString::fromStdString(m_games[itemID].serial));
+        }
+
+        if (selected == copyFirmwareVersion) {
             QClipboard* clipboard = QGuiApplication::clipboard();
             clipboard->setText(QString::fromStdString(m_games[itemID].serial));
         }

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -77,8 +77,8 @@ public:
         QMenu* copyMenu = new QMenu(tr("Copy info..."), widget);
         QAction* copyName = new QAction(tr("Copy Name"), widget);
         QAction* copySerial = new QAction(tr("Copy Serial"), widget);
-        QMenu* copyFirmware = new QMenu(tr("Copy Firmware..."), widget);
-        QMenu* copySize = new QMenu(tr("Copy Size..."), widget);
+        QAction* copyFirmware = new QMenu(tr("Copy Firmware..."), widget);
+        QAction* copySize = new QMenu(tr("Copy Size..."), widget);
         QAction* copyNameAll = new QAction(tr("Copy All"), widget);
 
         copyMenu->addAction(copyName);

--- a/src/qt_gui/translations/de.ts
+++ b/src/qt_gui/translations/de.ts
@@ -129,6 +129,14 @@
 			<translation>Seriennummer kopieren</translation>
 		</message>
 		<message>
+		        <source>Copy Firmware</source>
+			<translation>Firmware kopieren</translation>
+		</message>
+		<message>
+			<source>Copy Size</source>
+			<translation>Größe kopieren</translation>
+		</message>
+		<message>
 			<source>Copy All</source>
 			<translation>Alles kopieren</translation>
 		</message>

--- a/src/qt_gui/translations/de.ts
+++ b/src/qt_gui/translations/de.ts
@@ -129,8 +129,8 @@
 			<translation>Seriennummer kopieren</translation>
 		</message>
 		<message>
-		        <source>Copy Firmware</source>
-			<translation>Firmware kopieren</translation>
+		        <source>Copy Version</source>
+			<translation>Version kopieren</translation>
 		</message>
 		<message>
 			<source>Copy Size</source>

--- a/src/qt_gui/translations/de.ts
+++ b/src/qt_gui/translations/de.ts
@@ -1429,4 +1429,31 @@
 			<translation>TB</translation>
 		</message>
 	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Unknown</source>
+			<translation>Unbekannt</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>Nichts</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>Startet</translation>		
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>Menüs</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>ImSpiel</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>Spielbar</translation>
+		</message>
+	</context>
 </TS>

--- a/src/qt_gui/translations/en.ts
+++ b/src/qt_gui/translations/en.ts
@@ -125,8 +125,8 @@
 			<translation>Copy Serial</translation>
 		</message>
 		<message>
-			<source>Copy Firmware</source>
-			<translation>Copy Firmware</translation>
+			<source>Copy Version</source>
+			<translation>Copy Version</translation>
 		</message>
 		<message>
 			<source>Copy Size</source>

--- a/src/qt_gui/translations/en.ts
+++ b/src/qt_gui/translations/en.ts
@@ -131,7 +131,7 @@
 		<message>
 			<source>Copy Size</source>
 			<translation>Copy Size</translation>		 
-	        </message>
+	 </message>
 		<message>
 			<source>Copy All</source>
 			<translation>Copy All</translation>

--- a/src/qt_gui/translations/en.ts
+++ b/src/qt_gui/translations/en.ts
@@ -125,6 +125,14 @@
 			<translation>Copy Serial</translation>
 		</message>
 		<message>
+			<source>Copy Firmware</source>
+			<translation>Copy Firmware</translation>
+		</message>
+		<message>
+			<source>Copy Size</source>
+			<translation>Copy Size</translation>		 
+	        </message>
+		<message>
 			<source>Copy All</source>
 			<translation>Copy All</translation>
 		</message>


### PR DESCRIPTION
This pr adds the ability to copy the game version and the size of a game via the gui individually + adds the buttons to the English and German translation file (with german translation ofc). It also implements an other pr for German translations about game status.

The ability to copy the size and the version was already implemented but only was used when the option "Copy All" was used