### PR TITLE
vk_rasterizer: Bump size of buffer_views

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -111,7 +111,7 @@ private:
         cb_descs;
     std::optional<std::pair<VideoCore::ImageId, VideoCore::TextureCache::DepthTargetDesc>> db_desc;
     boost::container::static_vector<vk::DescriptorImageInfo, 64> image_infos;
-    boost::container::static_vector<vk::BufferView, 8> buffer_views;
+    boost::container::static_vector<vk::BufferView, 16> buffer_views;
     boost::container::static_vector<vk::DescriptorBufferInfo, 32> buffer_infos;
     boost::container::static_vector<VideoCore::ImageId, 64> bound_images;
 


### PR DESCRIPTION
Uncharted 4 (and perhaps some other games) fill this up, causing an `Unhandled exception: boost::container::bad_alloc thrown` exception.