### PR TITLE
Implement DS_ORDERED_COUNT

### DIFF
--- a/src/shader_recompiler/frontend/translate/data_share.cpp
+++ b/src/shader_recompiler/frontend/translate/data_share.cpp
@@ -77,6 +77,8 @@ void Translator::EmitDataShare(const GcnInst& inst) {
         return DS_READ(64, false, true, false, inst);
     case Opcode::DS_READ2ST64_B64:
         return DS_READ(64, false, true, true, inst);
+    case Opcode::DS_ORDERED_COUNT:
+        return DS_ORDERED_COUNT(inst);
     default:
         LogMissingOpcode(inst);
     }

--- a/src/shader_recompiler/frontend/translate/data_share.cpp
+++ b/src/shader_recompiler/frontend/translate/data_share.cpp
@@ -326,4 +326,13 @@ void Translator::DS_CONSUME(const GcnInst& inst) {
     SetDst(inst.dst[0], prev);
 }
 
+void Translator::DS_ORDERED_COUNT(const GcnInst& inst) {
+    const IR::U32 addr{GetSrc(inst.src[0])};
+    const IR::U32 offset =
+        ir.Imm32((u32(inst.control.ds.offset1) << 8u) + u32(inst.control.ds.offset0));
+    const IR::U32 addr_offset = ir.IAdd(addr, offset);
+    const IR::Value original_val = ir.SharedAtomicIIncrement(addr_offset);
+    SetDst(inst.dst[0], IR::U32{original_val});
+}
+
 } // namespace Shader::Gcn

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -278,6 +278,7 @@ public:
     void DS_SUB_U32(const GcnInst& inst, bool rtn);
     void DS_INC_U32(const GcnInst& inst, bool rtn);
     void DS_DEC_U32(const GcnInst& inst, bool rtn);
+    void DS_ORDERED_COUNT(const GcnInst& inst);
 
     // Buffer Memory
     // MUBUF / MTBUF


### PR DESCRIPTION
Implementing DS_ORDERED_COUNT, found in Dreams (CUSA04301) after using both PR #2774 and PR #2819 together. Game still won't boot with all these changes though (will crash on ``[Debug] <Critical> tile_manager.cpp:273 operator(): Assertion Failed!``).

Here's the log with both the PRs merged together:

``[Render.Recompiler] <Error> translate.cpp:542 LogMissingOpcode: Unknown opcode DS_ORDERED_COUNT (1087, category = DataShare)``
``[Lib.AudioIn] <Error> audioin.cpp:112 sceAudioInInput: (STUBBED) called``
``[Lib.Net] <Error> sys_net.cpp:222 sys_recvfrom: error code returned : 0x8041012d``
``[Debug] <Critical> structured_control_flow.cpp:835 operator(): Assertion Failed!``
``Shader translation has failed``

[CUSA04301.log](https://github.com/user-attachments/files/20138883/CUSA04301.log)
