### PR TITLE
vulkan: load VK_EXT_extended_dynamic_state

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -177,8 +177,8 @@ void BufferCache::BindVertexBuffers(const Vulkan::GraphicsPipeline& pipeline) {
     if (instance.IsVertexInputDynamicState()) {
         cmdbuf.bindVertexBuffers(0, num_buffers, host_buffers.data(), host_offsets.data());
     } else {
-        cmdbuf.bindVertexBuffers2EXT(0, num_buffers, host_buffers.data(), host_offsets.data(),
-                                     host_sizes.data(), host_strides.data());
+        cmdbuf.bindVertexBuffers2(0, num_buffers, host_buffers.data(), host_offsets.data(),
+                                  host_sizes.data(), host_strides.data());
     }
 }
 


### PR DESCRIPTION
fixes Bloodborne crashing on RX 580

Bloodborne crashes in https://github.com/shadps4-emu/shadPS4/blob/17b6343f18a39bbd6436a94956fb6cb90f8f554c/src/video_core/buffer_cache/buffer_cache.cpp#L180