### PR TITLE
libkernel: Implement sceKernelMemoryPoolBatch

### DIFF
--- a/src/core/libraries/kernel/memory.h
+++ b/src/core/libraries/kernel/memory.h
@@ -172,8 +172,8 @@ s32 PS4_SYSV_ABI sceKernelMemoryPoolReserve(void* addrIn, size_t len, size_t ali
                                             void** addrOut);
 s32 PS4_SYSV_ABI sceKernelMemoryPoolCommit(void* addr, size_t len, int type, int prot, int flags);
 s32 PS4_SYSV_ABI sceKernelMemoryPoolDecommit(void* addr, size_t len, int flags);
-s32 PS4_SYSV_ABI sceKernelMemoryPoolBatch(const OrbisKernelMemoryPoolBatchEntry* entries,
-                                          s32 count, s32* num_processed, s32 flags);
+s32 PS4_SYSV_ABI sceKernelMemoryPoolBatch(const OrbisKernelMemoryPoolBatchEntry* entries, s32 count,
+                                          s32* num_processed, s32 flags);
 
 int PS4_SYSV_ABI sceKernelMunmap(void* addr, size_t len);
 

--- a/src/core/libraries/kernel/memory.h
+++ b/src/core/libraries/kernel/memory.h
@@ -81,6 +81,48 @@ struct OrbisKernelBatchMapEntry {
     int operation;
 };
 
+enum class OrbisKernelMemoryPoolOpcode : u32 {
+    Commit = 1,
+    Decommit = 2,
+    Protect = 3,
+    TypeProtect = 4,
+    Move = 5,
+};
+
+struct OrbisKernelMemoryPoolBatchEntry {
+    OrbisKernelMemoryPoolOpcode opcode;
+    u32 flags;
+    union {
+        struct {
+            void* addr;
+            u64 len;
+            u8 prot;
+            u8 type;
+        } commit_params;
+        struct {
+            void* addr;
+            u64 len;
+        } decommit_params;
+        struct {
+            void* addr;
+            u64 len;
+            u8 prot;
+        } protect_params;
+        struct {
+            void* addr;
+            u64 len;
+            u8 prot;
+            u8 type;
+        } type_protect_params;
+        struct {
+            void* dest_addr;
+            void* src_addr;
+            u64 len;
+        } move_params;
+        uintptr_t padding[3];
+    };
+};
+
 u64 PS4_SYSV_ABI sceKernelGetDirectMemorySize();
 int PS4_SYSV_ABI sceKernelAllocateDirectMemory(s64 searchStart, s64 searchEnd, u64 len,
                                                u64 alignment, int memoryType, s64* physAddrOut);
@@ -130,6 +172,8 @@ s32 PS4_SYSV_ABI sceKernelMemoryPoolReserve(void* addrIn, size_t len, size_t ali
                                             void** addrOut);
 s32 PS4_SYSV_ABI sceKernelMemoryPoolCommit(void* addr, size_t len, int type, int prot, int flags);
 s32 PS4_SYSV_ABI sceKernelMemoryPoolDecommit(void* addr, size_t len, int flags);
+s32 PS4_SYSV_ABI sceKernelMemoryPoolBatch(const OrbisKernelMemoryPoolBatchEntry* entries,
+                                          s32 count, s32* num_processed, s32 flags);
 
 int PS4_SYSV_ABI sceKernelMunmap(void* addr, size_t len);
 


### PR DESCRIPTION
Implements sceKernelMemoryPoolBatch based on hardware tests and our sceKernelBatchMap implementation.

I've tested the Commit and Decommit opcodes on real hardware through homebrew, Protect and TypeProtect are currently untested.

This is reportedly used in DAYS GONE (CUSA09176), I'll need @gandalfthewhite19890404 to test that title for me.