### PR TITLE
Fix stick drift in games that assume already corrected input values

### DIFF
--- a/src/input/input_handler.cpp
+++ b/src/input/input_handler.cpp
@@ -550,18 +550,18 @@ void ControllerOutput::FinalizeUpdate() {
             break;
         case Axis::TriggerLeft:
             ApplyDeadzone(new_param, lefttrigger_deadzone);
-            controller->Axis(0, c_axis, GetAxis(0x0, 0x80, *new_param));
+            controller->Axis(0, c_axis, GetAxis(0x0, 0x7f, *new_param));
             controller->CheckButton(0, OrbisPadButtonDataOffset::L2, *new_param > 0x20);
             return;
         case Axis::TriggerRight:
             ApplyDeadzone(new_param, righttrigger_deadzone);
-            controller->Axis(0, c_axis, GetAxis(0x0, 0x80, *new_param));
+            controller->Axis(0, c_axis, GetAxis(0x0, 0x7f, *new_param));
             controller->CheckButton(0, OrbisPadButtonDataOffset::R2, *new_param > 0x20);
             return;
         default:
             break;
         }
-        controller->Axis(0, c_axis, GetAxis(-0x80, 0x80, *new_param * multiplier));
+        controller->Axis(0, c_axis, GetAxis(-0x80, 0x7f, *new_param * multiplier));
     }
 }
 

--- a/src/input/input_mouse.cpp
+++ b/src/input/input_mouse.cpp
@@ -61,11 +61,11 @@ Uint32 MousePolling(void* param, Uint32 id, Uint32 interval) {
     float a_x = cos(angle) * output_speed, a_y = sin(angle) * output_speed;
 
     if (d_x != 0 && d_y != 0) {
-        controller->Axis(0, axis_x, GetAxis(-0x80, 0x80, a_x));
-        controller->Axis(0, axis_y, GetAxis(-0x80, 0x80, a_y));
+        controller->Axis(0, axis_x, GetAxis(-0x80, 0x7f, a_x));
+        controller->Axis(0, axis_y, GetAxis(-0x80, 0x7f, a_y));
     } else {
-        controller->Axis(0, axis_x, GetAxis(-0x80, 0x80, 0));
-        controller->Axis(0, axis_y, GetAxis(-0x80, 0x80, 0));
+        controller->Axis(0, axis_x, GetAxis(-0x80, 0x7f, 0));
+        controller->Axis(0, axis_y, GetAxis(-0x80, 0x7f, 0));
     }
 
     return interval;


### PR DESCRIPTION
Some games like Dragon's Crown assume that the input values for axes are already pre-corrected, and don't have any internal deadzones. Since almost no other game does this and each has at least the barest minimum of deadzones, but in this game the cursor you're controlling with the joystick only stops when the input is exactly zero, an otherwise harmless bug made its presence known: 
The maximum allowed value for joystick axis inputs was set to 128 instead of 127, which in turn led to the function that converted the input range to the output data structure that the PS4 games can read, to unintentionally round up an input of zero to an output of one. The fix ended up being embarrassingly simple, as it was just replacing 128-s with 127-s in the relevant places.