### PR TITLE
Improve parameter checks for posix_pthread_rename_np

### DIFF
--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -389,6 +389,9 @@ int PS4_SYSV_ABI posix_pthread_rename_np(PthreadT thread, const char* name) {
     if (thread == nullptr) {
         return POSIX_EINVAL;
     }
+    if (name == nullptr) {
+        return 0;
+    }
     LOG_INFO(Kernel_Pthread, "name = {}", name);
     Common::SetThreadName(reinterpret_cast<void*>(thread->native_thr.GetHandle()), name);
     thread->name = name;


### PR DESCRIPTION
Based on libkernel decomp, when `posix_pthread_rename_np` is called with a null name, the function effectively does nothing and returns 0.

This fixes a `fmt::v11::format_error` thrown by CUSA14619 during a `posix_pthread_rename_np` call.