### PR TITLE
Fix time - sceKernelClockGettime

### DIFF
--- a/src/core/libraries/kernel/time.cpp
+++ b/src/core/libraries/kernel/time.cpp
@@ -115,14 +115,16 @@ int PS4_SYSV_ABI sceKernelClockGettime(s32 clock_id, OrbisKernelTimespec* tp) {
         break;
     }
 
-    timespec t{};
-    int result = clock_gettime(pclock_id, &t);
-    tp->tv_sec = t.tv_sec;
-    tp->tv_nsec = t.tv_nsec;
-    if (result == 0) {
-        return ORBIS_OK;
+    time_t raw_time = time(nullptr);
+
+    if (raw_time == (time_t)(-1)) {
+        return ORBIS_KERNEL_ERROR_EINVAL;
     }
-    return ORBIS_KERNEL_ERROR_EINVAL;
+
+    tp->tv_sec = static_cast<long>(raw_time);
+    tp->tv_nsec = 0;
+
+    return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI posix_clock_gettime(s32 clock_id, OrbisKernelTimespec* time) {


### PR DESCRIPTION
sceKernelClockGettime was not correctly getting the current date

When saving a game, this function was called, but it wasn’t returning the date correctly, as seen in the image with 1969 or 1970.
And as shown, the last two saves have the correct date, as this PR was used to save.

*If you have any game that shows the wrong date, it will only be corrected after making a new save.

Game: VA-11 Hall-A
![image](https://github.com/user-attachments/assets/965864bf-526a-45f1-8f14-b2cba12f200a)
*Yes, 02/03/2025 is correct because I am in Brazil, so it shows my date format, dd/mm/yyyy. This varies according to your system, as shown in the screenshot below.

Game: KNACK 2
| Before | After | 
|-------------|-------------|
![image](https://github.com/user-attachments/assets/8a88a53d-ea5a-4fbc-a93a-e00720c37160) | ![image](https://github.com/user-attachments/assets/dd8fad2d-a5ea-4930-9bd5-0363fb5422ea)

It's very likely that this is also used in other places besides the save. I remember seeing some logs with incorrect dates.
