### PR TITLE
Add error message when trophy data extraction fails

### DIFF
--- a/src/qt_gui/trophy_viewer.cpp
+++ b/src/qt_gui/trophy_viewer.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <QMessageBox>
 #include "common/path_util.h"
 #include "trophy_viewer.h"
 
@@ -29,8 +30,13 @@ void TrophyViewer::PopulateTrophyWidget(QString title) {
     QDir dir(trophyDirQt);
     if (!dir.exists()) {
         std::filesystem::path path = Common::FS::PathFromQString(gameTrpPath_);
-        if (!trp.Extract(path, title.toStdString()))
+        if (!trp.Extract(path, title.toStdString())) {
+            QMessageBox::critical(this, "Trophy Data Extraction Error",
+                                  "Unable to extract Trophy data, please ensure you have "
+                                  "inputted a trophy key in the settings menu.");
+            QWidget::close();
             return;
+        }
     }
     QFileInfoList dirList = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
     if (dirList.isEmpty())


### PR DESCRIPTION
When the trophy viewer is used without a trophy key, shadPS4 currently just opens an empty dialog without any error message, which is probably going to be confusing to those who do not know about trophy keys.

![2](https://github.com/user-attachments/assets/6aa0ba69-5c35-4f89-ad5d-5a65640e2fc2)

This PR adds an error after trp.extract fails (which outside of probably extremely rate filesystem errors will be due to lack of trophy key) and closes the dialog after failed extraction.

![1](https://github.com/user-attachments/assets/7677d63f-03ce-4c8a-9963-1ff35cfc5b63)

Translations not included
