### PR TITLE
Fix list after deleting a game

### DIFF
--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -13,6 +13,7 @@
 #include <qt_gui/background_music_player.h>
 #include "cheats_patches.h"
 #include "common/config.h"
+#include "common/path_util.h"
 #include "common/version.h"
 #include "compatibility_info.h"
 #include "game_info.h"
@@ -26,12 +27,11 @@
 #include <shobjidl.h>
 #include <wrl/client.h>
 #endif
-#include "common/path_util.h"
 
 class GuiContextMenus : public QObject {
     Q_OBJECT
 public:
-    void RequestGameMenu(const QPoint& pos, QVector<GameInfo> m_games,
+    void RequestGameMenu(const QPoint& pos, QVector<GameInfo>& m_games,
                          std::shared_ptr<CompatibilityInfoClass> m_compat_info,
                          QTableWidget* widget, bool isList) {
         QPoint global_pos = widget->viewport()->mapToGlobal(pos);


### PR DESCRIPTION
Fix https://github.com/shadps4-emu/shadPS4/issues/2568

After deleting, it was only removed from the interface, but the game list was not updated.
So after deleting the old list, it remained despite the visual deception.