### PR TITLE
Fix the "Open Update Folder" for folders ending with "-patch"

### DIFF
--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -140,12 +140,12 @@ public:
             QString open_update_path;
             Common::FS::PathToQString(open_update_path, m_games[itemID].path);
             open_update_path += "-UPDATE";
-            if (std::filesystem::exists(Common::FS::PathFromQString(open_update_path))) {
+            if (!std::filesystem::exists(Common::FS::PathFromQString(open_update_path))) {
                 QDesktopServices::openUrl(QUrl::fromLocalFile(open_update_path));
             } else {
                 Common::FS::PathToQString(open_update_path, m_games[itemID].path);
                 open_update_path += "-patch";
-                if (std::filesystem::exists(Common::FS::PathFromQString(open_update_path))) {
+                if (!std::filesystem::exists(Common::FS::PathFromQString(open_update_path))) {
                     QDesktopServices::openUrl(QUrl::fromLocalFile(open_update_path));
                 } else {
                     QMessageBox::critical(nullptr, tr("Error"),

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -140,15 +140,17 @@ public:
             QString open_update_path;
             Common::FS::PathToQString(open_update_path, m_games[itemID].path);
             open_update_path += "-UPDATE";
-            if (!std::filesystem::exists(Common::FS::PathFromQString(open_update_path))) {
+            if (std::filesystem::exists(Common::FS::PathFromQString(open_update_path))) {
+                QDesktopServices::openUrl(QUrl::fromLocalFile(open_update_path));
+            } else {
                 Common::FS::PathToQString(open_update_path, m_games[itemID].path);
                 open_update_path += "-patch";
-                if (!std::filesystem::exists(Common::FS::PathFromQString(open_update_path))) {
+                if (std::filesystem::exists(Common::FS::PathFromQString(open_update_path))) {
+                    QDesktopServices::openUrl(QUrl::fromLocalFile(open_update_path));
+                } else {
                     QMessageBox::critical(nullptr, tr("Error"),
                                           QString(tr("This game has no update folder to open!")));
                 }
-            } else {
-                QDesktopServices::openUrl(QUrl::fromLocalFile(open_update_path));
             }
         }
 


### PR DESCRIPTION
Currently the "Open Update Folder" button in the GUI only works when the folder is named "CUSA00000-UPDATE" but not when the folder is named "CUSA00000-patch":

https://github.com/user-attachments/assets/09809259-b556-4e51-8592-17f7894fc21f

This PR fixes this issue:

https://github.com/user-attachments/assets/677b021b-d4c3-4ed6-9cbd-1c74723496ac

I spent an hour trying to figure this out by trial and error at 4 AM (and I still don't understand every single word in those code lines) so if there's a better way to do it please correct me, all I know is that this worked in the end so I'm already happy.

