### PR TITLE
Fix overlapping elements in translated KBM GUI for certain languages

### DIFF
--- a/src/qt_gui/kbm_gui.ui
+++ b/src/qt_gui/kbm_gui.ui
@@ -11,9 +11,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1193</width>
-    <height>754</height>
+    <width>1234</width>
+    <height>796</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="focusPolicy">
    <enum>Qt::FocusPolicy::StrongFocus</enum>
@@ -38,8 +44,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>1173</width>
-        <height>704</height>
+        <width>1214</width>
+        <height>746</height>
        </rect>
       </property>
       <widget class="QWidget" name="layoutWidget">
@@ -47,8 +53,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>1171</width>
-         <height>703</height>
+         <width>1211</width>
+         <height>741</height>
         </rect>
        </property>
        <layout class="QHBoxLayout" name="RemapLayout">
@@ -63,7 +69,7 @@
              <bool>true</bool>
             </property>
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
@@ -149,6 +155,12 @@
               <layout class="QHBoxLayout" name="layout_dpad_left_right">
                <item>
                 <widget class="QGroupBox" name="gb_dpad_left">
+                 <property name="minimumSize">
+                  <size>
+                   <width>160</width>
+                   <height>0</height>
+                  </size>
+                 </property>
                  <property name="title">
                   <string>Left</string>
                  </property>
@@ -180,6 +192,12 @@
                </item>
                <item>
                 <widget class="QGroupBox" name="gb_dpad_right">
+                 <property name="minimumSize">
+                  <size>
+                   <width>160</width>
+                   <height>0</height>
+                  </size>
+                 </property>
                  <property name="title">
                   <string>Right</string>
                  </property>
@@ -282,10 +300,16 @@
           <item>
            <widget class="QGroupBox" name="LeftStickDeadZoneGB">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>344</width>
+              <height>16777215</height>
+             </size>
             </property>
             <property name="title">
              <string>Left Analog Halfmode</string>
@@ -319,7 +343,7 @@
           <item>
            <widget class="QGroupBox" name="gb_left_stick">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
@@ -405,6 +429,12 @@
               <layout class="QHBoxLayout" name="layout_left_stick_left_right">
                <item>
                 <widget class="QGroupBox" name="gb_left_stick_left">
+                 <property name="minimumSize">
+                  <size>
+                   <width>160</width>
+                   <height>0</height>
+                  </size>
+                 </property>
                  <property name="title">
                   <string>Left</string>
                  </property>
@@ -436,6 +466,12 @@
                </item>
                <item>
                 <widget class="QGroupBox" name="gb_left_stick_right">
+                 <property name="minimumSize">
+                  <size>
+                   <width>160</width>
+                   <height>0</height>
+                  </size>
+                 </property>
                  <property name="maximumSize">
                   <size>
                    <width>179</width>
@@ -528,17 +564,23 @@
          </layout>
         </item>
         <item>
-         <layout class="QVBoxLayout" name="verticalLayout_middle" stretch="0,0,0,0,0,0">
+         <layout class="QVBoxLayout" name="verticalLayout_middle" stretch="0,0,0,0,0">
           <property name="spacing">
            <number>0</number>
           </property>
           <item>
            <widget class="QGroupBox" name="ProfileGroupBox">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
             </property>
             <property name="font">
              <font>
@@ -652,6 +694,18 @@
              <layout class="QVBoxLayout" name="layout_l1_l2">
               <item>
                <widget class="QGroupBox" name="gb_l1">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>160</width>
+                  <height>0</height>
+                 </size>
+                </property>
                 <property name="title">
                  <string>L1</string>
                 </property>
@@ -670,6 +724,12 @@
                  </property>
                  <item>
                   <widget class="QPushButton" name="L1Button">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
                    <property name="focusPolicy">
                     <enum>Qt::FocusPolicy::NoFocus</enum>
                    </property>
@@ -683,6 +743,12 @@
               </item>
               <item>
                <widget class="QGroupBox" name="gb_l2">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
                 <property name="minimumSize">
                  <size>
                   <width>160</width>
@@ -707,6 +773,12 @@
                  </property>
                  <item>
                   <widget class="QPushButton" name="L2Button">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
                    <property name="focusPolicy">
                     <enum>Qt::FocusPolicy::NoFocus</enum>
                    </property>
@@ -724,6 +796,18 @@
              <layout class="QVBoxLayout" name="layout_system_buttons" stretch="0">
               <item>
                <widget class="QGroupBox" name="groupBox_4">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>0</height>
+                 </size>
+                </property>
                 <property name="font">
                  <font>
                   <bold>true</bold>
@@ -735,6 +819,12 @@
                 <layout class="QVBoxLayout" name="verticalLayout_20">
                  <item>
                   <widget class="QPushButton" name="TextEditorButton">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
                    <property name="focusPolicy">
                     <enum>Qt::FocusPolicy::NoFocus</enum>
                    </property>
@@ -745,6 +835,12 @@
                  </item>
                  <item>
                   <widget class="QPushButton" name="HelpButton">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
                    <property name="focusPolicy">
                     <enum>Qt::FocusPolicy::NoFocus</enum>
                    </property>
@@ -762,6 +858,12 @@
              <layout class="QVBoxLayout" name="layout_r1_r2">
               <item>
                <widget class="QGroupBox" name="gb_r1">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
                 <property name="minimumSize">
                  <size>
                   <width>160</width>
@@ -786,6 +888,12 @@
                  </property>
                  <item>
                   <widget class="QPushButton" name="R1Button">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
                    <property name="focusPolicy">
                     <enum>Qt::FocusPolicy::NoFocus</enum>
                    </property>
@@ -799,6 +907,18 @@
               </item>
               <item>
                <widget class="QGroupBox" name="gb_r2">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>160</width>
+                  <height>0</height>
+                 </size>
+                </property>
                 <property name="title">
                  <string>R2</string>
                 </property>
@@ -817,6 +937,12 @@
                  </property>
                  <item>
                   <widget class="QPushButton" name="R2Button">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
                    <property name="focusPolicy">
                     <enum>Qt::FocusPolicy::NoFocus</enum>
                    </property>
@@ -857,7 +983,7 @@
               <widget class="QLabel" name="l_controller">
                <property name="maximumSize">
                 <size>
-                 <width>420</width>
+                 <width>500</width>
                  <height>200</height>
                 </size>
                </property>
@@ -887,6 +1013,12 @@
              <layout class="QVBoxLayout" name="verticalLayout_4">
               <item>
                <widget class="QGroupBox" name="gb_l3">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
                 <property name="minimumSize">
                  <size>
                   <width>160</width>
@@ -911,6 +1043,12 @@
                  </property>
                  <item>
                   <widget class="QPushButton" name="L3Button">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
                    <property name="focusPolicy">
                     <enum>Qt::FocusPolicy::NoFocus</enum>
                    </property>
@@ -924,12 +1062,30 @@
               </item>
               <item>
                <widget class="QGroupBox" name="gb_touchpad">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>160</width>
+                  <height>0</height>
+                 </size>
+                </property>
                 <property name="title">
                  <string>Touchpad Click</string>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_9">
                  <item>
                   <widget class="QPushButton" name="TouchpadButton">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
                    <property name="focusPolicy">
                     <enum>Qt::FocusPolicy::NoFocus</enum>
                    </property>
@@ -947,6 +1103,18 @@
              <layout class="QVBoxLayout" name="verticalLayout_21">
               <item>
                <widget class="QGroupBox" name="groupBox_5">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>0</height>
+                 </size>
+                </property>
                 <property name="title">
                  <string>Mouse to Joystick</string>
                 </property>
@@ -982,6 +1150,12 @@
              <layout class="QVBoxLayout" name="verticalLayout_12">
               <item>
                <widget class="QGroupBox" name="gb_r3">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
                 <property name="minimumSize">
                  <size>
                   <width>160</width>
@@ -1006,6 +1180,12 @@
                  </property>
                  <item>
                   <widget class="QPushButton" name="R3Button">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
                    <property name="focusPolicy">
                     <enum>Qt::FocusPolicy::NoFocus</enum>
                    </property>
@@ -1019,9 +1199,15 @@
               </item>
               <item>
                <widget class="QGroupBox" name="gb_options">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
                 <property name="minimumSize">
                  <size>
-                  <width>145</width>
+                  <width>160</width>
                   <height>0</height>
                  </size>
                 </property>
@@ -1043,6 +1229,12 @@
                  </property>
                  <item>
                   <widget class="QPushButton" name="OptionsButton">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
                    <property name="focusPolicy">
                     <enum>Qt::FocusPolicy::NoFocus</enum>
                    </property>
@@ -1064,6 +1256,12 @@
              <layout class="QVBoxLayout" name="verticalLayout_14">
               <item>
                <widget class="QGroupBox" name="MouseParamsBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
                 <property name="font">
                  <font>
                   <bold>false</bold>
@@ -1196,25 +1394,31 @@
                    </item>
                   </layout>
                  </item>
+                 <item>
+                  <widget class="QLabel" name="MoreInfoLabel">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="font">
+                    <font>
+                     <italic>true</italic>
+                     <bold>false</bold>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>note: click Help Button/Special Keybindings for more information</string>
+                   </property>
+                  </widget>
+                 </item>
                 </layout>
                </widget>
               </item>
              </layout>
             </item>
            </layout>
-          </item>
-          <item>
-           <widget class="QLabel" name="MoreInfoLabel">
-            <property name="font">
-             <font>
-              <italic>true</italic>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>note: click Help Button/Special Keybindings for more information</string>
-            </property>
-           </widget>
           </item>
          </layout>
         </item>
@@ -1226,7 +1430,7 @@
           <item>
            <widget class="QGroupBox" name="gb_face_buttons">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
@@ -1306,6 +1510,12 @@
               <layout class="QHBoxLayout" name="layout_square_circle">
                <item>
                 <widget class="QGroupBox" name="gb_square">
+                 <property name="minimumSize">
+                  <size>
+                   <width>160</width>
+                   <height>0</height>
+                  </size>
+                 </property>
                  <property name="title">
                   <string>Square</string>
                  </property>
@@ -1337,6 +1547,12 @@
                </item>
                <item>
                 <widget class="QGroupBox" name="gb_circle">
+                 <property name="minimumSize">
+                  <size>
+                   <width>160</width>
+                   <height>0</height>
+                  </size>
+                 </property>
                  <property name="title">
                   <string>Circle</string>
                  </property>
@@ -1444,6 +1660,12 @@
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
+            <property name="maximumSize">
+             <size>
+              <width>344</width>
+              <height>16777215</height>
+             </size>
+            </property>
             <property name="title">
              <string>Right Analog Halfmode</string>
             </property>
@@ -1476,7 +1698,7 @@
           <item>
            <widget class="QGroupBox" name="gb_right_stick">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
@@ -1568,6 +1790,12 @@
               <layout class="QHBoxLayout" name="layout_right_stick_left_right">
                <item>
                 <widget class="QGroupBox" name="gb_right_stick_left">
+                 <property name="minimumSize">
+                  <size>
+                   <width>160</width>
+                   <height>0</height>
+                  </size>
+                 </property>
                  <property name="title">
                   <string>Left</string>
                  </property>
@@ -1599,6 +1827,12 @@
                </item>
                <item>
                 <widget class="QGroupBox" name="gb_right_stick_right">
+                 <property name="minimumSize">
+                  <size>
+                   <width>160</width>
+                   <height>0</height>
+                  </size>
+                 </property>
                  <property name="title">
                   <string>Right</string>
                  </property>


### PR DESCRIPTION
Prevent overlapping elements when translated strings in the KBM remapping GUI are too long, mostly by widening the middle layouts and changing size policies for some groupboxes.

Main (Russian):
![main](https://github.com/user-attachments/assets/56caf5ae-1e22-4db8-be23-5b4d9a208f60)

PR (Russian):
![PR2](https://github.com/user-attachments/assets/485116c9-a649-44f6-b75c-dcb71799b17c)
