### PR TITLE
renderer_vulkan: Use more depth-stencil dynamic state.

### DIFF
--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -1423,6 +1423,10 @@ struct Liverpool {
             return num_samples;
         }
 
+        bool IsClipDisabled() const {
+            return clipper_control.clip_disable || primitive_type == PrimitiveType::RectList;
+        }
+
         void SetDefaults();
     };
 

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -39,18 +39,6 @@ struct GraphicsPipelineKey {
     vk::Format depth_format;
     vk::Format stencil_format;
 
-    struct {
-        bool clip_disable : 1;
-        bool depth_test_enable : 1;
-        bool depth_write_enable : 1;
-        bool depth_bounds_test_enable : 1;
-        bool depth_bias_enable : 1;
-        bool stencil_test_enable : 1;
-        // Must be named to be zero-initialized.
-        u8 _unused : 2;
-    };
-    vk::CompareOp depth_compare_op;
-
     u32 num_samples;
     u32 mrt_mask;
     AmdGpu::PrimitiveType prim_type;
@@ -92,10 +80,6 @@ public:
 
     auto GetMrtMask() const {
         return key.mrt_mask;
-    }
-
-    auto IsClipDisabled() const {
-        return key.clip_disable;
     }
 
     [[nodiscard]] bool IsPrimitiveListTopology() const {

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -247,6 +247,7 @@ bool Instance::CreateDevice() {
     add_extension(VK_EXT_SHADER_DEMOTE_TO_HELPER_INVOCATION_EXTENSION_NAME);
     add_extension(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     add_extension(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
+    add_extension(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
     add_extension(VK_EXT_TOOLING_INFO_EXTENSION_NAME);
     const bool maintenance4 = add_extension(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
 
@@ -379,6 +380,9 @@ bool Instance::CreateDevice() {
         },
         vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT{
             .extendedDynamicState = true,
+        },
+        vk::PhysicalDeviceExtendedDynamicState2FeaturesEXT{
+            .extendedDynamicState2 = true,
         },
         vk::PhysicalDeviceMaintenance4FeaturesKHR{
             .maintenance4 = true,

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -84,6 +84,11 @@ public:
         return features.samplerAnisotropy;
     }
 
+    /// Returns true if depth bounds testing is supported
+    bool IsDepthBoundsSupported() const {
+        return features.depthBounds;
+    }
+
     /// Returns true when VK_EXT_custom_border_color is supported
     bool IsCustomBorderColorSupported() const {
         return custom_border_color;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -76,7 +76,8 @@ private:
     void EliminateFastClear();
 
     void UpdateDynamicState(const GraphicsPipeline& pipeline);
-    void UpdateViewportScissorState(const GraphicsPipeline& pipeline);
+    void UpdateViewportScissorState();
+    void UpdateDepthStencilState();
 
     bool FilterDraw();
 


### PR DESCRIPTION
Introduces use of more dynamic depth-stencil state from `VK_EXT_extended_dynamic_state` and `VK_EXT_extended_dynamic_state2`. We already assume we have these as extensions that were promoted to Vulkan 1.3. May help reduce the number of pipelines needed in some cases.