### PR TITLE
Qt: Resizing Font Size and Icon Grid Size

### DIFF
--- a/src/qt_gui/game_grid_frame.cpp
+++ b/src/qt_gui/game_grid_frame.cpp
@@ -117,7 +117,12 @@ void GameGridFrame::PopulateGameGrid(QVector<GameInfo> m_games_search, bool from
         layout->addWidget(image_label);
         layout->addWidget(name_label);
 
-        name_label->setStyleSheet("color: white; font-size: 12px; font-weight: bold;");
+        // Resizing of font-size.
+        float fontSize = (Config::getIconSizeGrid() / 5.5f);
+        QString styleSheet =
+            QString("color: white; font-weight: bold; font-size: %1px;").arg(fontSize);
+        name_label->setStyleSheet(styleSheet);
+
         QGraphicsDropShadowEffect* shadowEffect = new QGraphicsDropShadowEffect();
         shadowEffect->setBlurRadius(5);               // Set the blur radius of the shadow
         shadowEffect->setColor(QColor(0, 0, 0, 160)); // Set the color and opacity of the shadow


### PR DESCRIPTION
This avoids having the name very small when the icons are very large.

Before:

https://github.com/user-attachments/assets/ea476caf-9134-4677-8f0b-1f476edda43a

After:

https://github.com/user-attachments/assets/a1bfb870-191a-4ebe-9445-fd961cb40fec