### PR TITLE
VideoOut event cleanup

### DIFF
--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -106,8 +106,8 @@ struct EqueueEvent {
                 if (counter != 0xf) {
                     counter++;
                 }
-                event.data = (time & 0xfff) | (counter << 0xc) |
-                             (event_hint_raw & 0xffffffffffff0000);
+                event.data =
+                    (time & 0xfff) | (counter << 0xc) | (event_hint_raw & 0xffffffffffff0000);
             }
         }
     }

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -5,7 +5,6 @@
 
 #include <condition_variable>
 #include <mutex>
-#include <bit>
 #include <string>
 #include <vector>
 #include <boost/asio/steady_timer.hpp>

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -107,7 +107,7 @@ struct EqueueEvent {
                 if (counter != 0xf) {
                     counter++;
                 }
-                event.data = (time & 0xfff) | (counter << 12) | (event_hint_raw & 0xffffffffffff);
+                event.data = (time & 0xfff) | (counter << 0xc) | (event_hint_raw & 0xffffffffffff);
             }
         }
     }

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -5,6 +5,7 @@
 
 #include <condition_variable>
 #include <mutex>
+#include <bit>
 #include <string>
 #include <vector>
 #include <boost/asio/steady_timer.hpp>
@@ -61,6 +62,18 @@ struct SceKernelEvent {
     void* udata = nullptr; /* opaque user data identifier */
 };
 
+struct DceHint {
+    u64 event_id : 8;
+    u64 video_id : 8;
+    u64 flip_arg : 48;
+};
+
+struct DceData {
+    u64 time : 12;
+    u64 count : 4;
+    u64 flip_arg : 48;
+};
+
 struct EqueueEvent {
     SceKernelEvent event;
     void* data = nullptr;
@@ -84,19 +97,17 @@ struct EqueueEvent {
 
     void TriggerDisplay(void* data) {
         is_triggered = true;
-        auto hint = reinterpret_cast<u64>(data);
-        if (hint != 0) {
-            auto hint_h = static_cast<u32>(hint >> 8) & 0xFFFFFF;
-            auto ident_h = static_cast<u32>(event.ident >> 40);
-            if ((static_cast<u32>(hint) & 0xFF) == event.ident && event.ident != 0xFE &&
-                ((hint_h ^ ident_h) & 0xFF) == 0) {
+        if (data != nullptr) {
+            auto event_data = static_cast<DceData>(event.data);
+            auto event_hint_raw = reinterpret_cast<u64>(data);
+            auto event_hint = static_cast<DceHint>(event_hint_raw);
+            if (event_hint.event_id == event.ident && event.ident != 0xfe) {
                 auto time = Common::FencedRDTSC();
-                auto mask = 0xF000;
-                if ((static_cast<u32>(event.data) & 0xF000) != 0xF000) {
-                    mask = (static_cast<u32>(event.data) + 0x1000) & 0xF000;
+                auto counter = event_data.count;
+                if (counter != 0xf) {
+                    counter++;
                 }
-                event.data = (mask | static_cast<u64>(static_cast<u32>(time) & 0xFFF) |
-                              (hint & 0xFFFFFFFFFFFF0000));
+                event.data = (time & 0xfff) | (counter << 12) | (event_hint_raw & 0xffffffffffff);
             }
         }
     }

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -106,7 +106,8 @@ struct EqueueEvent {
                 if (counter != 0xf) {
                     counter++;
                 }
-                event.data = (time & 0xfff) | (counter << 0xc) | (event_hint_raw & 0xffffffffffff);
+                event.data = (time & 0xfff) | (counter << 0xc) |
+                             (event_hint_raw & 0xffffffffffff0000);
             }
         }
     }

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -61,13 +61,13 @@ struct SceKernelEvent {
     void* udata = nullptr; /* opaque user data identifier */
 };
 
-struct DceHint {
+struct OrbisVideoOutEventHint {
     u64 event_id : 8;
     u64 video_id : 8;
     u64 flip_arg : 48;
 };
 
-struct DceData {
+struct OrbisVideoOutEventData {
     u64 time : 12;
     u64 count : 4;
     u64 flip_arg : 48;
@@ -97,9 +97,9 @@ struct EqueueEvent {
     void TriggerDisplay(void* data) {
         is_triggered = true;
         if (data != nullptr) {
-            auto event_data = static_cast<DceData>(event.data);
+            auto event_data = static_cast<OrbisVideoOutEventData>(event.data);
             auto event_hint_raw = reinterpret_cast<u64>(data);
-            auto event_hint = static_cast<DceHint>(event_hint_raw);
+            auto event_hint = static_cast<OrbisVideoOutEventHint>(event_hint_raw);
             if (event_hint.event_id == event.ident && event.ident != 0xfe) {
                 auto time = Common::FencedRDTSC();
                 auto counter = event_data.count;

--- a/src/core/libraries/videoout/video_out.cpp
+++ b/src/core/libraries/videoout/video_out.cpp
@@ -233,7 +233,7 @@ s32 PS4_SYSV_ABI sceVideoOutGetEventCount(const Kernel::SceKernelEvent* ev) {
         return ORBIS_VIDEO_OUT_ERROR_INVALID_EVENT;
     }
 
-    auto event_data = static_cast<VideoOutEventData>(ev->data);
+    auto event_data = static_cast<OrbisVideoOutEventData>(ev->data);
     return event_data.count;
 }
 

--- a/src/core/libraries/videoout/video_out.cpp
+++ b/src/core/libraries/videoout/video_out.cpp
@@ -220,7 +220,7 @@ s32 PS4_SYSV_ABI sceVideoOutGetEventData(const Kernel::SceKernelEvent* ev, s64* 
     if (ev->ident != static_cast<s32>(OrbisVideoOutInternalEventId::Flip) || ev->data == 0) {
         *data = event_data;
     } else {
-        *data = event_data | 0xFFFF000000000000;
+        *data = event_data | 0xffff000000000000;
     }
     return ORBIS_OK;
 }
@@ -233,7 +233,8 @@ s32 PS4_SYSV_ABI sceVideoOutGetEventCount(const Kernel::SceKernelEvent* ev) {
         return ORBIS_VIDEO_OUT_ERROR_INVALID_EVENT;
     }
 
-    return (ev->data >> 0xc) & 0xf;
+    auto event_data = static_cast<VideoOutEventData>(ev->data);
+    return event_data.count;
 }
 
 s32 PS4_SYSV_ABI sceVideoOutGetFlipStatus(s32 handle, FlipStatus* status) {

--- a/src/core/libraries/videoout/video_out.h
+++ b/src/core/libraries/videoout/video_out.h
@@ -111,6 +111,12 @@ struct SceVideoOutColorSettings {
     u32 reserved[3];
 };
 
+struct VideoOutEventData {
+    u64 time : 12;
+    u64 count : 4;
+    u64 flip_arg : 48;
+};
+
 void PS4_SYSV_ABI sceVideoOutSetBufferAttribute(BufferAttribute* attribute, PixelFormat pixelFormat,
                                                 u32 tilingMode, u32 aspectRatio, u32 width,
                                                 u32 height, u32 pitchInPixel);

--- a/src/core/libraries/videoout/video_out.h
+++ b/src/core/libraries/videoout/video_out.h
@@ -111,7 +111,7 @@ struct SceVideoOutColorSettings {
     u32 reserved[3];
 };
 
-struct VideoOutEventData {
+struct OrbisVideoOutEventData {
     u64 time : 12;
     u64 count : 4;
     u64 flip_arg : 48;

--- a/src/core/libraries/videoout/video_out.h
+++ b/src/core/libraries/videoout/video_out.h
@@ -134,8 +134,8 @@ s32 PS4_SYSV_ABI sceVideoOutGetResolutionStatus(s32 handle, SceVideoOutResolutio
 s32 PS4_SYSV_ABI sceVideoOutOpen(SceUserServiceUserId userId, s32 busType, s32 index,
                                  const void* param);
 s32 PS4_SYSV_ABI sceVideoOutClose(s32 handle);
-int PS4_SYSV_ABI sceVideoOutGetEventId(const Kernel::SceKernelEvent* ev);
-int PS4_SYSV_ABI sceVideoOutGetEventData(const Kernel::SceKernelEvent* ev, int64_t* data);
+s32 PS4_SYSV_ABI sceVideoOutGetEventId(const Kernel::SceKernelEvent* ev);
+s32 PS4_SYSV_ABI sceVideoOutGetEventData(const Kernel::SceKernelEvent* ev, s64* data);
 s32 PS4_SYSV_ABI sceVideoOutColorSettingsSetGamma(SceVideoOutColorSettings* settings, float gamma);
 s32 PS4_SYSV_ABI sceVideoOutAdjustColor(s32 handle, const SceVideoOutColorSettings* settings);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -154,7 +154,7 @@ int main(int argc, char* argv[]) {
     // If no game directory is set and no command line argument, prompt for it
     if (Config::getGameInstallDirs().empty()) {
         std::cout << "Warning: No game folder set, please set it by calling shadps4"
-                     " with the --add-game-folder <folder_name> argument";
+                     " with the --add-game-folder <folder_name> argument\n";
     }
 
     if (!has_game_argument) {


### PR DESCRIPTION
Cleans up the code for triggering VideoOut events, based on fpPS4's current code.
Also adds a VideoOutEventData struct to libSceVideoOut, to make our sceVideoOutGetEventCount implementation look cleaner.

Also includes a fix for a very minor annoyance that got hidden in a now-deleted PR.

This PR doesn't appear to regress any games dependent on this behavior in my testing.