### PR TITLE
Core: Fix module load addresses

### DIFF
--- a/src/core/address_space.h
+++ b/src/core/address_space.h
@@ -19,8 +19,6 @@ enum class MemoryPermission : u32 {
 };
 DECLARE_ENUM_FLAG_OPERATORS(MemoryPermission)
 
-constexpr VAddr CODE_BASE_OFFSET = 0x100000000ULL;
-
 constexpr VAddr SYSTEM_MANAGED_MIN = 0x00000400000ULL;
 constexpr VAddr SYSTEM_MANAGED_MAX = 0x07FFFFBFFFULL;
 constexpr VAddr SYSTEM_RESERVED_MIN = 0x07FFFFC000ULL;

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -19,8 +19,7 @@ namespace Core {
 
 using EntryFunc = PS4_SYSV_ABI int (*)(size_t args, const void* argp, void* param);
 
-static u64 LoadOffset = CODE_BASE_OFFSET;
-static constexpr u64 CODE_BASE_INCR = 0x010000000u;
+static u64 LoadOffset = 0;
 
 static u64 GetAlignedSize(const elf_program_header& phdr) {
     return (phdr.p_align != 0 ? (phdr.p_memsz + (phdr.p_align - 1)) & ~(phdr.p_align - 1)
@@ -116,7 +115,7 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
     memory->MapMemory(out_addr, memory->SystemReservedVirtualBase() + LoadOffset,
                       aligned_base_size + TrampolineSize, MemoryProt::CpuReadWrite,
                       MemoryMapFlags::Fixed, VMAType::Code, name, true);
-    LoadOffset += CODE_BASE_INCR * (1 + aligned_base_size / CODE_BASE_INCR);
+    LoadOffset += aligned_base_size + TrampolineSize;
     LOG_INFO(Core_Linker, "Loading module {} to {}", name, fmt::ptr(*out_addr));
 
 #ifdef ARCH_X86_64

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -19,6 +19,7 @@ namespace Core {
 
 using EntryFunc = PS4_SYSV_ABI int (*)(size_t args, const void* argp, void* param);
 
+static constexpr u64 ModuleLoadBase = 0x800000000;
 static u64 LoadOffset = 0;
 
 static u64 GetAlignedSize(const elf_program_header& phdr) {
@@ -112,7 +113,7 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
 
     // Map module segments (and possible TLS trampolines)
     void** out_addr = reinterpret_cast<void**>(&base_virtual_addr);
-    memory->MapMemory(out_addr, memory->SystemReservedVirtualBase() + LoadOffset,
+    memory->MapMemory(out_addr, ModuleLoadBase + LoadOffset,
                       aligned_base_size + TrampolineSize, MemoryProt::CpuReadWrite,
                       MemoryMapFlags::Fixed, VMAType::Code, name, true);
     LoadOffset += aligned_base_size + TrampolineSize;

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -226,7 +226,7 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
     LOG_INFO(Core_Linker, "program entry addr ..........: {:#018x}", entry_addr);
 
     if (MemoryPatcher::g_eboot_address == 0) {
-        if (name == "eboot") {
+        if (name == "eboot.bin") {
             MemoryPatcher::g_eboot_address = base_virtual_addr;
             MemoryPatcher::g_eboot_image_size = base_size;
             MemoryPatcher::OnGameLoaded();

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -113,9 +113,8 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
 
     // Map module segments (and possible TLS trampolines)
     void** out_addr = reinterpret_cast<void**>(&base_virtual_addr);
-    memory->MapMemory(out_addr, ModuleLoadBase + LoadOffset,
-                      aligned_base_size + TrampolineSize, MemoryProt::CpuReadWrite,
-                      MemoryMapFlags::Fixed, VMAType::Code, name, true);
+    memory->MapMemory(out_addr, ModuleLoadBase + LoadOffset, aligned_base_size + TrampolineSize,
+                      MemoryProt::CpuReadWrite, MemoryMapFlags::Fixed, VMAType::Code, name, true);
     LoadOffset += aligned_base_size + TrampolineSize;
     LOG_INFO(Core_Linker, "Loading module {} to {}", name, fmt::ptr(*out_addr));
 

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -20,7 +20,6 @@ namespace Core {
 using EntryFunc = PS4_SYSV_ABI int (*)(size_t args, const void* argp, void* param);
 
 static constexpr u64 ModuleLoadBase = 0x800000000;
-static u64 LoadOffset = 0;
 
 static u64 GetAlignedSize(const elf_program_header& phdr) {
     return (phdr.p_align != 0 ? (phdr.p_memsz + (phdr.p_align - 1)) & ~(phdr.p_align - 1)
@@ -113,9 +112,8 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
 
     // Map module segments (and possible TLS trampolines)
     void** out_addr = reinterpret_cast<void**>(&base_virtual_addr);
-    memory->MapMemory(out_addr, ModuleLoadBase + LoadOffset, aligned_base_size + TrampolineSize,
-                      MemoryProt::CpuReadWrite, MemoryMapFlags::Fixed, VMAType::Code, name, true);
-    LoadOffset += aligned_base_size + TrampolineSize;
+    memory->MapMemory(out_addr, ModuleLoadBase, aligned_base_size + TrampolineSize,
+                      MemoryProt::CpuReadWrite, MemoryMapFlags::NoFlags, VMAType::Code, name, true);
     LOG_INFO(Core_Linker, "Loading module {} to {}", name, fmt::ptr(*out_addr));
 
 #ifdef ARCH_X86_64

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -83,7 +83,7 @@ static std::string StringToNid(std::string_view symbol) {
 }
 
 Module::Module(Core::MemoryManager* memory_, const std::filesystem::path& file_, u32& max_tls_index)
-    : memory{memory_}, file{file_}, name{file.stem().string()} {
+    : memory{memory_}, file{file_}, name{file.filename().string()} {
     elf.Open(file);
     if (elf.IsElfFile()) {
         LoadModuleToMemory(max_tls_index);


### PR DESCRIPTION
On a PS4, all modules are mapped starting at address `0x800000000`, and with no gaps in-between. Since all platforms are able to map to these addresses, we can hard code this address as a constant and use that as the "base" address we map to.

The information this PR is based on comes from observations visible in this klog:
[Memory Map Query klog.txt](https://github.com/user-attachments/files/20025668/Memory.Map.Query.klog.txt)

These changes fix `[Debug] <Critical> memory.cpp:331 operator(): Assertion Failed!` when booting some Call of Duty games.
Specifically from my testing, this fixes updated versions of Call of Duty®: Advanced Warfare (CUSA00803) crashing on startup (note that these titles still need to be loaded from `default.elf` to bypass `sceSystemServiceLoadExec`)
[CoD AW main log.txt](https://github.com/user-attachments/files/20025613/CoD.AW.main.log.txt)
[CoD AW PR log.txt](https://github.com/user-attachments/files/20025617/CoD.AW.PR.log.txt)

![Screenshot from 2025-05-03 20-29-05](https://github.com/user-attachments/assets/30624b60-7160-4933-9cd3-31cbf250f92c)

This doesn't appear to regress any games on my end, wouldn't hurt to have testers though.