### PR TITLE
kernel: Clean up and fix some mistakes.

### DIFF
--- a/src/common/va_ctx.h
+++ b/src/common/va_ctx.h
@@ -8,7 +8,7 @@
 #define VA_ARGS                                                                                    \
     uint64_t rdi, uint64_t rsi, uint64_t rdx, uint64_t rcx, uint64_t r8, uint64_t r9,              \
         uint64_t overflow_arg_area, __m128 xmm0, __m128 xmm1, __m128 xmm2, __m128 xmm3,            \
-        __m128 xmm4, __m128 xmm5, __m128 xmm6, __m128 xmm7, ...
+        __m128 xmm4, __m128 xmm5, __m128 xmm6, __m128 xmm7
 
 #define VA_CTX(ctx)                                                                                \
     alignas(16)::Common::VaCtx ctx{};                                                              \

--- a/src/core/libraries/kernel/aio.cpp
+++ b/src/core/libraries/kernel/aio.cpp
@@ -19,7 +19,7 @@ namespace Libraries::Kernel {
 static s32* id_state;
 static s32 id_index;
 
-s32 sceKernelAioInitializeImpl(void* p, s32 size) {
+s32 PS4_SYSV_ABI sceKernelAioInitializeImpl(void* p, s32 size) {
 
     return 0;
 }

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -581,12 +581,9 @@ int PS4_SYSV_ABI posix_pthread_setaffinity_np(PthreadT thread, size_t cpusetsize
     return thread->SetAffinity(cpusetp);
 }
 
-int PS4_SYSV_ABI scePthreadSetaffinity(PthreadT thread, const Cpuset mask) {
-    int result = posix_pthread_setaffinity_np(thread, 0x10, &mask);
-    if (result != 0) {
-        return ErrnoToSceKernelError(result);
-    }
-    return 0;
+int PS4_SYSV_ABI scePthreadSetaffinity(PthreadT thread, const u64 mask) {
+    const Cpuset cpuset = {.bits = mask};
+    return posix_pthread_setaffinity_np(thread, sizeof(Cpuset), &cpuset);
 }
 
 void RegisterThread(Core::Loader::SymbolsResolver* sym) {
@@ -635,7 +632,7 @@ void RegisterThread(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("W0Hpm2X0uPE", "libkernel", 1, "libkernel", 1, 1, ORBIS(posix_pthread_setprio));
     LIB_FUNCTION("rNhWz+lvOMU", "libkernel", 1, "libkernel", 1, 1, _sceKernelSetThreadDtors);
     LIB_FUNCTION("6XG4B33N09g", "libkernel", 1, "libkernel", 1, 1, sched_yield);
-    LIB_FUNCTION("bt3CTBKmGyI", "libkernel", 1, "libkernel", 1, 1, scePthreadSetaffinity)
+    LIB_FUNCTION("bt3CTBKmGyI", "libkernel", 1, "libkernel", 1, 1, ORBIS(scePthreadSetaffinity));
 }
 
 } // namespace Libraries::Kernel

--- a/src/core/libraries/kernel/threads/pthread.h
+++ b/src/core/libraries/kernel/threads/pthread.h
@@ -159,6 +159,7 @@ enum class SchedPolicy : u32 {
 
 struct Cpuset {
     u64 bits;
+    u64 _reserved;
 };
 
 struct PthreadAttr {
@@ -269,7 +270,7 @@ struct Pthread {
     bool no_cancel;
     bool cancel_async;
     bool cancelling;
-    Cpuset sigmask;
+    u64 sigmask;
     bool unblock_sigcancel;
     bool in_sigsuspend;
     bool force_exit;

--- a/src/core/libraries/libs.h
+++ b/src/core/libraries/libs.h
@@ -3,13 +3,8 @@
 
 #pragma once
 
-#include <functional>
-
-#include "common/logging/log.h"
 #include "core/loader/elf.h"
 #include "core/loader/symbols_resolver.h"
-
-#define W(foo) foo
 
 #define LIB_FUNCTION(nid, lib, libversion, mod, moduleVersionMajor, moduleVersionMinor, function)  \
     {                                                                                              \
@@ -25,7 +20,7 @@
         sym->AddSymbol(sr, func);                                                                  \
     }
 
-#define LIB_OBJ(nid, lib, libversion, mod, moduleVersionMajor, moduleVersionMinor, function)       \
+#define LIB_OBJ(nid, lib, libversion, mod, moduleVersionMajor, moduleVersionMinor, obj)            \
     {                                                                                              \
         Core::Loader::SymbolResolver sr{};                                                         \
         sr.name = nid;                                                                             \
@@ -35,8 +30,7 @@
         sr.module_version_major = moduleVersionMajor;                                              \
         sr.module_version_minor = moduleVersionMinor;                                              \
         sr.type = Core::Loader::SymbolType::Object;                                                \
-        auto func = reinterpret_cast<u64>(function);                                               \
-        sym->AddSymbol(sr, func);                                                                  \
+        sym->AddSymbol(sr, reinterpret_cast<u64>(obj));                                            \
     }
 
 namespace Libraries {

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -127,7 +127,7 @@ void Linker::Execute(const std::vector<std::string> args) {
             }
         }
         params.entry_addr = module->GetEntryAddress();
-        RunMainEntry(&params);
+        ExecuteGuest(RunMainEntry, &params);
     });
 }
 
@@ -366,7 +366,8 @@ void* Linker::TlsGetAddr(u64 module_index, u64 offset) {
     if (!addr) {
         // Module was just loaded by above code. Allocate TLS block for it.
         const u32 init_image_size = module->tls.init_image_size;
-        u8* dest = reinterpret_cast<u8*>(heap_api->heap_malloc(module->tls.image_size));
+        u8* dest = reinterpret_cast<u8*>(
+            Core::ExecuteGuest(heap_api->heap_malloc, module->tls.image_size));
         const u8* src = reinterpret_cast<const u8*>(module->tls.image_virtual_addr);
         std::memcpy(dest, src, init_image_size);
         std::memset(dest + init_image_size, 0, module->tls.image_size - init_image_size);


### PR DESCRIPTION
Isolating some misc changes from https://github.com/shadps4-emu/shadPS4/pull/2905 to:
* Make sure they get in regardless of whether that works
* Make sure that these aren't causing some of the issues with that PR.

Summary:
* Remove extra var-args definition from `VA_ARGS` macro to make the functions wrappable. As far as I can tell this wasn't needed.
* Add missing `PS4_SYSV_ABI` to `sceKernelAioInitializeImpl`.
* Clean up some commented debugging stuff from the `ORBIS` wrapper to make backtrace symbols cleaner.
* Fix size of `Cpuset` in pthread affinity functions.
* Simplify `scePthreadSetaffinity` using `ORBIS` similar to how we do `scePthreadAttrGetaffinity`/`scePthreadAttrSetaffinity`: create a separate function that just handles the argument difference, then wrap it to handle the error code translation.
* Make clear that the parameter to `LIB_OBJ` is an object pointer, not a function.
* Fix some missing uses of `ExecuteGuest` in the linker code.

Regression testing is appreciated.