### PR TITLE
Code Review: SuspiciousPriority

### DIFF
--- a/src/common/memory_patcher.cpp
+++ b/src/common/memory_patcher.cpp
@@ -169,7 +169,8 @@ void OnGameLoaded() {
                             if (type == "mask_jump32")
                                 patchMask = MemoryPatcher::PatchMask::Mask_Jump32;
 
-                            if (type == "mask" || type == "mask_jump32" && !maskOffsetStr.empty()) {
+                            if ((type == "mask" || type == "mask_jump32") &&
+                                !maskOffsetStr.empty()) {
                                 maskOffsetValue = std::stoi(maskOffsetStr, 0, 10);
                             }
 

--- a/src/qt_gui/cheats_patches.cpp
+++ b/src/qt_gui/cheats_patches.cpp
@@ -1387,7 +1387,7 @@ void CheatsPatches::applyPatch(const QString& patchName, bool enabled) {
             if (type == "mask_jump32")
                 patchMask = MemoryPatcher::PatchMask::Mask_Jump32;
 
-            if (type == "mask" || type == "mask_jump32" && !maskOffsetStr.toStdString().empty()) {
+            if ((type == "mask" || type == "mask_jump32") && !maskOffsetStr.toStdString().empty()) {
                 maskOffsetValue = std::stoi(maskOffsetStr.toStdString(), 0, 10);
             }
 


### PR DESCRIPTION
Priority of the '&&' operation is higher than that of the '||' operation.It's possible that parentheses should be used in the expression.