### PR TITLE
Revert libSceGnmDriver library init emulation

### DIFF
--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -112,18 +112,6 @@ void Linker::Execute(const std::vector<std::string> args) {
                                                                  0, "SceKernelInternalMemory");
     ASSERT_MSG(ret == 0, "Unable to perform sceKernelInternalMemory mapping");
 
-    // Simulate libSceGnmDriver initialization, which maps a chunk of direct memory.
-    // Some games fail without accurately emulating this behavior.
-    s64 phys_addr{};
-    ret = Libraries::Kernel::sceKernelAllocateDirectMemory(
-        0, Libraries::Kernel::sceKernelGetDirectMemorySize(), 0x10000, 0x10000, 3, &phys_addr);
-    if (ret == 0) {
-        void* addr{reinterpret_cast<void*>(0xfe0000000)};
-        ret = Libraries::Kernel::sceKernelMapNamedDirectMemory(&addr, 0x10000, 0x13, 0, phys_addr,
-                                                               0x10000, "SceGnmDriver");
-    }
-    ASSERT_MSG(ret == 0, "Unable to emulate libSceGnmDriver initialization");
-
     main_thread.Run([this, module, args](std::stop_token) {
         Common::SetCurrentThreadName("GAME_MainThread");
         LoadSharedLibraries();


### PR DESCRIPTION
Some games map memory extremely early in game code, before most modules initialize. In cases like these, if games are providing high alignments to allocation calls, they may not be able to allocate as much memory as they expect due to the misplaced SceGnmDriver allocation.
Until there's a better way to accurately emulate libSceGnmDriver's initialization, games will break.

This partial revert of https://github.com/shadps4-emu/shadPS4/pull/2807 fixes the regression in games using the GFD engine, and un-fixes NBA titles.