### PR TITLE
Replacing const with constexpr

### DIFF
--- a/src/common/decoder.cpp
+++ b/src/common/decoder.cpp
@@ -15,7 +15,7 @@ DecoderImpl::~DecoderImpl() = default;
 
 std::string DecoderImpl::disassembleInst(ZydisDecodedInstruction& inst,
                                          ZydisDecodedOperand* operands, u64 address) {
-    const int bufLen = 256;
+    constexpr int bufLen = 256;
     char szBuffer[bufLen];
     ZydisFormatterFormatInstruction(&m_formatter, &inst, operands, inst.operand_count_visible,
                                     szBuffer, sizeof(szBuffer), address, ZYAN_NULL);

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -74,7 +74,7 @@ public:
         bytes_written += file.WriteString(FormatLogMessage(entry).append(1, '\n'));
 
         // Prevent logs from exceeding a set maximum size in the event that log entries are spammed.
-        const auto write_limit = 100_MB;
+        constexpr auto write_limit = 100_MB;
         const bool write_limit_exceeded = bytes_written > write_limit;
         if (entry.log_level >= Level::Error || write_limit_exceeded) {
             if (write_limit_exceeded) {

--- a/src/common/number_utils.cpp
+++ b/src/common/number_utils.cpp
@@ -31,7 +31,7 @@ float Uf11ToF32(u16 val) {
 
     if (exponent == 0) {
         if (mantissa != 0) {
-            const float scale = 1.0 / (1 << 20);
+            constexpr float scale = 1.0 / (1 << 20);
             f32.f = scale * mantissa;
         }
     } else if (exponent == 31) {
@@ -64,7 +64,7 @@ float Uf10ToF32(u16 val) {
 
     if (exponent == 0) {
         if (mantissa != 0) {
-            const float scale = 1.0 / (1 << 19);
+            constexpr float scale = 1.0 / (1 << 19);
             f32.f = scale * mantissa;
         }
     } else if (exponent == 31) {

--- a/src/common/thread.cpp
+++ b/src/common/thread.cpp
@@ -119,7 +119,7 @@ static void AccurateSleep(std::chrono::nanoseconds duration) {
 void SetCurrentThreadPriority(ThreadPriority new_priority) {
     pthread_t this_thread = pthread_self();
 
-    const auto scheduling_type = SCHED_OTHER;
+    constexpr auto scheduling_type = SCHED_OTHER;
     s32 max_prio = sched_get_priority_max(scheduling_type);
     s32 min_prio = sched_get_priority_min(scheduling_type);
     u32 level = std::max(static_cast<u32>(new_priority) + 1, 4U);

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -28,12 +28,12 @@ using PAddr = uintptr_t;
 #define PS4_SYSV_ABI __attribute__((sysv_abi))
 
 // UDLs for memory size values
-constexpr unsigned long long operator""_KB(unsigned long long x) {
+constexpr unsigned long long operator""_KB(const unsigned long long x) {
     return 1024ULL * x;
 }
-constexpr unsigned long long operator""_MB(unsigned long long x) {
+constexpr unsigned long long operator""_MB(const unsigned long long x) {
     return 1024_KB * x;
 }
-constexpr unsigned long long operator""_GB(unsigned long long x) {
+constexpr unsigned long long operator""_GB(const unsigned long long x) {
     return 1024_MB * x;
 }

--- a/src/core/cpu_patches.cpp
+++ b/src/core/cpu_patches.cpp
@@ -687,8 +687,8 @@ static void GenerateEXTRQ(const ZydisDecodedOperand* operands, Xbyak::CodeGenera
 
         LOG_DEBUG(Core, "Patching immediate form EXTRQ, length: {}, index: {}", length, index);
 
-        const Xbyak::Reg64 scratch1 = rax;
-        const Xbyak::Reg64 scratch2 = rcx;
+        constexpr Xbyak::Reg64 scratch1 = rax;
+        constexpr Xbyak::Reg64 scratch2 = rcx;
 
         // Set rsp to before red zone and save scratch registers
         c.lea(rsp, ptr[rsp - 128]);
@@ -741,9 +741,9 @@ static void GenerateEXTRQ(const ZydisDecodedOperand* operands, Xbyak::CodeGenera
 
         Xbyak::Xmm xmm_src = *reinterpret_cast<const Xbyak::Xmm*>(&src);
 
-        const Xbyak::Reg64 scratch1 = rax;
-        const Xbyak::Reg64 scratch2 = rcx;
-        const Xbyak::Reg64 mask = rdx;
+        constexpr Xbyak::Reg64 scratch1 = rax;
+        constexpr Xbyak::Reg64 scratch2 = rcx;
+        constexpr Xbyak::Reg64 mask = rdx;
 
         Xbyak::Label length_zero, end;
 
@@ -808,9 +808,9 @@ static void GenerateINSERTQ(const ZydisDecodedOperand* operands, Xbyak::CodeGene
         u8 length = operands[2].imm.value.u & 0x3F;
         u8 index = operands[3].imm.value.u & 0x3F;
 
-        const Xbyak::Reg64 scratch1 = rax;
-        const Xbyak::Reg64 scratch2 = rcx;
-        const Xbyak::Reg64 mask = rdx;
+        constexpr Xbyak::Reg64 scratch1 = rax;
+        constexpr Xbyak::Reg64 scratch2 = rcx;
+        constexpr Xbyak::Reg64 mask = rdx;
 
         // Set rsp to before red zone and save scratch registers
         c.lea(rsp, ptr[rsp - 128]);
@@ -860,10 +860,10 @@ static void GenerateINSERTQ(const ZydisDecodedOperand* operands, Xbyak::CodeGene
                        operands[3].type == ZYDIS_OPERAND_TYPE_UNUSED,
                    "operands 2 and 3 must be unused for register form.");
 
-        const Xbyak::Reg64 scratch1 = rax;
-        const Xbyak::Reg64 scratch2 = rcx;
-        const Xbyak::Reg64 index = rdx;
-        const Xbyak::Reg64 mask = rbx;
+        constexpr Xbyak::Reg64 scratch1 = rax;
+        constexpr Xbyak::Reg64 scratch2 = rcx;
+        constexpr Xbyak::Reg64 index = rdx;
+        constexpr Xbyak::Reg64 mask = rbx;
 
         Xbyak::Label length_zero, end;
 

--- a/src/core/devtools/widget/imgui_memory_editor.h
+++ b/src/core/devtools/widget/imgui_memory_editor.h
@@ -709,7 +709,7 @@ struct MemoryEditor {
     }
 
     size_t DataTypeGetSize(ImGuiDataType data_type) const {
-        const size_t sizes[] = {1, 1, 2, 2, 4, 4, 8, 8, sizeof(float), sizeof(double)};
+        constexpr size_t sizes[] = {1, 1, 2, 2, 4, 4, 8, 8, sizeof(float), sizeof(double)};
         IM_ASSERT(data_type >= 0 && data_type < IM_ARRAYSIZE(sizes));
         return sizes[data_type];
     }

--- a/src/core/devtools/widget/text_editor.cpp
+++ b/src/core/devtools/widget/text_editor.cpp
@@ -1813,7 +1813,7 @@ void TextEditor::Redo(int aSteps) {
 }
 
 const TextEditor::Palette& TextEditor::GetDarkPalette() {
-    const static Palette p = {{
+    constexpr static Palette p = {{
         0xff7f7f7f, // Default
         0xffd69c56, // Keyword
         0xff00ff00, // Number
@@ -1840,7 +1840,7 @@ const TextEditor::Palette& TextEditor::GetDarkPalette() {
 }
 
 const TextEditor::Palette& TextEditor::GetLightPalette() {
-    const static Palette p = {{
+    constexpr static Palette p = {{
         0xff7f7f7f, // None
         0xffff0c06, // Keyword
         0xff008000, // Number
@@ -1867,7 +1867,7 @@ const TextEditor::Palette& TextEditor::GetLightPalette() {
 }
 
 const TextEditor::Palette& TextEditor::GetRetroBluePalette() {
-    const static Palette p = {{
+    constexpr static Palette p = {{
         0xff00ffff, // None
         0xffffff00, // Keyword
         0xff00ff00, // Number

--- a/src/core/libraries/audio3d/audio3d.h
+++ b/src/core/libraries/audio3d/audio3d.h
@@ -68,20 +68,20 @@ enum class OrbisAudio3dAmbisonics : u32 {
     Q = 15
 };
 
-static const OrbisAudio3dAttributeId s_sceAudio3dAttributePcm = 0x00000001;
-static const OrbisAudio3dAttributeId s_sceAudio3dAttributePriority = 0x00000002;
-static const OrbisAudio3dAttributeId s_sceAudio3dAttributePosition = 0x00000003;
-static const OrbisAudio3dAttributeId s_sceAudio3dAttributeSpread = 0x00000004;
-static const OrbisAudio3dAttributeId s_sceAudio3dAttributeGain = 0x00000005;
-static const OrbisAudio3dAttributeId s_sceAudio3dAttributePassthrough = 0x00000006;
-static const OrbisAudio3dAttributeId s_sceAudio3dAttributeResetState = 0x00000007;
-static const OrbisAudio3dAttributeId s_sceAudio3dAttributeApplicationSpecific = 0x00000008;
-static const OrbisAudio3dAttributeId s_sceAudio3dAttributeAmbisonics = 0x00000009;
-static const OrbisAudio3dAttributeId s_sceAudio3dAttributeRestricted = 0x0000000A;
-static const OrbisAudio3dAttributeId s_sceAudio3dAttributeOutputRoute = 0x0000000B;
-static const OrbisAudio3dAttributeId s_sceAudio3dAttributeLateReverbLevel = 0x00010001;
-static const OrbisAudio3dAttributeId s_sceAudio3dAttributeDownmixSpreadRadius = 0x00010002;
-static const OrbisAudio3dAttributeId s_sceAudio3dAttributeDownmixSpreadHeightAware = 0x00010003;
+static constexpr OrbisAudio3dAttributeId s_sceAudio3dAttributePcm = 0x00000001;
+static constexpr OrbisAudio3dAttributeId s_sceAudio3dAttributePriority = 0x00000002;
+static constexpr OrbisAudio3dAttributeId s_sceAudio3dAttributePosition = 0x00000003;
+static constexpr OrbisAudio3dAttributeId s_sceAudio3dAttributeSpread = 0x00000004;
+static constexpr OrbisAudio3dAttributeId s_sceAudio3dAttributeGain = 0x00000005;
+static constexpr OrbisAudio3dAttributeId s_sceAudio3dAttributePassthrough = 0x00000006;
+static constexpr OrbisAudio3dAttributeId s_sceAudio3dAttributeResetState = 0x00000007;
+static constexpr OrbisAudio3dAttributeId s_sceAudio3dAttributeApplicationSpecific = 0x00000008;
+static constexpr OrbisAudio3dAttributeId s_sceAudio3dAttributeAmbisonics = 0x00000009;
+static constexpr OrbisAudio3dAttributeId s_sceAudio3dAttributeRestricted = 0x0000000A;
+static constexpr OrbisAudio3dAttributeId s_sceAudio3dAttributeOutputRoute = 0x0000000B;
+static constexpr OrbisAudio3dAttributeId s_sceAudio3dAttributeLateReverbLevel = 0x00010001;
+static constexpr OrbisAudio3dAttributeId s_sceAudio3dAttributeDownmixSpreadRadius = 0x00010002;
+static constexpr OrbisAudio3dAttributeId s_sceAudio3dAttributeDownmixSpreadHeightAware = 0x00010003;
 
 struct OrbisAudio3dSpeakerArray;
 using OrbisAudio3dSpeakerArrayHandle = OrbisAudio3dSpeakerArray*; // head

--- a/src/core/libraries/libc_internal/printf.h
+++ b/src/core/libraries/libc_internal/printf.h
@@ -280,11 +280,11 @@ static inline size_t _ftoa(out_fct_type out, char* buffer, size_t idx, size_t ma
     double diff = 0.0;
 
     // if input is larger than thres_max, revert to exponential
-    const double thres_max = (double)0x7FFFFFFF;
+    constexpr double thres_max = (double)0x7FFFFFFF;
 
     // powers of 10
-    static const double pow10[] = {1,      10,      100,      1000,      10000,
-                                   100000, 1000000, 10000000, 100000000, 1000000000};
+    static constexpr double pow10[] = {1,      10,      100,      1000,      10000,
+                                       100000, 1000000, 10000000, 100000000, 1000000000};
 
     // test for negative
     bool negative = false;

--- a/src/core/libraries/ngs2/ngs2.h
+++ b/src/core/libraries/ngs2/ngs2.h
@@ -26,9 +26,9 @@ enum class OrbisNgs2HandleType : u32 {
     VoiceControl = 6
 };
 
-static const int ORBIS_NGS2_MAX_VOICE_CHANNELS = 8;
-static const int ORBIS_NGS2_WAVEFORM_INFO_MAX_BLOCKS = 4;
-static const int ORBIS_NGS2_MAX_MATRIX_LEVELS =
+static constexpr int ORBIS_NGS2_MAX_VOICE_CHANNELS = 8;
+static constexpr int ORBIS_NGS2_WAVEFORM_INFO_MAX_BLOCKS = 4;
+static constexpr int ORBIS_NGS2_MAX_MATRIX_LEVELS =
     (ORBIS_NGS2_MAX_VOICE_CHANNELS * ORBIS_NGS2_MAX_VOICE_CHANNELS);
 
 struct OrbisNgs2WaveformFormat {

--- a/src/core/libraries/ngs2/ngs2_custom.h
+++ b/src/core/libraries/ngs2/ngs2_custom.h
@@ -10,9 +10,9 @@ namespace Libraries::Ngs2 {
 
 class Ngs2Custom;
 
-static const int ORBIS_NGS2_CUSTOM_MAX_MODULES = 24;
-static const int ORBIS_NGS2_CUSTOM_MAX_PORTS = 16;
-static const int ORBIS_NGS2_CUSTOM_DELAY_MAX_TAPS = 8;
+static constexpr int ORBIS_NGS2_CUSTOM_MAX_MODULES = 24;
+static constexpr int ORBIS_NGS2_CUSTOM_MAX_PORTS = 16;
+static constexpr int ORBIS_NGS2_CUSTOM_DELAY_MAX_TAPS = 8;
 
 struct OrbisNgs2CustomModuleOption {
     u32 size;

--- a/src/core/libraries/ngs2/ngs2_impl.h
+++ b/src/core/libraries/ngs2/ngs2_impl.h
@@ -7,8 +7,8 @@
 
 namespace Libraries::Ngs2 {
 
-static const int ORBIS_NGS2_SYSTEM_NAME_LENGTH = 16;
-static const int ORBIS_NGS2_RACK_NAME_LENGTH = 16;
+static constexpr int ORBIS_NGS2_SYSTEM_NAME_LENGTH = 16;
+static constexpr int ORBIS_NGS2_RACK_NAME_LENGTH = 16;
 
 typedef uintptr_t OrbisNgs2Handle;
 

--- a/src/core/loader/elf.h
+++ b/src/core/loader/elf.h
@@ -243,7 +243,7 @@ struct elf_ident {
 };
 
 struct elf_header {
-    static const u32 signature = 0x7F454C46u;
+    static constexpr u32 signature = 0x7F454C46u;
 
     elf_ident e_ident;      /* ELF identification */
     e_type_s e_type;        /* Object file type */

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -280,7 +280,7 @@ int MemoryManager::Reserve(void** out_addr, VAddr virtual_addr, size_t size, Mem
 int MemoryManager::PoolCommit(VAddr virtual_addr, size_t size, MemoryProt prot) {
     std::scoped_lock lk{mutex};
 
-    const u64 alignment = 64_KB;
+    constexpr u64 alignment = 64_KB;
 
     // When virtual addr is zero, force it to virtual_base. The guest cannot pass Fixed
     // flag so we will take the branch that searches for free (or reserved) mappings.

--- a/src/imgui/renderer/imgui_impl_sdl3.cpp
+++ b/src/imgui/renderer/imgui_impl_sdl3.cpp
@@ -753,7 +753,7 @@ static void UpdateGamepads() {
     io.BackendFlags |= ImGuiBackendFlags_HasGamepad;
 
     // Update gamepad inputs
-    const int thumb_dead_zone = 8000; // SDL_gamepad.h suggests using this value.
+    constexpr int thumb_dead_zone = 8000; // SDL_gamepad.h suggests using this value.
     UpdateGamepadButton(bd, io, ImGuiKey_GamepadStart, SDL_GAMEPAD_BUTTON_START);
     UpdateGamepadButton(bd, io, ImGuiKey_GamepadBack, SDL_GAMEPAD_BUTTON_BACK);
     /*UpdateGamepadButton(bd, io, ImGuiKey_GamepadFaceLeft,

--- a/src/input/controller.cpp
+++ b/src/input/controller.cpp
@@ -168,8 +168,8 @@ void GameController::Acceleration(int id, const float acceleration[3]) {
 // Stolen from
 // https://github.com/xioTechnologies/Open-Source-AHRS-With-x-IMU/blob/master/x-IMU%20IMU%20and%20AHRS%20Algorithms/x-IMU%20IMU%20and%20AHRS%20Algorithms/AHRS/MahonyAHRS.cs
 float eInt[3] = {0.0f, 0.0f, 0.0f}; // Integral error terms
-const float Kp = 50.0f;             // Proportional gain
-const float Ki = 1.0f;              // Integral gain
+constexpr float Kp = 50.0f;         // Proportional gain
+constexpr float Ki = 1.0f;          // Integral gain
 Libraries::Pad::OrbisFQuaternion o = {1, 0, 0, 0};
 void GameController::CalculateOrientation(Libraries::Pad::OrbisFVector3& acceleration,
                                           Libraries::Pad::OrbisFVector3& angularVelocity,

--- a/src/input/input_handler.h
+++ b/src/input/input_handler.h
@@ -43,7 +43,7 @@ struct AxisMapping {
 };
 
 enum class InputType { Axis, KeyboardMouse, Controller, Count };
-const std::array<std::string, 4> input_type_names = {"Axis", "KBM", "Controller", "Unknown"};
+constexpr std::array<std::string, 4> input_type_names = {"Axis", "KBM", "Controller", "Unknown"};
 
 class InputID {
 public:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -169,7 +169,7 @@ int main(int argc, char* argv[]) {
     if (!std::filesystem::exists(eboot_path)) {
         // If not a file, treat it as a game ID and search in install directories recursively
         bool game_found = false;
-        const int max_depth = 5;
+        constexpr int max_depth = 5;
         for (const auto& install_dir : Config::getGameInstallDirs()) {
             if (auto found_path = Common::FS::FindGameByID(install_dir, game_path, max_depth)) {
                 eboot_path = *found_path;

--- a/src/qt_gui/game_info.cpp
+++ b/src/qt_gui/game_info.cpp
@@ -8,7 +8,7 @@
 #include "game_info.h"
 
 // Maximum depth to search for games in subdirectories
-const int max_recursion_depth = 5;
+constexpr int max_recursion_depth = 5;
 
 void ScanDirectoryRecursively(const QString& dir, QStringList& filePaths, int current_depth = 0) {
     // Stop recursion if we've reached the maximum depth

--- a/src/qt_gui/main.cpp
+++ b/src/qt_gui/main.cpp
@@ -185,7 +185,7 @@ int main(int argc, char* argv[]) {
         if (!std::filesystem::exists(game_file_path)) {
             // If not a file, treat it as a game ID and search in install directories recursively
             bool game_found = false;
-            const int max_depth = 5;
+            constexpr int max_depth = 5;
             for (const auto& install_dir : Config::getGameInstallDirs()) {
                 if (auto found_path = Common::FS::FindGameByID(install_dir, game_path, max_depth)) {
                     game_file_path = *found_path;

--- a/src/shader_recompiler/backend/spirv/emit_spirv_barriers.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_barriers.cpp
@@ -7,7 +7,7 @@
 namespace Shader::Backend::SPIRV {
 namespace {
 void MemoryBarrier(EmitContext& ctx, spv::Scope scope) {
-    const auto semantics{
+    constexpr auto semantics{
         spv::MemorySemanticsMask::AcquireRelease | spv::MemorySemanticsMask::UniformMemory |
         spv::MemorySemanticsMask::WorkgroupMemory | spv::MemorySemanticsMask::AtomicCounterMemory |
         spv::MemorySemanticsMask::ImageMemory};

--- a/src/video_core/amdgpu/pixel_format.cpp
+++ b/src/video_core/amdgpu/pixel_format.cpp
@@ -125,7 +125,7 @@ int NumComponents(DataFormat format) {
 }
 
 int NumBits(DataFormat format) {
-    const std::array num_bits_per_element = {
+    constexpr std::array num_bits_per_element = {
         0,  8,  16, 16, 32, 32, 32, 32, 32, 32, 32, 64, 64, 96, 128, -1, 16, 16, 16, 16, 32,
         32, 64, -1, -1, -1, -1, -1, -1, -1, -1, -1, 16, 16, 32, 4,   8,  8,  4,  8,  8,  8,
         -1, -1, 8,  8,  8,  8,  8,  8,  16, 16, 32, 32, 32, 64, 64,  8,  16, 1,  1};

--- a/src/video_core/renderer_vulkan/host_passes/fsr_pass.cpp
+++ b/src/video_core/renderer_vulkan/host_passes/fsr_pass.cpp
@@ -70,7 +70,7 @@ void FsrPass::Create(vk::Device device, VmaAllocator allocator, u32 num_images) 
             .pBindings = layoutBindings.data(),
         }));
 
-    const vk::PushConstantRange push_constants{
+    constexpr vk::PushConstantRange push_constants{
         .stageFlags = vk::ShaderStageFlagBits::eCompute,
         .offset = 0,
         .size = sizeof(FSRConstants),
@@ -164,7 +164,7 @@ vk::ImageView FsrPass::Render(vk::CommandBuffer cmdbuf, vk::ImageView input,
         CreateImages(img);
     }
 
-    static const int thread_group_work_region_dim = 16;
+    static constexpr int thread_group_work_region_dim = 16;
     int dispatch_x = (width + (thread_group_work_region_dim - 1)) / thread_group_work_region_dim;
     int dispatch_y = (height + (thread_group_work_region_dim - 1)) / thread_group_work_region_dim;
 

--- a/src/video_core/renderer_vulkan/host_passes/pp_pass.cpp
+++ b/src/video_core/renderer_vulkan/host_passes/pp_pass.cpp
@@ -15,7 +15,7 @@
 namespace Vulkan::HostPasses {
 
 void PostProcessingPass::Create(vk::Device device) {
-    static const std::array pp_shaders{
+    static constexpr std::array pp_shaders{
         HostShaders::FS_TRI_VERT,
         HostShaders::POST_PROCESS_FRAG,
     };
@@ -38,7 +38,7 @@ void PostProcessingPass::Create(vk::Device device) {
     desc_set_layout = Check<"create pp descriptor set layout">(
         device.createDescriptorSetLayoutUnique(desc_layout_ci));
 
-    const vk::PushConstantRange push_constants{
+    constexpr vk::PushConstantRange push_constants{
         .stageFlags = vk::ShaderStageFlagBits::eFragment,
         .offset = 0,
         .size = sizeof(Settings),
@@ -75,7 +75,7 @@ void PostProcessingPass::Create(vk::Device device) {
     pipeline_layout =
         Check<"create pp pipeline layout">(device.createPipelineLayoutUnique(layout_info));
 
-    const std::array pp_color_formats{
+    constexpr std::array pp_color_formats{
         vk::Format::eB8G8R8A8Unorm, // swapchain.GetSurfaceFormat().format,
     };
     const vk::PipelineRenderingCreateInfoKHR pipeline_rendering_ci{
@@ -83,7 +83,7 @@ void PostProcessingPass::Create(vk::Device device) {
         .pColorAttachmentFormats = pp_color_formats.data(),
     };
 
-    const vk::PipelineVertexInputStateCreateInfo vertex_input_info{
+    constexpr vk::PipelineVertexInputStateCreateInfo vertex_input_info{
         .vertexBindingDescriptionCount = 0u,
         .vertexAttributeDescriptionCount = 0u,
     };
@@ -92,7 +92,7 @@ void PostProcessingPass::Create(vk::Device device) {
         .topology = vk::PrimitiveTopology::eTriangleList,
     };
 
-    const vk::Viewport viewport{
+    constexpr vk::Viewport viewport{
         .x = 0.0f,
         .y = 0.0f,
         .width = 1.0f,
@@ -101,7 +101,7 @@ void PostProcessingPass::Create(vk::Device device) {
         .maxDepth = 1.0f,
     };
 
-    const vk::Rect2D scissor = {
+    constexpr vk::Rect2D scissor = {
         .offset = {0, 0},
         .extent = {1, 1},
     };
@@ -113,7 +113,7 @@ void PostProcessingPass::Create(vk::Device device) {
         .pScissors = &scissor,
     };
 
-    const vk::PipelineRasterizationStateCreateInfo raster_state{
+    constexpr vk::PipelineRasterizationStateCreateInfo raster_state{
         .depthClampEnable = false,
         .rasterizerDiscardEnable = false,
         .polygonMode = vk::PolygonMode::eFill,
@@ -123,11 +123,11 @@ void PostProcessingPass::Create(vk::Device device) {
         .lineWidth = 1.0f,
     };
 
-    const vk::PipelineMultisampleStateCreateInfo multisampling{
+    constexpr vk::PipelineMultisampleStateCreateInfo multisampling{
         .rasterizationSamples = vk::SampleCountFlagBits::e1,
     };
 
-    const std::array attachments{
+    constexpr std::array attachments{
         vk::PipelineColorBlendAttachmentState{
             .blendEnable = false,
             .colorWriteMask = vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG |
@@ -143,7 +143,7 @@ void PostProcessingPass::Create(vk::Device device) {
         .blendConstants = std::array{1.0f, 1.0f, 1.0f, 1.0f},
     };
 
-    const std::array dynamic_states{
+    constexpr std::array dynamic_states{
         vk::DynamicState::eViewport,
         vk::DynamicState::eScissor,
     };
@@ -175,7 +175,7 @@ void PostProcessingPass::Create(vk::Device device) {
     device.destroyShaderModule(fs_module);
 
     // Create sampler resource
-    const vk::SamplerCreateInfo sampler_ci{
+    constexpr vk::SamplerCreateInfo sampler_ci{
         .magFilter = vk::Filter::eLinear,
         .minFilter = vk::Filter::eLinear,
         .mipmapMode = vk::SamplerMipmapMode::eNearest,

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -664,8 +664,8 @@ std::span<const SurfaceFormatInfo> SurfaceFormats() {
 }
 
 // Table 8.13 Data and Image Formats [Sea Islands Series Instruction Set Architecture]
-static const size_t amd_gpu_data_format_bit_size = 6;   // All values are under 64
-static const size_t amd_gpu_number_format_bit_size = 4; // All values are under 16
+static constexpr size_t amd_gpu_data_format_bit_size = 6;   // All values are under 64
+static constexpr size_t amd_gpu_number_format_bit_size = 4; // All values are under 16
 
 static size_t GetSurfaceFormatTableIndex(AmdGpu::DataFormat data_format,
                                          AmdGpu::NumberFormat num_format) {

--- a/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
@@ -55,7 +55,7 @@ ComputePipeline::ComputePipeline(const Instance& instance, Scheduler& scheduler,
         });
     }
 
-    const vk::PushConstantRange push_constants = {
+    constexpr vk::PushConstantRange push_constants = {
         .stageFlags = vk::ShaderStageFlagBits::eCompute,
         .offset = 0,
         .size = sizeof(Shader::PushData),

--- a/src/video_core/renderer_vulkan/vk_platform.cpp
+++ b/src/video_core/renderer_vulkan/vk_platform.cpp
@@ -394,7 +394,7 @@ vk::UniqueInstance CreateInstance(Frontend::WindowSystemType window_type, bool e
 }
 
 vk::UniqueDebugUtilsMessengerEXT CreateDebugCallback(vk::Instance instance) {
-    const vk::DebugUtilsMessengerCreateInfoEXT msg_ci = {
+    constexpr vk::DebugUtilsMessengerCreateInfoEXT msg_ci = {
         .messageSeverity = vk::DebugUtilsMessageSeverityFlagBitsEXT::eInfo |
                            vk::DebugUtilsMessageSeverityFlagBitsEXT::eError |
                            vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning |

--- a/src/video_core/renderer_vulkan/vk_presenter.cpp
+++ b/src/video_core/renderer_vulkan/vk_presenter.cpp
@@ -172,7 +172,7 @@ void Presenter::RecreateFrame(Frame* frame, u32 width, u32 height) {
                  vk::ImageUsageFlagBits::eTransferSrc | vk::ImageUsageFlagBits::eSampled,
     };
 
-    const VmaAllocationCreateInfo alloc_info = {
+    constexpr VmaAllocationCreateInfo alloc_info = {
         .flags = VMA_ALLOCATION_CREATE_WITHIN_BUDGET_BIT,
         .usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE,
         .requiredFlags = 0,
@@ -239,7 +239,7 @@ Frame* Presenter::PrepareLastFrame() {
     scheduler.EndRendering();
     const auto cmdbuf = scheduler.CommandBuffer();
 
-    const auto frame_subresources = vk::ImageSubresourceRange{
+    constexpr auto frame_subresources = vk::ImageSubresourceRange{
         .aspectMask = vk::ImageAspectFlagBits::eColor,
         .baseMipLevel = 0,
         .levelCount = 1,
@@ -289,7 +289,7 @@ Frame* Presenter::PrepareFrameInternal(VideoCore::ImageId image_id, bool is_eop)
         });
     }
 
-    const auto frame_subresources = vk::ImageSubresourceRange{
+    constexpr auto frame_subresources = vk::ImageSubresourceRange{
         .aspectMask = vk::ImageAspectFlagBits::eColor,
         .baseMipLevel = 0,
         .levelCount = 1,

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -51,7 +51,7 @@ void Rasterizer::CpSync() {
     scheduler.EndRendering();
     auto cmdbuf = scheduler.CommandBuffer();
 
-    const vk::MemoryBarrier ib_barrier{
+    constexpr vk::MemoryBarrier ib_barrier{
         .srcAccessMask = vk::AccessFlagBits::eShaderWrite,
         .dstAccessMask = vk::AccessFlagBits::eIndirectCommandRead,
     };
@@ -1024,10 +1024,10 @@ void Rasterizer::UpdateDynamicState(const GraphicsPipeline& pipeline) {
 void Rasterizer::UpdateViewportScissorState(const GraphicsPipeline& pipeline) {
     const auto& regs = liverpool->regs;
 
-    const auto combined_scissor_value_tl = [](s16 scr, s16 win, s16 gen, s16 win_offset) {
+    constexpr auto combined_scissor_value_tl = [](s16 scr, s16 win, s16 gen, s16 win_offset) {
         return std::max({scr, s16(win + win_offset), s16(gen + win_offset)});
     };
-    const auto combined_scissor_value_br = [](s16 scr, s16 win, s16 gen, s16 win_offset) {
+    constexpr auto combined_scissor_value_br = [](s16 scr, s16 win, s16 gen, s16 win_offset) {
         return std::min({scr, s16(win + win_offset), s16(gen + win_offset)});
     };
     const bool enable_offset = !regs.window_scissor.window_offset_disable.Value();

--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -88,7 +88,7 @@ void Scheduler::Wait(u64 tick) {
 }
 
 void Scheduler::AllocateWorkerCommandBuffers() {
-    const vk::CommandBufferBeginInfo begin_info = {
+    constexpr vk::CommandBufferBeginInfo begin_info = {
         .flags = vk::CommandBufferUsageFlagBits::eOneTimeSubmit,
     };
 

--- a/src/video_core/renderer_vulkan/vk_shader_util.cpp
+++ b/src/video_core/renderer_vulkan/vk_shader_util.cpp
@@ -170,7 +170,7 @@ vk::ShaderModule Compile(std::string_view code, vk::ShaderStageFlagBits stage, v
         static_cast<EShMessages>(EShMsgDefault | EShMsgSpvRules | EShMsgVulkanRules);
     EShLanguage lang = ToEshShaderStage(stage);
 
-    const int default_version = 450;
+    constexpr int default_version = 450;
     const char* pass_source_code = code.data();
     int pass_source_code_length = static_cast<int>(code.size());
 

--- a/src/video_core/texture_cache/host_compatibility.h
+++ b/src/video_core/texture_cache/host_compatibility.h
@@ -112,7 +112,7 @@ enum class FORMAT_COMPATIBILITY_CLASS {
  * @note This is copied directly from Vulkan Validation Layers and doesn't follow the Skyline naming
  * conventions
  */
-static const std::unordered_map<VkFormat, FORMAT_COMPATIBILITY_CLASS> vkFormatClassTable{
+static const std::unordered_map<VkFormat, const FORMAT_COMPATIBILITY_CLASS> vkFormatClassTable{
     {VK_FORMAT_A1R5G5B5_UNORM_PACK16, FORMAT_COMPATIBILITY_CLASS::_16BIT},
     {VK_FORMAT_A2B10G10R10_SINT_PACK32, FORMAT_COMPATIBILITY_CLASS::_32BIT},
     {VK_FORMAT_A2B10G10R10_SNORM_PACK32, FORMAT_COMPATIBILITY_CLASS::_32BIT},

--- a/src/video_core/texture_cache/image.cpp
+++ b/src/video_core/texture_cache/image.cpp
@@ -128,7 +128,7 @@ void UniqueImage::Create(const vk::ImageCreateInfo& image_ci) {
     if (image) {
         vmaDestroyImage(allocator, image, allocation);
     }
-    const VmaAllocationCreateInfo alloc_info = {
+    constexpr VmaAllocationCreateInfo alloc_info = {
         .flags = VMA_ALLOCATION_CREATE_WITHIN_BUDGET_BIT,
         .usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE,
         .requiredFlags = 0,

--- a/src/video_core/texture_cache/tile_manager.cpp
+++ b/src/video_core/texture_cache/tile_manager.cpp
@@ -76,7 +76,7 @@ struct DetilerParams {
 
 TileManager::TileManager(const Vulkan::Instance& instance, Vulkan::Scheduler& scheduler)
     : instance{instance}, scheduler{scheduler} {
-    static const std::array detiler_shaders{
+    static constexpr std::array detiler_shaders{
         HostShaders::MICRO_8BPP_COMP,          HostShaders::MICRO_16BPP_COMP,
         HostShaders::MICRO_32BPP_COMP,         HostShaders::MICRO_64BPP_COMP,
         HostShaders::MICRO_128BPP_COMP,        HostShaders::MACRO_8BPP_COMP,
@@ -110,7 +110,7 @@ TileManager::TileManager(const Vulkan::Instance& instance, Vulkan::Scheduler& sc
                vk::to_string(desc_layout_result.result));
     desc_layout = std::move(desc_layout_result.value);
 
-    const vk::PushConstantRange push_constants = {
+    constexpr vk::PushConstantRange push_constants = {
         .stageFlags = vk::ShaderStageFlagBits::eCompute,
         .offset = 0,
         .size = sizeof(DetilerParams),


### PR DESCRIPTION
Use constexpr because it's more optimized since the value is set at compile time and not at startup.