### PR TITLE
liverpool: Log more information on SetQueueReg.

### DIFF
--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -864,6 +864,11 @@ Liverpool::Task Liverpool::ProcessCompute(const u32* acb, u32 acb_dwords, u32 vq
             }
             break;
         }
+        case PM4ItOpcode::SetQueueReg: {
+            const auto* set_data = reinterpret_cast<const PM4CmdSetQueueReg*>(header);
+            UNREACHABLE_MSG("Encountered compute SetQueueReg: vqid = {}, reg_offset = {:#x}",
+                            set_data->vqid.Value(), set_data->reg_offset.Value());
+        }
         case PM4ItOpcode::DispatchDirect: {
             const auto* dispatch_direct = reinterpret_cast<const PM4CmdDispatchDirect*>(header);
             auto& cs_program = GetCsRegs();

--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -211,6 +211,21 @@ struct PM4CmdSetData {
     }
 };
 
+struct PM4CmdSetQueueReg {
+    PM4Type3Header header;
+    union {
+        u32 raw;
+        BitField<0, 8, u32> reg_offset;  ///< Offset in DWords from the register base address
+        BitField<15, 1, u32> defer_exec; ///< Defer execution
+        BitField<16, 10, u32> vqid;      ///< Queue ID
+    };
+    u32 data[0];
+
+    [[nodiscard]] u32 Size() const {
+        return header.count << 2u;
+    }
+};
+
 struct PM4CmdNop {
     PM4Type3Header header;
     u32 data_block[0];


### PR DESCRIPTION
I don't know currently exactly what register area this operates on to implement it, but we can at least add in the proper structure and start logging out the queue and register offset being operated on.