### PR TITLE
Handle "-patch" as the suffix for game update folders

### DIFF
--- a/src/core/file_format/pkg.cpp
+++ b/src/core/file_format/pkg.cpp
@@ -350,7 +350,7 @@ bool PKG::Extract(const std::filesystem::path& filepath, const std::filesystem::
                     auto title_id = GetTitleID();
 
                     if (parent_path.filename() != title_id &&
-                        !fmt::UTF(extract_path.u8string()).data.ends_with("-UPDATE")) {
+                        !fmt::UTF(extract_path.u8string()).data.ends_with("-patch")) {
                         extractPaths[ndinode_counter] = parent_path / title_id;
                     } else {
                         // DLCs path has different structure

--- a/src/core/file_sys/fs.cpp
+++ b/src/core/file_sys/fs.cpp
@@ -70,7 +70,7 @@ std::filesystem::path MntPoints::GetHostPath(std::string_view path, bool* is_rea
     std::filesystem::path host_path = mount->host_path / rel_path;
     std::filesystem::path patch_path = mount->host_path;
     patch_path += "-UPDATE";
-    if(!std::filesystem::exists(patch_path)) {
+    if (!std::filesystem::exists(patch_path)) {
         patch_path = mount->host_path;
         patch_path += "-patch";
     }

--- a/src/core/file_sys/fs.cpp
+++ b/src/core/file_sys/fs.cpp
@@ -70,6 +70,10 @@ std::filesystem::path MntPoints::GetHostPath(std::string_view path, bool* is_rea
     std::filesystem::path host_path = mount->host_path / rel_path;
     std::filesystem::path patch_path = mount->host_path;
     patch_path += "-UPDATE";
+    if(!std::filesystem::exists(patch_path)) {
+        patch_path = mount->host_path;
+        patch_path += "-patch";
+    }
     patch_path /= rel_path;
 
     if ((corrected_path.starts_with("/app0") || corrected_path.starts_with("/hostapp")) &&

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -80,7 +80,7 @@ void Emulator::Run(const std::filesystem::path& file, const std::vector<std::str
     const auto eboot_name = file.filename().string();
     auto game_folder = file.parent_path();
     if (const auto game_folder_name = game_folder.filename().string();
-        game_folder_name.ends_with("-UPDATE")) {
+        game_folder_name.ends_with("-UPDATE") || game_folder_name.ends_with("-patch")) {
         // If an executable was launched from a separate update directory,
         // use the base game directory as the game folder.
         const auto base_name = game_folder_name.substr(0, game_folder_name.size() - 7);

--- a/src/qt_gui/game_info.cpp
+++ b/src/qt_gui/game_info.cpp
@@ -20,7 +20,7 @@ void ScanDirectoryRecursively(const QString& dir, QStringList& filePaths, int cu
     QFileInfoList entries = directory.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
 
     for (const auto& entry : entries) {
-        if (entry.fileName().endsWith("-UPDATE")) {
+        if (entry.fileName().endsWith("-UPDATE") || entry.fileName().endsWith("-patch")) {
             continue;
         }
 

--- a/src/qt_gui/game_info.h
+++ b/src/qt_gui/game_info.h
@@ -34,6 +34,12 @@ public:
         game_update_path += "-UPDATE";
         if (std::filesystem::exists(game_update_path / "sce_sys" / "param.sfo")) {
             sce_folder_path = game_update_path / "sce_sys" / "param.sfo";
+        } else {
+            game_update_path = filePath;
+            game_update_path += "-patch";
+            if (std::filesystem::exists(game_update_path / "sce_sys" / "param.sfo")) {
+                sce_folder_path = game_update_path / "sce_sys" / "param.sfo";
+            }
         }
 
         PSF psf;

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -142,8 +142,12 @@ public:
             Common::FS::PathToQString(open_update_path, m_games[itemID].path);
             open_update_path += "-UPDATE";
             if (!std::filesystem::exists(Common::FS::PathFromQString(open_update_path))) {
-                QMessageBox::critical(nullptr, tr("Error"),
-                                      QString(tr("This game has no update folder to open!")));
+                Common::FS::PathToQString(open_update_path, m_games[itemID].path);
+                open_update_path += "-patch";
+                if (!std::filesystem::exists(Common::FS::PathFromQString(open_update_path))) {
+                    QMessageBox::critical(nullptr, tr("Error"),
+                                          QString(tr("This game has no update folder to open!")));
+                }
             } else {
                 QDesktopServices::openUrl(QUrl::fromLocalFile(open_update_path));
             }
@@ -218,6 +222,12 @@ public:
             game_update_path += "-UPDATE";
             if (std::filesystem::exists(game_update_path)) {
                 game_folder_path = game_update_path;
+            } else {
+                game_update_path = game_folder_path;
+                game_update_path += "-patch";
+                if (std::filesystem::exists(game_update_path)) {
+                    game_folder_path = game_update_path;
+                }
             }
             if (psf.Open(game_folder_path / "sce_sys" / "param.sfo")) {
                 int rows = psf.GetEntries().size();
@@ -314,6 +324,12 @@ public:
             game_update_path += "-UPDATE";
             if (std::filesystem::exists(game_update_path)) {
                 Common::FS::PathToQString(gameTrpPath, game_update_path);
+            } else {
+                game_update_path = Common::FS::PathFromQString(gameTrpPath);
+                game_update_path += "-patch";
+                if (std::filesystem::exists(game_update_path)) {
+                    Common::FS::PathToQString(gameTrpPath, game_update_path);
+                }
             }
             TrophyViewer* trophyViewer = new TrophyViewer(trophyPath, gameTrpPath);
             trophyViewer->show();
@@ -434,6 +450,9 @@ public:
             QString folder_path, game_update_path, dlc_path, save_data_path, trophy_data_path;
             Common::FS::PathToQString(folder_path, m_games[itemID].path);
             game_update_path = folder_path + "-UPDATE";
+            if(!std::filesystem::exists(Common::FS::PathFromQString(game_update_path))){
+                game_update_path = folder_path + "-patch";
+            }
             Common::FS::PathToQString(
                 dlc_path, Config::getAddonInstallDir() /
                               Common::FS::PathFromQString(folder_path).parent_path().filename());

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -450,7 +450,7 @@ public:
             QString folder_path, game_update_path, dlc_path, save_data_path, trophy_data_path;
             Common::FS::PathToQString(folder_path, m_games[itemID].path);
             game_update_path = folder_path + "-UPDATE";
-            if(!std::filesystem::exists(Common::FS::PathFromQString(game_update_path))){
+            if (!std::filesystem::exists(Common::FS::PathFromQString(game_update_path))) {
                 game_update_path = folder_path + "-patch";
             }
             Common::FS::PathToQString(

--- a/src/qt_gui/kbm_config_dialog.cpp
+++ b/src/qt_gui/kbm_config_dialog.cpp
@@ -225,7 +225,8 @@ void EditorDialog::loadInstalledGames() {
         QDir parentFolder(installDir);
         QFileInfoList fileList = parentFolder.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
         for (const auto& fileInfo : fileList) {
-            if (fileInfo.isDir() && (!fileInfo.filePath().endsWith("-UPDATE") || !fileInfo.filePath().endsWith("-patch"))) {
+            if (fileInfo.isDir() && (!fileInfo.filePath().endsWith("-UPDATE") ||
+                                     !fileInfo.filePath().endsWith("-patch"))) {
                 gameComboBox->addItem(fileInfo.fileName()); // Add game name to combo box
             }
         }

--- a/src/qt_gui/kbm_config_dialog.cpp
+++ b/src/qt_gui/kbm_config_dialog.cpp
@@ -225,7 +225,7 @@ void EditorDialog::loadInstalledGames() {
         QDir parentFolder(installDir);
         QFileInfoList fileList = parentFolder.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
         for (const auto& fileInfo : fileList) {
-            if (fileInfo.isDir() && !fileInfo.filePath().endsWith("-UPDATE")) {
+            if (fileInfo.isDir() && (!fileInfo.filePath().endsWith("-UPDATE") || !fileInfo.filePath().endsWith("-patch"))) {
                 gameComboBox->addItem(fileInfo.fileName()); // Add game name to combo box
             }
         }

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -840,7 +840,7 @@ void MainWindow::InstallDragDropPkg(std::filesystem::path file, int pkgNum, int 
         // Default paths
         auto game_folder_path = game_install_dir / pkg.GetTitleID();
         auto game_update_path = use_game_update ? game_folder_path.parent_path() /
-                                                      (std::string{pkg.GetTitleID()} + "-UPDATE")
+                                                      (std::string{pkg.GetTitleID()} + "-patch")
                                                 : game_folder_path;
         const int max_depth = 5;
 
@@ -851,7 +851,7 @@ void MainWindow::InstallDragDropPkg(std::filesystem::path file, int pkgNum, int 
             if (found_game.has_value()) {
                 game_folder_path = found_game.value().parent_path();
                 game_update_path = use_game_update ? game_folder_path.parent_path() /
-                                                         (std::string{pkg.GetTitleID()} + "-UPDATE")
+                                                         (std::string{pkg.GetTitleID()} + "-patch")
                                                    : game_folder_path;
             }
         } else {
@@ -866,7 +866,7 @@ void MainWindow::InstallDragDropPkg(std::filesystem::path file, int pkgNum, int 
                 game_folder_path = game_install_dir / pkg.GetTitleID();
             }
             game_update_path = use_game_update ? game_folder_path.parent_path() /
-                                                     (std::string{pkg.GetTitleID()} + "-UPDATE")
+                                                     (std::string{pkg.GetTitleID()} + "-patch")
                                                : game_folder_path;
         }
 


### PR DESCRIPTION
Some game dumping tools name game updates `CUSAXXXXX-patch`, so the user had to rename that to `CUSAXXXXX-UPDATE` previously. With this PR, those dumps now become plug-and-play. Everything works as far as I could see from my testing, but I do admit that just like a typical programmer I also don't like to test extensively, so some things might be wrong.