### PR TITLE
Add global/common user folder for Windows

### DIFF
--- a/src/common/path_util.cpp
+++ b/src/common/path_util.cpp
@@ -17,6 +17,8 @@
 #ifdef _WIN32
 // This is the maximum number of UTF-16 code units permissible in Windows file paths
 #define MAX_PATH 260
+#include <Shlobj.h>
+#include <windows.h>
 #else
 // This is the maximum number of UTF-8 code units permissible in all other OSes' file paths
 #define MAX_PATH 1024
@@ -106,6 +108,10 @@ static auto UserPaths = [] {
         } else {
             user_dir = std::filesystem::path(getenv("HOME")) / ".local" / "share" / "shadPS4";
         }
+#elif _WIN32
+        TCHAR appdata[MAX_PATH] = {0};
+        SHGetFolderPath(NULL, CSIDL_APPDATA, NULL, 0, appdata);
+        user_dir = std::filesystem::path(appdata) / "shadPS4";
 #endif
     }
 

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -668,7 +668,7 @@ void SettingsDialog::updateNoteTextEdit(const QString& elementName) {
     } else if (elementName == "removeFolderButton") {
         text = tr("Remove:\\nRemove a folder from the list.");
     } else if (elementName == "PortableUserFolderGroupBox") {
-        text = tr("Portable user folder:\\nStores shadPS4 settings and data that will be applied only to the shadPS4 build located in the current folder");
+        text = tr("Portable user folder:\\nStores shadPS4 settings and data that will be applied only to the shadPS4 build located in the current folder. Restart the app after creating the portable user folder to begin using it.");
     }
 
     // Save Data

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -5,6 +5,7 @@
 #include <QDirIterator>
 #include <QFileDialog>
 #include <QHoverEvent>
+#include <QMessageBox>
 #include <fmt/format.h>
 
 #include "common/config.h"
@@ -234,6 +235,21 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices,
                                       Common::FS::GetUserPath(Common::FS::PathType::CustomTrophy));
             QDesktopServices::openUrl(QUrl::fromLocalFile(userPath));
         });
+
+        connect(ui->PortableUserButton, &QPushButton::clicked, this, []() {
+            QString userDir;
+            Common::FS::PathToQString(userDir, std::filesystem::current_path() / "user");
+            if (std::filesystem::exists(std::filesystem::current_path() / "user")) {
+                QMessageBox::information(NULL, "Cannot create portable user folder",
+                                         userDir + " already exists");
+            } else {
+                std::filesystem::copy(Common::FS::GetUserPath(Common::FS::PathType::UserDir),
+                                      std::filesystem::current_path() / "user",
+                                      std::filesystem::copy_options::recursive);
+                QMessageBox::information(NULL, "Portable user folder created",
+                                         userDir + " successfully created");
+            }
+        });
     }
 
     // Input TAB
@@ -344,6 +360,7 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices,
         ui->saveDataGroupBox->installEventFilter(this);
         ui->currentSaveDataPath->installEventFilter(this);
         ui->browseButton->installEventFilter(this);
+        ui->PortableUserFolderGroupBox->installEventFilter(this);
 
         // Debug
         ui->debugDump->installEventFilter(this);
@@ -650,6 +667,8 @@ void SettingsDialog::updateNoteTextEdit(const QString& elementName) {
         text = tr("Add:\\nAdd a folder to the list.");
     } else if (elementName == "removeFolderButton") {
         text = tr("Remove:\\nRemove a folder from the list.");
+    } else if (elementName == "PortableUserFolderGroupBox") {
+        text = tr("Portable user folder:\\nStores shadPS4 settings and data that will be applied only to the shadPS4 build located in the current folder");
     }
 
     // Save Data

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -31,7 +31,7 @@
    <string>Settings</string>
   </property>
   <property name="windowIcon">
-   <iconset>
+   <iconset resource="../shadps4.qrc">
     <normaloff>:/images/shadps4.ico</normaloff>:/images/shadps4.ico</iconset>
   </property>
   <property name="sizeGripEnabled">
@@ -59,7 +59,7 @@
       </size>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>5</number>
      </property>
      <widget class="QScrollArea" name="generalTab">
       <property name="widgetResizable">
@@ -74,7 +74,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>545</height>
+         <height>536</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="generalTabVLayout" stretch="0">
@@ -130,9 +130,6 @@
                <property name="bottomMargin">
                 <number>9</number>
                </property>
-               <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
-                 </property>
                <item>
                 <layout class="QVBoxLayout" name="emulatorverticalLayout">
                  <property name="spacing">
@@ -455,7 +452,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>545</height>
+         <height>536</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="guiTabVLayout" stretch="0">
@@ -904,7 +901,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>545</height>
+         <height>536</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="graphicsTabVLayout" stretch="0,0">
@@ -1199,7 +1196,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>545</height>
+         <height>536</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="userTabVLayout" stretch="0,0,1">
@@ -1306,14 +1303,14 @@
                     <string>Top</string>
                    </property>
                   </widget>
-                  </item>
+                 </item>
                  <item>
                   <widget class="QRadioButton" name="radioButton_Bottom">
                    <property name="text">
                     <string>Bottom</string>
                    </property>
                   </widget>
-                  </item>
+                 </item>
                 </layout>
                </item>
                <item>
@@ -1335,8 +1332,7 @@
                   </widget>
                  </item>
                  <item>
-                  <widget class="QDoubleSpinBox" name="popUpDurationSpinBox">
-                  </widget>
+                  <widget class="QDoubleSpinBox" name="popUpDurationSpinBox"/>
                  </item>
                  <item>
                   <spacer name="horizontalSpacer_4">
@@ -1442,7 +1438,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>545</height>
+         <height>536</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="inputTabVLayout" stretch="0,0">
@@ -1726,7 +1722,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>545</height>
+         <height>536</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="pathsTabLayout">
@@ -1800,6 +1796,58 @@
           </layout>
          </widget>
         </item>
+        <item>
+         <widget class="QGroupBox" name="PortableUserFolderGroupBox">
+          <property name="title">
+           <string>Portable User Folder</string>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_2">
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_9">
+             <item>
+              <spacer name="horizontalSpacer_6">
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QPushButton" name="PortableUserButton">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Create Portable User Folder from Common User Folder</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_5">
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+        </item>
        </layout>
       </widget>
      </widget>
@@ -1816,7 +1864,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>545</height>
+         <height>536</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="debugTabVLayout" stretch="0,0">
@@ -2068,6 +2116,8 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../shadps4.qrc"/>
+ </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
Closes https://github.com/shadps4-emu/shadPS4/issues/2549

Similar to other OS's, this creates a global user folder for shadps4 on Windows (Appdata/Roaming/shadps4). Same as other OS, if there is a portable user folder present, shadPS4 will use that instead, so users can still have separate settings per folder if they want.

Also adds a button for easily creating a portable user folder under Settings Dialog / paths tab:

![Screenshot 2025-03-04 164751](https://github.com/user-attachments/assets/7005aebd-3b5d-4715-ad23-d097e5370f4a)