### PR TITLE
Qt: Fix deprecation warning on 6.7.0 and above

### DIFF
--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -178,8 +178,14 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices,
         connect(ui->chooseHomeTabComboBox, &QComboBox::currentTextChanged, this,
                 [](const QString& hometab) { Config::setChooseHomeTab(hometab.toStdString()); });
 
-        connect(ui->showBackgroundImageCheckBox, &QCheckBox::stateChanged, this,
-                [](int state) { Config::setShowBackgroundImage(state == Qt::Checked); });
+#if (QT_VERSION < QT_VERSION_CHECK(6, 7, 0))
+        connect(ui->showBackgroundImageCheckBox, &QCheckBox::stateChanged, this, [](int state) {
+#else
+        connect(ui->showBackgroundImageCheckBox, &QCheckBox::checkStateChanged, this,
+                [](Qt::CheckState state) {
+#endif
+            Config::setShowBackgroundImage(state == Qt::Checked);
+        });
     }
     // Input TAB
     {


### PR DESCRIPTION
This change is already present in other places in the code, so I guess this was just missed
It is nothing major, just one less warning while building the project