### PR TITLE
renderer_vulkan: Make some primitive state dynamic.

### DIFF
--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -156,6 +156,18 @@ vk::CullModeFlags CullMode(Liverpool::CullMode mode) {
     }
 }
 
+vk::FrontFace FrontFace(Liverpool::FrontFace face) {
+    switch (face) {
+    case Liverpool::FrontFace::Clockwise:
+        return vk::FrontFace::eClockwise;
+    case Liverpool::FrontFace::CounterClockwise:
+        return vk::FrontFace::eCounterClockwise;
+    default:
+        UNREACHABLE();
+        return vk::FrontFace::eClockwise;
+    }
+}
+
 vk::BlendFactor BlendFactor(Liverpool::BlendControl::BlendFactor factor) {
     using BlendFactor = Liverpool::BlendControl::BlendFactor;
     switch (factor) {

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.h
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.h
@@ -26,6 +26,8 @@ vk::PolygonMode PolygonMode(Liverpool::PolygonMode mode);
 
 vk::CullModeFlags CullMode(Liverpool::CullMode mode);
 
+vk::FrontFace FrontFace(Liverpool::FrontFace mode);
+
 vk::BlendFactor BlendFactor(Liverpool::BlendControl::BlendFactor factor);
 
 vk::BlendOp BlendOp(Liverpool::BlendControl::BlendFunc func);

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -42,11 +42,7 @@ struct GraphicsPipelineKey {
     u32 num_samples;
     u32 mrt_mask;
     AmdGpu::PrimitiveType prim_type;
-    u32 enable_primitive_restart;
-    u32 primitive_restart_index;
     Liverpool::PolygonMode polygon_mode;
-    Liverpool::CullMode cull_mode;
-    Liverpool::FrontFace front_face;
     Liverpool::ClipSpace clip_space;
     Liverpool::ColorBufferMask cb_shader_mask;
     std::array<Liverpool::BlendControl, Liverpool::NumColorBuffers> blend_controls;
@@ -80,16 +76,6 @@ public:
 
     auto GetMrtMask() const {
         return key.mrt_mask;
-    }
-
-    [[nodiscard]] bool IsPrimitiveListTopology() const {
-        return key.prim_type == AmdGpu::PrimitiveType::PointList ||
-               key.prim_type == AmdGpu::PrimitiveType::LineList ||
-               key.prim_type == AmdGpu::PrimitiveType::TriangleList ||
-               key.prim_type == AmdGpu::PrimitiveType::AdjLineList ||
-               key.prim_type == AmdGpu::PrimitiveType::AdjTriangleList ||
-               key.prim_type == AmdGpu::PrimitiveType::RectList ||
-               key.prim_type == AmdGpu::PrimitiveType::QuadList;
     }
 
     /// Gets the attributes and bindings for vertex inputs.

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -292,6 +292,11 @@ public:
                properties.limits.framebufferStencilSampleCounts;
     }
 
+    /// Returns whether disabling primitive restart is supported.
+    bool IsPrimitiveRestartDisableSupported() const {
+        return driver_id != vk::DriverId::eMoltenvk;
+    }
+
 private:
     /// Creates the logical device opportunistically enabling extensions
     bool CreateDevice();

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -283,12 +283,8 @@ bool PipelineCache::RefreshGraphicsKey() {
     }
 
     key.prim_type = regs.primitive_type;
-    key.enable_primitive_restart = regs.enable_primitive_restart & 1;
-    key.primitive_restart_index = regs.primitive_restart_index;
     key.polygon_mode = regs.polygon_control.PolyMode();
-    key.cull_mode = regs.polygon_control.CullingMode();
     key.clip_space = regs.clipper_control.clip_space;
-    key.front_face = regs.polygon_control.front_face;
     key.num_samples = regs.NumSamples();
 
     const bool skip_cb_binding =

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -78,6 +78,7 @@ private:
     void UpdateDynamicState(const GraphicsPipeline& pipeline) const;
     void UpdateViewportScissorState() const;
     void UpdateDepthStencilState() const;
+    void UpdatePrimitiveState() const;
 
     bool FilterDraw();
 

--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -290,7 +290,9 @@ void DynamicState::Commit(const Instance& instance, const vk::CommandBuffer& cmd
     }
     if (dirty_state.primitive_restart_enable) {
         dirty_state.primitive_restart_enable = false;
-        cmdbuf.setPrimitiveRestartEnableEXT(primitive_restart_enable);
+        if (instance.IsPrimitiveRestartDisableSupported()) {
+            cmdbuf.setPrimitiveRestartEnableEXT(primitive_restart_enable);
+        }
     }
     if (dirty_state.cull_mode) {
         dirty_state.cull_mode = false;

--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -288,6 +288,18 @@ void DynamicState::Commit(const Instance& instance, const vk::CommandBuffer& cmd
             }
         }
     }
+    if (dirty_state.primitive_restart_enable) {
+        dirty_state.primitive_restart_enable = false;
+        cmdbuf.setPrimitiveRestartEnableEXT(primitive_restart_enable);
+    }
+    if (dirty_state.cull_mode) {
+        dirty_state.cull_mode = false;
+        cmdbuf.setCullModeEXT(cull_mode);
+    }
+    if (dirty_state.front_face) {
+        dirty_state.front_face = false;
+        cmdbuf.setFrontFaceEXT(front_face);
+    }
     if (dirty_state.blend_constants) {
         dirty_state.blend_constants = false;
         cmdbuf.setBlendConstants(blend_constants);

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -95,6 +95,10 @@ struct DynamicState {
         bool stencil_back_write_mask : 1;
         bool stencil_back_compare_mask : 1;
 
+        bool primitive_restart_enable : 1;
+        bool cull_mode : 1;
+        bool front_face : 1;
+
         bool blend_constants : 1;
         bool color_write_masks : 1;
     } dirty_state{};
@@ -124,6 +128,10 @@ struct DynamicState {
     u32 stencil_back_reference{};
     u32 stencil_back_write_mask{};
     u32 stencil_back_compare_mask{};
+
+    bool primitive_restart_enable{};
+    vk::CullModeFlags cull_mode{};
+    vk::FrontFace front_face{};
 
     float blend_constants[4]{};
     ColorWriteMasks color_write_masks{};
@@ -251,6 +259,27 @@ struct DynamicState {
         if (stencil_back_compare_mask != back_compare_mask) {
             stencil_back_compare_mask = back_compare_mask;
             dirty_state.stencil_back_compare_mask = true;
+        }
+    }
+
+    void SetPrimitiveRestartEnabled(const bool enabled) {
+        if (primitive_restart_enable != enabled) {
+            primitive_restart_enable = enabled;
+            dirty_state.primitive_restart_enable = true;
+        }
+    }
+
+    void SetCullMode(const vk::CullModeFlags cull_mode_) {
+        if (cull_mode != cull_mode_) {
+            cull_mode = cull_mode_;
+            dirty_state.cull_mode = true;
+        }
+    }
+
+    void SetFrontFace(const vk::FrontFace front_face_) {
+        if (front_face != front_face_) {
+            front_face = front_face_;
+            dirty_state.front_face = true;
         }
     }
 


### PR DESCRIPTION
Adds some more dynamic state usage, this time for some primitive state:
* Primitive restart enabled
* Cull mode
* Front face

Primitive type is technically available but more complicated since, without an optional feature from `VK_EXT_extended_dynamic_state3`, you can't change between primitive types of different topology classes from the pipeline. Thus it remains as pipeline state at least for now.