### PR TITLE
Fix #2613: Game icon size not working properly on grid view

### DIFF
--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -517,9 +517,11 @@ void MainWindow::CreateConnects() {
             Config::setIconSize(36);
             Config::setSliderPosition(0);
         } else {
+            m_game_grid_frame->icon_size = 69;
             ui->sizeSlider->setValue(0); // icone_size - 36
             Config::setIconSizeGrid(69);
             Config::setSliderPositionGrid(0);
+            m_game_grid_frame->PopulateGameGrid(m_game_info->m_games, false);
         }
     });
 
@@ -530,9 +532,11 @@ void MainWindow::CreateConnects() {
             Config::setIconSize(64);
             Config::setSliderPosition(28);
         } else {
+            m_game_grid_frame->icon_size = 97;
             ui->sizeSlider->setValue(28);
             Config::setIconSizeGrid(97);
             Config::setSliderPositionGrid(28);
+            m_game_grid_frame->PopulateGameGrid(m_game_info->m_games, false);
         }
     });
 
@@ -543,9 +547,11 @@ void MainWindow::CreateConnects() {
             Config::setIconSize(128);
             Config::setSliderPosition(92);
         } else {
+            m_game_grid_frame->icon_size = 161;
             ui->sizeSlider->setValue(92);
-            Config::setIconSizeGrid(160);
-            Config::setSliderPositionGrid(91);
+            Config::setIconSizeGrid(161);
+            Config::setSliderPositionGrid(92);
+            m_game_grid_frame->PopulateGameGrid(m_game_info->m_games, false);
         }
     });
 
@@ -556,9 +562,11 @@ void MainWindow::CreateConnects() {
             Config::setIconSize(256);
             Config::setSliderPosition(220);
         } else {
+            m_game_grid_frame->icon_size = 256;
             ui->sizeSlider->setValue(220);
             Config::setIconSizeGrid(256);
             Config::setSliderPositionGrid(220);
+            m_game_grid_frame->PopulateGameGrid(m_game_info->m_games, false);
         }
     });
     // List
@@ -578,6 +586,7 @@ void MainWindow::CreateConnects() {
         ui->sizeSlider->setEnabled(true);
         ui->sizeSlider->setSliderPosition(slider_pos);
         ui->mw_searchbar->setText("");
+        SetLastIconSizeBullet();
     });
     // Grid
     connect(ui->setlistModeGridAct, &QAction::triggered, m_dock_widget.data(), [this]() {
@@ -596,6 +605,7 @@ void MainWindow::CreateConnects() {
         ui->sizeSlider->setEnabled(true);
         ui->sizeSlider->setSliderPosition(slider_pos_grid);
         ui->mw_searchbar->setText("");
+        SetLastIconSizeBullet();
     });
     // Elf Viewer
     connect(ui->setlistElfAct, &QAction::triggered, m_dock_widget.data(), [this]() {
@@ -607,6 +617,7 @@ void MainWindow::CreateConnects() {
         isTableList = false;
         ui->sizeSlider->setDisabled(true);
         Config::setTableMode(2);
+        SetLastIconSizeBullet();
     });
 
     // Cheats/Patches Download.
@@ -1032,19 +1043,38 @@ void MainWindow::SetLastUsedTheme() {
 void MainWindow::SetLastIconSizeBullet() {
     // set QAction bullet point if applicable
     int lastSize = Config::getIconSize();
-    switch (lastSize) {
-    case 36:
-        ui->setIconSizeTinyAct->setChecked(true);
-        break;
-    case 64:
-        ui->setIconSizeSmallAct->setChecked(true);
-        break;
-    case 128:
-        ui->setIconSizeMediumAct->setChecked(true);
-        break;
-    case 256:
-        ui->setIconSizeLargeAct->setChecked(true);
-        break;
+    int lastSizeGrid = Config::getIconSizeGrid();
+    if (isTableList) {
+        switch (lastSize) {
+        case 36:
+            ui->setIconSizeTinyAct->setChecked(true);
+            break;
+        case 64:
+            ui->setIconSizeSmallAct->setChecked(true);
+            break;
+        case 128:
+            ui->setIconSizeMediumAct->setChecked(true);
+            break;
+        case 256:
+            ui->setIconSizeLargeAct->setChecked(true);
+            break;
+        }
+    }
+    else {
+        switch (lastSizeGrid) {
+        case 69:
+            ui->setIconSizeTinyAct->setChecked(true);
+            break;
+        case 97:
+            ui->setIconSizeSmallAct->setChecked(true);
+            break;
+        case 161:
+            ui->setIconSizeMediumAct->setChecked(true);
+            break;
+        case 256:
+            ui->setIconSizeLargeAct->setChecked(true);
+            break;
+        }
     }
 }
 

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -1059,8 +1059,7 @@ void MainWindow::SetLastIconSizeBullet() {
             ui->setIconSizeLargeAct->setChecked(true);
             break;
         }
-    }
-    else {
+    } else {
         switch (lastSizeGrid) {
         case 69:
             ui->setIconSizeTinyAct->setChecked(true);


### PR DESCRIPTION
Fixes #2613 
When you select grid view mode and try to change the game icon size, the icons change to the wrong size, or don't change at all. To solve this I added a line to call the function that populates the game grid with the games when the user changes the icon size. That way the size of the icons is updated to match the size selected by the user, which is the intended behavior. I also added code to update the check on the size when changing view mode.