### PR TITLE
clock_gettime fixes for windows

### DIFF
--- a/src/core/libraries/kernel/time.cpp
+++ b/src/core/libraries/kernel/time.cpp
@@ -121,7 +121,7 @@ static u64 FileTimeTo100Ns(FILETIME& ft) {
     return *reinterpret_cast<u64*>(&ft);
 }
 
-static s32 clock_gettime(u32 clock_id, struct OrbisKernelTimespec* ts) {
+static s32 clock_gettime(u32 clock_id, struct timespec* ts) {
     switch (clock_id) {
     case CLOCK_REALTIME:
     case CLOCK_REALTIME_COARSE: {
@@ -273,13 +273,10 @@ int PS4_SYSV_ABI orbis_clock_gettime(s32 clock_id, struct OrbisKernelTimespec* t
 }
 
 int PS4_SYSV_ABI sceKernelClockGettime(s32 clock_id, OrbisKernelTimespec* tp) {
-    struct OrbisKernelTimespec ts;
-    const auto res = orbis_clock_gettime(clock_id, &ts);
+    const auto res = orbis_clock_gettime(clock_id, tp);
     if (res < 0) {
         return ErrnoToSceKernelError(res);
     }
-    tp->tv_sec = ts.tv_sec;
-    tp->tv_nsec = ts.tv_nsec;
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/kernel/time.cpp
+++ b/src/core/libraries/kernel/time.cpp
@@ -265,7 +265,11 @@ int PS4_SYSV_ABI orbis_clock_gettime(s32 clock_id, struct OrbisKernelTimespec* t
         return EINVAL;
     }
 
-    return clock_gettime(pclock_id, ts);
+    timespec t{};
+    int result = clock_gettime(pclock_id, &t);
+    ts->tv_sec = t.tv_sec;
+    ts->tv_nsec = t.tv_nsec;
+    return result;
 }
 
 int PS4_SYSV_ABI sceKernelClockGettime(s32 clock_id, OrbisKernelTimespec* tp) {

--- a/src/core/libraries/kernel/time.cpp
+++ b/src/core/libraries/kernel/time.cpp
@@ -121,7 +121,7 @@ static u64 FileTimeTo100Ns(FILETIME& ft) {
     return *reinterpret_cast<u64*>(&ft);
 }
 
-static s32 clock_gettime(u32 clock_id, struct timespec* ts) {
+static s32 clock_gettime(u32 clock_id, struct OrbisKernelTimespec* ts) {
     switch (clock_id) {
     case CLOCK_REALTIME:
     case CLOCK_REALTIME_COARSE: {
@@ -172,7 +172,7 @@ static s32 clock_gettime(u32 clock_id, struct timespec* ts) {
 }
 #endif
 
-int PS4_SYSV_ABI orbis_clock_gettime(s32 clock_id, struct timespec* ts) {
+int PS4_SYSV_ABI orbis_clock_gettime(s32 clock_id, struct OrbisKernelTimespec* ts) {
     if (ts == nullptr) {
         return ORBIS_KERNEL_ERROR_EFAULT;
     }
@@ -269,7 +269,7 @@ int PS4_SYSV_ABI orbis_clock_gettime(s32 clock_id, struct timespec* ts) {
 }
 
 int PS4_SYSV_ABI sceKernelClockGettime(s32 clock_id, OrbisKernelTimespec* tp) {
-    struct timespec ts;
+    struct OrbisKernelTimespec ts;
     const auto res = orbis_clock_gettime(clock_id, &ts);
     if (res < 0) {
         return ErrnoToSceKernelError(res);


### PR DESCRIPTION
This PR changes `struct timespec` to `OrbisKernelTimespec` in `orbis_clock_gettime`, to fix binary compatibility issues with some games, such as Deathlight, Mages of mystralia and Mad max on windows. 

Also for me hollow knight can load savefiles too after this. Before only could start a new game. 

Makes those games boot again and deatlight can probably be full playable. Haven ask for a new report on it. 

