### PR TITLE
vulkan: Handle incompatible depth format using null binding.

### DIFF
--- a/src/shader_recompiler/info.h
+++ b/src/shader_recompiler/info.h
@@ -281,6 +281,11 @@ constexpr AmdGpu::Image ImageResource::GetSharp(const Info& info) const noexcept
         // Fall back to null image if unbound.
         return AmdGpu::Image::Null();
     }
+    const auto data_fmt = image.GetDataFmt();
+    if (is_depth && data_fmt != AmdGpu::DataFormat::Format16 &&
+        data_fmt != AmdGpu::DataFormat::Format32) {
+        return AmdGpu::Image::NullDepth();
+    }
     return image;
 }
 

--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -363,6 +363,12 @@ void PatchImageSharp(IR::Block& block, IR::Inst& inst, Info& info, Descriptors& 
         LOG_ERROR(Render_Vulkan, "Shader compiled with unbound image!");
         image = AmdGpu::Image::Null();
     }
+    const auto data_fmt = image.GetDataFmt();
+    if (inst_info.is_depth && data_fmt != AmdGpu::DataFormat::Format16 &&
+        data_fmt != AmdGpu::DataFormat::Format32) {
+        LOG_ERROR(Render_Vulkan, "Shader compiled using non-depth image with depth instruction!");
+        image = AmdGpu::Image::NullDepth();
+    }
     ASSERT(image.GetType() != AmdGpu::ImageType::Invalid);
     const bool is_written = inst.GetOpcode() == IR::Opcode::ImageWrite;
 

--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -219,6 +219,19 @@ struct Image {
         return image;
     }
 
+    static constexpr Image NullDepth() {
+        Image image{};
+        image.data_format = u64(DataFormat::Format32);
+        image.num_format = u64(NumberFormat::Float);
+        image.dst_sel_x = u64(CompSwizzle::Red);
+        image.dst_sel_y = u64(CompSwizzle::Green);
+        image.dst_sel_z = u64(CompSwizzle::Blue);
+        image.dst_sel_w = u64(CompSwizzle::Alpha);
+        image.tiling_index = u64(TilingMode::Texture_MicroTiled);
+        image.type = u64(ImageType::Color2D);
+        return image;
+    }
+
     bool Valid() const {
         return (type & 0x8u) != 0;
     }

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -618,8 +618,9 @@ void Rasterizer::BindTextures(const Shader::Info& stage, Shader::Backend::Bindin
             if (instance.IsNullDescriptorSupported()) {
                 image_infos.emplace_back(VK_NULL_HANDLE, VK_NULL_HANDLE, vk::ImageLayout::eGeneral);
             } else {
-                auto& null_image = texture_cache.GetImageView(VideoCore::NULL_IMAGE_VIEW_ID);
-                image_infos.emplace_back(VK_NULL_HANDLE, *null_image.image_view,
+                auto& null_image_view =
+                    texture_cache.FindTexture(VideoCore::NULL_IMAGE_ID, desc.view_info);
+                image_infos.emplace_back(VK_NULL_HANDLE, *null_image_view.image_view,
                                          vk::ImageLayout::eGeneral);
             }
         } else {

--- a/src/video_core/texture_cache/image_view.h
+++ b/src/video_core/texture_cache/image_view.h
@@ -34,8 +34,6 @@ struct ImageViewInfo {
 
 struct Image;
 
-constexpr Common::SlotId NULL_IMAGE_VIEW_ID{0};
-
 struct ImageView {
     ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info, Image& image,
               ImageId image_id);

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -246,6 +246,9 @@ private:
         }
     }
 
+    /// Gets or creates a null image for a particular format.
+    ImageId GetNullImage(vk::Format format);
+
     /// Create an image from the given parameters
     [[nodiscard]] ImageId InsertImage(const ImageInfo& info, VAddr cpu_addr);
 
@@ -285,6 +288,7 @@ private:
     Common::SlotVector<Image> slot_images;
     Common::SlotVector<ImageView> slot_image_views;
     tsl::robin_map<u64, Sampler> samplers;
+    tsl::robin_map<vk::Format, ImageId> null_images;
     PageTable page_table;
     std::mutex mutex;
 


### PR DESCRIPTION
Builds on latest version of https://github.com/shadps4-emu/shadPS4/pull/2818 a bit with some additional parts to bind the dummy depth image to a proper Vulkan-side image.

Essentially, for a complete view of what this does:
* If we encounter a depth image instruction operating on a non-depth image in a shader, we replace it with a stand-in null depth image, using a format compatible with depth.
* On the Vulkan texture cache side, when we would normally return the fixed null image ID, now we try to return a null image that is appropriately typed to the request. This ensures that we won't try to resolve the new null depth image to a Vulkan image that still isn't compatible with depth formats.

I believe this will allow the depth promote workaround here to also pass Vulkan validation. Please test with some games that hit this issue and see if they get past it. If you know how, please also check to make sure there aren't any weird format incompatibility validation errors when the assert would normally happen.