### PR TITLE
Avoid post-increment of SGPR in S_*_LOAD_DWORD

### DIFF
--- a/src/shader_recompiler/frontend/translate/scalar_memory.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_memory.cpp
@@ -53,7 +53,7 @@ void Translator::S_LOAD_DWORD(int num_dwords, const GcnInst& inst) {
         ir.CompositeConstruct(ir.GetScalarReg(sbase), ir.GetScalarReg(sbase + 1));
     IR::ScalarReg dst_reg{inst.dst[0].code};
     for (u32 i = 0; i < num_dwords; i++) {
-        ir.SetScalarReg(dst_reg++, ir.ReadConst(base, ir.Imm32(dword_offset + i)));
+        ir.SetScalarReg(dst_reg + i, ir.ReadConst(base, ir.Imm32(dword_offset + i)));
     }
 }
 
@@ -75,7 +75,7 @@ void Translator::S_BUFFER_LOAD_DWORD(int num_dwords, const GcnInst& inst) {
     IR::ScalarReg dst_reg{inst.dst[0].code};
     for (u32 i = 0; i < num_dwords; i++) {
         const IR::U32 index = ir.IAdd(dword_offset, ir.Imm32(i));
-        ir.SetScalarReg(dst_reg++, ir.ReadConstBuffer(vsharp, index));
+        ir.SetScalarReg(dst_reg + i, ir.ReadConstBuffer(vsharp, index));
     }
 }
 


### PR DESCRIPTION
Hit by Killzone Shadow Fall - when translating an instruction like `s_load_dwordx8  s[96:103], ...`, the post-increment would hit an overflow error on the last iteration of the loop