### PR TITLE
Change Background Image for games

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -673,8 +673,6 @@ void load(const std::filesystem::path& path) {
         checkCompatibilityOnStartup =
             toml::find_or<bool>(general, "checkCompatibilityOnStartup", false);
         chooseHomeTab = toml::find_or<std::string>(general, "chooseHomeTab", "Release");
-        backgroundImageOpacity = toml::find_or<int>(general, "backgroundImageOpacity", 50);
-        showBackgroundImage = toml::find_or<bool>(general, "showBackgroundImage", true);
     }
 
     if (data.contains("Input")) {
@@ -751,6 +749,8 @@ void load(const std::filesystem::path& path) {
         m_recent_files = toml::find_or<std::vector<std::string>>(gui, "recentFiles", {});
         m_table_mode = toml::find_or<int>(gui, "gameTableMode", 0);
         emulator_language = toml::find_or<std::string>(gui, "emulatorLanguage", "en");
+        backgroundImageOpacity = toml::find_or<int>(gui, "backgroundImageOpacity", 50);
+        showBackgroundImage = toml::find_or<bool>(gui, "showBackgroundImage", true);
     }
 
     if (data.contains("Settings")) {
@@ -803,8 +803,6 @@ void save(const std::filesystem::path& path) {
     data["General"]["separateUpdateEnabled"] = separateupdatefolder;
     data["General"]["compatibilityEnabled"] = compatibilityData;
     data["General"]["checkCompatibilityOnStartup"] = checkCompatibilityOnStartup;
-    data["General"]["backgroundImageOpacity"] = backgroundImageOpacity;
-    data["General"]["showBackgroundImage"] = showBackgroundImage;
     data["Input"]["cursorState"] = cursorState;
     data["Input"]["cursorHideTimeout"] = cursorHideTimeout;
     data["Input"]["backButtonBehavior"] = backButtonBehavior;
@@ -843,6 +841,8 @@ void save(const std::filesystem::path& path) {
     data["GUI"]["addonInstallDir"] =
         std::string{fmt::UTF(settings_addon_install_dir.u8string()).data};
     data["GUI"]["emulatorLanguage"] = emulator_language;
+    data["GUI"]["backgroundImageOpacity"] = backgroundImageOpacity;
+    data["GUI"]["showBackgroundImage"] = showBackgroundImage;
     data["Settings"]["consoleLanguage"] = m_language;
 
     std::ofstream file(path, std::ios::binary);

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -96,6 +96,7 @@ std::vector<std::string> m_elf_viewer;
 std::vector<std::string> m_recent_files;
 std::string emulator_language = "en";
 static int backgroundImageOpacity = 50;
+static bool showBackgroundImage = true;
 
 // Language
 u32 m_language = 1; // english
@@ -620,6 +621,14 @@ void setBackgroundImageOpacity(int opacity) {
     backgroundImageOpacity = std::clamp(opacity, 0, 100);
 }
 
+bool getShowBackgroundImage() {
+    return showBackgroundImage;
+}
+
+void setShowBackgroundImage(bool show) {
+    showBackgroundImage = show;
+}
+
 void load(const std::filesystem::path& path) {
     // If the configuration file does not exist, create it and return
     std::error_code error;
@@ -665,6 +674,7 @@ void load(const std::filesystem::path& path) {
             toml::find_or<bool>(general, "checkCompatibilityOnStartup", false);
         chooseHomeTab = toml::find_or<std::string>(general, "chooseHomeTab", "Release");
         backgroundImageOpacity = toml::find_or<int>(general, "backgroundImageOpacity", 50);
+        showBackgroundImage = toml::find_or<bool>(general, "showBackgroundImage", true);
     }
 
     if (data.contains("Input")) {
@@ -794,6 +804,7 @@ void save(const std::filesystem::path& path) {
     data["General"]["compatibilityEnabled"] = compatibilityData;
     data["General"]["checkCompatibilityOnStartup"] = checkCompatibilityOnStartup;
     data["General"]["backgroundImageOpacity"] = backgroundImageOpacity;
+    data["General"]["showBackgroundImage"] = showBackgroundImage;
     data["Input"]["cursorState"] = cursorState;
     data["Input"]["cursorHideTimeout"] = cursorHideTimeout;
     data["Input"]["backButtonBehavior"] = backButtonBehavior;
@@ -926,6 +937,7 @@ void setDefaultValues() {
     compatibilityData = false;
     checkCompatibilityOnStartup = false;
     backgroundImageOpacity = 50;
+    showBackgroundImage = true;
 }
 
 constexpr std::string_view GetDefaultKeyboardConfig() {

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -95,6 +95,7 @@ std::vector<std::string> m_pkg_viewer;
 std::vector<std::string> m_elf_viewer;
 std::vector<std::string> m_recent_files;
 std::string emulator_language = "en";
+static int backgroundImageOpacity = 50;
 
 // Language
 u32 m_language = 1; // english
@@ -611,6 +612,14 @@ u32 GetLanguage() {
     return m_language;
 }
 
+int getBackgroundImageOpacity() {
+    return backgroundImageOpacity;
+}
+
+void setBackgroundImageOpacity(int opacity) {
+    backgroundImageOpacity = std::clamp(opacity, 0, 100);
+}
+
 void load(const std::filesystem::path& path) {
     // If the configuration file does not exist, create it and return
     std::error_code error;
@@ -655,6 +664,7 @@ void load(const std::filesystem::path& path) {
         checkCompatibilityOnStartup =
             toml::find_or<bool>(general, "checkCompatibilityOnStartup", false);
         chooseHomeTab = toml::find_or<std::string>(general, "chooseHomeTab", "Release");
+        backgroundImageOpacity = toml::find_or<int>(general, "backgroundImageOpacity", 50);
     }
 
     if (data.contains("Input")) {
@@ -783,6 +793,7 @@ void save(const std::filesystem::path& path) {
     data["General"]["separateUpdateEnabled"] = separateupdatefolder;
     data["General"]["compatibilityEnabled"] = compatibilityData;
     data["General"]["checkCompatibilityOnStartup"] = checkCompatibilityOnStartup;
+    data["General"]["backgroundImageOpacity"] = backgroundImageOpacity;
     data["Input"]["cursorState"] = cursorState;
     data["Input"]["cursorHideTimeout"] = cursorHideTimeout;
     data["Input"]["backButtonBehavior"] = backButtonBehavior;
@@ -914,6 +925,7 @@ void setDefaultValues() {
     separateupdatefolder = false;
     compatibilityData = false;
     checkCompatibilityOnStartup = false;
+    backgroundImageOpacity = 50;
 }
 
 constexpr std::string_view GetDefaultKeyboardConfig() {

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -30,6 +30,7 @@ bool getEnableDiscordRPC();
 bool getSeparateUpdateEnabled();
 bool getCompatibilityEnabled();
 bool getCheckCompatibilityOnStartup();
+int getBackgroundImageOpacity();
 
 std::string getLogFilter();
 std::string getLogType();
@@ -88,6 +89,7 @@ void setGameInstallDirs(const std::vector<std::filesystem::path>& settings_insta
 void setSaveDataPath(const std::filesystem::path& path);
 void setCompatibilityEnabled(bool use);
 void setCheckCompatibilityOnStartup(bool use);
+void setBackgroundImageOpacity(int opacity);
 
 void setCursorState(s16 cursorState);
 void setCursorHideTimeout(int newcursorHideTimeout);

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -31,6 +31,7 @@ bool getSeparateUpdateEnabled();
 bool getCompatibilityEnabled();
 bool getCheckCompatibilityOnStartup();
 int getBackgroundImageOpacity();
+bool getShowBackgroundImage();
 
 std::string getLogFilter();
 std::string getLogType();
@@ -90,6 +91,7 @@ void setSaveDataPath(const std::filesystem::path& path);
 void setCompatibilityEnabled(bool use);
 void setCheckCompatibilityOnStartup(bool use);
 void setBackgroundImageOpacity(int opacity);
+void setShowBackgroundImage(bool show);
 
 void setCursorState(s16 cursorState);
 void setCursorHideTimeout(int newcursorHideTimeout);

--- a/src/qt_gui/game_grid_frame.cpp
+++ b/src/qt_gui/game_grid_frame.cpp
@@ -82,6 +82,8 @@ void GameGridFrame::PlayBackgroundMusic(QString path) {
 }
 
 void GameGridFrame::PopulateGameGrid(QVector<GameInfo> m_games_search, bool fromSearch) {
+    this->crtRow = -1;
+    this->crtColumn = -1;
     QVector<GameInfo> m_games_;
     this->clearContents();
     if (fromSearch)

--- a/src/qt_gui/game_grid_frame.cpp
+++ b/src/qt_gui/game_grid_frame.cpp
@@ -38,17 +38,34 @@ GameGridFrame::GameGridFrame(std::shared_ptr<GameInfoClass> game_info_get,
 
 void GameGridFrame::onCurrentCellChanged(int currentRow, int currentColumn, int previousRow,
                                          int previousColumn) {
-    crtRow = currentRow;
-    crtColumn = currentColumn;
-    columnCnt = this->columnCount();
-
-    auto itemID = (crtRow * columnCnt) + currentColumn;
-    if (itemID > m_game_info->m_games.count() - 1) {
+    // Early exit for invalid indices
+    if (currentRow < 0 || currentColumn < 0) {
         cellClicked = false;
         validCellSelected = false;
         BackgroundMusicPlayer::getInstance().stopMusic();
         return;
     }
+
+    crtRow = currentRow;
+    crtColumn = currentColumn;
+    columnCnt = this->columnCount();
+
+    // Prevent integer overflow
+    if (columnCnt <= 0 || crtRow > (std::numeric_limits<int>::max() / columnCnt)) {
+        cellClicked = false;
+        validCellSelected = false;
+        BackgroundMusicPlayer::getInstance().stopMusic();
+        return;
+    }
+
+    auto itemID = (crtRow * columnCnt) + currentColumn;
+    if (itemID < 0 || itemID > m_game_info->m_games.count() - 1) {
+        cellClicked = false;
+        validCellSelected = false;
+        BackgroundMusicPlayer::getInstance().stopMusic();
+        return;
+    }
+
     cellClicked = true;
     validCellSelected = true;
     SetGridBackgroundImage(crtRow, crtColumn);

--- a/src/qt_gui/game_grid_frame.cpp
+++ b/src/qt_gui/game_grid_frame.cpp
@@ -162,6 +162,7 @@ void GameGridFrame::SetGridBackgroundImage(int row, int column) {
         return;
     }
 
+    // If background images are hidden, clear the background image
     if (!Config::getShowBackgroundImage()) {
         backgroundImage = QImage();
         RefreshGridBackgroundImage();
@@ -170,31 +171,11 @@ void GameGridFrame::SetGridBackgroundImage(int row, int column) {
 
     const auto& game = (*m_games_shared)[itemID];
     const int opacity = Config::getBackgroundImageOpacity();
-    const auto cache_path = Common::FS::GetUserPath(Common::FS::PathType::MetaDataDir) /
-                            game.serial / fmt::format("pic1_{}.png", opacity);
 
-    // Fast path - try to load cached version first
-    if (std::filesystem::exists(cache_path)) {
-        backgroundImage = QImage(QString::fromStdString(cache_path.string()));
-        if (!backgroundImage.isNull()) {
-            RefreshGridBackgroundImage();
-            return;
-        }
-    }
-
-    // Cache miss - generate and store
-    m_game_list_utils.CleanupOldOpacityImages(cache_path.parent_path());
     QImage original_image(QString::fromStdString(game.pic_path.string()));
     if (!original_image.isNull()) {
-        std::filesystem::create_directories(cache_path.parent_path());
         backgroundImage = m_game_list_utils.ChangeImageOpacity(
             original_image, original_image.rect(), opacity / 100.0f);
-        if (!backgroundImage.isNull()) {
-            // Save the image to the cache asynchronously
-            QFuture<void> future = QtConcurrent::run([this, cache_path]() {
-                backgroundImage.save(QString::fromStdString(cache_path.string()), "PNG");
-            });
-        }
     }
 
     RefreshGridBackgroundImage();

--- a/src/qt_gui/game_grid_frame.cpp
+++ b/src/qt_gui/game_grid_frame.cpp
@@ -150,7 +150,7 @@ void GameGridFrame::SetGridBackgroundImage(int row, int column) {
         backgroundImage = QImage(blurredPic1PathQt);
         if (backgroundImage.isNull()) {
             QImage image(pic1Path);
-            backgroundImage = m_game_list_utils.BlurImage(image, image.rect(), 16);
+            backgroundImage = m_game_list_utils.ChangeImageOpacity(image, image.rect(), 0.5);
 
             std::filesystem::path img_path =
                 Common::FS::GetUserPath(Common::FS::PathType::MetaDataDir) /

--- a/src/qt_gui/game_grid_frame.cpp
+++ b/src/qt_gui/game_grid_frame.cpp
@@ -162,6 +162,12 @@ void GameGridFrame::SetGridBackgroundImage(int row, int column) {
         return;
     }
 
+    if (!Config::getShowBackgroundImage()) {
+        backgroundImage = QImage();
+        RefreshGridBackgroundImage();
+        return;
+    }
+
     const auto& game = (*m_games_shared)[itemID];
     const int opacity = Config::getBackgroundImageOpacity();
     const auto cache_path = Common::FS::GetUserPath(Common::FS::PathType::MetaDataDir) /
@@ -195,14 +201,14 @@ void GameGridFrame::SetGridBackgroundImage(int row, int column) {
 }
 
 void GameGridFrame::RefreshGridBackgroundImage() {
-    if (!backgroundImage.isNull()) {
-        QPalette palette;
+    QPalette palette;
+    if (!backgroundImage.isNull() && Config::getShowBackgroundImage()) {
         palette.setBrush(QPalette::Base,
                          QBrush(backgroundImage.scaled(size(), Qt::IgnoreAspectRatio)));
-        QColor transparentColor = QColor(135, 206, 235, 40);
-        palette.setColor(QPalette::Highlight, transparentColor);
-        this->setPalette(palette);
     }
+    QColor transparentColor = QColor(135, 206, 235, 40);
+    palette.setColor(QPalette::Highlight, transparentColor);
+    this->setPalette(palette);
 }
 
 bool GameGridFrame::IsValidCellSelected() {

--- a/src/qt_gui/game_grid_frame.h
+++ b/src/qt_gui/game_grid_frame.h
@@ -33,6 +33,8 @@ private:
     std::shared_ptr<CompatibilityInfoClass> m_compat_info;
     std::shared_ptr<QVector<GameInfo>> m_games_shared;
     bool validCellSelected = false;
+    int m_last_opacity = -1; // Track last opacity to avoid unnecessary recomputation
+    std::filesystem::path m_current_game_path; // Track current game path to detect changes
 
 public:
     explicit GameGridFrame(std::shared_ptr<GameInfoClass> game_info_get,

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -89,6 +89,7 @@ void GameListFrame::onCurrentCellChanged(int currentRow, int currentColumn, int 
     if (!item) {
         return;
     }
+    m_current_item = item; // Store current item
     SetListBackgroundImage(item);
     PlayBackgroundMusic(item);
 }
@@ -387,4 +388,8 @@ QString GameListFrame::GetPlayTime(const std::string& serial) {
 
     file.close();
     return playTime;
+}
+
+QTableWidgetItem* GameListFrame::GetCurrentItem() {
+    return m_current_item;
 }

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -177,7 +177,7 @@ void GameListFrame::SetListBackgroundImage(QTableWidgetItem* item) {
     backgroundImage = QImage(blurredPic1PathQt);
     if (backgroundImage.isNull()) {
         QImage image(pic1Path);
-        backgroundImage = m_game_list_utils.BlurImage(image, image.rect(), 16);
+        backgroundImage = m_game_list_utils.ChangeImageOpacity(image, image.rect(), 0.5);
 
         std::filesystem::path img_path =
             Common::FS::GetUserPath(Common::FS::PathType::MetaDataDir) /

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -167,6 +167,13 @@ void GameListFrame::SetListBackgroundImage(QTableWidgetItem* item) {
         return;
     }
 
+    // If background images are hidden, clear the background image
+    if (!Config::getShowBackgroundImage()) {
+        backgroundImage = QImage();
+        RefreshListBackgroundImage();
+        return;
+    }
+
     const auto& game = m_game_info->m_games[item->row()];
     const int opacity = Config::getBackgroundImageOpacity();
     const auto cache_path = Common::FS::GetUserPath(Common::FS::PathType::MetaDataDir) /
@@ -200,14 +207,14 @@ void GameListFrame::SetListBackgroundImage(QTableWidgetItem* item) {
 }
 
 void GameListFrame::RefreshListBackgroundImage() {
-    if (!backgroundImage.isNull()) {
-        QPalette palette;
+    QPalette palette;
+    if (!backgroundImage.isNull() && Config::getShowBackgroundImage()) {
         palette.setBrush(QPalette::Base,
                          QBrush(backgroundImage.scaled(size(), Qt::IgnoreAspectRatio)));
-        QColor transparentColor = QColor(135, 206, 235, 40);
-        palette.setColor(QPalette::Highlight, transparentColor);
-        this->setPalette(palette);
     }
+    QColor transparentColor = QColor(135, 206, 235, 40);
+    palette.setColor(QPalette::Highlight, transparentColor);
+    this->setPalette(palette);
 }
 
 void GameListFrame::SortNameAscending(int columnIndex) {

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -171,6 +171,8 @@ void GameListFrame::SetListBackgroundImage(QTableWidgetItem* item) {
     // If background images are hidden, clear the background image
     if (!Config::getShowBackgroundImage()) {
         backgroundImage = QImage();
+        m_last_opacity = -1;         // Reset opacity tracking when disabled
+        m_current_game_path.clear(); // Reset current game path
         RefreshListBackgroundImage();
         return;
     }
@@ -178,10 +180,15 @@ void GameListFrame::SetListBackgroundImage(QTableWidgetItem* item) {
     const auto& game = m_game_info->m_games[item->row()];
     const int opacity = Config::getBackgroundImageOpacity();
 
-    QImage original_image(QString::fromStdString(game.pic_path.string()));
-    if (!original_image.isNull()) {
-        backgroundImage = m_game_list_utils.ChangeImageOpacity(
-            original_image, original_image.rect(), opacity / 100.0f);
+    // Recompute if opacity changed or we switched to a different game
+    if (opacity != m_last_opacity || game.pic_path != m_current_game_path) {
+        QImage original_image(QString::fromStdString(game.pic_path.string()));
+        if (!original_image.isNull()) {
+            backgroundImage = m_game_list_utils.ChangeImageOpacity(
+                original_image, original_image.rect(), opacity / 100.0f);
+            m_last_opacity = opacity;
+            m_current_game_path = game.pic_path;
+        }
     }
 
     RefreshListBackgroundImage();

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -105,6 +105,7 @@ void GameListFrame::PlayBackgroundMusic(QTableWidgetItem* item) {
 }
 
 void GameListFrame::PopulateGameList(bool isInitialPopulation) {
+    this->m_current_item = nullptr;
     // Do not show status column if it is not enabled
     this->setColumnHidden(2, !Config::getCompatibilityEnabled());
     this->setColumnHidden(6, !Config::GetLoadGameSizeEnabled());

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -176,31 +176,11 @@ void GameListFrame::SetListBackgroundImage(QTableWidgetItem* item) {
 
     const auto& game = m_game_info->m_games[item->row()];
     const int opacity = Config::getBackgroundImageOpacity();
-    const auto cache_path = Common::FS::GetUserPath(Common::FS::PathType::MetaDataDir) /
-                            game.serial / fmt::format("pic1_{}.png", opacity);
 
-    // Fast path - try to load cached version first
-    if (std::filesystem::exists(cache_path)) {
-        backgroundImage = QImage(QString::fromStdString(cache_path.string()));
-        if (!backgroundImage.isNull()) {
-            RefreshListBackgroundImage();
-            return;
-        }
-    }
-
-    // Cache miss - generate and store
-    m_game_list_utils.CleanupOldOpacityImages(cache_path.parent_path());
     QImage original_image(QString::fromStdString(game.pic_path.string()));
     if (!original_image.isNull()) {
-        std::filesystem::create_directories(cache_path.parent_path());
         backgroundImage = m_game_list_utils.ChangeImageOpacity(
             original_image, original_image.rect(), opacity / 100.0f);
-        if (!backgroundImage.isNull()) {
-            // Save the image to the cache asynchronously
-            QFuture<void> future = QtConcurrent::run([this, cache_path]() {
-                backgroundImage.save(QString::fromStdString(cache_path.string()), "PNG");
-            });
-        }
     }
 
     RefreshListBackgroundImage();

--- a/src/qt_gui/game_list_frame.h
+++ b/src/qt_gui/game_list_frame.h
@@ -45,6 +45,8 @@ private:
     GameInfoClass* game_inf_get = nullptr;
     bool ListSortedAsc = true;
     QTableWidgetItem* m_current_item = nullptr;
+    int m_last_opacity = -1; // Track last opacity to avoid unnecessary recomputation
+    std::filesystem::path m_current_game_path; // Track current game path to detect changes
 
 public:
     void PopulateGameList(bool isInitialPopulation = true);

--- a/src/qt_gui/game_list_frame.h
+++ b/src/qt_gui/game_list_frame.h
@@ -44,11 +44,12 @@ private:
     QList<QAction*> m_columnActs;
     GameInfoClass* game_inf_get = nullptr;
     bool ListSortedAsc = true;
+    QTableWidgetItem* m_current_item = nullptr;
 
 public:
     void PopulateGameList(bool isInitialPopulation = true);
     void ResizeIcons(int iconSize);
-
+    QTableWidgetItem* GetCurrentItem();
     QImage backgroundImage;
     GameListUtils m_game_list_utils;
     GuiContextMenus m_gui_context_menus;

--- a/src/qt_gui/game_list_utils.h
+++ b/src/qt_gui/game_list_utils.h
@@ -202,16 +202,17 @@ public:
         return result;
     }
 
-    QImage ChangeImageOpacity(const QImage& image, const QRect& rect, float opacity) {
+    // Opacity is a float between 0 and 1
+    static QImage ChangeImageOpacity(const QImage& image, const QRect& rect, float opacity) {
         // Convert to ARGB32 format to ensure alpha channel support
         QImage result = image.convertToFormat(QImage::Format_ARGB32);
-        
+
         // Ensure opacity is between 0 and 1
         opacity = std::clamp(opacity, 0.0f, 1.0f);
-        
+
         // Convert opacity to integer alpha value (0-255)
         int alpha = static_cast<int>(opacity * 255);
-        
+
         // Process only the specified rectangle area
         for (int y = rect.top(); y <= rect.bottom(); ++y) {
             QRgb* line = reinterpret_cast<QRgb*>(result.scanLine(y));
@@ -223,7 +224,20 @@ public:
                 line[x] = qRgba(qRed(pixel), qGreen(pixel), qBlue(pixel), newAlpha);
             }
         }
-        
+
         return result;
+    }
+
+    void CleanupOldOpacityImages(const std::filesystem::path& dir) {
+        if (!std::filesystem::exists(dir)) {
+            return;
+        }
+
+        for (const auto& entry : std::filesystem::directory_iterator(dir)) {
+            const auto& path = entry.path();
+            if (path.filename().string().starts_with("pic1") && path.extension() == ".png") {
+                std::filesystem::remove(path);
+            }
+        }
     }
 };

--- a/src/qt_gui/game_list_utils.h
+++ b/src/qt_gui/game_list_utils.h
@@ -227,17 +227,4 @@ public:
 
         return result;
     }
-
-    void CleanupOldOpacityImages(const std::filesystem::path& dir) {
-        if (!std::filesystem::exists(dir)) {
-            return;
-        }
-
-        for (const auto& entry : std::filesystem::directory_iterator(dir)) {
-            const auto& path = entry.path();
-            if (path.filename().string().starts_with("pic1") && path.extension() == ".png") {
-                std::filesystem::remove(path);
-            }
-        }
-    }
 };

--- a/src/qt_gui/game_list_utils.h
+++ b/src/qt_gui/game_list_utils.h
@@ -201,4 +201,29 @@ public:
 
         return result;
     }
+
+    QImage ChangeImageOpacity(const QImage& image, const QRect& rect, float opacity) {
+        // Convert to ARGB32 format to ensure alpha channel support
+        QImage result = image.convertToFormat(QImage::Format_ARGB32);
+        
+        // Ensure opacity is between 0 and 1
+        opacity = std::clamp(opacity, 0.0f, 1.0f);
+        
+        // Convert opacity to integer alpha value (0-255)
+        int alpha = static_cast<int>(opacity * 255);
+        
+        // Process only the specified rectangle area
+        for (int y = rect.top(); y <= rect.bottom(); ++y) {
+            QRgb* line = reinterpret_cast<QRgb*>(result.scanLine(y));
+            for (int x = rect.left(); x <= rect.right(); ++x) {
+                // Get current pixel
+                QRgb pixel = line[x];
+                // Keep RGB values, but modify alpha while preserving relative transparency
+                int newAlpha = (qAlpha(pixel) * alpha) / 255;
+                line[x] = qRgba(qRed(pixel), qGreen(pixel), qBlue(pixel), newAlpha);
+            }
+        }
+        
+        return result;
+    }
 };

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -292,6 +292,19 @@ void MainWindow::CreateConnects() {
         connect(settingsDialog, &SettingsDialog::CompatibilityChanged, this,
                 &MainWindow::RefreshGameTable);
 
+        // Connect background opacity changes to refresh both frames
+        connect(
+            settingsDialog, &SettingsDialog::BackgroundOpacityChanged, this, [this](int opacity) {
+                Config::setBackgroundImageOpacity(opacity);
+                if (m_game_list_frame) {
+                    m_game_list_frame->SetListBackgroundImage(m_game_list_frame->GetCurrentItem());
+                }
+                if (m_game_grid_frame) {
+                    m_game_grid_frame->SetGridBackgroundImage(m_game_grid_frame->crtRow,
+                                                              m_game_grid_frame->crtColumn);
+                }
+            });
+
         settingsDialog->exec();
     });
 

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -292,18 +292,22 @@ void MainWindow::CreateConnects() {
         connect(settingsDialog, &SettingsDialog::CompatibilityChanged, this,
                 &MainWindow::RefreshGameTable);
 
-        // Connect background opacity changes to refresh both frames
-        connect(
-            settingsDialog, &SettingsDialog::BackgroundOpacityChanged, this, [this](int opacity) {
-                Config::setBackgroundImageOpacity(opacity);
-                if (m_game_list_frame) {
-                    m_game_list_frame->SetListBackgroundImage(m_game_list_frame->GetCurrentItem());
-                }
-                if (m_game_grid_frame) {
-                    m_game_grid_frame->SetGridBackgroundImage(m_game_grid_frame->crtRow,
-                                                              m_game_grid_frame->crtColumn);
-                }
-            });
+        connect(settingsDialog, &SettingsDialog::BackgroundOpacityChanged, this,
+                [this](int opacity) {
+                    Config::setBackgroundImageOpacity(opacity);
+                    if (m_game_list_frame) {
+                        QTableWidgetItem* current = m_game_list_frame->GetCurrentItem();
+                        if (current) {
+                            m_game_list_frame->SetListBackgroundImage(current);
+                        }
+                    }
+                    if (m_game_grid_frame) {
+                        if (m_game_grid_frame->IsValidCellSelected()) {
+                            m_game_grid_frame->SetGridBackgroundImage(m_game_grid_frame->crtRow,
+                                                                      m_game_grid_frame->crtColumn);
+                        }
+                    }
+                });
 
         settingsDialog->exec();
     });

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -174,7 +174,8 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices,
         connect(ui->chooseHomeTabComboBox, &QComboBox::currentTextChanged, this,
                 [](const QString& hometab) { Config::setChooseHomeTab(hometab.toStdString()); });
 
-        // Add background image opacity slider connection
+        connect(ui->showBackgroundImageCheckBox, &QCheckBox::stateChanged, this,
+                [](int state) { Config::setShowBackgroundImage(state == Qt::Checked); });
         connect(ui->backgroundImageOpacitySlider, &QSlider::valueChanged, this,
                 [](int value) { Config::setBackgroundImageOpacity(value); });
     }
@@ -416,6 +417,7 @@ void SettingsDialog::LoadValuesFromConfig() {
     ui->removeFolderButton->setEnabled(!ui->gameFoldersListWidget->selectedItems().isEmpty());
     ResetInstallFolders();
     ui->backgroundImageOpacitySlider->setValue(Config::getBackgroundImageOpacity());
+    ui->showBackgroundImageCheckBox->setChecked(Config::getShowBackgroundImage());
 }
 
 void SettingsDialog::InitializeEmulatorLanguages() {
@@ -646,6 +648,8 @@ void SettingsDialog::UpdateSettings() {
     Config::setChooseHomeTab(ui->chooseHomeTabComboBox->currentText().toStdString());
     Config::setCompatibilityEnabled(ui->enableCompatibilityCheckBox->isChecked());
     Config::setCheckCompatibilityOnStartup(ui->checkCompatibilityOnStartupCheckBox->isChecked());
+    Config::setBackgroundImageOpacity(ui->backgroundImageOpacitySlider->value());
+    Config::setShowBackgroundImage(ui->showBackgroundImageCheckBox->isChecked());
 
 #ifdef ENABLE_DISCORD_RPC
     auto* rpc = Common::Singleton<DiscordRPCHandler::RPC>::Instance();

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -176,8 +176,6 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices,
 
         connect(ui->showBackgroundImageCheckBox, &QCheckBox::stateChanged, this,
                 [](int state) { Config::setShowBackgroundImage(state == Qt::Checked); });
-        connect(ui->backgroundImageOpacitySlider, &QSlider::valueChanged, this,
-                [](int value) { Config::setBackgroundImageOpacity(value); });
     }
     // Input TAB
     {
@@ -649,6 +647,7 @@ void SettingsDialog::UpdateSettings() {
     Config::setCompatibilityEnabled(ui->enableCompatibilityCheckBox->isChecked());
     Config::setCheckCompatibilityOnStartup(ui->checkCompatibilityOnStartupCheckBox->isChecked());
     Config::setBackgroundImageOpacity(ui->backgroundImageOpacitySlider->value());
+    emit BackgroundOpacityChanged(ui->backgroundImageOpacitySlider->value());
     Config::setShowBackgroundImage(ui->showBackgroundImageCheckBox->isChecked());
 
 #ifdef ENABLE_DISCORD_RPC

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -173,6 +173,10 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices,
     {
         connect(ui->chooseHomeTabComboBox, &QComboBox::currentTextChanged, this,
                 [](const QString& hometab) { Config::setChooseHomeTab(hometab.toStdString()); });
+
+        // Add background image opacity slider connection
+        connect(ui->backgroundImageOpacitySlider, &QSlider::valueChanged, this,
+                [](int value) { Config::setBackgroundImageOpacity(value); });
     }
     // Input TAB
     {
@@ -251,6 +255,7 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices,
 #ifdef ENABLE_UPDATER
         ui->updaterGroupBox->installEventFilter(this);
 #endif
+        ui->GUIBackgroundImageGroupBox->installEventFilter(this);
         ui->GUIMusicGroupBox->installEventFilter(this);
         ui->disableTrophycheckBox->installEventFilter(this);
         ui->enableCompatibilityCheckBox->installEventFilter(this);
@@ -410,6 +415,7 @@ void SettingsDialog::LoadValuesFromConfig() {
 
     ui->removeFolderButton->setEnabled(!ui->gameFoldersListWidget->selectedItems().isEmpty());
     ResetInstallFolders();
+    ui->backgroundImageOpacitySlider->setValue(Config::getBackgroundImageOpacity());
 }
 
 void SettingsDialog::InitializeEmulatorLanguages() {
@@ -504,6 +510,8 @@ void SettingsDialog::updateNoteTextEdit(const QString& elementName) {
     } else if (elementName == "updaterGroupBox") {
         text = tr("updaterGroupBox");
 #endif
+    } else if (elementName == "GUIBackgroundImageGroupBox") {
+        text = tr("GUIBackgroundImageGroupBox");
     } else if (elementName == "GUIMusicGroupBox") {
         text = tr("GUIMusicGroupBox");
     } else if (elementName == "disableTrophycheckBox") {

--- a/src/qt_gui/settings_dialog.h
+++ b/src/qt_gui/settings_dialog.h
@@ -33,6 +33,7 @@ public:
 signals:
     void LanguageChanged(const std::string& locale);
     void CompatibilityChanged();
+    void BackgroundOpacityChanged(int opacity);
 
 private:
     void LoadValuesFromConfig();

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -584,6 +584,76 @@
                 </widget>
                </item>
                <item>
+                <widget class="QGroupBox" name="GUIBackgroundImageGroupBox">
+                 <property name="title">
+                  <string>Background Image</string>
+                 </property>
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <layout class="QVBoxLayout" name="backgroundImageVLayout">
+                  <item>
+                   <widget class="QCheckBox" name="showBackgroundImageCheckBox">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>Show Background Image</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="opacityLayout">
+                    <property name="spacing">
+                     <number>9</number>
+                    </property>
+                    <item>
+                     <widget class="QLabel" name="backgroundImageOpacityLabel">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="text">
+                       <string>Opacity</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QSlider" name="backgroundImageOpacitySlider">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="minimum">
+                       <number>0</number>
+                      </property>
+                      <property name="maximum">
+                       <number>100</number>
+                      </property>
+                      <property name="value">
+                       <number>50</number>
+                      </property>
+                      <property name="orientation">
+                       <enum>Qt::Orientation::Horizontal</enum>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
                 <widget class="QGroupBox" name="GUIMusicGroupBox">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">

--- a/src/qt_gui/translations/en.ts
+++ b/src/qt_gui/translations/en.ts
@@ -750,6 +750,18 @@
 			<translation>Disable Trophy Pop-ups</translation>
 		</message>
 		<message>
+			<source>Background Image</source>
+			<translation>Background Image</translation>
+		</message>
+		<message>
+			<source>Show Background Image</source>
+			<translation>Show Background Image</translation>
+		</message>
+		<message>
+			<source>Opacity</source>
+			<translation>Opacity</translation>
+		</message>
+		<message>
 			<source>Play title music</source>
 			<translation>Play title music</translation>
 		</message>
@@ -844,6 +856,10 @@
 		<message>
 			<source>updaterGroupBox</source>
 			<translation>Update:\nRelease: Official versions released every month that may be very outdated, but are more reliable and tested.\nNightly: Development versions that have all the latest features and fixes, but may contain bugs and are less stable.</translation>
+		</message>
+		<message>
+			<source>GUIBackgroundImageGroupBox</source>
+			<translation>Background Image:\nControl the opacity of the game background image.</translation>
 		</message>
 		<message>
 			<source>GUIMusicGroupBox</source>

--- a/src/qt_gui/translations/es_ES.ts
+++ b/src/qt_gui/translations/es_ES.ts
@@ -749,6 +749,18 @@
 			<translation>Disable Trophy Pop-ups</translation>
 		</message>
 		<message>
+			<source>Background Image</source>
+			<translation>Imagen de fondo</translation>
+		</message>
+		<message>
+			<source>Show Background Image</source>
+			<translation>Mostrar Imagen de Fondo</translation>
+		</message>
+		<message>
+			<source>Opacity</source>
+			<translation>Opacidad</translation>
+		</message>
+		<message>
 			<source>Play title music</source>
 			<translation>Reproducir la música de apertura</translation>
 		</message>
@@ -843,6 +855,10 @@
 		<message>
 			<source>updaterGroupBox</source>
 			<translation>Actualización:\nRelease: Versiones oficiales lanzadas cada mes que pueden estar muy desactualizadas, pero son más confiables y están probadas.\nNightly: Versiones de desarrollo que tienen todas las últimas funciones y correcciones, pero pueden contener errores y son menos estables.</translation>
+		</message>
+		<message>
+			<source>GUIBackgroundImageGroupBox</source>
+			<translation>Imagen de fondo:\nControle la opacidad de la imagen de fondo del juego.</translation>
 		</message>
 		<message>
 			<source>GUIMusicGroupBox</source>


### PR DESCRIPTION
This pr aims to fix [this](https://github.com/shadps4-emu/shadPS4/issues/2258) issue, by changing the way the background image for games is computed and also adding a checkbox to be able to hide the background image and a slider to change the opacity of the displayed image.

Also while using grid view I came across a bug that would cause the emulator to crash if a cell was selected and the refresh button was pressed, this caused an integer overflow on onCurrentCellChanged, this was easily fixed by some bounds checking.

List view example:
![output](https://github.com/user-attachments/assets/b4d022d2-96e3-43d7-aab8-94d0af6302be)

Grid view example:
![output1](https://github.com/user-attachments/assets/997d54a6-d99d-477e-9417-80dc4211436d)

Added base English translations for the new UI elements and Spanish translations aswell.

