### PR TITLE
Fix cache size

### DIFF
--- a/src/qt_gui/game_list_utils.h
+++ b/src/qt_gui/game_list_utils.h
@@ -69,8 +69,12 @@ public:
         }
 
         // Cache path
-        QFile size_cache_file(Common::FS::GetUserPath(Common::FS::PathType::MetaDataDir) /
-                              game.serial / "size_cache.txt");
+        QDir cacheDir =
+            QDir(Common::FS::GetUserPath(Common::FS::PathType::MetaDataDir) / game.serial);
+        if (!cacheDir.exists()) {
+            cacheDir.mkpath(".");
+        }
+        QFile size_cache_file(cacheDir.absoluteFilePath("size_cache.txt"));
         QFileInfo cacheInfo(size_cache_file);
         QFileInfo dirInfo(dirPath);
 


### PR DESCRIPTION
The cache file that saves the size of the games was only saved if the folder existed. However, from what I've analyzed, these folders were only being created if you had the trophy keys, and when opening each game individually, so now before saving the cache file, the folder for it is created.