### PR TITLE
add scePthreadSetaffinity and emulate affinity

### DIFF
--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -541,31 +541,33 @@ int Pthread::SetAffinity(const Cpuset* cpuset) {
         return POSIX_ESRCH;
     }
 
-/* We don't use this currently because some games gets performance problems when applying affinity even on strong hardware
-#ifdef _WIN64
-    DWORD_PTR affinity_mask = static_cast<DWORD_PTR>(mask);
-    if (!SetThreadAffinityMask(reinterpret_cast<HANDLE>(handle), affinity_mask)) {
-        return POSIX_EINVAL;
-    }
-
-#elif defined(__linux__)
-    cpu_set_t cpu_set;
-    CPU_ZERO(&cpu_set);
-
-    u64 mask = cpuset->bits;
-    for (int cpu = 0; cpu < std::min(64, CPU_SETSIZE); ++cpu) {
-        if (mask & (1ULL << cpu)) {
-            CPU_SET(cpu, &cpu_set);
+    //  We don't use this currently because some games gets performance problems
+    // when applying affinity event
+    /*
+    #ifdef _WIN64
+        DWORD_PTR affinity_mask = static_cast<DWORD_PTR>(mask);
+        if (!SetThreadAffinityMask(reinterpret_cast<HANDLE>(handle), affinity_mask)) {
+            return POSIX_EINVAL;
         }
-    }
 
-    int result =
-        pthread_setaffinity_np(static_cast<pthread_t>(handle), sizeof(cpu_set_t), &cpu_set);
-    if (result != 0) {
-        return POSIX_EINVAL;
-    }
-#endif
-*/
+    #elif defined(__linux__)
+        cpu_set_t cpu_set;
+        CPU_ZERO(&cpu_set);
+
+        u64 mask = cpuset->bits;
+        for (int cpu = 0; cpu < std::min(64, CPU_SETSIZE); ++cpu) {
+            if (mask & (1ULL << cpu)) {
+                CPU_SET(cpu, &cpu_set);
+            }
+        }
+
+        int result =
+            pthread_setaffinity_np(static_cast<pthread_t>(handle), sizeof(cpu_set_t), &cpu_set);
+        if (result != 0) {
+            return POSIX_EINVAL;
+        }
+    #endif
+    */
     return 0;
 }
 

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -541,8 +541,8 @@ int Pthread::SetAffinity(const Cpuset* cpuset) {
         return POSIX_ESRCH;
     }
 
-    //  We don't use this currently because some games gets performance problems
-    // when applying affinity event
+    // We don't use this currently because some games gets performance problems
+    // when applying affinity even on strong hardware
     /*
     #ifdef _WIN64
         DWORD_PTR affinity_mask = static_cast<DWORD_PTR>(mask);

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -523,6 +523,7 @@ int PS4_SYSV_ABI posix_pthread_setcancelstate(PthreadCancelState state,
     if (oldstate) {
         *oldstate = oldval ? PthreadCancelState::Enable : PthreadCancelState::Disable;
     }
+    return 0;
 }
 
 int Pthread::SetAffinity(const Cpuset* cpuset) {

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -554,7 +554,7 @@ int Pthread::SetAffinity(const Cpuset* cpuset) {
         return POSIX_EINVAL;
     }
 
-#else ifdef _LINUX
+#elif defined(__linux__)
     cpu_set_t cpu_set;
     CPU_ZERO(&cpu_set);
 

--- a/src/core/libraries/kernel/threads/pthread.h
+++ b/src/core/libraries/kernel/threads/pthread.h
@@ -332,6 +332,7 @@ struct Pthread {
             return true;
         }
     }
+
     int SetAffinity(const Cpuset* cpuset);
 };
 using PthreadT = Pthread*;

--- a/src/core/libraries/kernel/threads/pthread.h
+++ b/src/core/libraries/kernel/threads/pthread.h
@@ -332,6 +332,7 @@ struct Pthread {
             return true;
         }
     }
+    int SetAffinity(const Cpuset* cpuset);
 };
 using PthreadT = Pthread*;
 


### PR DESCRIPTION
Fixes spam in UE games and also applies affinity settings to the host cpu if it has at least 8 cores
Someone should test this on Linux because i only have Windows