### PR TITLE
QT: Fix search in Grid mode

### DIFF
--- a/src/qt_gui/game_info.cpp
+++ b/src/qt_gui/game_info.cpp
@@ -49,6 +49,9 @@ void GameInfoClass::GetGameInfo(QWidget* parent) {
                   return readGameInfo(Common::FS::PathFromQString(path));
               }).results();
 
+    // used to retrieve values after performing a search
+    m_games_backup = m_games;
+
     // Progress bar, please be patient :)
     QProgressDialog dialog(tr("Loading game list, please wait :3"), tr("Cancel"), 0, 0, parent);
     dialog.setWindowTitle(tr("Loading..."));

--- a/src/qt_gui/game_info.h
+++ b/src/qt_gui/game_info.h
@@ -17,6 +17,7 @@ public:
     ~GameInfoClass();
     void GetGameInfo(QWidget* parent = nullptr);
     QVector<GameInfo> m_games;
+    QVector<GameInfo> m_games_backup;
 
     static bool CompareStrings(GameInfo& a, GameInfo& b) {
         std::string name_a = a.name, name_b = b.name;

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -658,18 +658,24 @@ void MainWindow::StartGame() {
     }
 }
 
+bool isTable;
 void MainWindow::SearchGameTable(const QString& text) {
-    m_game_info->m_games = m_game_info->m_games_backup;
-
     if (isTableList) {
-        m_game_list_frame->PopulateGameList();
+        if (isTable != true) {
+            m_game_info->m_games = m_game_info->m_games_backup;
+            m_game_list_frame->PopulateGameList();
+            isTable = true;
+        }
         for (int row = 0; row < m_game_list_frame->rowCount(); row++) {
             QString game_name = QString::fromStdString(m_game_info->m_games[row].name);
             bool match = (game_name.contains(text, Qt::CaseInsensitive)); // Check only in column 1
             m_game_list_frame->setRowHidden(row, !match);
         }
     } else {
+        isTable = false;
+        m_game_info->m_games = m_game_info->m_games_backup;
         m_game_grid_frame->PopulateGameGrid(m_game_info->m_games, false);
+
         QVector<GameInfo> filteredGames;
         for (const auto& gameInfo : m_game_info->m_games) {
             QString game_name = QString::fromStdString(gameInfo.name);

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -659,6 +659,10 @@ void MainWindow::StartGame() {
 }
 
 void MainWindow::SearchGameTable(const QString& text) {
+    m_game_info->m_games = m_game_info->m_games_backup;
+    m_game_grid_frame->PopulateGameGrid(m_game_info->m_games, false);
+    m_game_list_frame->PopulateGameList();
+
     if (isTableList) {
         for (int row = 0; row < m_game_list_frame->rowCount(); row++) {
             QString game_name = QString::fromStdString(m_game_info->m_games[row].name);
@@ -674,6 +678,7 @@ void MainWindow::SearchGameTable(const QString& text) {
             }
         }
         std::sort(filteredGames.begin(), filteredGames.end(), m_game_info->CompareStrings);
+        m_game_info->m_games = filteredGames;
         m_game_grid_frame->PopulateGameGrid(filteredGames, true);
     }
 }

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -413,6 +413,7 @@ void MainWindow::CreateConnects() {
         int slider_pos = Config::getSliderPosition();
         ui->sizeSlider->setEnabled(true);
         ui->sizeSlider->setSliderPosition(slider_pos);
+        ui->mw_searchbar->setText("");
     });
     // Grid
     connect(ui->setlistModeGridAct, &QAction::triggered, m_dock_widget.data(), [this]() {
@@ -430,6 +431,7 @@ void MainWindow::CreateConnects() {
         int slider_pos_grid = Config::getSliderPositionGrid();
         ui->sizeSlider->setEnabled(true);
         ui->sizeSlider->setSliderPosition(slider_pos_grid);
+        ui->mw_searchbar->setText("");
     });
     // Elf Viewer
     connect(ui->setlistElfAct, &QAction::triggered, m_dock_widget.data(), [this]() {

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -660,16 +660,16 @@ void MainWindow::StartGame() {
 
 void MainWindow::SearchGameTable(const QString& text) {
     m_game_info->m_games = m_game_info->m_games_backup;
-    m_game_grid_frame->PopulateGameGrid(m_game_info->m_games, false);
-    m_game_list_frame->PopulateGameList();
 
     if (isTableList) {
+        m_game_list_frame->PopulateGameList();
         for (int row = 0; row < m_game_list_frame->rowCount(); row++) {
             QString game_name = QString::fromStdString(m_game_info->m_games[row].name);
             bool match = (game_name.contains(text, Qt::CaseInsensitive)); // Check only in column 1
             m_game_list_frame->setRowHidden(row, !match);
         }
     } else {
+        m_game_grid_frame->PopulateGameGrid(m_game_info->m_games, false);
         QVector<GameInfo> filteredGames;
         for (const auto& gameInfo : m_game_info->m_games) {
             QString game_name = QString::fromStdString(gameInfo.name);


### PR DESCRIPTION
The search works correctly in list mode. However, when using search in grid mode, the results are correct, but the itemID values in gui_context_menus.h were not accurate.

What was happening? After searching for a game, it would show up correctly in the list. However, when trying to open or interact with it in any way (such as using cheats/patches, opening or deleting the folder, or in any other context), it was using the ID from the table without the search filter.

Watch the video, it's easier to understand:

https://github.com/user-attachments/assets/1c494e51-f9ad-4ed8-8c8f-1fd7a0ab06b3

This PR fixes this issue, and also when switching from Grid to List or vice versa the search field is reset, as this would cause problems.