### PR TITLE
renderer_vulkan: Bind descriptors to specific stages in layout.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_pipeline_common.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_common.cpp
@@ -37,7 +37,7 @@ void Pipeline::BindResources(DescriptorWrites& set_writes, const BufferBarriers&
         cmdbuf.pipelineBarrier2(dependencies);
     }
 
-    const auto stage_flags = IsCompute() ? vk::ShaderStageFlagBits::eCompute : gp_stage_flags;
+    const auto stage_flags = IsCompute() ? vk::ShaderStageFlagBits::eCompute : AllGraphicsStageBits;
     cmdbuf.pushConstants(*pipeline_layout, stage_flags, 0u, sizeof(push_data), &push_data);
 
     // Bind descriptor set.

--- a/src/video_core/renderer_vulkan/vk_pipeline_common.h
+++ b/src/video_core/renderer_vulkan/vk_pipeline_common.h
@@ -15,7 +15,7 @@ class BufferCache;
 
 namespace Vulkan {
 
-static constexpr auto gp_stage_flags =
+static constexpr auto AllGraphicsStageBits =
     vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eTessellationControl |
     vk::ShaderStageFlagBits::eTessellationEvaluation | vk::ShaderStageFlagBits::eGeometry |
     vk::ShaderStageFlagBits::eFragment;


### PR DESCRIPTION
When defining descriptor set layouts, instead of attaching descriptors to all stages, attach only to the stage they came from.

This reduces the per-stage binding pressure, which can help MoltenVK in particular when using push descriptors to have enough binding slots for its own internal buffers for purposes like tessellation data.

Should fix https://github.com/shadps4-emu/shadPS4/issues/1820