### PR TITLE
fix:[#2513] align emulator settings content top

### DIFF
--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -130,6 +130,9 @@
                <property name="bottomMargin">
                 <number>9</number>
                </property>
+               <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+                 </property>
                <item>
                 <layout class="QVBoxLayout" name="emulatorverticalLayout">
                  <property name="spacing">


### PR DESCRIPTION
set the alignment of the emulator section contents to left top

![image](https://github.com/user-attachments/assets/560fdc2d-f8b5-40af-a85e-f7060aeaf5bf)

closes #2513 