### PR TITLE
vk_instance: Re-enable getToolPropertiesEXT on AMD proprietary.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -537,10 +537,6 @@ void Instance::CollectDeviceParameters() {
 }
 
 void Instance::CollectToolingInfo() {
-    if (GetDriverID() == vk::DriverId::eAmdProprietary) {
-        // Currently causes issues with Reshade on AMD proprietary, disabled until fix released.
-        return;
-    }
     const auto [tools_result, tools] = physical_device.getToolPropertiesEXT();
     if (tools_result != vk::Result::eSuccess) {
         LOG_ERROR(Render_Vulkan, "Could not get Vulkan tool properties: {}",


### PR DESCRIPTION
Issue with Reshade should be fixed in new version 6.4.0, need someone to test.