### PR TITLE
build: Target same CPU architecture level as PS4.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,8 @@ else()
 endif()
 
 if (ARCHITECTURE STREQUAL "x86_64")
-    # Set x86_64 target level to Sandy Bridge to generally match what is supported for PS4 guest code with CPU patches.
-    add_compile_options(-march=sandybridge)
+    # Target the same x86_64 feature set as the PS4 CPU to match requirements.
+    add_compile_options(-march=btver2 -mno-sse4a)
 endif()
 
 if (APPLE AND ARCHITECTURE STREQUAL "x86_64" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")


### PR DESCRIPTION
Improves the build target CPU architecture by setting to `btver2` (Bobcat Version 2 - the name used by compilers for AMD Jaguar), which matches the actual PS4 CPU. SSE4a is explicitly excluded to not inadvertently use AMD-only instructions.

This enables more instruction set extensions than approximating with `sandybridge` does, increasing support for potential optimizations while still preventing the CPU requirements from exceeding those of games themselves.