### PR TITLE
Change logtype from async to sync

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -41,7 +41,7 @@ static u32 screenWidth = 1280;
 static u32 screenHeight = 720;
 static s32 gpuId = -1; // Vulkan physical device index. Set to negative for auto select
 static std::string logFilter;
-static std::string logType = "async";
+static std::string logType = "sync";
 static std::string userName = "shadPS4";
 static std::string updateChannel;
 static std::string chooseHomeTab;
@@ -1117,7 +1117,7 @@ void setDefaultValues() {
     screenWidth = 1280;
     screenHeight = 720;
     logFilter = "";
-    logType = "async";
+    logType = "sync";
     userName = "shadPS4";
     if (Common::isRelease) {
         updateChannel = "Release";


### PR DESCRIPTION
This has been asked multiple times in the Discord server but no clear answer as to why the logtype should be kept to async was given, so I thought I'd make a PR in order to make sure it's finally discussed 😄.
Tested on a brand new PC and the log was set to sync so I guess I didn't miss anything (let me know if I did).
I don't think the performance cost of sync is that much of a problem, and it's easier for troubleshooting, I think it's best to keep it this way until the emulator is stable enough where troubleshooting won't be as common, but do let me know if you think this is not a good idea.