### PR TITLE
QT: Fix Fullscreen

### DIFF
--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -677,7 +677,8 @@ void SettingsDialog::UpdateSettings() {
 
     const QVector<std::string> TouchPadIndex = {"left", "center", "right", "none"};
     Config::setBackButtonBehavior(TouchPadIndex[ui->backButtonBehaviorComboBox->currentIndex()]);
-    Config::setIsFullscreen(ui->displayModeComboBox->currentText().toStdString() != "Windowed");
+    Config::setIsFullscreen(screenModeMap.value(ui->displayModeComboBox->currentText()) !=
+                            "Windowed");
     Config::setFullscreenMode(
         screenModeMap.value(ui->displayModeComboBox->currentText()).toStdString());
     Config::setIsMotionControlsEnabled(ui->motionControlsCheckBox->isChecked());


### PR DESCRIPTION
There are these 2 options about full screen, and 'Fullscreen' was being set to 'true' because it was comparing the word "Windowed" with the interface information, but if you are using another language it might not identify it and even using 'Borderless' the screen would be full.