### PR TITLE
(Attempted) Fix buffer memory tracking in case of composite buffers

### DIFF
--- a/src/video_core/buffer_cache/word_manager.h
+++ b/src/video_core/buffer_cache/word_manager.h
@@ -169,7 +169,7 @@ public:
             func(cpu_addr + pending_offset * BYTES_PER_PAGE,
                  (pending_pointer - pending_offset) * BYTES_PER_PAGE);
         };
-        IterateWords(offset, size, [&](size_t index, u64 mask) {
+        IterateWords(offset, size - offset, [&](size_t index, u64 mask) {
             if constexpr (type == Type::GPU) {
                 mask &= ~untracked[index];
             }


### PR DESCRIPTION
This is _not_ a proper solution

What I've found during testing is a situation that causes the assert of 'Attempted to track non-GPU mapped memory...". Prerequisites are as follow:
- there is a pooled area mapped that spans exactly the buffer size
- there is a composite buffer used by one of the shaders, bound with varying offsets

As an example, a game maps a pooled area at 0x2052c00000 with size 0x280000. Then a shader uses three V#s pointing into this buffer: one with base 0x2052c00000 and dfmt Format32_32_32, one with base 0x2052c0000c and dfmt Format16_16 and one with base 0x2052c00010 and dfmt Format8_8_8_8. All of them specify stride 0x14 and size 0x280000 (exactly the pooled area).

The problem arises when the size calculation does not take into account the offset and element size, using only stride and num_records. When the time comes to track the buffer's memory, it adds the calculated size to the base address, and aligns the result up to the page boundary. In this case, 0x2052c0000c + 0x280000 will spill over the pooled area and cause the assert trying to protect page outside the mapped memory,

I've tried fixing the size calculation itself but it seemed to work worse, like some logos when Resident Evil 2 boots were not visible 🤔

The same problem can happen with Image resources, but the underlying issue is different. Please test and let me know your thoughts