### PR TITLE
pp_pass: Use correct surface format.

### DIFF
--- a/src/video_core/renderer_vulkan/host_passes/pp_pass.cpp
+++ b/src/video_core/renderer_vulkan/host_passes/pp_pass.cpp
@@ -14,7 +14,7 @@
 
 namespace Vulkan::HostPasses {
 
-void PostProcessingPass::Create(vk::Device device) {
+void PostProcessingPass::Create(vk::Device device, const vk::Format surface_format) {
     static const std::array pp_shaders{
         HostShaders::FS_TRI_VERT,
         HostShaders::POST_PROCESS_FRAG,
@@ -76,7 +76,7 @@ void PostProcessingPass::Create(vk::Device device) {
         Check<"create pp pipeline layout">(device.createPipelineLayoutUnique(layout_info));
 
     const std::array pp_color_formats{
-        vk::Format::eB8G8R8A8Unorm, // swapchain.GetSurfaceFormat().format,
+        surface_format,
     };
     const vk::PipelineRenderingCreateInfo pipeline_rendering_ci{
         .colorAttachmentCount = pp_color_formats.size(),

--- a/src/video_core/renderer_vulkan/host_passes/pp_pass.h
+++ b/src/video_core/renderer_vulkan/host_passes/pp_pass.h
@@ -19,7 +19,7 @@ public:
         u32 hdr = 0;
     };
 
-    void Create(vk::Device device);
+    void Create(vk::Device device, vk::Format surface_format);
 
     void Render(vk::CommandBuffer cmdbuf, vk::ImageView input, vk::Extent2D input_size,
                 Frame& output, Settings settings);

--- a/src/video_core/renderer_vulkan/vk_presenter.cpp
+++ b/src/video_core/renderer_vulkan/vk_presenter.cpp
@@ -130,7 +130,7 @@ Presenter::Presenter(Frontend::WindowSDL& window_, AmdGpu::Liverpool* liverpool_
     }
 
     fsr_pass.Create(device, instance.GetAllocator(), num_images);
-    pp_pass.Create(device);
+    pp_pass.Create(device, swapchain.GetSurfaceFormat().format);
 
     ImGui::Layer::AddLayer(Common::Singleton<Core::Devtools::Layer>::Instance());
 }


### PR DESCRIPTION
Use the actual format of the frame instead of fixing to a specific format.