### PR TITLE
Log mismatching picture size in GetPictureInfo

### DIFF
--- a/src/core/libraries/videodec/videodec2.cpp
+++ b/src/core/libraries/videodec/videodec2.cpp
@@ -163,6 +163,8 @@ s32 PS4_SYSV_ABI sceVideodec2GetPictureInfo(const OrbisVideodec2OutputInfo* outp
         OrbisVideodec2AvcPictureInfo* picInfo =
             static_cast<OrbisVideodec2AvcPictureInfo*>(p1stPictureInfoOut);
         if (picInfo->thisSize != sizeof(OrbisVideodec2AvcPictureInfo)) {
+            LOG_CRITICAL(Lib_Vdec2, "Mismatching sizes, first = {}, second = {}", picInfo->thisSize,
+                      sizeof(OrbisVideodec2AvcPictureInfo));
             return ORBIS_VIDEODEC2_ERROR_STRUCT_SIZE;
         }
         *picInfo = gPictureInfos.back();


### PR DESCRIPTION
Alright, fixing that problem is a bit harder than i thought...
Still, it needs to be logged.
Currently it's set at critical, since the emu crashes if it returns before setting *picInfo
