### PR TITLE
cmake: Cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 if(APPLE)
-    enable_language(OBJC)
+    list(APPEND ADDITIONAL_LANGUAGES OBJC)
     set(CMAKE_OSX_DEPLOYMENT_TARGET 14)
 endif()
 
@@ -16,7 +16,7 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 
-project(shadPS4 CXX C ASM)
+project(shadPS4 CXX C ASM ${ADDITIONAL_LANGUAGES})
 
 # Forcing PIE makes sure that the base address is high enough so that it doesn't clash with the PS4 memory.
 if(UNIX AND NOT APPLE)

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -18,8 +18,6 @@ endif()
 
 # Boost
 if (NOT TARGET Boost::headers)
-    set(BOOST_ROOT "${CMAKE_SOURCE_DIR}/externals/ext-boost" CACHE STRING "")
-    set(Boost_NO_SYSTEM_PATHS ON CACHE BOOL "")
     add_subdirectory(ext-boost)
 endif()
 
@@ -77,6 +75,7 @@ endif()
 
 # SDL3
 if (NOT TARGET SDL3::SDL3)
+    set(SDL_TEST_LIBRARY OFF)
     set(SDL_PIPEWIRE OFF)
     add_subdirectory(sdl3)
 endif()
@@ -131,6 +130,14 @@ endif()
 # Toml11
 if (NOT TARGET toml11::toml11)
     add_subdirectory(toml11)
+
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      if (CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+        get_target_property(_toml11_compile_options toml11 INTERFACE_COMPILE_OPTIONS)
+        list(REMOVE_ITEM _toml11_compile_options "/Zc:preprocessor")
+        set_target_properties(toml11 PROPERTIES INTERFACE_COMPILE_OPTIONS ${_toml11_compile_options})
+      endif()
+    endif()
 endif()
 
 # xxHash

--- a/externals/gcn/CMakeLists.txt
+++ b/externals/gcn/CMakeLists.txt
@@ -3,6 +3,10 @@
 
 project(gcn LANGUAGES CXX)
 
-add_library(gcn dummy.cpp)
+add_library(gcn INTERFACE)
+target_sources(gcn PRIVATE
+  "include/gcn/si_ci_vi_merged_offset.h"
+  "include/gcn/si_ci_vi_merged_pm4_it_opcodes.h"
+)
 
 target_include_directories(gcn INTERFACE include)

--- a/externals/gcn/dummy.cpp
+++ b/externals/gcn/dummy.cpp
@@ -1,2 +1,0 @@
-//  SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
-//  SPDX-License-Identifier: GPL-2.0-or-later


### PR DESCRIPTION
- Don't call `enable_language` before `project`.
See CMake docs for CMP0165.
- Remove boost-related cache variables.
It's too late to set them because `Boost::headers` has already been found.
- Don't build `SDL3-test` library.
Not used by shadps4.
- Remove `/Zc:preprocessor` from toml11's `INTERFACE_COMPILE_OPTIONS`.
Clang-cl does not support this flag and emits a lot of warnings.
- Remove `dummy.cpp` and make `gcn` a proper `INTERFACE` target