### PR TITLE
Better bounds checks for sceKernelDlsym

### DIFF
--- a/src/core/libraries/kernel/process.cpp
+++ b/src/core/libraries/kernel/process.cpp
@@ -75,6 +75,9 @@ s32 PS4_SYSV_ABI sceKernelLoadStartModule(const char* moduleFileName, size_t arg
 s32 PS4_SYSV_ABI sceKernelDlsym(s32 handle, const char* symbol, void** addrp) {
     auto* linker = Common::Singleton<Core::Linker>::Instance();
     auto* module = linker->GetModule(handle);
+    if (module == nullptr) {
+        return ORBIS_KERNEL_ERROR_ESRCH;
+    }
     *addrp = module->FindByName(symbol);
     if (*addrp == nullptr) {
         return ORBIS_KERNEL_ERROR_ESRCH;

--- a/src/core/linker.h
+++ b/src/core/linker.h
@@ -83,7 +83,10 @@ public:
     }
 
     Module* GetModule(s32 index) const {
-        return m_modules.at(index).get();
+        if (index >= 0 || index < m_modules.size()) {
+            return m_modules.at(index).get();
+        }
+        return nullptr;
     }
 
     u32 FindByName(const std::filesystem::path& name) const {


### PR DESCRIPTION
Unity, being the awful game engine it is, checks for a return value of zero to determine if sceKernelLoadStartModule failed. This results in it throwing an error code into sceKernelDlsym's handle parameter when the module it's searching for doesn't exist in a game's files.

To solve this, I added proper bounds checks to Linker::GetModule, and relevant error handling in sceKernelDlsym.
This improves behavior in NEO : The World Ends with You (CUSA26376)