### PR TITLE
docs: add qt6-tools to Arch build guide

### DIFF
--- a/documents/building-linux.md
+++ b/documents/building-linux.md
@@ -36,7 +36,7 @@ sudo dnf install clang git cmake libatomic alsa-lib-devel \
 
 ```bash
 sudo pacman -S base-devel clang git cmake sndio jack2 openal \
-    qt6-base qt6-declarative qt6-multimedia sdl2 \
+    qt6-base qt6-declarative qt6-multimedia qt6-tools sdl2 \
     vulkan-validation-layers libpng
 ```
 


### PR DESCRIPTION
Build was failing on Arch Linux following the guide with:
```
CMake Error at CMakeLists.txt:200 (find_package):
  Found package configuration file:

    /usr/lib/cmake/Qt6/Qt6Config.cmake

  but it set Qt6_FOUND to FALSE so package "Qt6" is considered to be NOT
  FOUND.  Reason given by package:

  Failed to find required Qt component "LinguistTools".

  Expected Config file at
  "/usr/lib/cmake/Qt6LinguistTools/Qt6LinguistToolsConfig.cmake" does NOT
  exist



  Configuring with --debug-find-pkg=Qt6LinguistTools might reveal details why
  the package was not found.

  Configuring with -DQT_DEBUG_FIND_PACKAGE=ON will print the values of some
  of the path variables that find_package uses to try and find the package.
```

Resolved by adding `qt6-tools` to required build dependencies.

Also verified build on Ubuntu, Fedora and OpenSUSE VMs. No changes needed to their dependencies.
- Ubuntu has `qt6-tools-dev`
- Fedora has `qt6-qttools-devel`
- Suse has `qt6-linguist-devel`

Didn't verify Nix, but I guess `pkgs.qt6.qttools` is probably the one, which is already present.