### PR TITLE
libkernel: Fix sceKernelAllocateDirectMemory and sceKernelAvailableDirectMemorySize

### DIFF
--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -19,7 +19,7 @@
 namespace Libraries::Kernel {
 
 u64 PS4_SYSV_ABI sceKernelGetDirectMemorySize() {
-    LOG_WARNING(Kernel_Vmm, "called");
+    LOG_TRACE(Kernel_Vmm, "called");
     const auto* memory = Core::Memory::Instance();
     return memory->GetTotalDirectSize();
 }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -639,7 +639,7 @@ int MemoryManager::DirectQueryAvailable(PAddr search_start, PAddr search_end, si
             continue;
         }
 
-        const auto aligned_base = alignment > 0 ? Common::AlignUp(dmem_area->second.base, alignment)
+        auto aligned_base = alignment > 0 ? Common::AlignUp(dmem_area->second.base, alignment)
                                                 : dmem_area->second.base;
         const auto alignment_size = aligned_base - dmem_area->second.base;
         auto remaining_size =
@@ -650,6 +650,7 @@ int MemoryManager::DirectQueryAvailable(PAddr search_start, PAddr search_end, si
             remaining_size = remaining_size > (search_start - dmem_area->second.base)
                                  ? remaining_size - (search_start - dmem_area->second.base)
                                  : 0;
+            aligned_base = Common::AlignUp(search_start, alignment);
         }
 
         if (dmem_area->second.GetEnd() > search_end) {

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -651,7 +651,7 @@ int MemoryManager::DirectQueryAvailable(PAddr search_start, PAddr search_end, si
                                  ? remaining_size - (search_start - dmem_area->second.base)
                                  : 0;
             aligned_base = alignment > 0 ? Common::AlignUp(search_start, alignment)
-                                 : dmem_area->second.base;
+                                 : search_start;
         }
 
         if (dmem_area->second.GetEnd() > search_end) {

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -139,35 +139,30 @@ PAddr MemoryManager::Allocate(PAddr search_start, PAddr search_end, size_t size,
     alignment = alignment > 0 ? alignment : 16_KB;
 
     auto dmem_area = FindDmemArea(search_start);
+    auto mapping_start = search_start > dmem_area->second.base ? Common::AlignUp(search_start, alignment) : Common::AlignUp(dmem_area->second.base, alignment);
+    auto mapping_end = Common::AlignUp(mapping_start + size, alignment);
 
-    const auto is_suitable = [&] {
-        if (dmem_area == dmem_map.end()) {
-            return false;
-        }
-        const auto aligned_base = Common::AlignUp(dmem_area->second.base, alignment);
-        const auto alignment_size = aligned_base - dmem_area->second.base;
-        const auto remaining_size =
-            dmem_area->second.size >= alignment_size ? dmem_area->second.size - alignment_size : 0;
-        return dmem_area->second.is_free && remaining_size >= size;
-    };
-    while (dmem_area != dmem_map.end() && !is_suitable() &&
-           dmem_area->second.GetEnd() <= search_end) {
-        ++dmem_area;
+    // Find the first free, large enough dmem area in the range.
+    while ((!dmem_area->second.is_free || dmem_area->second.GetEnd() < mapping_end) && dmem_area != dmem_map.end()) {
+        // The current dmem_area isn't suitable, move to the next one.
+        dmem_area++;
+
+        // Update local variables based on the new dmem_area
+        mapping_start = search_start > dmem_area->second.base ? Common::AlignUp(search_start, alignment) : Common::AlignUp(dmem_area->second.base, alignment);
+        mapping_end = Common::AlignUp(mapping_start + size, alignment);
     }
-    if (!is_suitable()) {
+
+    if (dmem_area == dmem_map.end()) {
+        // There are no suitable mappings in this range
         LOG_ERROR(Kernel_Vmm, "Unable to find free direct memory area: size = {:#x}", size);
         return -1;
     }
 
-    // Align free position
-    PAddr free_addr = dmem_area->second.base;
-    free_addr = Common::AlignUp(free_addr, alignment);
-
     // Add the allocated region to the list and commit its pages.
-    auto& area = CarveDmemArea(free_addr, size)->second;
+    auto& area = CarveDmemArea(mapping_start, size)->second;
     area.memory_type = memory_type;
     area.is_free = false;
-    return free_addr;
+    return mapping_start;
 }
 
 void MemoryManager::Free(PAddr phys_addr, size_t size) {

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -650,7 +650,8 @@ int MemoryManager::DirectQueryAvailable(PAddr search_start, PAddr search_end, si
             remaining_size = remaining_size > (search_start - dmem_area->second.base)
                                  ? remaining_size - (search_start - dmem_area->second.base)
                                  : 0;
-            aligned_base = Common::AlignUp(search_start, alignment);
+            aligned_base = alignment > 0 ? Common::AlignUp(search_start, alignment)
+                                 : dmem_area->second.base;
         }
 
         if (dmem_area->second.GetEnd() > search_end) {

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -640,7 +640,7 @@ int MemoryManager::DirectQueryAvailable(PAddr search_start, PAddr search_end, si
         }
 
         auto aligned_base = alignment > 0 ? Common::AlignUp(dmem_area->second.base, alignment)
-                                                : dmem_area->second.base;
+                                          : dmem_area->second.base;
         const auto alignment_size = aligned_base - dmem_area->second.base;
         auto remaining_size =
             dmem_area->second.size >= alignment_size ? dmem_area->second.size - alignment_size : 0;
@@ -650,8 +650,7 @@ int MemoryManager::DirectQueryAvailable(PAddr search_start, PAddr search_end, si
             remaining_size = remaining_size > (search_start - dmem_area->second.base)
                                  ? remaining_size - (search_start - dmem_area->second.base)
                                  : 0;
-            aligned_base = alignment > 0 ? Common::AlignUp(search_start, alignment)
-                                 : search_start;
+            aligned_base = alignment > 0 ? Common::AlignUp(search_start, alignment) : search_start;
         }
 
         if (dmem_area->second.GetEnd() > search_end) {

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -139,16 +139,21 @@ PAddr MemoryManager::Allocate(PAddr search_start, PAddr search_end, size_t size,
     alignment = alignment > 0 ? alignment : 16_KB;
 
     auto dmem_area = FindDmemArea(search_start);
-    auto mapping_start = search_start > dmem_area->second.base ? Common::AlignUp(search_start, alignment) : Common::AlignUp(dmem_area->second.base, alignment);
+    auto mapping_start = search_start > dmem_area->second.base
+                             ? Common::AlignUp(search_start, alignment)
+                             : Common::AlignUp(dmem_area->second.base, alignment);
     auto mapping_end = Common::AlignUp(mapping_start + size, alignment);
 
     // Find the first free, large enough dmem area in the range.
-    while ((!dmem_area->second.is_free || dmem_area->second.GetEnd() < mapping_end) && dmem_area != dmem_map.end()) {
+    while ((!dmem_area->second.is_free || dmem_area->second.GetEnd() < mapping_end) &&
+           dmem_area != dmem_map.end()) {
         // The current dmem_area isn't suitable, move to the next one.
         dmem_area++;
 
         // Update local variables based on the new dmem_area
-        mapping_start = search_start > dmem_area->second.base ? Common::AlignUp(search_start, alignment) : Common::AlignUp(dmem_area->second.base, alignment);
+        mapping_start = search_start > dmem_area->second.base
+                            ? Common::AlignUp(search_start, alignment)
+                            : Common::AlignUp(dmem_area->second.base, alignment);
         mapping_end = Common::AlignUp(mapping_start + size, alignment);
     }
 
@@ -637,19 +642,21 @@ int MemoryManager::DirectQueryAvailable(PAddr search_start, PAddr search_end, si
         const auto aligned_base = alignment > 0 ? Common::AlignUp(dmem_area->second.base, alignment)
                                                 : dmem_area->second.base;
         const auto alignment_size = aligned_base - dmem_area->second.base;
-        auto remaining_size = 
+        auto remaining_size =
             dmem_area->second.size >= alignment_size ? dmem_area->second.size - alignment_size : 0;
 
         if (dmem_area->second.base < search_start) {
             // We need to trim remaining_size to ignore addresses before search_start
-            remaining_size = remaining_size > (search_start - dmem_area->second.base) ?
-                             remaining_size - (search_start - dmem_area->second.base) : 0;
+            remaining_size = remaining_size > (search_start - dmem_area->second.base)
+                                 ? remaining_size - (search_start - dmem_area->second.base)
+                                 : 0;
         }
 
         if (dmem_area->second.GetEnd() > search_end) {
             // We need to trim remaining_size to ignore addresses beyond search_end
-            remaining_size = remaining_size > (search_start - dmem_area->second.base) ?
-                             remaining_size - (dmem_area->second.GetEnd() - search_end) : 0;
+            remaining_size = remaining_size > (search_start - dmem_area->second.base)
+                                 ? remaining_size - (dmem_area->second.GetEnd() - search_end)
+                                 : 0;
         }
 
         if (remaining_size > max_size) {


### PR DESCRIPTION
Both sceKernelAllocateDirectMemory and sceKernelAvailableDirectMemorySize handled the search area parameters improperly. This PR adjusts these functions to behave closer to observed hardware behavior.

Real hardware:
![image](https://github.com/user-attachments/assets/5eed3042-6ec7-4007-bfa5-116c014d560d)

Main:
![image](https://github.com/user-attachments/assets/5caf0132-0588-4a2e-901b-9d17cb3c176f)

This PR:
![image](https://github.com/user-attachments/assets/15241d55-1027-43df-ba0d-b087b3322da8)

I've also reduced the log severity of sceKernelGetDirectMemorySize, since it's behavior appears to be hardware accurate.

So far I've tested a few games and it seems like it doesn't break anything. Wouldn't hurt to have more people test though.