### PR TITLE
 Videodec2 mismatching picture info size crash fix

### DIFF
--- a/src/core/libraries/videodec/videodec2.cpp
+++ b/src/core/libraries/videodec/videodec2.cpp
@@ -162,12 +162,15 @@ s32 PS4_SYSV_ABI sceVideodec2GetPictureInfo(const OrbisVideodec2OutputInfo* outp
     if (p1stPictureInfoOut) {
         OrbisVideodec2AvcPictureInfo* picInfo =
             static_cast<OrbisVideodec2AvcPictureInfo*>(p1stPictureInfoOut);
+
+        *picInfo = gPictureInfos.back();
+
         if (picInfo->thisSize != sizeof(OrbisVideodec2AvcPictureInfo)) {
-            LOG_CRITICAL(Lib_Vdec2, "Mismatching sizes, first = {}, second = {}",
+            LOG_ERROR(Lib_Vdec2, "Mismatching sizes, first = {}, second = {}",
                          picInfo->thisSize, sizeof(OrbisVideodec2AvcPictureInfo));
             return ORBIS_VIDEODEC2_ERROR_STRUCT_SIZE;
         }
-        *picInfo = gPictureInfos.back();
+        
     }
 
     if (outputInfo->pictureCount > 1) {

--- a/src/core/libraries/videodec/videodec2.cpp
+++ b/src/core/libraries/videodec/videodec2.cpp
@@ -163,6 +163,8 @@ s32 PS4_SYSV_ABI sceVideodec2GetPictureInfo(const OrbisVideodec2OutputInfo* outp
         OrbisVideodec2AvcPictureInfo* picInfo =
             static_cast<OrbisVideodec2AvcPictureInfo*>(p1stPictureInfoOut);
         if (picInfo->thisSize != sizeof(OrbisVideodec2AvcPictureInfo)) {
+            LOG_CRITICAL(Lib_Vdec2, "GetPictureInfo mismatching sizes, first = {}, second = {}",
+                         picInfo->thisSize, sizeof(OrbisVideodec2AvcPictureInfo));
             return ORBIS_VIDEODEC2_ERROR_STRUCT_SIZE;
         }
         *picInfo = gPictureInfos.back();

--- a/src/core/libraries/videodec/videodec2.cpp
+++ b/src/core/libraries/videodec/videodec2.cpp
@@ -163,7 +163,7 @@ s32 PS4_SYSV_ABI sceVideodec2GetPictureInfo(const OrbisVideodec2OutputInfo* outp
         OrbisVideodec2AvcPictureInfo* picInfo =
             static_cast<OrbisVideodec2AvcPictureInfo*>(p1stPictureInfoOut);
         if (picInfo->thisSize != sizeof(OrbisVideodec2AvcPictureInfo)) {
-            LOG_CRITICAL(Lib_Vdec2, "GetPictureInfo mismatching sizes, first = {}, second = {}",
+            LOG_CRITICAL(Lib_Vdec2, "Mismatching sizes, first = {}, second = {}",
                          picInfo->thisSize, sizeof(OrbisVideodec2AvcPictureInfo));
             return ORBIS_VIDEODEC2_ERROR_STRUCT_SIZE;
         }


### PR DESCRIPTION
Returning before setting *picInfo causes the emu to crash. I think it's better to let it deal with whatever corrupted size it is, rather than forcing the emu to crash.
Also added logging.

Closes the https://github.com/shadps4-emu/shadPS4/issues/2604

First pull request here, please correct me if something's wrong.