### PR TITLE
qt: Delay physical device enumeration to settings open.

### DIFF
--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -24,7 +24,6 @@
 #include "main_window.h"
 #include "settings_dialog.h"
 
-#include "video_core/renderer_vulkan/vk_instance.h"
 #ifdef ENABLE_DISCORD_RPC
 #include "common/discord_rpc_handler.h"
 #endif
@@ -53,7 +52,6 @@ bool MainWindow::Init() {
     CreateConnects();
     SetLastUsedTheme();
     SetLastIconSizeBullet();
-    GetPhysicalDevices();
     // show ui
     setMinimumSize(720, 405);
     std::string window_title = "";
@@ -368,19 +366,6 @@ void MainWindow::CheckUpdateMain(bool checkSave) {
 }
 #endif
 
-void MainWindow::GetPhysicalDevices() {
-    Vulkan::Instance instance(false, false);
-    auto physical_devices = instance.GetPhysicalDevices();
-    for (const vk::PhysicalDevice physical_device : physical_devices) {
-        auto prop = physical_device.getProperties();
-        QString name = QString::fromUtf8(prop.deviceName, -1);
-        if (prop.apiVersion < Vulkan::TargetVulkanApiVersion) {
-            name += tr(" * Unsupported Vulkan Version");
-        }
-        m_physical_devices.push_back(name);
-    }
-}
-
 void MainWindow::CreateConnects() {
     connect(this, &MainWindow::WindowResized, this, &MainWindow::HandleResize);
     connect(ui->mw_searchbar, &QLineEdit::textChanged, this, &MainWindow::SearchGameTable);
@@ -421,7 +406,7 @@ void MainWindow::CreateConnects() {
             &MainWindow::StartGame);
 
     connect(ui->configureAct, &QAction::triggered, this, [this]() {
-        auto settingsDialog = new SettingsDialog(m_physical_devices, m_compat_info, this);
+        auto settingsDialog = new SettingsDialog(m_compat_info, this);
 
         connect(settingsDialog, &SettingsDialog::LanguageChanged, this,
                 &MainWindow::OnLanguageChanged);
@@ -454,7 +439,7 @@ void MainWindow::CreateConnects() {
     });
 
     connect(ui->settingsButton, &QPushButton::clicked, this, [this]() {
-        auto settingsDialog = new SettingsDialog(m_physical_devices, m_compat_info, this);
+        auto settingsDialog = new SettingsDialog(m_compat_info, this);
 
         connect(settingsDialog, &SettingsDialog::LanguageChanged, this,
                 &MainWindow::OnLanguageChanged);

--- a/src/qt_gui/main_window.h
+++ b/src/qt_gui/main_window.h
@@ -60,7 +60,6 @@ private:
     void toggleFullscreen();
     void CreateRecentGameActions();
     void CreateDockWindows();
-    void GetPhysicalDevices();
     void LoadGameLists();
 
 #ifdef ENABLE_UPDATER
@@ -96,8 +95,6 @@ private:
     QScopedPointer<ElfViewer> m_elf_viewer;
     // Status Bar.
     QScopedPointer<QStatusBar> statusBar;
-    // Available GPU devices
-    std::vector<QString> m_physical_devices;
 
     PSF psf;
 

--- a/src/qt_gui/settings_dialog.h
+++ b/src/qt_gui/settings_dialog.h
@@ -20,8 +20,7 @@ class SettingsDialog;
 class SettingsDialog : public QDialog {
     Q_OBJECT
 public:
-    explicit SettingsDialog(std::span<const QString> physical_devices,
-                            std::shared_ptr<CompatibilityInfoClass> m_compat_info,
+    explicit SettingsDialog(std::shared_ptr<CompatibilityInfoClass> m_compat_info,
                             QWidget* parent = nullptr);
     ~SettingsDialog();
 


### PR DESCRIPTION
Delay enumerating Vulkan physical devices for the settings menu until the settings UI has been opened.

Should fix this assert with AMD GPUs (unless you open the settings UI before the game):
```
[Debug] address_space.cpp:82 operator(): Assertion Failed!
Unable to reserve virtual address space: Not enough memory resources are available to process this command.
```