### PR TITLE
core: Implement Linux TCB access using guest<->host swapping.

### DIFF
--- a/src/core/cpu_patches.h
+++ b/src/core/cpu_patches.h
@@ -11,7 +11,4 @@ namespace Core {
 void RegisterPatchModule(void* module_ptr, u64 module_size, void* trampoline_area_ptr,
                          u64 trampoline_area_size);
 
-/// Applies CPU patches that need to be done before beginning executions.
-void PrePatchInstructions(u64 segment_addr, u64 segment_size);
-
 } // namespace Core

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -163,11 +163,6 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
             LOG_INFO(Core_Linker, "segment_mode ..........: {}", segment_mode);
 
             add_segment(elf_pheader[i]);
-#ifdef ARCH_X86_64
-            if (elf_pheader[i].p_flags & PF_EXEC) {
-                PrePatchInstructions(segment_addr, segment_file_size);
-            }
-#endif
             break;
         }
         case PT_DYNAMIC:


### PR DESCRIPTION
Reviving an old experiment I had to implement TCB access without code patches on Linux. Essentially, whenever a call to guest code happens, we swap GS and FS so the guest TCB is in FS, and when a call to host code happens we do the reverse.

I've done some basic testing with asserts to check that the TCB should be in the correct state when swaps happen during execution of a few games. Needs actual testing from Linux users though to make sure it's working correctly.