### PR TITLE
Core: Memory Fixes

### DIFF
--- a/src/core/address_space.h
+++ b/src/core/address_space.h
@@ -31,11 +31,11 @@ constexpr VAddr SYSTEM_RESERVED_MAX = 0xFBFFFFFFFULL;
 constexpr VAddr SYSTEM_RESERVED_MAX = 0xFFFFFFFFFULL;
 #endif
 constexpr VAddr USER_MIN = 0x1000000000ULL;
-constexpr VAddr USER_MAX = 0xFFFFFFFFFFFULL;
+constexpr VAddr USER_MAX = 0xFBFFFFFFFFULL;
 
 static constexpr size_t SystemManagedSize = SYSTEM_MANAGED_MAX - SYSTEM_MANAGED_MIN + 1;
 static constexpr size_t SystemReservedSize = SYSTEM_RESERVED_MAX - SYSTEM_RESERVED_MIN + 1;
-static constexpr size_t UserSize = USER_MAX - USER_MIN + 1;
+static constexpr size_t UserSize = 1ULL << 40;
 
 /**
  * Represents the user virtual address space backed by a dmem memory block

--- a/src/core/address_space.h
+++ b/src/core/address_space.h
@@ -31,11 +31,11 @@ constexpr VAddr SYSTEM_RESERVED_MAX = 0xFBFFFFFFFULL;
 constexpr VAddr SYSTEM_RESERVED_MAX = 0xFFFFFFFFFULL;
 #endif
 constexpr VAddr USER_MIN = 0x1000000000ULL;
-constexpr VAddr USER_MAX = 0xFBFFFFFFFFULL;
+constexpr VAddr USER_MAX = 0xFFFFFFFFFFFULL;
 
 static constexpr size_t SystemManagedSize = SYSTEM_MANAGED_MAX - SYSTEM_MANAGED_MIN + 1;
 static constexpr size_t SystemReservedSize = SYSTEM_RESERVED_MAX - SYSTEM_RESERVED_MIN + 1;
-static constexpr size_t UserSize = 1ULL << 40;
+static constexpr size_t UserSize = USER_MAX - USER_MIN + 1;
 
 /**
  * Represents the user virtual address space backed by a dmem memory block

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -126,9 +126,6 @@ s32 PS4_SYSV_ABI sceKernelAvailableDirectMemorySize(u64 searchStart, u64 searchE
 s32 PS4_SYSV_ABI sceKernelVirtualQuery(const void* addr, int flags, OrbisVirtualQueryInfo* info,
                                        size_t infoSize) {
     LOG_INFO(Kernel_Vmm, "called addr = {}, flags = {:#x}", fmt::ptr(addr), flags);
-    if (!addr) {
-        return ORBIS_KERNEL_ERROR_EACCES;
-    }
     auto* memory = Core::Memory::Instance();
     return memory->VirtualQuery(std::bit_cast<VAddr>(addr), flags, info);
 }

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -168,15 +168,22 @@ int PS4_SYSV_ABI sceKernelMapNamedDirectMemory(void** addr, u64 len, int prot, i
         LOG_ERROR(Kernel_Vmm, "Map size is either zero or not 16KB aligned!");
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
+
     if (!Common::Is16KBAligned(directMemoryStart)) {
         LOG_ERROR(Kernel_Vmm, "Start address is not 16KB aligned!");
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
+
     if (alignment != 0) {
         if ((!std::has_single_bit(alignment) && !Common::Is16KBAligned(alignment))) {
             LOG_ERROR(Kernel_Vmm, "Alignment value is invalid!");
             return ORBIS_KERNEL_ERROR_EINVAL;
         }
+    }
+
+    if (std::strlen(name) >= ORBIS_KERNEL_MAXIMUM_NAME_LENGTH) {
+        LOG_ERROR(Kernel_Vmm, "name exceeds 32 bytes!");
+        return ORBIS_KERNEL_ERROR_ENAMETOOLONG;
     }
 
     const VAddr in_addr = reinterpret_cast<VAddr>(*addr);
@@ -207,15 +214,14 @@ s32 PS4_SYSV_ABI sceKernelMapNamedFlexibleMemory(void** addr_in_out, std::size_t
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
 
-    static constexpr size_t MaxNameSize = 32;
-    if (std::strlen(name) > MaxNameSize) {
-        LOG_ERROR(Kernel_Vmm, "name exceeds 32 bytes!");
-        return ORBIS_KERNEL_ERROR_ENAMETOOLONG;
-    }
-
     if (name == nullptr) {
         LOG_ERROR(Kernel_Vmm, "name is invalid!");
         return ORBIS_KERNEL_ERROR_EFAULT;
+    }
+
+    if (std::strlen(name) >= ORBIS_KERNEL_MAXIMUM_NAME_LENGTH) {
+        LOG_ERROR(Kernel_Vmm, "name exceeds 32 bytes!");
+        return ORBIS_KERNEL_ERROR_ENAMETOOLONG;
     }
 
     const VAddr in_addr = reinterpret_cast<VAddr>(*addr_in_out);
@@ -353,16 +359,16 @@ s32 PS4_SYSV_ABI sceKernelBatchMap2(OrbisKernelBatchMapEntry* entries, int numEn
 }
 
 s32 PS4_SYSV_ABI sceKernelSetVirtualRangeName(const void* addr, size_t len, const char* name) {
-    static constexpr size_t MaxNameSize = 32;
-    if (std::strlen(name) > MaxNameSize) {
-        LOG_ERROR(Kernel_Vmm, "name exceeds 32 bytes!");
-        return ORBIS_KERNEL_ERROR_ENAMETOOLONG;
-    }
-
     if (name == nullptr) {
         LOG_ERROR(Kernel_Vmm, "name is invalid!");
         return ORBIS_KERNEL_ERROR_EFAULT;
     }
+
+    if (std::strlen(name) >= ORBIS_KERNEL_MAXIMUM_NAME_LENGTH) {
+        LOG_ERROR(Kernel_Vmm, "name exceeds 32 bytes!");
+        return ORBIS_KERNEL_ERROR_ENAMETOOLONG;
+    }
+
     auto* memory = Core::Memory::Instance();
     memory->NameVirtualRange(std::bit_cast<VAddr>(addr), len, name);
     return ORBIS_OK;

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -152,9 +152,8 @@ s32 PS4_SYSV_ABI sceKernelReserveVirtualRange(void** addr, u64 len, int flags, u
     auto* memory = Core::Memory::Instance();
     const VAddr in_addr = reinterpret_cast<VAddr>(*addr);
     const auto map_flags = static_cast<Core::MemoryMapFlags>(flags);
-    memory->Reserve(addr, in_addr, len, map_flags, alignment);
 
-    return ORBIS_OK;
+    return memory->Reserve(addr, in_addr, len, map_flags, alignment);
 }
 
 int PS4_SYSV_ABI sceKernelMapNamedDirectMemory(void** addr, u64 len, int prot, int flags,

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -185,8 +185,8 @@ int PS4_SYSV_ABI sceKernelMapNamedDirectMemory(void** addr, u64 len, int prot, i
 
     auto* memory = Core::Memory::Instance();
     const auto ret =
-        memory->MapMemory(addr, in_addr, len, mem_prot, map_flags, Core::VMAType::Direct, "", false,
-                          directMemoryStart, alignment);
+        memory->MapMemory(addr, in_addr, len, mem_prot, map_flags, Core::VMAType::Direct, "anon",
+                          false, directMemoryStart, alignment);
 
     LOG_INFO(Kernel_Vmm, "out_addr = {}", fmt::ptr(*addr));
     return ret;
@@ -195,7 +195,8 @@ int PS4_SYSV_ABI sceKernelMapNamedDirectMemory(void** addr, u64 len, int prot, i
 int PS4_SYSV_ABI sceKernelMapDirectMemory(void** addr, u64 len, int prot, int flags,
                                           s64 directMemoryStart, u64 alignment) {
     LOG_INFO(Kernel_Vmm, "called, redirected to sceKernelMapNamedDirectMemory");
-    return sceKernelMapNamedDirectMemory(addr, len, prot, flags, directMemoryStart, alignment, "");
+    return sceKernelMapNamedDirectMemory(addr, len, prot, flags, directMemoryStart, alignment,
+                                         "anon");
 }
 
 s32 PS4_SYSV_ABI sceKernelMapNamedFlexibleMemory(void** addr_in_out, std::size_t len, int prot,
@@ -232,7 +233,7 @@ s32 PS4_SYSV_ABI sceKernelMapNamedFlexibleMemory(void** addr_in_out, std::size_t
 
 s32 PS4_SYSV_ABI sceKernelMapFlexibleMemory(void** addr_in_out, std::size_t len, int prot,
                                             int flags) {
-    return sceKernelMapNamedFlexibleMemory(addr_in_out, len, prot, flags, "");
+    return sceKernelMapNamedFlexibleMemory(addr_in_out, len, prot, flags, "anon");
 }
 
 int PS4_SYSV_ABI sceKernelQueryMemoryProtection(void* addr, void** start, void** end, u32* prot) {
@@ -300,7 +301,7 @@ s32 PS4_SYSV_ABI sceKernelBatchMap2(OrbisKernelBatchMapEntry* entries, int numEn
         case MemoryOpTypes::ORBIS_KERNEL_MAP_OP_MAP_DIRECT: {
             result = sceKernelMapNamedDirectMemory(&entries[i].start, entries[i].length,
                                                    entries[i].protection, flags,
-                                                   static_cast<s64>(entries[i].offset), 0, "");
+                                                   static_cast<s64>(entries[i].offset), 0, "anon");
             LOG_INFO(Kernel_Vmm,
                      "entry = {}, operation = {}, len = {:#x}, offset = {:#x}, type = {}, "
                      "result = {}",
@@ -322,7 +323,7 @@ s32 PS4_SYSV_ABI sceKernelBatchMap2(OrbisKernelBatchMapEntry* entries, int numEn
         }
         case MemoryOpTypes::ORBIS_KERNEL_MAP_OP_MAP_FLEXIBLE: {
             result = sceKernelMapNamedFlexibleMemory(&entries[i].start, entries[i].length,
-                                                     entries[i].protection, flags, "");
+                                                     entries[i].protection, flags, "anon");
             LOG_INFO(Kernel_Vmm,
                      "entry = {}, operation = {}, len = {:#x}, type = {}, "
                      "result = {}",

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -185,7 +185,7 @@ int PS4_SYSV_ABI sceKernelMapNamedDirectMemory(void** addr, u64 len, int prot, i
 
     auto* memory = Core::Memory::Instance();
     const auto ret =
-        memory->MapMemory(addr, in_addr, len, mem_prot, map_flags, Core::VMAType::Direct, "anon",
+        memory->MapMemory(addr, in_addr, len, mem_prot, map_flags, Core::VMAType::Direct, name,
                           false, directMemoryStart, alignment);
 
     LOG_INFO(Kernel_Vmm, "out_addr = {}", fmt::ptr(*addr));

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -131,9 +131,6 @@ s32 PS4_SYSV_ABI sceKernelVirtualQuery(const void* addr, int flags, OrbisVirtual
 }
 
 s32 PS4_SYSV_ABI sceKernelReserveVirtualRange(void** addr, u64 len, int flags, u64 alignment) {
-    LOG_INFO(Kernel_Vmm, "addr = {}, len = {:#x}, flags = {:#x}, alignment = {:#x}",
-             fmt::ptr(*addr), len, flags, alignment);
-
     if (addr == nullptr) {
         LOG_ERROR(Kernel_Vmm, "Address is invalid!");
         return ORBIS_KERNEL_ERROR_EINVAL;
@@ -153,7 +150,13 @@ s32 PS4_SYSV_ABI sceKernelReserveVirtualRange(void** addr, u64 len, int flags, u
     const VAddr in_addr = reinterpret_cast<VAddr>(*addr);
     const auto map_flags = static_cast<Core::MemoryMapFlags>(flags);
 
-    return memory->Reserve(addr, in_addr, len, map_flags, alignment);
+    s32 result = memory->Reserve(addr, in_addr, len, map_flags, alignment);
+    if (result == 0) {
+        LOG_INFO(Kernel_Vmm,
+                 "in_addr = {:#x}, out_addr = {}, len = {:#x}, flags = {:#x}, alignment = {:#x}",
+                 in_addr, fmt::ptr(*addr), len, flags, alignment);
+    }
+    return result;
 }
 
 int PS4_SYSV_ABI sceKernelMapNamedDirectMemory(void** addr, u64 len, int prot, int flags,

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -131,6 +131,8 @@ s32 PS4_SYSV_ABI sceKernelVirtualQuery(const void* addr, int flags, OrbisVirtual
 }
 
 s32 PS4_SYSV_ABI sceKernelReserveVirtualRange(void** addr, u64 len, int flags, u64 alignment) {
+    LOG_INFO(Kernel_Vmm, "addr = {}, len = {:#x}, flags = {:#x}, alignment = {:#x}",
+             fmt::ptr(*addr), len, flags, alignment);
     if (addr == nullptr) {
         LOG_ERROR(Kernel_Vmm, "Address is invalid!");
         return ORBIS_KERNEL_ERROR_EINVAL;
@@ -152,9 +154,7 @@ s32 PS4_SYSV_ABI sceKernelReserveVirtualRange(void** addr, u64 len, int flags, u
 
     s32 result = memory->Reserve(addr, in_addr, len, map_flags, alignment);
     if (result == 0) {
-        LOG_INFO(Kernel_Vmm,
-                 "in_addr = {:#x}, out_addr = {}, len = {:#x}, flags = {:#x}, alignment = {:#x}",
-                 in_addr, fmt::ptr(*addr), len, flags, alignment);
+        LOG_INFO(Kernel_Vmm, "out_addr = {}", fmt::ptr(*addr));
     }
     return result;
 }

--- a/src/core/libraries/kernel/memory.h
+++ b/src/core/libraries/kernel/memory.h
@@ -59,14 +59,12 @@ struct OrbisVirtualQueryInfo {
     size_t offset;
     s32 protection;
     s32 memory_type;
-    union {
-        BitField<0, 1, u32> is_flexible;
-        BitField<1, 1, u32> is_direct;
-        BitField<2, 1, u32> is_stack;
-        BitField<3, 1, u32> is_pooled;
-        BitField<4, 1, u32> is_committed;
-    };
-    std::array<char, 32> name;
+    u32 is_flexible : 1;
+    u32 is_direct : 1;
+    u32 is_stack : 1;
+    u32 is_pooled : 1;
+    u32 is_committed : 1;
+    char name[32];
 };
 
 struct OrbisKernelBatchMapEntry {

--- a/src/core/libraries/kernel/memory.h
+++ b/src/core/libraries/kernel/memory.h
@@ -47,6 +47,8 @@ enum MemoryOpTypes : u32 {
     ORBIS_KERNEL_MAP_OP_TYPE_PROTECT = 4
 };
 
+constexpr u32 ORBIS_KERNEL_MAXIMUM_NAME_LENGTH = 32;
+
 struct OrbisQueryInfo {
     uintptr_t start;
     uintptr_t end;
@@ -64,7 +66,7 @@ struct OrbisVirtualQueryInfo {
     u32 is_stack : 1;
     u32 is_pooled : 1;
     u32 is_committed : 1;
-    char name[32];
+    char name[ORBIS_KERNEL_MAXIMUM_NAME_LENGTH];
 };
 
 struct OrbisKernelBatchMapEntry {

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -233,7 +233,7 @@ int MemoryManager::PoolReserve(void** out_addr, VAddr virtual_addr, size_t size,
     auto& new_vma = new_vma_handle->second;
     new_vma.disallow_merge = True(flags & MemoryMapFlags::NoCoalesce);
     new_vma.prot = MemoryProt::NoAccess;
-    new_vma.name = "";
+    new_vma.name = "anon";
     new_vma.type = VMAType::PoolReserved;
     MergeAdjacent(vma_map, new_vma_handle);
 
@@ -275,7 +275,7 @@ int MemoryManager::Reserve(void** out_addr, VAddr virtual_addr, size_t size, Mem
     auto& new_vma = new_vma_handle->second;
     new_vma.disallow_merge = True(flags & MemoryMapFlags::NoCoalesce);
     new_vma.prot = MemoryProt::NoAccess;
-    new_vma.name = "";
+    new_vma.name = "anon";
     new_vma.type = VMAType::Reserved;
     MergeAdjacent(vma_map, new_vma_handle);
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -154,7 +154,7 @@ PAddr MemoryManager::Allocate(PAddr search_start, PAddr search_end, size_t size,
         if (dmem_area == dmem_map.end()) {
             break;
         }
-        
+
         // Update local variables based on the new dmem_area
         mapping_start = Common::AlignUp(dmem_area->second.base, alignment);
         mapping_end = mapping_start + size;
@@ -601,8 +601,8 @@ s32 MemoryManager::Protect(VAddr addr, size_t size, MemoryProt prot) {
     do {
         auto it = FindVMA(addr + protected_bytes);
         auto& vma_base = it->second;
-        ASSERT_MSG(vma_base.Contains(addr + protected_bytes, 0),
-                   "Address {:#x} is out of bounds", addr + protected_bytes);
+        ASSERT_MSG(vma_base.Contains(addr + protected_bytes, 0), "Address {:#x} is out of bounds",
+                   addr + protected_bytes);
         auto result = 0;
         result = ProtectBytes(addr + protected_bytes, vma_base, size - protected_bytes, prot);
         if (result < 0) {
@@ -751,7 +751,8 @@ VAddr MemoryManager::SearchFree(VAddr virtual_addr, size_t size, u32 alignment) 
 
     // If the requested address is beyond the maximum our code can handle, throw an assert
     auto max_search_address = impl.UserVirtualBase() + impl.UserVirtualSize();
-    ASSERT_MSG(virtual_addr <= max_search_address, "Input address {:#x} is out of bounds", virtual_addr);
+    ASSERT_MSG(virtual_addr <= max_search_address, "Input address {:#x} is out of bounds",
+               virtual_addr);
 
     auto it = FindVMA(virtual_addr);
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -593,12 +593,14 @@ int MemoryManager::VirtualQuery(VAddr addr, int flags,
     info->end = vma.base + vma.size;
     info->offset = vma.phys_base;
     info->protection = static_cast<s32>(vma.prot);
-    info->is_flexible.Assign(vma.type == VMAType::Flexible);
-    info->is_direct.Assign(vma.type == VMAType::Direct);
-    info->is_stack.Assign(vma.type == VMAType::Stack);
-    info->is_pooled.Assign(vma.type == VMAType::PoolReserved || vma.type == VMAType::Pooled);
-    info->is_committed.Assign(vma.IsMapped());
-    vma.name.copy(info->name.data(), std::min(info->name.size(), vma.name.size()));
+    info->is_flexible = vma.type == VMAType::Flexible ? 1 : 0;
+    info->is_direct = vma.type == VMAType::Direct ? 1 : 0;
+    info->is_stack = vma.type == VMAType::Stack ? 1 : 0;
+    info->is_pooled = vma.type == VMAType::PoolReserved || vma.type == VMAType::Pooled ? 1 : 0;
+    info->is_committed = vma.IsMapped() ? 1 : 0;
+
+    strcpy(info->name, vma.name.data());
+
     if (vma.type == VMAType::Direct) {
         const auto dmem_it = FindDmemArea(vma.phys_base);
         ASSERT(dmem_it != dmem_map.end());

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -305,7 +305,7 @@ int MemoryManager::PoolCommit(VAddr virtual_addr, size_t size, MemoryProt prot) 
     const auto& vma = FindVMA(mapped_addr)->second;
     const size_t remaining_size = vma.base + vma.size - mapped_addr;
     ASSERT_MSG(!vma.IsMapped() && remaining_size >= size,
-               "Memory region  {:#x} to {:#x} isn't free enough to map region {:#x} to {:#x}",
+               "Memory region {:#x} to {:#x} isn't free enough to map region {:#x} to {:#x}",
                vma.base, vma.base + vma.size, virtual_addr, virtual_addr + size);
 
     // Perform the mapping.
@@ -350,7 +350,7 @@ int MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, size_t size, M
         const auto& vma = FindVMA(mapped_addr)->second;
         const size_t remaining_size = vma.base + vma.size - mapped_addr;
         ASSERT_MSG(!vma.IsMapped() && remaining_size >= size,
-                   "Memory region  {:#x} to {:#x} isn't free enough to map region {:#x} to {:#x}",
+                   "Memory region {:#x} to {:#x} isn't free enough to map region {:#x} to {:#x}",
                    vma.base, vma.base + vma.size, virtual_addr, virtual_addr + size);
     }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -257,7 +257,7 @@ int MemoryManager::Reserve(void** out_addr, VAddr virtual_addr, size_t size, Mem
 
     // Fixed mapping means the virtual address must exactly match the provided one.
     if (True(flags & MemoryMapFlags::Fixed)) {
-        auto& vma = FindVMA(mapped_addr)->second;
+        auto vma = FindVMA(mapped_addr)->second;
         // If the VMA is mapped, unmap the region first.
         if (vma.IsMapped()) {
             UnmapMemoryImpl(mapped_addr, size);

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -352,7 +352,7 @@ int MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, size_t size, M
         // To account for this, unmap any reserved areas within this mapping range first.
         auto unmap_addr = mapped_addr;
         auto unmap_size = size;
-        while (!vma.IsMapped() && vma.base < mapped_addr + size && remaining_size < size) {
+        while (!vma.IsMapped() && unmap_addr < mapped_addr + size && remaining_size < size) {
             auto unmapped = UnmapBytesFromEntry(unmap_addr, vma, unmap_size);
             unmap_addr += unmapped;
             unmap_size -= unmapped;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -720,6 +720,7 @@ VAddr MemoryManager::SearchFree(VAddr virtual_addr, size_t size, u32 alignment) 
     // If the requested address is beyond the maximum our code can handle, return an error.
     auto max_search_address = 0x10000000000;
     if (virtual_addr >= max_search_address) {
+        LOG_ERROR(Kernel_Vmm, "Address {:#x} is too high", virtual_addr);
         return -1;
     }
 
@@ -748,6 +749,7 @@ VAddr MemoryManager::SearchFree(VAddr virtual_addr, size_t size, u32 alignment) 
 
         // Make sure the address is within our defined bounds
         if (virtual_addr >= max_search_address) {
+            LOG_ERROR(Kernel_Vmm, "Address {:#x} is too high", virtual_addr);
             return -1;
         }
 
@@ -760,6 +762,8 @@ VAddr MemoryManager::SearchFree(VAddr virtual_addr, size_t size, u32 alignment) 
     }
 
     // Couldn't find a suitable VMA, return an error.
+    LOG_ERROR(Kernel_Vmm, "Couldn't find a free mapping for address {:#x}, size {:#x}",
+              virtual_addr, size);
     return -1;
 }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -607,7 +607,7 @@ int MemoryManager::VirtualQuery(VAddr addr, int flags,
     }
     auto it = FindVMA(query_addr);
 
-    while (it->second.type == VMAType::Free && flags == 1 && it != vma_map.end()) {
+    if (it->second.type == VMAType::Free && flags == 1) {
         ++it;
     }
     if (it->second.type == VMAType::Free) {

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -588,12 +588,12 @@ int MemoryManager::VirtualQuery(VAddr addr, int flags,
     std::scoped_lock lk{mutex};
 
     // FindVMA on addresses before the vma_map return garbage data.
-    auto query_addr = addr < impl.SystemManagedVirtualBase() ?
-                             impl.SystemManagedVirtualBase() : addr;
+    auto query_addr =
+        addr < impl.SystemManagedVirtualBase() ? impl.SystemManagedVirtualBase() : addr;
     if (addr < query_addr && flags == 0) {
         LOG_WARNING(Kernel_Vmm, "VirtualQuery on free memory region");
         return ORBIS_KERNEL_ERROR_EACCES;
-    } 
+    }
     auto it = FindVMA(query_addr);
 
     if (it->second.type == VMAType::Free && flags == 1) {

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -346,9 +346,21 @@ int MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, size_t size, M
 
     // Fixed mapping means the virtual address must exactly match the provided one.
     if (True(flags & MemoryMapFlags::Fixed)) {
-        // This should return SCE_KERNEL_ERROR_ENOMEM but shouldn't normally happen.
-        const auto& vma = FindVMA(mapped_addr)->second;
-        const size_t remaining_size = vma.base + vma.size - mapped_addr;
+        auto vma = FindVMA(mapped_addr)->second;
+        // There's a possible edge case where we're mapping to a partially reserved range.
+        // To account for this, unmap any reserved areas within this mapping range first.
+        auto unmap_addr = mapped_addr;
+        auto unmap_size = size;
+        while (!vma.IsMapped() && vma.base < mapped_addr + size) {
+            auto unmapped = UnmapBytesFromEntry(unmap_addr, vma, unmap_size);
+            unmap_addr += unmapped;
+            unmap_size -= unmapped;
+            vma = FindVMA(unmap_addr)->second;
+        }
+
+        // This should return SCE_KERNEL_ERROR_ENOMEM but rarely happens.
+        vma = FindVMA(mapped_addr)->second;
+        size_t remaining_size = vma.base + vma.size - mapped_addr;
         ASSERT_MSG(!vma.IsMapped() && remaining_size >= size,
                    "Memory region {:#x} to {:#x} isn't free enough to map region {:#x} to {:#x}",
                    vma.base, vma.base + vma.size, virtual_addr, virtual_addr + size);

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -306,7 +306,7 @@ int MemoryManager::PoolCommit(VAddr virtual_addr, size_t size, MemoryProt prot) 
     const size_t remaining_size = vma.base + vma.size - mapped_addr;
     ASSERT_MSG(!vma.IsMapped() && remaining_size >= size,
                "Memory region  {:#x} to {:#x} isn't free enough to map region {:#x} to {:#x}",
-               vma.base, vma.base + size, virtual_addr, virtual_addr + size);
+               vma.base, vma.base + vma.size, virtual_addr, virtual_addr + size);
 
     // Perform the mapping.
     void* out_addr = impl.Map(mapped_addr, size, alignment, -1, false);
@@ -351,7 +351,7 @@ int MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, size_t size, M
         const size_t remaining_size = vma.base + vma.size - mapped_addr;
         ASSERT_MSG(!vma.IsMapped() && remaining_size >= size,
                    "Memory region  {:#x} to {:#x} isn't free enough to map region {:#x} to {:#x}",
-                   vma.base, vma.base + size, virtual_addr, virtual_addr + size);
+                   vma.base, vma.base + vma.size, virtual_addr, virtual_addr + size);
     }
 
     // Find the first free area starting with provided virtual address.

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -571,7 +571,15 @@ int MemoryManager::VirtualQuery(VAddr addr, int flags,
                                 ::Libraries::Kernel::OrbisVirtualQueryInfo* info) {
     std::scoped_lock lk{mutex};
 
-    auto it = FindVMA(addr);
+    // FindVMA on addresses before the vma_map return garbage data.
+    auto query_addr = addr < impl.SystemManagedVirtualBase() ?
+                             impl.SystemManagedVirtualBase() : addr;
+    if (addr < query_addr && flags == 0) {
+        LOG_WARNING(Kernel_Vmm, "VirtualQuery on free memory region");
+        return ORBIS_KERNEL_ERROR_EACCES;
+    } 
+    auto it = FindVMA(query_addr);
+
     if (it->second.type == VMAType::Free && flags == 1) {
         ++it;
     }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -615,7 +615,7 @@ int MemoryManager::VirtualQuery(VAddr addr, int flags,
     info->is_pooled = vma.type == VMAType::PoolReserved || vma.type == VMAType::Pooled ? 1 : 0;
     info->is_committed = vma.IsMapped() ? 1 : 0;
 
-    strcpy(info->name, vma.name.data());
+    strncpy(info->name, vma.name.data(), 32);
 
     if (vma.type == VMAType::Direct) {
         const auto dmem_it = FindDmemArea(vma.phys_base);

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -615,7 +615,7 @@ int MemoryManager::VirtualQuery(VAddr addr, int flags,
     info->is_pooled = vma.type == VMAType::PoolReserved || vma.type == VMAType::Pooled ? 1 : 0;
     info->is_committed = vma.IsMapped() ? 1 : 0;
 
-    strncpy(info->name, vma.name.data(), 32);
+    strncpy(info->name, vma.name.data(), ::Libraries::Kernel::ORBIS_KERNEL_MAXIMUM_NAME_LENGTH);
 
     if (vma.type == VMAType::Direct) {
         const auto dmem_it = FindDmemArea(vma.phys_base);

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -75,7 +75,8 @@ u64 MemoryManager::ClampRangeSize(VAddr virtual_addr, u64 size) {
 
     // Clamp size to the remaining size of the current VMA.
     auto vma = FindVMA(virtual_addr);
-    ASSERT_MSG(vma != vma_map.end(), "Attempted to access invalid GPU address {:#x}", virtual_addr);
+    ASSERT_MSG(vma->second.Contains(virtual_addr, 0),
+               "Attempted to access invalid GPU address {:#x}", virtual_addr);
     u64 clamped_size = vma->second.base + vma->second.size - virtual_addr;
     ++vma;
 
@@ -96,6 +97,8 @@ u64 MemoryManager::ClampRangeSize(VAddr virtual_addr, u64 size) {
 bool MemoryManager::TryWriteBacking(void* address, const void* data, u32 num_bytes) {
     const VAddr virtual_addr = std::bit_cast<VAddr>(address);
     const auto& vma = FindVMA(virtual_addr)->second;
+    ASSERT_MSG(vma.Contains(virtual_addr, 0),
+               "Attempting to access out of bounds memory at address {:#x}", virtual_addr);
     if (vma.type != VMAType::Direct) {
         return false;
     }
@@ -145,11 +148,13 @@ PAddr MemoryManager::Allocate(PAddr search_start, PAddr search_end, size_t size,
     auto mapping_end = mapping_start + size;
 
     // Find the first free, large enough dmem area in the range.
-    while ((!dmem_area->second.is_free || dmem_area->second.GetEnd() < mapping_end) &&
-           dmem_area != dmem_map.end()) {
+    while (!dmem_area->second.is_free || dmem_area->second.GetEnd() < mapping_end) {
         // The current dmem_area isn't suitable, move to the next one.
         dmem_area++;
-
+        if (dmem_area == dmem_map.end()) {
+            break;
+        }
+        
         // Update local variables based on the new dmem_area
         mapping_start = Common::AlignUp(dmem_area->second.base, alignment);
         mapping_end = mapping_start + size;
@@ -172,7 +177,6 @@ void MemoryManager::Free(PAddr phys_addr, size_t size) {
     std::scoped_lock lk{mutex};
 
     auto dmem_area = CarveDmemArea(phys_addr, size);
-    ASSERT(dmem_area != dmem_map.end() && dmem_area->second.size >= size);
 
     // Release any dmem mappings that reference this physical block.
     std::vector<std::pair<VAddr, u64>> remove_list;
@@ -216,7 +220,9 @@ int MemoryManager::PoolReserve(void** out_addr, VAddr virtual_addr, size_t size,
             vma = FindVMA(mapped_addr)->second;
         }
         const size_t remaining_size = vma.base + vma.size - mapped_addr;
-        ASSERT_MSG(vma.type == VMAType::Free && remaining_size >= size);
+        ASSERT_MSG(vma.type == VMAType::Free && remaining_size >= size,
+                   "Memory region {:#x} to {:#x} is not large enough to reserve {:#x} to {:#x}",
+                   vma.base, vma.base + vma.size, virtual_addr, virtual_addr + size);
     }
 
     // Find the first free area starting with provided virtual address.
@@ -258,7 +264,9 @@ int MemoryManager::Reserve(void** out_addr, VAddr virtual_addr, size_t size, Mem
             vma = FindVMA(mapped_addr)->second;
         }
         const size_t remaining_size = vma.base + vma.size - mapped_addr;
-        ASSERT_MSG(vma.type == VMAType::Free && remaining_size >= size);
+        ASSERT_MSG(vma.type == VMAType::Free && remaining_size >= size,
+                   "Memory region {:#x} to {:#x} is not large enough to reserve {:#x} to {:#x}",
+                   vma.base, vma.base + vma.size, virtual_addr, virtual_addr + size);
     }
 
     // Find the first free area starting with provided virtual address.
@@ -296,7 +304,9 @@ int MemoryManager::PoolCommit(VAddr virtual_addr, size_t size, MemoryProt prot) 
     // This should return SCE_KERNEL_ERROR_ENOMEM but shouldn't normally happen.
     const auto& vma = FindVMA(mapped_addr)->second;
     const size_t remaining_size = vma.base + vma.size - mapped_addr;
-    ASSERT_MSG(!vma.IsMapped() && remaining_size >= size);
+    ASSERT_MSG(!vma.IsMapped() && remaining_size >= size,
+               "Memory region  {:#x} to {:#x} isn't free enough to map region {:#x} to {:#x}",
+               vma.base, vma.base + size, virtual_addr, virtual_addr + size);
 
     // Perform the mapping.
     void* out_addr = impl.Map(mapped_addr, size, alignment, -1, false);
@@ -339,7 +349,9 @@ int MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, size_t size, M
         // This should return SCE_KERNEL_ERROR_ENOMEM but shouldn't normally happen.
         const auto& vma = FindVMA(mapped_addr)->second;
         const size_t remaining_size = vma.base + vma.size - mapped_addr;
-        ASSERT_MSG(!vma.IsMapped() && remaining_size >= size);
+        ASSERT_MSG(!vma.IsMapped() && remaining_size >= size,
+                   "Memory region  {:#x} to {:#x} isn't free enough to map region {:#x} to {:#x}",
+                   vma.base, vma.base + size, virtual_addr, virtual_addr + size);
     }
 
     // Find the first free area starting with provided virtual address.
@@ -393,7 +405,9 @@ int MemoryManager::MapFile(void** out_addr, VAddr virtual_addr, size_t size, Mem
     if (True(flags & MemoryMapFlags::Fixed)) {
         const auto& vma = FindVMA(virtual_addr)->second;
         const size_t remaining_size = vma.base + vma.size - virtual_addr;
-        ASSERT_MSG(!vma.IsMapped() && remaining_size >= size);
+        ASSERT_MSG(!vma.IsMapped() && remaining_size >= size,
+                   "Memory region {:#x} to {:#x} isn't free enough to map region {:#x} to {:#x}",
+                   vma.base, vma.base + vma.size, virtual_addr, virtual_addr + size);
     }
 
     // Map the file.
@@ -498,6 +512,8 @@ s32 MemoryManager::UnmapMemoryImpl(VAddr virtual_addr, u64 size) {
     do {
         auto it = FindVMA(virtual_addr + unmapped_bytes);
         auto& vma_base = it->second;
+        ASSERT_MSG(vma_base.Contains(virtual_addr + unmapped_bytes, 0),
+                   "Address {:#x} is out of bounds", virtual_addr + unmapped_bytes);
         auto unmapped =
             UnmapBytesFromEntry(virtual_addr + unmapped_bytes, vma_base, size - unmapped_bytes);
         ASSERT_MSG(unmapped > 0, "Failed to unmap memory, progress is impossible");
@@ -582,6 +598,8 @@ s32 MemoryManager::Protect(VAddr addr, size_t size, MemoryProt prot) {
     do {
         auto it = FindVMA(addr + protected_bytes);
         auto& vma_base = it->second;
+        ASSERT_MSG(vma_base.Contains(addr + protected_bytes, 0),
+                   "Address {:#x} is out of bounds", addr + protected_bytes);
         auto result = 0;
         result = ProtectBytes(addr + protected_bytes, vma_base, size - protected_bytes, prot);
         if (result < 0) {
@@ -607,7 +625,7 @@ int MemoryManager::VirtualQuery(VAddr addr, int flags,
     }
     auto it = FindVMA(query_addr);
 
-    if (it->second.type == VMAType::Free && flags == 1) {
+    while (it->second.type == VMAType::Free && flags == 1 && it != --vma_map.end()) {
         ++it;
     }
     if (it->second.type == VMAType::Free) {
@@ -630,7 +648,7 @@ int MemoryManager::VirtualQuery(VAddr addr, int flags,
 
     if (vma.type == VMAType::Direct) {
         const auto dmem_it = FindDmemArea(vma.phys_base);
-        ASSERT(dmem_it != dmem_map.end());
+        ASSERT_MSG(vma.phys_base <= dmem_it->second.GetEnd(), "vma.phys_base is not in dmem_map!");
         info->memory_type = dmem_it->second.memory_type;
     } else {
         info->memory_type = ::Libraries::Kernel::SCE_KERNEL_WB_ONION;
@@ -644,11 +662,11 @@ int MemoryManager::DirectMemoryQuery(PAddr addr, bool find_next,
     std::scoped_lock lk{mutex};
 
     auto dmem_area = FindDmemArea(addr);
-    while (dmem_area != dmem_map.end() && dmem_area->second.is_free && find_next) {
+    while (dmem_area != --dmem_map.end() && dmem_area->second.is_free && find_next) {
         dmem_area++;
     }
 
-    if (dmem_area == dmem_map.end() || dmem_area->second.is_free) {
+    if (dmem_area->second.is_free) {
         LOG_ERROR(Core, "Unable to find allocated direct memory region to query!");
         return ORBIS_KERNEL_ERROR_EACCES;
     }
@@ -728,15 +746,11 @@ VAddr MemoryManager::SearchFree(VAddr virtual_addr, size_t size, u32 alignment) 
         virtual_addr = min_search_address;
     }
 
-    // If the requested address is beyond the maximum our code can handle, return an error.
+    // If the requested address is beyond the maximum our code can handle, throw an assert
     auto max_search_address = impl.UserVirtualBase() + impl.UserVirtualSize();
-    if (virtual_addr >= max_search_address) {
-        LOG_ERROR(Kernel_Vmm, "Input address {:#x} is too high", virtual_addr);
-        return -1;
-    }
+    ASSERT_MSG(virtual_addr <= max_search_address, "Input address {:#x} is out of bounds", virtual_addr);
 
     auto it = FindVMA(virtual_addr);
-    ASSERT_MSG(it != vma_map.end(), "Specified mapping address was not found!");
 
     // If the VMA is free and contains the requested mapping we are done.
     if (it->second.IsFree() && it->second.Contains(virtual_addr, size)) {
@@ -780,7 +794,7 @@ VAddr MemoryManager::SearchFree(VAddr virtual_addr, size_t size, u32 alignment) 
 
 MemoryManager::VMAHandle MemoryManager::CarveVMA(VAddr virtual_addr, size_t size) {
     auto vma_handle = FindVMA(virtual_addr);
-    ASSERT_MSG(vma_handle != vma_map.end(), "Virtual address not in vm_map");
+    ASSERT_MSG(vma_handle->second.Contains(virtual_addr, 0), "Virtual address not in vm_map");
 
     const VirtualMemoryArea& vma = vma_handle->second;
     ASSERT_MSG(vma.base <= virtual_addr, "Adding a mapping to already mapped region");
@@ -809,7 +823,7 @@ MemoryManager::VMAHandle MemoryManager::CarveVMA(VAddr virtual_addr, size_t size
 
 MemoryManager::DMemHandle MemoryManager::CarveDmemArea(PAddr addr, size_t size) {
     auto dmem_handle = FindDmemArea(addr);
-    ASSERT_MSG(dmem_handle != dmem_map.end(), "Physical address not in dmem_map");
+    ASSERT_MSG(addr <= dmem_handle->second.GetEnd(), "Physical address not in dmem_map");
 
     const DirectMemoryArea& area = dmem_handle->second;
     ASSERT_MSG(area.base <= addr, "Adding an allocation to already allocated region");
@@ -864,7 +878,7 @@ int MemoryManager::GetDirectMemoryType(PAddr addr, int* directMemoryTypeOut,
 
     auto dmem_area = FindDmemArea(addr);
 
-    if (dmem_area == dmem_map.end() || dmem_area->second.is_free) {
+    if (addr > dmem_area->second.GetEnd() || dmem_area->second.is_free) {
         LOG_ERROR(Core, "Unable to find allocated direct memory region to check type!");
         return ORBIS_KERNEL_ERROR_ENOENT;
     }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -528,7 +528,10 @@ int MemoryManager::QueryProtection(VAddr addr, void** start, void** end, u32* pr
 
     const auto it = FindVMA(addr);
     const auto& vma = it->second;
-    ASSERT_MSG(vma.type != VMAType::Free, "Provided address is not mapped");
+    if (!vma.Contains(addr, 0) || vma.IsFree()) {
+        LOG_ERROR(Kernel_Vmm, "Address {:#x} is not mapped", addr);
+        return ORBIS_KERNEL_ERROR_EACCES;
+    }
 
     if (start != nullptr) {
         *start = reinterpret_cast<void*>(vma.base);

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -483,8 +483,8 @@ u64 MemoryManager::UnmapBytesFromEntry(VAddr virtual_addr, VirtualMemoryArea vma
         flexible_usage -= adjusted_size;
     }
 
-    if (IsValidGpuMapping(virtual_addr, size)) {
-        rasterizer->UnmapMemory(virtual_addr, size);
+    if (IsValidGpuMapping(virtual_addr, adjusted_size)) {
+        rasterizer->UnmapMemory(virtual_addr, adjusted_size);
     }
 
     // Mark region as free and attempt to coalesce it with neighbours.

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -596,7 +596,7 @@ int MemoryManager::VirtualQuery(VAddr addr, int flags,
     }
     auto it = FindVMA(query_addr);
 
-    if (it->second.type == VMAType::Free && flags == 1) {
+    while (it->second.type == VMAType::Free && flags == 1 && it != vma_map.end()) {
         ++it;
     }
     if (it->second.type == VMAType::Free) {

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -186,7 +186,7 @@ public:
     int PoolCommit(VAddr virtual_addr, size_t size, MemoryProt prot);
 
     int MapMemory(void** out_addr, VAddr virtual_addr, size_t size, MemoryProt prot,
-                  MemoryMapFlags flags, VMAType type, std::string_view name = "",
+                  MemoryMapFlags flags, VMAType type, std::string_view name = "anon",
                   bool is_exec = false, PAddr phys_addr = -1, u64 alignment = 0);
 
     int MapFile(void** out_addr, VAddr virtual_addr, size_t size, MemoryProt prot,

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -157,6 +157,12 @@ public:
         return impl.SystemReservedVirtualBase();
     }
 
+    bool IsValidGpuMapping(VAddr virtual_addr, u64 size) {
+        // The PS4's GPU can only handle 40 bit addresses.
+        const VAddr max_gpu_address{0x10000000000};
+        return virtual_addr + size < max_gpu_address;
+    }
+
     bool IsValidAddress(const void* addr) const noexcept {
         const VAddr virtual_addr = reinterpret_cast<VAddr>(addr);
         const auto end_it = std::prev(vma_map.end());


### PR DESCRIPTION
This PR makes our memory code more robust, preventing a variety of exceptions and strange behavior I observed when using my recently shared memory stress test homebrew on shadPS4.

- Fixes `OrbisVirtualQueryInfo` struct. My homebrew was reading garbage data with the BitFields and array in place. I've replaced the BitField class use with C-style bitfields, and the std::array with a primitive char array instead.
- Proper low address handling in `sceKernelVirtualQuery`. Our previous code didn't check if the inputted address was below our vma map, which led to OOB memory accesses. My edge case error returns are based on hardware tests here.
- Edge case handling for `SearchFree`. Our previous code encountered unpredictable behavior if the inputted address was too high, or if there were no free memory areas to map.
- Changed default nameless memory mapping behavior. On real hardware, nameless mappings will have the name "anon" followed by the code address responsible for the memory call. For simplicity sake, I just used "anon" as the default name instead.
- Fixes a variety of broken memory asserts, caused by a fundamental misunderstanding of how `FindVMA` and `FindDmemArea` behave.
- Fixes a long unnoticed regression caused by #2080 
- Fixes an issue where `MapMemory` would assert when the area to map was only partially reserved.

With these fixes, my memory homebrew now executes all tests on shadPS4. Many of the returned results are still inaccurate, but these are due to deeper issues that I believe are out of scope for this PR.

Currently:
- Regresses EA SPORTS™ UFC® (CUSA00264) 
     - The only reason this game works in main is due to a bug in our code. Fixing this bug broke the game, and attempting to properly fix the regression broke Windows support.
- Improves Evolve (CUSA00432)
- Improves Cars 3: Driven to Win (CUSA07027)
- Improves Shadow of the Tomb Raider (CUSA10872)
- Improves The Order: 1886 (CUSA00076)
- Improves Final Fantasy XV (CUSA01633)