### PR TITLE
QT: Various interface fixes

### DIFF
--- a/src/qt_gui/cheats_patches.cpp
+++ b/src/qt_gui/cheats_patches.cpp
@@ -26,8 +26,10 @@
 #include <QTextEdit>
 #include <QVBoxLayout>
 #include <QXmlStreamReader>
-#include <common/logging/log.h>
+
 #include "cheats_patches.h"
+#include "common/config.h"
+#include "common/logging/log.h"
 #include "common/memory_patcher.h"
 #include "common/path_util.h"
 #include "core/module.h"
@@ -92,7 +94,7 @@ void CheatsPatches::setupUI() {
     gameVersionLabel->setAlignment(Qt::AlignLeft);
     gameInfoLayout->addWidget(gameVersionLabel);
 
-    if (m_gameSize.left(4) != "0.00") {
+    if (Config::GetLoadGameSizeEnabled()) {
         QLabel* gameSizeLabel = new QLabel(tr("Size: ") + m_gameSize);
         gameSizeLabel->setAlignment(Qt::AlignLeft);
         gameInfoLayout->addWidget(gameSizeLabel);

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -84,7 +84,9 @@ public:
         copyMenu->addAction(copyName);
         copyMenu->addAction(copySerial);
         copyMenu->addAction(copyVersion);
-        copyMenu->addAction(copySize);
+        if (Config::GetLoadGameSizeEnabled()) {
+            copyMenu->addAction(copySize);
+        }
         copyMenu->addAction(copyNameAll);
 
         menu.addMenu(copyMenu);
@@ -362,12 +364,18 @@ public:
         }
 
         if (selected == copyNameAll) {
+            QString GameSizeEnabled;
+            if (Config::GetLoadGameSizeEnabled()) {
+                GameSizeEnabled = " | Size:" + QString::fromStdString(m_games[itemID].size);
+            }
+
             QClipboard* clipboard = QGuiApplication::clipboard();
-            QString combinedText = QString("Name:%1 | Serial:%2 | Version:%3 | Size:%4")
+            QString combinedText = QString("Name:%1 | Serial:%2 | Version:%3%4")
                                        .arg(QString::fromStdString(m_games[itemID].name))
                                        .arg(QString::fromStdString(m_games[itemID].serial))
                                        .arg(QString::fromStdString(m_games[itemID].version))
-                                       .arg(QString::fromStdString(m_games[itemID].size));
+                                       .arg(GameSizeEnabled);
+
             clipboard->setText(combinedText);
         }
 

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -290,6 +290,27 @@ void MainWindow::CreateConnects() {
         connect(settingsDialog, &SettingsDialog::CompatibilityChanged, this,
                 &MainWindow::RefreshGameTable);
 
+        connect(settingsDialog, &SettingsDialog::accepted, this, &MainWindow::RefreshGameTable);
+        connect(settingsDialog, &SettingsDialog::rejected, this, &MainWindow::RefreshGameTable);
+        connect(settingsDialog, &SettingsDialog::close, this, &MainWindow::RefreshGameTable);
+
+        connect(settingsDialog, &SettingsDialog::BackgroundOpacityChanged, this,
+                [this](int opacity) {
+                    Config::setBackgroundImageOpacity(opacity);
+                    if (m_game_list_frame) {
+                        QTableWidgetItem* current = m_game_list_frame->GetCurrentItem();
+                        if (current) {
+                            m_game_list_frame->SetListBackgroundImage(current);
+                        }
+                    }
+                    if (m_game_grid_frame) {
+                        if (m_game_grid_frame->IsValidCellSelected()) {
+                            m_game_grid_frame->SetGridBackgroundImage(m_game_grid_frame->crtRow,
+                                                                      m_game_grid_frame->crtColumn);
+                        }
+                    }
+                });
+
         settingsDialog->exec();
     });
 
@@ -301,6 +322,10 @@ void MainWindow::CreateConnects() {
 
         connect(settingsDialog, &SettingsDialog::CompatibilityChanged, this,
                 &MainWindow::RefreshGameTable);
+
+        connect(settingsDialog, &SettingsDialog::accepted, this, &MainWindow::RefreshGameTable);
+        connect(settingsDialog, &SettingsDialog::rejected, this, &MainWindow::RefreshGameTable);
+        connect(settingsDialog, &SettingsDialog::close, this, &MainWindow::RefreshGameTable);
 
         connect(settingsDialog, &SettingsDialog::BackgroundOpacityChanged, this,
                 [this](int opacity) {

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -118,6 +118,7 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices,
     connect(ui->buttonBox, &QDialogButtonBox::clicked, this,
             [this, config_dir](QAbstractButton* button) {
                 if (button == ui->buttonBox->button(QDialogButtonBox::Save)) {
+                    is_saving = true;
                     UpdateSettings();
                     Config::save(config_dir / "config.toml");
                     QWidget::close();
@@ -341,6 +342,16 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices,
         ui->collectShaderCheckBox->installEventFilter(this);
         ui->copyGPUBuffersCheckBox->installEventFilter(this);
     }
+}
+
+void SettingsDialog::closeEvent(QCloseEvent* event) {
+    if (!is_saving) {
+        ui->backgroundImageOpacitySlider->setValue(backgroundImageOpacitySlider_backup);
+        emit BackgroundOpacityChanged(backgroundImageOpacitySlider_backup);
+        ui->BGMVolumeSlider->setValue(bgm_volume_backup);
+        BackgroundMusicPlayer::getInstance().setVolume(bgm_volume_backup);
+    }
+    QDialog::closeEvent(event);
 }
 
 void SettingsDialog::LoadValuesFromConfig() {

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -197,6 +197,12 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices,
 
     // Gui TAB
     {
+        connect(ui->backgroundImageOpacitySlider, &QSlider::valueChanged, this,
+                [this](int value) { emit BackgroundOpacityChanged(value); });
+
+        connect(ui->BGMVolumeSlider, &QSlider::valueChanged, this,
+                [](int value) { BackgroundMusicPlayer::getInstance().setVolume(value); });
+
         connect(ui->chooseHomeTabComboBox, &QComboBox::currentTextChanged, this,
                 [](const QString& hometab) { Config::setChooseHomeTab(hometab.toStdString()); });
 

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -129,6 +129,10 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices,
                     Config::save(config_dir / "config.toml");
                     LoadValuesFromConfig();
                 } else if (button == ui->buttonBox->button(QDialogButtonBox::Close)) {
+                    ui->backgroundImageOpacitySlider->setValue(backgroundImageOpacitySlider_backup);
+                    emit BackgroundOpacityChanged(backgroundImageOpacitySlider_backup);
+                    ui->BGMVolumeSlider->setValue(bgm_volume_backup);
+                    BackgroundMusicPlayer::getInstance().setVolume(bgm_volume_backup);
                     ResetInstallFolders();
                 }
                 if (Common::Log::IsActive()) {
@@ -337,13 +341,6 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices,
         ui->collectShaderCheckBox->installEventFilter(this);
         ui->copyGPUBuffersCheckBox->installEventFilter(this);
     }
-}
-void SettingsDialog::closeEvent(QCloseEvent* event) {
-    ui->backgroundImageOpacitySlider->setValue(backgroundImageOpacitySlider_backup);
-    emit BackgroundOpacityChanged(backgroundImageOpacitySlider_backup);
-    ui->BGMVolumeSlider->setValue(bgm_volume_backup);
-    BackgroundMusicPlayer::getInstance().setVolume(bgm_volume_backup);
-    QDialog::closeEvent(event);
 }
 
 void SettingsDialog::LoadValuesFromConfig() {

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -63,6 +63,9 @@ QMap<QString, QString> logTypeMap;
 QMap<QString, QString> fullscreenModeMap;
 QMap<QString, QString> chooseHomeTabMap;
 
+int backgroundImageOpacitySlider_backup;
+int bgm_volume_backup;
+
 SettingsDialog::SettingsDialog(std::span<const QString> physical_devices,
                                std::shared_ptr<CompatibilityInfoClass> m_compat_info,
                                QWidget* parent)
@@ -110,7 +113,14 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices,
     defaultTextEdit = tr("Point your mouse at an option to display its description.");
     ui->descriptionText->setText(defaultTextEdit);
 
-    connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &QWidget::close);
+    connect(ui->buttonBox, &QDialogButtonBox::rejected, this, [this]() {
+        ui->backgroundImageOpacitySlider->setValue(backgroundImageOpacitySlider_backup);
+        emit BackgroundOpacityChanged(backgroundImageOpacitySlider_backup);
+
+        ui->BGMVolumeSlider->setValue(bgm_volume_backup);
+        BackgroundMusicPlayer::getInstance().setVolume(bgm_volume_backup);
+        this->close();
+    });
 
     connect(ui->buttonBox, &QDialogButtonBox::clicked, this,
             [this, config_dir](QAbstractButton* button) {
@@ -335,6 +345,13 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices,
         ui->copyGPUBuffersCheckBox->installEventFilter(this);
     }
 }
+void SettingsDialog::closeEvent(QCloseEvent* event) {
+    ui->backgroundImageOpacitySlider->setValue(backgroundImageOpacitySlider_backup);
+    emit BackgroundOpacityChanged(backgroundImageOpacitySlider_backup);
+    ui->BGMVolumeSlider->setValue(bgm_volume_backup);
+    BackgroundMusicPlayer::getInstance().setVolume(bgm_volume_backup);
+    QDialog::closeEvent(event);
+}
 
 void SettingsDialog::LoadValuesFromConfig() {
 
@@ -466,6 +483,9 @@ void SettingsDialog::LoadValuesFromConfig() {
     ResetInstallFolders();
     ui->backgroundImageOpacitySlider->setValue(Config::getBackgroundImageOpacity());
     ui->showBackgroundImageCheckBox->setChecked(Config::getShowBackgroundImage());
+
+    backgroundImageOpacitySlider_backup = Config::getBackgroundImageOpacity();
+    bgm_volume_backup = Config::getBGMvolume();
 }
 
 void SettingsDialog::InitializeEmulatorLanguages() {

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -113,14 +113,7 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices,
     defaultTextEdit = tr("Point your mouse at an option to display its description.");
     ui->descriptionText->setText(defaultTextEdit);
 
-    connect(ui->buttonBox, &QDialogButtonBox::rejected, this, [this]() {
-        ui->backgroundImageOpacitySlider->setValue(backgroundImageOpacitySlider_backup);
-        emit BackgroundOpacityChanged(backgroundImageOpacitySlider_backup);
-
-        ui->BGMVolumeSlider->setValue(bgm_volume_backup);
-        BackgroundMusicPlayer::getInstance().setVolume(bgm_volume_backup);
-        this->close();
-    });
+    connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &QWidget::close);
 
     connect(ui->buttonBox, &QDialogButtonBox::clicked, this,
             [this, config_dir](QAbstractButton* button) {

--- a/src/qt_gui/settings_dialog.h
+++ b/src/qt_gui/settings_dialog.h
@@ -42,6 +42,7 @@ private:
     void InitializeEmulatorLanguages();
     void OnLanguageChanged(int index);
     void OnCursorStateChanged(s16 index);
+    void closeEvent(QCloseEvent* event) override;
 
     std::unique_ptr<Ui::SettingsDialog> ui;
 
@@ -50,4 +51,6 @@ private:
     QString defaultTextEdit;
 
     int initialHeight;
+
+    bool is_saving = false;
 };

--- a/src/qt_gui/settings_dialog.h
+++ b/src/qt_gui/settings_dialog.h
@@ -36,7 +36,6 @@ signals:
     void BackgroundOpacityChanged(int opacity);
 
 private:
-    void closeEvent(QCloseEvent* event) override;
     void LoadValuesFromConfig();
     void UpdateSettings();
     void ResetInstallFolders();

--- a/src/qt_gui/settings_dialog.h
+++ b/src/qt_gui/settings_dialog.h
@@ -36,6 +36,7 @@ signals:
     void BackgroundOpacityChanged(int opacity);
 
 private:
+    void closeEvent(QCloseEvent* event) override;
     void LoadValuesFromConfig();
     void UpdateSettings();
     void ResetInstallFolders();


### PR DESCRIPTION
- The 'Title Music' volume slider updates in real-time.

https://github.com/user-attachments/assets/ded77c81-d058-4748-9203-1687081b3a46

----


- The 'Background Image' opacity slider updates in real-time.

https://github.com/user-attachments/assets/e0c3d014-289e-4810-9a0b-a3f865e9f6d6

----

When you close the settings screen, the information will be updated. For example, if you enable/disable the "Show Game Size in List" option and close the settings screen, you will immediately see the changes without needing to manually refresh the list.

If "Show Game Size in List" is disabled, the "Copy Size" option will not appear, and 'Size' will also be missing from the "Copy All" option.



