### PR TITLE
Fix "Open Update Folder" 

### DIFF
--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -140,12 +140,12 @@ public:
             QString open_update_path;
             Common::FS::PathToQString(open_update_path, m_games[itemID].path);
             open_update_path += "-UPDATE";
-            if (!std::filesystem::exists(Common::FS::PathFromQString(open_update_path))) {
+            if (std::filesystem::exists(Common::FS::PathFromQString(open_update_path))) {
                 QDesktopServices::openUrl(QUrl::fromLocalFile(open_update_path));
             } else {
                 Common::FS::PathToQString(open_update_path, m_games[itemID].path);
                 open_update_path += "-patch";
-                if (!std::filesystem::exists(Common::FS::PathFromQString(open_update_path))) {
+                if (std::filesystem::exists(Common::FS::PathFromQString(open_update_path))) {
                     QDesktopServices::openUrl(QUrl::fromLocalFile(open_update_path));
                 } else {
                     QMessageBox::critical(nullptr, tr("Error"),


### PR DESCRIPTION
Seems like I added an extra commit earlier on PR #2712 thinking I had deleted something for no reason, but that commit broke the "Open Update Folder" completely, so this is just a quick fix that should make it behave as expected in both cases like the PR description stated.