### PR TITLE
Update ime_dialog.h

### DIFF
--- a/src/core/libraries/ime/ime_dialog.h
+++ b/src/core/libraries/ime/ime_dialog.h
@@ -13,7 +13,7 @@ class SymbolsResolver;
 
 namespace Libraries::ImeDialog {
 
-constexpr u32 ORBIS_IME_DIALOG_MAX_TEXT_LENGTH = 0x78;
+constexpr u32 ORBIS_IME_DIALOG_MAX_TEXT_LENGTH = 2048;
 
 enum class Error : u32 {
     OK = 0x0,


### PR DESCRIPTION
Fix the incorrect ORBIS_IME_DIALOG_MAX_TEXT_LENGTH; a larger value is required for at least the game Undertale