### PR TITLE
Show a dialog only if no game directories are set

### DIFF
--- a/src/qt_gui/main.cpp
+++ b/src/qt_gui/main.cpp
@@ -158,8 +158,7 @@ int main(int argc, char* argv[]) {
     }
 
     bool allInstallDirsDisabled =
-        std::all_of(Config::getGameInstallDirsEnabled().begin(),
-                    Config::getGameInstallDirsEnabled().end(), [](bool val) { return !val; });
+        std::ranges::all_of(Config::getGameInstallDirsEnabled(), [](bool val) { return !val; });
 
     // If no game directory is set and no command line argument, prompt for it
     if (Config::getGameInstallDirs().empty() && allInstallDirsDisabled &&

--- a/src/qt_gui/main.cpp
+++ b/src/qt_gui/main.cpp
@@ -157,7 +157,7 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    // If no game directory is set and no command line argument, prompt for it
+    // If no game directories are set and no command line argument, prompt for it
     if (Config::getGameInstallDirsEnabled().empty() &&
         !has_command_line_argument) {
         GameInstallDialog dlg;

--- a/src/qt_gui/main.cpp
+++ b/src/qt_gui/main.cpp
@@ -157,11 +157,8 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    bool allInstallDirsDisabled =
-        std::ranges::all_of(Config::getGameInstallDirsEnabled(), [](bool val) { return !val; });
-
     // If no game directory is set and no command line argument, prompt for it
-    if (Config::getGameInstallDirs().empty() && allInstallDirsDisabled &&
+    if (Config::getGameInstallDirsEnabled().empty() &&
         !has_command_line_argument) {
         GameInstallDialog dlg;
         dlg.exec();

--- a/src/qt_gui/main.cpp
+++ b/src/qt_gui/main.cpp
@@ -158,8 +158,7 @@ int main(int argc, char* argv[]) {
     }
 
     // If no game directories are set and no command line argument, prompt for it
-    if (Config::getGameInstallDirsEnabled().empty() &&
-        !has_command_line_argument) {
+    if (Config::getGameInstallDirsEnabled().empty() && !has_command_line_argument) {
         GameInstallDialog dlg;
         dlg.exec();
     }


### PR DESCRIPTION
Changed the code to be more in line with what [PR 2676](https://github.com/shadps4-emu/shadPS4/pull/2676) set out to do - only show the dialog if there are no directories at all (regardless of them being checked/unchecked).