### PR TITLE
vk_presenter: Use correct format and swizzle for output frame image view.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_presenter.h
+++ b/src/video_core/renderer_vulkan/vk_presenter.h
@@ -70,11 +70,12 @@ public:
         auto desc = VideoCore::TextureCache::VideoOutDesc{attribute, cpu_address};
         const auto image_id = texture_cache.FindImage(desc);
         texture_cache.UpdateImage(image_id, is_eop ? nullptr : &flip_scheduler);
-        return PrepareFrameInternal(image_id, is_eop);
+        return PrepareFrameInternal(image_id, attribute.attrib.pixel_format, is_eop);
     }
 
     Frame* PrepareBlankFrame(bool is_eop) {
-        return PrepareFrameInternal(VideoCore::NULL_IMAGE_ID, is_eop);
+        return PrepareFrameInternal(VideoCore::NULL_IMAGE_ID,
+                                    Libraries::VideoOut::PixelFormat::Unknown, is_eop);
     }
 
     VideoCore::Image& RegisterVideoOutSurface(
@@ -119,7 +120,8 @@ public:
     }
 
 private:
-    Frame* PrepareFrameInternal(VideoCore::ImageId image_id, bool is_eop = true);
+    Frame* PrepareFrameInternal(VideoCore::ImageId image_id,
+                                Libraries::VideoOut::PixelFormat format, bool is_eop = true);
     Frame* GetRenderFrame();
 
     void SetExpectedGameSize(s32 width, s32 height);

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -16,14 +16,15 @@ using VideoOutFormat = Libraries::VideoOut::PixelFormat;
 
 static vk::Format ConvertPixelFormat(const VideoOutFormat format) {
     switch (format) {
-    case VideoOutFormat::A8R8G8B8Srgb:
-        return vk::Format::eB8G8R8A8Srgb;
     case VideoOutFormat::A8B8G8R8Srgb:
+    // Remaining formats are mapped to RGBA for internal consistency and changed to BGRA in the
+    // frame image view.
+    case VideoOutFormat::A8R8G8B8Srgb:
         return vk::Format::eR8G8B8A8Srgb;
     case VideoOutFormat::A2R10G10B10:
     case VideoOutFormat::A2R10G10B10Srgb:
     case VideoOutFormat::A2R10G10B10Bt2020Pq:
-        return vk::Format::eA2R10G10B10UnormPack32;
+        return vk::Format::eA2B10G10R10UnormPack32;
     default:
         break;
     }


### PR DESCRIPTION
Video out frames can have some versions of formats that are not present for other images, for example BGRA Srgb instead of RGBA Srgb. In cases like this the texture cache will likely contain the RGBA version, especially if exact format was requested by a resolve operation. To handle this, use Vulkan formats for video out frames consistent with other supported GPU formats, and perform any required swizzle in the frame image view. This basically reverses the swizzle that games do when rendering to BGRA for the final frame.

Should fix inverted colors in several games: https://github.com/shadps4-emu/shadPS4/issues/2650