### PR TITLE
cpu_patches: Lower extrq/insertq log to trace.

### DIFF
--- a/src/core/cpu_patches.cpp
+++ b/src/core/cpu_patches.cpp
@@ -1041,10 +1041,10 @@ static bool TryExecuteIllegalInstruction(void* ctx, void* code_address) {
             if (length + index > 64) {
                 // Undefined behavior if length + index is bigger than 64 according to the spec,
                 // we'll warn and continue execution.
-                LOG_WARNING(Core,
-                            "extrq at {} with length {} and index {} is bigger than 64, "
-                            "undefined behavior",
-                            fmt::ptr(code_address), length, index);
+                LOG_TRACE(Core,
+                          "extrq at {} with length {} and index {} is bigger than 64, "
+                          "undefined behavior",
+                          fmt::ptr(code_address), length, index);
             }
 
             lowQWordDst >>= index;
@@ -1101,10 +1101,10 @@ static bool TryExecuteIllegalInstruction(void* ctx, void* code_address) {
             if (length + index > 64) {
                 // Undefined behavior if length + index is bigger than 64 according to the spec,
                 // we'll warn and continue execution.
-                LOG_WARNING(Core,
-                            "insertq at {} with length {} and index {} is bigger than 64, "
-                            "undefined behavior",
-                            fmt::ptr(code_address), length, index);
+                LOG_TRACE(Core,
+                          "insertq at {} with length {} and index {} is bigger than 64, "
+                          "undefined behavior",
+                          fmt::ptr(code_address), length, index);
             }
 
             lowQWordSrc &= mask;


### PR DESCRIPTION
If a game uses `extrq`/`insertq` instructions in a way with undefined behavior according to spec, this log can spam a lot and slow things down. Since this is an expected and handled case, lower it to trace to keep logs out of the hot path.