### PR TITLE
Implement DS_READ2ST64_B64

### DIFF
--- a/src/shader_recompiler/frontend/translate/data_share.cpp
+++ b/src/shader_recompiler/frontend/translate/data_share.cpp
@@ -67,6 +67,8 @@ void Translator::EmitDataShare(const GcnInst& inst) {
         return DS_READ(64, false, false, false, inst);
     case Opcode::DS_READ2_B64:
         return DS_READ(64, false, true, false, inst);
+    case Opcode::DS_READ2ST64_B64:
+        return DS_READ(64, false, true, true, inst);
     default:
         LogMissingOpcode(inst);
     }


### PR DESCRIPTION
Implementing shader opcode DS_READ2ST64_B64, this opcode is needed for [Monster Hunter World](https://github.com/shadps4-emu/shadPS4/issues/496#issuecomment-2585562987) according to the the Missing opcodes aggregate issue.