### PR TITLE
Qt: Use Qt::SmoothTransformation for Background Image

### DIFF
--- a/src/qt_gui/game_grid_frame.cpp
+++ b/src/qt_gui/game_grid_frame.cpp
@@ -197,7 +197,8 @@ void GameGridFrame::RefreshGridBackgroundImage() {
     QPalette palette;
     if (!backgroundImage.isNull() && Config::getShowBackgroundImage()) {
         palette.setBrush(QPalette::Base,
-                         QBrush(backgroundImage.scaled(size(), Qt::IgnoreAspectRatio)));
+                         QBrush(backgroundImage.scaled(size(), Qt::IgnoreAspectRatio,
+                                                       Qt::SmoothTransformation)));
     }
     QColor transparentColor = QColor(135, 206, 235, 40);
     palette.setColor(QPalette::Highlight, transparentColor);

--- a/src/qt_gui/game_list_frame.cpp
+++ b/src/qt_gui/game_list_frame.cpp
@@ -201,7 +201,8 @@ void GameListFrame::RefreshListBackgroundImage() {
     QPalette palette;
     if (!backgroundImage.isNull() && Config::getShowBackgroundImage()) {
         palette.setBrush(QPalette::Base,
-                         QBrush(backgroundImage.scaled(size(), Qt::IgnoreAspectRatio)));
+                         QBrush(backgroundImage.scaled(size(), Qt::IgnoreAspectRatio,
+                                                       Qt::SmoothTransformation)));
     }
     QColor transparentColor = QColor(135, 206, 235, 40);
     palette.setColor(QPalette::Highlight, transparentColor);


### PR DESCRIPTION
Minor Improvement of the Qt GUI.
Makes the background less pixelated.

Before:
![Before](https://github.com/user-attachments/assets/6236845d-8387-497e-b660-8536bfc1b37f) 
![Before1](https://github.com/user-attachments/assets/fd0be433-4c48-485e-bb16-ac95a060958e)

After:
![After](https://github.com/user-attachments/assets/1c0baca3-ad50-4ad9-b571-1675f9bde970)
![After1](https://github.com/user-attachments/assets/4cd2897f-cb75-4fa4-929d-5b90cc036681)