### PR TITLE
added language pt_PT

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -813,8 +813,8 @@ void load(const std::filesystem::path& path) {
     // Check if the loaded language is in the allowed list
     const std::vector<std::string> allowed_languages = {
         "ar_SA", "da_DK", "de_DE", "el_GR", "en_US", "es_ES", "fa_IR", "fi_FI", "fr_FR", "hu_HU",
-        "id_ID", "it_IT", "ja_JP", "ko_KR", "lt_LT", "nl_NL", "no_NO", "pl_PL", "pt_BR", "ro_RO",
-        "ru_RU", "sq_AL", "sv_SE", "tr_TR", "uk_UA", "vi_VN", "zh_CN", "zh_TW"};
+        "id_ID", "it_IT", "ja_JP", "ko_KR", "lt_LT", "nl_NL", "no_NO", "pl_PL", "pt_BR", "pt_PT",
+        "ro_RO", "ru_RU", "sq_AL", "sv_SE", "tr_TR", "uk_UA", "vi_VN", "zh_CN", "zh_TW"};
 
     if (std::find(allowed_languages.begin(), allowed_languages.end(), emulator_language) ==
         allowed_languages.end()) {


### PR DESCRIPTION
The Portuguese language pt_PT has been added
https://crowdin.com/editor/shadps4-emulator/14/en-pt

Now all that's left is to translate !