### PR TITLE
Add HDR option to settings menu

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -341,6 +341,10 @@ void setNullGpu(bool enable) {
     isNullGpu = enable;
 }
 
+void setAllowHDR(bool enable) {
+    isHDRAllowed = enable;
+}
+
 void setCopyGPUCmdBuffers(bool enable) {
     shouldCopyGPUBuffers = enable;
 }

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -69,6 +69,7 @@ void setCollectShaderForDebug(bool enable);
 void setShowSplash(bool enable);
 void setAutoUpdate(bool enable);
 void setNullGpu(bool enable);
+void setAllowHDR(bool enable);
 void setCopyGPUCmdBuffers(bool enable);
 void setDumpShaders(bool enable);
 void setVblankDiv(u32 value);

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -277,6 +277,7 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices,
         ui->heightDivider->installEventFilter(this);
         ui->dumpShadersCheckBox->installEventFilter(this);
         ui->nullGpuCheckBox->installEventFilter(this);
+        ui->enableHDRCheckBox->installEventFilter(this);
 
         // Paths
         ui->gameFoldersGroupBox->installEventFilter(this);
@@ -346,6 +347,7 @@ void SettingsDialog::LoadValuesFromConfig() {
     ui->vblankSpinBox->setValue(toml::find_or<int>(data, "GPU", "vblankDivider", 1));
     ui->dumpShadersCheckBox->setChecked(toml::find_or<bool>(data, "GPU", "dumpShaders", false));
     ui->nullGpuCheckBox->setChecked(toml::find_or<bool>(data, "GPU", "nullGpu", false));
+    ui->enableHDRCheckBox->setChecked(toml::find_or<bool>(data, "General", "isHDRAllowed", false));
     ui->playBGMCheckBox->setChecked(toml::find_or<bool>(data, "General", "playBGM", false));
     ui->disableTrophycheckBox->setChecked(
         toml::find_or<bool>(data, "General", "isTrophyPopupDisabled", false));
@@ -518,6 +520,8 @@ void SettingsDialog::updateNoteTextEdit(const QString& elementName) {
         text = tr("GUIBackgroundImageGroupBox");
     } else if (elementName == "GUIMusicGroupBox") {
         text = tr("GUIMusicGroupBox");
+    } else if (elementName == "enableHDRCheckBox") {
+        text = tr("enableHDRCheckBox");
     } else if (elementName == "disableTrophycheckBox") {
         text = tr("disableTrophycheckBox");
     } else if (elementName == "enableCompatibilityCheckBox") {
@@ -618,6 +622,7 @@ void SettingsDialog::UpdateSettings() {
     Config::setIsMotionControlsEnabled(ui->motionControlsCheckBox->isChecked());
     Config::setisTrophyPopupDisabled(ui->disableTrophycheckBox->isChecked());
     Config::setPlayBGM(ui->playBGMCheckBox->isChecked());
+    Config::setAllowHDR(ui->enableHDRCheckBox->isChecked());
     Config::setLogType(ui->logTypeComboBox->currentText().toStdString());
     Config::setLogFilter(ui->logFilterLineEdit->text().toStdString());
     Config::setUserName(ui->userNameLineEdit->text().toStdString());

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -74,7 +74,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>536</height>
+         <height>535</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="generalTabVLayout" stretch="0">
@@ -169,6 +169,13 @@
                      </widget>
                     </item>
                    </layout>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QCheckBox" name="enableHDRCheckBox">
+                   <property name="text">
+                    <string>Enable HDR</string>
+                   </property>
                   </widget>
                  </item>
                  <item>
@@ -417,7 +424,7 @@
                <item>
                 <widget class="QPushButton" name="checkUpdateButton">
                  <property name="sizePolicy">
-                  <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                    <horstretch>0</horstretch>
                    <verstretch>0</verstretch>
                   </sizepolicy>
@@ -481,7 +488,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>536</height>
+         <height>535</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="guiTabVLayout" stretch="0">
@@ -585,14 +592,14 @@
                </item>
                <item>
                 <widget class="QGroupBox" name="GUIBackgroundImageGroupBox">
-                 <property name="title">
-                  <string>Background Image</string>
-                 </property>
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
                    <horstretch>0</horstretch>
                    <verstretch>0</verstretch>
                   </sizepolicy>
+                 </property>
+                 <property name="title">
+                  <string>Background Image</string>
                  </property>
                  <layout class="QVBoxLayout" name="backgroundImageVLayout">
                   <item>
@@ -930,7 +937,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>536</height>
+         <height>535</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="graphicsTabVLayout" stretch="0,0">
@@ -1174,7 +1181,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>536</height>
+         <height>535</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="userTabVLayout" stretch="0,0,1">
@@ -1318,7 +1325,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>536</height>
+         <height>535</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="inputTabVLayout" stretch="0,0">
@@ -1602,7 +1609,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>536</height>
+         <height>535</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="pathsTabLayout">
@@ -1692,7 +1699,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>536</height>
+         <height>535</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="debugTabVLayout" stretch="0,0">

--- a/src/qt_gui/translations/en.ts
+++ b/src/qt_gui/translations/en.ts
@@ -673,6 +673,10 @@
 			<translation>Enable NULL GPU</translation>
 		</message>
 		<message>
+		    <source>Enable HDR</source>
+			<translation>Enable HDR</translation>
+		</message>
+		<message>
 			<source>Paths</source>
 			<translation>Paths</translation>
 		</message>
@@ -948,6 +952,10 @@
 		<message>
 			<source>nullGpuCheckBox</source>
 			<translation>Enable Null GPU:\nFor the sake of technical debugging, disables game rendering as if there were no graphics card.</translation>
+		</message>
+		<message>
+		    <source>enableHDRCheckBox</source>
+			<translation>Enable HDR:\nEnables HDR in games that support it.\nYour monitor must have support for the BT2020 PQ color space and the RGB10A2 swapchain format.</translation>
 		</message>
 		<message>
 			<source>gameFoldersBox</source>


### PR DESCRIPTION
Adds an option to the settings dialog window for the HDR option introduced in #2381. Also adds `setAllowHDR` to the config.h and config.cpp files, so that there are no compilation errors.

![image](https://github.com/user-attachments/assets/53e12fa3-f35c-4395-9e51-038618655e19)
