### PR TITLE
Implement DmaDataSrc::MemoryUsingL2 and DmaDataDst::MemoryUsingL2

### DIFF
--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -771,19 +771,24 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
             }
             if (dma_data->src_sel == DmaDataSrc::Data && dma_data->dst_sel == DmaDataDst::Gds) {
                 rasterizer->InlineData(dma_data->dst_addr_lo, &dma_data->data, sizeof(u32), true);
-            } else if (dma_data->src_sel == DmaDataSrc::Memory &&
+            } else if ((dma_data->src_sel == DmaDataSrc::Memory ||
+                        dma_data->src_sel == DmaDataSrc::MemoryUsingL2) &&
                        dma_data->dst_sel == DmaDataDst::Gds) {
                 rasterizer->InlineData(dma_data->dst_addr_lo, dma_data->SrcAddress<const void*>(),
                                        dma_data->NumBytes(), true);
             } else if (dma_data->src_sel == DmaDataSrc::Data &&
-                       dma_data->dst_sel == DmaDataDst::Memory) {
+                       (dma_data->dst_sel == DmaDataDst::Memory ||
+                        dma_data->dst_sel == DmaDataDst::MemoryUsingL2)) {
                 rasterizer->InlineData(dma_data->DstAddress<VAddr>(), &dma_data->data, sizeof(u32),
                                        false);
             } else if (dma_data->src_sel == DmaDataSrc::Gds &&
-                       dma_data->dst_sel == DmaDataDst::Memory) {
+                       (dma_data->dst_sel == DmaDataDst::Memory ||
+                        dma_data->dst_sel == DmaDataDst::MemoryUsingL2)) {
                 // LOG_WARNING(Render_Vulkan, "GDS memory read");
-            } else if (dma_data->src_sel == DmaDataSrc::Memory &&
-                       dma_data->dst_sel == DmaDataDst::Memory) {
+            } else if ((dma_data->src_sel == DmaDataSrc::Memory ||
+                        dma_data->src_sel == DmaDataSrc::MemoryUsingL2) &&
+                       (dma_data->dst_sel == DmaDataDst::Memory ||
+                        dma_data->dst_sel == DmaDataDst::MemoryUsingL2)) {
                 rasterizer->InlineData(dma_data->DstAddress<VAddr>(),
                                        dma_data->SrcAddress<const void*>(), dma_data->NumBytes(),
                                        false);

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -602,20 +602,25 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
                 if (dma_data->src_sel == DmaDataSrc::Data && dma_data->dst_sel == DmaDataDst::Gds) {
                     rasterizer->InlineData(dma_data->dst_addr_lo, &dma_data->data, sizeof(u32),
                                            true);
-                } else if (dma_data->src_sel == DmaDataSrc::Memory &&
+                } else if ((dma_data->src_sel == DmaDataSrc::Memory ||
+                            dma_data->src_sel == DmaDataSrc::MemoryUsingL2) &&
                            dma_data->dst_sel == DmaDataDst::Gds) {
                     rasterizer->InlineData(dma_data->dst_addr_lo,
                                            dma_data->SrcAddress<const void*>(),
                                            dma_data->NumBytes(), true);
                 } else if (dma_data->src_sel == DmaDataSrc::Data &&
-                           dma_data->dst_sel == DmaDataDst::Memory) {
+                           (dma_data->dst_sel == DmaDataDst::Memory ||
+                            dma_data->dst_sel == DmaDataDst::MemoryUsingL2)) {
                     rasterizer->InlineData(dma_data->DstAddress<VAddr>(), &dma_data->data,
                                            sizeof(u32), false);
                 } else if (dma_data->src_sel == DmaDataSrc::Gds &&
-                           dma_data->dst_sel == DmaDataDst::Memory) {
+                           (dma_data->dst_sel == DmaDataDst::Memory ||
+                            dma_data->dst_sel == DmaDataDst::MemoryUsingL2)) {
                     // LOG_WARNING(Render_Vulkan, "GDS memory read");
-                } else if (dma_data->src_sel == DmaDataSrc::Memory &&
-                           dma_data->dst_sel == DmaDataDst::Memory) {
+                } else if ((dma_data->src_sel == DmaDataSrc::Memory ||
+                            dma_data->src_sel == DmaDataSrc::MemoryUsingL2) &&
+                           (dma_data->dst_sel == DmaDataDst::Memory ||
+                            dma_data->dst_sel == DmaDataDst::MemoryUsingL2)) {
                     rasterizer->InlineData(dma_data->DstAddress<VAddr>(),
                                            dma_data->SrcAddress<const void*>(),
                                            dma_data->NumBytes(), false);

--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -377,12 +377,14 @@ struct PM4CmdAcquireMem {
 enum class DmaDataDst : u32 {
     Memory = 0,
     Gds = 1,
+    MemoryUsingL2 = 3,
 };
 
 enum class DmaDataSrc : u32 {
     Memory = 0,
     Gds = 1,
     Data = 2,
+    MemoryUsingL2 = 3,
 };
 
 struct PM4DmaData {


### PR DESCRIPTION
Implements the above two DmaData source and destination types, by handling them the same way as ::Memory is handled. This is based on observations in CUSA01127 (which uses this), and also code from fpPS4:
https://github.com/red-prig/fpPS4/blob/kern/chip/pm4defs.pas#L552-L567
https://github.com/red-prig/fpPS4/blob/kern/chip/pm4_me.pas#L2978

Fixes the following unreachable in CUSA01127, CUSA00575 and CUSA00211:
```
[Debug] <Critical> liverpool.cpp:ProcessGraphics:627: Unreachable code!
WriteData src_sel = 3, dst_sel = 3
```