### PR TITLE
vulkan: Lower list primitive restart warning to debug log.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -77,8 +77,8 @@ GraphicsPipeline::GraphicsPipeline(
 
     auto prim_restart = key.enable_primitive_restart != 0;
     if (prim_restart && IsPrimitiveListTopology() && !instance.IsListRestartSupported()) {
-        LOG_WARNING(Render_Vulkan,
-                    "Primitive restart is enabled for list topology but not supported by driver.");
+        LOG_DEBUG(Render_Vulkan,
+                  "Primitive restart is enabled for list topology but not supported by driver.");
         prim_restart = false;
     }
     const vk::PipelineInputAssemblyStateCreateInfo input_assembly = {


### PR DESCRIPTION
Lowers the log when list primitive restart is not supported from warning to debug. In practice most games don't actually seem to use list restart and probably just left primitive restart turned on, so it's usually just log noise. Leaving it as a debug log though just in case.