### PR TITLE
Game-compatibility - improved

### DIFF
--- a/src/qt_gui/compatibility_info.cpp
+++ b/src/qt_gui/compatibility_info.cpp
@@ -34,7 +34,7 @@ void CompatibilityInfoClass::UpdateCompatibilityDatabase(QWidget* parent, bool f
     if (!WaitForReply(reply)) {
         reply->deleteLater();
         QMessageBox::critical(parent, tr("Error"),
-                              tr("Tempo limite ao baixar os dados de compatibilidade."));
+                              tr("Timeout while downloading compatibility data."));
         return;
     }
 

--- a/src/qt_gui/compatibility_info.cpp
+++ b/src/qt_gui/compatibility_info.cpp
@@ -49,17 +49,19 @@ void CompatibilityInfoClass::UpdateCompatibilityDatabase(QWidget* parent, bool f
     loop.exec();
 
     if (reply->error() != QNetworkReply::NoError) {
-        QMessageBox::critical(parent, tr("Error"),
-                              tr("Unable to update compatibility data! Try again later.") +
-                                  reply->errorString());
         reply->deleteLater();
+        QMessageBox::critical(parent, tr("Error"),
+                              tr("Unable to update compatibility data! Try again later."));
+        // Try loading compatibility_file.json again
+        if (!forced)
+            LoadCompatibilityFile();
         return;
     }
 
     QFile compatibility_file(m_compatibility_filename);
     if (!compatibility_file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
         QMessageBox::critical(parent, tr("Error"),
-                              tr("Unable to open compatibility.json for writing."));
+                              tr("Unable to open compatibility_data.json for writing."));
         reply->deleteLater();
         return;
     }

--- a/src/qt_gui/compatibility_info.h
+++ b/src/qt_gui/compatibility_info.h
@@ -47,7 +47,7 @@ struct CompatibilityEntry {
     QString version;
     QDateTime last_tested;
     QString url;
-    int issue_number;
+    QString issue_number;
 };
 
 class CompatibilityInfoClass : public QObject {
@@ -80,7 +80,6 @@ public:
     CompatibilityEntry GetCompatibilityInfo(const std::string& serial);
     const QString GetCompatStatusString(const CompatibilityStatus status);
     void ExtractCompatibilityInfo(QByteArray response);
-    static bool WaitForReply(QNetworkReply* reply);
 
 private:
     QNetworkAccessManager* m_network_manager;

--- a/src/qt_gui/compatibility_info.h
+++ b/src/qt_gui/compatibility_info.h
@@ -11,8 +11,6 @@
 #include "common/config.h"
 #include "core/file_format/psf.h"
 
-static constexpr int COMPAT_DB_VERSION = 1;
-
 enum class CompatibilityStatus {
     Unknown,
     Nothing,
@@ -83,7 +81,6 @@ public:
     const QString GetCompatStatusString(const CompatibilityStatus status);
     void ExtractCompatibilityInfo(QByteArray response);
     static bool WaitForReply(QNetworkReply* reply);
-    QNetworkReply* FetchPage(int page_num);
 
 private:
     QNetworkAccessManager* m_network_manager;

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -77,7 +77,7 @@ GameListFrame::GameListFrame(std::shared_ptr<GameInfoClass> game_info_get,
     });
 
     connect(this, &QTableWidget::cellClicked, this, [=, this](int row, int column) {
-        if (column == 2) {
+        if (column == 2 && m_game_info->m_games[row].compatibility.issue_number != "") {
             auto url_issues = "https://github.com/shadps4-emu/shadps4-game-compatibility/issues/";
             QDesktopServices::openUrl(
                 QUrl(url_issues + m_game_info->m_games[row].compatibility.issue_number));
@@ -280,7 +280,8 @@ void GameListFrame::SetCompatibilityItem(int row, int column, CompatibilityEntry
         tooltip_string = status_explanation;
     } else {
         tooltip_string =
-            "<p> <i>" + tr("Click to go to issue") + "</i>" + "<br>" + tr("Last updated") +
+            "<p> <i>" + tr("Click to see details on github") + "</i>" + "<br>" +
+            tr("Last updated") +
             QString(": %1 (%2)").arg(entry.last_tested.toString("yyyy-MM-dd"), entry.version) +
             "<br>" + status_explanation + "</p>";
     }
@@ -297,6 +298,7 @@ void GameListFrame::SetCompatibilityItem(int row, int column, CompatibilityEntry
     dotLabel->setPixmap(circle_pixmap);
 
     QLabel* label = new QLabel(m_compat_info->GetCompatStatusString(entry.status), widget);
+    this->horizontalHeader()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
 
     label->setStyleSheet("color: white; font-size: 16px; font-weight: bold;");
 

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -77,8 +77,10 @@ GameListFrame::GameListFrame(std::shared_ptr<GameInfoClass> game_info_get,
     });
 
     connect(this, &QTableWidget::cellClicked, this, [=, this](int row, int column) {
-        if (column == 2 && !m_game_info->m_games[row].compatibility.url.isEmpty()) {
-            QDesktopServices::openUrl(QUrl(m_game_info->m_games[row].compatibility.url));
+        if (column == 2) {
+            auto url_issues = "https://github.com/shadps4-emu/shadps4-game-compatibility/issues/";
+            QDesktopServices::openUrl(
+                QUrl(url_issues + m_game_info->m_games[row].compatibility.issue_number));
         }
     });
 }

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -202,10 +202,14 @@ void MainWindow::CreateDockWindows() {
 }
 
 void MainWindow::LoadGameLists() {
+    // Load compatibility database
+    if (Config::getCompatibilityEnabled())
+        m_compat_info->LoadCompatibilityFile();
+
     // Update compatibility database
-    if (Config::getCheckCompatibilityOnStartup()) {
+    if (Config::getCheckCompatibilityOnStartup())
         m_compat_info->UpdateCompatibilityDatabase(this);
-    }
+
     // Get game info from game folders.
     m_game_info->GetGameInfo(this);
     if (isTableList) {

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -159,14 +159,18 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices,
                 });
 
 #if (QT_VERSION < QT_VERSION_CHECK(6, 7, 0))
-        connect(ui->enableCompatibilityCheckBox, &QCheckBox::stateChanged, this, [this](int state) {
+        connect(ui->enableCompatibilityCheckBox, &QCheckBox::stateChanged, this,
+                [this, m_compat_info](int state) {
 #else
         connect(ui->enableCompatibilityCheckBox, &QCheckBox::checkStateChanged, this,
-                [this](Qt::CheckState state) {
+                [this, m_compat_info](Qt::CheckState state) {
 #endif
-            Config::setCompatibilityEnabled(state);
-            emit CompatibilityChanged();
-        });
+                    Config::setCompatibilityEnabled(state);
+                    if (state) {
+                        m_compat_info->LoadCompatibilityFile();
+                    }
+                    emit CompatibilityChanged();
+                });
     }
 
     // Gui TAB

--- a/src/qt_gui/translations/ar.ts
+++ b/src/qt_gui/translations/ar.ts
@@ -629,7 +629,7 @@
 			<translation>الرسومات</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>واجهة</translation>
 		</message>
 		<message>
@@ -1278,6 +1278,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>انقر لرؤية التفاصيل على GitHub</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>آخر تحديث</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1403,6 +1411,61 @@
 		<message>
 			<source>TB</source>
 			<translation>TB</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>جاري جلب بيانات التوافق، يرجى الانتظار</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>إلغاء</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>جاري التحميل...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>خطأ</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>تعذر تحديث بيانات التوافق! حاول مرة أخرى لاحقاً.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>تعذر فتح compatibility_data.json للكتابة.</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>غير معروف</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>لا شيء</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>أحذية</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>قوائم</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>داخل اللعبة</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>قابل للعب</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>غير معروف</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/da_DK.ts
+++ b/src/qt_gui/translations/da_DK.ts
@@ -629,7 +629,7 @@
 			<translation>Graphics</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>Interface</translation>
 		</message>
 		<message>
@@ -1278,6 +1278,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>Klik for at se detaljer på GitHub</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>Sidst opdateret</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1403,6 +1411,61 @@
 		<message>
 			<source>TB</source>
 			<translation>TB</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>Henter kompatibilitetsdata, vent venligst</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>Annuller</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>Indlæser...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Fejl</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>Kan ikke opdatere kompatibilitetsdata! Prøv igen senere.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>Kan ikke åbne compatibility_data.json til skrivning.</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Ukendt</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>Intet</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>Støvler</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>Menuer</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>I spillet</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>Spilbar</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Ukendt</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/de.ts
+++ b/src/qt_gui/translations/de.ts
@@ -653,7 +653,7 @@
 			<translation>Grafik</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>Benutzeroberfläche</translation>
 		</message>
 		<message>
@@ -1302,6 +1302,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Spiel kann mit spielbarer Leistung und keinen großen Störungen abgeschlossen werden</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>Klicken Sie hier, um Details auf GitHub zu sehen</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>Zuletzt aktualisiert</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1454,6 +1462,61 @@
 		<message>
 			<source>Playable</source>
 			<translation>Spielbar</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>Lade Kompatibilitätsdaten, bitte warten</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>Abbrechen</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>Lädt...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Fehler</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>Kompatibilitätsdaten konnten nicht aktualisiert werden! Versuchen Sie es später erneut.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>Kann compatibility_data.json nicht zum Schreiben öffnen.</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Unbekannt</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>Nichts</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>Stiefel</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>Menüs</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>Im Spiel</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>Spielbar</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Unbekannt</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/el.ts
+++ b/src/qt_gui/translations/el.ts
@@ -629,7 +629,7 @@
 			<translation>Graphics</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>Διεπαφή</translation>
 		</message>
 		<message>
@@ -1278,6 +1278,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>Κάντε κλικ για να δείτε λεπτομέρειες στο GitHub</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>Τελευταία ενημέρωση</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1403,6 +1411,61 @@
 		<message>
 			<source>TB</source>
 			<translation>TB</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>Φόρτωση δεδομένων συμβατότητας, παρακαλώ περιμένετε</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>Ακύρωση</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>Φόρτωση...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Σφάλμα</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>Δεν ήταν δυνατή η ενημέρωση των δεδομένων συμβατότητας! Προσπαθήστε αργότερα.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>Αδύνατο να ανοίξετε το compatibility_data.json για εγγραφή.</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Άγνωστο</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>Τίποτα</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>Μπότες</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>Μενού</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>Εντός παιχνιδιού</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>Παιχνιδεύσιμο</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Άγνωστο</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/en.ts
+++ b/src/qt_gui/translations/en.ts
@@ -637,7 +637,7 @@
 			<translation>Graphics</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>Gui</translation>
 		</message>
 		<message>
@@ -1311,6 +1311,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>Click to see details on GitHub</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>Last updated</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1441,6 +1449,30 @@
 	<context>
 		<name>CompatibilityInfoClass</name>
 		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>Fetching compatibility data, please wait</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>Cancel</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>Loading...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Error</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>Unable to update compatibility data! Try again later.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>Unable to open compatibility_data.json for writing.</translation>
+		</message>
+		<message>
 			<source>Unknown</source>
 			<translation>Unknown</translation>
 		</message>
@@ -1463,6 +1495,10 @@
 		<message>
 			<source>Playable</source>
 			<translation>Playable</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Unknown</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/es_ES.ts
+++ b/src/qt_gui/translations/es_ES.ts
@@ -629,7 +629,7 @@
 			<translation>Gráficos</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>Interfaz</translation>
 		</message>
 		<message>
@@ -1294,6 +1294,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>Haz clic para ver detalles en GitHub</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>Última actualización</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1446,6 +1454,61 @@
 		<message>
 			<source>Playable</source>
 			<translation>Jugable</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>Obteniendo datos de compatibilidad, por favor espera</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>Cancelar</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>Cargando...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Error</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>¡No se pudo actualizar los datos de compatibilidad! Intenta de nuevo más tarde.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>No se pudo abrir compatibility_data.json para escribir.</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Desconocido</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>Nada</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>Botas</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>Menús</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>En el juego</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>Jugable</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Desconocido</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/fa_IR.ts
+++ b/src/qt_gui/translations/fa_IR.ts
@@ -629,7 +629,7 @@
 			<translation>گرافیک</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>رابط کاربری</translation>
 		</message>
 		<message>
@@ -1278,6 +1278,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>بازی با عملکرد قابل قبول و بدون اشکالات عمده قابل بازی است.</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>برای مشاهده جزئیات در GitHub کلیک کنید</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>آخرین به‌روزرسانی</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1403,6 +1411,61 @@
 		<message>
 			<source>TB</source>
 			<translation>TB</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>در حال بارگذاری داده‌های سازگاری، لطفاً صبر کنید</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>لغو</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>در حال بارگذاری...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>خطا</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>ناتوان از بروزرسانی داده‌های سازگاری! لطفاً بعداً دوباره تلاش کنید.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>امکان باز کردن compatibility_data.json برای نوشتن وجود ندارد.</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>ناشناخته</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>هیچ چیز</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>چکمه‌ها</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>منوها</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>داخل بازی</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>قابل بازی</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>ناشناخته</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/fi.ts
+++ b/src/qt_gui/translations/fi.ts
@@ -629,7 +629,7 @@
 			<translation>Grafiikka</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>Rajapinta</translation>
 		</message>
 		<message>
@@ -1278,6 +1278,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Pelillä on hyväksyttävä suorituskyky, eikä mitään suuria häiriöitä</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>Napsauta nähdäksesi lisätiedot GitHubissa</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>Viimeksi päivitetty</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1403,6 +1411,61 @@
 		<message>
 			<source>TB</source>
 			<translation>TB</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>Haetaan yhteensopivuustietoja, odota</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>Peruuta</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>Ladataan...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Virhe</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>Yhteensopivuustietoja ei voitu päivittää! Yritä myöhemmin uudelleen.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>Ei voitu avata compatibility_data.json-tiedostoa kirjoittamista varten.</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Tuntematon</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>Ei mitään</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>Sahat</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>Valikot</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>Pelin aikana</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>Pelattava</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Tuntematon</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/fr.ts
+++ b/src/qt_gui/translations/fr.ts
@@ -629,7 +629,7 @@
 			<translation>Graphismes</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>Interface</translation>
 		</message>
 		<message>
@@ -1278,6 +1278,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Le jeu peut être terminé avec des performances acceptables et sans problèmes majeurs</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>Cliquez pour voir les détails sur GitHub</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>Dernière mise à jour</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1430,6 +1438,61 @@
 		<message>
 			<source>Playable</source>
 			<translation>Jouable</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>Récupération des données de compatibilité, veuillez patienter</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>Annuler</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>Chargement...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Erreur</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>Impossible de mettre à jour les données de compatibilité ! Essayez plus tard.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>Impossible d'ouvrir compatibility_data.json en écriture.</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Inconnu</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>Rien</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>Bottes</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>Menus</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>En jeu</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>Jouable</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Inconnu</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/hu_HU.ts
+++ b/src/qt_gui/translations/hu_HU.ts
@@ -629,7 +629,7 @@
 			<translation>Grafika</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>Felület</translation>
 		</message>
 		<message>
@@ -1278,6 +1278,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>Kattintson a részletek megtekintéséhez a GitHubon</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>Utoljára frissítve</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1403,6 +1411,61 @@
 		<message>
 			<source>TB</source>
 			<translation>TB</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>Kompatibilitási adatok betöltése, kérem várjon</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>Megszakítás</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>Betöltés...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Hiba</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>Nem sikerült frissíteni a kompatibilitási adatokat! Kérem próbálja újra később.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>Nem sikerült megnyitni a compatibility_data.json fájlt írásra.</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Ismeretlen</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>Semmi</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>Csizmák</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>Menük</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>Játékban</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>Játszható</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Ismeretlen</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/id.ts
+++ b/src/qt_gui/translations/id.ts
@@ -629,7 +629,7 @@
 			<translation>Graphics</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>Antarmuka</translation>
 		</message>
 		<message>
@@ -1278,6 +1278,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>Klik untuk melihat detail di GitHub</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>Terakhir diperbarui</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1403,6 +1411,61 @@
 		<message>
 			<source>TB</source>
 			<translation>TB</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>Memuat data kompatibilitas, harap tunggu</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>Batal</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>Memuat...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Kesalahan</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>Tidak dapat memperbarui data kompatibilitas! Coba lagi nanti.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>Tidak dapat membuka compatibility_data.json untuk menulis.</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Tidak Dikenal</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>Tidak ada</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>Sepatu Bot</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>Menu</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>Dalam Permainan</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>Playable</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Tidak Dikenal</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/it.ts
+++ b/src/qt_gui/translations/it.ts
@@ -629,7 +629,7 @@
 			<translation>Grafica</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>Interfaccia</translation>
 		</message>
 		<message>
@@ -1278,6 +1278,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Il gioco può essere completato con buone prestazioni e senza problemi gravi</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>Fai clic per vedere i dettagli su GitHub</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>Ultimo aggiornamento</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1403,6 +1411,61 @@
 		<message>
 			<source>TB</source>
 			<translation>TB</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>Recuperando dati di compatibilità, per favore attendere</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>Annulla</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>Caricamento...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Errore</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>Impossibile aggiornare i dati di compatibilità! Riprova più tardi.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>Impossibile aprire compatibility_data.json per la scrittura.</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Sconosciuto</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>Niente</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>Stivali</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>Menu</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>In gioco</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>Giocabile</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Sconosciuto</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/ja_JP.ts
+++ b/src/qt_gui/translations/ja_JP.ts
@@ -629,7 +629,7 @@
 			<translation>グラフィックス</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>インターフェース</translation>
 		</message>
 		<message>
@@ -1278,6 +1278,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>パフォーマンスに問題はなく、大きな不具合なしでゲームをプレイすることができます</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>詳細を見るにはGitHubをクリックしてください</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>最終更新</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1403,6 +1411,61 @@
 		<message>
 			<source>TB</source>
 			<translation>TB</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>互換性データを取得しています。少々お待ちください。</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>キャンセル</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>読み込み中...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>エラー</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>互換性データを更新できませんでした！後で再試行してください。</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>compatibility_data.jsonを開いて書き込むことができませんでした。</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>不明</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>何もない</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>ブーツ</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>メニュー</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>ゲーム内</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>プレイ可能</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>不明</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/ko_KR.ts
+++ b/src/qt_gui/translations/ko_KR.ts
@@ -629,7 +629,7 @@
 			<translation>Graphics</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>인터페이스</translation>
 		</message>
 		<message>
@@ -1278,6 +1278,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>GitHub에서 세부 정보를 보려면 클릭하세요</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>마지막 업데이트</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1403,6 +1411,61 @@
 		<message>
 			<source>TB</source>
 			<translation>TB</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>호환성 데이터를 가져오는 중, 잠시만 기다려 주세요</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>취소</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>로딩 중...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>오류</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>호환성 데이터를 업데이트할 수 없습니다! 나중에 다시 시도해 주세요.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>compatibility_data.json을 열어 쓸 수 없습니다.</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>알 수 없음</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>없음</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>부츠</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>메뉴</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>게임 내</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>플레이 가능</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>알 수 없음</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/lt_LT.ts
+++ b/src/qt_gui/translations/lt_LT.ts
@@ -629,7 +629,7 @@
 			<translation>Graphics</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>Interfeisa</translation>
 		</message>
 		<message>
@@ -1278,6 +1278,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>Spustelėkite, kad pamatytumėte detales GitHub</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>Paskutinį kartą atnaujinta</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1403,6 +1411,61 @@
 		<message>
 			<source>TB</source>
 			<translation>TB</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>Naudojamos suderinamumo duomenis, prašome palaukti</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>Atšaukti</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>Kraunama...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Klaida</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>Negalima atnaujinti suderinamumo duomenų! Bandykite vėliau.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>Negalima atidaryti compatibility_data.json failo rašymui.</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Nežinoma</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>Nėra</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>Batai</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>Meniu</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>Žaidime</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>Žaidžiamas</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Nežinoma</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/nb.ts
+++ b/src/qt_gui/translations/nb.ts
@@ -1323,8 +1323,8 @@
 			<translation>Spillet kan fullføres med spillbar ytelse og uten store feil</translation>
 		</message>
 		<message>
-			<source>Click to go to issue</source>
-			<translation>Klikk for å gå til rapporten</translation>
+			<source>Click to see details on github</source>
+			<translation>Klikk for å se detaljer på GitHub</translation>
 		</message>
 		<message>
 			<source>Last updated</source>
@@ -1494,6 +1494,61 @@
 		<message>
 			<source>Loading...</source>
 			<translation>Laster...</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>Henter kompatibilitetsdata, vennligst vent</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>Avbryt</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>Laster...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Feil</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>Kan ikke oppdatere kompatibilitetsdata! Prøv igjen senere.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>Kan ikke åpne compatibility_data.json for skriving.</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Ukendt</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>Ingenting</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>Støvler</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>Menyene</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>I spill</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>Spillbar</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Ukendt</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/nl.ts
+++ b/src/qt_gui/translations/nl.ts
@@ -629,7 +629,7 @@
 			<translation>Graphics</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>Interface</translation>
 		</message>
 		<message>
@@ -1278,6 +1278,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>Klik om details op GitHub te bekijken</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>Laatst bijgewerkt</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1403,6 +1411,61 @@
 		<message>
 			<source>TB</source>
 			<translation>TB</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>Compatibiliteitsgegevens ophalen, even geduld</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>Annuleren</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>Laden...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Fout</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>Kan compatibiliteitsgegevens niet bijwerken! Probeer het later opnieuw.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>Kan compatibility_data.json niet openen voor schrijven.</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Onbekend</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>Niets</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>Laarsjes</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>Menu's</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>In het spel</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>Speelbaar</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Onbekend</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/pl_PL.ts
+++ b/src/qt_gui/translations/pl_PL.ts
@@ -629,7 +629,7 @@
 			<translation>Grafika</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>Interfejs</translation>
 		</message>
 		<message>
@@ -1278,6 +1278,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Grę można ukończyć z grywalną wydajnością i bez większych usterek</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>Kliknij, aby zobaczyć szczegóły na GitHub</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>Ostatnia aktualizacja</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1403,6 +1411,61 @@
 		<message>
 			<source>TB</source>
 			<translation>TB</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>Pobieranie danych o kompatybilności, proszę czekać</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>Anuluj</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>Ładowanie...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Błąd</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>Nie można zaktualizować danych o kompatybilności! Spróbuj ponownie później.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>Nie można otworzyć pliku compatibility_data.json do zapisu.</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Nieznany</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>Nic</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>Buty</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>Menu</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>W grze</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>Do grania</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Nieznany</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/pt_BR.ts
+++ b/src/qt_gui/translations/pt_BR.ts
@@ -629,7 +629,7 @@
 			<translation>Gráficos</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>Interface</translation>
 		</message>
 		<message>
@@ -1282,6 +1282,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>O jogo pode ser concluído com desempenho jogável e sem grandes falhas</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>Clique para ver detalhes no github</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>Última atualização</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1407,6 +1415,61 @@
 		<message>
 			<source>TB</source>
 			<translation>TB</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>Obtendo dados de compatibilidade, por favor aguarde</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>Cancelar</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>Carregando...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Erro</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>Não foi possível atualizar os dados de compatibilidade! Tente novamente mais tarde.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>Não foi possível abrir o compatibility_data.json para escrita.</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Desconhecido</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>Nada</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>Boot</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>Menus</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>Em jogo</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>Jogável</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Desconhecido</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/ro_RO.ts
+++ b/src/qt_gui/translations/ro_RO.ts
@@ -629,7 +629,7 @@
 			<translation>Graphics</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>Interfață</translation>
 		</message>
 		<message>
@@ -1278,6 +1278,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>Faceți clic pentru a vedea detalii pe GitHub</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>Ultima actualizare</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1403,6 +1411,61 @@
 		<message>
 			<source>TB</source>
 			<translation>TB</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>Se colectează datele de compatibilitate, vă rugăm să așteptați</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>Anulează</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>Se încarcă...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Eroare</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>Nu se poate actualiza datele de compatibilitate! Încercați din nou mai târziu.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>Nu se poate deschide compatibility_data.json pentru scriere.</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Necunoscut</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>Nimic</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>Botine</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>Meniuri</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>În joc</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>Jucabil</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Necunoscut</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/ru_RU.ts
+++ b/src/qt_gui/translations/ru_RU.ts
@@ -697,7 +697,7 @@
         <translation>Графика</translation>
     </message>
     <message>
-        <source>Gui</source>
+        <source>GUI</source>
         <translation>Интерфейс</translation>
     </message>
     <message>
@@ -1422,14 +1422,14 @@
         <source>Game can be completed with playable performance and no major glitches</source>
         <translation>Игра может быть пройдена с хорошей производительностью и без серьезных сбоев</translation>
     </message>
-    <message>
-        <source>Click to go to issue</source>
-        <translation>Нажмите, чтобы перейти к проблеме</translation>
-    </message>
-    <message>
-        <source>Last updated</source>
-        <translation>Последнее обновление</translation>
-    </message>
+	<message>
+		<source>Click to see details on github</source>
+		<translation>Нажмите, чтобы увидеть детали на GitHub</translation>
+	</message>
+	<message>
+		<source>Last updated</source>
+		<translation>Последнее обновление</translation>
+	</message>
 </context>
 <context>
     <name>CheckUpdate</name>
@@ -1580,8 +1580,8 @@
         <translation>Не удалось обновить данные совместимости! Повторите попытку позже.</translation>
     </message>
     <message>
-        <source>Unable to open compatibility.json for writing.</source>
-        <translation>Не удалось открыть файл compatibility.json для записи.</translation>
+        <source>Unable to open compatibility_data.json for writing.</source>
+        <translation>Не удалось открыть файл compatibility_data.json для записи.</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -1607,5 +1607,60 @@
         <source>Playable</source>
         <translation>Играбельно</translation>
     </message>
+</context>
+<context>
+	<name>CompatibilityInfoClass</name>
+	<message>
+		<source>Fetching compatibility data, please wait</source>
+		<translation>Загрузка данных о совместимости, пожалуйста подождите</translation>
+	</message>
+	<message>
+		<source>Cancel</source>
+		<translation>Отменить</translation>
+	</message>
+	<message>
+		<source>Loading...</source>
+		<translation>Загрузка...</translation>
+	</message>
+	<message>
+		<source>Error</source>
+		<translation>Ошибка</translation>
+	</message>
+	<message>
+		<source>Unable to update compatibility data! Try again later.</source>
+		<translation>Не удалось обновить данные о совместимости! Попробуйте позже.</translation>
+	</message>
+	<message>
+		<source>Unable to open compatibility_data.json for writing.</source>
+		<translation>Не удается открыть compatibility_data.json для записи.</translation>
+	</message>
+	<message>
+		<source>Unknown</source>
+		<translation>Неизвестно</translation>
+	</message>
+	<message>
+		<source>Nothing</source>
+		<translation>Ничего</translation>
+	</message>
+	<message>
+		<source>Boots</source>
+		<translation>Ботинки</translation>
+	</message>
+	<message>
+		<source>Menus</source>
+		<translation>Меню</translation>
+	</message>
+	<message>
+		<source>Ingame</source>
+		<translation>В игре</translation>
+	</message>
+	<message>
+		<source>Playable</source>
+		<translation>Играбельно</translation>
+	</message>
+	<message>
+		<source>Unknown</source>
+		<translation>Неизвестно</translation>
+	</message>
 </context>
 </TS>

--- a/src/qt_gui/translations/sq.ts
+++ b/src/qt_gui/translations/sq.ts
@@ -629,7 +629,7 @@
 			<translation>Grafika</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>Ndërfaqja</translation>
 		</message>
 		<message>
@@ -1278,6 +1278,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Loja mund të përfundohet me performancë të luajtshme dhe pa probleme të mëdha</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>Kliko për të parë detajet në GitHub</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>Përditësimi i fundit</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1403,6 +1411,61 @@
 		<message>
 			<source>TB</source>
 			<translation>TB</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>Po merrni të dhënat e pajtueshmërisë, ju lutemi prisni</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>Anulo</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>Po ngarkohet...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Gabim</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>Nuk mund të përditësohen të dhënat e pajtueshmërisë! Provoni përsëri më vonë.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>Nuk mund të hapet compatibility_data.json për të shkruar.</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Jo i njohur</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>Asgjë</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>Çizme</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>Menutë</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>Në lojë</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>I luajtshëm</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Jo i njohur</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/sv.ts
+++ b/src/qt_gui/translations/sv.ts
@@ -383,8 +383,8 @@
         <translation>Kunde inte uppdatera kompatibilitetsdata! Försök igen senare.</translation>
     </message>
     <message>
-        <source>Unable to open compatibility.json for writing.</source>
-        <translation>Kunde inte öppna compatibility.json för skrivning.</translation>
+        <source>Unable to open compatibility_data.json for writing.</source>
+        <translation>Kunde inte öppna compatibility_data.json för skrivning.</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -538,14 +538,14 @@
         <source>Game can be completed with playable performance and no major glitches</source>
         <translation>Spelet kan spelas klart med spelbar prestanda och utan större problem</translation>
     </message>
-    <message>
-        <source>Click to go to issue</source>
-        <translation>Klicka för att gå till problem</translation>
-    </message>
-    <message>
-        <source>Last updated</source>
-        <translation>Senast uppdaterad</translation>
-    </message>
+	<message>
+		<source>Click to see details on github</source>
+		<translation>Klicka för att se detaljer på GitHub</translation>
+	</message>
+	<message>
+		<source>Last updated</source>
+		<translation>Senast uppdaterad</translation>
+	</message>
 </context>
 <context>
     <name>GameListUtils</name>
@@ -1177,7 +1177,7 @@
         <translation>Grafik</translation>
     </message>
     <message>
-        <source>Gui</source>
+        <source>GUI</source>
         <translation>Gränssnitt</translation>
     </message>
     <message>
@@ -1579,5 +1579,60 @@
         <source>Trophy Viewer</source>
         <translation>Trofé-visare</translation>
     </message>
+</context>
+<context>
+	<name>CompatibilityInfoClass</name>
+	<message>
+		<source>Fetching compatibility data, please wait</source>
+		<translation>Hämtar kompatibilitetsdata, vänligen vänta</translation>
+	</message>
+	<message>
+		<source>Cancel</source>
+		<translation>Avbryt</translation>
+	</message>
+	<message>
+		<source>Loading...</source>
+		<translation>Laddar...</translation>
+	</message>
+	<message>
+		<source>Error</source>
+		<translation>Fel</translation>
+	</message>
+	<message>
+		<source>Unable to update compatibility data! Try again later.</source>
+		<translation>Det går inte att uppdatera kompatibilitetsdata! Försök igen senare.</translation>
+	</message>
+	<message>
+		<source>Unable to open compatibility_data.json for writing.</source>
+		<translation>Kan inte öppna compatibility_data.json för skrivning.</translation>
+	</message>
+	<message>
+		<source>Unknown</source>
+		<translation>Okänt</translation>
+	</message>
+	<message>
+		<source>Nothing</source>
+		<translation>Inget</translation>
+	</message>
+	<message>
+		<source>Boots</source>
+		<translation>Stövlar</translation>
+	</message>
+	<message>
+		<source>Menus</source>
+		<translation>Menyer</translation>
+	</message>
+	<message>
+		<source>Ingame</source>
+		<translation>I spelet</translation>
+	</message>
+	<message>
+		<source>Playable</source>
+		<translation>Spelbar</translation>
+	</message>
+	<message>
+		<source>Unknown</source>
+		<translation>Okänt</translation>
+	</message>
 </context>
 </TS>

--- a/src/qt_gui/translations/tr_TR.ts
+++ b/src/qt_gui/translations/tr_TR.ts
@@ -629,7 +629,7 @@
 			<translation>Grafikler</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>Arayüz</translation>
 		</message>
 		<message>
@@ -1278,6 +1278,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Oyun, oynanabilir performansla tamamlanabilir ve büyük aksaklık yok</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>Detayları görmek için GitHub’a tıklayın</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>Son güncelleme</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1403,6 +1411,61 @@
 		<message>
 			<source>TB</source>
 			<translation>TB</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>Uyumluluk verileri alınıyor, lütfen bekleyin</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>İptal</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>Yükleniyor...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Hata</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>Uyumluluk verileri güncellenemedi! Lütfen daha sonra tekrar deneyin.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>compatibility_data.json dosyasını yazmak için açamadık.</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Bilinmeyen</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>Hiçbir şey</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>Botlar</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>Menüler</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>Oyunda</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>Oynanabilir</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Bilinmeyen</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/uk_UA.ts
+++ b/src/qt_gui/translations/uk_UA.ts
@@ -1375,6 +1375,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Гру можна пройти з хорошою продуктивністю та без серйозних глюків.</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>Натисніть, щоб переглянути деталі на GitHub</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>Останнє оновлення</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1525,8 +1533,8 @@
         	<translation>Не вдалося оновити дані про сумісність! Спробуйте ще раз пізніше.</translation>
     	</message>
     	<message>
-        	<source>Unable to open compatibility.json for writing.</source>
-        	<translation>Не вдалося відкрити файл compatibility.json для запису.</translation>
+        	<source>Unable to open compatibility_data.json for writing.</source>
+        	<translation>Не вдалося відкрити файл compatibility_data.json для запису.</translation>
     	</message>
 		<message>
 			<source>Unknown</source>
@@ -1551,6 +1559,61 @@
 		<message>
 			<source>Playable</source>
 			<translation>Іграбельно</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>Завантаження даних про сумісність, будь ласка, зачекайте</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>Скасувати</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>Завантаження...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Помилка</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>Не вдалося оновити дані про сумісність! Спробуйте пізніше.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>Не вдалося відкрити compatibility_data.json для запису.</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Невідомо</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>Нічого</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>Чоботи</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>Меню</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>У грі</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>Іграбельно</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Невідомо</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/vi_VN.ts
+++ b/src/qt_gui/translations/vi_VN.ts
@@ -629,7 +629,7 @@
 			<translation>Graphics</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>Giao diện</translation>
 		</message>
 		<message>
@@ -1278,6 +1278,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>Nhấp để xem chi tiết trên GitHub</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>Cập nhật lần cuối</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1403,6 +1411,61 @@
 		<message>
 			<source>TB</source>
 			<translation>TB</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>Đang tải dữ liệu tương thích, vui lòng chờ</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>Hủy bỏ</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>Đang tải...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>Lỗi</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>Không thể cập nhật dữ liệu tương thích! Vui lòng thử lại sau.</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>Không thể mở compatibility_data.json để ghi.</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Không xác định</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>Không có gì</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>Giày ủng</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>Menu</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>Trong game</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>Có thể chơi</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>Không xác định</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/zh_CN.ts
+++ b/src/qt_gui/translations/zh_CN.ts
@@ -629,7 +629,7 @@
 			<translation>图像</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>界面</translation>
 		</message>
 		<message>
@@ -1287,6 +1287,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>游戏能在可玩的性能下通关且没有重大 Bug</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>点击查看 GitHub 上的详细信息</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>最后更新</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1439,6 +1447,61 @@
 		<message>
 			<source>Playable</source>
 			<translation>可通关</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>正在获取兼容性数据，请稍等</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>取消</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>加载中...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>错误</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>无法更新兼容性数据！稍后再试。</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>无法打开 compatibility_data.json 进行写入。</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>未知</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>没有</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>靴子</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>菜单</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>游戏内</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>可玩</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>未知</translation>
 		</message>
 	</context>
 </TS>

--- a/src/qt_gui/translations/zh_TW.ts
+++ b/src/qt_gui/translations/zh_TW.ts
@@ -629,7 +629,7 @@
 			<translation>Graphics</translation>
 		</message>
 		<message>
-			<source>Gui</source>
+			<source>GUI</source>
 			<translation>介面</translation>
 		</message>
 		<message>
@@ -1278,6 +1278,14 @@
 			<source>Game can be completed with playable performance and no major glitches</source>
 			<translation>Game can be completed with playable performance and no major glitches</translation>
 		</message>
+		<message>
+			<source>Click to see details on github</source>
+			<translation>點擊查看 GitHub 上的詳細資訊</translation>
+		</message>
+		<message>
+			<source>Last updated</source>
+			<translation>最後更新</translation>
+		</message>
 	</context>
 	<context>
 		<name>CheckUpdate</name>
@@ -1403,6 +1411,61 @@
 		<message>
 			<source>TB</source>
 			<translation>TB</translation>
+		</message>
+	</context>
+	<context>
+		<name>CompatibilityInfoClass</name>
+		<message>
+			<source>Fetching compatibility data, please wait</source>
+			<translation>正在取得相容性資料，請稍候</translation>
+		</message>
+		<message>
+			<source>Cancel</source>
+			<translation>取消</translation>
+		</message>
+		<message>
+			<source>Loading...</source>
+			<translation>載入中...</translation>
+		</message>
+		<message>
+			<source>Error</source>
+			<translation>錯誤</translation>
+		</message>
+		<message>
+			<source>Unable to update compatibility data! Try again later.</source>
+			<translation>無法更新相容性資料！請稍後再試。</translation>
+		</message>
+		<message>
+			<source>Unable to open compatibility_data.json for writing.</source>
+			<translation>無法開啟 compatibility_data.json 進行寫入。</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>未知</translation>
+		</message>
+		<message>
+			<source>Nothing</source>
+			<translation>無</translation>
+		</message>
+		<message>
+			<source>Boots</source>
+			<translation>靴子</translation>
+		</message>
+		<message>
+			<source>Menus</source>
+			<translation>選單</translation>
+		</message>
+		<message>
+			<source>Ingame</source>
+			<translation>遊戲內</translation>
+		</message>
+		<message>
+			<source>Playable</source>
+			<translation>可玩</translation>
+		</message>
+		<message>
+			<source>Unknown</source>
+			<translation>未知</translation>
 		</message>
 	</context>
 </TS>


### PR DESCRIPTION
Let's go...
In short, it improves file loading at startup and makes fewer requests.

If `Display Compatibility Data` is checked, it will load the information already downloaded locally every time you start the emulator. And when you click on it, in addition to adding the columns, it will fill in if you have the file. Because before it would only load if the `Update Compatibility Database On Startup` option was checked.

And speaking of updating, it made more than 20 requests to GitHub to get this data, because it is only possible to request 100 items per page and we currently have more than 2000 issues. https://github.com/shadps4-emu/shadPS4/issues/2364
And this excess of requests ended up affecting the autoUpdate, because there is a limit of 60 requests per hour that GitHub allows without authentication. To solve this I made [this other PR](https://github.com/shadps4-emu/shadps4-game-compatibility/pull/2409), but in the `shadps4-game-compatibility` repository, where the `github action` itself creates the `compatibility_data.json` and no longer the emulator, updating it `every 3 hours`, creating the file in a 'release' and deleting the old ones. this way the emulator will only need to make a request to update the compatibility data.

This PR is in draft status for the following reasons:

- [X] [shadps4-game-compatibility/pull/2409](https://github.com/shadps4-emu/shadps4-game-compatibility/pull/2409) needs to be approved;
- [X] Create token with access to 'repo' `SHADPS4_TOKEN_COMPATIBILITY` in repository 'shadps4-game-compatibility';
- [X] Press 'Run workflow' once to create the .json file;
- [x]  Fix the problem that for some reason sometimes creates a release as a draft
- [x] Changing the repository link in this PR as it is being tested with my fork
- [x] And it's also good for someone to check if everything is working correctly 

*I also removed version_number, I didn't find it necessary...


