### PR TITLE
Fix for intel 12 gen up Crashes on Bloodborne

### DIFF
--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -39,14 +39,10 @@ void FmtLogMessage(Class log_class, Level log_level, const char* filename, unsig
     Common::Log::FmtLogMessage(log_class, log_level, Common::Log::TrimSourcePath(__FILE__),        \
                                __LINE__, __func__, __VA_ARGS__)
 
-#ifdef _DEBUG
 #define LOG_TRACE(log_class, ...)                                                                  \
     Common::Log::FmtLogMessage(Common::Log::Class::log_class, Common::Log::Level::Trace,           \
                                Common::Log::TrimSourcePath(__FILE__), __LINE__, __func__,          \
                                __VA_ARGS__)
-#else
-#define LOG_TRACE(log_class, fmt, ...) (void(0))
-#endif
 
 #define LOG_DEBUG(log_class, ...)                                                                  \
     Common::Log::FmtLogMessage(Common::Log::Class::log_class, Common::Log::Level::Debug,           \


### PR DESCRIPTION
Seems like this debug trace was the cause of the intel crash on windows for 12 gen and up. 

tested several times and with several sfx, also it was taken from av improvements pr that had this and i backtrace the fix to find it was this. so the fix came from @roamic thanks 