### PR TITLE
Reduce redundant calls to sceKernelIsNeoMode, improve BB frame times

### DIFF
--- a/src/core/libraries/kernel/process.cpp
+++ b/src/core/libraries/kernel/process.cpp
@@ -13,7 +13,6 @@
 namespace Libraries::Kernel {
 
 int PS4_SYSV_ABI sceKernelIsNeoMode() {
-    LOG_DEBUG(Kernel_Sce, "called");
     return Config::isNeoModeConsole() &&
            Common::ElfInfo::Instance().GetPSFAttributes().support_neo_mode;
 }


### PR DESCRIPTION
I found this call to `sceKernelIsNeoMode` while poking around in the profiler. I saw that calls are very frequent (especially inside the conversion of texture descriptors to the Vulkan renderer). They are taking up some 750+ ms out of a 10 second sample. I sampled in several different places, and these calls were often only taking up as much as 400ms, depending on the scene being rendered, but still a not small chunk.

This change makes the code very slightly less appealing, but it's reducing 6040 calls to 65 (at least, those are the ones the sample-based profiler caught in a 10 second sample). Specifically, that sample was taken at the top of the DLC Nightmare Catherdral, notably the worst performing part of the game I've been able to find.

Before:
![image](https://github.com/user-attachments/assets/ed42988a-8f70-40e9-992d-3180c6613fa0)

After:
![image](https://github.com/user-attachments/assets/7e37a6dc-c037-4734-9cc9-177ac01e9aaa)

I made an automation build here and tested both EXEs side by side in several parts of the game, and have screenshots from those tests. I loaded the emulator and loaded the save game, straight into these areas, and did not move the camera. I let the frame rate settle before taking screenshots, and attempted to capture the screenshot that got the highest frame rate I was seeing. If I missed the screenshot, I let it settle a bit again before taking another one.

Test Configuration -

Game Mods:
- Vertex explosions fix (modifies base game files)
- Skip intro
- Disable motion blur
- Disable chromatic aberration
- Disable HTTP calls
- 60fps patch
- vsync off
- vblank divider 2

Box:
- Windows 10
- 64GB RAM
- nVidia RTX 3080 10GB VRAM
- AMD 5950x (16-core processor)

In almost every scene there is a slight performance improvement.

Some other folks in chat also did some A/B testing, took some screenshots, and were getting a bit of a performance increase.

Before:
![1-before](https://github.com/user-attachments/assets/ec1b9a9f-1aec-420f-a4b9-b3875b61db5c)

After:
![1-after](https://github.com/user-attachments/assets/e15773d7-08f2-4530-948d-f1ec7309c677)

Before:
![2-before](https://github.com/user-attachments/assets/58c91f14-0b6b-4d49-ba6d-8d7bddc7049f)

After:
![2-after](https://github.com/user-attachments/assets/64e7994f-7f70-450b-9c47-a9dbadcd2e09)

Before:
![3-before](https://github.com/user-attachments/assets/c1950a3b-8b59-4640-94a2-501cbed93211)

After:
![3-after](https://github.com/user-attachments/assets/934f9b68-2216-481a-9ecc-6e539f41ceb9)

Before:
![4-before](https://github.com/user-attachments/assets/21bee82a-308c-4689-8589-28bc422b26af)

After
![4-after](https://github.com/user-attachments/assets/e6749079-7527-4234-a648-786c8c25bab7)

Before:
![5-before](https://github.com/user-attachments/assets/53683c79-0e46-41d6-9cb3-a2d30503c0aa)

After:
![5-after](https://github.com/user-attachments/assets/894db2bd-0640-419e-b7c4-7259e08bbd12)

Before:
![6-before](https://github.com/user-attachments/assets/27fa18cf-5bf6-4c36-8e79-0b5884a4761b)

After:
![6-after](https://github.com/user-attachments/assets/9b9c8c33-2395-49dd-bff1-ac461793d7bc)

Before:
![7-before](https://github.com/user-attachments/assets/c7a596f5-ffe1-4f3e-a412-49017dd92454)

After:
![7-after](https://github.com/user-attachments/assets/d8553e98-8c83-4dd0-8a76-be5f6a9d7f08)

Before:
![8-before](https://github.com/user-attachments/assets/7e47c58d-8c61-449a-bb2e-b9e8fd74555b)

After:
![8-after](https://github.com/user-attachments/assets/335aa804-2e39-479e-b181-88b7b6f22751)
