### PR TITLE
Fork detection: Fix PR actions only showing HEAD as the branch name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,28 +113,45 @@ git_describe(GIT_DESC --always --long --dirty)
 git_branch_name(GIT_BRANCH)
 string(TIMESTAMP BUILD_DATE "%Y-%m-%d %H:%M:%S")
 
+message("start git things")
 # Try to get the upstream remote and branch
 execute_process(
   COMMAND git rev-parse --abbrev-ref --symbolic-full-name @{u}
   OUTPUT_VARIABLE GIT_REMOTE_NAME
-  RESULT_VARIABLE GIT_BRANCH_RESULT
-  ERROR_QUIET
+  RESULT_VARIABLE GIT_REMOTE_RESULT
+  #ERROR_QUIET
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
-
 # If there's no upstream set or the command failed, check remote.pushDefault
-if (GIT_BRANCH_RESULT OR GIT_REMOTE_NAME STREQUAL "")
+if (GIT_REMOTE_RESULT OR GIT_REMOTE_NAME STREQUAL "")
   execute_process(
     COMMAND git config --get remote.pushDefault
     OUTPUT_VARIABLE GIT_REMOTE_NAME
-    RESULT_VARIABLE GIT_PUSH_DEFAULT_RESULT
-    ERROR_QUIET
+    RESULT_VARIABLE GIT_REMOTE_RESULT
+    #ERROR_QUIET
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
-  
-  # If remote.pushDefault is not set or fails, default to origin
-  if (GIT_PUSH_DEFAULT_RESULT OR GIT_REMOTE_NAME STREQUAL "")
-    set(GIT_REMOTE_NAME "origin")
+endif()
+# If running in GitHub Actions and the above fails
+if (GIT_REMOTE_RESULT OR GIT_REMOTE_NAME STREQUAL "")
+  message("check github")
+  set(GIT_REMOTE_NAME "origin")
+
+  if (DEFINED ENV{GITHUB_HEAD_REF})  # PR branch name
+    set(GIT_BRANCH "pr-$ENV{GITHUB_HEAD_REF}")
+  elseif (DEFINED ENV{GITHUB_REF})  # Normal branch name
+    string(REGEX REPLACE "^refs/[^/]*/" "" GIT_BRANCH "$ENV{GITHUB_REF}")
+  elseif (DEFINED ENV{GITHUB_EVENT_PATH})
+    # Extract PR number from GitHub event JSON
+    file(READ "$ENV{GITHUB_EVENT_PATH}" GITHUB_EVENT_JSON)
+    string(JSON PR_NUMBER GET ${GITHUB_EVENT_JSON} "number")
+    if (PR_NUMBER)
+      set(GIT_BRANCH "pr-${PR_NUMBER}")
+    else()
+      set(GIT_BRANCH "detached-head1")
+    endif()
+  else()
+    set(GIT_BRANCH "detached-head2")
   endif()
 else()
   # Extract remote name if the output contains a remote/branch format
@@ -155,6 +172,8 @@ execute_process(
 )
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/common/scm_rev.cpp.in" "${CMAKE_CURRENT_BINARY_DIR}/src/common/scm_rev.cpp" @ONLY)
+
+message("end git things, remote: ${GIT_REMOTE_NAME}, branch: ${GIT_BRANCH}")
 
 find_package(Boost 1.84.0 CONFIG)
 find_package(FFmpeg 5.1.2 MODULE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ execute_process(
   COMMAND git rev-parse --abbrev-ref --symbolic-full-name @{u}
   OUTPUT_VARIABLE GIT_REMOTE_NAME
   RESULT_VARIABLE GIT_REMOTE_RESULT
-  #ERROR_QUIET
+  ERROR_QUIET
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 # If there's no upstream set or the command failed, check remote.pushDefault
@@ -130,7 +130,7 @@ if (GIT_REMOTE_RESULT OR GIT_REMOTE_NAME STREQUAL "")
     COMMAND git config --get remote.pushDefault
     OUTPUT_VARIABLE GIT_REMOTE_NAME
     RESULT_VARIABLE GIT_REMOTE_RESULT
-    #ERROR_QUIET
+    ERROR_QUIET
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 endif()
@@ -158,7 +158,8 @@ else()
   endif()
 endif()
 
-# Get remote linkmessage("getting remote link")
+# Get remote link
+message("getting remote link")
 execute_process(
   COMMAND git config --get remote.${GIT_REMOTE_NAME}.url
   OUTPUT_VARIABLE GIT_REMOTE_URL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ string(TIMESTAMP BUILD_DATE "%Y-%m-%d %H:%M:%S")
 
 message("start git things")
 # Try to get the upstream remote and branch
+message("check for remote and branch")
 execute_process(
   COMMAND git rev-parse --abbrev-ref --symbolic-full-name @{u}
   OUTPUT_VARIABLE GIT_REMOTE_NAME
@@ -124,6 +125,7 @@ execute_process(
 )
 # If there's no upstream set or the command failed, check remote.pushDefault
 if (GIT_REMOTE_RESULT OR GIT_REMOTE_NAME STREQUAL "")
+  message("check default push")
   execute_process(
     COMMAND git config --get remote.pushDefault
     OUTPUT_VARIABLE GIT_REMOTE_NAME
@@ -141,17 +143,9 @@ if (GIT_REMOTE_RESULT OR GIT_REMOTE_NAME STREQUAL "")
     set(GIT_BRANCH "pr-$ENV{GITHUB_HEAD_REF}")
   elseif (DEFINED ENV{GITHUB_REF})  # Normal branch name
     string(REGEX REPLACE "^refs/[^/]*/" "" GIT_BRANCH "$ENV{GITHUB_REF}")
-  elseif (DEFINED ENV{GITHUB_EVENT_PATH})
-    # Extract PR number from GitHub event JSON
-    file(READ "$ENV{GITHUB_EVENT_PATH}" GITHUB_EVENT_JSON)
-    string(JSON PR_NUMBER GET ${GITHUB_EVENT_JSON} "number")
-    if (PR_NUMBER)
-      set(GIT_BRANCH "pr-${PR_NUMBER}")
-    else()
-      set(GIT_BRANCH "detached-head1")
-    endif()
   else()
-    set(GIT_BRANCH "detached-head2")
+    message("couldn't find branch")
+    set(GIT_BRANCH "detached-head")
   endif()
 else()
   # Extract remote name if the output contains a remote/branch format
@@ -164,7 +158,7 @@ else()
   endif()
 endif()
 
-# Get remote link
+# Get remote linkmessage("getting remote link")
 execute_process(
   COMMAND git config --get remote.${GIT_REMOTE_NAME}.url
   OUTPUT_VARIABLE GIT_REMOTE_URL


### PR DESCRIPTION
This will probably have quite a few commits of me trying random shit until something finally works, as I don't know how to debug Github runners locally, but when it works, it should make artifacts downloaded from PR actions be more easily identifiable
Also, due to how this works I can't even just test it without opening a PR for it as actions on one's own fork work fine :(