### PR TITLE
Adds missing tr functions for certain GUI strings that should be translatable

### DIFF
--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -100,8 +100,8 @@ void ControlSettings::SaveControllerConfig(bool CloseOnSave) {
     if (count_axis_left_x > 1 | count_axis_left_y > 1 | count_axis_right_x > 1 |
         count_axis_right_y > 1) {
         QMessageBox::StandardButton nosave;
-        nosave = QMessageBox::information(this, "Unable to Save",
-                                          "Cannot bind axis values more than once");
+        nosave = QMessageBox::information(this, tr("Unable to Save"),
+                                          tr("Cannot bind axis values more than once"));
         return;
     }
 

--- a/src/qt_gui/kbm_config_dialog.cpp
+++ b/src/qt_gui/kbm_config_dialog.cpp
@@ -28,7 +28,7 @@ HelpDialog* helpDialog;
 
 EditorDialog::EditorDialog(QWidget* parent) : QDialog(parent) {
 
-    setWindowTitle("Edit Keyboard + Mouse and Controller input bindings");
+    setWindowTitle(tr("Edit Keyboard + Mouse and Controller input bindings"));
     resize(600, 400);
 
     // Create the editor widget
@@ -42,7 +42,7 @@ EditorDialog::EditorDialog(QWidget* parent) : QDialog(parent) {
     // Load all installed games
     loadInstalledGames();
 
-    QCheckBox* unifiedInputCheckBox = new QCheckBox("Use Per-Game configs", this);
+    QCheckBox* unifiedInputCheckBox = new QCheckBox(tr("Use Per-Game configs"), this);
     unifiedInputCheckBox->setChecked(!Config::GetUseUnifiedInputConfig());
 
     // Connect checkbox signal
@@ -94,7 +94,7 @@ void EditorDialog::loadFile(QString game) {
         originalConfig = editor->toPlainText();
         file.close();
     } else {
-        QMessageBox::warning(this, "Error", "Could not open the file for reading");
+        QMessageBox::warning(this, tr("Error"), tr("Could not open the file for reading"));
     }
 }
 
@@ -108,7 +108,7 @@ void EditorDialog::saveFile(QString game) {
         out << editor->toPlainText();
         file.close();
     } else {
-        QMessageBox::warning(this, "Error", "Could not open the file for writing");
+        QMessageBox::warning(this, tr("Error"), tr("Could not open the file for writing"));
     }
 }
 
@@ -121,7 +121,7 @@ void EditorDialog::closeEvent(QCloseEvent* event) {
     }
     if (hasUnsavedChanges()) {
         QMessageBox::StandardButton reply;
-        reply = QMessageBox::question(this, "Save Changes", "Do you want to save changes?",
+        reply = QMessageBox::question(this, tr("Save Changes"), tr("Do you want to save changes?"),
                                       QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
 
         if (reply == QMessageBox::Yes) {
@@ -168,7 +168,7 @@ void EditorDialog::onCancelClicked() {
 void EditorDialog::onHelpClicked() {
     if (!isHelpOpen) {
         helpDialog = new HelpDialog(&isHelpOpen, this);
-        helpDialog->setWindowTitle("Help");
+        helpDialog->setWindowTitle(tr("Help"));
         helpDialog->setAttribute(Qt::WA_DeleteOnClose); // Clean up on close
         // Get the position and size of the Config window
         QRect configGeometry = this->geometry();
@@ -188,10 +188,10 @@ void EditorDialog::onResetToDefaultClicked() {
     bool default_default = gameComboBox->currentText() == "default";
     QString prompt =
         default_default
-            ? "Do you want to reset your custom default config to the original default config?"
-            : "Do you want to reset this config to your custom default config?";
-    QMessageBox::StandardButton reply =
-        QMessageBox::question(this, "Reset to Default", prompt, QMessageBox::Yes | QMessageBox::No);
+            ? tr("Do you want to reset your custom default config to the original default config?")
+            : tr("Do you want to reset this config to your custom default config?");
+    QMessageBox::StandardButton reply = QMessageBox::question(this, tr("Reset to Default"), prompt,
+                                                              QMessageBox::Yes | QMessageBox::No);
 
     if (reply == QMessageBox::Yes) {
         if (default_default) {
@@ -206,7 +206,7 @@ void EditorDialog::onResetToDefaultClicked() {
             editor->setPlainText(in.readAll());
             file.close();
         } else {
-            QMessageBox::warning(this, "Error", "Could not open the file for reading");
+            QMessageBox::warning(this, tr("Error"), tr("Could not open the file for reading"));
         }
         // saveFile(gameComboBox->currentText());
     }

--- a/src/qt_gui/kbm_gui.cpp
+++ b/src/qt_gui/kbm_gui.cpp
@@ -88,14 +88,15 @@ KBMSettings::KBMSettings(std::shared_ptr<GameInfoClass> game_info_get, QWidget* 
     connect(ui->CopyCommonButton, &QPushButton::clicked, this, [this] {
         if (ui->ProfileComboBox->currentText() == "Common Config") {
             QMessageBox::information(this, tr("Common Config Selected"),
-                                     tr("This button copies mappings from the Common Config to the "
-                                        "currently selected profile, and cannot be used when the "
-                                        "currently selected profile is the Common Config."));
+                                     // clang-format off
+tr("This button copies mappings from the Common Config to the currently selected profile, and cannot be used when the currently selected profile is the Common Config."));
+            // clang-format on
         } else {
             QMessageBox::StandardButton reply =
                 QMessageBox::question(this, tr("Copy values from Common Config"),
-                                      tr("Do you want to overwrite existing mappings with the "
-                                         "mappings from the Common Config?"),
+                                      // clang-format off
+tr("Do you want to overwrite existing mappings with the mappings from the Common Config?"),
+                                      // clang-format on
                                       QMessageBox::Yes | QMessageBox::No);
             if (reply == QMessageBox::Yes) {
                 SetUIValuestoMappings("default");

--- a/src/qt_gui/kbm_gui.cpp
+++ b/src/qt_gui/kbm_gui.cpp
@@ -87,15 +87,15 @@ KBMSettings::KBMSettings(std::shared_ptr<GameInfoClass> game_info_get, QWidget* 
 
     connect(ui->CopyCommonButton, &QPushButton::clicked, this, [this] {
         if (ui->ProfileComboBox->currentText() == "Common Config") {
-            QMessageBox::information(this, "Common Config Selected",
-                                     "This button copies mappings from the Common Config to the "
-                                     "currently selected profile, and cannot be used when the "
-                                     "currently selected profile is the Common Config.");
+            QMessageBox::information(this, tr("Common Config Selected"),
+                                     tr("This button copies mappings from the Common Config to the "
+                                        "currently selected profile, and cannot be used when the "
+                                        "currently selected profile is the Common Config."));
         } else {
             QMessageBox::StandardButton reply =
-                QMessageBox::question(this, "Copy values from Common Config",
-                                      "Do you want to overwrite existing mappings with the "
-                                      "mappings from the Common Config?",
+                QMessageBox::question(this, tr("Copy values from Common Config"),
+                                      tr("Do you want to overwrite existing mappings with the "
+                                         "mappings from the Common Config?"),
                                       QMessageBox::Yes | QMessageBox::No);
             if (reply == QMessageBox::Yes) {
                 SetUIValuestoMappings("default");
@@ -423,8 +423,8 @@ void KBMSettings::SaveKBMConfig(bool CloseOnSave) {
     // Prevent duplicate inputs for KBM as this breaks the engine
     for (auto it = inputs.begin(); it != inputs.end(); ++it) {
         if (std::find(it + 1, inputs.end(), *it) != inputs.end()) {
-            QMessageBox::information(this, "Unable to Save",
-                                     "Cannot bind any unique input more than once");
+            QMessageBox::information(this, tr("Unable to Save"),
+                                     tr("Cannot bind any unique input more than once"));
             return;
         }
     }
@@ -625,7 +625,7 @@ void KBMSettings::GetGameTitle() {
 void KBMSettings::onHelpClicked() {
     if (!HelpWindowOpen) {
         HelpWindow = new HelpDialog(&HelpWindowOpen, this);
-        HelpWindow->setWindowTitle("Help");
+        HelpWindow->setWindowTitle(tr("Help"));
         HelpWindow->setAttribute(Qt::WA_DeleteOnClose); // Clean up on close
         HelpWindow->show();
         HelpWindowOpen = true;
@@ -643,7 +643,7 @@ void KBMSettings::StartTimer(QPushButton*& button) {
     mapping = button->text();
 
     DisableMappingButtons();
-    button->setText("Press a key [" + QString::number(MappingTimer) + "]");
+    button->setText(tr("Press a key") + " [" + QString::number(MappingTimer) + "]");
     timer = new QTimer(this);
     MappingButton = button;
     connect(timer, &QTimer::timeout, this, [this]() { CheckMapping(MappingButton); });
@@ -652,7 +652,7 @@ void KBMSettings::StartTimer(QPushButton*& button) {
 
 void KBMSettings::CheckMapping(QPushButton*& button) {
     MappingTimer -= 1;
-    button->setText("Press a key [" + QString::number(MappingTimer) + "]");
+    button->setText(tr("Press a key") + " [" + QString::number(MappingTimer) + "]");
 
     if (MappingCompleted) {
         EnableMapping = false;
@@ -1003,15 +1003,15 @@ bool KBMSettings::eventFilter(QObject* obj, QEvent* event) {
                 if (std::find(AxisList.begin(), AxisList.end(), MappingButton) == AxisList.end()) {
                     SetMapping("mousewheelup");
                 } else {
-                    QMessageBox::information(this, "Cannot set mapping",
-                                             "Mousewheel cannot be mapped to stick outputs");
+                    QMessageBox::information(this, tr("Cannot set mapping"),
+                                             tr("Mousewheel cannot be mapped to stick outputs"));
                 }
             } else if (wheelEvent->angleDelta().y() < -5) {
                 if (std::find(AxisList.begin(), AxisList.end(), MappingButton) == AxisList.end()) {
                     SetMapping("mousewheeldown");
                 } else {
-                    QMessageBox::information(this, "Cannot set mapping",
-                                             "Mousewheel cannot be mapped to stick outputs");
+                    QMessageBox::information(this, tr("Cannot set mapping"),
+                                             tr("Mousewheel cannot be mapped to stick outputs"));
                 }
             }
             if (wheelEvent->angleDelta().x() > 5) {
@@ -1023,8 +1023,8 @@ bool KBMSettings::eventFilter(QObject* obj, QEvent* event) {
                         SetMapping("mousewheelright");
                     }
                 } else {
-                    QMessageBox::information(this, "Cannot set mapping",
-                                             "Mousewheel cannot be mapped to stick outputs");
+                    QMessageBox::information(this, tr("Cannot set mapping"),
+                                             tr("Mousewheel cannot be mapped to stick outputs"));
                 }
             } else if (wheelEvent->angleDelta().x() < -5) {
                 if (std::find(AxisList.begin(), AxisList.end(), MappingButton) == AxisList.end()) {
@@ -1034,8 +1034,8 @@ bool KBMSettings::eventFilter(QObject* obj, QEvent* event) {
                         SetMapping("mousewheelleft");
                     }
                 } else {
-                    QMessageBox::information(this, "Cannot set mapping",
-                                             "Mousewheel cannot be mapped to stick outputs");
+                    QMessageBox::information(this, tr("Cannot set mapping"),
+                                             tr("Mousewheel cannot be mapped to stick outputs"));
                 }
             }
             return true;

--- a/src/qt_gui/kbm_help_dialog.cpp
+++ b/src/qt_gui/kbm_help_dialog.cpp
@@ -77,11 +77,11 @@ HelpDialog::HelpDialog(bool* open_flag, QWidget* parent) : QDialog(parent) {
     QVBoxLayout* containerLayout = new QVBoxLayout(containerWidget);
 
     // Add expandable sections to container layout
-    auto* quickstartSection = new ExpandableSection("Quickstart", quickstart());
-    auto* faqSection = new ExpandableSection("FAQ", faq());
-    auto* syntaxSection = new ExpandableSection("Syntax", syntax());
-    auto* specialSection = new ExpandableSection("Special Bindings", special());
-    auto* bindingsSection = new ExpandableSection("Keybindings", bindings());
+    auto* quickstartSection = new ExpandableSection(tr("Quickstart"), quickstart());
+    auto* faqSection = new ExpandableSection(tr("FAQ"), faq());
+    auto* syntaxSection = new ExpandableSection(tr("Syntax"), syntax());
+    auto* specialSection = new ExpandableSection(tr("Special Bindings"), special());
+    auto* bindingsSection = new ExpandableSection(tr("Keybindings"), bindings());
 
     containerLayout->addWidget(quickstartSection);
     containerLayout->addWidget(faqSection);

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -235,21 +235,6 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices,
                                       Common::FS::GetUserPath(Common::FS::PathType::CustomTrophy));
             QDesktopServices::openUrl(QUrl::fromLocalFile(userPath));
         });
-
-        connect(ui->PortableUserButton, &QPushButton::clicked, this, []() {
-            QString userDir;
-            Common::FS::PathToQString(userDir, std::filesystem::current_path() / "user");
-            if (std::filesystem::exists(std::filesystem::current_path() / "user")) {
-                QMessageBox::information(NULL, tr("Cannot create portable user folder"),
-                                         userDir + " " + tr("already exists"));
-            } else {
-                std::filesystem::copy(Common::FS::GetUserPath(Common::FS::PathType::UserDir),
-                                      std::filesystem::current_path() / "user",
-                                      std::filesystem::copy_options::recursive);
-                QMessageBox::information(NULL, tr("Portable user folder created"),
-                                         userDir + " " + tr("successfully created"));
-            }
-        });
     }
 
     // Input TAB
@@ -298,6 +283,21 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices,
             if (!file_path.empty()) {
                 Config::setSaveDataPath(file_path);
                 ui->currentSaveDataPath->setText(save_data_path_string);
+            }
+        });
+
+        connect(ui->PortableUserButton, &QPushButton::clicked, this, []() {
+            QString userDir;
+            Common::FS::PathToQString(userDir, std::filesystem::current_path() / "user");
+            if (std::filesystem::exists(std::filesystem::current_path() / "user")) {
+                QMessageBox::information(NULL, tr("Cannot create portable user folder"),
+                                         tr("%1 already exists").arg(userDir));
+            } else {
+                std::filesystem::copy(Common::FS::GetUserPath(Common::FS::PathType::UserDir),
+                                      std::filesystem::current_path() / "user",
+                                      std::filesystem::copy_options::recursive);
+                QMessageBox::information(NULL, tr("Portable user folder created"),
+                                         tr("%1 successfully created.").arg(userDir));
             }
         });
     }

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -240,14 +240,14 @@ SettingsDialog::SettingsDialog(std::span<const QString> physical_devices,
             QString userDir;
             Common::FS::PathToQString(userDir, std::filesystem::current_path() / "user");
             if (std::filesystem::exists(std::filesystem::current_path() / "user")) {
-                QMessageBox::information(NULL, "Cannot create portable user folder",
-                                         userDir + " already exists");
+                QMessageBox::information(NULL, tr("Cannot create portable user folder"),
+                                         userDir + " " + tr("already exists"));
             } else {
                 std::filesystem::copy(Common::FS::GetUserPath(Common::FS::PathType::UserDir),
                                       std::filesystem::current_path() / "user",
                                       std::filesystem::copy_options::recursive);
-                QMessageBox::information(NULL, "Portable user folder created",
-                                         userDir + " successfully created");
+                QMessageBox::information(NULL, tr("Portable user folder created"),
+                                         userDir + " " + tr("successfully created"));
             }
         });
     }


### PR DESCRIPTION
Some GUI strings which are user-facing currently do not have tr functions, so they cannot be translated. There are some more other than this which are more difficult to do (some requiring maps, and some like the special keybinding section which are difficult to handle), but at least this quick PR covers the easy ones.