### PR TITLE
Handle compute packets that are split between the ends of two command buffers

### DIFF
--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -736,7 +736,7 @@ Liverpool::Task Liverpool::ProcessCompute(const u32* acb, u32 acb_dwords, u32 vq
         u32 next_dw_off = header->type3.NumWords() + 1;
 
         // If we have a buffered packet, use it.
-        if (queue.tmp_dwords > 0) {
+        if (queue.tmp_dwords > 0) [[unlikely]] {
             header = reinterpret_cast<const PM4Header*>(queue.tmp_packet.data());
             next_dw_off = header->type3.NumWords() + 1 - queue.tmp_dwords;
             std::memcpy(queue.tmp_packet.data() + queue.tmp_dwords, acb, next_dw_off * sizeof(u32));
@@ -744,7 +744,7 @@ Liverpool::Task Liverpool::ProcessCompute(const u32* acb, u32 acb_dwords, u32 vq
         }
 
         // If the packet is split across ring boundary, buffer until next submission
-        if (next_dw_off > acb_dwords) {
+        if (next_dw_off > acb_dwords) [[unlikely]] {
             std::memcpy(queue.tmp_packet.data(), acb, acb_dwords * sizeof(u32));
             queue.tmp_dwords = acb_dwords;
             if constexpr (!is_indirect) {

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -757,7 +757,7 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
                     compute_cutoff_end_to_prepend[vqid].size();
         PM4Header possible_next_command = std::bit_cast<PM4Header>(acb[remainder]);
         if (acb.size() == remainder || possible_next_command.type == 3) {
-            if (acb.data()[0].type != 3) {
+            if (std::bit_cast<PM4Header>(acb[0]).type != 3) {
                 std::copy(acb.data(), acb.data() + remainder,
                           std::back_inserter(compute_cutoff_end_to_prepend[vqid]));
 

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -757,12 +757,14 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
                     compute_cutoff_end_to_prepend[vqid].size();
         PM4Header possible_next_command = std::bit_cast<PM4Header>(acb[remainder]);
         if (acb.size() == remainder || possible_next_command.type == 3) {
-            std::copy(acb.data(), acb.data() + remainder,
-                      std::back_inserter(compute_cutoff_end_to_prepend[vqid]));
+            if (acb.data()[0].type != 3) {
+                std::copy(acb.data(), acb.data() + remainder,
+                          std::back_inserter(compute_cutoff_end_to_prepend[vqid]));
 
-            use_split_instruction = true;
-            LOG_INFO(Render_Vulkan, "Start of buffer 2: {}", fmt::ptr(acb.data()));
-            LOG_INFO(Render_Vulkan, "Executing split command!");
+                use_split_instruction = true;
+                LOG_INFO(Render_Vulkan, "Start of buffer 2: {}", fmt::ptr(acb.data()));
+                LOG_INFO(Render_Vulkan, "Executing split command!");
+            }
         } else {
             LOG_INFO(Render_Vulkan,
                      "The buffer wasn't split, the next command would have been type: "

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -761,6 +761,7 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
                       std::back_inserter(compute_cutoff_end_to_prepend[vqid]));
 
             use_split_instruction = true;
+            LOG_INFO(Render_Vulkan, "Start of buffer 2: {}", fmt::ptr(acb.data()));
             LOG_INFO(Render_Vulkan, "Executing split command!");
         } else {
             LOG_INFO(Render_Vulkan,
@@ -795,6 +796,7 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
             carry.reserve(packet_size_dw);
             carry.insert(carry.end(), acb.begin(), acb.end());
             compute_cutoff_end_to_prepend[vqid] = std::move(carry);
+            LOG_INFO(Render_Vulkan, "  End of buffer 1: {}", fmt::ptr(acb.data() + acb.size() - 1));
             acb = {};
             use_split_instruction = true;
             break;

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -1496,10 +1496,13 @@ public:
     }
 
     struct AscQueueInfo {
+        static constexpr size_t Pm4BufferSize = 1024;
         VAddr map_addr;
         u32* read_addr;
         u32 ring_size_dw;
         u32 pipe_id;
+        std::array<u32, Pm4BufferSize> tmp_packet;
+        u32 tmp_dwords;
     };
     Common::SlotVector<AscQueueInfo> asc_queues{};
 
@@ -1541,7 +1544,7 @@ private:
     Task ProcessGraphics(std::span<const u32> dcb, std::span<const u32> ccb);
     Task ProcessCeUpdate(std::span<const u32> ccb);
     template <bool is_indirect = false>
-    Task ProcessCompute(std::span<const u32> acb, u32 vqid);
+    Task ProcessCompute(const u32* acb, u32 acb_dwords, u32 vqid);
 
     void Process(std::stop_token stoken);
 


### PR DESCRIPTION
For some reason P.T. submits compute command buffers that are not aligned at instruction ends, so some instructions end up having data in two buffers. This PR fixes the issue, by doing the following:
- If an instruction is longer than the remaining buffer size, we copy the incomplete part out to a buffer
- When the next instrucion buffer arrives, we check if there were any "leftovers" from the previous one, and if so, do the following:
- Check that if we took the appropriate amount of commands from the start of the buffer, the next data is a valid instruction
- If so, we finish setting up the command by copying the remaining data to the end of the previous one, then execute this command
- We then finish handling this new buffer, starting from the appropriate offset.

If any of these fail, we proceed to handle the new buffer as normal.