### PR TITLE
core: Introduce host call wrapper.

### DIFF
--- a/src/core/libraries/kernel/threads.h
+++ b/src/core/libraries/kernel/threads.h
@@ -35,7 +35,7 @@ public:
         this->func = std::move(func);
         PthreadAttrT attr{};
         posix_pthread_attr_init(&attr);
-        posix_pthread_create(&thread, &attr, RunWrapper, this);
+        posix_pthread_create(&thread, &attr, HOST_CALL(RunWrapper), this);
         posix_pthread_attr_destroy(&attr);
     }
 

--- a/src/core/libraries/libs.h
+++ b/src/core/libraries/libs.h
@@ -5,6 +5,7 @@
 
 #include "core/loader/elf.h"
 #include "core/loader/symbols_resolver.h"
+#include "core/tls.h"
 
 #define LIB_FUNCTION(nid, lib, libversion, mod, moduleVersionMajor, moduleVersionMinor, function)  \
     {                                                                                              \
@@ -16,7 +17,7 @@
         sr.module_version_major = moduleVersionMajor;                                              \
         sr.module_version_minor = moduleVersionMinor;                                              \
         sr.type = Core::Loader::SymbolType::Function;                                              \
-        auto func = reinterpret_cast<u64>(function);                                               \
+        auto func = reinterpret_cast<u64>(HOST_CALL(function));                                    \
         sym->AddSymbol(sr, func);                                                                  \
     }
 

--- a/src/core/tls.h
+++ b/src/core/tls.h
@@ -58,4 +58,16 @@ ReturnType ExecuteGuest(PS4_SYSV_ABI ReturnType (*func)(FuncArgs...), CallArgs&&
     return func(std::forward<CallArgs>(args)...);
 }
 
+template <class F, F f>
+struct HostCallWrapperImpl;
+
+template <class ReturnType, class... Args, PS4_SYSV_ABI ReturnType (*func)(Args...)>
+struct HostCallWrapperImpl<PS4_SYSV_ABI ReturnType (*)(Args...), func> {
+    static ReturnType PS4_SYSV_ABI wrap(Args... args) {
+        return func(args...);
+    }
+};
+
+#define HOST_CALL(func) (Core::HostCallWrapperImpl<decltype(&(func)), func>::wrap)
+
 } // namespace Core


### PR DESCRIPTION
Splitting out another working part of https://github.com/shadps4-emu/shadPS4/pull/2905, to reduce the scope of changes there further. Having this in can make sure we don't break compatibility with having a general library function wrapper, and can provide a useful point to intercept calls and insert debugging.