### PR TITLE
Emulator: Create a Log Backup

### DIFF
--- a/src/common/path_util.cpp
+++ b/src/common/path_util.cpp
@@ -132,6 +132,17 @@ static auto UserPaths = [] {
     return paths;
 }();
 
+void RenameLog() {
+    // Renaming shad_log.txt to shad_log.old.txt when booting.
+    const auto LogDir = Common::FS::GetUserPath(Common::FS::PathType::LogDir);
+    const auto CurrentLog = LogDir / LOG_FILE;
+    const auto NewLogName = LogDir / "shad_log.old.txt";
+    // Avoid crash due to shad_log.txt not existing.
+    if (std::filesystem::exists(CurrentLog)) {
+        rename(CurrentLog, NewLogName);
+    }
+}
+
 bool ValidatePath(const fs::path& path) {
     if (path.empty()) {
         LOG_ERROR(Common_Filesystem, "Input path is empty, path={}", PathToUTF8String(path));

--- a/src/common/path_util.h
+++ b/src/common/path_util.h
@@ -48,6 +48,8 @@ constexpr auto METADATA_DIR = "game_data";
 // Filenames
 constexpr auto LOG_FILE = "shad_log.txt";
 
+void RenameLog();
+
 /**
  * Validates a given path.
  *

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -44,11 +44,20 @@ Frontend::WindowSDL* g_window = nullptr;
 namespace Core {
 
 Emulator::Emulator() {
-    // Initialize NT API functions and set high priority
+    // Initialize NT API functions and set high priority.
 #ifdef _WIN32
     Common::NtApi::Initialize();
     SetPriorityClass(GetCurrentProcess(), ABOVE_NORMAL_PRIORITY_CLASS);
 #endif
+
+    // Renaming shad_log.txt to shad_log.old.txt when booting.
+    const auto LogDir = Common::FS::GetUserPath(Common::FS::PathType::LogDir);
+    const auto CurrentLog = LogDir / "shad_log.txt";
+    const auto NewLogName = LogDir / "shad_log.old.txt";
+    // Avoid crash due to shad_log.txt not existing.
+    if (std::filesystem::exists(CurrentLog)) {
+        rename(CurrentLog, NewLogName);
+    }
 
     // Start logger.
     Common::Log::Initialize();

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -50,14 +50,8 @@ Emulator::Emulator() {
     SetPriorityClass(GetCurrentProcess(), ABOVE_NORMAL_PRIORITY_CLASS);
 #endif
 
-    // Renaming shad_log.txt to shad_log.old.txt when booting.
-    const auto LogDir = Common::FS::GetUserPath(Common::FS::PathType::LogDir);
-    const auto CurrentLog = LogDir / "shad_log.txt";
-    const auto NewLogName = LogDir / "shad_log.old.txt";
-    // Avoid crash due to shad_log.txt not existing.
-    if (std::filesystem::exists(CurrentLog)) {
-        rename(CurrentLog, NewLogName);
-    }
+    // Rename shad_log.txt to shad_log.old.txt
+    Common::FS::RenameLog();
 
     // Start logger.
     Common::Log::Initialize();


### PR DESCRIPTION
Like yuzu and other emulators, it is good to have a log backup.
When starting shadPS4, the log of the previous session is renamed to `shad_log.old.txt`.
This can be useful to compare logs when making changes.
I tried to make the code as understandable as possible.

![image](https://github.com/user-attachments/assets/68d8bcc9-b629-43e7-aab5-5de498d2af31)