### PR TITLE
vk_instance: Enable robustImageAccess2

### DIFF
--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -261,6 +261,8 @@ bool Instance::CreateDevice() {
         robustness2_features = feature_chain.get<vk::PhysicalDeviceRobustness2FeaturesEXT>();
         LOG_INFO(Render_Vulkan, "- robustBufferAccess2: {}",
                  robustness2_features.robustBufferAccess2);
+        LOG_INFO(Render_Vulkan, "- robustImageAccess2: {}",
+                 robustness2_features.robustImageAccess2);
         LOG_INFO(Render_Vulkan, "- nullDescriptor: {}", robustness2_features.nullDescriptor);
     }
     custom_border_color = add_extension(VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
@@ -395,6 +397,7 @@ bool Instance::CreateDevice() {
         },
         vk::PhysicalDeviceRobustness2FeaturesEXT{
             .robustBufferAccess2 = robustness2_features.robustBufferAccess2,
+            .robustImageAccess2 = robustness2_features.robustImageAccess2,
             .nullDescriptor = robustness2_features.nullDescriptor,
         },
         vk::PhysicalDeviceVertexInputDynamicStateFeaturesEXT{


### PR DESCRIPTION
Small change to log and enable `robustImageAccess2` when supported, providing further guarantees for out-of-bounds image accesses across GPUs. Not expected to change much.