### PR TITLE
Changing the maximum amount of contributors on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Open a PR and we'll check it :)
 
 # Translations
 
-If you want to translate shadPS4 to your language we use [**crowdin**](https://crowdin.com/project/shadps4-emulator).
+If you want to translate shadPS4 to your language we use [**Crowdin**](https://crowdin.com/project/shadps4-emulator).
 # Contributors
 
 <a href="https://github.com/shadps4-emu/shadPS4/graphs/contributors">

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ If you want to translate shadPS4 to your language we use [**crowdin**](https://c
 # Contributors
 
 <a href="https://github.com/shadps4-emu/shadPS4/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=shadps4-emu/shadPS4&max=15">
+  <img src="https://contrib.rocks/image?repo=shadps4-emu/shadPS4&max=24">
 </a>
 
 


### PR DESCRIPTION
Completely useless change honestly, it's purely for esthetic reasons, not sure if that would make the page longer to charge or ask more out of GitHub, in this case I'd change it to 12 instead of the original 15, let me know.

Before: 
![Screenshot 2025-04-18 111145](https://github.com/user-attachments/assets/b52cf94d-8aa2-4234-a635-8543a304cab1)

After:
![Screenshot 2025-04-18 111300](https://github.com/user-attachments/assets/9de93674-4a1e-4e68-b459-99a3d93779dd)

Also added the capitalization to the Crowdin hyperlink.
