### PR TITLE
Qt: Fix Small Window

### DIFF
--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -57,7 +57,7 @@ bool MainWindow::Init() {
     SetLastIconSizeBullet();
     GetPhysicalDevices();
     // show ui
-    setMinimumSize(350, minimumSizeHint().height());
+    setMinimumSize(720, 405);
     std::string window_title = "";
     if (Common::isRelease) {
         window_title = fmt::format("shadPS4 v{}", Common::VERSION);


### PR DESCRIPTION
Minor Fix for the Qt GUI.
This allows the entire interface to be visible even when the window is at its smallest size.

Before:
![Before](https://github.com/user-attachments/assets/df470663-210a-4674-b370-3e403d9a37cc)

After:
![After](https://github.com/user-attachments/assets/9a71ff8d-5cae-4054-9240-a70901aacf9e)