### PR TITLE
vk_rasterizer: Control mapped_ranges access with shared lock.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <shared_mutex>
+
 #include "video_core/buffer_cache/buffer_cache.h"
 #include "video_core/page_manager.h"
 #include "video_core/renderer_vulkan/vk_pipeline_cache.h"
@@ -106,6 +108,7 @@ private:
     AmdGpu::Liverpool* liverpool;
     Core::MemoryManager* memory;
     boost::icl::interval_set<VAddr> mapped_ranges;
+    std::shared_mutex mapped_ranges_mutex;
     PipelineCache pipeline_cache;
 
     boost::container::static_vector<


### PR DESCRIPTION
The GPU mapped memory ranges set may be modified by one thread at the same time as another thread checks it. Reading the set mid-write like this can produce an incorrect result, making it think that valid memory is not mapped.

To address this, add a shared lock to control access to `mapped_ranges`. Any number of readers can access the map at the same time, but when it is being written by a map/unmap operation, that is given exclusive access.

Also made the intervals and set contains check a bit more correct.

Fixes instances of incorrect `Attempted to track non-GPU memory` assert in games that map and unmap memory a lot beyond boot.