### PR TITLE
ci: Fix macOS SDL build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,11 +206,11 @@ jobs:
         mkdir upload
         mv ${{github.workspace}}/build/shadps4 upload
         cp ${{github.workspace}}/build/externals/MoltenVK/libMoltenVK.dylib upload
-        tar cf shadps4-macos-sdl.tar.gz -C upload .
+        install_name_tool -add_rpath "@executable_path" upload/shadps4
     - uses: actions/upload-artifact@v4
       with:
         name: shadps4-macos-sdl-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}
-        path: shadps4-macos-sdl.tar.gz
+        path: upload/
 
   macos-qt:
     runs-on: macos-15


### PR DESCRIPTION
* Fix macOS SDL build not having right rpath to find `libMoltenVK.dylib` next to it.
* Fix macOS SDL build being double-packed in a zip and a tar.gz