### PR TITLE
vulkan: Use more supported 4444 format.

### DIFF
--- a/src/video_core/amdgpu/types.h
+++ b/src/video_core/amdgpu/types.h
@@ -322,6 +322,15 @@ inline CompMapping RemapSwizzle(const DataFormat format, const CompMapping swizz
         result.a = swizzle.a;
         return result;
     }
+    case DataFormat::Format4_4_4_4: {
+        // Remap to a more supported component order.
+        CompMapping result;
+        result.r = swizzle.a;
+        result.g = swizzle.r;
+        result.b = swizzle.g;
+        result.a = swizzle.b;
+        return result;
+    }
     default:
         return swizzle;
     }

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -618,7 +618,7 @@ std::span<const SurfaceFormatInfo> SurfaceFormats() {
                                 vk::Format::eR5G5B5A1UnormPack16),
         // 4_4_4_4
         CreateSurfaceFormatInfo(AmdGpu::DataFormat::Format4_4_4_4, AmdGpu::NumberFormat::Unorm,
-                                vk::Format::eA4B4G4R4UnormPack16),
+                                vk::Format::eB4G4R4A4UnormPack16),
         // 8_24
         // 24_8
         // X24_8_32

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -251,7 +251,6 @@ bool Instance::CreateDevice() {
     add_extension(VK_EXT_SHADER_DEMOTE_TO_HELPER_INVOCATION_EXTENSION_NAME);
     add_extension(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     add_extension(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
-    add_extension(VK_EXT_4444_FORMATS_EXTENSION_NAME);
     tooling_info = add_extension(VK_EXT_TOOLING_INFO_EXTENSION_NAME);
     const bool maintenance4 = add_extension(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
 
@@ -372,9 +371,6 @@ bool Instance::CreateDevice() {
         },
         vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT{
             .extendedDynamicState = true,
-        },
-        vk::PhysicalDevice4444FormatsFeaturesEXT{
-            .formatA4B4G4R4 = true,
         },
         vk::PhysicalDeviceMaintenance4FeaturesKHR{
             .maintenance4 = true,


### PR DESCRIPTION
Use more supported 4444 format, as the one currently used is not supported on some Intel GPUs.

Someone with Intel GPU please check if this fixes the recent crash on boot.