### PR TITLE
Fix shader type names

### DIFF
--- a/src/shader_recompiler/ir/type.cpp
+++ b/src/shader_recompiler/ir/type.cpp
@@ -9,9 +9,10 @@ namespace Shader::IR {
 
 std::string NameOf(Type type) {
     static constexpr std::array names{
-        "Opaque", "Label", "Reg",   "Pred",  "Attribute", "U1",    "U8",    "U16",          "U32",
-        "U64",    "F16",   "F32",   "F64",   "U32x2",     "U32x3", "U32x4", "F16x2",        "F16x3",
-        "F16x4",  "F32x2", "F32x3", "F32x4", "F64x2",     "F64x3", "F64x4", "StringLiteral"};
+        "Opaque", "ScalarReg", "VectorReg", "Attribute", "Patch",        "U1",    "U8",
+        "U16",    "U32",       "U64",       "F16",       "F32",          "F64",   "U32x2",
+        "U32x3",  "U32x4",     "F16x2",     "F16x3",     "F16x4",        "F32x2", "F32x3",
+        "F32x4",  "F64x2",     "F64x3",     "F64x4",     "StringLiteral"};
     const size_t bits{static_cast<size_t>(type)};
     if (bits == 0) {
         return "Void";


### PR DESCRIPTION
Names didn't match definition in type.h

https://github.com/shadps4-emu/shadPS4/blob/8ad650582a947fecd4308d29d83955de9be9f11a/src/shader_recompiler/ir/type.h#L12-L40