### PR TITLE
QT: Fix PR 2662 - checkbox/Choose directory

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -82,6 +82,7 @@ static std::string trophyKey;
 // Gui
 static bool load_game_size = true;
 static std::vector<GameInstallDir> settings_install_dirs = {};
+std::vector<bool> install_dirs_enabled = {};
 std::filesystem::path settings_addon_install_dir = {};
 std::filesystem::path save_data_path = {};
 u32 main_window_geometry_x = 400;
@@ -643,8 +644,8 @@ const std::vector<std::filesystem::path> getGameInstallDirs() {
     return enabled_dirs;
 }
 
-const std::vector<GameInstallDir>& getAllGameInstallDirs() {
-    return settings_install_dirs;
+const std::vector<bool> getGameInstallDirsEnabled() {
+    return install_dirs_enabled;
 }
 
 std::filesystem::path getAddonInstallDir() {
@@ -839,7 +840,6 @@ void load(const std::filesystem::path& path) {
         const auto install_dir_array =
             toml::find_or<std::vector<std::string>>(gui, "installDirs", {});
 
-        std::vector<bool> install_dirs_enabled;
         try {
             install_dirs_enabled = toml::find<std::vector<bool>>(gui, "installDirsEnabled");
         } catch (...) {

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -161,7 +161,7 @@ u32 getMainWindowGeometryY();
 u32 getMainWindowGeometryW();
 u32 getMainWindowGeometryH();
 const std::vector<std::filesystem::path> getGameInstallDirs();
-const std::vector<GameInstallDir>& getAllGameInstallDirs();
+const std::vector<bool> getGameInstallDirsEnabled();
 std::filesystem::path getAddonInstallDir();
 u32 getMainWindowTheme();
 u32 getIconSize();

--- a/src/qt_gui/main.cpp
+++ b/src/qt_gui/main.cpp
@@ -157,8 +157,13 @@ int main(int argc, char* argv[]) {
         }
     }
 
+    bool allInstallDirsDisabled =
+        std::all_of(Config::getGameInstallDirsEnabled().begin(),
+                    Config::getGameInstallDirsEnabled().end(), [](bool val) { return !val; });
+
     // If no game directory is set and no command line argument, prompt for it
-    if (Config::getGameInstallDirs().empty() && !has_command_line_argument) {
+    if (Config::getGameInstallDirs().empty() && allInstallDirsDisabled &&
+        !has_command_line_argument) {
         GameInstallDialog dlg;
         dlg.exec();
     }

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -821,7 +821,7 @@ void SettingsDialog::ResetInstallFolders() {
 
         std::vector<bool> install_dirs_enabled;
         try {
-            install_dirs_enabled = toml::find<std::vector<bool>>(gui, "installDirsEnabled");
+            install_dirs_enabled = Config::getGameInstallDirsEnabled();
         } catch (...) {
             // If it does not exist, assume that all are enabled.
             install_dirs_enabled.resize(install_dir_array.size(), true);


### PR DESCRIPTION
After [PR 2662](https://github.com/shadps4-emu/shadPS4/pull/2662) added a checkbox to the list of game folders, if they were all disabled, when opening the emulator the screen to add a new folder appeared, as if none had been added.
This PR fixes this. That screen will only appear if there are no folders added.

*getAllGameInstallDirs was removed as it was not used.

![image](https://github.com/user-attachments/assets/aa167728-8a26-4f8b-a984-2516adacd31f)
