### PR TITLE
Implementing DS_SUB_U32, DS_INC_U32, DS_DEC_U32.

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_atomic.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_atomic.cpp
@@ -21,6 +21,15 @@ Id SharedAtomicU32(EmitContext& ctx, Id offset, Id value,
     return (ctx.*atomic_func)(ctx.U32[1], pointer, scope, semantics, value);
 }
 
+Id SharedAtomicU32_IncDec(EmitContext& ctx, Id offset,
+                          Id (Sirit::Module::*atomic_func)(Id, Id, Id, Id)) {
+    const Id shift_id{ctx.ConstU32(2U)};
+    const Id index{ctx.OpShiftRightArithmetic(ctx.U32[1], offset, shift_id)};
+    const Id pointer{ctx.OpAccessChain(ctx.shared_u32, ctx.shared_memory_u32, index)};
+    const auto [scope, semantics]{AtomicArgs(ctx)};
+    return (ctx.*atomic_func)(ctx.U32[1], pointer, scope, semantics);
+}
+
 Id BufferAtomicU32BoundsCheck(EmitContext& ctx, Id index, Id buffer_size, auto emit_func) {
     if (Sirit::ValidId(buffer_size)) {
         // Bounds checking enabled, wrap in a conditional branch to make sure that
@@ -97,6 +106,18 @@ Id EmitSharedAtomicOr32(EmitContext& ctx, Id offset, Id value) {
 
 Id EmitSharedAtomicXor32(EmitContext& ctx, Id offset, Id value) {
     return SharedAtomicU32(ctx, offset, value, &Sirit::Module::OpAtomicXor);
+}
+
+Id EmitSharedAtomicISub32(EmitContext& ctx, Id offset, Id value) {
+    return SharedAtomicU32(ctx, offset, value, &Sirit::Module::OpAtomicISub);
+}
+
+Id EmitSharedAtomicIIncrement32(EmitContext& ctx, Id offset) {
+    return SharedAtomicU32_IncDec(ctx, offset, &Sirit::Module::OpAtomicIIncrement);
+}
+
+Id EmitSharedAtomicIDecrement32(EmitContext& ctx, Id offset) {
+    return SharedAtomicU32_IncDec(ctx, offset, &Sirit::Module::OpAtomicIDecrement);
 }
 
 Id EmitBufferAtomicIAdd32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address, Id value) {

--- a/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
@@ -130,6 +130,10 @@ Id EmitSharedAtomicSMin32(EmitContext& ctx, Id offset, Id value);
 Id EmitSharedAtomicAnd32(EmitContext& ctx, Id offset, Id value);
 Id EmitSharedAtomicOr32(EmitContext& ctx, Id offset, Id value);
 Id EmitSharedAtomicXor32(EmitContext& ctx, Id offset, Id value);
+Id EmitSharedAtomicIIncrement32(EmitContext& ctx, Id offset);
+Id EmitSharedAtomicIDecrement32(EmitContext& ctx, Id offset);
+Id EmitSharedAtomicISub32(EmitContext& ctx, Id offset, Id value);
+
 Id EmitCompositeConstructU32x2(EmitContext& ctx, IR::Inst* inst, Id e1, Id e2);
 Id EmitCompositeConstructU32x3(EmitContext& ctx, IR::Inst* inst, Id e1, Id e2, Id e3);
 Id EmitCompositeConstructU32x4(EmitContext& ctx, IR::Inst* inst, Id e1, Id e2, Id e3, Id e4);

--- a/src/shader_recompiler/frontend/translate/data_share.cpp
+++ b/src/shader_recompiler/frontend/translate/data_share.cpp
@@ -19,8 +19,6 @@ void Translator::EmitDataShare(const GcnInst& inst) {
         return DS_INC_U32(inst, false);
     case Opcode::DS_DEC_U32:
         return DS_DEC_U32(inst, false);
-    case Opcode::DS_SUB_RTN_U32:
-        return DS_SUB_U32(inst, true);
     case Opcode::DS_MIN_I32:
         return DS_MIN_U32(inst, true, false);
     case Opcode::DS_MAX_I32:
@@ -43,6 +41,8 @@ void Translator::EmitDataShare(const GcnInst& inst) {
         return DS_WRITE(32, false, true, true, inst);
     case Opcode::DS_ADD_RTN_U32:
         return DS_ADD_U32(inst, true);
+    case Opcode::DS_SUB_RTN_U32:
+        return DS_SUB_U32(inst, true);
     case Opcode::DS_MIN_RTN_U32:
         return DS_MIN_U32(inst, false, true);
     case Opcode::DS_MAX_RTN_U32:

--- a/src/shader_recompiler/frontend/translate/data_share.cpp
+++ b/src/shader_recompiler/frontend/translate/data_share.cpp
@@ -13,6 +13,18 @@ void Translator::EmitDataShare(const GcnInst& inst) {
         // DS
     case Opcode::DS_ADD_U32:
         return DS_ADD_U32(inst, false);
+    case Opcode::DS_SUB_U32:
+        return DS_SUB_U32(inst, false);
+    case Opcode::DS_INC_U32:
+        return DS_INC_U32(inst, false);
+    case Opcode::DS_DEC_U32:
+        return DS_DEC_U32(inst, false);
+    case Opcode::DS_WRITE_SRC2_B32:
+        return DS_WRITE_SRC2_B32(inst, true);
+    case Opcode::DS_WRITE_SRC2_B64:
+        return DS_WRITE_SRC2_B64(inst, true);
+    case Opcode::DS_SUB_RTN_U32:
+        return DS_SUB_U32(inst, true);
     case Opcode::DS_MIN_I32:
         return DS_MIN_U32(inst, true, false);
     case Opcode::DS_MAX_I32:
@@ -226,6 +238,57 @@ void Translator::DS_SWIZZLE_B32(const GcnInst& inst) {
     const IR::U32 base = ir.ShiftLeftLogical(id_in_group, ir.Imm32(1));
     const IR::U32 index = ir.BitFieldExtract(ir.Imm32(offset0), base, ir.Imm32(2));
     SetDst(inst.dst[0], ir.QuadShuffle(src, index));
+}
+
+void Translator::DS_INC_U32(const GcnInst& inst, bool rtn) {
+    const IR::U32 addr{GetSrc(inst.src[0])};
+    const IR::U32 offset =
+        ir.Imm32((u32(inst.control.ds.offset1) << 8u) + u32(inst.control.ds.offset0));
+    const IR::U32 addr_offset = ir.IAdd(addr, offset);
+    const IR::Value original_val = ir.SharedAtomicIAdd(addr_offset, ir.Imm32(1));
+    if (rtn) {
+        SetDst(inst.dst[0], IR::U32{original_val});
+    }
+}
+
+void Translator::DS_DEC_U32(const GcnInst& inst, bool rtn) {
+    const IR::U32 addr{GetSrc(inst.src[0])};
+    const IR::U32 offset =
+        ir.Imm32((u32(inst.control.ds.offset1) << 8u) + u32(inst.control.ds.offset0));
+    const IR::U32 addr_offset = ir.IAdd(addr, offset);
+    const IR::Value original_val = ir.SharedAtomicIAdd(addr_offset, ir.Imm32(-1));
+    if (rtn) {
+        SetDst(inst.dst[0], IR::U32{original_val});
+    }
+}
+
+void Translator::DS_WRITE_SRC2_B32(const GcnInst& inst, bool rtn) {
+    const IR::U32 addr{GetSrc(inst.src[0])};
+    const IR::U32 data{GetSrc(inst.src[1])};
+    const u32 offset = (inst.control.ds.offset1 << 8u) + inst.control.ds.offset0;
+    const IR::U32 addr_offset = ir.IAdd(addr, ir.Imm32(offset));
+    ir.WriteShared(32, addr_offset, data);
+}
+
+void Translator::DS_WRITE_SRC2_B64(const GcnInst& inst, bool rtn) {
+    const IR::U32 addr{GetSrc(inst.src[0])};
+    const IR::U32 data0{GetSrc(inst.src[1])};
+    const IR::U32 data1{GetSrc(inst.src[2])};
+    const u32 offset = (inst.control.ds.offset1 << 8u) + inst.control.ds.offset0;
+    const IR::U32 addr_offset = ir.IAdd(addr, ir.Imm32(offset));
+    ir.WriteShared(64, ir.CompositeConstruct(data0, data1), addr_offset);
+}
+
+void Translator::DS_SUB_U32(const GcnInst& inst, bool rtn) {
+    const IR::U32 addr{GetSrc(inst.src[0])};
+    const IR::U32 data{GetSrc(inst.src[1])};
+    const IR::U32 offset =
+        ir.Imm32((u32(inst.control.ds.offset1) << 8u) + u32(inst.control.ds.offset0));
+    const IR::U32 addr_offset = ir.IAdd(addr, offset);
+    const IR::Value original_val = ir.SharedAtomicIAdd(addr_offset, data);
+    if (rtn) {
+        SetDst(inst.dst[0], IR::U32{original_val});
+    }
 }
 
 void Translator::DS_READ(int bit_size, bool is_signed, bool is_pair, bool stride64,

--- a/src/shader_recompiler/frontend/translate/scalar_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_alu.cpp
@@ -521,21 +521,6 @@ void Translator::S_BFE(const GcnInst& inst, bool is_signed) {
     ir.SetScc(ir.INotEqual(result, ir.Imm32(0)));
 }
 
-void Translator::S_BFE_I32(const GcnInst& inst) {
-    const IR::U32 src0{GetSrc(inst.src[0])};
-    const IR::U32 src1{GetSrc(inst.src[1])};
-
-    const IR::U32 offset{ir.BitwiseAnd(src1, ir.Imm32(0x1F))};
-
-    const IR::U32 count{ir.BitFieldExtract(src1, ir.Imm32(16), ir.Imm32(7))};
-
-    const IR::U32 result{ir.BitFieldExtract(src0, offset, count, false)};
-
-    SetDst(inst.dst[0], result);
-
-    ir.SetScc(ir.INotEqual(result, ir.Imm32(0)));
-}
-
 void Translator::S_ABSDIFF_I32(const GcnInst& inst) {
     const IR::U32 src0{GetSrc(inst.src[0])};
     const IR::U32 src1{GetSrc(inst.src[1])};

--- a/src/shader_recompiler/frontend/translate/scalar_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_alu.cpp
@@ -521,6 +521,21 @@ void Translator::S_BFE(const GcnInst& inst, bool is_signed) {
     ir.SetScc(ir.INotEqual(result, ir.Imm32(0)));
 }
 
+void Translator::S_BFE_I32(const GcnInst& inst) {
+    const IR::U32 src0{GetSrc(inst.src[0])};
+    const IR::U32 src1{GetSrc(inst.src[1])};
+
+    const IR::U32 offset{ir.BitwiseAnd(src1, ir.Imm32(0x1F))};
+
+    const IR::U32 count{ir.BitFieldExtract(src1, ir.Imm32(16), ir.Imm32(7))};
+
+    const IR::U32 result{ir.BitFieldExtract(src0, offset, count, false)};
+
+    SetDst(inst.dst[0], result);
+
+    ir.SetScc(ir.INotEqual(result, ir.Imm32(0)));
+}
+
 void Translator::S_ABSDIFF_I32(const GcnInst& inst) {
     const IR::U32 src0{GetSrc(inst.src[0])};
     const IR::U32 src1{GetSrc(inst.src[1])};

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -278,8 +278,6 @@ public:
     void DS_SUB_U32(const GcnInst& inst, bool);
     void DS_INC_U32(const GcnInst& inst, bool rtn);
     void DS_DEC_U32(const GcnInst& inst, bool rtn);
-    void DS_WRITE_SRC2_B32(const GcnInst& inst, bool rtn);
-    void DS_WRITE_SRC2_B64(const GcnInst& inst, bool rtn);
 
     // Buffer Memory
     // MUBUF / MTBUF

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -275,7 +275,7 @@ public:
     void DS_READ(int bit_size, bool is_signed, bool is_pair, bool stride64, const GcnInst& inst);
     void DS_APPEND(const GcnInst& inst);
     void DS_CONSUME(const GcnInst& inst);
-    void DS_SUB_U32(const GcnInst& inst, bool);
+    void DS_SUB_U32(const GcnInst& inst, bool rtn);
     void DS_INC_U32(const GcnInst& inst, bool rtn);
     void DS_DEC_U32(const GcnInst& inst, bool rtn);
 

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -275,6 +275,11 @@ public:
     void DS_READ(int bit_size, bool is_signed, bool is_pair, bool stride64, const GcnInst& inst);
     void DS_APPEND(const GcnInst& inst);
     void DS_CONSUME(const GcnInst& inst);
+    void DS_SUB_U32(const GcnInst& inst, bool);
+    void DS_INC_U32(const GcnInst& inst, bool rtn);
+    void DS_DEC_U32(const GcnInst& inst, bool rtn);
+    void DS_WRITE_SRC2_B32(const GcnInst& inst, bool rtn);
+    void DS_WRITE_SRC2_B64(const GcnInst& inst, bool rtn);
 
     // Buffer Memory
     // MUBUF / MTBUF

--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -357,6 +357,18 @@ U32 IREmitter::SharedAtomicXor(const U32& address, const U32& data) {
     return Inst<U32>(Opcode::SharedAtomicXor32, address, data);
 }
 
+U32 IREmitter::SharedAtomicIIncrement(const U32& address) {
+    return Inst<U32>(Opcode::SharedAtomicIIncrement32, address);
+}
+
+U32 IREmitter::SharedAtomicIDecrement(const U32& address) {
+    return Inst<U32>(Opcode::SharedAtomicIDecrement32, address);
+}
+
+U32 IREmitter::SharedAtomicISub(const U32& address, const U32& data) {
+    return Inst<U32>(Opcode::SharedAtomicISub32, address, data);
+}
+
 U32 IREmitter::ReadConst(const Value& base, const U32& offset) {
     return Inst<U32>(Opcode::ReadConst, base, offset);
 }

--- a/src/shader_recompiler/ir/ir_emitter.h
+++ b/src/shader_recompiler/ir/ir_emitter.h
@@ -106,6 +106,10 @@ public:
     [[nodiscard]] U32 SharedAtomicOr(const U32& address, const U32& data);
     [[nodiscard]] U32 SharedAtomicXor(const U32& address, const U32& data);
 
+    [[nodiscard]] U32 SharedAtomicIIncrement(const U32& address);
+    [[nodiscard]] U32 SharedAtomicIDecrement(const U32& address);
+    [[nodiscard]] U32 SharedAtomicISub(const U32& address, const U32& data);
+
     [[nodiscard]] U32 ReadConst(const Value& base, const U32& offset);
     [[nodiscard]] U32 ReadConstBuffer(const Value& handle, const U32& index);
 

--- a/src/shader_recompiler/ir/opcodes.inc
+++ b/src/shader_recompiler/ir/opcodes.inc
@@ -44,6 +44,9 @@ OPCODE(SharedAtomicUMax32,                                  U32,            U32,
 OPCODE(SharedAtomicAnd32,                                   U32,            U32,            U32,                                                            )
 OPCODE(SharedAtomicOr32,                                    U32,            U32,            U32,                                                            )
 OPCODE(SharedAtomicXor32,                                   U32,            U32,            U32,                                                            )
+OPCODE(SharedAtomicISub32,                                  U32,            U32,            U32,                                                            )
+OPCODE(SharedAtomicIIncrement32,                            U32,            U32,                                                                            )
+OPCODE(SharedAtomicIDecrement32,                            U32,            U32,                                                                            )
 
 // Context getters/setters
 OPCODE(GetUserData,                                         U32,            ScalarReg,                                                                      )


### PR DESCRIPTION
Based on AMD GCN ISA documentaion this pr add some of the missing opcode cases for read and write memory(DS), this is my first implementation of this cases so feel free to correct me if i missed something. Most of the implementations are based on the already done ones. This will only benefit games that use shared memory but for the long run i guess is better to add them first instead of being needed. 