### PR TITLE
Fix VideoOut events

### DIFF
--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -84,7 +84,11 @@ bool EqueueInternal::TriggerEvent(u64 ident, s16 filter, void* trigger_data) {
         std::scoped_lock lock{m_mutex};
         for (auto& event : m_events) {
             if (event.event.ident == ident && event.event.filter == filter) {
-                event.Trigger(trigger_data);
+                if (filter == SceKernelEvent::Filter::VideoOut) {
+                    event.TriggerDisplay(trigger_data);
+                } else {
+                    event.Trigger(trigger_data);
+                }
                 has_found = true;
             }
         }

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -87,16 +87,17 @@ struct EqueueEvent {
         auto hint = reinterpret_cast<u64>(data);
         if (hint != 0) {
             auto event_id = event.ident >> 48;
-            auto hint_h = u32(hint >> 8) & 0xFFFFFF;
-            auto ident_h = u32(event.ident >> 40);
-            if ((u32(hint) & 0xFF) == event_id && event_id != 0xFE &&
+            auto hint_h = static_cast<u32>(hint >> 8) & 0xFFFFFF;
+            auto ident_h = static_cast<u32>(event.ident >> 40);
+            if ((static_cast<u32>(hint) & 0xFF) == event_id && event_id != 0xFE &&
                 ((hint_h ^ ident_h) & 0xFF) == 0) {
                 auto time = Common::FencedRDTSC();
                 auto mask = 0xF000;
-                if ((u32(event.data) & 0xF000) != 0xF000) {
-                    mask = (u32(event.data) + 0x1000) & 0xF000;
+                if ((static_cast<u32>(event.data) & 0xF000) != 0xF000) {
+                    mask = (static_cast<u32>(event.data) + 0x1000) & 0xF000;
                 }
-                event.data = (mask | u64(u32(time) & 0xFFF) | (hint & 0xFFFFFFFFFFFF0000));
+                event.data = (mask | static_cast<u64>(static_cast<u32>(time) & 0xFFF) |
+                                (hint & 0xFFFFFFFFFFFF0000));
             }
         }
     }

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -97,7 +97,7 @@ struct EqueueEvent {
                     mask = (static_cast<u32>(event.data) + 0x1000) & 0xF000;
                 }
                 event.data = (mask | static_cast<u64>(static_cast<u32>(time) & 0xFFF) |
-                                (hint & 0xFFFFFFFFFFFF0000));
+                              (hint & 0xFFFFFFFFFFFF0000));
             }
         }
     }

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -86,10 +86,9 @@ struct EqueueEvent {
         is_triggered = true;
         auto hint = reinterpret_cast<u64>(data);
         if (hint != 0) {
-            auto event_id = event.ident >> 48;
             auto hint_h = static_cast<u32>(hint >> 8) & 0xFFFFFF;
             auto ident_h = static_cast<u32>(event.ident >> 40);
-            if ((static_cast<u32>(hint) & 0xFF) == event_id && event_id != 0xFE &&
+            if ((static_cast<u32>(hint) & 0xFF) == event.ident && event.ident != 0xFE &&
                 ((hint_h ^ ident_h) & 0xFF) == 0) {
                 auto time = Common::FencedRDTSC();
                 auto mask = 0xF000;

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -81,6 +81,30 @@ struct EqueueEvent {
         event.data = reinterpret_cast<uintptr_t>(data);
     }
 
+    void TriggerDisplay(void* data) {
+        is_triggered = true;
+        auto hint = reinterpret_cast<u64>(data);
+        if (data == 0) {
+            event.data = (hint >> 12) & 0xF;
+        } else {
+            auto event_id = event.ident << 48;
+            auto hint_h = u32(hint >> 8) & 0xFFFFFF;
+            auto ident_h = u32(event.ident >> 40);
+            auto i = 0;
+            if ((u32(hint) & 0xFF) == event_id && event_id != 0xFE && ((hint_h ^ ident_h) & 0xFF) == 0) {
+                auto time = __rdtsc();
+                auto mask = 0xF000;
+                if ((u32(event.data) & 0xF000) != 0xF000) {
+                    mask = (u32(event.data) + 0x1000) & 0xF000;
+                }
+                i = 1;
+                event.data = (mask | u64(u32(time) & 0xFFF) | (hint & 0xFFFFFFFFFFFF0000));
+            } else {
+                event.data = 1;
+            }
+        }
+    }
+
     bool IsTriggered() const {
         return is_triggered;
     }

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -86,7 +86,7 @@ struct EqueueEvent {
         is_triggered = true;
         auto hint = reinterpret_cast<u64>(data);
         if (hint != 0) {
-            auto event_id = event.ident << 48;
+            auto event_id = event.ident >> 48;
             auto hint_h = u32(hint >> 8) & 0xFFFFFF;
             auto ident_h = u32(event.ident >> 40);
             if ((u32(hint) & 0xFF) == event_id && event_id != 0xFE &&

--- a/src/core/libraries/videoout/driver.cpp
+++ b/src/core/libraries/videoout/driver.cpp
@@ -185,9 +185,11 @@ void VideoOutDriver::Flip(const Request& req) {
     // Trigger flip events for the port.
     for (auto& event : port->flip_events) {
         if (event != nullptr) {
-            event->TriggerEvent(static_cast<u64>(OrbisVideoOutInternalEventId::Flip),
-                                Kernel::SceKernelEvent::Filter::VideoOut,
-                                reinterpret_cast<void*>(static_cast<u64>(OrbisVideoOutInternalEventId::Flip) | (req.flip_arg << 16)));
+            event->TriggerEvent(
+                static_cast<u64>(OrbisVideoOutInternalEventId::Flip),
+                Kernel::SceKernelEvent::Filter::VideoOut,
+                reinterpret_cast<void*>(static_cast<u64>(OrbisVideoOutInternalEventId::Flip) |
+                                        (req.flip_arg << 16)));
         }
     }
 

--- a/src/core/libraries/videoout/driver.cpp
+++ b/src/core/libraries/videoout/driver.cpp
@@ -187,7 +187,7 @@ void VideoOutDriver::Flip(const Request& req) {
         if (event != nullptr) {
             event->TriggerEvent(u64(OrbisVideoOutEventId::Flip),
                                 Kernel::SceKernelEvent::Filter::VideoOut,
-                                reinterpret_cast<void*>(req.flip_arg));
+                                (void*)(u64(OrbisVideoOutEventId::Flip) | (req.flip_arg << 16)));
         }
     }
 

--- a/src/core/libraries/videoout/driver.cpp
+++ b/src/core/libraries/videoout/driver.cpp
@@ -185,9 +185,9 @@ void VideoOutDriver::Flip(const Request& req) {
     // Trigger flip events for the port.
     for (auto& event : port->flip_events) {
         if (event != nullptr) {
-            event->TriggerEvent(u64(OrbisVideoOutEventId::Flip),
+            event->TriggerEvent(static_cast<u64>(OrbisVideoOutInternalEventId::Flip),
                                 Kernel::SceKernelEvent::Filter::VideoOut,
-                                (void*)(u64(OrbisVideoOutEventId::Flip) | (req.flip_arg << 16)));
+                                reinterpret_cast<void*>(static_cast<u64>(OrbisVideoOutInternalEventId::Flip) | (req.flip_arg << 16)));
         }
     }
 
@@ -323,7 +323,7 @@ void VideoOutDriver::PresentThread(std::stop_token token) {
         // Trigger flip events for the port.
         for (auto& event : main_port.vblank_events) {
             if (event != nullptr) {
-                event->TriggerEvent(u64(OrbisVideoOutEventId::Vblank),
+                event->TriggerEvent(static_cast<u64>(OrbisVideoOutInternalEventId::Vblank),
                                     Kernel::SceKernelEvent::Filter::VideoOut, nullptr);
             }
         }

--- a/src/core/libraries/videoout/video_out.cpp
+++ b/src/core/libraries/videoout/video_out.cpp
@@ -159,7 +159,8 @@ int PS4_SYSV_ABI sceVideoOutGetEventId(const Kernel::SceKernelEvent* ev) {
         return ORBIS_VIDEO_OUT_ERROR_INVALID_EVENT;
     }
 
-    OrbisVideoOutInternalEventId internal_event_id = static_cast<OrbisVideoOutInternalEventId>(ev->ident);
+    OrbisVideoOutInternalEventId internal_event_id =
+        static_cast<OrbisVideoOutInternalEventId>(ev->ident);
     switch (internal_event_id) {
     case OrbisVideoOutInternalEventId::Flip:
         return static_cast<s32>(OrbisVideoOutEventId::Flip);

--- a/src/core/libraries/videoout/video_out.cpp
+++ b/src/core/libraries/videoout/video_out.cpp
@@ -50,7 +50,7 @@ s32 PS4_SYSV_ABI sceVideoOutAddFlipEvent(Kernel::SceKernelEqueue eq, s32 handle,
     }
 
     Kernel::EqueueEvent event{};
-    event.event.ident = u64(OrbisVideoOutEventId::Flip);
+    event.event.ident = static_cast<u64>(OrbisVideoOutInternalEventId::Flip);
     event.event.filter = Kernel::SceKernelEvent::Filter::VideoOut;
     event.event.flags = Kernel::SceKernelEvent::Flags::Add;
     event.event.udata = udata;
@@ -76,7 +76,7 @@ s32 PS4_SYSV_ABI sceVideoOutAddVblankEvent(Kernel::SceKernelEqueue eq, s32 handl
     }
 
     Kernel::EqueueEvent event{};
-    event.event.ident = u64(OrbisVideoOutEventId::Vblank);
+    event.event.ident = static_cast<u64>(OrbisVideoOutInternalEventId::Vblank);
     event.event.filter = Kernel::SceKernelEvent::Filter::VideoOut;
     event.event.flags = Kernel::SceKernelEvent::Flags::Add;
     event.event.udata = udata;
@@ -156,9 +156,26 @@ int PS4_SYSV_ABI sceVideoOutGetEventId(const Kernel::SceKernelEvent* ev) {
         return ORBIS_VIDEO_OUT_ERROR_INVALID_ADDRESS;
     }
     if (ev->filter != Kernel::SceKernelEvent::Filter::VideoOut) {
-        return ORBIS_VIDEO_OUT_ERROR_INVALID_EVENT_QUEUE;
+        return ORBIS_VIDEO_OUT_ERROR_INVALID_EVENT;
     }
-    return ev->ident;
+
+    OrbisVideoOutInternalEventId internal_event_id = static_cast<OrbisVideoOutInternalEventId>(ev->ident);
+    switch (internal_event_id) {
+    case OrbisVideoOutInternalEventId::Flip:
+        return static_cast<s32>(OrbisVideoOutEventId::Flip);
+    case OrbisVideoOutInternalEventId::Vblank:
+    case OrbisVideoOutInternalEventId::SysVblank:
+        return static_cast<s32>(OrbisVideoOutEventId::Vblank);
+    case OrbisVideoOutInternalEventId::PreVblankStart:
+        return static_cast<s32>(OrbisVideoOutEventId::PreVblankStart);
+    case OrbisVideoOutInternalEventId::SetMode:
+        return static_cast<s32>(OrbisVideoOutEventId::SetMode);
+    case OrbisVideoOutInternalEventId::Position:
+        return static_cast<s32>(OrbisVideoOutEventId::Position);
+    default: {
+        return ORBIS_VIDEO_OUT_ERROR_INVALID_EVENT;
+    }
+    }
 }
 
 int PS4_SYSV_ABI sceVideoOutGetEventData(const Kernel::SceKernelEvent* ev, int64_t* data) {

--- a/src/core/libraries/videoout/video_out.h
+++ b/src/core/libraries/videoout/video_out.h
@@ -40,7 +40,22 @@ constexpr int SCE_VIDEO_OUT_BUFFER_ATTRIBUTE_OPTION_NONE = 0;
 constexpr int SCE_VIDEO_OUT_BUFFER_ATTRIBUTE_OPTION_VR = 7;
 constexpr int SCE_VIDEO_OUT_BUFFER_ATTRIBUTE_OPTION_STRICT_COLORIMETRY = 8;
 
-enum class OrbisVideoOutEventId : s16 { Flip = 0, Vblank = 1, PreVblankStart = 2 };
+enum class OrbisVideoOutEventId : s16 {
+    Flip = 0,
+    Vblank = 1,
+    PreVblankStart = 2,
+    SetMode = 8,
+    Position = 12,
+};
+
+enum class OrbisVideoOutInternalEventId : s16 {
+    Flip = 0x6,
+    Vblank = 0x7,
+    SetMode = 0x51,
+    Position = 0x58,
+    PreVblankStart = 0x59,
+    SysVblank = 0x63,
+};
 
 enum class AspectRatioMode : s32 {
     Ratio16_9 = 0,


### PR DESCRIPTION
The data for events with the VideoOut filter is packed in a very specific way, containing an event id, timestamp, and the flip argument. Our prior code only passed along the flip argument, and didn't fill the data bytes accurately. As a result, games checking the event data on VideoOut events weren't seeing the expected data.

This PR adds a new function that fills the data for VideoOut events based on some decompilation work shared by @red-prig. Handling this properly fixes the early hang in The Last of Us Remastered (CUSA00552).