### PR TITLE
address_space: Split macOS reserved memory region.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1016,7 +1016,7 @@ if (APPLE)
 
   if (ARCHITECTURE STREQUAL "x86_64")
       # Reserve system-managed memory space.
-      target_link_options(shadps4 PRIVATE -Wl,-no_pie,-no_fixup_chains,-no_huge,-pagezero_size,0x4000,-segaddr,TCB_SPACE,0x4000,-segaddr,GUEST_SYSTEM,0x400000,-image_base,0x20000000000)
+      target_link_options(shadps4 PRIVATE -Wl,-no_pie,-no_fixup_chains,-no_huge,-pagezero_size,0x4000,-segaddr,TCB_SPACE,0x4000,-segaddr,SYSTEM_MANAGED,0x400000,-segaddr,SYSTEM_RESERVED,0x7FFFFC000,-image_base,0x20000000000)
   endif()
 
   # Replacement for std::chrono::time_zone

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -21,7 +21,8 @@
 
 #if defined(__APPLE__) && defined(ARCH_X86_64)
 // Reserve space for the system address space using a zerofill section.
-asm(".zerofill GUEST_SYSTEM,GUEST_SYSTEM,__guest_system,0xFBFC00000");
+asm(".zerofill SYSTEM_MANAGED,SYSTEM_MANAGED,__SYSTEM_MANAGED,0x7FFBFC000");
+asm(".zerofill SYSTEM_RESERVED,SYSTEM_RESERVED,__SYSTEM_RESERVED,0x7C0004000");
 #endif
 
 namespace Core {


### PR DESCRIPTION
Doesn't really change functionality, just useful to have the regions split into separate reservations for my own debugging purposes.