### PR TITLE
Skip PromoteFormatToDepth in the case of a dummy image

### DIFF
--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -219,6 +219,19 @@ struct Image {
         return image;
     }
 
+    static constexpr Image DummyDepth() {
+        Image image{};
+        image.data_format = u64(DataFormat::Format32);
+        image.num_format = u64(NumberFormat::Float);
+        image.dst_sel_x = u64(CompSwizzle::Red);
+        image.dst_sel_y = u64(CompSwizzle::Green);
+        image.dst_sel_z = u64(CompSwizzle::Blue);
+        image.dst_sel_w = u64(CompSwizzle::Alpha);
+        image.tiling_index = u64(TilingMode::Texture_MicroTiled);
+        image.type = u64(ImageType::Color2D);
+        return image;
+    }
+
     bool Valid() const {
         return (type & 0x8u) != 0;
     }

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.h
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.h
@@ -100,14 +100,13 @@ static inline bool IsFormatStencilCompatible(vk::Format fmt) {
     }
 }
 
-static inline vk::Format PromoteFormatToDepth(vk::Format fmt, bool& valid) {
+static inline vk::Format PromoteFormatToDepth(vk::Format fmt) {
     if (fmt == vk::Format::eR32Sfloat || fmt == vk::Format::eR32Uint) {
         return vk::Format::eD32Sfloat;
     } else if (fmt == vk::Format::eR16Unorm) {
         return vk::Format::eD16Unorm;
     }
-    valid = false;
-    return fmt; // move the unreachable one step up to be able to print more info
+    return vk::Format::eUndefined;
 }
 
 } // namespace Vulkan::LiverpoolToVK

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.h
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.h
@@ -100,13 +100,14 @@ static inline bool IsFormatStencilCompatible(vk::Format fmt) {
     }
 }
 
-static inline vk::Format PromoteFormatToDepth(vk::Format fmt) {
+static inline vk::Format PromoteFormatToDepth(vk::Format fmt, bool& valid) {
     if (fmt == vk::Format::eR32Sfloat || fmt == vk::Format::eR32Uint) {
         return vk::Format::eD32Sfloat;
     } else if (fmt == vk::Format::eR16Unorm) {
         return vk::Format::eD16Unorm;
     }
-    UNREACHABLE_MSG("Unexpected depth format {}", vk::to_string(fmt));
+    valid = false;
+    return fmt; // move the unreachable one step up to be able to print more info
 }
 
 } // namespace Vulkan::LiverpoolToVK

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -134,6 +134,8 @@ ImageInfo::ImageInfo(const AmdGpu::Image& image, const Shader::ImageResource& de
             "PromoteFormatToDepth failed, info dump: format: {}, size: {}x{}, data_format: {}",
             vk::to_string(pixel_format), image.width + 1, image.height + 1,
             AmdGpu::NameOf(image.GetDataFmt()));
+    } else if (image.width == 0 && image.height == 0) {
+        pixel_format = vk::Format::eD32Sfloat;
     }
     type = ConvertImageType(image.GetType());
     props.is_tiled = image.IsTiled();

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -129,13 +129,14 @@ ImageInfo::ImageInfo(const AmdGpu::Image& image, const Shader::ImageResource& de
     // Override format if image is forced to be a depth target, except if the image is a dummy one
     if (desc.is_depth && (image.width != 0 && image.height != 0)) {
         pixel_format = Vulkan::LiverpoolToVK::PromoteFormatToDepth(pixel_format);
-        ASSERT_MSG(
-            pixel_format != vk::Format::eUndefined,
-            "PromoteFormatToDepth failed, info dump: format: {}, size: {}x{}, data_format: {}",
-            vk::to_string(pixel_format), image.width + 1, image.height + 1,
-            AmdGpu::NameOf(image.GetDataFmt()));
-    } else if (image.width == 0 && image.height == 0) {
-        pixel_format = vk::Format::eD32Sfloat;
+        if (pixel_format == vk::Format::eUndefined) {
+            ASSERT_MSG(
+                image.width == 0 && image.height == 0,
+                "PromoteFormatToDepth failed, info dump: format: {}, size: {}x{}, data_format: {}",
+                vk::to_string(pixel_format), image.width, image.height,
+                AmdGpu::NameOf(image.GetDataFmt()));
+            pixel_format = vk::Format::eD32Sfloat;
+        }
     }
     type = ConvertImageType(image.GetType());
     props.is_tiled = image.IsTiled();

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -128,10 +128,9 @@ ImageInfo::ImageInfo(const AmdGpu::Image& image, const Shader::ImageResource& de
     pixel_format = LiverpoolToVK::SurfaceFormat(image.GetDataFmt(), image.GetNumberFmt());
     // Override format if image is forced to be a depth target, except if the image is a dummy one
     if (desc.is_depth && (image.width != 0 && image.height != 0)) {
-        bool valid = true;
-        pixel_format = Vulkan::LiverpoolToVK::PromoteFormatToDepth(pixel_format, valid);
+        pixel_format = Vulkan::LiverpoolToVK::PromoteFormatToDepth(pixel_format);
         ASSERT_MSG(
-            valid,
+            pixel_format != vk::Format::eUndefined,
             "PromoteFormatToDepth failed, info dump: format: {}, size: {}x{}, data_format: {}",
             vk::to_string(pixel_format), image.width + 1, image.height + 1,
             AmdGpu::NameOf(image.GetDataFmt()));

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -127,14 +127,18 @@ ImageInfo::ImageInfo(const AmdGpu::Image& image, const Shader::ImageResource& de
     tiling_mode = image.GetTilingMode();
     pixel_format = LiverpoolToVK::SurfaceFormat(image.GetDataFmt(), image.GetNumberFmt());
     // Override format if image is forced to be a depth target, except if the image is a dummy one
-    if (desc.is_depth && (image.width != 0 && image.height != 0)) {
-        pixel_format = Vulkan::LiverpoolToVK::PromoteFormatToDepth(pixel_format);
-        if (pixel_format == vk::Format::eUndefined) {
-            ASSERT_MSG(
-                image.width == 0 && image.height == 0,
-                "PromoteFormatToDepth failed, info dump: format: {}, size: {}x{}, data_format: {}",
-                vk::to_string(pixel_format), image.width, image.height,
-                AmdGpu::NameOf(image.GetDataFmt()));
+    if (desc.is_depth) {
+        if (image.width != 0 && image.height != 0) {
+            pixel_format = Vulkan::LiverpoolToVK::PromoteFormatToDepth(pixel_format);
+            if (pixel_format == vk::Format::eUndefined) {
+                ASSERT_MSG(image.width == 0 && image.height == 0,
+                           "PromoteFormatToDepth failed, info dump: format: {}, size: {}x{}, "
+                           "data_format: {}",
+                           vk::to_string(pixel_format), image.width, image.height,
+                           AmdGpu::NameOf(image.GetDataFmt()));
+                pixel_format = vk::Format::eD32Sfloat;
+            }
+        } else {
             pixel_format = vk::Format::eD32Sfloat;
         }
     }

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -40,12 +40,14 @@ ImageViewInfo::ImageViewInfo(const AmdGpu::Image& image, const Shader::ImageReso
     // Override format if image is forced to be a depth target, except if the image is a dummy one
     if (desc.is_depth && (image.width != 0 && image.height != 0)) {
         format = Vulkan::LiverpoolToVK::PromoteFormatToDepth(format);
-        ASSERT_MSG(
-            format != vk::Format::eUndefined,
-            "PromoteFormatToDepth failed, info dump: format: {}, size: {}x{}, data_format: {}",
-            vk::to_string(format), image.width, image.height, AmdGpu::NameOf(image.GetDataFmt()));
-    } else if (image.width == 0 && image.height == 0) {
-        format = vk::Format::eD32Sfloat;
+        if (format == vk::Format::eUndefined) {
+            ASSERT_MSG(
+                image.width == 0 && image.height == 0,
+                "PromoteFormatToDepth failed, info dump: format: {}, size: {}x{}, data_format: {}",
+                vk::to_string(format), image.width, image.height,
+                AmdGpu::NameOf(image.GetDataFmt()));
+            format = vk::Format::eD32Sfloat;
+        }
     }
 
     range.base.level = image.base_level;

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -44,6 +44,8 @@ ImageViewInfo::ImageViewInfo(const AmdGpu::Image& image, const Shader::ImageReso
             format != vk::Format::eUndefined,
             "PromoteFormatToDepth failed, info dump: format: {}, size: {}x{}, data_format: {}",
             vk::to_string(format), image.width, image.height, AmdGpu::NameOf(image.GetDataFmt()));
+    } else if (image.width == 0 && image.height == 0) {
+        format = vk::Format::eD32Sfloat;
     }
 
     range.base.level = image.base_level;

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -38,14 +38,18 @@ ImageViewInfo::ImageViewInfo(const AmdGpu::Image& image, const Shader::ImageReso
     }
     format = Vulkan::LiverpoolToVK::SurfaceFormat(dfmt, nfmt);
     // Override format if image is forced to be a depth target, except if the image is a dummy one
-    if (desc.is_depth && (image.width != 0 && image.height != 0)) {
-        format = Vulkan::LiverpoolToVK::PromoteFormatToDepth(format);
-        if (format == vk::Format::eUndefined) {
-            ASSERT_MSG(
-                image.width == 0 && image.height == 0,
-                "PromoteFormatToDepth failed, info dump: format: {}, size: {}x{}, data_format: {}",
-                vk::to_string(format), image.width, image.height,
-                AmdGpu::NameOf(image.GetDataFmt()));
+    if (desc.is_depth) {
+        if (image.width != 0 && image.height != 0) {
+            format = Vulkan::LiverpoolToVK::PromoteFormatToDepth(format);
+            if (format == vk::Format::eUndefined) {
+                ASSERT_MSG(image.width == 0 && image.height == 0,
+                           "PromoteFormatToDepth failed, info dump: format: {}, size: {}x{}, "
+                           "data_format: {}",
+                           vk::to_string(format), image.width, image.height,
+                           AmdGpu::NameOf(image.GetDataFmt()));
+                format = vk::Format::eD32Sfloat;
+            }
+        } else {
             format = vk::Format::eD32Sfloat;
         }
     }

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -39,10 +39,9 @@ ImageViewInfo::ImageViewInfo(const AmdGpu::Image& image, const Shader::ImageReso
     format = Vulkan::LiverpoolToVK::SurfaceFormat(dfmt, nfmt);
     // Override format if image is forced to be a depth target, except if the image is a dummy one
     if (desc.is_depth && (image.width != 0 && image.height != 0)) {
-        bool valid = true;
-        format = Vulkan::LiverpoolToVK::PromoteFormatToDepth(format, valid);
+        format = Vulkan::LiverpoolToVK::PromoteFormatToDepth(format);
         ASSERT_MSG(
-            valid,
+            format != vk::Format::eUndefined,
             "PromoteFormatToDepth failed, info dump: format: {}, size: {}x{}, data_format: {}",
             vk::to_string(format), image.width, image.height, AmdGpu::NameOf(image.GetDataFmt()));
     }

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -37,8 +37,14 @@ ImageViewInfo::ImageViewInfo(const AmdGpu::Image& image, const Shader::ImageReso
         nfmt = AmdGpu::NumberFormat::Unorm;
     }
     format = Vulkan::LiverpoolToVK::SurfaceFormat(dfmt, nfmt);
-    if (desc.is_depth) {
-        format = Vulkan::LiverpoolToVK::PromoteFormatToDepth(format);
+    // Override format if image is forced to be a depth target, except if the image is a dummy one
+    if (desc.is_depth && (image.width != 0 && image.height != 0)) {
+        bool valid = true;
+        format = Vulkan::LiverpoolToVK::PromoteFormatToDepth(format, valid);
+        ASSERT_MSG(
+            valid,
+            "PromoteFormatToDepth failed, info dump: format: {}, size: {}x{}, data_format: {}",
+            vk::to_string(format), image.width, image.height, AmdGpu::NameOf(image.GetDataFmt()));
     }
 
     range.base.level = image.base_level;


### PR DESCRIPTION
Attempts to solve some cases of the `PromoteFormatToDepth` unreachable, by not calling the function if the image is a dummy 1x1 image, and in those cases, the format is also set to be eD32Sfloat, so it is a valid depth image.
Also adds more debug info in case of a failure