### PR TITLE
Fix SDL gyro and acceleration sensor handling

### DIFF
--- a/src/core/libraries/pad/pad.cpp
+++ b/src/core/libraries/pad/pad.cpp
@@ -315,6 +315,7 @@ int PS4_SYSV_ABI scePadRead(s32 handle, OrbisPadData* pData, s32 num) {
         pData[i].angularVelocity.x = states[i].angularVelocity.x;
         pData[i].angularVelocity.y = states[i].angularVelocity.y;
         pData[i].angularVelocity.z = states[i].angularVelocity.z;
+        pData[i].orientation = {0.0f, 0.0f, 0.0f, 1.0f};
         if (engine) {
             const auto gyro_poll_rate = engine->GetAccelPollRate();
             if (gyro_poll_rate != 0.0f) {
@@ -384,6 +385,7 @@ int PS4_SYSV_ABI scePadReadState(s32 handle, OrbisPadData* pData) {
     pData->angularVelocity.x = state.angularVelocity.x;
     pData->angularVelocity.y = state.angularVelocity.y;
     pData->angularVelocity.z = state.angularVelocity.z;
+    pData->orientation = {0.0f, 0.0f, 0.0f, 1.0f};
     if (engine) {
         const auto gyro_poll_rate = engine->GetAccelPollRate();
         if (gyro_poll_rate != 0.0f) {

--- a/src/core/libraries/pad/pad.cpp
+++ b/src/core/libraries/pad/pad.cpp
@@ -316,11 +316,11 @@ int PS4_SYSV_ABI scePadRead(s32 handle, OrbisPadData* pData, s32 num) {
         pData[i].angularVelocity.y = states[i].angularVelocity.y;
         pData[i].angularVelocity.z = states[i].angularVelocity.z;
         if (engine) {
-            const auto accel_poll_rate = engine->GetAccelPollRate();
-            if (accel_poll_rate != 0.0f) {
+            const auto gyro_poll_rate = engine->GetAccelPollRate();
+            if (gyro_poll_rate != 0.0f) {
                 GameController::CalculateOrientation(pData[i].acceleration,
                                                      pData[i].angularVelocity,
-                                                     1.0f / accel_poll_rate, pData[i].orientation);
+                                                     1.0f / gyro_poll_rate, pData[i].orientation);
             }
         }
         pData[i].touchData.touchNum =
@@ -385,10 +385,10 @@ int PS4_SYSV_ABI scePadReadState(s32 handle, OrbisPadData* pData) {
     pData->angularVelocity.y = state.angularVelocity.y;
     pData->angularVelocity.z = state.angularVelocity.z;
     if (engine) {
-        const auto accel_poll_rate = engine->GetAccelPollRate();
-        if (accel_poll_rate != 0.0f) {
+        const auto gyro_poll_rate = engine->GetAccelPollRate();
+        if (gyro_poll_rate != 0.0f) {
             GameController::CalculateOrientation(pData->acceleration, pData->angularVelocity,
-                                                 1.0f / accel_poll_rate, pData->orientation);
+                                                 1.0f / gyro_poll_rate, pData->orientation);
         }
     }
     pData->touchData.touchNum =

--- a/src/input/controller.cpp
+++ b/src/input/controller.cpp
@@ -182,7 +182,7 @@ void GameController::CalculateOrientation(Libraries::Pad::OrbisFVector3& acceler
 
     // Normalize accelerometer measurement
     float norm = std::sqrt(ax * ax + ay * ay + az * az);
-    if (norm == 0.0f)
+    if (norm == 0.0f || deltaTime == 0.0f)
         return; // Handle NaN
     norm = 1.0f / norm;
     ax *= norm;

--- a/src/sdl_window.cpp
+++ b/src/sdl_window.cpp
@@ -134,14 +134,16 @@ void SDLInputEngine::Init() {
             m_gyro_poll_rate = SDL_GetGamepadSensorDataRate(m_gamepad, SDL_SENSOR_GYRO);
             LOG_INFO(Input, "Gyro initialized, poll rate: {}", m_gyro_poll_rate);
         } else {
-            LOG_ERROR(Input, "Failed to initialize gyro controls for gamepad, error: {}", SDL_GetError());
+            LOG_ERROR(Input, "Failed to initialize gyro controls for gamepad, error: {}",
+                      SDL_GetError());
             SDL_SetGamepadSensorEnabled(m_gamepad, SDL_SENSOR_GYRO, false);
         }
         if (SDL_SetGamepadSensorEnabled(m_gamepad, SDL_SENSOR_ACCEL, true)) {
             m_accel_poll_rate = SDL_GetGamepadSensorDataRate(m_gamepad, SDL_SENSOR_ACCEL);
             LOG_INFO(Input, "Accel initialized, poll rate: {}", m_accel_poll_rate);
         } else {
-            LOG_ERROR(Input, "Failed to initialize accel controls for gamepad, error: {}", SDL_GetError());
+            LOG_ERROR(Input, "Failed to initialize accel controls for gamepad, error: {}",
+                      SDL_GetError());
             SDL_SetGamepadSensorEnabled(m_gamepad, SDL_SENSOR_ACCEL, false);
         }
     }

--- a/src/sdl_window.cpp
+++ b/src/sdl_window.cpp
@@ -134,13 +134,15 @@ void SDLInputEngine::Init() {
             m_gyro_poll_rate = SDL_GetGamepadSensorDataRate(m_gamepad, SDL_SENSOR_GYRO);
             LOG_INFO(Input, "Gyro initialized, poll rate: {}", m_gyro_poll_rate);
         } else {
-            LOG_ERROR(Input, "Failed to initialize gyro controls for gamepad");
+            LOG_ERROR(Input, "Failed to initialize gyro controls for gamepad, error: {}", SDL_GetError());
+            SDL_SetGamepadSensorEnabled(m_gamepad, SDL_SENSOR_GYRO, false);
         }
         if (SDL_SetGamepadSensorEnabled(m_gamepad, SDL_SENSOR_ACCEL, true)) {
             m_accel_poll_rate = SDL_GetGamepadSensorDataRate(m_gamepad, SDL_SENSOR_ACCEL);
             LOG_INFO(Input, "Accel initialized, poll rate: {}", m_accel_poll_rate);
         } else {
-            LOG_ERROR(Input, "Failed to initialize accel controls for gamepad");
+            LOG_ERROR(Input, "Failed to initialize accel controls for gamepad, error: {}", SDL_GetError());
+            SDL_SetGamepadSensorEnabled(m_gamepad, SDL_SENSOR_ACCEL, false);
         }
     }
 

--- a/src/sdl_window.h
+++ b/src/sdl_window.h
@@ -27,8 +27,8 @@ public:
 private:
     SDL_Gamepad* m_gamepad = nullptr;
 
-    float m_gyro_poll_rate{};
-    float m_accel_poll_rate{};
+    float m_gyro_poll_rate = 0.0f;
+    float m_accel_poll_rate = 0.0f;
 };
 
 } // namespace Input


### PR DESCRIPTION
Fixes the blackscreen in GRR upon trying to float
The issue comes from the fact that for some reason enabling the gyro both works and throws an operation not permitted error, so the emulator assumes that the function is unavailable, so it logs the error, but it's still enabled nevertheless, and it gets read anyway, but when it's time to convert it to orientation values, the deltatime is still an uninitialized zero, which messes up the calculations and outputs garbage orientation data that's so out of expected ranges (the quaternion should be normalized to length 1, and this makes some coordinates to be in the thousands), that the camera position calculation in the game just gives up, and that's why the game turns black apart from the HUD

This has the side effect of orientation not being available to users who had this issue, but for Arch users, I found this "fix" (might work for other distros too):
```bash
sudo nano /etc/udev/rules.d/99-gamepad-motion.rules
```
Add the following text:
```ini
KERNEL=="event*", SUBSYSTEM=="input", MODE="0666"
```
Reload this config:
```bash
sudo udevadm control --reload-rules
sudo udevadm trigger
```