### PR TITLE
HLE discmap

### DIFF
--- a/src/core/libraries/disc_map/disc_map.cpp
+++ b/src/core/libraries/disc_map/disc_map.cpp
@@ -13,11 +13,11 @@ int PS4_SYSV_ABI sceDiscMapGetPackageSize(s64 fflags, int* ret1, int* ret2) {
     return ORBIS_DISC_MAP_ERROR_NO_BITMAP_INFO;
 }
 
-int PS4_SYSV_ABI sceDiscMapIsRequestOnHDD(char* path, s64 param2, s64 param3, int* ret) {
+int PS4_SYSV_ABI sceDiscMapIsRequestOnHDD(char* path, s64 offset, s64 nbytes, int* ret) {
     return ORBIS_DISC_MAP_ERROR_NO_BITMAP_INFO;
 }
 
-int PS4_SYSV_ABI Func_7C980FFB0AA27E7A(char* path, s64 param2, s64 param3, int* flags, int* ret1,
+int PS4_SYSV_ABI Func_7C980FFB0AA27E7A(char* path, s64 offset, s64 nbytes, int* flags, int* ret1,
                                        int* ret2) {
     *flags = 0;
     *ret1 = 0;
@@ -25,7 +25,7 @@ int PS4_SYSV_ABI Func_7C980FFB0AA27E7A(char* path, s64 param2, s64 param3, int* 
     return ORBIS_OK;
 }
 
-int PS4_SYSV_ABI Func_8A828CAEE7EDD5E9(char* path, s64 param2, s64 param3, int* flags, int* ret1,
+int PS4_SYSV_ABI Func_8A828CAEE7EDD5E9(char* path, s64 offset, s64 nbytes, int* flags, int* ret1,
                                        int* ret2) {
     return ORBIS_DISC_MAP_ERROR_NO_BITMAP_INFO;
 }

--- a/src/core/libraries/disc_map/disc_map.cpp
+++ b/src/core/libraries/disc_map/disc_map.cpp
@@ -9,29 +9,29 @@
 
 namespace Libraries::DiscMap {
 
-int PS4_SYSV_ABI sceDiscMapGetPackageSize() {
-    LOG_WARNING(Lib_DiscMap, "(DUMMY) called");
+int PS4_SYSV_ABI sceDiscMapGetPackageSize(s64 fflags, int* ret1, int* ret2) {
     return ORBIS_DISC_MAP_ERROR_NO_BITMAP_INFO;
 }
 
-int PS4_SYSV_ABI sceDiscMapIsRequestOnHDD() {
-    LOG_WARNING(Lib_DiscMap, "(DUMMY) called");
+int PS4_SYSV_ABI sceDiscMapIsRequestOnHDD(char* path, s64 param2, s64 param3, int* ret) {
     return ORBIS_DISC_MAP_ERROR_NO_BITMAP_INFO;
 }
 
-int PS4_SYSV_ABI Func_7C980FFB0AA27E7A() {
-    LOG_ERROR(Lib_DiscMap, "(STUBBED) called");
+int PS4_SYSV_ABI Func_7C980FFB0AA27E7A(char* path, s64 param2, s64 param3, int* flags, int* ret1,
+                                       int* ret2) {
+    *flags = 0;
+    *ret1 = 0;
+    *ret2 = 0;
     return ORBIS_OK;
 }
 
-int PS4_SYSV_ABI Func_8A828CAEE7EDD5E9() {
-    LOG_ERROR(Lib_DiscMap, "(STUBBED) called");
-    return ORBIS_OK;
+int PS4_SYSV_ABI Func_8A828CAEE7EDD5E9(char* path, s64 param2, s64 param3, int* flags, int* ret1,
+                                       int* ret2) {
+    return ORBIS_DISC_MAP_ERROR_NO_BITMAP_INFO;
 }
 
 int PS4_SYSV_ABI Func_E7EBCE96E92F91F8() {
-    LOG_ERROR(Lib_DiscMap, "(STUBBED) called");
-    return ORBIS_OK;
+    return ORBIS_DISC_MAP_ERROR_NO_BITMAP_INFO;
 }
 
 void RegisterlibSceDiscMap(Core::Loader::SymbolsResolver* sym) {

--- a/src/core/libraries/disc_map/disc_map.h
+++ b/src/core/libraries/disc_map/disc_map.h
@@ -10,10 +10,12 @@ class SymbolsResolver;
 }
 namespace Libraries::DiscMap {
 
-int PS4_SYSV_ABI sceDiscMapGetPackageSize();
-int PS4_SYSV_ABI sceDiscMapIsRequestOnHDD();
-int PS4_SYSV_ABI Func_7C980FFB0AA27E7A();
-int PS4_SYSV_ABI Func_8A828CAEE7EDD5E9();
+int PS4_SYSV_ABI sceDiscMapGetPackageSize(s64 fflags, int* ret1, int* ret2);
+int PS4_SYSV_ABI sceDiscMapIsRequestOnHDD(char* path, s64 param2, s64 param3, int* ret);
+int PS4_SYSV_ABI Func_7C980FFB0AA27E7A(char* path, s64 param2, s64 param3, int* flags, int* ret1,
+                                       int* ret2);
+int PS4_SYSV_ABI Func_8A828CAEE7EDD5E9(char* path, s64 param2, s64 param3, int* flags, int* ret1,
+                                       int* ret2);
 int PS4_SYSV_ABI Func_E7EBCE96E92F91F8();
 
 void RegisterlibSceDiscMap(Core::Loader::SymbolsResolver* sym);

--- a/src/core/libraries/disc_map/disc_map.h
+++ b/src/core/libraries/disc_map/disc_map.h
@@ -11,10 +11,10 @@ class SymbolsResolver;
 namespace Libraries::DiscMap {
 
 int PS4_SYSV_ABI sceDiscMapGetPackageSize(s64 fflags, int* ret1, int* ret2);
-int PS4_SYSV_ABI sceDiscMapIsRequestOnHDD(char* path, s64 param2, s64 param3, int* ret);
-int PS4_SYSV_ABI Func_7C980FFB0AA27E7A(char* path, s64 param2, s64 param3, int* flags, int* ret1,
+int PS4_SYSV_ABI sceDiscMapIsRequestOnHDD(char* path, s64 offset, s64 nbytes, int* ret);
+int PS4_SYSV_ABI Func_7C980FFB0AA27E7A(char* path, s64 offset, s64 nbytes, int* flags, int* ret1,
                                        int* ret2);
-int PS4_SYSV_ABI Func_8A828CAEE7EDD5E9(char* path, s64 param2, s64 param3, int* flags, int* ret1,
+int PS4_SYSV_ABI Func_8A828CAEE7EDD5E9(char* path, s64 offset, s64 nbytes, int* flags, int* ret1,
                                        int* ret2);
 int PS4_SYSV_ABI Func_E7EBCE96E92F91F8();
 

--- a/src/core/libraries/libs.cpp
+++ b/src/core/libraries/libs.cpp
@@ -58,7 +58,6 @@
 #include "core/libraries/zlib/zlib_sce.h"
 #include "fiber/fiber.h"
 #include "jpeg/jpegenc.h"
-#include "core/libraries/disc_map/disc_map.h
 
 namespace Libraries {
 

--- a/src/core/libraries/libs.cpp
+++ b/src/core/libraries/libs.cpp
@@ -58,6 +58,7 @@
 #include "core/libraries/zlib/zlib_sce.h"
 #include "fiber/fiber.h"
 #include "jpeg/jpegenc.h"
+#include "core/libraries/disc_map/disc_map.h
 
 namespace Libraries {
 
@@ -115,6 +116,7 @@ void InitHLELibs(Core::Loader::SymbolsResolver* sym) {
     Libraries::NpParty::RegisterlibSceNpParty(sym);
     Libraries::Zlib::RegisterlibSceZlib(sym);
     Libraries::Hmd::RegisterlibSceHmd(sym);
+    Libraries::DiscMap::RegisterlibSceDiscMap(sym);
 }
 
 } // namespace Libraries

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -289,13 +289,12 @@ void Emulator::Run(const std::filesystem::path& file, const std::vector<std::str
 }
 
 void Emulator::LoadSystemModules(const std::string& game_serial) {
-    constexpr std::array<SysModules, 11> ModulesToLoad{
+    constexpr std::array<SysModules, 10> ModulesToLoad{
         {{"libSceNgs2.sprx", &Libraries::Ngs2::RegisterlibSceNgs2},
          {"libSceUlt.sprx", nullptr},
          {"libSceJson.sprx", nullptr},
          {"libSceJson2.sprx", nullptr},
          {"libSceLibcInternal.sprx", &Libraries::LibcInternal::RegisterlibSceLibcInternal},
-         {"libSceDiscMap.sprx", &Libraries::DiscMap::RegisterlibSceDiscMap},
          {"libSceRtc.sprx", &Libraries::Rtc::RegisterlibSceRtc},
          {"libSceCesCs.sprx", nullptr},
          {"libSceFont.sprx", nullptr},


### PR DESCRIPTION
This eliminates the need for discmap , based on @red-prig suggestions

According to RE on ghidra all calls seems to check if lib is init first using a global

`  if (DAT_010080e0 == 0) {
    uVar2 = ORBIS_DISC_MAP_ERROR_NO_BITMAP_INFO;
  }`

so it is rather safe to return this , since it is likely the same we do when we load this lib lle