### PR TITLE
Set language to en_US if value is incorrect

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -768,7 +768,21 @@ void load(const std::filesystem::path& path) {
         m_elf_viewer = toml::find_or<std::vector<std::string>>(gui, "elfDirs", {});
         m_recent_files = toml::find_or<std::vector<std::string>>(gui, "recentFiles", {});
         m_table_mode = toml::find_or<int>(gui, "gameTableMode", 0);
+
         emulator_language = toml::find_or<std::string>(gui, "emulatorLanguage", "en_US");
+
+        // Check if the loaded language is in the allowed list
+        const std::vector<std::string> allowed_languages = {
+            "ar_SA", "da_DK", "de_DE", "el_GR", "en_US", "es_ES", "fa_IR",
+            "fi_FI", "fr_FR", "hu_HU", "id_ID", "it_IT", "ja_JP", "ko_KR",
+            "lt_LT", "nl_NL", "no_NO", "pl_PL", "pt_BR", "ro_RO", "ru_RU",
+            "sq_AL", "sv_SE", "tr_TR", "uk_UA", "vi_VN", "zh_CN", "zh_TW"};
+
+        if (std::find(allowed_languages.begin(), allowed_languages.end(), emulator_language) ==
+            allowed_languages.end()) {
+            emulator_language = "en_US"; // Default to en_US if not in the list
+            save(path);
+        }
         backgroundImageOpacity = toml::find_or<int>(gui, "backgroundImageOpacity", 50);
         showBackgroundImage = toml::find_or<bool>(gui, "showBackgroundImage", true);
     }


### PR DESCRIPTION
Recently, some changes were made to the languages, and the name 'en' was changed to 'en_US'.

The emulator was not handling names outside of the known ones, so the first one in the list was selected as 'Albanian'.

If emulatorLanguage is not one of the known languages, it will set the language to 'en_US'.