### PR TITLE
Unified Memory Allocation

### DIFF
--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -276,7 +276,7 @@ int PS4_SYSV_ABI sceKernelDirectMemoryQuery(u64 offset, int flags, OrbisQueryInf
 
 s32 PS4_SYSV_ABI sceKernelAvailableFlexibleMemorySize(size_t* out_size) {
     auto* memory = Core::Memory::Instance();
-    *out_size = memory->GetTotalUnifiedMemorySize();
+    *out_size = memory->GetAvailableUnifiedMemorySize();
     LOG_INFO(Kernel_Vmm, "called size = {:#x}", *out_size);
     return ORBIS_OK;
 }

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -22,7 +22,7 @@ namespace Libraries::Kernel {
 u64 PS4_SYSV_ABI sceKernelGetDirectMemorySize() {
     LOG_WARNING(Kernel_Vmm, "called");
     const auto* memory = Core::Memory::Instance();
-    return memory->GetTotalDirectSize();
+    return memory->GetTotalUnifiedMemorySize();
 }
 
 int PS4_SYSV_ABI sceKernelAllocateDirectMemory(s64 searchStart, s64 searchEnd, u64 len,
@@ -276,7 +276,7 @@ int PS4_SYSV_ABI sceKernelDirectMemoryQuery(u64 offset, int flags, OrbisQueryInf
 
 s32 PS4_SYSV_ABI sceKernelAvailableFlexibleMemorySize(size_t* out_size) {
     auto* memory = Core::Memory::Instance();
-    *out_size = memory->GetAvailableFlexibleSize();
+    *out_size = memory->GetTotalUnifiedMemorySize();
     LOG_INFO(Kernel_Vmm, "called size = {:#x}", *out_size);
     return ORBIS_OK;
 }
@@ -511,7 +511,7 @@ s32 PS4_SYSV_ABI sceKernelConfiguredFlexibleMemorySize(u64* sizeOut) {
     }
 
     auto* memory = Core::Memory::Instance();
-    *sizeOut = memory->GetTotalFlexibleSize();
+    *sizeOut = memory->GetTotalUnifiedMemorySize();
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/kernel/memory.h
+++ b/src/core/libraries/kernel/memory.h
@@ -6,8 +6,8 @@
 #include "common/bit_field.h"
 #include "common/types.h"
 
-constexpr u64 SCE_KERNEL_TOTAL_MEM = 5248_MB;
-constexpr u64 SCE_KERNEL_TOTAL_MEM_PRO = 5888_MB;
+constexpr u64 SCE_KERNEL_TOTAL_MEM = 5248_MB * 4;
+constexpr u64 SCE_KERNEL_TOTAL_MEM_PRO = 5888_MB * 4;
 
 constexpr u64 SCE_FLEXIBLE_MEMORY_BASE = 64_MB;
 constexpr u64 SCE_FLEXIBLE_MEMORY_SIZE = 512_MB;

--- a/src/core/libraries/kernel/memory.h
+++ b/src/core/libraries/kernel/memory.h
@@ -5,17 +5,14 @@
 
 #include "common/bit_field.h"
 #include "common/types.h"
-#include "core/linker.h"
-#include "core/memory.h"
-#include "src/common/memory_patcher.h"  
 
-constexpr bool USE_EXPANDED_MEMORY = true;
+constexpr bool USE_EXPANDED_MEMORY = false;
 
-constexpr u64 SCE_KERNEL_TOTAL_MEM = (USE_EXPANDED_MEMORY ? 5248_MB * 1.2 : 5248_MB);
-constexpr u64 SCE_KERNEL_TOTAL_MEM_PRO = (USE_EXPANDED_MEMORY ? 5888_MB * 1.2 : 5888_MB);
+constexpr u64 SCE_KERNEL_TOTAL_MEM = 5248_MB;
+constexpr u64 SCE_KERNEL_TOTAL_MEM_PRO = (USE_EXPANDED_MEMORY ? 5888_MB * 1.5 : 5888_MB);
 
-constexpr u64 SCE_FLEXIBLE_MEMORY_BASE = (USE_EXPANDED_MEMORY ? 64_MB * 1.2 : 64_MB);
-constexpr u64 SCE_FLEXIBLE_MEMORY_SIZE = (USE_EXPANDED_MEMORY ? 512_MB * 1.2 : 512_MB);
+constexpr u64 SCE_FLEXIBLE_MEMORY_BASE = 64_MB;
+constexpr u64 SCE_FLEXIBLE_MEMORY_SIZE = (USE_EXPANDED_MEMORY ? 512_MB * 1.5 : 512_MB);
 
 namespace Core::Loader {
 class SymbolsResolver;

--- a/src/core/libraries/kernel/memory.h
+++ b/src/core/libraries/kernel/memory.h
@@ -5,12 +5,17 @@
 
 #include "common/bit_field.h"
 #include "common/types.h"
+#include "core/linker.h"
+#include "core/memory.h"
+#include "src/common/memory_patcher.h"  
 
-constexpr u64 SCE_KERNEL_TOTAL_MEM = 5248_MB * 4;
-constexpr u64 SCE_KERNEL_TOTAL_MEM_PRO = 5888_MB * 4;
+constexpr bool USE_EXPANDED_MEMORY = true;
 
-constexpr u64 SCE_FLEXIBLE_MEMORY_BASE = 64_MB;
-constexpr u64 SCE_FLEXIBLE_MEMORY_SIZE = 512_MB;
+constexpr u64 SCE_KERNEL_TOTAL_MEM = (USE_EXPANDED_MEMORY ? 5248_MB * 1.2 : 5248_MB);
+constexpr u64 SCE_KERNEL_TOTAL_MEM_PRO = (USE_EXPANDED_MEMORY ? 5888_MB * 1.2 : 5888_MB);
+
+constexpr u64 SCE_FLEXIBLE_MEMORY_BASE = (USE_EXPANDED_MEMORY ? 64_MB * 1.2 : 64_MB);
+constexpr u64 SCE_FLEXIBLE_MEMORY_SIZE = (USE_EXPANDED_MEMORY ? 512_MB * 1.2 : 512_MB);
 
 namespace Core::Loader {
 class SymbolsResolver;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -37,14 +37,23 @@ MemoryManager::~MemoryManager() = default;
 void MemoryManager::SetupMemoryRegions(u64 flexible_size, bool use_extended_mem1,
                                        bool use_extended_mem2) {
     const bool is_neo = ::Libraries::Kernel::sceKernelIsNeoMode();
+
     auto total_size = is_neo ? SCE_KERNEL_TOTAL_MEM_PRO : SCE_KERNEL_TOTAL_MEM;
+    if (NeedsExtraMemory()) {
+        total_size = SCE_KERNEL_TOTAL_MEM * 1.2;
+    }
+
     if (!use_extended_mem1 && is_neo) {
         total_size -= 256_MB;
     }
     if (!use_extended_mem2 && !is_neo) {
         total_size -= 128_MB;
     }
+
     total_flexible_size = flexible_size - SCE_FLEXIBLE_MEMORY_BASE;
+    if (NeedsExtraMemory()) {
+        total_flexible_size = flexible_size - SCE_FLEXIBLE_MEMORY_BASE * 1.2;
+    }
     total_direct_size = total_size - flexible_size;
 
     // Insert an area that covers direct memory physical block.

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -37,23 +37,14 @@ MemoryManager::~MemoryManager() = default;
 void MemoryManager::SetupMemoryRegions(u64 flexible_size, bool use_extended_mem1,
                                        bool use_extended_mem2) {
     const bool is_neo = ::Libraries::Kernel::sceKernelIsNeoMode();
-
     auto total_size = is_neo ? SCE_KERNEL_TOTAL_MEM_PRO : SCE_KERNEL_TOTAL_MEM;
-    if (NeedsExtraMemory()) {
-        total_size = SCE_KERNEL_TOTAL_MEM * 1.2;
-    }
-
     if (!use_extended_mem1 && is_neo) {
         total_size -= 256_MB;
     }
     if (!use_extended_mem2 && !is_neo) {
         total_size -= 128_MB;
     }
-
     total_flexible_size = flexible_size - SCE_FLEXIBLE_MEMORY_BASE;
-    if (NeedsExtraMemory()) {
-        total_flexible_size = flexible_size - SCE_FLEXIBLE_MEMORY_BASE * 1.2;
-    }
     total_direct_size = total_size - flexible_size;
 
     // Insert an area that covers direct memory physical block.

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -164,12 +164,22 @@ public:
         return virtual_addr >= vma_map.begin()->first && virtual_addr < end_addr;
     }
     bool NeedsExtraMemory() {
-        static const std::unordered_set<std::string> extra_memory_games = {
-            "CUSA28615", // Example game that needs extra memory
-            "CUSA03173"  // Add other games here if needed
-        };
+        if (IsNeoModeEnabled()) {
+            bool USE_EXPANDED_MEMORY = false;
+            return true;
+        }
+        return false;
+    }
 
-        return extra_memory_games.find(MemoryPatcher::g_game_serial) != extra_memory_games.end();
+    bool IsNeoModeEnabled() {
+        return (getSystemMemoryFlag() == SCE_KERNEL_TOTAL_MEM_PRO);
+    }
+
+    uint64_t getSystemMemoryFlag() {
+        if (USE_EXPANDED_MEMORY) {
+            return SCE_KERNEL_TOTAL_MEM_PRO; // Expanded memory
+        }
+        return SCE_KERNEL_TOTAL_MEM; // Regular memory
     }
 
     u64 ClampRangeSize(VAddr virtual_addr, u64 size);

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -5,12 +5,15 @@
 
 #include <map>
 #include <mutex>
+#include <unordered_set>
+
 #include <string_view>
 #include "common/enum.h"
 #include "common/singleton.h"
 #include "common/types.h"
 #include "core/address_space.h"
 #include "core/libraries/kernel/memory.h"
+#include "src/common/memory_patcher.h"
 
 namespace Vulkan {
 class Rasterizer;
@@ -162,6 +165,13 @@ public:
         const auto end_it = std::prev(vma_map.end());
         const VAddr end_addr = end_it->first + end_it->second.size;
         return virtual_addr >= vma_map.begin()->first && virtual_addr < end_addr;
+    }
+    bool NeedsExtraMemory() {
+        static const std::unordered_set<std::string> extra_memory_games = {
+            // here should be games with needs of extra memory as EXAMPLE
+            "CUSA03173"};
+
+        return extra_memory_games.find(MemoryPatcher::g_game_serial) != extra_memory_games.end();
     }
 
     u64 ClampRangeSize(VAddr virtual_addr, u64 size);

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -36,6 +36,7 @@ enum class MemoryProt : u32 {
     GpuRead = 16,
     GpuWrite = 32,
     GpuReadWrite = 48,
+    UnifiedReadWrite = 50,
 };
 DECLARE_ENUM_FLAG_OPERATORS(MemoryProt)
 
@@ -144,16 +145,12 @@ public:
         return impl;
     }
 
-    u64 GetTotalDirectSize() const {
-        return total_direct_size;
+    u64 GetTotalUnifiedMemorySize() const {
+        return total_direct_size + total_flexible_size;
     }
 
-    u64 GetTotalFlexibleSize() const {
-        return total_flexible_size;
-    }
-
-    u64 GetAvailableFlexibleSize() const {
-        return total_flexible_size - flexible_usage;
+    u64 GetAvailableUnifiedMemorySize() const {
+        return GetTotalUnifiedMemorySize() - flexible_usage;
     }
 
     VAddr SystemReservedVirtualBase() noexcept {
@@ -168,8 +165,9 @@ public:
     }
     bool NeedsExtraMemory() {
         static const std::unordered_set<std::string> extra_memory_games = {
-            // here should be games with needs of extra memory as EXAMPLE
-            "CUSA03173"};
+            "CUSA28615", // Example game that needs extra memory
+            "CUSA03173"  // Add other games here if needed
+        };
 
         return extra_memory_games.find(MemoryPatcher::g_game_serial) != extra_memory_games.end();
     }


### PR DESCRIPTION
 Allow a game to expand memory when needs it implementing a basic way for a game to call for more memory in a dynamic way. 

Makes Shadow Returns CUSA28615 get ingame. 

![image](https://github.com/user-attachments/assets/d0ee3b85-8885-4ae7-a0ed-32100c7d0cd2)


![image](https://github.com/user-attachments/assets/0d15e759-6935-4fb7-b67d-b386b264824d)

![image](https://github.com/user-attachments/assets/2034af79-9b5a-4432-9619-9511980cdf70)
