### PR TITLE
renderer_vulkan: Only update dynamic state when changed.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -75,9 +75,9 @@ private:
     void DepthStencilCopy(bool is_depth, bool is_stencil);
     void EliminateFastClear();
 
-    void UpdateDynamicState(const GraphicsPipeline& pipeline);
-    void UpdateViewportScissorState();
-    void UpdateDepthStencilState();
+    void UpdateDynamicState(const GraphicsPipeline& pipeline) const;
+    void UpdateViewportScissorState() const;
+    void UpdateDepthStencilState() const;
 
     bool FilterDraw();
 

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -7,6 +7,7 @@
 #include <boost/container/static_vector.hpp>
 #include "common/types.h"
 #include "common/unique_function.h"
+#include "video_core/amdgpu/liverpool.h"
 #include "video_core/renderer_vulkan/vk_master_semaphore.h"
 #include "video_core/renderer_vulkan/vk_resource_pool.h"
 
@@ -55,6 +56,219 @@ struct SubmitInfo {
     }
 };
 
+using Viewports = boost::container::static_vector<vk::Viewport, AmdGpu::Liverpool::NumViewports>;
+using Scissors = boost::container::static_vector<vk::Rect2D, AmdGpu::Liverpool::NumViewports>;
+using ColorWriteMasks = std::array<vk::ColorComponentFlags, AmdGpu::Liverpool::NumColorBuffers>;
+struct StencilOps {
+    vk::StencilOp fail_op{};
+    vk::StencilOp pass_op{};
+    vk::StencilOp depth_fail_op{};
+    vk::CompareOp compare_op{};
+
+    bool operator==(const StencilOps& other) const {
+        return fail_op == other.fail_op && pass_op == other.pass_op &&
+               depth_fail_op == other.depth_fail_op && compare_op == other.compare_op;
+    }
+};
+struct DynamicState {
+    struct {
+        bool viewports : 1;
+        bool scissors : 1;
+
+        bool depth_test_enabled : 1;
+        bool depth_write_enabled : 1;
+        bool depth_compare_op : 1;
+
+        bool depth_bounds_test_enabled : 1;
+        bool depth_bounds : 1;
+
+        bool depth_bias_enabled : 1;
+        bool depth_bias : 1;
+
+        bool stencil_test_enabled : 1;
+        bool stencil_front_ops : 1;
+        bool stencil_front_reference : 1;
+        bool stencil_front_write_mask : 1;
+        bool stencil_front_compare_mask : 1;
+        bool stencil_back_ops : 1;
+        bool stencil_back_reference : 1;
+        bool stencil_back_write_mask : 1;
+        bool stencil_back_compare_mask : 1;
+
+        bool blend_constants : 1;
+        bool color_write_masks : 1;
+    } dirty_state{};
+
+    Viewports viewports{};
+    Scissors scissors{};
+
+    bool depth_test_enabled{};
+    bool depth_write_enabled{};
+    vk::CompareOp depth_compare_op{};
+
+    bool depth_bounds_test_enabled{};
+    float depth_bounds_min{};
+    float depth_bounds_max{};
+
+    bool depth_bias_enabled{};
+    float depth_bias_constant{};
+    float depth_bias_clamp{};
+    float depth_bias_slope{};
+
+    bool stencil_test_enabled{};
+    StencilOps stencil_front_ops{};
+    u32 stencil_front_reference{};
+    u32 stencil_front_write_mask{};
+    u32 stencil_front_compare_mask{};
+    StencilOps stencil_back_ops{};
+    u32 stencil_back_reference{};
+    u32 stencil_back_write_mask{};
+    u32 stencil_back_compare_mask{};
+
+    float blend_constants[4]{};
+    ColorWriteMasks color_write_masks{};
+
+    /// Commits the dynamic state to the provided command buffer.
+    void Commit(const Instance& instance, const vk::CommandBuffer& cmdbuf);
+
+    /// Invalidates all dynamic state to be flushed into the next command buffer.
+    void Invalidate() {
+        std::memset(&dirty_state, 0xFF, sizeof(dirty_state));
+    }
+
+    void SetViewports(const Viewports& viewports_) {
+        if (!std::ranges::equal(viewports, viewports_)) {
+            viewports = viewports_;
+            dirty_state.viewports = true;
+        }
+    }
+
+    void SetScissors(const Scissors& scissors_) {
+        if (!std::ranges::equal(scissors, scissors_)) {
+            scissors = scissors_;
+            dirty_state.scissors = true;
+        }
+    }
+
+    void SetDepthTestEnabled(const bool enabled) {
+        if (depth_test_enabled != enabled) {
+            depth_test_enabled = enabled;
+            dirty_state.depth_test_enabled = true;
+        }
+    }
+
+    void SetDepthWriteEnabled(const bool enabled) {
+        if (depth_write_enabled != enabled) {
+            depth_write_enabled = enabled;
+            dirty_state.depth_write_enabled = true;
+        }
+    }
+
+    void SetDepthCompareOp(const vk::CompareOp compare_op) {
+        if (depth_compare_op != compare_op) {
+            depth_compare_op = compare_op;
+            dirty_state.depth_compare_op = true;
+        }
+    }
+
+    void SetDepthBoundsTestEnabled(const bool enabled) {
+        if (depth_bounds_test_enabled != enabled) {
+            depth_bounds_test_enabled = enabled;
+            dirty_state.depth_bounds_test_enabled = true;
+        }
+    }
+
+    void SetDepthBounds(const float min, const float max) {
+        if (depth_bounds_min != min || depth_bounds_max != max) {
+            depth_bounds_min = min;
+            depth_bounds_max = max;
+            dirty_state.depth_bounds = true;
+        }
+    }
+
+    void SetDepthBiasEnabled(const bool enabled) {
+        if (depth_bias_enabled != enabled) {
+            depth_bias_enabled = enabled;
+            dirty_state.depth_bias_enabled = true;
+        }
+    }
+
+    void SetDepthBias(const float constant, const float clamp, const float slope) {
+        if (depth_bias_constant != constant || depth_bias_clamp != clamp ||
+            depth_bias_slope != slope) {
+            depth_bias_constant = constant;
+            depth_bias_clamp = clamp;
+            depth_bias_slope = slope;
+            dirty_state.depth_bias = true;
+        }
+    }
+
+    void SetStencilTestEnabled(const bool enabled) {
+        if (stencil_test_enabled != enabled) {
+            stencil_test_enabled = enabled;
+            dirty_state.stencil_test_enabled = true;
+        }
+    }
+
+    void SetStencilOps(const StencilOps& front_ops, const StencilOps& back_ops) {
+        if (stencil_front_ops != front_ops) {
+            stencil_front_ops = front_ops;
+            dirty_state.stencil_front_ops = true;
+        }
+        if (stencil_back_ops != back_ops) {
+            stencil_back_ops = back_ops;
+            dirty_state.stencil_back_ops = true;
+        }
+    }
+
+    void SetStencilReferences(const u32 front_reference, const u32 back_reference) {
+        if (stencil_front_reference != front_reference) {
+            stencil_front_reference = front_reference;
+            dirty_state.stencil_front_reference = true;
+        }
+        if (stencil_back_reference != back_reference) {
+            stencil_back_reference = back_reference;
+            dirty_state.stencil_back_reference = true;
+        }
+    }
+
+    void SetStencilWriteMasks(const u32 front_write_mask, const u32 back_write_mask) {
+        if (stencil_front_write_mask != front_write_mask) {
+            stencil_front_write_mask = front_write_mask;
+            dirty_state.stencil_front_write_mask = true;
+        }
+        if (stencil_back_write_mask != back_write_mask) {
+            stencil_back_write_mask = back_write_mask;
+            dirty_state.stencil_back_write_mask = true;
+        }
+    }
+
+    void SetStencilCompareMasks(const u32 front_compare_mask, const u32 back_compare_mask) {
+        if (stencil_front_compare_mask != front_compare_mask) {
+            stencil_front_compare_mask = front_compare_mask;
+            dirty_state.stencil_front_compare_mask = true;
+        }
+        if (stencil_back_compare_mask != back_compare_mask) {
+            stencil_back_compare_mask = back_compare_mask;
+            dirty_state.stencil_back_compare_mask = true;
+        }
+    }
+
+    void SetBlendConstants(const float blend_constants_[4]) {
+        if (!std::equal(blend_constants, std::end(blend_constants), blend_constants_)) {
+            std::memcpy(blend_constants, blend_constants_, sizeof(blend_constants));
+            dirty_state.blend_constants = true;
+        }
+    }
+
+    void SetColorWriteMasks(const ColorWriteMasks& color_write_masks_) {
+        if (!std::ranges::equal(color_write_masks, color_write_masks_)) {
+            color_write_masks = color_write_masks_;
+            dirty_state.color_write_masks = true;
+        }
+    }
+};
+
 class Scheduler {
 public:
     explicit Scheduler(const Instance& instance);
@@ -79,6 +293,10 @@ public:
     /// Returns the current render state.
     const RenderState& GetRenderState() const {
         return render_state;
+    }
+
+    DynamicState& GetDynamicState() {
+        return dynamic_state;
     }
 
     /// Returns the current command buffer.
@@ -125,6 +343,7 @@ private:
     };
     std::queue<PendingOp> pending_ops;
     RenderState render_state;
+    DynamicState dynamic_state;
     bool is_rendering = false;
     tracy::VkCtxScope* profiler_scope{};
 };


### PR DESCRIPTION
Implements dynamic state tracking to only emit state update commands when necessary.

Details:
* Keeps track of all dynamic state values along with corresponding dirty flags.
* Dirty flags are only set when a value changes or the command buffer changes, to apply the state to the new command buffer.
* State is only set in the command buffer when needed; for example, if stencil test is disabled, updating any stencil test parameters is skipped. Once it is enabled, any deferred dirty state will be set.

This system will allow us to continue expanding our use of dynamic state where possible without ballooning the number of commands issued for every draw.