### PR TITLE
sceKernelAddTimerEvent implementation

### DIFF
--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -363,7 +363,6 @@ int PS4_SYSV_ABI sceKernelAddTimerEvent(SceKernelEqueue eq, int id, SceKernelUse
     auto timer = std::make_shared<boost::asio::steady_timer>(
         io_context, std::chrono::milliseconds(interval_ms));
 
-    KernelSignalRequest();
 
     if (!eq->AddEvent(event)) {
         return ORBIS_KERNEL_ERROR_ENOMEM;
@@ -373,6 +372,8 @@ int PS4_SYSV_ABI sceKernelAddTimerEvent(SceKernelEqueue eq, int id, SceKernelUse
         [eq, event_data = event.event, interval_ms, timer](const boost::system::error_code& ec) {
             TimerCallback(ec, eq, event_data, interval_ms);
         });
+
+    KernelSignalRequest();
 
     return ORBIS_OK;
 }

--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -324,9 +324,10 @@ static void TimerCallback(const boost::system::error_code& error, SceKernelEqueu
             auto timer = std::make_shared<boost::asio::steady_timer>(
                 io_context, std::chrono::milliseconds(interval_ms));
 
-            timer->async_wait([eq, kevent, interval_ms, timer](const boost::system::error_code& ec) {
-                TimerCallback(ec, eq, kevent, interval_ms);
-            });
+            timer->async_wait(
+                [eq, kevent, interval_ms, timer](const boost::system::error_code& ec) {
+                    TimerCallback(ec, eq, kevent, interval_ms);
+                });
         }
     }
 }
@@ -348,9 +349,8 @@ int PS4_SYSV_ABI sceKernelAddTimerEvent(SceKernelEqueue eq, int id, SceKernelUse
     event.event.udata = udata;
     event.time_added = std::chrono::steady_clock::now();
     LOG_DEBUG(Kernel_Event,
-             "Added timing event: queue name={}, queue id={}, ms-intevall={}, pointer={:x}",
-             eq->GetName(), event.event.ident, interval_ms,
-             reinterpret_cast<uintptr_t>(udata));
+              "Added timing event: queue name={}, queue id={}, ms-intevall={}, pointer={:x}",
+              eq->GetName(), event.event.ident, interval_ms, reinterpret_cast<uintptr_t>(udata));
 
     auto timer = std::make_shared<boost::asio::steady_timer>(
         io_context, std::chrono::milliseconds(interval_ms));

--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -348,6 +348,14 @@ int PS4_SYSV_ABI sceKernelAddTimerEvent(SceKernelEqueue eq, int id, SceKernelUse
     event.event.data = interval_ms;
     event.event.udata = udata;
     event.time_added = std::chrono::steady_clock::now();
+
+    if (eq->EventExists(event.event.ident, event.event.filter)) {
+        eq->RemoveEvent(id, SceKernelEvent::Filter::Timer);
+        LOG_DEBUG(Kernel_Event,
+                  "Timer event already exists, removing it: queue name={}, queue id={}",
+                  eq->GetName(), event.event.ident);
+    }
+
     LOG_DEBUG(Kernel_Event,
               "Added timing event: queue name={}, queue id={}, ms-intevall={}, pointer={:x}",
               eq->GetName(), event.event.ident, interval_ms, reinterpret_cast<uintptr_t>(udata));

--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -364,16 +364,15 @@ int PS4_SYSV_ABI sceKernelAddTimerEvent(SceKernelEqueue eq, int id, SceKernelUse
         io_context, std::chrono::milliseconds(interval_ms));
 
     KernelSignalRequest();
-    std::thread([]() { io_context.run(); }).detach();
+
+    if (!eq->AddEvent(event)) {
+        return ORBIS_KERNEL_ERROR_ENOMEM;
+    }
 
     timer->async_wait(
         [eq, event_data = event.event, interval_ms, timer](const boost::system::error_code& ec) {
             TimerCallback(ec, eq, event_data, interval_ms);
         });
-
-    if (!eq->AddEvent(event)) {
-        return ORBIS_KERNEL_ERROR_ENOMEM;
-    }
 
     return ORBIS_OK;
 }

--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -363,7 +363,6 @@ int PS4_SYSV_ABI sceKernelAddTimerEvent(SceKernelEqueue eq, int id, SceKernelUse
     auto timer = std::make_shared<boost::asio::steady_timer>(
         io_context, std::chrono::milliseconds(interval_ms));
 
-
     if (!eq->AddEvent(event)) {
         return ORBIS_KERNEL_ERROR_ENOMEM;
     }

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -155,9 +155,9 @@ public:
     bool EventExists(u64 id, s16 filter);
 
 private:
+    std::string m_name;
     std::mutex m_mutex;
     std::vector<EqueueEvent> m_events;
-    std::string m_name;
     EqueueEvent small_timer_event{};
     std::condition_variable m_cond;
 };

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -152,10 +152,12 @@ public:
 
     int WaitForSmallTimer(SceKernelEvent* ev, int num, u32 micros);
 
-private:
-    std::string m_name;
     std::mutex m_mutex;
     std::vector<EqueueEvent> m_events;
+
+private:
+    std::string m_name;
+
     EqueueEvent small_timer_event{};
     std::condition_variable m_cond;
 };

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -152,12 +152,12 @@ public:
 
     int WaitForSmallTimer(SceKernelEvent* ev, int num, u32 micros);
 
-    std::mutex m_mutex;
-    std::vector<EqueueEvent> m_events;
+    bool EventExists(u64 id, s16 filter);
 
 private:
+    std::mutex m_mutex;
+    std::vector<EqueueEvent> m_events;
     std::string m_name;
-
     EqueueEvent small_timer_event{};
     std::condition_variable m_cond;
 };


### PR DESCRIPTION
sceKernelAddTimerEvent was implemented based on RE and the existing functions.
It’s used in CUSA05786, but I can’t confirm that it changes anything.
However, based on the RE of how sceKernelAddTimerEvent is used in the game and the output in the emulator, it appears to behave correctly.