### PR TITLE
adding info about MSYS2 builds state

### DIFF
--- a/documents/building-windows.md
+++ b/documents/building-windows.md
@@ -69,6 +69,9 @@ To automatically populate the necessary files to run shadPS4.exe, run in a comma
 
 ## Option 2: MSYS2/MinGW
 
+> [!IMPORTANT]
+> Building with MSYS2 is broken as of right now, the only way to build on Windows is to use [Option 1: Visual Studio 2022](https://github.com/shadps4-emu/shadPS4/blob/main/documents/building-windows.md#option-1-visual-studio-2022).
+
 ### (Prerequisite) Download [**MSYS2**](https://www.msys2.org/)
 
 Go through the MSYS2 installation as normal


### PR DESCRIPTION
Adding information about MSYS2 builds being broken right now and redirecting people to the VS 2022 option (I believe those builds are still broken because I saw people talking about it recently, so I thought it would be best to let people know o the building file, if they're fixed let me know and I'll close it).