### PR TITLE
Format log lines to make it possible to ctrl click on them and go to the corresponding line in the source code

### DIFF
--- a/src/common/logging/text_formatter.cpp
+++ b/src/common/logging/text_formatter.cpp
@@ -23,8 +23,8 @@ std::string FormatLogMessage(const Entry& entry) {
     const char* class_name = GetLogClassName(entry.log_class);
     const char* level_name = GetLevelName(entry.log_level);
 
-    return fmt::format("[{}] <{}> {}:{}:{}: {}", class_name, level_name, entry.filename,
-                       entry.function, entry.line_num, entry.message);
+    return fmt::format("[{}] <{}> {}:{} {}: {}", class_name, level_name, entry.filename,
+                       entry.line_num, entry.function, entry.message);
 }
 
 void PrintMessage(const Entry& entry) {


### PR DESCRIPTION
This is only going to be useful for me and like 5 other people who work on this project and use VS code and its builtin terminal (and maybe it works in some other IDEs that also have an integrated terminal). For everyone else, this doesn't affect anything, other than the fact that a log line looks slightly different.