### PR TITLE
Add default values for Lightbar sliders and checkbox, per-game config

### DIFF
--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -311,6 +311,7 @@ void ControlSettings::SetDefault() {
     ui->GSlider->setValue(0);
     ui->BSlider->setValue(255);
     ui->LightbarCheckBox->setChecked(false);
+    ui->PerGameCheckBox->setChecked(false);
 }
 
 void ControlSettings::AddBoxItems() {

--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -306,6 +306,11 @@ void ControlSettings::SetDefault() {
 
     ui->LeftDeadzoneSlider->setValue(2);
     ui->RightDeadzoneSlider->setValue(2);
+
+    ui->RSlider->setValue(0);
+    ui->GSlider->setValue(0);
+    ui->BSlider->setValue(255);
+    ui->LightbarCheckBox->setChecked(false);
 }
 
 void ControlSettings::AddBoxItems() {


### PR DESCRIPTION
Restoring default values currently does not include the lightbar settings, this adds the defaults for the 3 lightbar sliders and checkbox

EDIT: added default for per-game config checkbox as well