### PR TITLE
sceKernelAllocateDirectMemory hotfixes

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -151,9 +151,7 @@ PAddr MemoryManager::Allocate(PAddr search_start, PAddr search_end, size_t size,
         dmem_area++;
 
         // Update local variables based on the new dmem_area
-        mapping_start = search_start > dmem_area->second.base
-                            ? Common::AlignUp(search_start, alignment)
-                            : Common::AlignUp(dmem_area->second.base, alignment);
+        mapping_start = Common::AlignUp(dmem_area->second.base, alignment);
         mapping_end = mapping_start + size;
     }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -142,7 +142,7 @@ PAddr MemoryManager::Allocate(PAddr search_start, PAddr search_end, size_t size,
     auto mapping_start = search_start > dmem_area->second.base
                              ? Common::AlignUp(search_start, alignment)
                              : Common::AlignUp(dmem_area->second.base, alignment);
-    auto mapping_end = Common::AlignUp(mapping_start + size, alignment);
+    auto mapping_end = mapping_start + size;
 
     // Find the first free, large enough dmem area in the range.
     while ((!dmem_area->second.is_free || dmem_area->second.GetEnd() < mapping_end) &&
@@ -154,7 +154,7 @@ PAddr MemoryManager::Allocate(PAddr search_start, PAddr search_end, size_t size,
         mapping_start = search_start > dmem_area->second.base
                             ? Common::AlignUp(search_start, alignment)
                             : Common::AlignUp(dmem_area->second.base, alignment);
-        mapping_end = Common::AlignUp(mapping_start + size, alignment);
+        mapping_end = mapping_start + size;
     }
 
     if (dmem_area == dmem_map.end()) {


### PR DESCRIPTION
This should (hopefully) be the last time I'll need to PR fixes to this thing.

The main issue this addresses is that the end of an allocation doesn't need to be aligned to our alignment value. Fixing this should address the regression seen in https://github.com/shadps4-emu/shadps4-game-compatibility/issues/451

I've also cleaned up the logic slightly, as we should never need to check against search_start in the while loop. That code will never execute on a dmem area containing the search_start address, since the dmem area returned by FindDmemArea will contain search_start, and the while loop only triggers when we need to iterate past that mapping.