### PR TITLE
libkernel: improve module finding in sceKernelLoadStartModule

### DIFF
--- a/src/core/libraries/kernel/process.cpp
+++ b/src/core/libraries/kernel/process.cpp
@@ -47,23 +47,12 @@ s32 PS4_SYSV_ABI sceKernelLoadStartModule(const char* moduleFileName, size_t arg
     s32 handle;
 
     if (guest_path[0] == '/') {
-        path = mnt->GetHostPath("/system/common/lib" + guest_path);
-        handle = linker->LoadAndStartModule(path, args, argp, pRes);
-        if (handle != -1) {
-            return handle;
-        }
-
-        path = mnt->GetHostPath("/system/priv/lib" + guest_path);
-        handle = linker->LoadAndStartModule(path, args, argp, pRes);
-        if (handle != -1) {
-            return handle;
-        }
-
         path = mnt->GetHostPath(guest_path);
         handle = linker->LoadAndStartModule(path, args, argp, pRes);
         if (handle != -1) {
             return handle;
         }
+        ASSERT_MSG(0, "Trying to load system module {}", guest_path);
     } else {
         auto* process_params = linker->GetProcParam();
         if (process_params->sdk_version > 0x3ffffff) {
@@ -72,11 +61,7 @@ s32 PS4_SYSV_ABI sceKernelLoadStartModule(const char* moduleFileName, size_t arg
                 if (guest_path.contains("libScePigletv2VSH") ||
                     guest_path.contains("libSceSysCore") ||
                     guest_path.contains("libSceVideoCoreServerInterface")) {
-                    path = mnt->GetHostPath(guest_path);
-                    handle = linker->LoadAndStartModule(path, args, argp, pRes);
-                    if (handle != -1) {
-                        return handle;
-                    }
+                    ASSERT_MSG(0, "Trying to load system module {}", guest_path);
                 } else {
                     // loading prohibited
                     return ORBIS_KERNEL_ERROR_ENOENT;
@@ -93,17 +78,7 @@ s32 PS4_SYSV_ABI sceKernelLoadStartModule(const char* moduleFileName, size_t arg
                 return handle;
             }
             if ((flags & 0x10000) != 0) {
-                path = mnt->GetHostPath("/system/priv/lib/" + guest_path);
-                handle = linker->LoadAndStartModule(path, args, argp, pRes);
-                if (handle != -1) {
-                    return handle;
-                }
-
-                path = mnt->GetHostPath("/system/common/lib" + guest_path);
-                handle = linker->LoadAndStartModule(path, args, argp, pRes);
-                if (handle != -1) {
-                    return handle;
-                }
+                ASSERT_MSG(0, "Trying to load system module {}", guest_path);
             }
         } else {
             path = mnt->GetHostPath(guest_path);

--- a/src/core/libraries/kernel/process.cpp
+++ b/src/core/libraries/kernel/process.cpp
@@ -36,9 +36,7 @@ s32 PS4_SYSV_ABI sceKernelLoadStartModule(const char* moduleFileName, size_t arg
                                           u32 flags, const void* pOpt, int* pRes) {
     LOG_INFO(Lib_Kernel, "called filename = {}, args = {}", moduleFileName, args);
 
-    if (flags != 0) {
-        return ORBIS_KERNEL_ERROR_EINVAL;
-    }
+    ASSERT(flags == 0);
 
     std::string guest_path(moduleFileName);
     auto* mnt = Common::Singleton<Core::FileSys::MntPoints>::Instance();
@@ -52,33 +50,14 @@ s32 PS4_SYSV_ABI sceKernelLoadStartModule(const char* moduleFileName, size_t arg
         if (handle != -1) {
             return handle;
         }
-        ASSERT_MSG(0, "Trying to load system module {}", guest_path);
+        //Trying to load a system module
+        UNREACHABLE();
     } else {
-        auto* process_params = linker->GetProcParam();
-        if (process_params->sdk_version > 0x3ffffff) {
-            if (process_params->process_name != nullptr &&
-                strstr(process_params->process_name, "web_core.elf")) {
-                if (guest_path.contains("libScePigletv2VSH") ||
-                    guest_path.contains("libSceSysCore") ||
-                    guest_path.contains("libSceVideoCoreServerInterface")) {
-                    ASSERT_MSG(0, "Trying to load system module {}", guest_path);
-                } else {
-                    // loading prohibited
-                    return ORBIS_KERNEL_ERROR_ENOENT;
-                }
-            } else {
-                // loading prohibited
-                return ORBIS_KERNEL_ERROR_ENOENT;
-            }
-        }
         if (!guest_path.contains('/')) {
             path = mnt->GetHostPath("/app0/" + guest_path);
             handle = linker->LoadAndStartModule(path, args, argp, pRes);
             if (handle != -1) {
                 return handle;
-            }
-            if ((flags & 0x10000) != 0) {
-                ASSERT_MSG(0, "Trying to load system module {}", guest_path);
             }
         } else {
             path = mnt->GetHostPath(guest_path);

--- a/src/core/libraries/kernel/process.cpp
+++ b/src/core/libraries/kernel/process.cpp
@@ -50,7 +50,7 @@ s32 PS4_SYSV_ABI sceKernelLoadStartModule(const char* moduleFileName, size_t arg
         if (handle != -1) {
             return handle;
         }
-        //Trying to load a system module
+        // Trying to load a system module
         UNREACHABLE();
     } else {
         if (!guest_path.contains('/')) {

--- a/src/core/libraries/kernel/process.cpp
+++ b/src/core/libraries/kernel/process.cpp
@@ -46,7 +46,7 @@ s32 PS4_SYSV_ABI sceKernelLoadStartModule(const char* moduleFileName, size_t arg
     std::filesystem::path path;
     s32 handle;
 
-    if(guest_path[0] == '/') {
+    if (guest_path[0] == '/') {
         path = mnt->GetHostPath("/system/common/lib" + guest_path);
         handle = linker->LoadAndStartModule(path, args, argp, pRes);
         if (handle != -1) {

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -139,7 +139,7 @@ s32 Linker::LoadModule(const std::filesystem::path& elf_name, bool is_dynamic) {
     return m_modules.size() - 1;
 }
 
-s32 Linker::LoadAndStartModule(const std::filesystem::path& path, size_t args, const void* argp,
+s32 Linker::LoadAndStartModule(const std::filesystem::path& path, u64 args, const void* argp,
                                int* pRes) {
     u32 handle = FindByName(path);
     if (handle != -1) {

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -139,6 +139,35 @@ s32 Linker::LoadModule(const std::filesystem::path& elf_name, bool is_dynamic) {
     return m_modules.size() - 1;
 }
 
+s32 Linker::LoadAndStartModule(const std::filesystem::path& path, size_t args, const void* argp,
+                               int* pRes) {
+    u32 handle = FindByName(path);
+    if (handle != -1) {
+        return handle;
+    }
+    handle = LoadModule(path, true);
+    if (handle == -1) {
+        return -1;
+    }
+    auto* module = GetModule(handle);
+    RelocateAnyImports(module);
+
+    // If the new module has a TLS image, trigger its load when TlsGetAddr is called.
+    if (module->tls.image_size != 0) {
+        AdvanceGenerationCounter();
+    }
+
+    // Retrieve and verify proc param according to libkernel.
+    u64* param = module->GetProcParam<u64*>();
+    ASSERT_MSG(!param || param[0] >= 0x18, "Invalid module param size: {}", param[0]);
+    s32 ret = module->Start(args, argp, param);
+    if (pRes) {
+        *pRes = ret;
+    }
+
+    return handle;
+}
+
 Module* Linker::FindByAddress(VAddr address) {
     for (auto& module : m_modules) {
         const VAddr base = module->GetBaseAddress();

--- a/src/core/linker.h
+++ b/src/core/linker.h
@@ -144,7 +144,7 @@ public:
     void FreeTlsForNonPrimaryThread(void* pointer);
 
     s32 LoadModule(const std::filesystem::path& elf_name, bool is_dynamic = false);
-    s32 LoadAndStartModule(const std::filesystem::path& path, size_t args, const void* argp,
+    s32 LoadAndStartModule(const std::filesystem::path& path, u64 args, const void* argp,
                            int* pRes);
     Module* FindByAddress(VAddr address);
 

--- a/src/core/linker.h
+++ b/src/core/linker.h
@@ -144,6 +144,8 @@ public:
     void FreeTlsForNonPrimaryThread(void* pointer);
 
     s32 LoadModule(const std::filesystem::path& elf_name, bool is_dynamic = false);
+    s32 LoadAndStartModule(const std::filesystem::path& path, size_t args, const void* argp,
+                           int* pRes);
     Module* FindByAddress(VAddr address);
 
     void Relocate(Module* module);

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -94,7 +94,7 @@ Module::Module(Core::MemoryManager* memory_, const std::filesystem::path& file_,
 
 Module::~Module() = default;
 
-s32 Module::Start(size_t args, const void* argp, void* param) {
+s32 Module::Start(u64 args, const void* argp, void* param) {
     LOG_INFO(Core_Linker, "Module started : {}", name);
     const VAddr addr = dynamic_info.init_virtual_addr + GetBaseAddress();
     return ExecuteGuest(reinterpret_cast<EntryFunc>(addr), args, argp, param);

--- a/src/core/module.h
+++ b/src/core/module.h
@@ -203,7 +203,7 @@ public:
         return (rela_bits[index >> 3] >> (index & 7)) & 1;
     }
 
-    s32 Start(size_t args, const void* argp, void* param);
+    s32 Start(u64 args, const void* argp, void* param);
     void LoadModuleToMemory(u32& max_tls_index);
     void LoadDynamicInfo();
     void LoadSymbols();


### PR DESCRIPTION
This PR changes sceKernelLoadStartModule to follow its implementation in a more precise manner. It's based on the comment on a previous MR (https://github.com/shadps4-emu/shadPS4/pull/2246#issuecomment-2621075627)

This also makes Battle Garegga (https://github.com/shadps4-emu/shadps4-game-compatibility/issues/398) playable.