### PR TITLE
Ajm: Avoid processing job buffers before codec initialization

### DIFF
--- a/src/core/libraries/ajm/ajm_instance.cpp
+++ b/src/core/libraries/ajm/ajm_instance.cpp
@@ -66,6 +66,7 @@ void AjmInstance::ExecuteJob(AjmJob& job) {
         LOG_TRACE(Lib_Ajm, "Initializing instance {}", job.instance_id);
         auto& params = job.input.init_params.value();
         m_codec->Initialize(&params, sizeof(params));
+        is_initialized = true;
     }
     if (job.input.resample_parameters.has_value()) {
         LOG_ERROR(Lib_Ajm, "Unimplemented: resample parameters");
@@ -87,6 +88,10 @@ void AjmInstance::ExecuteJob(AjmJob& job) {
             m_gapless.current.skip_samples += max - m_gapless.init.skip_samples;
             m_gapless.init.skip_samples = max;
         }
+    }
+
+    if (!is_initialized) {
+        return;
     }
 
     if (!job.input.buffer.empty() && !job.output.buffers.empty()) {

--- a/src/core/libraries/ajm/ajm_instance.h
+++ b/src/core/libraries/ajm/ajm_instance.h
@@ -96,6 +96,7 @@ private:
     AjmSidebandResampleParameters m_resample_parameters{};
     u32 m_total_samples{};
     std::unique_ptr<AjmCodec> m_codec;
+    bool is_initialized = false;
 };
 
 } // namespace Libraries::Ajm


### PR DESCRIPTION
Some games send audio jobs before sending an initialization job. Currently, this results in trying to run the decoders before actually initializing them.
This added check fixes Ajm-related crashes in Dragon Ball FighterZ and The Last of Us Remastered.