### PR TITLE
sceKernelReleaseDirectMemory fix

### DIFF
--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -79,6 +79,9 @@ s32 PS4_SYSV_ABI sceKernelAllocateMainDirectMemory(size_t len, size_t alignment,
 }
 
 s32 PS4_SYSV_ABI sceKernelCheckedReleaseDirectMemory(u64 start, size_t len) {
+    if (len == 0) {
+        return ORBIS_OK;
+    }
     LOG_INFO(Kernel_Vmm, "called start = {:#x}, len = {:#x}", start, len);
     auto* memory = Core::Memory::Instance();
     memory->Free(start, len);
@@ -86,6 +89,9 @@ s32 PS4_SYSV_ABI sceKernelCheckedReleaseDirectMemory(u64 start, size_t len) {
 }
 
 s32 PS4_SYSV_ABI sceKernelReleaseDirectMemory(u64 start, size_t len) {
+    if (len == 0) {
+        return ORBIS_OK;
+    }
     auto* memory = Core::Memory::Instance();
     memory->Free(start, len);
     return ORBIS_OK;

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -506,8 +506,8 @@ s32 PS4_SYSV_ABI sceKernelConfiguredFlexibleMemorySize(u64* sizeOut) {
 
 int PS4_SYSV_ABI sceKernelMunmap(void* addr, size_t len) {
     LOG_INFO(Kernel_Vmm, "addr = {}, len = {:#x}", fmt::ptr(addr), len);
-    if (len == 0) {
-        return ORBIS_OK;
+    if (len <= 0) {
+        return ORBIS_KERNEL_ERROR_EINVAL;
     }
     auto* memory = Core::Memory::Instance();
     return memory->UnmapMemory(std::bit_cast<VAddr>(addr), len);

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -512,7 +512,7 @@ s32 PS4_SYSV_ABI sceKernelConfiguredFlexibleMemorySize(u64* sizeOut) {
 
 int PS4_SYSV_ABI sceKernelMunmap(void* addr, size_t len) {
     LOG_INFO(Kernel_Vmm, "addr = {}, len = {:#x}", fmt::ptr(addr), len);
-    if (len <= 0) {
+    if (len == 0) {
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
     auto* memory = Core::Memory::Instance();


### PR DESCRIPTION
This addresses an issue with the `ReleaseDirectMemory` functions, where some games would hit an assert by calling them with `len = 0`. I also fixed an inaccurate error return in `sceKernelMunmap` (based on FreeBSD documentation), though I don't have any games that were hitting that error return.

This should fix some cases of `[Debug] <Critical> memory.cpp:766 operator(): Assertion Failed!`

This brings TerraTech (CUSA11362) ingame.
![image](https://github.com/user-attachments/assets/49144ab2-14f4-4cf9-a792-9e344cbb551a)
