### PR TITLE
Revert "build: Target same CPU architecture level as PS4. (#2745)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,9 @@ else()
 endif()
 
 if (ARCHITECTURE STREQUAL "x86_64")
-    # Set x86_64 target level to Sandy Bridge to generally match what is supported for PS4 guest code with CPU patches.
-    add_compile_options(-march=sandybridge)
+    # Target Sandy Bridge as a reasonable subset of instructions supported by PS4 and host CPUs.
+    # Note that the native PS4 architecture 'btver2' has been attempted but causes issues with M1 CPUs.
+    add_compile_options(-march=sandybridge -mtune=generic)
 endif()
 
 if (APPLE AND ARCHITECTURE STREQUAL "x86_64" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,8 @@ else()
 endif()
 
 if (ARCHITECTURE STREQUAL "x86_64")
-    # Target the same x86_64 feature set as the PS4 CPU to match requirements.
-    add_compile_options(-march=btver2 -mno-sse4a)
+    # Set x86_64 target level to Sandy Bridge to generally match what is supported for PS4 guest code with CPU patches.
+    add_compile_options(-march=sandybridge)
 endif()
 
 if (APPLE AND ARCHITECTURE STREQUAL "x86_64" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")


### PR DESCRIPTION
* Reverts change of build architecture back to `sandybridge` from `btver2`, as something that the new architecture included is causing issues with Rosetta 2 on M1 CPUs.
* Add `-mtune=generic` to make sure build is optimized for generic CPU instead of Sandy Bridge specifically. `-march` will limit the instruction sets to use and `-mtune` will determine how to micro-optimize.

Should fix https://github.com/shadps4-emu/shadPS4/issues/2750 (no idea if the game will actually work but it should fix the provided crash, beyond that much I think it should be a compatibility report)