### PR TITLE
shader_recompiler: Always mark buffers as storage buffers.

### DIFF
--- a/src/shader_recompiler/info.h
+++ b/src/shader_recompiler/info.h
@@ -62,7 +62,14 @@ struct BufferResource {
     }
 
     bool IsStorage(const AmdGpu::Buffer& buffer, const Profile& profile) const noexcept {
-        return buffer.GetSize() > profile.max_ubo_size || is_written;
+        // When using uniform buffers, a size is required at compilation time, so we need to
+        // either compile a lot of shader specializations to handle each size or just force it to
+        // the maximum possible size always. However, for some vendors the shader-supplied size is
+        // used for bounds checking uniform buffer accesses, so the latter would effectively turn
+        // off buffer robustness behavior. Instead, force storage buffers which are bounds checked
+        // using the actual buffer size. We are assuming the performance hit from this is
+        // acceptable.
+        return true; // buffer.GetSize() > profile.max_ubo_size || is_written;
     }
 
     [[nodiscard]] constexpr AmdGpu::Buffer GetSharp(const Info& info) const noexcept;


### PR DESCRIPTION
Experiment with always binding buffers as storage buffers, to avoid some limitations related to uniform buffer size and bounds checking.

Interested in seeing how this affects NVIDIA in particular. If you want to test, please report if this degrades performance and to what extent, and for device loss crashes, please only report if this improves the issue as this isn't expected to fix all cases.