### PR TITLE
libraries: Reduce some controller log spam.

### DIFF
--- a/src/core/libraries/move/move.cpp
+++ b/src/core/libraries/move/move.cpp
@@ -9,12 +9,17 @@
 namespace Libraries::Move {
 
 int PS4_SYSV_ABI sceMoveOpen() {
-    LOG_ERROR(Lib_Move, "(STUBBED) called");
+    LOG_TRACE(Lib_Move, "(STUBBED) called");
     return ORBIS_FAIL;
 }
 
 int PS4_SYSV_ABI sceMoveGetDeviceInfo() {
     LOG_ERROR(Lib_Move, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+int PS4_SYSV_ABI sceMoveReadStateLatest() {
+    LOG_TRACE(Lib_Move, "(STUBBED) called");
     return ORBIS_OK;
 }
 
@@ -36,6 +41,7 @@ int PS4_SYSV_ABI sceMoveInit() {
 void RegisterlibSceMove(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("HzC60MfjJxU", "libSceMove", 1, "libSceMove", 1, 1, sceMoveOpen);
     LIB_FUNCTION("GWXTyxs4QbE", "libSceMove", 1, "libSceMove", 1, 1, sceMoveGetDeviceInfo);
+    LIB_FUNCTION("ttU+JOhShl4", "libSceMove", 1, "libSceMove", 1, 1, sceMoveReadStateLatest);
     LIB_FUNCTION("f2bcpK6kJfg", "libSceMove", 1, "libSceMove", 1, 1, sceMoveReadStateRecent);
     LIB_FUNCTION("tsZi60H4ypY", "libSceMove", 1, "libSceMove", 1, 1, sceMoveTerm);
     LIB_FUNCTION("j1ITE-EoJmE", "libSceMove", 1, "libSceMove", 1, 1, sceMoveInit);

--- a/src/core/libraries/pad/pad.cpp
+++ b/src/core/libraries/pad/pad.cpp
@@ -250,7 +250,6 @@ int PS4_SYSV_ABI scePadMbusTerm() {
 }
 
 int PS4_SYSV_ABI scePadOpen(s32 userId, s32 type, s32 index, const OrbisPadOpenParam* pParam) {
-    LOG_INFO(Lib_Pad, "(DUMMY) called user_id = {} type = {} index = {}", userId, type, index);
     if (userId == -1) {
         return ORBIS_PAD_ERROR_DEVICE_NO_HANDLE;
     }
@@ -261,6 +260,7 @@ int PS4_SYSV_ABI scePadOpen(s32 userId, s32 type, s32 index, const OrbisPadOpenP
         if (type != ORBIS_PAD_PORT_TYPE_STANDARD && type != ORBIS_PAD_PORT_TYPE_REMOTE_CONTROL)
             return ORBIS_PAD_ERROR_DEVICE_NOT_CONNECTED;
     }
+    LOG_INFO(Lib_Pad, "(DUMMY) called user_id = {} type = {} index = {}", userId, type, index);
     scePadResetLightBar(1);
     return 1; // dummy
 }


### PR DESCRIPTION
Reduce some log spam related to controllers:
* Downgrade `sceMoveOpen` log, since games may spam it until it succeeds. We can determine if a game is using PS Move in logs by `sceMoveInit` anyway.
* Move the `scePadOpen` log down below the pad type checks, as some games may similarly spam until a special type pad is detected.
* Add `sceMoveReadStateLatest` stub.