### PR TITLE
Input: configurable controller light setting

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -71,6 +71,8 @@ static bool rdocEnable = false;
 static s16 cursorState = HideCursorState::Idle;
 static int cursorHideTimeout = 5; // 5 seconds (default)
 static bool useUnifiedInputConfig = true;
+static bool overrideControllerColor = false;
+static int controllerCustomColorRGB[3] = {0, 0, 255};
 static bool separateupdatefolder = false;
 static bool compatibilityData = false;
 static bool checkCompatibilityOnStartup = false;
@@ -113,6 +115,24 @@ bool GetUseUnifiedInputConfig() {
 
 void SetUseUnifiedInputConfig(bool use) {
     useUnifiedInputConfig = use;
+}
+
+bool GetOverrideControllerColor() {
+    return overrideControllerColor;
+}
+
+void SetOverrideControllerColor(bool enable) {
+    overrideControllerColor = enable;
+}
+
+int* GetControllerCustomColor() {
+    return controllerCustomColorRGB;
+}
+
+void SetControllerCustomColor(int r, int b, int g) {
+    controllerCustomColorRGB[0] = r;
+    controllerCustomColorRGB[1] = b;
+    controllerCustomColorRGB[2] = g;
 }
 
 std::string getTrophyKey() {
@@ -1034,6 +1054,8 @@ axis_right_y = axis_right_y
 # Range of deadzones: 1 (almost none) to 127 (max)
 analog_deadzone = leftjoystick, 2, 127
 analog_deadzone = rightjoystick, 2, 127
+
+override_controller_color = false, 0, 0, 255
 )";
 }
 std::filesystem::path GetFoolproofKbmConfigFile(const std::string& game_id) {

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -47,6 +47,10 @@ int getSpecialPadClass();
 bool getIsMotionControlsEnabled();
 bool GetUseUnifiedInputConfig();
 void SetUseUnifiedInputConfig(bool use);
+bool GetOverrideControllerColor();
+void SetOverrideControllerColor(bool enable);
+int* GetControllerCustomColor();
+void SetControllerCustomColor(int r, int b, int g);
 
 u32 getScreenWidth();
 u32 getScreenHeight();

--- a/src/core/libraries/pad/pad.cpp
+++ b/src/core/libraries/pad/pad.cpp
@@ -261,6 +261,7 @@ int PS4_SYSV_ABI scePadOpen(s32 userId, s32 type, s32 index, const OrbisPadOpenP
         if (type != ORBIS_PAD_PORT_TYPE_STANDARD && type != ORBIS_PAD_PORT_TYPE_REMOTE_CONTROL)
             return ORBIS_PAD_ERROR_DEVICE_NOT_CONNECTED;
     }
+    scePadResetLightBar(1);
     return 1; // dummy
 }
 
@@ -412,7 +413,13 @@ int PS4_SYSV_ABI scePadReadStateExt() {
 }
 
 int PS4_SYSV_ABI scePadResetLightBar(s32 handle) {
-    LOG_ERROR(Lib_Pad, "(STUBBED) called");
+    LOG_INFO(Lib_Pad, "(DUMMY) called");
+    if (handle != 1) {
+        return ORBIS_PAD_ERROR_INVALID_HANDLE;
+    }
+    auto* controller = Common::Singleton<GameController>::Instance();
+    int* rgb = Config::GetControllerCustomColor();
+    controller->SetLightBarRGB(rgb[0], rgb[1], rgb[2]);
     return ORBIS_OK;
 }
 
@@ -472,6 +479,9 @@ int PS4_SYSV_ABI scePadSetForceIntercepted() {
 }
 
 int PS4_SYSV_ABI scePadSetLightBar(s32 handle, const OrbisPadLightBarParam* pParam) {
+    if (Config::GetOverrideControllerColor()) {
+        return ORBIS_OK;
+    }
     if (pParam != nullptr) {
         LOG_DEBUG(Lib_Pad, "called handle = {} rgb = {} {} {}", handle, pParam->r, pParam->g,
                   pParam->b);

--- a/src/sdl_window.cpp
+++ b/src/sdl_window.cpp
@@ -129,7 +129,8 @@ void SDLInputEngine::Init() {
         };
     }
     SDL_free(gamepads);
-    SetLightBarRGB(0, 0, 255);
+    int* rgb = Config::GetControllerCustomColor();
+    SetLightBarRGB(rgb[0], rgb[1], rgb[2]);
 }
 
 void SDLInputEngine::SetLightBarRGB(u8 r, u8 g, u8 b) {


### PR DESCRIPTION
Adds a feature to configure your controller's lightbar. Example:
`override_controller_color = false, 0, 0, 255`
This means that the colors aren't overridden, and the game can still update them, however, if you make the first parameter `true`, your custom set color will be the color of your controller. The other 3 parameters are a standard RGB value.
Also adds a dummy implementation of scePadResetLightBar, by making that change the color of your controller to the value that is set.
By default, the game can update this, and the default color is blue.
Draft because I still have some things to do, for example at booting something sets the color to blue and it doesn't get updated to the correct user set color for a few seconds