### PR TITLE
Emulate memory behavior of libSceGnmDriver initialization

### DIFF
--- a/src/core/libraries/gnmdriver/gnmdriver.cpp
+++ b/src/core/libraries/gnmdriver/gnmdriver.cpp
@@ -2804,7 +2804,7 @@ void RegisterlibSceGnmDriver(Core::Loader::SymbolsResolver* sym) {
     liverpool = std::make_unique<AmdGpu::Liverpool>();
     presenter = std::make_unique<Vulkan::Presenter>(*g_window, liverpool.get());
 
-    const int result = sceKernelGetCompiledSdkVersion(&sdk_version);
+    const s32 result = sceKernelGetCompiledSdkVersion(&sdk_version);
     if (result != ORBIS_OK) {
         sdk_version = 0;
     }

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -106,12 +106,6 @@ s32 PS4_SYSV_ABI sceKernelAvailableDirectMemorySize(u64 searchStart, u64 searchE
     if (physAddrOut == nullptr || sizeOut == nullptr) {
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
-    if (searchEnd > sceKernelGetDirectMemorySize()) {
-        return ORBIS_KERNEL_ERROR_EINVAL;
-    }
-    if (searchEnd <= searchStart) {
-        return ORBIS_KERNEL_ERROR_ENOMEM;
-    }
 
     auto* memory = Core::Memory::Instance();
 

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -118,7 +118,7 @@ void Linker::Execute(const std::vector<std::string> args) {
     ret = Libraries::Kernel::sceKernelAllocateDirectMemory(
         0, Libraries::Kernel::sceKernelGetDirectMemorySize(), 0x10000, 0x10000, 3, &phys_addr);
     if (ret == 0) {
-        void* addr{};
+        void* addr{reinterpret_cast<void*>(0xfe0000000)};
         ret = Libraries::Kernel::sceKernelMapNamedDirectMemory(&addr, 0x10000, 0x13, 0, phys_addr,
                                                                0x10000, "SceGnmDriver");
     }

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -108,15 +108,15 @@ void Linker::Execute(const std::vector<std::string> args) {
     static constexpr s64 InternalMemorySize = 0x1000000;
     void* addr_out{reinterpret_cast<void*>(KernelAllocBase)};
 
-    s32 ret = Libraries::Kernel::sceKernelMapNamedFlexibleMemory(
-        &addr_out, InternalMemorySize, 3, 0, "SceKernelInternalMemory");
+    s32 ret = Libraries::Kernel::sceKernelMapNamedFlexibleMemory(&addr_out, InternalMemorySize, 3,
+                                                                 0, "SceKernelInternalMemory");
     ASSERT_MSG(ret == 0, "Unable to perform sceKernelInternalMemory mapping");
 
     // Simulate libSceGnmDriver initialization, which maps a chunk of direct memory.
     // Some games fail without accurately emulating this behavior.
     s64 phys_addr{};
-    ret = Libraries::Kernel::sceKernelAllocateDirectMemory(0,
-        Libraries::Kernel::sceKernelGetDirectMemorySize(), 0x10000, 0x10000, 3, &phys_addr);
+    ret = Libraries::Kernel::sceKernelAllocateDirectMemory(
+        0, Libraries::Kernel::sceKernelGetDirectMemorySize(), 0x10000, 0x10000, 3, &phys_addr);
     if (ret == 0) {
         void* addr{};
         ret = Libraries::Kernel::sceKernelMapNamedDirectMemory(&addr, 0x10000, 0x13, 0, phys_addr,

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -108,9 +108,21 @@ void Linker::Execute(const std::vector<std::string> args) {
     static constexpr s64 InternalMemorySize = 0x1000000;
     void* addr_out{reinterpret_cast<void*>(KernelAllocBase)};
 
-    const s32 ret = Libraries::Kernel::sceKernelMapNamedFlexibleMemory(
+    s32 ret = Libraries::Kernel::sceKernelMapNamedFlexibleMemory(
         &addr_out, InternalMemorySize, 3, 0, "SceKernelInternalMemory");
     ASSERT_MSG(ret == 0, "Unable to perform sceKernelInternalMemory mapping");
+
+    // Simulate libSceGnmDriver initialization, which maps a chunk of direct memory.
+    // Some games fail without accurately emulating this behavior.
+    s64 phys_addr{};
+    ret = Libraries::Kernel::sceKernelAllocateDirectMemory(0,
+        Libraries::Kernel::sceKernelGetDirectMemorySize(), 0x10000, 0x10000, 3, &phys_addr);
+    if (ret == 0) {
+        void* addr{};
+        ret = Libraries::Kernel::sceKernelMapNamedDirectMemory(&addr, 0x10000, 0x13, 0, phys_addr,
+                                                               0x10000, "SceGnmDriver");
+    }
+    ASSERT_MSG(ret == 0, "Unable to emulate libSceGnmDriver initialization");
 
     main_thread.Run([this, module, args](std::stop_token) {
         Common::SetCurrentThreadName("GAME_MainThread");

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -655,7 +655,7 @@ int MemoryManager::DirectQueryAvailable(PAddr search_start, PAddr search_end, si
 
         if (dmem_area->second.GetEnd() > search_end) {
             // We need to trim remaining_size to ignore addresses beyond search_end
-            remaining_size = remaining_size > (search_start - dmem_area->second.base)
+            remaining_size = remaining_size > (dmem_area->second.GetEnd() - search_end)
                                  ? remaining_size - (dmem_area->second.GetEnd() - search_end)
                                  : 0;
         }


### PR DESCRIPTION
Some games check if sceKernelAllocateDirectMemory failed by looking at the phys_addr_out returned, treating a returned value of 0 as a failed call. On real hardware, a phys_addr_out of 0 is never returned due to libSceGnmDriver's initialization performing a direct memory mapping. This PR naively implements this by adding the relevant code to Linker::Execute, similar to how I handled the SceKernelInternalMemory mapping.

Also includes a hotfix for sceKernelAvailableDirectMemorySize, as emulating this mapping revealed a typo in my code.

This PR fixes an early crash in NBA2K18 (CUSA08500), and fixes the remaining discrepancy shown in the tests I did for https://github.com/shadps4-emu/shadPS4/pull/2803