### PR TITLE
Revert use of embedded icons

### DIFF
--- a/src/core/libraries/np_trophy/trophy_ui.cpp
+++ b/src/core/libraries/np_trophy/trophy_ui.cpp
@@ -31,23 +31,6 @@ TrophyUI::TrophyUI(const std::filesystem::path& trophyIconPath, const std::strin
                   fmt::UTF(trophyIconPath.u8string()));
     }
 
-    std::string pathString;
-    if (trophy_type == "P") {
-        pathString = "Resources/platinum.png";
-    } else if (trophy_type == "G") {
-        pathString = "Resources/gold.png";
-    } else if (trophy_type == "S") {
-        pathString = "Resources/silver.png";
-    } else if (trophy_type == "B") {
-        pathString = "Resources/bronze.png";
-    }
-
-    auto resource = cmrc::res::get_filesystem();
-    auto trophytypefile = resource.open(pathString);
-    std::filesystem::path trophyTypePath = pathString;
-    if (std::filesystem::exists(trophyTypePath))
-        trophy_type_icon = RefCountedTexture::DecodePngFile(trophyTypePath);
-
     AddLayer(this);
 }
 
@@ -76,38 +59,24 @@ void TrophyUI::Draw() {
     if (Begin("Trophy Window", nullptr,
               ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings |
                   ImGuiWindowFlags_NoInputs)) {
-        if (trophy_type_icon) {
+        if (trophy_icon) {
             SetCursorPosY((window_size.y * 0.5f) - (25 * AdjustHeight));
-            Image(trophy_type_icon.GetTexture().im_id,
-                  ImVec2((50 * AdjustWidth), (50 * AdjustHeight)));
+            Image(trophy_icon.GetTexture().im_id, ImVec2((50 * AdjustWidth), (50 * AdjustHeight)));
+            ImGui::SameLine();
         } else {
             // placeholder
             const auto pos = GetCursorScreenPos();
             ImGui::GetWindowDrawList()->AddRectFilled(pos, pos + ImVec2{50.0f * AdjustHeight},
                                                       GetColorU32(ImVec4{0.7f}));
+            ImGui::Indent(60);
         }
-
-        ImGui::SameLine();
 
         SetWindowFontScale((1.2 * AdjustHeight));
         char earned_text[] = "Trophy earned!\n%s";
         const float text_height =
             ImGui::CalcTextSize(std::strcat(earned_text, trophy_name.c_str())).y;
         SetCursorPosY((window_size.y - text_height) * 0.5f);
-
-        ImGui::PushTextWrapPos(window_size.x - (60 * AdjustWidth));
         TextWrapped("Trophy earned!\n%s", trophy_name.c_str());
-        ImGui::SameLine(window_size.x - (60 * AdjustWidth));
-
-        if (trophy_icon) {
-            SetCursorPosY((window_size.y * 0.5f) - (25 * AdjustHeight));
-            Image(trophy_icon.GetTexture().im_id, ImVec2((50 * AdjustWidth), (50 * AdjustHeight)));
-        } else {
-            // placeholder
-            const auto pos = GetCursorScreenPos();
-            ImGui::GetWindowDrawList()->AddRectFilled(pos, pos + ImVec2{30.0f * AdjustHeight},
-                                                      GetColorU32(ImVec4{0.7f}));
-        }
     }
     End();
 

--- a/src/qt_gui/trophy_viewer.cpp
+++ b/src/qt_gui/trophy_viewer.cpp
@@ -118,20 +118,18 @@ void TrophyViewer::PopulateTrophyWidget(QString title) {
             item->setData(Qt::DecorationRole, icon);
             item->setFlags(item->flags() & ~Qt::ItemIsEditable);
             tableWidget->setItem(row, 1, item);
-
-            const std::string filename = GetTrpType(trpType[row].at(0));
             QTableWidgetItem* typeitem = new QTableWidgetItem();
 
-            auto resource = cmrc::res::get_filesystem();
-            std::string resourceString = "Resources/" + filename;
-            auto trophytypefile = resource.open(resourceString);
-
-            QImage type_icon =
-                QImage(QString::fromStdString(resourceString))
-                    .scaled(QSize(64, 64), Qt::KeepAspectRatio, Qt::SmoothTransformation);
-            typeitem->setData(Qt::DecorationRole, type_icon);
-            typeitem->setFlags(typeitem->flags() & ~Qt::ItemIsEditable);
-            tableWidget->setItem(row, 6, typeitem);
+            QString type;
+            if (trpType[row] == "P") {
+                type = "Platinum";
+            } else if (trpType[row] == "G") {
+                type = "Gold";
+            } else if (trpType[row] == "S") {
+                type = "Silver";
+            } else if (trpType[row] == "B") {
+                type = "Bronze";
+            }
 
             std::string detailString = trophyDetails[row].toStdString();
             std::size_t newline_pos = 0;
@@ -146,6 +144,7 @@ void TrophyViewer::PopulateTrophyWidget(QString title) {
                 SetTableItem(tableWidget, row, 3, QString::fromStdString(detailString));
                 SetTableItem(tableWidget, row, 4, trpId[row]);
                 SetTableItem(tableWidget, row, 5, trpHidden[row]);
+                SetTableItem(tableWidget, row, 6, type);
                 SetTableItem(tableWidget, row, 7, trpPid[row]);
             }
             tableWidget->verticalHeader()->resizeSection(row, icon.height());

--- a/src/qt_gui/trophy_viewer.h
+++ b/src/qt_gui/trophy_viewer.h
@@ -31,18 +31,4 @@ private:
     QStringList headers;
     QString gameTrpPath_;
     TRP trp;
-
-    std::string GetTrpType(const QChar trp_) {
-        switch (trp_.toLatin1()) {
-        case 'B':
-            return "bronze.png";
-        case 'S':
-            return "silver.png";
-        case 'G':
-            return "gold.png";
-        case 'P':
-            return "platinum.png";
-        }
-        return "Unknown";
-    }
 };


### PR DESCRIPTION
So the embedded icons in https://github.com/shadps4-emu/shadPS4/pull/2493 are broken for a lot of people, and it does not look like an easy fix, This reverts the use of the embedded icons temporarily while I work on it, still keeping the other fixes in the PR