### PR TITLE
shader_recompiler: Misc shader fixes.

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_floating_point.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_floating_point.cpp
@@ -267,12 +267,12 @@ Id EmitFPFrexpSig64(EmitContext& ctx, Id value) {
 
 Id EmitFPFrexpExp32(EmitContext& ctx, Id value) {
     const auto frexp = ctx.OpFrexpStruct(ctx.frexp_result_f32, value);
-    return ctx.OpCompositeExtract(ctx.U32[1], frexp, 1);
+    return ctx.OpBitcast(ctx.U32[1], ctx.OpCompositeExtract(ctx.S32[1], frexp, 1));
 }
 
 Id EmitFPFrexpExp64(EmitContext& ctx, Id value) {
     const auto frexp = ctx.OpFrexpStruct(ctx.frexp_result_f64, value);
-    return ctx.OpCompositeExtract(ctx.U32[1], frexp, 1);
+    return ctx.OpBitcast(ctx.U32[1], ctx.OpCompositeExtract(ctx.S32[1], frexp, 1));
 }
 
 Id EmitFPOrdEqual16(EmitContext& ctx, Id lhs, Id rhs) {

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -153,9 +153,9 @@ void EmitContext::DefineArithmeticTypes() {
 
     full_result_i32x2 = Name(TypeStruct(S32[1], S32[1]), "full_result_i32x2");
     full_result_u32x2 = Name(TypeStruct(U32[1], U32[1]), "full_result_u32x2");
-    frexp_result_f32 = Name(TypeStruct(F32[1], U32[1]), "frexp_result_f32");
+    frexp_result_f32 = Name(TypeStruct(F32[1], S32[1]), "frexp_result_f32");
     if (info.uses_fp64) {
-        frexp_result_f64 = Name(TypeStruct(F64[1], U32[1]), "frexp_result_f64");
+        frexp_result_f64 = Name(TypeStruct(F64[1], S32[1]), "frexp_result_f64");
     }
 }
 

--- a/src/shader_recompiler/frontend/format.cpp
+++ b/src/shader_recompiler/frontend/format.cpp
@@ -2784,8 +2784,7 @@ constexpr std::array<InstFormat, 256> InstructionFormatDS = {{
     // 62 = DS_APPEND
     {InstClass::DsAppendCon, InstCategory::DataShare, 3, 1, ScalarType::Uint32, ScalarType::Uint32},
     // 63 = DS_ORDERED_COUNT
-    {InstClass::GdsOrdCnt, InstCategory::DataShare, 3, 1, ScalarType::Undefined,
-     ScalarType::Undefined},
+    {InstClass::GdsOrdCnt, InstCategory::DataShare, 3, 1, ScalarType::Uint32, ScalarType::Uint32},
     // 64 = DS_ADD_U64
     {InstClass::DsAtomicArith64, InstCategory::DataShare, 3, 1, ScalarType::Uint64,
      ScalarType::Uint64},

--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -1010,8 +1010,10 @@ void Translator::V_CMP_CLASS_F32(const GcnInst& inst) {
             value = ir.FPIsNan(src0);
         } else if ((class_mask & IR::FloatClassFunc::Infinity) == IR::FloatClassFunc::Infinity) {
             value = ir.FPIsInf(src0);
+        } else if ((class_mask & IR::FloatClassFunc::Negative) == IR::FloatClassFunc::Negative) {
+            value = ir.FPLessThanEqual(src0, ir.Imm32(-0.f));
         } else {
-            UNREACHABLE();
+            UNREACHABLE_MSG("Unsupported float class mask: {:#x}", static_cast<u32>(class_mask));
         }
     } else {
         // We don't know the type yet, delay its resolution.

--- a/src/shader_recompiler/ir/reg.h
+++ b/src/shader_recompiler/ir/reg.h
@@ -25,6 +25,7 @@ enum class FloatClassFunc : u32 {
 
     NaN = SignalingNan | QuietNan,
     Infinity = PositiveInfinity | NegativeInfinity,
+    Negative = NegativeInfinity | NegativeNormal | NegativeDenorm | NegativeZero,
     Finite = NegativeNormal | NegativeDenorm | NegativeZero | PositiveNormal | PositiveDenorm |
              PositiveZero,
 };


### PR DESCRIPTION
Few shader fixes from taking a quick look at CUSA08010:
* `OpFrexpStruct` exponent parameter is supposed to be a signed integer; fix the typing to be `S32` and then cast to `U32` to keep our type handling consistent. This was causing a compile failure in MoltenVK.
* Implement `V_CMP_CLASS_F32` class mask that checks for any type of negative value.
* Define operands for `DS_ORDERED_COUNT` in instruction table (still not implemented yet though).