### PR TITLE
making init func work after load modules 

### DIFF
--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -333,7 +333,7 @@ void Emulator::LoadSystemModules(const std::string& game_serial) {
             LOG_INFO(Loader, "Loading {} from game serial file {}", entry.path().string(),
                      game_serial);
             if (linker->LoadModule(entry.path()) == -1) {
-                entry.path().string();
+                LOG_ERROR(Loader, "Failed to load module: {}", entry.path().string());
             }
         }
     }

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -313,9 +313,6 @@ void Emulator::LoadSystemModules(const std::string& game_serial) {
             LOG_INFO(Loader, "Loading {}", it->string());
             if (linker->LoadModule(*it) != -1) {
                 loaded = true;
-                if (init_func) {
-                    init_func(&linker->GetHLESymbols());
-                }
             }
         }
         if (!loaded) {

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -312,7 +312,7 @@ void Emulator::LoadSystemModules(const std::string& game_serial) {
             LOG_INFO(Loader, "Loading {}", it->string());
             if (linker->LoadModule(*it) != -1) {
                 if (init_func) {
-                    init_func();
+                    init_func(&linker->GetHLESymbols());
                 }
             }
         }

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -311,7 +311,9 @@ void Emulator::LoadSystemModules(const std::string& game_serial) {
         if (it != found_modules.end()) {
             LOG_INFO(Loader, "Loading {}", it->string());
             if (linker->LoadModule(*it) != -1) {
-                continue;
+                if (init_func) {
+                    init_func();
+                }
             }
         }
         if (init_func) {


### PR DESCRIPTION
right now it seems init func is not working properly, this helps init func to be able to pass any custom sycalls or anything similar and ensure any customization gets invoked after loading the module adding a check and simplifying it a bit. 