### PR TITLE
Add information about firmware files (sys modules) in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ R3 | M |
 Keyboard and mouse inputs can be customized in the settings menu by clicking the Controller button, and further details and help on controls are  also found there. Custom bindings are saved per-game. Inputs support up to three keys per binding, mouse buttons, mouse movement mapped to joystick input, and more.
 
 
-## Firmware files:
+# Firmware files
 
 shadPS4 can load some PlayStation 4 firmware files, these must be dumped from your legally owned PlayStation 4 console.\
 The following firmware modules are supported and must be placed in shadPS4's `user/sys_modules` folder.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,27 @@ R3 | M |
 Keyboard and mouse inputs can be customized in the settings menu by clicking the Controller button, and further details and help on controls are  also found there. Custom bindings are saved per-game. Inputs support up to three keys per binding, mouse buttons, mouse movement mapped to joystick input, and more.
 
 
+## Firmware files:
+
+shadPS4 can load some PlayStation 4 firmware files, these must be dumped from your legally owned PlayStation 4 console.\
+The following firmware modules are supported and must be placed in shadPS4's `user/sys_modules` folder.
+
+<div align="center">
+
+| Modules                 | Modules                 | Modules                 | Modules                 |  
+|-------------------------|-------------------------|-------------------------|-------------------------|  
+| libSceCesCs.sprx        | libSceDiscMap.sprx      | libSceFont.sprx         | libSceFontFt.sprx       |  
+| libSceFreeTypeOt.sprx   | libSceJson.sprx         | libSceJson2.sprx        | libSceLibcInternal.sprx |  
+| libSceNgs2.sprx         | libSceRtc.sprx          | libSceUlt.sprx          |                         |  
+
+</div>
+
+> [!Caution]
+> The above modules are required to run the games properly and must be extracted from your PlayStation 4.\
+> **We do not provide any information or support on how to do this**.
+
+
+
 # Main team
 
 - [**georgemoralis**](https://github.com/georgemoralis)

--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ The following firmware modules are supported and must be placed in shadPS4's `us
 
 | Modules                 | Modules                 | Modules                 | Modules                 |  
 |-------------------------|-------------------------|-------------------------|-------------------------|  
-| libSceCesCs.sprx        | libSceDiscMap.sprx      | libSceFont.sprx         | libSceFontFt.sprx       |  
-| libSceFreeTypeOt.sprx   | libSceJson.sprx         | libSceJson2.sprx        | libSceLibcInternal.sprx |  
-| libSceNgs2.sprx         | libSceRtc.sprx          | libSceUlt.sprx          |                         |  
+| libSceCesCs.sprx        | libSceFont.sprx         | libSceFontFt.sprx       | libSceFreeTypeOt.sprx   |
+| libSceJson.sprx         | libSceJson2.sprx        | libSceLibcInternal.sprx | libSceNgs2.sprx         |  
+| libSceRtc.sprx          | libSceUlt.sprx          |                         |                         |
 
 </div>
 


### PR DESCRIPTION
Adding a simple mention about system modules in the README, it was already on the compatibility list repository but it would make more sense to also have it on the main repository README so that more people are aware about their existence. Maybe it could be placed somewhere else in the README I just decided to place it below the KMB mappings.