### PR TITLE
Cheats/Patches: Fix Mask Offset

### DIFF
--- a/src/common/memory_patcher.cpp
+++ b/src/common/memory_patcher.cpp
@@ -174,7 +174,7 @@ void OnGameLoaded() {
                                 patchMask = MemoryPatcher::PatchMask::Mask_Jump32;
 
                             MemoryPatcher::PatchMemory(currentPatchName, address, patchValue, false,
-                                                       littleEndian, patchMask);
+                                                       littleEndian, patchMask, maskOffsetValue);
                         }
                     }
                 }
@@ -278,6 +278,7 @@ void OnGameLoaded() {
                             lineObject["Type"] = attributes.value("Type").toString();
                             lineObject["Address"] = attributes.value("Address").toString();
                             lineObject["Value"] = attributes.value("Value").toString();
+                            lineObject["Offset"] = attributes.value("Offset").toString();
                             linesArray.append(lineObject);
                         }
                     }
@@ -321,7 +322,7 @@ void OnGameLoaded() {
 
                             MemoryPatcher::PatchMemory(currentPatchName, address.toStdString(),
                                                        patchValue.toStdString(), false,
-                                                       littleEndian, patchMask);
+                                                       littleEndian, patchMask, maskOffsetValue);
                         }
                     }
                 }


### PR DESCRIPTION
This will allow patches that use an `offset` other than `0` in `mask` to work.
Example:
![image](https://github.com/user-attachments/assets/3518e72a-17aa-4c7d-8ed3-57cf708d2a37)
There aren't many games working yet to test this, but I managed to activate a 60 fps path that didn't work before.
![image](https://github.com/user-attachments/assets/29807c03-58da-4832-a8e4-a5cef802b3b4)



