### PR TITLE
Proper ulobjmgr stubs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,6 +578,8 @@ set(MISC_LIBS  src/core/libraries/screenshot/screenshot.cpp
                src/core/libraries/screenshot/screenshot.h
                src/core/libraries/move/move.cpp
                src/core/libraries/move/move.h
+               src/core/libraries/ulobjmgr/ulobjmgr.cpp
+               src/core/libraries/ulobjmgr/ulobjmgr.h
 )
 
 set(DEV_TOOLS src/core/devtools/layer.cpp

--- a/src/core/libraries/libs.cpp
+++ b/src/core/libraries/libs.cpp
@@ -50,6 +50,7 @@
 #include "core/libraries/system/sysmodule.h"
 #include "core/libraries/system/systemservice.h"
 #include "core/libraries/system/userservice.h"
+#include "core/libraries/ulobjmgr/ulobjmgr.h"
 #include "core/libraries/usbd/usbd.h"
 #include "core/libraries/videodec/videodec.h"
 #include "core/libraries/videodec/videodec2.h"
@@ -116,6 +117,7 @@ void InitHLELibs(Core::Loader::SymbolsResolver* sym) {
     Libraries::Zlib::RegisterlibSceZlib(sym);
     Libraries::Hmd::RegisterlibSceHmd(sym);
     Libraries::DiscMap::RegisterlibSceDiscMap(sym);
+    Libraries::Ulobjmgr::RegisterlibSceUlobjmgr(sym);
 }
 
 } // namespace Libraries

--- a/src/core/libraries/ulobjmgr/ulobjmgr.cpp
+++ b/src/core/libraries/ulobjmgr/ulobjmgr.cpp
@@ -9,7 +9,7 @@
 
 namespace Libraries::Ulobjmgr {
 
-s64 PS4_SYSV_ABI Func_046DBA8411A2365C(u64 unk1, s32 unk2, u32* unk3) {
+s32 PS4_SYSV_ABI Func_046DBA8411A2365C(u64 arg0, s32 arg1, u32* arg2) {
     if (unk1 == 0 || unk2 == 0 || unk3 == nullptr) {
         return POSIX_EINVAL;
     }
@@ -17,18 +17,18 @@ s64 PS4_SYSV_ABI Func_046DBA8411A2365C(u64 unk1, s32 unk2, u32* unk3) {
     return ORBIS_OK;
 }
 
-s64 PS4_SYSV_ABI Func_1D9F50D9CFB8054E() {
+s32 PS4_SYSV_ABI Func_1D9F50D9CFB8054E() {
     return ORBIS_OK;
 }
 
-s64 PS4_SYSV_ABI Func_4A67FE7D435B94F7(u32 unk) {
+s32 PS4_SYSV_ABI Func_4A67FE7D435B94F7(u32 arg0) {
     if (unk >= 0x4000) {
         return POSIX_EINVAL;
     }
     return ORBIS_OK;
 }
 
-s64 PS4_SYSV_ABI Func_4B07893BBB77A649(u64 unk) {
+s32 PS4_SYSV_ABI Func_4B07893BBB77A649(u64 arg0) {
     if (unk == 0) {
         return POSIX_EINVAL;
     }

--- a/src/core/libraries/ulobjmgr/ulobjmgr.cpp
+++ b/src/core/libraries/ulobjmgr/ulobjmgr.cpp
@@ -10,10 +10,10 @@
 namespace Libraries::Ulobjmgr {
 
 s32 PS4_SYSV_ABI Func_046DBA8411A2365C(u64 arg0, s32 arg1, u32* arg2) {
-    if (unk1 == 0 || unk2 == 0 || unk3 == nullptr) {
+    if (arg0 == 0 || arg1 == 0 || arg2 == nullptr) {
         return POSIX_EINVAL;
     }
-    *unk3 = 0;
+    *arg2 = 0;
     return ORBIS_OK;
 }
 
@@ -22,14 +22,14 @@ s32 PS4_SYSV_ABI Func_1D9F50D9CFB8054E() {
 }
 
 s32 PS4_SYSV_ABI Func_4A67FE7D435B94F7(u32 arg0) {
-    if (unk >= 0x4000) {
+    if (arg0 >= 0x4000) {
         return POSIX_EINVAL;
     }
     return ORBIS_OK;
 }
 
 s32 PS4_SYSV_ABI Func_4B07893BBB77A649(u64 arg0) {
-    if (unk == 0) {
+    if (arg0 == 0) {
         return POSIX_EINVAL;
     }
     return ORBIS_OK;

--- a/src/core/libraries/ulobjmgr/ulobjmgr.cpp
+++ b/src/core/libraries/ulobjmgr/ulobjmgr.cpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "common/logging/log.h"
+#include "core/libraries/error_codes.h"
+#include "core/libraries/kernel/posix_error.h"
+#include "core/libraries/libs.h"
+#include "core/libraries/ulobjmgr/ulobjmgr.h"
+
+namespace Libraries::Ulobjmgr {
+
+s64 PS4_SYSV_ABI Func_046DBA8411A2365C(u64 unk1, s32 unk2, u32* unk3) {
+    if (unk1 == 0 || unk2 == 0 || unk3 == nullptr) {
+        return POSIX_EINVAL;
+    }
+    *unk3 = 0;
+    return ORBIS_OK;
+}
+
+s64 PS4_SYSV_ABI Func_1D9F50D9CFB8054E() {
+    return ORBIS_OK;
+}
+
+s64 PS4_SYSV_ABI Func_4A67FE7D435B94F7(u32 unk) {
+    if (unk >= 0x4000) {
+        return POSIX_EINVAL;
+    }
+    return ORBIS_OK;
+}
+
+s64 PS4_SYSV_ABI Func_4B07893BBB77A649(u64 unk) {
+    if (unk == 0) {
+        return POSIX_EINVAL;
+    }
+    return ORBIS_OK;
+}
+
+void RegisterlibSceUlobjmgr(Core::Loader::SymbolsResolver* sym) {
+    LIB_FUNCTION("BG26hBGiNlw", "ulobjmgr", 1, "ulobjmgr", 1, 1, Func_046DBA8411A2365C);
+    LIB_FUNCTION("HZ9Q2c+4BU4", "ulobjmgr", 1, "ulobjmgr", 1, 1, Func_1D9F50D9CFB8054E);
+    LIB_FUNCTION("Smf+fUNblPc", "ulobjmgr", 1, "ulobjmgr", 1, 1, Func_4A67FE7D435B94F7);
+    LIB_FUNCTION("SweJO7t3pkk", "ulobjmgr", 1, "ulobjmgr", 1, 1, Func_4B07893BBB77A649);
+};
+
+} // namespace Libraries::Ulobjmgr

--- a/src/core/libraries/ulobjmgr/ulobjmgr.h
+++ b/src/core/libraries/ulobjmgr/ulobjmgr.h
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "common/types.h"
+
+namespace Core::Loader {
+class SymbolsResolver;
+}
+
+namespace Libraries::Ulobjmgr {
+void RegisterlibSceUlobjmgr(Core::Loader::SymbolsResolver* sym);
+} // namespace Libraries::Ulobjmgr


### PR DESCRIPTION
This PR adds basic ulobjmgr stubs to stop all the Unknown stub logging games would do when using libSceUlt or libSceJobManager (or both). As the library is seemingly unimportant, these errors were just cluttering logs for no reason.

Return types, parameter types, and error returns are solely based on what Ghidra outputted when trying to decompile the library.

I called the library libSceUlobjmgr internally because one of the internal strings stored in the library is "sceUlobjmgrDebugInfoArray", and I figure libSceUlobjmgr looks a lot nicer than ulobjmgr. That's pretty easy to change if desired though.
