### PR TITLE
Add unexcepted depth format to PromoteFormatToDepth unreachable

### DIFF
--- a/src/video_core/renderer_vulkan/liverpool_to_vk.h
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.h
@@ -104,7 +104,7 @@ static inline vk::Format PromoteFormatToDepth(vk::Format fmt) {
     } else if (fmt == vk::Format::eR16Unorm) {
         return vk::Format::eD16Unorm;
     }
-    UNREACHABLE();
+    UNREACHABLE_MSG("Unexpected depth format {}", vk::to_string(fmt));
 }
 
 } // namespace Vulkan::LiverpoolToVK


### PR DESCRIPTION
Demonstration on PC Building Simulator (CUSA14566):
![image](https://github.com/user-attachments/assets/43cfdda2-43be-4a6d-851d-eedb50132c39)