### PR TITLE
Adding requirements to the App Bug Report template based on the Game Bug Report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/app-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/app-bug-report.yaml
@@ -74,10 +74,3 @@ body:
       placeholder: "Example: 16 GB"
     validations:
       required: true
-  - type: input
-    id: vram
-    attributes:
-      label: Amount of VRAM in GB
-      placeholder: "Example: 8 GB"
-    validations:
-      required: true

--- a/.github/ISSUE_TEMPLATE/app-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/app-bug-report.yaml
@@ -53,3 +53,31 @@ body:
       placeholder: "Example: Windows 11, Arch Linux, MacOS 15"
     validations:
       required: true
+  - type: input
+    id: cpu
+    attributes:
+      label: CPU
+      placeholder: "Example: Intel Core i7-8700"
+    validations:
+      required: true
+  - type: input
+    id: gpu
+    attributes:
+      label: GPU
+      placeholder: "Example: nVidia GTX 1650"
+    validations:
+      required: true
+  - type: input
+    id: ram
+    attributes:
+      label: Amount of RAM in GB
+      placeholder: "Example: 16 GB"
+    validations:
+      required: true
+  - type: input
+    id: vram
+    attributes:
+      label: Amount of VRAM in GB
+      placeholder: "Example: 8 GB"
+    validations:
+      required: true


### PR DESCRIPTION
Forcing people to fill information about their hardware (like in the Game Bug Report template) to make it easier for debugging problems when App Bugs are reported. 
Example: "shad crashes after I open it" with this we can tell if the user has specs below the requirements, if they have a CPU with an iGPU that needs its drivers updated ...
I saw two issues on the first page where hardware information would be beneficial to know if it's a shadPS4 problem or a user problem (#2729 and #2770). I'll ask for specs myself under those two issues to try and find the problem instead of leaving them open for weeks.