### PR TITLE
shader_recompiler: Exclude defaulted fragment inputs from quad/rect passthrough.

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_quad_rect.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_quad_rect.cpp
@@ -254,10 +254,14 @@ private:
             gl_per_vertex = AddOutput(gl_per_vertex_type);
         }
         for (int i = 0; i < fs_info.num_inputs; i++) {
+            const auto& input = fs_info.inputs[i];
+            if (input.IsDefault()) {
+                continue;
+            }
             outputs[i] = AddOutput(model == spv::ExecutionModel::TessellationControl
                                        ? TypeArray(vec4_id, Int(4))
                                        : vec4_id);
-            Decorate(outputs[i], spv::Decoration::Location, fs_info.inputs[i].param_index);
+            Decorate(outputs[i], spv::Decoration::Location, input.param_index);
         }
     }
 
@@ -273,8 +277,12 @@ private:
         gl_in = AddInput(gl_per_vertex_array);
         const Id float_arr{TypeArray(vec4_id, Int(32))};
         for (int i = 0; i < fs_info.num_inputs; i++) {
+            const auto& input = fs_info.inputs[i];
+            if (input.IsDefault()) {
+                continue;
+            }
             inputs[i] = AddInput(float_arr);
-            Decorate(inputs[i], spv::Decoration::Location, fs_info.inputs[i].param_index);
+            Decorate(inputs[i], spv::Decoration::Location, input.param_index);
         }
     }
 

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -316,7 +316,7 @@ void EmitContext::DefineInputs() {
             const auto& input = runtime_info.fs_info.inputs[i];
             const u32 semantic = input.param_index;
             ASSERT(semantic < IR::NumParams);
-            if (input.is_default && !input.is_flat) {
+            if (input.IsDefault()) {
                 input_params[semantic] = {
                     MakeDefaultValue(*this, input.default_value), input_f32, F32[1], 4, false, true,
                 };

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -174,6 +174,10 @@ struct FragmentRuntimeInfo {
         bool is_flat;
         u8 default_value;
 
+        [[nodiscard]] bool IsDefault() const {
+            return is_default && !is_flat;
+        }
+
         auto operator<=>(const PsInput&) const noexcept = default;
     };
     AmdGpu::Liverpool::PsInput en_flags;


### PR DESCRIPTION
Defaulted parameters are not declared as inputs to the fragment shader. In the quad list / rect list tessellation shaders, fix some validation errors around missing shader inputs from vertex stage by using the same condition on the passthrough declarations as used for declaring the inputs in fragment shaders.