### PR TITLE
imgui: Displays FPS color based on FPS

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -68,6 +68,7 @@ static bool vkCrashDiagnostic = false;
 static bool vkHostMarkers = false;
 static bool vkGuestMarkers = false;
 static bool rdocEnable = false;
+static bool isFpsColor = true;
 static s16 cursorState = HideCursorState::Idle;
 static int cursorHideTimeout = 5; // 5 seconds (default)
 static bool useUnifiedInputConfig = true;
@@ -280,6 +281,10 @@ bool patchShaders() {
 
 bool isRdocEnabled() {
     return rdocEnable;
+}
+
+bool fpsColor() {
+    return isFpsColor;
 }
 
 u32 vblankDiv() {
@@ -757,6 +762,7 @@ void load(const std::filesystem::path& path) {
 
         isDebugDump = toml::find_or<bool>(debug, "DebugDump", false);
         isShaderDebug = toml::find_or<bool>(debug, "CollectShader", false);
+        isFpsColor = toml::find_or<bool>(debug, "FPSColor", true);
     }
 
     if (data.contains("GUI")) {
@@ -881,6 +887,7 @@ void save(const std::filesystem::path& path) {
     data["Vulkan"]["rdocEnable"] = rdocEnable;
     data["Debug"]["DebugDump"] = isDebugDump;
     data["Debug"]["CollectShader"] = isShaderDebug;
+    data["Debug"]["FPSColor"] = isFpsColor;
 
     data["Keys"]["TrophyKey"] = trophyKey;
 

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -67,6 +67,7 @@ bool copyGPUCmdBuffers();
 bool dumpShaders();
 bool patchShaders();
 bool isRdocEnabled();
+bool fpsColor();
 u32 vblankDiv();
 
 void setDebugDump(bool enable);

--- a/src/core/devtools/layer.cpp
+++ b/src/core/devtools/layer.cpp
@@ -259,7 +259,19 @@ void L::DrawAdvanced() {
 
 void L::DrawSimple() {
     const float frameRate = DebugState.Framerate;
+    if (Config::fpsColor()) {
+        if (frameRate < 10) {
+            PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.0f, 0.0f, 1.0f)); // Red
+        } else if (frameRate >= 10 && frameRate < 20) {
+            PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.5f, 0.0f, 1.0f)); // Orange
+        } else {
+            PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 1.0f)); // White
+        }
+    } else {
+        PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, 1.0f)); // White
+    }
     Text("%d FPS (%.1f ms)", static_cast<int>(std::round(frameRate)), 1000.0f / frameRate);
+    PopStyleColor();
 }
 
 static void LoadSettings(const char* line) {


### PR DESCRIPTION
This allows the color to change depending on the performance.
I put colors without thinking too much so I am ready to make changes if you want to change the colors, the threshold at which such color is displayed...

60 FPS:
![60](https://github.com/user-attachments/assets/c2dc1323-41e2-4e8a-a1c5-e6c6168aa54d)

< 30 FPS:
![19](https://github.com/user-attachments/assets/479554fd-36a7-4a54-923a-9d59f474c954)

< 15 FPS (Bloodborne ahh performance 🙏):
![13](https://github.com/user-attachments/assets/87158c79-606c-4573-8075-a3179e9150b3)

PS: The limits have been changed. See https://github.com/shadps4-emu/shadPS4/pull/2437#issuecomment-2660236727