### PR TITLE
Update building-linux.md

### DIFF
--- a/documents/building-linux.md
+++ b/documents/building-linux.md
@@ -36,7 +36,7 @@ sudo dnf install clang git cmake libatomic alsa-lib-devel \
 
 ```bash
 sudo pacman -S base-devel clang git cmake sndio jack2 openal \
-    qt6-base qt6-declarative qt6-multimedia sdl2 \
+    qt6-base qt6-tools qt6-declarative qt6-multimedia sdl2 \
     vulkan-validation-layers libpng
 ```
 


### PR DESCRIPTION
Without `qt6-tools` in Arch Linux, the following error occurs when building
`cmake -S . -B build/ -DENABLE_QT_GUI=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++`
:

```
-- Could NOT find Qt6LinguistTools (missing: Qt6LinguistTools_DIR) CMake Error at CMakeLists.txt:200 (find_package):
  Found package configuration file:

    /usr/lib/cmake/Qt6/Qt6Config.cmake

  but it set Qt6_FOUND to FALSE so package "Qt6" is considered to be NOT
  FOUND.  Reason given by package:

  Failed to find required Qt component "LinguistTools".

  Expected Config file at
  "/usr/lib/cmake/Qt6LinguistTools/Qt6LinguistToolsConfig.cmake" does NOT
  exist



  Configuring with --debug-find-pkg=Qt6LinguistTools might reveal details why
  the package was not found.

  Configuring with -DQT_DEBUG_FIND_PACKAGE=ON will print the values of some
  of the path variables that find_package uses to try and find the package.
```