### PR TITLE
Implement sceKernelGetModuleInfo, sceKernelGetModuleInfoInternal, and sceKernelGetModuleList

### DIFF
--- a/src/core/libraries/kernel/process.cpp
+++ b/src/core/libraries/kernel/process.cpp
@@ -127,6 +127,41 @@ int PS4_SYSV_ABI sceKernelGetModuleInfoFromAddr(VAddr addr, int flags,
     return ORBIS_OK;
 }
 
+s32 PS4_SYSV_ABI sceKernelGetModuleInfo(s32 handle, Core::OrbisKernelModuleInfo* info) {
+    auto* linker = Common::Singleton<Core::Linker>::Instance();
+    auto* module = linker->GetModule(handle);
+    if (module == nullptr) {
+        return ORBIS_KERNEL_ERROR_ESRCH;
+    }
+    *info = module->GetModuleInfo();
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceKernelGetModuleInfoInternal(s32 handle, Core::OrbisKernelModuleInfoEx* info) {
+    auto* linker = Common::Singleton<Core::Linker>::Instance();
+    auto* module = linker->GetModule(handle);
+    if (module == nullptr) {
+        return ORBIS_KERNEL_ERROR_ESRCH;
+    }
+    *info = module->GetModuleInfoEx();
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceKernelGetModuleList(s32* handles, u64 num_array, u64* out_count) {
+    auto* linker = Common::Singleton<Core::Linker>::Instance();
+    
+    u64 count = 0;
+    auto* module = linker->GetModule(count);
+    while (module != nullptr && count < num_array) {
+        handles[count] = count;
+        count++;
+        module = linker->GetModule(count);
+    }
+
+    *out_count = count;
+    return ORBIS_OK;
+}
+
 s32 PS4_SYSV_ABI exit(s32 status) {
     UNREACHABLE_MSG("Exiting with status code {}", status);
     return 0;
@@ -141,6 +176,9 @@ void RegisterProcess(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("LwG8g3niqwA", "libkernel", 1, "libkernel", 1, 1, sceKernelDlsym);
     LIB_FUNCTION("RpQJJVKTiFM", "libkernel", 1, "libkernel", 1, 1, sceKernelGetModuleInfoForUnwind);
     LIB_FUNCTION("f7KBOafysXo", "libkernel", 1, "libkernel", 1, 1, sceKernelGetModuleInfoFromAddr);
+    LIB_FUNCTION("kUpgrXIrz7Q", "libkernel", 1, "libkernel", 1, 1, sceKernelGetModuleInfo);
+    LIB_FUNCTION("HZO7xOos4xc", "libkernel", 1, "libkernel", 1, 1, sceKernelGetModuleInfoInternal);
+    LIB_FUNCTION("IuxnUuXk6Bg", "libkernel", 1, "libkernel", 1, 1, sceKernelGetModuleList);
     LIB_FUNCTION("6Z83sYWFlA8", "libkernel", 1, "libkernel", 1, 1, exit);
 }
 

--- a/src/core/libraries/kernel/process.cpp
+++ b/src/core/libraries/kernel/process.cpp
@@ -149,7 +149,7 @@ s32 PS4_SYSV_ABI sceKernelGetModuleInfoInternal(s32 handle, Core::OrbisKernelMod
 
 s32 PS4_SYSV_ABI sceKernelGetModuleList(s32* handles, u64 num_array, u64* out_count) {
     auto* linker = Common::Singleton<Core::Linker>::Instance();
-    
+
     u64 count = 0;
     auto* module = linker->GetModule(count);
     while (module != nullptr && count < num_array) {

--- a/src/core/libraries/kernel/process.cpp
+++ b/src/core/libraries/kernel/process.cpp
@@ -148,14 +148,21 @@ s32 PS4_SYSV_ABI sceKernelGetModuleInfoInternal(s32 handle, Core::OrbisKernelMod
 }
 
 s32 PS4_SYSV_ABI sceKernelGetModuleList(s32* handles, u64 num_array, u64* out_count) {
-    auto* linker = Common::Singleton<Core::Linker>::Instance();
+    if (handles == nullptr || out_count == nullptr) {
+        return ORBIS_KERNEL_ERROR_EFAULT;
+    }
 
+    auto* linker = Common::Singleton<Core::Linker>::Instance();
     u64 count = 0;
     auto* module = linker->GetModule(count);
     while (module != nullptr && count < num_array) {
         handles[count] = count;
         count++;
         module = linker->GetModule(count);
+    }
+
+    if (count == num_array && module != nullptr) {
+        return ORBIS_KERNEL_ERROR_ENOMEM;
     }
 
     *out_count = count;

--- a/src/core/libraries/kernel/process.cpp
+++ b/src/core/libraries/kernel/process.cpp
@@ -128,6 +128,13 @@ int PS4_SYSV_ABI sceKernelGetModuleInfoFromAddr(VAddr addr, int flags,
 }
 
 s32 PS4_SYSV_ABI sceKernelGetModuleInfo(s32 handle, Core::OrbisKernelModuleInfo* info) {
+    if (info == nullptr) {
+        return ORBIS_KERNEL_ERROR_EFAULT;
+    }
+    if (info->st_size != sizeof(Core::OrbisKernelModuleInfo)) {
+        return ORBIS_KERNEL_ERROR_EINVAL;
+    }
+    
     auto* linker = Common::Singleton<Core::Linker>::Instance();
     auto* module = linker->GetModule(handle);
     if (module == nullptr) {
@@ -138,6 +145,13 @@ s32 PS4_SYSV_ABI sceKernelGetModuleInfo(s32 handle, Core::OrbisKernelModuleInfo*
 }
 
 s32 PS4_SYSV_ABI sceKernelGetModuleInfoInternal(s32 handle, Core::OrbisKernelModuleInfoEx* info) {
+    if (info == nullptr) {
+        return ORBIS_KERNEL_ERROR_EFAULT;
+    }
+    if (info->st_size != sizeof(Core::OrbisKernelModuleInfoEx)) {
+        return ORBIS_KERNEL_ERROR_EINVAL;
+    }
+
     auto* linker = Common::Singleton<Core::Linker>::Instance();
     auto* module = linker->GetModule(handle);
     if (module == nullptr) {

--- a/src/core/libraries/kernel/process.cpp
+++ b/src/core/libraries/kernel/process.cpp
@@ -134,7 +134,7 @@ s32 PS4_SYSV_ABI sceKernelGetModuleInfo(s32 handle, Core::OrbisKernelModuleInfo*
     if (info->st_size != sizeof(Core::OrbisKernelModuleInfo)) {
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
-    
+
     auto* linker = Common::Singleton<Core::Linker>::Instance();
     auto* module = linker->GetModule(handle);
     if (module == nullptr) {

--- a/src/core/linker.h
+++ b/src/core/linker.h
@@ -83,7 +83,7 @@ public:
     }
 
     Module* GetModule(s32 index) const {
-        if (index >= 0 || index < m_modules.size()) {
+        if (index >= 0 && index < m_modules.size()) {
             return m_modules.at(index).get();
         }
         return nullptr;

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -135,10 +135,14 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
         if (do_map) {
             elf.LoadSegment(segment_addr, phdr.p_offset, phdr.p_filesz);
         }
-        auto& segment = info.segments[info.num_segments++];
-        segment.address = segment_addr;
-        segment.prot = phdr.p_flags;
-        segment.size = GetAlignedSize(phdr);
+        if (info.num_segments < 4) {
+            auto& segment = info.segments[info.num_segments++];
+            segment.address = segment_addr;
+            segment.prot = phdr.p_flags;
+            segment.size = GetAlignedSize(phdr);
+        } else {
+            LOG_ERROR(Core_Linker, "Attempting to add too many segments!");
+        }
     };
 
     for (u16 i = 0; i < elf_header.e_phnum; i++) {


### PR DESCRIPTION
These are implemented based on real hardware behavior and a homebrew sample written by red_prig.
Also contains a bugfix for a broken index check in Linker::GetModule, and prevents possible OOB memory writes in Module::LoadModuleToMemory