### PR TITLE
Changing "submit report" button behavior in the GUI

### DIFF
--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -521,7 +521,7 @@ public:
                 "title", QString("%1 - %2").arg(QString::fromStdString(m_games[itemID].serial),
                                                 QString::fromStdString(m_games[itemID].name)));
             query.addQueryItem("game-name", QString::fromStdString(m_games[itemID].name));
-            query.addQueryItem("game-code", QString::fromStdString(m_games[itemID].serial));
+            query.addQueryItem("game-serial", QString::fromStdString(m_games[itemID].serial));
             query.addQueryItem("game-version", QString::fromStdString(m_games[itemID].version));
             query.addQueryItem("emulator-version", QString(Common::VERSION));
             url.setQuery(query);

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -523,7 +523,6 @@ public:
             query.addQueryItem("game-name", QString::fromStdString(m_games[itemID].name));
             query.addQueryItem("game-serial", QString::fromStdString(m_games[itemID].serial));
             query.addQueryItem("game-version", QString::fromStdString(m_games[itemID].version));
-            query.addQueryItem("emulator-version", QString(Common::VERSION));
             url.setQuery(query);
 
             QDesktopServices::openUrl(url);

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -522,8 +522,8 @@ public:
                                                 QString::fromStdString(m_games[itemID].name)));
             query.addQueryItem("game-name", QString::fromStdString(m_games[itemID].name));
             query.addQueryItem("game-serial", QString::fromStdString(m_games[itemID].serial));
-            query.addQueryItem("game-serial", QString::fromStdString(m_games[itemID].serial));
             query.addQueryItem("game-version", QString::fromStdString(m_games[itemID].version));
+            query.addQueryItem("emulator-version", QString(Common::VERSION));
             url.setQuery(query);
 
             QDesktopServices::openUrl(url);

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -522,6 +522,7 @@ public:
                                                 QString::fromStdString(m_games[itemID].name)));
             query.addQueryItem("game-name", QString::fromStdString(m_games[itemID].name));
             query.addQueryItem("game-serial", QString::fromStdString(m_games[itemID].serial));
+            query.addQueryItem("game-serial", QString::fromStdString(m_games[itemID].serial));
             query.addQueryItem("game-version", QString::fromStdString(m_games[itemID].version));
             url.setQuery(query);
 


### PR DESCRIPTION
Disabling the emulator version automatically filling up when creating a report with the GUI, also changing game-code to game-serial. Need to wait for another change to happen first before merging this. Also would be nice if someone could figure out a way to completely disable the option to report on a WIP builds and only allow it on Release ones, the deleted line is a temporary workaround at best.