### PR TITLE
Fix and add back Trophy type icons for both the trophy pop-up and viewer

### DIFF
--- a/src/core/libraries/np_trophy/trophy_ui.cpp
+++ b/src/core/libraries/np_trophy/trophy_ui.cpp
@@ -11,8 +11,6 @@
 #include "imgui/imgui_std.h"
 #include "trophy_ui.h"
 
-CMRC_DECLARE(res);
-
 using namespace ImGui;
 namespace Libraries::NpTrophy {
 

--- a/src/core/libraries/np_trophy/trophy_ui.cpp
+++ b/src/core/libraries/np_trophy/trophy_ui.cpp
@@ -88,12 +88,22 @@ void TrophyUI::Draw() {
             ImGui::Indent(60);
         }
 
-        SetWindowFontScale((1.2 * AdjustHeight));
-        char earned_text[] = "Trophy earned!\n%s";
-        const float text_height =
-            ImGui::CalcTextSize(std::strcat(earned_text, trophy_name.c_str())).y;
-        SetCursorPosY((window_size.y - text_height) * 0.5f);
-
+        const std::string combinedString = "Trophy earned!\n%s" + trophy_name;
+        const float wrap_width =
+            CalcWrapWidthForPos(GetCursorScreenPos(), (window_size.x - (60 * AdjustWidth)));
+        SetWindowFontScale(1.2 * AdjustHeight);
+        // If trophy name exceeds 1 line
+        if (CalcTextSize(trophy_name.c_str()).x > wrap_width) {
+            SetCursorPosY(5 * AdjustHeight);
+            if (CalcTextSize(trophy_name.c_str()).x > (wrap_width * 2)) {
+                SetWindowFontScale(0.95 * AdjustHeight);
+            } else {
+                SetWindowFontScale(1.1 * AdjustHeight);
+            }
+        } else {
+            const float text_height = ImGui::CalcTextSize(combinedString.c_str()).y;
+            SetCursorPosY((window_size.y - text_height) * 0.5);
+        }
         ImGui::PushTextWrapPos(window_size.x - (60 * AdjustWidth));
         TextWrapped("Trophy earned!\n%s", trophy_name.c_str());
         ImGui::SameLine(window_size.x - (60 * AdjustWidth));
@@ -104,7 +114,7 @@ void TrophyUI::Draw() {
         } else {
             // placeholder
             const auto pos = GetCursorScreenPos();
-            ImGui::GetWindowDrawList()->AddRectFilled(pos, pos + ImVec2{30.0f * AdjustHeight},
+            ImGui::GetWindowDrawList()->AddRectFilled(pos, pos + ImVec2{50.0f * AdjustHeight},
                                                       GetColorU32(ImVec4{0.7f}));
         }
     }

--- a/src/qt_gui/trophy_viewer.cpp
+++ b/src/qt_gui/trophy_viewer.cpp
@@ -118,18 +118,19 @@ void TrophyViewer::PopulateTrophyWidget(QString title) {
             item->setData(Qt::DecorationRole, icon);
             item->setFlags(item->flags() & ~Qt::ItemIsEditable);
             tableWidget->setItem(row, 1, item);
+
+            const std::string filename = GetTrpType(trpType[row].at(0));
             QTableWidgetItem* typeitem = new QTableWidgetItem();
 
-            QString type;
-            if (trpType[row] == "P") {
-                type = "Platinum";
-            } else if (trpType[row] == "G") {
-                type = "Gold";
-            } else if (trpType[row] == "S") {
-                type = "Silver";
-            } else if (trpType[row] == "B") {
-                type = "Bronze";
-            }
+            auto resource = cmrc::res::get_filesystem();
+            std::string resourceString = "Resources/" + filename;
+            auto file = resource.open(resourceString);
+            std::vector<char> imgdata(file.begin(), file.end());
+            QImage type_icon = QImage::fromData(imgdata).scaled(QSize(64, 64), Qt::KeepAspectRatio,
+                                                                Qt::SmoothTransformation);
+            typeitem->setData(Qt::DecorationRole, type_icon);
+            typeitem->setFlags(typeitem->flags() & ~Qt::ItemIsEditable);
+            tableWidget->setItem(row, 6, typeitem);
 
             std::string detailString = trophyDetails[row].toStdString();
             std::size_t newline_pos = 0;
@@ -144,7 +145,6 @@ void TrophyViewer::PopulateTrophyWidget(QString title) {
                 SetTableItem(tableWidget, row, 3, QString::fromStdString(detailString));
                 SetTableItem(tableWidget, row, 4, trpId[row]);
                 SetTableItem(tableWidget, row, 5, trpHidden[row]);
-                SetTableItem(tableWidget, row, 6, type);
                 SetTableItem(tableWidget, row, 7, trpPid[row]);
             }
             tableWidget->verticalHeader()->resizeSection(row, icon.height());

--- a/src/qt_gui/trophy_viewer.h
+++ b/src/qt_gui/trophy_viewer.h
@@ -31,4 +31,18 @@ private:
     QStringList headers;
     QString gameTrpPath_;
     TRP trp;
+
+    std::string GetTrpType(const QChar trp_) {
+        switch (trp_.toLatin1()) {
+        case 'B':
+            return "bronze.png";
+        case 'S':
+            return "silver.png";
+        case 'G':
+            return "gold.png";
+        case 'P':
+            return "platinum.png";
+        }
+        return "Unknown";
+    }
 };


### PR DESCRIPTION
Fixes and adds back the type icons in the trophy viewer. Does not include the trophy pop-up icons yet, that one is a bit more complicated.

*Should be working now, but would like some tests from other people to be sure

![image](https://github.com/user-attachments/assets/5f497e6c-1dcc-45e2-95be-51fb8a096f7a)


