### PR TITLE
renderer_vulkan: Properly enable dualSrcBlend feature.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -337,6 +337,7 @@ bool Instance::CreateDevice() {
                 .independentBlend = features.independentBlend,
                 .geometryShader = features.geometryShader,
                 .tessellationShader = features.tessellationShader,
+                .dualSrcBlend = features.dualSrcBlend
                 .logicOp = features.logicOp,
                 .multiDrawIndirect = features.multiDrawIndirect,
                 .depthBiasClamp = features.depthBiasClamp,

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -337,7 +337,7 @@ bool Instance::CreateDevice() {
                 .independentBlend = features.independentBlend,
                 .geometryShader = features.geometryShader,
                 .tessellationShader = features.tessellationShader,
-                .dualSrcBlend = features.dualSrcBlend
+                .dualSrcBlend = features.dualSrcBlend,
                 .logicOp = features.logicOp,
                 .multiDrawIndirect = features.multiDrawIndirect,
                 .depthBiasClamp = features.depthBiasClamp,


### PR DESCRIPTION
Fixes a validation error seen in CUSA00223.