### PR TITLE
Fix space

### DIFF
--- a/src/qt_gui/kbm_gui.cpp
+++ b/src/qt_gui/kbm_gui.cpp
@@ -105,19 +105,19 @@ KBMSettings::KBMSettings(std::shared_ptr<GameInfoClass> game_info_get, QWidget* 
 
     connect(ui->DeadzoneOffsetSlider, &QSlider::valueChanged, this, [this](int value) {
         QString DOSValue = QString::number(value / 100.0, 'f', 2);
-        QString DOSString = tr("Deadzone Offset (def 0.50): ") + DOSValue;
+        QString DOSString = tr("Deadzone Offset (def 0.50):") + " " + DOSValue;
         ui->DeadzoneOffsetLabel->setText(DOSString);
     });
 
     connect(ui->SpeedMultiplierSlider, &QSlider::valueChanged, this, [this](int value) {
         QString SMSValue = QString::number(value / 10.0, 'f', 1);
-        QString SMSString = tr("Speed Multiplier (def 1.0): ") + SMSValue;
+        QString SMSString = tr("Speed Multiplier (def 1.0):") + " " + SMSValue;
         ui->SpeedMultiplierLabel->setText(SMSString);
     });
 
     connect(ui->SpeedOffsetSlider, &QSlider::valueChanged, this, [this](int value) {
         QString SOSValue = QString::number(value / 1000.0, 'f', 3);
-        QString SOSString = tr("Speed Offset (def 0.125): ") + " " + SOSValue;
+        QString SOSString = tr("Speed Offset (def 0.125):") + " " + SOSValue;
         ui->SpeedOffsetLabel->setText(SOSString);
     });
 }
@@ -576,7 +576,7 @@ void KBMSettings::SetUIValuestoMappings(std::string config_id) {
                     int DOffsetInt = int(DOffsetValue);
                     ui->DeadzoneOffsetSlider->setValue(DOffsetInt);
                     QString LabelValue = QString::number(DOffsetInt / 100.0, 'f', 2);
-                    QString LabelString = tr("Deadzone Offset (def 0.50): ") + LabelValue;
+                    QString LabelString = tr("Deadzone Offset (def 0.50):") + " " + LabelValue;
                     ui->DeadzoneOffsetLabel->setText(LabelString);
 
                     std::string SMSOstring = line.substr(comma_pos + 1);
@@ -591,7 +591,7 @@ void KBMSettings::SetUIValuestoMappings(std::string config_id) {
                             SpeedMultInt = 50;
                         ui->SpeedMultiplierSlider->setValue(SpeedMultInt);
                         LabelValue = QString::number(SpeedMultInt / 10.0, 'f', 1);
-                        LabelString = tr("Speed Multiplier (def 1.0): ") + LabelValue;
+                        LabelString = tr("Speed Multiplier (def 1.0):") + " " + LabelValue;
                         ui->SpeedMultiplierLabel->setText(LabelString);
 
                         std::string SOstring = SMSOstring.substr(comma_pos2 + 1);
@@ -599,7 +599,7 @@ void KBMSettings::SetUIValuestoMappings(std::string config_id) {
                         int SOffsetInt = int(SOffsetValue);
                         ui->SpeedOffsetSlider->setValue(SOffsetInt);
                         LabelValue = QString::number(SOffsetInt / 1000.0, 'f', 3);
-                        LabelString = tr("Speed Offset (def 0.125): ") + LabelValue;
+                        LabelString = tr("Speed Offset (def 0.125):") + " " + LabelValue;
                         ui->SpeedOffsetLabel->setText(LabelString);
                     }
                 }

--- a/src/qt_gui/kbm_gui.cpp
+++ b/src/qt_gui/kbm_gui.cpp
@@ -117,7 +117,7 @@ KBMSettings::KBMSettings(std::shared_ptr<GameInfoClass> game_info_get, QWidget* 
 
     connect(ui->SpeedOffsetSlider, &QSlider::valueChanged, this, [this](int value) {
         QString SOSValue = QString::number(value / 1000.0, 'f', 3);
-        QString SOSString = tr("Speed Offset (def 0.125):") + " " + SOSValue;
+        QString SOSString = tr("Speed Offset (def 0.125): ") + " " + SOSValue;
         ui->SpeedOffsetLabel->setText(SOSString);
     });
 }

--- a/src/qt_gui/kbm_gui.ui
+++ b/src/qt_gui/kbm_gui.ui
@@ -634,7 +634,7 @@
                   <enum>Qt::FocusPolicy::NoFocus</enum>
                  </property>
                  <property name="text">
-                  <string>Copy  from Common Config</string>
+                  <string>Copy from Common Config</string>
                  </property>
                 </widget>
                </item>


### PR DESCRIPTION
Remove the spaces from the translation string for mouse parameters, so the translators don't have to add the extra space at the end.

Also fixes one string needing two translations because one instance has a space and one does not