### PR TITLE
Sync text editor changes to KBM GUI

### DIFF
--- a/src/qt_gui/kbm_gui.cpp
+++ b/src/qt_gui/kbm_gui.cpp
@@ -15,7 +15,6 @@
 #include "ui_kbm_gui.h"
 
 HelpDialog* HelpWindow;
-
 KBMSettings::KBMSettings(std::shared_ptr<GameInfoClass> game_info_get, QWidget* parent)
     : QDialog(parent), m_game_info(game_info_get), ui(new Ui::KBMSettings) {
 
@@ -48,6 +47,7 @@ KBMSettings::KBMSettings(std::shared_ptr<GameInfoClass> game_info_get, QWidget* 
 
     ui->ProfileComboBox->setCurrentText("Common Config");
     ui->TitleLabel->setText("Common Config");
+    config_id = "default";
 
     connect(ui->buttonBox, &QDialogButtonBox::clicked, this, [this](QAbstractButton* button) {
         if (button == ui->buttonBox->button(QDialogButtonBox::Save)) {
@@ -72,6 +72,7 @@ KBMSettings::KBMSettings(std::shared_ptr<GameInfoClass> game_info_get, QWidget* 
     connect(ui->TextEditorButton, &QPushButton::clicked, this, [this]() {
         auto kbmWindow = new EditorDialog(this);
         kbmWindow->exec();
+        SetUIValuestoMappings(config_id);
     });
 
     connect(ui->buttonBox, &QDialogButtonBox::rejected, this, [this] {
@@ -84,9 +85,6 @@ KBMSettings::KBMSettings(std::shared_ptr<GameInfoClass> game_info_get, QWidget* 
 
     connect(ui->ProfileComboBox, &QComboBox::currentTextChanged, this, [this] {
         GetGameTitle();
-        std::string config_id = (ui->ProfileComboBox->currentText() == "Common Config")
-                                    ? "default"
-                                    : ui->ProfileComboBox->currentText().toStdString();
         SetUIValuestoMappings(config_id);
     });
 
@@ -385,10 +383,6 @@ void KBMSettings::SaveKBMConfig(bool CloseOnSave) {
     lines.push_back(output_string + " = " + input_string);
 
     lines.push_back("");
-
-    std::string config_id = (ui->ProfileComboBox->currentText() == "Common Config")
-                                ? "default"
-                                : ui->ProfileComboBox->currentText().toStdString();
     const auto config_file = Config::GetFoolproofKbmConfigFile(config_id);
     std::fstream file(config_file);
     int lineCount = 0;
@@ -626,6 +620,9 @@ void KBMSettings::GetGameTitle() {
             }
         }
     }
+    config_id = (ui->ProfileComboBox->currentText() == "Common Config")
+                    ? "default"
+                    : ui->ProfileComboBox->currentText().toStdString();
 }
 
 void KBMSettings::onHelpClicked() {

--- a/src/qt_gui/kbm_gui.h
+++ b/src/qt_gui/kbm_gui.h
@@ -42,7 +42,7 @@ private:
     QTimer* timer;
     QPushButton* MappingButton;
     QList<QPushButton*> ButtonsList;
-
+    std::string config_id;
     const std::vector<std::string> ControllerInputs = {
         "cross",        "circle",    "square",      "triangle",    "l1",
         "r1",           "l2",        "r2",          "l3",


### PR DESCRIPTION
Loads the saved changes to the text editor in the GUI. Otherwise the non-updated values in the GUI will overwrite the changes made in the text editor if save or apply is pressed.