### PR TITLE
gnm: Implement sceGnmDrawIndexIndirectMulti

### DIFF
--- a/src/core/libraries/gnmdriver/gnmdriver.h
+++ b/src/core/libraries/gnmdriver/gnmdriver.h
@@ -51,7 +51,9 @@ s32 PS4_SYSV_ABI sceGnmDrawIndexIndirectCountMulti(u32* cmdbuf, u32 size, u32 da
                                                    u32 max_count, u64 count_addr, u32 shader_stage,
                                                    u32 vertex_sgpr_offset, u32 instance_sgpr_offset,
                                                    u32 flags);
-int PS4_SYSV_ABI sceGnmDrawIndexIndirectMulti();
+int PS4_SYSV_ABI sceGnmDrawIndexIndirectMulti(u32* cmdbuf, u32 size, u32 data_offset, u32 max_count,
+                                              u32 shader_stage, u32 vertex_sgpr_offset,
+                                              u32 instance_sgpr_offset, u32 flags);
 int PS4_SYSV_ABI sceGnmDrawIndexMultiInstanced();
 s32 PS4_SYSV_ABI sceGnmDrawIndexOffset(u32* cmdbuf, u32 size, u32 index_offset, u32 index_count,
                                        u32 flags);

--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -872,16 +872,34 @@ struct PM4CmdDrawIndexIndirectMulti {
         BitField<0, 16, u32> start_inst_loc; ///< Offset where the CP will write the
                                              ///< StartInstanceLocation it fetched from memory
     };
+    u32 count;          ///< Count of data structures to loop through before going to next packet
+    u32 stride;         ///< Stride in memory from one data structure to the next
+    u32 draw_initiator; ///< Draw Initiator Register
+};
+
+struct PM4CmdDrawIndexIndirectCountMulti {
+    PM4Type3Header header; ///< header
+    u32 data_offset;       ///< Byte aligned offset where the required data structure starts
+    union {
+        u32 dw2;
+        BitField<0, 16, u32> base_vtx_loc; ///< Offset where the CP will write the
+                                           ///< BaseVertexLocation it fetched from memory
+    };
+    union {
+        u32 dw3;
+        BitField<0, 16, u32> start_inst_loc; ///< Offset where the CP will write the
+                                             ///< StartInstanceLocation it fetched from memory
+    };
     union {
         u32 dw4;
-        BitField<0, 16, u32> drawIndexLoc; ///< register offset to write the Draw Index count
+        BitField<0, 16, u32> draw_index_loc; ///< register offset to write the Draw Index count
         BitField<30, 1, u32>
-            countIndirectEnable; ///< Indicates the data structure count is in memory
+            count_indirect_enable; ///< Indicates the data structure count is in memory
         BitField<31, 1, u32>
-            drawIndexEnable; ///< Enables writing of Draw Index count to DRAW_INDEX_LOC
+            draw_index_enable; ///< Enables writing of Draw Index count to DRAW_INDEX_LOC
     };
     u32 count;          ///< Count of data structures to loop through before going to next packet
-    u64 countAddr;      ///< DWord aligned Address[31:2]; Valid if countIndirectEnable is set
+    u64 count_addr;     ///< DWord aligned Address[31:2]; Valid if countIndirectEnable is set
     u32 stride;         ///< Stride in memory from one data structure to the next
     u32 draw_initiator; ///< Draw Initiator Register
 };

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -338,6 +338,7 @@ bool Instance::CreateDevice() {
                 .geometryShader = features.geometryShader,
                 .tessellationShader = features.tessellationShader,
                 .logicOp = features.logicOp,
+                .multiDrawIndirect = features.multiDrawIndirect,
                 .depthBiasClamp = features.depthBiasClamp,
                 .fillModeNonSolid = features.fillModeNonSolid,
                 .depthBounds = features.depthBounds,


### PR DESCRIPTION
Implements `sceGnmDrawIndexIndirectMulti`. It seems like it would be implemented using the same packet as `sceGnmDrawIndexIndirectCountMulti` with the count address disabled, but it actually seems to be a different packet ID and structure. I'm guessing this is due to it being an early version of the packet or something in the PS4 GPU.

Also fixed the validation condition for `sceGnmDrawIndexIndirectCountMulti` a bit.

Used by Final Fantasy XV.