### PR TITLE
sceKernelVirtualQuery Fixes VI

### DIFF
--- a/src/core/libraries/kernel/memory.h
+++ b/src/core/libraries/kernel/memory.h
@@ -68,6 +68,8 @@ struct OrbisVirtualQueryInfo {
     u8 is_committed : 1;
     char name[ORBIS_KERNEL_MAXIMUM_NAME_LENGTH];
 };
+static_assert(sizeof(OrbisVirtualQueryInfo) == 72,
+              "OrbisVirtualQueryInfo struct size is incorrect");
 
 struct OrbisKernelBatchMapEntry {
     void* start;

--- a/src/core/libraries/kernel/memory.h
+++ b/src/core/libraries/kernel/memory.h
@@ -61,11 +61,11 @@ struct OrbisVirtualQueryInfo {
     size_t offset;
     s32 protection;
     s32 memory_type;
-    u32 is_flexible : 1;
-    u32 is_direct : 1;
-    u32 is_stack : 1;
-    u32 is_pooled : 1;
-    u32 is_committed : 1;
+    u8 is_flexible : 1;
+    u8 is_direct : 1;
+    u8 is_stack : 1;
+    u8 is_pooled : 1;
+    u8 is_committed : 1;
     char name[ORBIS_KERNEL_MAXIMUM_NAME_LENGTH];
 };
 


### PR DESCRIPTION
Fixes the struct size for `sceKernelVirtualQuery`. Linux compilers were optimizing the size down to hardware-accurate levels, Windows compilers weren't.

And yes, I counted. This is the sixth PR I've made with fixes for this function. Hopefully it's the last.