### PR TITLE
fix rough mouse movement due to incorrect check

### DIFF
--- a/src/input/input_mouse.cpp
+++ b/src/input/input_mouse.cpp
@@ -60,7 +60,7 @@ Uint32 MousePolling(void* param, Uint32 id, Uint32 interval) {
     float angle = atan2(d_y, d_x);
     float a_x = cos(angle) * output_speed, a_y = sin(angle) * output_speed;
 
-    if (d_x != 0 && d_y != 0) {
+    if (d_x != 0 || d_y != 0) {
         controller->Axis(0, axis_x, GetAxis(-0x80, 0x7f, a_x));
         controller->Axis(0, axis_y, GetAxis(-0x80, 0x7f, a_y));
     } else {


### PR DESCRIPTION
Hey! I was having problems playing BB on a mouse, the movement was too rough, especially when i was trying to move mouse slowly.

Found a strange check in the mouse handler. When the mouse is moved perfectly horizontally or vertically, the controller values are not updated. 

Perhaps its better to use OR here? That solved the problems for me, now the mouse movements are pretty smooth