### PR TITLE
shader_recompiler: Widen num_conversion bitfield

### DIFF
--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -169,10 +169,10 @@ static constexpr u32 MaxColorBuffers = 8;
 
 struct PsColorBuffer {
     AmdGpu::NumberFormat num_format : 4;
-    AmdGpu::NumberConversion num_conversion : 2;
+    AmdGpu::NumberConversion num_conversion : 3;
     AmdGpu::Liverpool::ShaderExportFormat export_format : 4;
     u32 needs_unorm_fixup : 1;
-    u32 pad : 21;
+    u32 pad : 20;
     AmdGpu::CompMapping swizzle;
 
     auto operator<=>(const PsColorBuffer&) const noexcept = default;


### PR DESCRIPTION
We do this in order to be able to actually fit in all possible values from AmdGpu::NumberConversion.

Fixes gcc compiler warnings:
warning: ‘Shader::PsColorBuffer::num_conversion’ is too small to hold all values of ‘enum class AmdGpu::NumberConversion’