### PR TITLE
cmake: fix system libusb discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,7 @@ find_package(xxHash 0.8.2 MODULE)
 find_package(ZLIB 1.3 MODULE)
 find_package(Zydis 5.0.0 CONFIG)
 find_package(pugixml 1.14 CONFIG)
-find_package(usb-1.0 1.0.27 CONFIG)
+find_package(libusb 1.0.27 MODULE)
 
 if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR NOT MSVC)
     find_package(cryptopp 8.9.0 MODULE)
@@ -1062,7 +1062,7 @@ endif()
 create_target_directory_groups(shadps4)
 
 target_link_libraries(shadps4 PRIVATE magic_enum::magic_enum fmt::fmt toml11::toml11 tsl::robin_map xbyak::xbyak Tracy::TracyClient RenderDoc::API FFmpeg::ffmpeg Dear_ImGui gcn half::half ZLIB::ZLIB PNG::PNG)
-target_link_libraries(shadps4 PRIVATE Boost::headers GPUOpen::VulkanMemoryAllocator LibAtrac9 sirit Vulkan::Headers xxHash::xxhash Zydis::Zydis glslang::glslang SDL3::SDL3 pugixml::pugixml stb::headers usb-1.0)
+target_link_libraries(shadps4 PRIVATE Boost::headers GPUOpen::VulkanMemoryAllocator LibAtrac9 sirit Vulkan::Headers xxHash::xxhash Zydis::Zydis glslang::glslang SDL3::SDL3 pugixml::pugixml stb::headers libusb::usb)
 
 target_compile_definitions(shadps4 PRIVATE IMGUI_USER_CONFIG="imgui/imgui_config.h")
 target_compile_definitions(Dear_ImGui PRIVATE IMGUI_USER_CONFIG="${PROJECT_SOURCE_DIR}/src/imgui/imgui_config.h")

--- a/cmake/Findlibusb.cmake
+++ b/cmake/Findlibusb.cmake
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+find_package(PkgConfig QUIET)
+pkg_search_module(LIBUSB QUIET IMPORTED_TARGET libusb-1.0)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(libusb
+    REQUIRED_VARS LIBUSB_LINK_LIBRARIES
+    VERSION_VAR LIBUSB_VERSION
+)
+
+if (libusb_FOUND AND NOT TARGET libusb::usb)
+    add_library(libusb::usb ALIAS PkgConfig::LIBUSB)
+endif()

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -202,8 +202,9 @@ if (NOT TARGET pugixml::pugixml)
 endif()
 
 # libusb
-if (NOT TARGET usb-1.0)
+if (NOT TARGET libusb::usb)
     add_subdirectory(libusb)
+    add_library(libusb::usb ALIAS usb-1.0)
 endif()
 
 # Discord RPC


### PR DESCRIPTION
`libusb` is not distributed with a CMake config file but with a pkg-config file.