### PR TITLE
kernel: macos/linux Implement sceKernelUuidCreate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1094,9 +1094,12 @@ if (ENABLE_DISCORD_RPC)
     target_compile_definitions(shadps4 PRIVATE ENABLE_DISCORD_RPC)
 endif()
 
-# Optional due to https://github.com/shadps4-emu/shadPS4/issues/1704
-if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND ENABLE_USERFAULTFD)
-    target_compile_definitions(shadps4 PRIVATE ENABLE_USERFAULTFD)
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    # Optional due to https://github.com/shadps4-emu/shadPS4/issues/1704
+    if (ENABLE_USERFAULTFD)
+        target_compile_definitions(shadps4 PRIVATE ENABLE_USERFAULTFD)
+    endif()
+
     target_link_libraries(shadps4 PRIVATE uuid)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1097,6 +1097,7 @@ endif()
 # Optional due to https://github.com/shadps4-emu/shadPS4/issues/1704
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND ENABLE_USERFAULTFD)
     target_compile_definitions(shadps4 PRIVATE ENABLE_USERFAULTFD)
+    target_link_libraries(shadps4 PRIVATE uuid)
 endif()
 
 if (APPLE)

--- a/src/core/libraries/kernel/kernel.cpp
+++ b/src/core/libraries/kernel/kernel.cpp
@@ -168,10 +168,8 @@ int PS4_SYSV_ABI sceKernelUuidCreate(OrbisKernelUuid* orbisUuid) {
 #else
     uuid_t uuid;
     uuid_generate(uuid);
-    orbisUuid->timeLow = ((u32)uuid[0] << 24) |
-                         ((u32)uuid[1] << 16) |
-                         ((u32)uuid[2] << 8) |
-                         (u32)uuid[3];
+    orbisUuid->timeLow =
+        ((u32)uuid[0] << 24) | ((u32)uuid[1] << 16) | ((u32)uuid[2] << 8) | (u32)uuid[3];
     orbisUuid->timeMid = ((u16)uuid[4] << 8) | uuid[5];
     orbisUuid->timeHiAndVersion = ((u16)uuid[6] << 8) | uuid[7];
     orbisUuid->clockSeqHiAndReserved = uuid[8];

--- a/src/core/libraries/kernel/kernel.cpp
+++ b/src/core/libraries/kernel/kernel.cpp
@@ -28,6 +28,8 @@
 
 #ifdef _WIN64
 #include <Rpc.h>
+#else
+#include <uuid/uuid.h>
 #endif
 #include <common/singleton.h>
 #include "aio.h"
@@ -164,7 +166,19 @@ int PS4_SYSV_ABI sceKernelUuidCreate(OrbisKernelUuid* orbisUuid) {
         orbisUuid->node[i] = uuid.Data4[2 + i];
     }
 #else
-    LOG_ERROR(Kernel, "sceKernelUuidCreate: Add linux");
+    uuid_t uuid;
+    uuid_generate(uuid);
+    orbisUuid->timeLow = ((u32)uuid[0] << 24) |
+                         ((u32)uuid[1] << 16) |
+                         ((u32)uuid[2] << 8) |
+                         (u32)uuid[3];
+    orbisUuid->timeMid = ((u16)uuid[4] << 8) | uuid[5];
+    orbisUuid->timeHiAndVersion = ((u16)uuid[6] << 8) | uuid[7];
+    orbisUuid->clockSeqHiAndReserved = uuid[8];
+    orbisUuid->clockSeqLow = uuid[9];
+    for (int i = 0; i < 6; i++) {
+        orbisUuid->node[i] = uuid[10 + i];
+    }
 #endif
     return 0;
 }


### PR DESCRIPTION
fix crash when launching the game on Mac and Linux. 

Used by CUSA13793 LEGO Star Wars: The Skywalker Saga

Helps game to boot in macos 

fix crash when launching the game on mac and linux. 

Specs:
macOS 15.4
intel i7
AMD RX 6600

Tested on:
✅ macOS intel x64

Need to test
❓on linux
❓on arm macos and linux

For testers:
If the scene loads on startup, then the test is passed.

Still can't get to the menu, for those who want to play it

<details>
  <summary>But crash in intro with shaders after this scene</summary>
<img width="1392" alt="ps4_lego" src="https://github.com/user-attachments/assets/9139ac06-dd29-4c18-8c79-b8348f5e9383" />
<code>
[Render.Vulkan] <Info> vk_pipeline_cache.cpp:492 CompileModule: Compiling vs shader 0xbb76efee (permutation)
[Lib.Pad] <Info> pad.cpp:418 scePadResetLightBar: (DUMMY) called
[Lib.Pad] <Info> pad.cpp:418 scePadResetLightBar: (DUMMY) called
[Lib.Pad] <Info> pad.cpp:418 scePadResetLightBar: (DUMMY) called
[Render.Vulkan] <Info> vk_pipeline_cache.cpp:492 CompileModule: Compiling vs shader 0x59be8804 (permutation)
[Lib.Pad] <Info> pad.cpp:418 scePadResetLightBar: (DUMMY) called
[Lib.Pad] <Info> pad.cpp:418 scePadResetLightBar: (DUMMY) called
[Lib.Pad] <Info> pad.cpp:418 scePadResetLightBar: (DUMMY) called
[Lib.Pad] <Info> pad.cpp:418 scePadResetLightBar: (DUMMY) called
[Lib.Pad] <Info> pad.cpp:418 scePadResetLightBar: (DUMMY) called
[Lib.Pad] <Info> pad.cpp:418 scePadResetLightBar: (DUMMY) called
[Lib.Pad] <Info> pad.cpp:418 scePadResetLightBar: (DUMMY) called
[Lib.Pad] <Info> pad.cpp:418 scePadResetLightBar: (DUMMY) called
[Lib.Pad] <Info> pad.cpp:418 scePadResetLightBar: (DUMMY) called
[Lib.Pad] <Info> pad.cpp:418 scePadResetLightBar: (DUMMY) called
[Lib.Pad] <Info> pad.cpp:418 scePadResetLightBar: (DUMMY) called
[Lib.Pad] <Info> pad.cpp:418 scePadResetLightBar: (DUMMY) called
[Lib.Pad] <Info> pad.cpp:418 scePadResetLightBar: (DUMMY) called
[Lib.Pad] <Info> pad.cpp:418 scePadResetLightBar: (DUMMY) called
[Lib.Pad] <Info> pad.cpp:418 scePadResetLightBar: (DUMMY) called
[Lib.Pad] <Info> pad.cpp:418 scePadResetLightBar: (DUMMY) called
[Render.Vulkan] <Info> vk_pipeline_cache.cpp:492 CompileModule: Compiling cs shader 0x9fdfa83b
[mvk-error] VK_ERROR_INITIALIZATION_FAILED: Shader library compile failed (Error code 3):
program_source:737:37: error: unexpected type name 'uint': expected expression
                uint4 _1212 = uint4(uint _728, uint _727, _683, _682);
                                    ^
program_source:737:42: error: expected ')'
                uint4 _1212 = uint4(uint _728, uint _727, _683, _682);
                                         ^
program_source:737:36: note: to match this '('
                uint4 _1212 = uint4(uint _728, uint _727, _683, _682);
                                   ^
.
[mvk-error] VK_ERROR_INITIALIZATION_FAILED: Compute shader function could not be compiled into pipeline. See previous logged error.
[Debug] <Critical> vk_compute_pipeline.cpp:101 operator(): Assertion Failed!
Failed to create compute pipeline: ErrorInitializationFailed
[1]    41460 trace trap  ./shadps4.app/Contents/MacOS/shadps4
</code>
</details>


