### PR TITLE
Qt: Use Qt::SmoothTransformation for Cheats Manager

### DIFF
--- a/src/qt_gui/cheats_patches.cpp
+++ b/src/qt_gui/cheats_patches.cpp
@@ -71,7 +71,8 @@ void CheatsPatches::setupUI() {
 
     QLabel* gameImageLabel = new QLabel();
     if (!m_gameImage.isNull()) {
-        gameImageLabel->setPixmap(m_gameImage.scaled(275, 275, Qt::KeepAspectRatio));
+        gameImageLabel->setPixmap(
+            m_gameImage.scaled(275, 275, Qt::KeepAspectRatio, Qt::SmoothTransformation));
     } else {
         gameImageLabel->setText(tr("No Image Available"));
     }


### PR DESCRIPTION
Minor Improvement of the Qt GUI.
For the same purpose as [**this PR**](https://github.com/shadps4-emu/shadPS4/pull/2446).
Makes the cheats manager less pixelated.

Before:
![Before](https://github.com/user-attachments/assets/a926013a-5152-476f-a039-b376968e2b51)

After:
![After](https://github.com/user-attachments/assets/1c7df0c2-1855-440f-b5e2-0d80952ed44e)