### PR TITLE
Bypassing usb count error

### DIFF
--- a/src/core/libraries/usbd/usbd.cpp
+++ b/src/core/libraries/usbd/usbd.cpp
@@ -44,7 +44,18 @@ void PS4_SYSV_ABI sceUsbdExit() {
 s64 PS4_SYSV_ABI sceUsbdGetDeviceList(SceUsbdDevice*** list) {
     LOG_DEBUG(Lib_Usbd, "called");
 
-    return libusb_to_orbis_error(libusb_get_device_list(g_libusb_context, list));
+    static ssize_t last_count = -1;
+
+    ssize_t count = libusb_get_device_list(g_libusb_context, list);
+    if (count <= 0)
+        return libusb_to_orbis_error((int)count);
+
+    if (count != last_count) {
+        LOG_INFO(Lib_Usbd, "Found {} USB devices", count);
+        last_count = count;
+    }
+
+    return ORBIS_OK;
 }
 
 void PS4_SYSV_ABI sceUsbdFreeDeviceList(SceUsbdDevice** list, s32 unref_devices) {

--- a/src/core/libraries/usbd/usbd.cpp
+++ b/src/core/libraries/usbd/usbd.cpp
@@ -49,9 +49,9 @@ s64 PS4_SYSV_ABI sceUsbdGetDeviceList(SceUsbdDevice*** list) {
         return libusb_to_orbis_error((int)count);
 
     if (count > 2)
-        LOG_WARNING(Lib_Usbd, "Too Many USB Devices Connected");
+        LOG_WARNING(Lib_Usbd, "Too many USB devices connected to list: {}", count);
     libusb_unref_device((*list)[2]);
-    count = 0;
+    count = -1;
 
     return libusb_to_orbis_error((int)count);
 }

--- a/src/core/libraries/usbd/usbd.cpp
+++ b/src/core/libraries/usbd/usbd.cpp
@@ -51,7 +51,6 @@ s64 PS4_SYSV_ABI sceUsbdGetDeviceList(SceUsbdDevice*** list) {
 
     if (count != device_count) {
         LOG_INFO(Lib_Usbd, "Found {} USB devices", count);
-        device_count = count;
     }
     return ORBIS_FAIL;
 }

--- a/src/core/libraries/usbd/usbd.cpp
+++ b/src/core/libraries/usbd/usbd.cpp
@@ -44,16 +44,16 @@ void PS4_SYSV_ABI sceUsbdExit() {
 s64 PS4_SYSV_ABI sceUsbdGetDeviceList(SceUsbdDevice*** list) {
     LOG_DEBUG(Lib_Usbd, "called");
 
+    static ssize_t device_count = 2;
     ssize_t count = libusb_get_device_list(g_libusb_context, list);
-    if (count < 0)
+    if (count <= 0)
         return libusb_to_orbis_error((int)count);
 
-    if (count > 2)
-        LOG_WARNING(Lib_Usbd, "Too many USB devices connected to list: {}", count);
-    libusb_unref_device((*list)[2]);
-    count = -1;
-
-    return libusb_to_orbis_error((int)count);
+    if (count != device_count) {
+        LOG_INFO(Lib_Usbd, "Found {} USB devices", count);
+        device_count = count;
+    }
+    return ORBIS_FAIL;
 }
 
 void PS4_SYSV_ABI sceUsbdFreeDeviceList(SceUsbdDevice** list, s32 unref_devices) {

--- a/src/core/libraries/usbd/usbd.cpp
+++ b/src/core/libraries/usbd/usbd.cpp
@@ -44,18 +44,16 @@ void PS4_SYSV_ABI sceUsbdExit() {
 s64 PS4_SYSV_ABI sceUsbdGetDeviceList(SceUsbdDevice*** list) {
     LOG_DEBUG(Lib_Usbd, "called");
 
-    static ssize_t last_count = -1;
-
     ssize_t count = libusb_get_device_list(g_libusb_context, list);
-    if (count <= 0)
+    if (count < 0)
         return libusb_to_orbis_error((int)count);
 
-    if (count != last_count) {
-        LOG_INFO(Lib_Usbd, "Found {} USB devices", count);
-        last_count = count;
-    }
+    if (count > 2)
+        LOG_WARNING(Lib_Usbd, "Too Many USB Devices Connected");
+    libusb_unref_device((*list)[2]);
+    count = 0;
 
-    return ORBIS_OK;
+    return libusb_to_orbis_error((int)count);
 }
 
 void PS4_SYSV_ABI sceUsbdFreeDeviceList(SceUsbdDevice** list, s32 unref_devices) {


### PR DESCRIPTION
This helps some UE games to bypass the USB device count but also sending a log to the numbers of devices conected when its called by the game. Returning orbis ok to avoid booting errors. 

Helps UE game Souls Calibur 6 to boot. 

Its the only game i have that encounter issue with it as it dosent show any logging that this was the cause i had to go back to 0.7.0 to figure it out. 