### PR TITLE
Implement DS_WRITE2ST64_B64

### DIFF
--- a/src/shader_recompiler/frontend/translate/data_share.cpp
+++ b/src/shader_recompiler/frontend/translate/data_share.cpp
@@ -61,6 +61,8 @@ void Translator::EmitDataShare(const GcnInst& inst) {
         return DS_WRITE(64, false, false, false, inst);
     case Opcode::DS_WRITE2_B64:
         return DS_WRITE(64, false, true, false, inst);
+    case Opcode::DS_WRITE2ST64_B64:
+        return DS_WRITE(64, false, true, true, inst);
     case Opcode::DS_READ_B64:
         return DS_READ(64, false, false, false, inst);
     case Opcode::DS_READ2_B64:


### PR DESCRIPTION
Implementing shader opcode DS_WRITE2ST64_B64, this opcode is needed for both [Nier Replicant](https://github.com/shadps4-emu/shadPS4/issues/496#issuecomment-2627026963) and [Monster Hunter World](https://github.com/shadps4-emu/shadPS4/issues/496#issuecomment-2585562987) according to the the Missing opcodes aggregate issue. Allows Nier Replicant to reach menus.