### PR TITLE
Remove deprecated include

### DIFF
--- a/src/core/libraries/libc_internal/printf.h
+++ b/src/core/libraries/libc_internal/printf.h
@@ -56,7 +56,6 @@
 #include <stdio.h>
 
 #include <cstdarg>
-#include <cstdbool>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>


### PR DESCRIPTION
It builds without this too, at least for me and the Github runners