### PR TITLE
add lightbar color override to Controller GUI

### DIFF
--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -138,7 +138,7 @@ void ControlSettings::SaveControllerConfig(bool CloseOnSave) {
 
         if (std::find(ControllerInputs.begin(), ControllerInputs.end(), input_string) !=
                 ControllerInputs.end() ||
-            output_string == "analog_deadzone") {
+            output_string == "analog_deadzone" || output_string == "override_controller_color") {
             line.erase();
             continue;
         }
@@ -244,6 +244,14 @@ void ControlSettings::SaveControllerConfig(bool CloseOnSave) {
     deadzonevalue = std::to_string(ui->RightDeadzoneSlider->value());
     lines.push_back("analog_deadzone = rightjoystick, " + deadzonevalue + ", 127");
 
+    lines.push_back("");
+    std::string OverrideLB = ui->LightbarCheckBox->isChecked() ? "true" : "false";
+    std::string LightBarR = std::to_string(ui->RSlider->value());
+    std::string LightBarG = std::to_string(ui->GSlider->value());
+    std::string LightBarB = std::to_string(ui->BSlider->value());
+    lines.push_back("override_controller_color = " + OverrideLB + ", " + LightBarR + ", " +
+                    LightBarG + ", " + LightBarB);
+
     std::vector<std::string> save;
     bool CurrentLineEmpty = false, LastLineEmpty = false;
     for (auto const& line : lines) {
@@ -260,6 +268,9 @@ void ControlSettings::SaveControllerConfig(bool CloseOnSave) {
     output_file.close();
 
     Config::SetUseUnifiedInputConfig(!ui->PerGameCheckBox->isChecked());
+    Config::SetOverrideControllerColor(ui->LightbarCheckBox->isChecked());
+    Config::SetControllerCustomColor(ui->RSlider->value(), ui->GSlider->value(),
+                                     ui->BSlider->value());
     Config::save(Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "config.toml");
 
     if (CloseOnSave)
@@ -368,7 +379,7 @@ void ControlSettings::SetUIValuestoMappings() {
 
         if (std::find(ControllerInputs.begin(), ControllerInputs.end(), input_string) !=
                 ControllerInputs.end() ||
-            output_string == "analog_deadzone") {
+            output_string == "analog_deadzone" || output_string == "override_controller_color") {
             if (input_string == "cross") {
                 ui->ABox->setCurrentText(QString::fromStdString(output_string));
                 CrossExists = true;
@@ -453,9 +464,45 @@ void ControlSettings::SetUIValuestoMappings() {
                     ui->RightDeadzoneSlider->setValue(2);
                     ui->RightDeadzoneValue->setText("2");
                 }
+            } else if (output_string == "override_controller_color") {
+                std::size_t comma_pos = line.find(',');
+                if (comma_pos != std::string::npos) {
+                    std::string overridestring = line.substr(equal_pos + 1, comma_pos);
+                    bool override = overridestring.contains("true") ? true : false;
+                    ui->LightbarCheckBox->setChecked(override);
+
+                    std::string lightbarstring = line.substr(comma_pos + 1);
+                    std::size_t comma_pos2 = lightbarstring.find(',');
+                    if (comma_pos2 != std::string::npos) {
+                        std::string Rstring = lightbarstring.substr(0, comma_pos2);
+                        ui->RSlider->setValue(std::stoi(Rstring));
+                        QString RedValue = QString("%1").arg(std::stoi(Rstring), 3, 10, QChar('0'));
+                        QString RValue = "R: " + RedValue;
+                        ui->RLabel->setText(RValue);
+                    }
+
+                    std::string GBstring = lightbarstring.substr(comma_pos2 + 1);
+                    std::size_t comma_pos3 = GBstring.find(',');
+                    if (comma_pos3 != std::string::npos) {
+                        std::string Gstring = GBstring.substr(0, comma_pos3);
+                        ui->GSlider->setValue(std::stoi(Gstring));
+                        QString GreenValue =
+                            QString("%1").arg(std::stoi(Gstring), 3, 10, QChar('0'));
+                        QString GValue = "G: " + GreenValue;
+                        ui->GLabel->setText(GValue);
+
+                        std::string Bstring = GBstring.substr(comma_pos3 + 1);
+                        ui->BSlider->setValue(std::stoi(Bstring));
+                        QString BlueValue =
+                            QString("%1").arg(std::stoi(Bstring), 3, 10, QChar('0'));
+                        QString BValue = "B: " + BlueValue;
+                        ui->BLabel->setText(BValue);
+                    }
+                }
             }
         }
     }
+    file.close();
 
     // If an entry does not exist in the config file, we assume the user wants it unmapped
     if (!CrossExists)
@@ -507,8 +554,6 @@ void ControlSettings::SetUIValuestoMappings() {
         ui->RStickUpBox->setCurrentText("unmapped");
         ui->RStickDownBox->setCurrentText("unmapped");
     }
-
-    file.close();
 }
 
 void ControlSettings::GetGameTitle() {

--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -3,9 +3,9 @@
 
 #include <fstream>
 #include <QMessageBox>
+#include <QPushButton>
 #include "common/path_util.h"
 #include "control_settings.h"
-#include "kbm_config_dialog.h"
 #include "ui_control_settings.h"
 
 ControlSettings::ControlSettings(std::shared_ptr<GameInfoClass> game_info_get, QWidget* parent)
@@ -16,7 +16,7 @@ ControlSettings::ControlSettings(std::shared_ptr<GameInfoClass> game_info_get, Q
 
     AddBoxItems();
     SetUIValuestoMappings();
-    ui->KBMButton->setFocus();
+    UpdateLightbarColor();
 
     connect(ui->buttonBox, &QDialogButtonBox::clicked, this, [this](QAbstractButton* button) {
         if (button == ui->buttonBox->button(QDialogButtonBox::Save)) {
@@ -29,11 +29,7 @@ ControlSettings::ControlSettings(std::shared_ptr<GameInfoClass> game_info_get, Q
     });
 
     connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &QWidget::close);
-    connect(ui->KBMButton, &QPushButton::clicked, this, [this] {
-        auto KBMWindow = new EditorDialog(this);
-        KBMWindow->exec();
-        SetUIValuestoMappings();
-    });
+
     connect(ui->ProfileComboBox, &QComboBox::currentTextChanged, this, [this] {
         GetGameTitle();
         SetUIValuestoMappings();
@@ -61,6 +57,27 @@ ControlSettings::ControlSettings(std::shared_ptr<GameInfoClass> game_info_get, Q
             [this](int value) { ui->RStickLeftBox->setCurrentIndex(value); });
     connect(ui->RStickLeftBox, &QComboBox::currentIndexChanged, this,
             [this](int value) { ui->RStickRightBox->setCurrentIndex(value); });
+
+    connect(ui->RSlider, &QSlider::valueChanged, this, [this](int value) {
+        QString RedValue = QString("%1").arg(value, 3, 10, QChar('0'));
+        QString RValue = "R: " + RedValue;
+        ui->RLabel->setText(RValue);
+        UpdateLightbarColor();
+    });
+
+    connect(ui->GSlider, &QSlider::valueChanged, this, [this](int value) {
+        QString GreenValue = QString("%1").arg(value, 3, 10, QChar('0'));
+        QString GValue = "G: " + GreenValue;
+        ui->GLabel->setText(GValue);
+        UpdateLightbarColor();
+    });
+
+    connect(ui->BSlider, &QSlider::valueChanged, this, [this](int value) {
+        QString BlueValue = QString("%1").arg(value, 3, 10, QChar('0'));
+        QString BValue = "B: " + BlueValue;
+        ui->BLabel->setText(BValue);
+        UpdateLightbarColor();
+    });
 }
 
 void ControlSettings::SaveControllerConfig(bool CloseOnSave) {
@@ -505,6 +522,15 @@ void ControlSettings::GetGameTitle() {
             }
         }
     }
+}
+
+void ControlSettings::UpdateLightbarColor() {
+    ui->LightbarColorFrame->setStyleSheet("");
+    QString RValue = QString::number(ui->RSlider->value());
+    QString GValue = QString::number(ui->GSlider->value());
+    QString BValue = QString::number(ui->BSlider->value());
+    QString colorstring = "background-color: rgb(" + RValue + "," + GValue + "," + BValue + ")";
+    ui->LightbarColorFrame->setStyleSheet(colorstring);
 }
 
 ControlSettings::~ControlSettings() {}

--- a/src/qt_gui/control_settings.h
+++ b/src/qt_gui/control_settings.h
@@ -18,6 +18,7 @@ public:
 private Q_SLOTS:
     void SaveControllerConfig(bool CloseOnSave);
     void SetDefault();
+    void UpdateLightbarColor();
 
 private:
     std::unique_ptr<Ui::ControlSettings> ui;

--- a/src/qt_gui/control_settings.ui
+++ b/src/qt_gui/control_settings.ui
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+     SPDX-License-Identifier: GPL-2.0-or-later -->
 <ui version="4.0">
  <class>ControlSettings</class>
  <widget class="QDialog" name="ControlSettings">

--- a/src/qt_gui/control_settings.ui
+++ b/src/qt_gui/control_settings.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>1043</width>
-    <height>822</height>
+    <height>792</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -22,21 +22,26 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QTabWidget" name="TabWidget">
-     <property name="currentIndex">
-      <number>0</number>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
      </property>
-     <widget class="QWidget" name="RemapTab">
-      <attribute name="title">
-       <string>Controller Remapping</string>
-      </attribute>
-      <widget class="QWidget" name="">
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>1019</width>
+        <height>732</height>
+       </rect>
+      </property>
+      <widget class="QWidget" name="layoutWidget">
        <property name="geometry">
         <rect>
-         <x>10</x>
-         <y>10</y>
-         <width>1004</width>
-         <height>711</height>
+         <x>0</x>
+         <y>0</y>
+         <width>1021</width>
+         <height>731</height>
         </rect>
        </property>
        <layout class="QHBoxLayout" name="RemapLayout">

--- a/src/qt_gui/control_settings.ui
+++ b/src/qt_gui/control_settings.ui
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
-     SPDX-License-Identifier: GPL-2.0-or-later -->
 <ui version="4.0">
  <class>ControlSettings</class>
  <widget class="QDialog" name="ControlSettings">
@@ -11,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1012</width>
-    <height>721</height>
+    <width>1043</width>
+    <height>822</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -24,761 +22,677 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QScrollArea" name="scrollArea">
-     <property name="frameShape">
-      <enum>QFrame::Shape::NoFrame</enum>
-     </property>
-     <property name="lineWidth">
+    <widget class="QTabWidget" name="TabWidget">
+     <property name="currentIndex">
       <number>0</number>
      </property>
-     <property name="widgetResizable">
-      <bool>true</bool>
-     </property>
-     <widget class="QTabWidget" name="tabWidget">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>994</width>
-        <height>673</height>
-       </rect>
-      </property>
-      <widget class="QWidget" name="tab">
-       <attribute name="title">
-        <string>Control Settings</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="mainLayout">
-        <property name="leftMargin">
-         <number>5</number>
-        </property>
-        <property name="topMargin">
-         <number>5</number>
-        </property>
-        <property name="rightMargin">
-         <number>5</number>
-        </property>
-        <property name="bottomMargin">
-         <number>5</number>
-        </property>
+     <widget class="QWidget" name="RemapTab">
+      <attribute name="title">
+       <string>Controller Remapping</string>
+      </attribute>
+      <widget class="QWidget" name="">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>10</y>
+         <width>1004</width>
+         <height>711</height>
+        </rect>
+       </property>
+       <layout class="QHBoxLayout" name="RemapLayout">
         <item>
-         <layout class="QHBoxLayout" name="bottomLayout">
+         <layout class="QVBoxLayout" name="verticalLayout_left">
+          <property name="spacing">
+           <number>5</number>
+          </property>
           <item>
-           <layout class="QVBoxLayout" name="verticalLayout_left">
-            <property name="spacing">
-             <number>5</number>
+           <widget class="QGroupBox" name="gb_dpad">
+            <property name="enabled">
+             <bool>true</bool>
             </property>
-            <item>
-             <widget class="QGroupBox" name="gb_dpad">
-              <property name="enabled">
-               <bool>true</bool>
-              </property>
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="title">
-               <string>D-Pad</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_dpad_layout">
-               <property name="spacing">
-                <number>6</number>
-               </property>
-               <property name="leftMargin">
-                <number>5</number>
-               </property>
-               <property name="topMargin">
-                <number>5</number>
-               </property>
-               <property name="rightMargin">
-                <number>5</number>
-               </property>
-               <property name="bottomMargin">
-                <number>5</number>
-               </property>
-               <item>
-                <widget class="QWidget" name="dpad_up" native="true">
-                 <layout class="QHBoxLayout" name="dpad_up_layout">
-                  <property name="spacing">
-                   <number>0</number>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="title">
+             <string>D-Pad</string>
+            </property>
+            <layout class="QVBoxLayout" name="gb_dpad_layout">
+             <property name="spacing">
+              <number>6</number>
+             </property>
+             <property name="leftMargin">
+              <number>5</number>
+             </property>
+             <property name="topMargin">
+              <number>5</number>
+             </property>
+             <property name="rightMargin">
+              <number>5</number>
+             </property>
+             <property name="bottomMargin">
+              <number>5</number>
+             </property>
+             <item>
+              <widget class="QWidget" name="dpad_up" native="true">
+               <layout class="QHBoxLayout" name="dpad_up_layout">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QGroupBox" name="gb_dpad_up">
+                  <property name="minimumSize">
+                   <size>
+                    <width>124</width>
+                    <height>0</height>
+                   </size>
                   </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>0</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="title">
+                   <string>Up</string>
+                  </property>
+                  <layout class="QHBoxLayout" name="horizontalLayout_4">
+                   <item>
+                    <widget class="QComboBox" name="DpadUpBox">
+                     <property name="editable">
+                      <bool>false</bool>
+                     </property>
+                     <property name="sizeAdjustPolicy">
+                      <enum>QComboBox::SizeAdjustPolicy::AdjustToContents</enum>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="layout_dpad_left_right">
+               <item>
+                <widget class="QGroupBox" name="gb_dpad_left">
+                 <property name="title">
+                  <string>Left</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_dpad_left_layout">
                   <property name="leftMargin">
-                   <number>0</number>
+                   <number>5</number>
                   </property>
                   <property name="topMargin">
-                   <number>0</number>
+                   <number>5</number>
                   </property>
                   <property name="rightMargin">
-                   <number>0</number>
+                   <number>5</number>
                   </property>
                   <property name="bottomMargin">
-                   <number>0</number>
+                   <number>5</number>
                   </property>
                   <item>
-                   <widget class="QGroupBox" name="gb_dpad_up">
-                    <property name="minimumSize">
-                     <size>
-                      <width>124</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>0</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="title">
-                     <string>Up</string>
-                    </property>
-                    <layout class="QHBoxLayout" name="horizontalLayout_4">
-                     <item>
-                      <widget class="QComboBox" name="DpadUpBox">
-                       <property name="editable">
-                        <bool>false</bool>
-                       </property>
-                       <property name="sizeAdjustPolicy">
-                        <enum>QComboBox::SizeAdjustPolicy::AdjustToContents</enum>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
+                   <widget class="QComboBox" name="DpadLeftBox"/>
                   </item>
                  </layout>
                 </widget>
                </item>
                <item>
-                <layout class="QHBoxLayout" name="layout_dpad_left_right">
-                 <item>
-                  <widget class="QGroupBox" name="gb_dpad_left">
-                   <property name="title">
-                    <string>Left</string>
-                   </property>
-                   <layout class="QVBoxLayout" name="gb_dpad_left_layout">
-                    <property name="leftMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="topMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="rightMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="bottomMargin">
-                     <number>5</number>
-                    </property>
-                    <item>
-                     <widget class="QComboBox" name="DpadLeftBox"/>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QGroupBox" name="gb_dpad_right">
-                   <property name="title">
-                    <string>Right</string>
-                   </property>
-                   <layout class="QVBoxLayout" name="gb_dpad_right_layout">
-                    <property name="leftMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="topMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="rightMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="bottomMargin">
-                     <number>5</number>
-                    </property>
-                    <item>
-                     <widget class="QComboBox" name="DpadRightBox">
-                      <property name="editable">
-                       <bool>false</bool>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <widget class="QWidget" name="dpad_down" native="true">
-                 <layout class="QHBoxLayout" name="dpad_down_layout">
+                <widget class="QGroupBox" name="gb_dpad_right">
+                 <property name="title">
+                  <string>Right</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_dpad_right_layout">
                   <property name="leftMargin">
-                   <number>0</number>
+                   <number>5</number>
                   </property>
                   <property name="topMargin">
-                   <number>0</number>
+                   <number>5</number>
                   </property>
                   <property name="rightMargin">
-                   <number>0</number>
+                   <number>5</number>
                   </property>
                   <property name="bottomMargin">
-                   <number>0</number>
+                   <number>5</number>
                   </property>
                   <item>
-                   <widget class="QGroupBox" name="gb_dpad_down">
-                    <property name="maximumSize">
-                     <size>
-                      <width>124</width>
-                      <height>16777215</height>
-                     </size>
+                   <widget class="QComboBox" name="DpadRightBox">
+                    <property name="editable">
+                     <bool>false</bool>
                     </property>
-                    <property name="title">
-                     <string>Down</string>
-                    </property>
-                    <layout class="QHBoxLayout" name="horizontalLayout_3">
-                     <item>
-                      <widget class="QComboBox" name="DpadDownBox">
-                       <property name="enabled">
-                        <bool>true</bool>
-                       </property>
-                       <property name="sizePolicy">
-                        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                         <horstretch>0</horstretch>
-                         <verstretch>0</verstretch>
-                        </sizepolicy>
-                       </property>
-                       <property name="minimumSize">
-                        <size>
-                         <width>0</width>
-                         <height>0</height>
-                        </size>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
                    </widget>
                   </item>
                  </layout>
                 </widget>
                </item>
               </layout>
-             </widget>
-            </item>
-            <item>
-             <spacer name="verticalSpacer">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Policy::Maximum</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="LeftStickDeadZoneGB">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>Left Stick Deadzone (def:2 max:127)</string>
-              </property>
-              <layout class="QVBoxLayout" name="verticalLayout_15">
-               <item>
-                <widget class="QLabel" name="LeftDeadzoneValue">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>Left Deadzone</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QSlider" name="LeftDeadzoneSlider">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="minimum">
-                  <number>1</number>
-                 </property>
-                 <property name="maximum">
-                  <number>127</number>
-                 </property>
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Horizontal</enum>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_left_stick">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="title">
-               <string>Left Stick</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_left_stick_layout">
-               <property name="leftMargin">
-                <number>5</number>
-               </property>
-               <property name="topMargin">
-                <number>5</number>
-               </property>
-               <property name="rightMargin">
-                <number>5</number>
-               </property>
-               <property name="bottomMargin">
-                <number>5</number>
-               </property>
-               <item>
-                <widget class="QWidget" name="left_stick_up" native="true">
-                 <property name="maximumSize">
-                  <size>
-                   <width>16777215</width>
-                   <height>2121</height>
-                  </size>
-                 </property>
-                 <layout class="QHBoxLayout" name="left_stick_up_layout">
-                  <property name="leftMargin">
-                   <number>0</number>
+             </item>
+             <item>
+              <widget class="QWidget" name="dpad_down" native="true">
+               <layout class="QHBoxLayout" name="dpad_down_layout">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QGroupBox" name="gb_dpad_down">
+                  <property name="maximumSize">
+                   <size>
+                    <width>124</width>
+                    <height>16777215</height>
+                   </size>
                   </property>
-                  <property name="topMargin">
-                   <number>0</number>
+                  <property name="title">
+                   <string>Down</string>
                   </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QGroupBox" name="gb_left_stick_up">
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>124</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="title">
-                     <string>Up</string>
-                    </property>
-                    <layout class="QVBoxLayout" name="verticalLayout_10">
-                     <item>
-                      <widget class="QComboBox" name="LStickUpBox">
-                       <property name="enabled">
-                        <bool>true</bool>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="layout_left_stick_left_right">
-                 <item>
-                  <widget class="QGroupBox" name="gb_left_stick_left">
-                   <property name="title">
-                    <string>Left</string>
-                   </property>
-                   <layout class="QVBoxLayout" name="gb_left_stick_left_layout">
-                    <property name="leftMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="topMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="rightMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="bottomMargin">
-                     <number>5</number>
-                    </property>
-                    <item>
-                     <widget class="QComboBox" name="LStickLeftBox">
-                      <property name="enabled">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QGroupBox" name="gb_left_stick_right">
-                   <property name="maximumSize">
-                    <size>
-                     <width>179</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                   <property name="title">
-                    <string>Right</string>
-                   </property>
-                   <layout class="QVBoxLayout" name="gb_left_stick_right_layout">
-                    <property name="leftMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="topMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="rightMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="bottomMargin">
-                     <number>5</number>
-                    </property>
-                    <item>
-                     <widget class="QComboBox" name="LStickRightBox">
-                      <property name="enabled">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <widget class="QWidget" name="left_stick_down" native="true">
-                 <layout class="QHBoxLayout" name="left_stick_down_layout">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QGroupBox" name="gb_left_stick_down">
-                    <property name="minimumSize">
-                     <size>
-                      <width>124</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>124</width>
-                      <height>21212</height>
-                     </size>
-                    </property>
-                    <property name="title">
-                     <string>Down</string>
-                    </property>
-                    <layout class="QVBoxLayout" name="verticalLayout_8">
-                     <item>
-                      <widget class="QComboBox" name="LStickDownBox">
-                       <property name="enabled">
-                        <bool>true</bool>
-                       </property>
-                       <property name="editable">
-                        <bool>false</bool>
-                       </property>
-                       <property name="frame">
-                        <bool>false</bool>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-           </layout>
+                  <layout class="QHBoxLayout" name="horizontalLayout_3">
+                   <item>
+                    <widget class="QComboBox" name="DpadDownBox">
+                     <property name="enabled">
+                      <bool>true</bool>
+                     </property>
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="minimumSize">
+                      <size>
+                       <width>0</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+            </layout>
+           </widget>
           </item>
           <item>
-           <layout class="QVBoxLayout" name="verticalLayout_middle" stretch="0,0,0,0">
-            <property name="spacing">
-             <number>0</number>
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Orientation::Vertical</enum>
             </property>
-            <item>
-             <widget class="QGroupBox" name="ProfileGroupBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>12</pointsize>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="title">
-               <string>Config Selection</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignmentFlag::AlignCenter</set>
-              </property>
-              <layout class="QVBoxLayout" name="verticalLayout_16">
+            <property name="sizeType">
+             <enum>QSizePolicy::Policy::Maximum</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="LeftStickDeadZoneGB">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="title">
+             <string>Left Stick Deadzone (def:2 max:127)</string>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_15">
+             <item>
+              <widget class="QLabel" name="LeftDeadzoneValue">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Left Deadzone</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSlider" name="LeftDeadzoneSlider">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimum">
+                <number>1</number>
+               </property>
+               <property name="maximum">
+                <number>127</number>
+               </property>
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="gb_left_stick">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="title">
+             <string>Left Stick</string>
+            </property>
+            <layout class="QVBoxLayout" name="gb_left_stick_layout">
+             <property name="leftMargin">
+              <number>5</number>
+             </property>
+             <property name="topMargin">
+              <number>5</number>
+             </property>
+             <property name="rightMargin">
+              <number>5</number>
+             </property>
+             <property name="bottomMargin">
+              <number>5</number>
+             </property>
+             <item>
+              <widget class="QWidget" name="left_stick_up" native="true">
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>2121</height>
+                </size>
+               </property>
+               <layout class="QHBoxLayout" name="left_stick_up_layout">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QGroupBox" name="gb_left_stick_up">
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>124</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="title">
+                   <string>Up</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_10">
+                   <item>
+                    <widget class="QComboBox" name="LStickUpBox">
+                     <property name="enabled">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="layout_left_stick_left_right">
                <item>
-                <layout class="QHBoxLayout" name="horizontalLayout_6">
-                 <item>
-                  <widget class="QComboBox" name="ProfileComboBox">
-                   <property name="font">
-                    <font>
-                     <pointsize>9</pointsize>
-                     <bold>false</bold>
-                    </font>
-                   </property>
-                   <property name="currentText">
-                    <string/>
-                   </property>
-                   <property name="currentIndex">
-                    <number>-1</number>
-                   </property>
-                   <property name="placeholderText">
-                    <string>Common Config</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="TitleLabel">
-                   <property name="font">
-                    <font>
-                     <pointsize>10</pointsize>
-                     <bold>true</bold>
-                    </font>
-                   </property>
-                   <property name="text">
-                    <string>Common Config</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                   </property>
-                   <property name="wordWrap">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
+                <widget class="QGroupBox" name="gb_left_stick_left">
+                 <property name="title">
+                  <string>Left</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_left_stick_left_layout">
+                  <property name="leftMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>5</number>
+                  </property>
+                  <item>
+                   <widget class="QComboBox" name="LStickLeftBox">
+                    <property name="enabled">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
                </item>
                <item>
-                <widget class="QCheckBox" name="PerGameCheckBox">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
+                <widget class="QGroupBox" name="gb_left_stick_right">
+                 <property name="maximumSize">
+                  <size>
+                   <width>179</width>
+                   <height>16777215</height>
+                  </size>
                  </property>
+                 <property name="title">
+                  <string>Right</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_left_stick_right_layout">
+                  <property name="leftMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>5</number>
+                  </property>
+                  <item>
+                   <widget class="QComboBox" name="LStickRightBox">
+                    <property name="enabled">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <widget class="QWidget" name="left_stick_down" native="true">
+               <layout class="QHBoxLayout" name="left_stick_down_layout">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QGroupBox" name="gb_left_stick_down">
+                  <property name="minimumSize">
+                   <size>
+                    <width>124</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>124</width>
+                    <height>21212</height>
+                   </size>
+                  </property>
+                  <property name="title">
+                   <string>Down</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_8">
+                   <item>
+                    <widget class="QComboBox" name="LStickDownBox">
+                     <property name="enabled">
+                      <bool>true</bool>
+                     </property>
+                     <property name="editable">
+                      <bool>false</bool>
+                     </property>
+                     <property name="frame">
+                      <bool>false</bool>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_middle" stretch="0,0,0,0,0">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QGroupBox" name="ProfileGroupBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>12</pointsize>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="title">
+             <string>Config Selection</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignCenter</set>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_16">
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_6">
+               <item>
+                <widget class="QComboBox" name="ProfileComboBox">
                  <property name="font">
                   <font>
                    <pointsize>9</pointsize>
                    <bold>false</bold>
                   </font>
                  </property>
+                 <property name="currentText">
+                  <string/>
+                 </property>
+                 <property name="currentIndex">
+                  <number>-1</number>
+                 </property>
+                 <property name="placeholderText">
+                  <string>Common Config</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="TitleLabel">
+                 <property name="font">
+                  <font>
+                   <pointsize>10</pointsize>
+                   <bold>true</bold>
+                  </font>
+                 </property>
                  <property name="text">
-                  <string>Use per-game configs</string>
+                  <string>Common Config</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
                  </property>
                 </widget>
                </item>
               </layout>
-             </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="PerGameCheckBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="font">
+                <font>
+                 <pointsize>9</pointsize>
+                 <bold>false</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string>Use per-game configs</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="layout_middle_top">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <item>
+             <layout class="QVBoxLayout" name="layout_l1_l2">
+              <item>
+               <widget class="QGroupBox" name="gb_l1">
+                <property name="title">
+                 <string>L1 / LB</string>
+                </property>
+                <layout class="QVBoxLayout" name="gb_l1_layout">
+                 <property name="leftMargin">
+                  <number>5</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>5</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>5</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>5</number>
+                 </property>
+                 <item>
+                  <widget class="QComboBox" name="LBBox"/>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QGroupBox" name="gb_l2">
+                <property name="title">
+                 <string>L2 / LT</string>
+                </property>
+                <layout class="QVBoxLayout" name="gb_l2_layout">
+                 <property name="leftMargin">
+                  <number>5</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>5</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>5</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>5</number>
+                 </property>
+                 <item>
+                  <widget class="QComboBox" name="LTBox"/>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+             </layout>
             </item>
             <item>
-             <layout class="QHBoxLayout" name="layout_middle_top">
-              <property name="spacing">
-               <number>0</number>
-              </property>
+             <layout class="QVBoxLayout" name="layout_system_buttons">
               <item>
-               <layout class="QVBoxLayout" name="layout_l1_l2">
-                <item>
-                 <widget class="QGroupBox" name="gb_l1">
-                  <property name="title">
-                   <string>L1 / LB</string>
-                  </property>
-                  <layout class="QVBoxLayout" name="gb_l1_layout">
-                   <property name="leftMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>5</number>
-                   </property>
-                   <item>
-                    <widget class="QComboBox" name="LBBox"/>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QGroupBox" name="gb_l2">
-                  <property name="title">
-                   <string>L2 / LT</string>
-                  </property>
-                  <layout class="QVBoxLayout" name="gb_l2_layout">
-                   <property name="leftMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>5</number>
-                   </property>
-                   <item>
-                    <widget class="QComboBox" name="LTBox"/>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-               </layout>
+               <spacer name="verticalSpacer_3">
+                <property name="orientation">
+                 <enum>Qt::Orientation::Vertical</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Policy::Preferred</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>40</height>
+                 </size>
+                </property>
+               </spacer>
               </item>
               <item>
-               <layout class="QVBoxLayout" name="layout_system_buttons">
+               <layout class="QVBoxLayout" name="verticalLayout_4">
+                <property name="spacing">
+                 <number>10</number>
+                </property>
                 <item>
-                 <layout class="QVBoxLayout" name="verticalLayout_4">
-                  <property name="spacing">
-                   <number>10</number>
-                  </property>
-                  <item>
-                   <widget class="QGroupBox" name="groupBox">
-                    <property name="font">
-                     <font>
-                      <bold>true</bold>
-                     </font>
-                    </property>
-                    <property name="title">
-                     <string>KBM Controls</string>
-                    </property>
-                    <layout class="QVBoxLayout" name="verticalLayout_11">
-                     <item>
-                      <widget class="QPushButton" name="KBMButton">
-                       <property name="font">
-                        <font>
-                         <bold>true</bold>
-                        </font>
-                       </property>
-                       <property name="text">
-                        <string>KBM Editor</string>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QGroupBox" name="groupBox_2">
-                    <property name="title">
-                     <string>Back</string>
-                    </property>
-                    <layout class="QVBoxLayout" name="verticalLayout_9">
-                     <item>
-                      <widget class="QComboBox" name="BackBox"/>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                 </layout>
-                </item>
-               </layout>
-              </item>
-              <item>
-               <layout class="QVBoxLayout" name="layout_r1_r2">
-                <item>
-                 <widget class="QGroupBox" name="gb_r1">
+                 <widget class="QGroupBox" name="groupBox_2">
                   <property name="title">
-                   <string>R1 / RB</string>
+                   <string>Back</string>
                   </property>
-                  <layout class="QVBoxLayout" name="gb_r1_layout">
-                   <property name="leftMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>5</number>
-                   </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_9">
                    <item>
-                    <widget class="QComboBox" name="RBBox"/>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QGroupBox" name="gb_r2">
-                  <property name="title">
-                   <string>R2 / RT</string>
-                  </property>
-                  <layout class="QVBoxLayout" name="gb_r2_layout">
-                   <property name="leftMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>5</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>5</number>
-                   </property>
-                   <item>
-                    <widget class="QComboBox" name="RTBox"/>
+                    <widget class="QComboBox" name="BackBox"/>
                    </item>
                   </layout>
                  </widget>
@@ -788,62 +702,13 @@
              </layout>
             </item>
             <item>
-             <widget class="QWidget" name="widget_controller" native="true">
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>200</height>
-               </size>
-              </property>
-              <layout class="QHBoxLayout" name="widget_controller_layout">
-               <property name="leftMargin">
-                <number>0</number>
-               </property>
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
-                <number>0</number>
-               </property>
-               <item>
-                <widget class="QLabel" name="l_controller">
-                 <property name="maximumSize">
-                  <size>
-                   <width>415</width>
-                   <height>256</height>
-                  </size>
-                 </property>
-                 <property name="pixmap">
-                  <pixmap resource="../shadps4.qrc">:/images/ps4_controller.png</pixmap>
-                 </property>
-                 <property name="scaledContents">
-                  <bool>true</bool>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignHCenter</set>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <layout class="QHBoxLayout" name="layout_middle_bottom">
-              <property name="spacing">
-               <number>10</number>
-              </property>
-              <property name="sizeConstraint">
-               <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
-              </property>
+             <layout class="QVBoxLayout" name="layout_r1_r2">
               <item>
-               <widget class="QGroupBox" name="gb_l3">
+               <widget class="QGroupBox" name="gb_r1">
                 <property name="title">
-                 <string>L3</string>
+                 <string>R1 / RB</string>
                 </property>
-                <layout class="QVBoxLayout" name="gb_l3_layout">
+                <layout class="QVBoxLayout" name="gb_r1_layout">
                  <property name="leftMargin">
                   <number>5</number>
                  </property>
@@ -857,17 +722,17 @@
                   <number>5</number>
                  </property>
                  <item>
-                  <widget class="QComboBox" name="LClickBox"/>
+                  <widget class="QComboBox" name="RBBox"/>
                  </item>
                 </layout>
                </widget>
               </item>
               <item>
-               <widget class="QGroupBox" name="gb_start">
+               <widget class="QGroupBox" name="gb_r2">
                 <property name="title">
-                 <string>Options / Start</string>
+                 <string>R2 / RT</string>
                 </property>
-                <layout class="QVBoxLayout" name="gb_start_layout">
+                <layout class="QVBoxLayout" name="gb_r2_layout">
                  <property name="leftMargin">
                   <number>5</number>
                  </property>
@@ -881,31 +746,7 @@
                   <number>5</number>
                  </property>
                  <item>
-                  <widget class="QComboBox" name="StartBox"/>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="gb_r3">
-                <property name="title">
-                 <string>R3</string>
-                </property>
-                <layout class="QVBoxLayout" name="gb_r3_layout">
-                 <property name="leftMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>5</number>
-                 </property>
-                 <item>
-                  <widget class="QComboBox" name="RClickBox"/>
+                  <widget class="QComboBox" name="RTBox"/>
                  </item>
                 </layout>
                </widget>
@@ -915,22 +756,62 @@
            </layout>
           </item>
           <item>
-           <layout class="QVBoxLayout" name="verticalLayout_right">
+           <widget class="QWidget" name="widget_controller" native="true">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>200</height>
+             </size>
+            </property>
+            <layout class="QHBoxLayout" name="widget_controller_layout">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="l_controller">
+               <property name="maximumSize">
+                <size>
+                 <width>415</width>
+                 <height>256</height>
+                </size>
+               </property>
+               <property name="pixmap">
+                <pixmap resource="../shadps4.qrc">:/images/ps4_controller.png</pixmap>
+               </property>
+               <property name="scaledContents">
+                <bool>true</bool>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignHCenter</set>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="layout_middle_bottom">
             <property name="spacing">
-             <number>5</number>
+             <number>10</number>
+            </property>
+            <property name="sizeConstraint">
+             <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
             </property>
             <item>
-             <widget class="QGroupBox" name="gb_face_buttons">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
+             <widget class="QGroupBox" name="gb_l3">
               <property name="title">
-               <string>Face Buttons</string>
+               <string>L3</string>
               </property>
-              <layout class="QVBoxLayout" name="gb_face_buttons_layout">
+              <layout class="QVBoxLayout" name="gb_l3_layout">
                <property name="leftMargin">
                 <number>5</number>
                </property>
@@ -944,244 +825,17 @@
                 <number>5</number>
                </property>
                <item>
-                <widget class="QWidget" name="widget_triangle" native="true">
-                 <layout class="QHBoxLayout" name="widget_triangle_layout">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QGroupBox" name="gb_triangle">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>124</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>0</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="title">
-                     <string>Triangle / Y</string>
-                    </property>
-                    <layout class="QVBoxLayout" name="verticalLayout_3">
-                     <item>
-                      <widget class="QComboBox" name="YBox">
-                       <property name="enabled">
-                        <bool>true</bool>
-                       </property>
-                       <property name="sizePolicy">
-                        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                         <horstretch>0</horstretch>
-                         <verstretch>0</verstretch>
-                        </sizepolicy>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="layout_square_circle">
-                 <item>
-                  <widget class="QGroupBox" name="gb_square">
-                   <property name="title">
-                    <string>Square / X</string>
-                   </property>
-                   <layout class="QVBoxLayout" name="gb_square_layout">
-                    <property name="leftMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="topMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="rightMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="bottomMargin">
-                     <number>5</number>
-                    </property>
-                    <item>
-                     <widget class="QComboBox" name="XBox"/>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QGroupBox" name="gb_circle">
-                   <property name="title">
-                    <string>Circle / B</string>
-                   </property>
-                   <layout class="QVBoxLayout" name="gb_circle_layout">
-                    <property name="leftMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="topMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="rightMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="bottomMargin">
-                     <number>5</number>
-                    </property>
-                    <item>
-                     <widget class="QComboBox" name="BBox"/>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <widget class="QWidget" name="widget_cross" native="true">
-                 <layout class="QHBoxLayout" name="widget_cross_layout">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QGroupBox" name="gb_cross">
-                    <property name="minimumSize">
-                     <size>
-                      <width>124</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>124</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="title">
-                     <string>Cross / A</string>
-                    </property>
-                    <layout class="QVBoxLayout" name="verticalLayout_5">
-                     <item>
-                      <widget class="QComboBox" name="ABox"/>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
+                <widget class="QComboBox" name="LClickBox"/>
                </item>
               </layout>
              </widget>
             </item>
             <item>
-             <spacer name="verticalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Policy::Maximum</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="RightStickDeadZoneGB">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
+             <widget class="QGroupBox" name="gb_start">
               <property name="title">
-               <string>Right Stick Deadzone (def:2, max:127)</string>
+               <string>Options / Start</string>
               </property>
-              <layout class="QVBoxLayout" name="verticalLayout_13">
-               <item>
-                <widget class="QLabel" name="RightDeadzoneValue">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>Right Deadzone</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QSlider" name="RightDeadzoneSlider">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="minimum">
-                  <number>1</number>
-                 </property>
-                 <property name="maximum">
-                  <number>127</number>
-                 </property>
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Horizontal</enum>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_right_stick">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="title">
-               <string>Right Stick</string>
-              </property>
-              <layout class="QVBoxLayout" name="verticalLayout_2">
+              <layout class="QVBoxLayout" name="gb_start_layout">
                <property name="leftMargin">
                 <number>5</number>
                </property>
@@ -1195,163 +849,636 @@
                 <number>5</number>
                </property>
                <item>
-                <widget class="QWidget" name="widget_right_stick_up" native="true">
-                 <layout class="QHBoxLayout" name="widget_right_stick_up_layout">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QGroupBox" name="gb_right_stick_up">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>124</width>
-                      <height>1231321</height>
-                     </size>
-                    </property>
-                    <property name="title">
-                     <string>Up</string>
-                    </property>
-                    <layout class="QVBoxLayout" name="verticalLayout_7">
-                     <item>
-                      <widget class="QComboBox" name="RStickUpBox">
-                       <property name="enabled">
-                        <bool>true</bool>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
+                <widget class="QComboBox" name="StartBox"/>
                </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="gb_r3">
+              <property name="title">
+               <string>R3</string>
+              </property>
+              <layout class="QVBoxLayout" name="gb_r3_layout">
+               <property name="leftMargin">
+                <number>5</number>
+               </property>
+               <property name="topMargin">
+                <number>5</number>
+               </property>
+               <property name="rightMargin">
+                <number>5</number>
+               </property>
+               <property name="bottomMargin">
+                <number>5</number>
+               </property>
                <item>
-                <layout class="QHBoxLayout" name="layout_right_stick_left_right">
-                 <item>
-                  <widget class="QGroupBox" name="gb_right_stick_left">
-                   <property name="title">
-                    <string>Left</string>
-                   </property>
-                   <layout class="QVBoxLayout" name="gb_right_stick_left_layout">
-                    <property name="leftMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="topMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="rightMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="bottomMargin">
-                     <number>5</number>
-                    </property>
-                    <item>
-                     <widget class="QComboBox" name="RStickLeftBox">
-                      <property name="enabled">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QGroupBox" name="gb_right_stick_right">
-                   <property name="title">
-                    <string>Right</string>
-                   </property>
-                   <layout class="QVBoxLayout" name="gb_right_stick_right_layout">
-                    <property name="leftMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="topMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="rightMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="bottomMargin">
-                     <number>5</number>
-                    </property>
-                    <item>
-                     <widget class="QComboBox" name="RStickRightBox"/>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <widget class="QWidget" name="widget_right_stick_down" native="true">
-                 <layout class="QHBoxLayout" name="widget_right_stick_down_layout">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QGroupBox" name="gb_right_stick_down">
-                    <property name="minimumSize">
-                     <size>
-                      <width>124</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>124</width>
-                      <height>2121</height>
-                     </size>
-                    </property>
-                    <property name="title">
-                     <string>Down</string>
-                    </property>
-                    <layout class="QVBoxLayout" name="verticalLayout_6">
-                     <item>
-                      <widget class="QComboBox" name="RStickDownBox">
-                       <property name="enabled">
-                        <bool>true</bool>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
+                <widget class="QComboBox" name="RClickBox"/>
                </item>
               </layout>
              </widget>
             </item>
            </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_8">
+            <item>
+             <layout class="QVBoxLayout" name="verticalLayout_14">
+              <item>
+               <widget class="QGroupBox" name="groupBox">
+                <property name="font">
+                 <font>
+                  <bold>false</bold>
+                 </font>
+                </property>
+                <property name="title">
+                 <string>Color Adjustment</string>
+                </property>
+                <layout class="QVBoxLayout" name="verticalLayout_18">
+                 <item>
+                  <layout class="QHBoxLayout" name="horizontalLayout_9">
+                   <item>
+                    <widget class="QLabel" name="RLabel">
+                     <property name="font">
+                      <font>
+                       <bold>false</bold>
+                      </font>
+                     </property>
+                     <property name="text">
+                      <string>R: 000</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QSlider" name="RSlider">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="maximum">
+                      <number>255</number>
+                     </property>
+                     <property name="orientation">
+                      <enum>Qt::Orientation::Horizontal</enum>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
+                  <layout class="QHBoxLayout" name="horizontalLayout_10">
+                   <item>
+                    <widget class="QLabel" name="GLabel">
+                     <property name="font">
+                      <font>
+                       <bold>false</bold>
+                      </font>
+                     </property>
+                     <property name="text">
+                      <string>G: 000</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QSlider" name="GSlider">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="maximum">
+                      <number>255</number>
+                     </property>
+                     <property name="orientation">
+                      <enum>Qt::Orientation::Horizontal</enum>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
+                  <layout class="QHBoxLayout" name="horizontalLayout_11">
+                   <item>
+                    <widget class="QLabel" name="BLabel">
+                     <property name="font">
+                      <font>
+                       <bold>false</bold>
+                      </font>
+                     </property>
+                     <property name="text">
+                      <string>B: 255</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QSlider" name="BSlider">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="maximum">
+                      <number>255</number>
+                     </property>
+                     <property name="value">
+                      <number>255</number>
+                     </property>
+                     <property name="orientation">
+                      <enum>Qt::Orientation::Horizontal</enum>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QVBoxLayout" name="verticalLayout_17">
+              <item>
+               <widget class="QGroupBox" name="groupBox_3">
+                <property name="font">
+                 <font>
+                  <bold>false</bold>
+                 </font>
+                </property>
+                <property name="title">
+                 <string>Override Lightbar Color</string>
+                </property>
+                <layout class="QVBoxLayout" name="verticalLayout_19">
+                 <item>
+                  <widget class="QCheckBox" name="LightbarCheckBox">
+                   <property name="font">
+                    <font>
+                     <bold>false</bold>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>Override Color</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QFrame" name="LightbarColorFrame">
+                   <property name="frameShape">
+                    <enum>QFrame::Shape::StyledPanel</enum>
+                   </property>
+                   <property name="frameShadow">
+                    <enum>QFrame::Shadow::Raised</enum>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_right">
+          <property name="spacing">
+           <number>5</number>
+          </property>
+          <item>
+           <widget class="QGroupBox" name="gb_face_buttons">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="title">
+             <string>Face Buttons</string>
+            </property>
+            <layout class="QVBoxLayout" name="gb_face_buttons_layout">
+             <property name="leftMargin">
+              <number>5</number>
+             </property>
+             <property name="topMargin">
+              <number>5</number>
+             </property>
+             <property name="rightMargin">
+              <number>5</number>
+             </property>
+             <property name="bottomMargin">
+              <number>5</number>
+             </property>
+             <item>
+              <widget class="QWidget" name="widget_triangle" native="true">
+               <layout class="QHBoxLayout" name="widget_triangle_layout">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QGroupBox" name="gb_triangle">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>124</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>0</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="title">
+                   <string>Triangle / Y</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_3">
+                   <item>
+                    <widget class="QComboBox" name="YBox">
+                     <property name="enabled">
+                      <bool>true</bool>
+                     </property>
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="layout_square_circle">
+               <item>
+                <widget class="QGroupBox" name="gb_square">
+                 <property name="title">
+                  <string>Square / X</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_square_layout">
+                  <property name="leftMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>5</number>
+                  </property>
+                  <item>
+                   <widget class="QComboBox" name="XBox"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_circle">
+                 <property name="title">
+                  <string>Circle / B</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_circle_layout">
+                  <property name="leftMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>5</number>
+                  </property>
+                  <item>
+                   <widget class="QComboBox" name="BBox"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <widget class="QWidget" name="widget_cross" native="true">
+               <layout class="QHBoxLayout" name="widget_cross_layout">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QGroupBox" name="gb_cross">
+                  <property name="minimumSize">
+                   <size>
+                    <width>124</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>124</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="title">
+                   <string>Cross / A</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_5">
+                   <item>
+                    <widget class="QComboBox" name="ABox"/>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Orientation::Vertical</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Policy::Maximum</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="RightStickDeadZoneGB">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="title">
+             <string>Right Stick Deadzone (def:2, max:127)</string>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_13">
+             <item>
+              <widget class="QLabel" name="RightDeadzoneValue">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Right Deadzone</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSlider" name="RightDeadzoneSlider">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimum">
+                <number>1</number>
+               </property>
+               <property name="maximum">
+                <number>127</number>
+               </property>
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="gb_right_stick">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="title">
+             <string>Right Stick</string>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_2">
+             <property name="leftMargin">
+              <number>5</number>
+             </property>
+             <property name="topMargin">
+              <number>5</number>
+             </property>
+             <property name="rightMargin">
+              <number>5</number>
+             </property>
+             <property name="bottomMargin">
+              <number>5</number>
+             </property>
+             <item>
+              <widget class="QWidget" name="widget_right_stick_up" native="true">
+               <layout class="QHBoxLayout" name="widget_right_stick_up_layout">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QGroupBox" name="gb_right_stick_up">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>124</width>
+                    <height>1231321</height>
+                   </size>
+                  </property>
+                  <property name="title">
+                   <string>Up</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_7">
+                   <item>
+                    <widget class="QComboBox" name="RStickUpBox">
+                     <property name="enabled">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="layout_right_stick_left_right">
+               <item>
+                <widget class="QGroupBox" name="gb_right_stick_left">
+                 <property name="title">
+                  <string>Left</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_right_stick_left_layout">
+                  <property name="leftMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>5</number>
+                  </property>
+                  <item>
+                   <widget class="QComboBox" name="RStickLeftBox">
+                    <property name="enabled">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_right_stick_right">
+                 <property name="title">
+                  <string>Right</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_right_stick_right_layout">
+                  <property name="leftMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>5</number>
+                  </property>
+                  <item>
+                   <widget class="QComboBox" name="RStickRightBox"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <widget class="QWidget" name="widget_right_stick_down" native="true">
+               <layout class="QHBoxLayout" name="widget_right_stick_down_layout">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QGroupBox" name="gb_right_stick_down">
+                  <property name="minimumSize">
+                   <size>
+                    <width>124</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>124</width>
+                    <height>2121</height>
+                   </size>
+                  </property>
+                  <property name="title">
+                   <string>Down</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_6">
+                   <item>
+                    <widget class="QComboBox" name="RStickDownBox">
+                     <property name="enabled">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+            </layout>
+           </widget>
           </item>
          </layout>
         </item>


### PR DESCRIPTION
This adds the recently implemented lightbar color override to the remapping GUI, as shown below, with a color preview sample for easier customization.

Also removes the KBM Button from this view, since it was added as a new button in PR 2430

Translations not included. Tested with DS4, seems to work fine

![image](https://github.com/user-attachments/assets/e5ce4b46-aaca-4534-b332-410c0ec253b9)
