### PR TITLE
Handle error behavior in sceSysmoduleGetModuleInfoForUnwind stub

### DIFF
--- a/src/core/libraries/kernel/process.cpp
+++ b/src/core/libraries/kernel/process.cpp
@@ -85,18 +85,6 @@ s32 PS4_SYSV_ABI sceKernelDlsym(s32 handle, const char* symbol, void** addrp) {
     return ORBIS_OK;
 }
 
-static constexpr size_t ORBIS_DBG_MAX_NAME_LENGTH = 256;
-
-struct OrbisModuleInfoForUnwind {
-    u64 st_size;
-    std::array<char, ORBIS_DBG_MAX_NAME_LENGTH> name;
-    VAddr eh_frame_hdr_addr;
-    VAddr eh_frame_addr;
-    u64 eh_frame_size;
-    VAddr seg0_addr;
-    u64 seg0_size;
-};
-
 s32 PS4_SYSV_ABI sceKernelGetModuleInfoForUnwind(VAddr addr, int flags,
                                                  OrbisModuleInfoForUnwind* info) {
     if (flags >= 3) {

--- a/src/core/libraries/kernel/process.cpp
+++ b/src/core/libraries/kernel/process.cpp
@@ -85,7 +85,7 @@ s32 PS4_SYSV_ABI sceKernelDlsym(s32 handle, const char* symbol, void** addrp) {
     return ORBIS_OK;
 }
 
-s32 PS4_SYSV_ABI sceKernelGetModuleInfoForUnwind(VAddr addr, int flags,
+s32 PS4_SYSV_ABI sceKernelGetModuleInfoForUnwind(VAddr addr, s32 flags,
                                                  OrbisModuleInfoForUnwind* info) {
     if (flags >= 3) {
         std::memset(info, 0, sizeof(OrbisModuleInfoForUnwind));

--- a/src/core/libraries/kernel/process.h
+++ b/src/core/libraries/kernel/process.h
@@ -15,6 +15,20 @@ int PS4_SYSV_ABI sceKernelIsNeoMode();
 
 int PS4_SYSV_ABI sceKernelGetCompiledSdkVersion(int* ver);
 
+static constexpr size_t ORBIS_DBG_MAX_NAME_LENGTH = 256;
+
+struct OrbisModuleInfoForUnwind {
+    u64 st_size;
+    std::array<char, ORBIS_DBG_MAX_NAME_LENGTH> name;
+    VAddr eh_frame_hdr_addr;
+    VAddr eh_frame_addr;
+    u64 eh_frame_size;
+    VAddr seg0_addr;
+    u64 seg0_size;
+};
+
+s32 PS4_SYSV_ABI sceKernelGetModuleInfoForUnwind(VAddr addr, s32 flags, OrbisModuleInfoForUnwind* info);
+
 void RegisterProcess(Core::Loader::SymbolsResolver* sym);
 
 } // namespace Libraries::Kernel

--- a/src/core/libraries/kernel/process.h
+++ b/src/core/libraries/kernel/process.h
@@ -11,10 +11,6 @@ class SymbolsResolver;
 
 namespace Libraries::Kernel {
 
-int PS4_SYSV_ABI sceKernelIsNeoMode();
-
-int PS4_SYSV_ABI sceKernelGetCompiledSdkVersion(int* ver);
-
 static constexpr size_t ORBIS_DBG_MAX_NAME_LENGTH = 256;
 
 struct OrbisModuleInfoForUnwind {
@@ -27,7 +23,12 @@ struct OrbisModuleInfoForUnwind {
     u64 seg0_size;
 };
 
-s32 PS4_SYSV_ABI sceKernelGetModuleInfoForUnwind(VAddr addr, s32 flags, OrbisModuleInfoForUnwind* info);
+int PS4_SYSV_ABI sceKernelIsNeoMode();
+
+int PS4_SYSV_ABI sceKernelGetCompiledSdkVersion(int* ver);
+
+s32 PS4_SYSV_ABI sceKernelGetModuleInfoForUnwind(VAddr addr, s32 flags,
+                                                 OrbisModuleInfoForUnwind* info);
 
 void RegisterProcess(Core::Loader::SymbolsResolver* sym);
 

--- a/src/core/libraries/system/sysmodule.cpp
+++ b/src/core/libraries/system/sysmodule.cpp
@@ -7,10 +7,10 @@
 
 #include "common/logging/log.h"
 #include "core/libraries/error_codes.h"
+#include "core/libraries/kernel/process.h"
 #include "core/libraries/libs.h"
 #include "core/libraries/system/sysmodule.h"
 #include "core/libraries/system/system_error.h"
-#include "core/libraries/kernel/process.h"
 
 namespace Libraries::SysModule {
 

--- a/src/core/libraries/system/sysmodule.cpp
+++ b/src/core/libraries/system/sysmodule.cpp
@@ -10,6 +10,7 @@
 #include "core/libraries/libs.h"
 #include "core/libraries/system/sysmodule.h"
 #include "core/libraries/system/system_error.h"
+#include "core/libraries/kernel/process.h"
 
 namespace Libraries::SysModule {
 
@@ -18,9 +19,12 @@ int PS4_SYSV_ABI sceSysmoduleGetModuleHandleInternal() {
     return ORBIS_OK;
 }
 
-int PS4_SYSV_ABI sceSysmoduleGetModuleInfoForUnwind() {
+s32 PS4_SYSV_ABI sceSysmoduleGetModuleInfoForUnwind(VAddr addr, s32 flags, void* info) {
     LOG_ERROR(Lib_SysModule, "(STUBBED) called");
-    return ORBIS_OK;
+    Kernel::OrbisModuleInfoForUnwind module_info;
+    module_info.st_size = 0x130;
+    s32 res = Kernel::sceKernelGetModuleInfoForUnwind(addr, flags, &module_info);
+    return res;
 }
 
 int PS4_SYSV_ABI sceSysmoduleIsCalledFromSysModule() {

--- a/src/core/libraries/system/sysmodule.h
+++ b/src/core/libraries/system/sysmodule.h
@@ -152,7 +152,7 @@ enum class OrbisSysModuleInternal : u32 {
 };
 
 int PS4_SYSV_ABI sceSysmoduleGetModuleHandleInternal();
-int PS4_SYSV_ABI sceSysmoduleGetModuleInfoForUnwind();
+s32 PS4_SYSV_ABI sceSysmoduleGetModuleInfoForUnwind(VAddr addr, s32 flags, void* info);
 int PS4_SYSV_ABI sceSysmoduleIsCalledFromSysModule();
 int PS4_SYSV_ABI sceSysmoduleIsCameraPreloaded();
 int PS4_SYSV_ABI sceSysmoduleIsLoaded(OrbisSysModule id);


### PR DESCRIPTION
This PR partially implements `sceSysmoduleGetModuleInfoForUnwind` by calling `sceKernelGetModuleInfoForUnwind` and returning any errors that throws. I've avoided handling whatever internal struct libSceSysmodule uses here, since the struct seems to be somewhat different from the kernel's module info struct based on what I've decompiled, and the old return 0 behavior was working fine enough before.

Allowing this function to pass along errors fixes libc spamming `sceKernelGetModuleInfoForUnwind` calls with invalid addresses, fixing random crashes in Unity games caused by libc accessing invalid memory during exceptions.