### PR TITLE
Core: Pooled Memory Fixes

### DIFF
--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -477,9 +477,8 @@ s32 PS4_SYSV_ABI sceKernelMemoryPoolDecommit(void* addr, size_t len, int flags) 
 
     const VAddr pool_addr = reinterpret_cast<VAddr>(addr);
     auto* memory = Core::Memory::Instance();
-    memory->PoolDecommit(pool_addr, len);
 
-    return ORBIS_OK;
+    return memory->PoolDecommit(pool_addr, len);
 }
 
 int PS4_SYSV_ABI sceKernelMmap(void* addr, u64 len, int prot, int flags, int fd, size_t offset,

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -425,10 +425,6 @@ s32 PS4_SYSV_ABI sceKernelMemoryPoolReserve(void* addrIn, size_t len, size_t ali
     LOG_INFO(Kernel_Vmm, "addrIn = {}, len = {:#x}, alignment = {:#x}, flags = {:#x}",
              fmt::ptr(addrIn), len, alignment, flags);
 
-    if (addrIn == nullptr) {
-        LOG_ERROR(Kernel_Vmm, "Address is invalid!");
-        return ORBIS_KERNEL_ERROR_EINVAL;
-    }
     if (len == 0 || !Common::Is2MBAligned(len)) {
         LOG_ERROR(Kernel_Vmm, "Map size is either zero or not 2MB aligned!");
         return ORBIS_KERNEL_ERROR_EINVAL;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -302,7 +302,7 @@ int MemoryManager::PoolCommit(VAddr virtual_addr, size_t size, MemoryProt prot) 
     VAddr mapped_addr = Common::AlignUp(virtual_addr, alignment);
 
     auto& vma = FindVMA(mapped_addr)->second;
-    if (vma.type != VMAType::PoolReserved || vma.base + vma.size < virtual_addr + size) {
+    if (vma.type != VMAType::PoolReserved || !vma.Contains(mapped_addr, size)) {
         // If the VMA isn't PoolReserved or if there's not enough space to commit, return EINVAL
         LOG_ERROR(Kernel_Vmm,
                   "Pooled region {:#x} to {:#x} is not large enough to commit from {:#x} to {:#x}",

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -473,13 +473,12 @@ void MemoryManager::PoolDecommit(VAddr virtual_addr, size_t size) {
     vma.name = "anon";
     MergeAdjacent(vma_map, new_it);
 
-    if (vma_base.type != VMAType::Reserved && type != VMAType::PoolReserved) {
+    if (vma_base.type != VMAType::Reserved && vma_base.type != VMAType::PoolReserved) {
         // Unmap the memory region.
         impl.Unmap(vma_base_addr, vma_base_size, start_in_vma, start_in_vma + size, phys_base,
                    is_exec, false, false);
         TRACK_FREE(virtual_addr, "VMEM");
     }
-    
 }
 
 s32 MemoryManager::UnmapMemory(VAddr virtual_addr, size_t size) {

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -249,7 +249,6 @@ int MemoryManager::PoolReserve(void** out_addr, VAddr virtual_addr, size_t size,
     new_vma.prot = MemoryProt::NoAccess;
     new_vma.name = "anon";
     new_vma.type = VMAType::PoolReserved;
-    MergeAdjacent(vma_map, new_vma_handle);
 
     *out_addr = std::bit_cast<void*>(mapped_addr);
     return ORBIS_OK;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -307,7 +307,7 @@ int MemoryManager::PoolCommit(VAddr virtual_addr, size_t size, MemoryProt prot) 
         // If the VMA isn't PoolReserved or if there's not enough space to commit, return EINVAL
         LOG_ERROR(Kernel_Vmm,
                   "Pooled region {:#x} to {:#x} is not large enough to commit from {:#x} to {:#x}",
-                  vma.base, vma.size, mapped_addr, size);
+                  vma.base, vma.base + vma.size, mapped_addr, mapped_addr + size);
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -215,7 +215,7 @@ int MemoryManager::PoolReserve(void** out_addr, VAddr virtual_addr, size_t size,
     std::scoped_lock lk{mutex};
     alignment = alignment > 0 ? alignment : 2_MB;
     VAddr min_address = Common::AlignUp(impl.SystemManagedVirtualBase(), alignment);
-    VAddr mapped_addr = Common::AlignUp(virtual_addr, alignment);    
+    VAddr mapped_addr = Common::AlignUp(virtual_addr, alignment);
 
     // Fixed mapping means the virtual address must exactly match the provided one.
     if (True(flags & MemoryMapFlags::Fixed)) {

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -320,7 +320,6 @@ int MemoryManager::PoolCommit(VAddr virtual_addr, size_t size, MemoryProt prot) 
     new_vma.type = Core::VMAType::Pooled;
     new_vma.is_exec = false;
     new_vma.phys_base = 0;
-    MergeAdjacent(vma_map, new_vma_handle);
 
     // Perform the mapping
     void* out_addr = impl.Map(mapped_addr, size, alignment, -1, false);
@@ -473,7 +472,7 @@ void MemoryManager::PoolDecommit(VAddr virtual_addr, size_t size) {
     vma.name = "anon";
     MergeAdjacent(vma_map, new_it);
 
-    if (vma_base.type != VMAType::Reserved && vma_base.type != VMAType::PoolReserved) {
+    if (type != VMAType::Reserved && type != VMAType::PoolReserved) {
         // Unmap the memory region.
         impl.Unmap(vma_base_addr, vma_base_size, start_in_vma, start_in_vma + size, phys_base,
                    is_exec, false, false);

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -310,9 +310,6 @@ int MemoryManager::PoolCommit(VAddr virtual_addr, size_t size, MemoryProt prot) 
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
 
-    // Before mapping, the reserved VMA should have it's physical base incremented.
-    vma.phys_base += size;
-
     // Carve out the new VMA representing this mapping
     const auto new_vma_handle = CarveVMA(mapped_addr, size);
     auto& new_vma = new_vma_handle->second;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -227,7 +227,6 @@ int MemoryManager::PoolReserve(void** out_addr, VAddr virtual_addr, size_t size,
         if (vma.IsMapped() || remaining_size < size) {
             UnmapMemoryImpl(mapped_addr, size);
             vma = FindVMA(mapped_addr)->second;
-            remaining_size = vma.base + vma.size - mapped_addr;
         }
     }
 
@@ -270,7 +269,6 @@ int MemoryManager::Reserve(void** out_addr, VAddr virtual_addr, size_t size, Mem
         if (vma.IsMapped() || remaining_size < size) {
             UnmapMemoryImpl(mapped_addr, size);
             vma = FindVMA(mapped_addr)->second;
-            remaining_size = vma.base + vma.size - mapped_addr;
         }
     }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -308,15 +308,16 @@ int MemoryManager::PoolCommit(VAddr virtual_addr, size_t size, MemoryProt prot) 
 
     auto& vma = FindVMA(mapped_addr)->second;
     if (vma.type != VMAType::PoolReserved || vma.base + vma.size < virtual_addr + size) {
-        // If the VMA isn't PoolReserved or if there's not enough space
-        // to commit, this should return EINVAL
-        LOG_ERROR(Kernel_Vmm, "Trying to PoolCommit non-pooled memory!");
+        // If the VMA isn't PoolReserved or if there's not enough space to commit, return EINVAL
+        LOG_ERROR(Kernel_Vmm,
+                  "Pooled region {:#x} to {:#x} is not large enough to commit from {:#x} to {:#x}",
+                  vma.base, vma.size, mapped_addr, size);
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
-    
+
     // Before mapping, the reserved VMA should have it's physical base incremented.
     vma.phys_base += size;
-    
+
     // Carve out the new VMA representing this mapping
     const auto new_vma_handle = CarveVMA(mapped_addr, size);
     auto& new_vma = new_vma_handle->second;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -473,10 +473,13 @@ void MemoryManager::PoolDecommit(VAddr virtual_addr, size_t size) {
     vma.name = "anon";
     MergeAdjacent(vma_map, new_it);
 
-    // Unmap the memory region.
-    impl.Unmap(vma_base_addr, vma_base_size, start_in_vma, start_in_vma + size, phys_base, is_exec,
-               false, false);
-    TRACK_FREE(virtual_addr, "VMEM");
+    if (vma_base.type != VMAType::Reserved && type != VMAType::PoolReserved) {
+        // Unmap the memory region.
+        impl.Unmap(vma_base_addr, vma_base_size, start_in_vma, start_in_vma + size, phys_base, is_exec,
+                   false, false);
+        TRACK_FREE(virtual_addr, "VMEM");
+    }
+    
 }
 
 s32 MemoryManager::UnmapMemory(VAddr virtual_addr, size_t size) {

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -316,7 +316,7 @@ int MemoryManager::PoolCommit(VAddr virtual_addr, size_t size, MemoryProt prot) 
     auto& new_vma = new_vma_handle->second;
     new_vma.disallow_merge = false;
     new_vma.prot = prot;
-    new_vma.name = vma.name;
+    new_vma.name = "anon";
     new_vma.type = Core::VMAType::Pooled;
     new_vma.is_exec = false;
     new_vma.phys_base = 0;
@@ -470,7 +470,7 @@ void MemoryManager::PoolDecommit(VAddr virtual_addr, size_t size) {
     vma.prot = MemoryProt::NoAccess;
     vma.phys_base = 0;
     vma.disallow_merge = false;
-    vma.name = "";
+    vma.name = "anon";
     MergeAdjacent(vma_map, new_it);
 
     // Unmap the memory region.

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -475,8 +475,8 @@ void MemoryManager::PoolDecommit(VAddr virtual_addr, size_t size) {
 
     if (vma_base.type != VMAType::Reserved && type != VMAType::PoolReserved) {
         // Unmap the memory region.
-        impl.Unmap(vma_base_addr, vma_base_size, start_in_vma, start_in_vma + size, phys_base, is_exec,
-                   false, false);
+        impl.Unmap(vma_base_addr, vma_base_size, start_in_vma, start_in_vma + size, phys_base,
+                   is_exec, false, false);
         TRACK_FREE(virtual_addr, "VMEM");
     }
     

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -198,7 +198,7 @@ public:
     int MapFile(void** out_addr, VAddr virtual_addr, size_t size, MemoryProt prot,
                 MemoryMapFlags flags, uintptr_t fd, size_t offset);
 
-    void PoolDecommit(VAddr virtual_addr, size_t size);
+    s32 PoolDecommit(VAddr virtual_addr, size_t size);
 
     s32 UnmapMemory(VAddr virtual_addr, size_t size);
 
@@ -274,6 +274,7 @@ private:
     size_t total_direct_size{};
     size_t total_flexible_size{};
     size_t flexible_usage{};
+    size_t pool_budget{};
     Vulkan::Rasterizer* rasterizer{};
 
     friend class ::Core::Devtools::Widget::MemoryMapViewer;


### PR DESCRIPTION
This introduces a handful of bug fixes designed to make our memory pool implementation more hardware-accurate. All of these changes are based exclusively on hardware tests, so there may be some niche edge cases I've misinterpreted.

Changes:
- Don't coalesce PoolReserved memory
- ~Coalesce PoolCommitted memory~ - Removed change because of Windows.
- Fix another case of potential `vma_map` corruption introduced by #2080
- Handle `sceKernelMemoryPoolReserve` calls with `addrIn = 0`
- Update `sceKernelMemoryPoolExpand` with the updated logic used by `sceKernelAllocateDirectMemory`
- Handle `sceKernelMemoryPoolExpand` errors when there's not enough space to expand.
- Properly unmap before any type of memory reservations.
- Properly handle `sceKernelMemoryPoolCommit` address restrictions.
- Properly handle pooled memory budgets, and the error conditions surrounding these.

This should address #1485, though it doesn't affect any games I own.
Unreal Engine games using memory pools seem to be unaffected by my changes.