### PR TITLE
shader_recompiler: Few fixes for buffer number conversions.

### DIFF
--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -517,7 +517,9 @@ void Translator::EmitFetch(const GcnInst& inst) {
         const auto values =
             ir.CompositeConstruct(ir.GetAttribute(attr, 0), ir.GetAttribute(attr, 1),
                                   ir.GetAttribute(attr, 2), ir.GetAttribute(attr, 3));
-        const auto swizzled = ApplySwizzle(ir, values, buffer.DstSelect());
+        const auto converted =
+            IR::ApplyReadNumberConversionVec4(ir, values, buffer.GetNumberConversion());
+        const auto swizzled = ApplySwizzle(ir, converted, buffer.DstSelect());
         for (u32 i = 0; i < 4; i++) {
             ir.SetVectorReg(dst_reg++, IR::F32{ir.CompositeExtract(swizzled, i)});
         }

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -924,15 +924,11 @@ struct Liverpool {
         }
 
         [[nodiscard]] NumberFormat GetNumberFmt() const {
-            // There is a small difference between T# and CB number types, account for it.
-            return RemapNumberFormat(info.number_type == NumberFormat::SnormNz
-                                         ? NumberFormat::Srgb
-                                         : info.number_type.Value(),
-                                     info.format);
+            return RemapNumberFormat(GetFixedNumberFormat(), info.format);
         }
 
         [[nodiscard]] NumberConversion GetNumberConversion() const {
-            return MapNumberConversion(info.number_type);
+            return MapNumberConversion(GetFixedNumberFormat());
         }
 
         [[nodiscard]] CompMapping Swizzle() const {
@@ -972,6 +968,13 @@ struct Liverpool {
             const auto components_idx = NumComponents(info.format) - 1;
             const auto mrt_swizzle = mrt_swizzles[swap_idx][components_idx];
             return RemapSwizzle(info.format, mrt_swizzle);
+        }
+
+    private:
+        [[nodiscard]] NumberFormat GetFixedNumberFormat() const {
+            // There is a small difference between T# and CB number types, account for it.
+            return info.number_type == NumberFormat::SnormNz ? NumberFormat::Srgb
+                                                             : info.number_type.Value();
         }
     };
 


### PR DESCRIPTION
* Apply required number conversion to vertex inputs as well.
* Pass correct number format to conversion mapping in color buffers.