### PR TITLE
renderer_vulkan: Improve handling of required vs optional extensions.

### DIFF
--- a/documents/Quickstart/Quickstart.md
+++ b/documents/Quickstart/Quickstart.md
@@ -29,8 +29,8 @@ SPDX-License-Identifier: GPL-2.0-or-later
 ### GPU
 
 - A graphics card with at least 1GB of VRAM
-- Keep your graphics drivers up to date
-- Vulkan 1.3 support (required)
+- Up-to-date graphics drivers
+- Vulkan 1.3 with the `VK_KHR_swapchain` and `VK_KHR_push_descriptor` extensions
 
 ### RAM
 

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -242,18 +242,21 @@ bool Instance::CreateDevice() {
 
     // These extensions are promoted by Vulkan 1.3, but for greater compatibility we use Vulkan 1.2
     // with extensions.
-    add_extension(VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME);
-    add_extension(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
-    add_extension(VK_EXT_SHADER_DEMOTE_TO_HELPER_INVOCATION_EXTENSION_NAME);
-    add_extension(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
-    add_extension(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
-    add_extension(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
-    add_extension(VK_EXT_TOOLING_INFO_EXTENSION_NAME);
-    add_extension(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
+    ASSERT(add_extension(VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME));
+    ASSERT(add_extension(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME));
+    ASSERT(add_extension(VK_EXT_SHADER_DEMOTE_TO_HELPER_INVOCATION_EXTENSION_NAME));
+    ASSERT(add_extension(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME));
+    ASSERT(add_extension(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME));
+    ASSERT(add_extension(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME));
+    ASSERT(add_extension(VK_EXT_TOOLING_INFO_EXTENSION_NAME));
+    ASSERT(add_extension(VK_KHR_MAINTENANCE_4_EXTENSION_NAME));
 
-    add_extension(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
-    add_extension(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
-    add_extension(VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME);
+    // Required
+    ASSERT(add_extension(VK_KHR_SWAPCHAIN_EXTENSION_NAME));
+    ASSERT(add_extension(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME));
+
+    // Optional
+    depth_range_unrestricted = add_extension(VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME);
     dynamic_state_3 = add_extension(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
     if (dynamic_state_3) {
         dynamic_state_3_features =

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -104,6 +104,11 @@ public:
         return depth_clip_control;
     }
 
+    /// Returns true when VK_EXT_depth_range_unrestricted is supported
+    bool IsDepthRangeUnrestrictedSupported() const {
+        return depth_range_unrestricted;
+    }
+
     /// Returns true when the extendedDynamicState3ColorWriteMask feature of
     /// VK_EXT_extended_dynamic_state3 is supported.
     bool IsDynamicColorWriteMaskSupported() const {
@@ -340,6 +345,7 @@ private:
     bool custom_border_color{};
     bool fragment_shader_barycentric{};
     bool depth_clip_control{};
+    bool depth_range_unrestricted{};
     bool dynamic_state_3{};
     bool vertex_input_dynamic_state{};
     bool robustness2{};


### PR DESCRIPTION
* Add asserts on extensions that are required, to fail early and obviously.
* Handle missing support for `VK_EXT_depth_range_unrestricted`.
* Update quick-start to better indicate required Vulkan support level.