### PR TITLE
Make sceImeKeyboardOpen log debug only

### DIFF
--- a/src/core/libraries/ime/ime.cpp
+++ b/src/core/libraries/ime/ime.cpp
@@ -269,7 +269,7 @@ int PS4_SYSV_ABI sceImeKeyboardGetResourceId() {
 }
 
 s32 PS4_SYSV_ABI sceImeKeyboardOpen(s32 userId, const OrbisImeKeyboardParam* param) {
-    LOG_INFO(Lib_Ime, "called");
+    LOG_DEBUG(Lib_Ime, "called");
 
     if (!param) {
         return ORBIS_IME_ERROR_INVALID_ADDRESS;


### PR DESCRIPTION
I've recently found out that all my Unity games started spamming this every frame.
Reduces log spam in Unity games.