### PR TITLE
externals: Remove winpthreads.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,10 +30,6 @@
 	path = externals/xbyak
 	url = https://github.com/herumi/xbyak.git
 	shallow = true
-[submodule "externals/winpthreads"]
-	path = externals/winpthreads
-	url = https://github.com/shadps4-emu/winpthreads.git
-	shallow = true
 [submodule "externals/magic_enum"]
 	path = externals/magic_enum
 	url = https://github.com/Neargye/magic_enum.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,13 +239,6 @@ if (APPLE)
 endif()
 list(POP_BACK CMAKE_MODULE_PATH)
 
-# Note: Windows always has these functions through winpthreads
-include(CheckSymbolExists)
-check_symbol_exists(pthread_mutex_timedlock "pthread.h" HAVE_PTHREAD_MUTEX_TIMEDLOCK)
-if(HAVE_PTHREAD_MUTEX_TIMEDLOCK OR WIN32)
-    add_compile_options(-DHAVE_PTHREAD_MUTEX_TIMEDLOCK)
-endif()
-
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     # libc++ requires -fexperimental-library to enable std::jthread and std::stop_token support.
     include(CheckCXXSymbolExists)
@@ -1156,7 +1149,7 @@ if (ENABLE_QT_GUI)
 endif()
 
 if (WIN32)
-    target_link_libraries(shadps4 PRIVATE mincore winpthreads)
+    target_link_libraries(shadps4 PRIVATE mincore)
 
     if (MSVC)
         # MSVC likes putting opinions on what people can use, disable:

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -137,12 +137,6 @@ if (NOT TARGET Zydis::Zydis)
     add_subdirectory(zydis)
 endif()
 
-# Winpthreads
-if (WIN32)
-    add_subdirectory(winpthreads)
-    target_include_directories(winpthreads INTERFACE winpthreads/include)
-endif()
-
 # sirit
 add_subdirectory(sirit)
 if (WIN32)

--- a/src/common/thread.cpp
+++ b/src/common/thread.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2014 Citra Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <ctime>
 #include <string>
 #include <thread>
 
@@ -104,14 +105,24 @@ void SetCurrentThreadPriority(ThreadPriority new_priority) {
     SetThreadPriority(handle, windows_priority);
 }
 
-static void AccurateSleep(std::chrono::nanoseconds duration) {
+bool AccurateSleep(const std::chrono::nanoseconds duration, std::chrono::nanoseconds* remaining,
+                   const bool interruptible) {
+    const auto begin_sleep = std::chrono::high_resolution_clock::now();
+
     LARGE_INTEGER interval{
         .QuadPart = -1 * (duration.count() / 100u),
     };
     HANDLE timer = ::CreateWaitableTimer(NULL, TRUE, NULL);
     SetWaitableTimer(timer, &interval, 0, NULL, NULL, 0);
-    WaitForSingleObject(timer, INFINITE);
+    const auto ret = WaitForSingleObjectEx(timer, INFINITE, interruptible);
     ::CloseHandle(timer);
+
+    if (remaining) {
+        const auto end_sleep = std::chrono::high_resolution_clock::now();
+        const auto sleep_time = end_sleep - begin_sleep;
+        *remaining = duration > sleep_time ? duration - sleep_time : std::chrono::nanoseconds(0);
+    }
+    return ret == WAIT_OBJECT_0;
 }
 
 #else
@@ -134,8 +145,24 @@ void SetCurrentThreadPriority(ThreadPriority new_priority) {
     pthread_setschedparam(this_thread, scheduling_type, &params);
 }
 
-static void AccurateSleep(std::chrono::nanoseconds duration) {
-    std::this_thread::sleep_for(duration);
+bool AccurateSleep(const std::chrono::nanoseconds duration, std::chrono::nanoseconds* remaining,
+                   const bool interruptible) {
+    timespec request = {
+        .tv_sec = duration.count() / 1'000'000'000,
+        .tv_nsec = duration.count() % 1'000'000'000,
+    };
+    timespec remain;
+    int ret;
+    while ((ret = nanosleep(&request, &remain)) < 0 && errno == EINTR) {
+        if (interruptible) {
+            break;
+        }
+        request = remain;
+    }
+    if (remaining) {
+        *remaining = std::chrono::nanoseconds(remain.tv_sec * 1'000'000'000 + remain.tv_nsec);
+    }
+    return ret == 0 || errno != EINTR;
 }
 
 #endif
@@ -196,9 +223,9 @@ AccurateTimer::AccurateTimer(std::chrono::nanoseconds target_interval)
     : target_interval(target_interval) {}
 
 void AccurateTimer::Start() {
-    auto begin_sleep = std::chrono::high_resolution_clock::now();
+    const auto begin_sleep = std::chrono::high_resolution_clock::now();
     if (total_wait.count() > 0) {
-        AccurateSleep(total_wait);
+        AccurateSleep(total_wait, nullptr, false);
     }
     start_time = std::chrono::high_resolution_clock::now();
     total_wait -= std::chrono::duration_cast<std::chrono::nanoseconds>(start_time - begin_sleep);

--- a/src/common/thread.h
+++ b/src/common/thread.h
@@ -25,6 +25,9 @@ void SetCurrentThreadName(const char* name);
 
 void SetThreadName(void* thread, const char* name);
 
+bool AccurateSleep(std::chrono::nanoseconds duration, std::chrono::nanoseconds* remaining,
+                   bool interruptible);
+
 class AccurateTimer {
     std::chrono::nanoseconds target_interval{};
     std::chrono::nanoseconds total_wait{};

--- a/src/core/libraries/kernel/kernel.cpp
+++ b/src/core/libraries/kernel/kernel.cpp
@@ -108,6 +108,9 @@ void SetPosixErrno(int e) {
     case EACCES:
         g_posix_errno = POSIX_EACCES;
         break;
+    case EFAULT:
+        g_posix_errno = POSIX_EFAULT;
+        break;
     case EINVAL:
         g_posix_errno = POSIX_EINVAL;
         break;

--- a/src/core/libraries/kernel/time.cpp
+++ b/src/core/libraries/kernel/time.cpp
@@ -5,24 +5,23 @@
 
 #include "common/assert.h"
 #include "common/native_clock.h"
+#include "common/thread.h"
 #include "core/libraries/kernel/kernel.h"
 #include "core/libraries/kernel/orbis_error.h"
+#include "core/libraries/kernel/posix_error.h"
 #include "core/libraries/kernel/time.h"
 #include "core/libraries/libs.h"
 
 #ifdef _WIN64
-#include <pthread_time.h>
 #include <windows.h>
-
 #include "common/ntapi.h"
-
 #else
 #if __APPLE__
 #include <date/tz.h>
 #endif
+#include <ctime>
 #include <sys/resource.h>
 #include <sys/time.h>
-#include <time.h>
 #include <unistd.h>
 #endif
 
@@ -52,88 +51,116 @@ u64 PS4_SYSV_ABI sceKernelReadTsc() {
     return clock->GetUptime();
 }
 
-int PS4_SYSV_ABI sceKernelUsleep(u32 microseconds) {
-#ifdef _WIN64
-    const auto start_time = std::chrono::high_resolution_clock::now();
-    auto total_wait_time = std::chrono::microseconds(microseconds);
+static s32 posix_nanosleep_impl(const OrbisKernelTimespec* rqtp, OrbisKernelTimespec* rmtp,
+                                const bool interruptible) {
+    if (!rqtp || rqtp->tv_sec < 0 || rqtp->tv_nsec < 0 || rqtp->tv_nsec >= 1'000'000'000) {
+        SetPosixErrno(EINVAL);
+        return -1;
+    }
+    const auto duration = std::chrono::nanoseconds(rqtp->tv_sec * 1'000'000'000 + rqtp->tv_nsec);
+    std::chrono::nanoseconds remain;
+    const auto uninterrupted = Common::AccurateSleep(duration, &remain, interruptible);
+    if (rmtp) {
+        rmtp->tv_sec = remain.count() / 1'000'000'000;
+        rmtp->tv_nsec = remain.count() % 1'000'000'000;
+    }
+    if (!uninterrupted) {
+        SetPosixErrno(EINTR);
+        return -1;
+    }
+    return 0;
+}
 
-    while (total_wait_time.count() > 0) {
-        auto wait_time = std::chrono::ceil<std::chrono::milliseconds>(total_wait_time).count();
-        u64 res = SleepEx(static_cast<u64>(wait_time), true);
-        if (res == WAIT_IO_COMPLETION) {
-            auto elapsedTime = std::chrono::high_resolution_clock::now() - start_time;
-            auto elapsedMicroseconds =
-                std::chrono::duration_cast<std::chrono::microseconds>(elapsedTime).count();
-            total_wait_time = std::chrono::microseconds(microseconds - elapsedMicroseconds);
-        } else {
-            break;
-        }
+s32 PS4_SYSV_ABI posix_nanosleep(const OrbisKernelTimespec* rqtp, OrbisKernelTimespec* rmtp) {
+    return posix_nanosleep_impl(rqtp, rmtp, true);
+}
+
+s32 PS4_SYSV_ABI sceKernelNanosleep(const OrbisKernelTimespec* rqtp, OrbisKernelTimespec* rmtp) {
+    if (const auto ret = posix_nanosleep_impl(rqtp, rmtp, false); ret < 0) {
+        return ErrnoToSceKernelError(*__Error());
+    }
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI posix_usleep(u32 microseconds) {
+    const OrbisKernelTimespec ts = {
+        .tv_sec = microseconds / 1'000'000,
+        .tv_nsec = (microseconds % 1'000'000) * 1'000,
+    };
+    return posix_nanosleep(&ts, nullptr);
+}
+
+s32 PS4_SYSV_ABI sceKernelUsleep(u32 microseconds) {
+    const OrbisKernelTimespec ts = {
+        .tv_sec = microseconds / 1'000'000,
+        .tv_nsec = (microseconds % 1'000'000) * 1'000,
+    };
+    return sceKernelNanosleep(&ts, nullptr);
+}
+
+u32 PS4_SYSV_ABI posix_sleep(u32 seconds) {
+    const OrbisKernelTimespec ts = {
+        .tv_sec = seconds,
+        .tv_nsec = 0,
+    };
+    OrbisKernelTimespec rm;
+    if (const auto ret = posix_nanosleep(&ts, &rm); ret < 0) {
+        return *__Error() == POSIX_EINTR ? rm.tv_sec + (rm.tv_nsec == 0 ? 0 : 1) : seconds;
+    }
+    return 0;
+}
+
+s32 PS4_SYSV_ABI sceKernelSleep(u32 seconds) {
+    return sceKernelUsleep(seconds * 1'000'000);
+}
+
+s32 PS4_SYSV_ABI posix_clock_gettime(u32 clock_id, OrbisKernelTimespec* ts) {
+    if (ts == nullptr) {
+        SetPosixErrno(EFAULT);
+        return -1;
     }
 
-    return 0;
-#else
-    timespec start;
-    timespec remain;
-    start.tv_sec = microseconds / 1000000;
-    start.tv_nsec = (microseconds % 1000000) * 1000;
-    timespec* requested = &start;
-    int ret = 0;
-    do {
-        ret = nanosleep(requested, &remain);
-        requested = &remain;
-    } while (ret != 0);
-    return ret;
-#endif
-}
+    if (clock_id == ORBIS_CLOCK_PROCTIME) {
+        const auto us = sceKernelGetProcessTime();
+        ts->tv_sec = static_cast<s64>(us / 1'000'000);
+        ts->tv_nsec = static_cast<s64>((us % 1'000'000) * 1000);
+        return 0;
+    }
+    if (clock_id == ORBIS_CLOCK_EXT_NETWORK || clock_id == ORBIS_CLOCK_EXT_DEBUG_NETWORK ||
+        clock_id == ORBIS_CLOCK_EXT_AD_NETWORK || clock_id == ORBIS_CLOCK_EXT_RAW_NETWORK) {
+        LOG_ERROR(Lib_Kernel, "Unsupported clock type {}, using CLOCK_MONOTONIC", clock_id);
+        clock_id = ORBIS_CLOCK_MONOTONIC;
+    }
 
-int PS4_SYSV_ABI posix_usleep(u32 microseconds) {
-    return sceKernelUsleep(microseconds);
-}
-
-u32 PS4_SYSV_ABI sceKernelSleep(u32 seconds) {
-    std::this_thread::sleep_for(std::chrono::seconds(seconds));
-    return 0;
-}
-
-#ifdef _WIN64
-#ifndef CLOCK_REALTIME
-#define CLOCK_REALTIME 0
-#endif
-#ifndef CLOCK_MONOTONIC
-#define CLOCK_MONOTONIC 1
-#endif
-#ifndef CLOCK_PROCESS_CPUTIME_ID
-#define CLOCK_PROCESS_CPUTIME_ID 2
-#endif
-#ifndef CLOCK_THREAD_CPUTIME_ID
-#define CLOCK_THREAD_CPUTIME_ID 3
-#endif
-#ifndef CLOCK_REALTIME_COARSE
-#define CLOCK_REALTIME_COARSE 5
-#endif
-#ifndef CLOCK_MONOTONIC_COARSE
-#define CLOCK_MONOTONIC_COARSE 6
-#endif
-
-#define DELTA_EPOCH_IN_100NS 116444736000000000ULL
-
-static u64 FileTimeTo100Ns(FILETIME& ft) {
-    return *reinterpret_cast<u64*>(&ft);
-}
-
-static s32 clock_gettime(u32 clock_id, struct timespec* ts) {
+#ifdef _WIN32
+    static const auto FileTimeTo100Ns = [](FILETIME& ft) { return *reinterpret_cast<u64*>(&ft); };
     switch (clock_id) {
-    case CLOCK_REALTIME:
-    case CLOCK_REALTIME_COARSE: {
+    case ORBIS_CLOCK_REALTIME:
+    case ORBIS_CLOCK_REALTIME_PRECISE: {
         FILETIME ft;
-        GetSystemTimeAsFileTime(&ft);
-        const u64 ns = FileTimeTo100Ns(ft) - DELTA_EPOCH_IN_100NS;
+        GetSystemTimePreciseAsFileTime(&ft);
+        static constexpr u64 DeltaEpochIn100ns = 116444736000000000ULL;
+        const u64 ns = FileTimeTo100Ns(ft) - DeltaEpochIn100ns;
         ts->tv_sec = ns / 10'000'000;
         ts->tv_nsec = (ns % 10'000'000) * 100;
         return 0;
     }
-    case CLOCK_MONOTONIC:
-    case CLOCK_MONOTONIC_COARSE: {
+    case ORBIS_CLOCK_SECOND:
+    case ORBIS_CLOCK_REALTIME_FAST: {
+        FILETIME ft;
+        GetSystemTimeAsFileTime(&ft);
+        static constexpr u64 DeltaEpochIn100ns = 116444736000000000ULL;
+        const u64 ns = FileTimeTo100Ns(ft) - DeltaEpochIn100ns;
+        ts->tv_sec = ns / 10'000'000;
+        ts->tv_nsec = (ns % 10'000'000) * 100;
+        return 0;
+    }
+    case ORBIS_CLOCK_UPTIME:
+    case ORBIS_CLOCK_UPTIME_PRECISE:
+    case ORBIS_CLOCK_MONOTONIC:
+    case ORBIS_CLOCK_MONOTONIC_PRECISE:
+    case ORBIS_CLOCK_UPTIME_FAST:
+    case ORBIS_CLOCK_MONOTONIC_FAST: {
         static LARGE_INTEGER pf = [] {
             LARGE_INTEGER res{};
             QueryPerformanceFrequency(&pf);
@@ -141,43 +168,53 @@ static s32 clock_gettime(u32 clock_id, struct timespec* ts) {
         }();
 
         LARGE_INTEGER pc{};
-        QueryPerformanceCounter(&pc);
+        if (!QueryPerformanceCounter(&pc)) {
+            SetPosixErrno(EFAULT);
+            return -1;
+        }
         ts->tv_sec = pc.QuadPart / pf.QuadPart;
         ts->tv_nsec = ((pc.QuadPart % pf.QuadPart) * 1000'000'000) / pf.QuadPart;
         return 0;
     }
-    case CLOCK_PROCESS_CPUTIME_ID: {
+    case ORBIS_CLOCK_THREAD_CPUTIME_ID: {
         FILETIME ct, et, kt, ut;
-        if (!GetProcessTimes(GetCurrentProcess(), &ct, &et, &kt, &ut)) {
-            return EFAULT;
+        if (!GetThreadTimes(GetCurrentThread(), &ct, &et, &kt, &ut)) {
+            SetPosixErrno(EFAULT);
+            return -1;
         }
         const u64 ns = FileTimeTo100Ns(ut) + FileTimeTo100Ns(kt);
         ts->tv_sec = ns / 10'000'000;
         ts->tv_nsec = (ns % 10'000'000) * 100;
         return 0;
     }
-    case CLOCK_THREAD_CPUTIME_ID: {
+    case ORBIS_CLOCK_VIRTUAL: {
         FILETIME ct, et, kt, ut;
-        if (!GetThreadTimes(GetCurrentThread(), &ct, &et, &kt, &ut)) {
-            return EFAULT;
+        if (!GetProcessTimes(GetCurrentProcess(), &ct, &et, &kt, &ut)) {
+            SetPosixErrno(EFAULT);
+            return -1;
         }
-        const u64 ns = FileTimeTo100Ns(ut) + FileTimeTo100Ns(kt);
+        const u64 ns = FileTimeTo100Ns(ut);
+        ts->tv_sec = ns / 10'000'000;
+        ts->tv_nsec = (ns % 10'000'000) * 100;
+        return 0;
+    }
+    case ORBIS_CLOCK_PROF: {
+        FILETIME ct, et, kt, ut;
+        if (!GetProcessTimes(GetCurrentProcess(), &ct, &et, &kt, &ut)) {
+            SetPosixErrno(EFAULT);
+            return -1;
+        }
+        const u64 ns = FileTimeTo100Ns(kt);
         ts->tv_sec = ns / 10'000'000;
         ts->tv_nsec = (ns % 10'000'000) * 100;
         return 0;
     }
     default:
-        return EINVAL;
+        SetPosixErrno(EFAULT);
+        return -1;
     }
-}
-#endif
-
-int PS4_SYSV_ABI orbis_clock_gettime(s32 clock_id, struct OrbisKernelTimespec* ts) {
-    if (ts == nullptr) {
-        return ORBIS_KERNEL_ERROR_EFAULT;
-    }
-
-    clockid_t pclock_id = CLOCK_MONOTONIC;
+#else
+    clockid_t pclock_id;
     switch (clock_id) {
     case ORBIS_CLOCK_REALTIME:
     case ORBIS_CLOCK_REALTIME_PRECISE:
@@ -185,7 +222,7 @@ int PS4_SYSV_ABI orbis_clock_gettime(s32 clock_id, struct OrbisKernelTimespec* t
         break;
     case ORBIS_CLOCK_SECOND:
     case ORBIS_CLOCK_REALTIME_FAST:
-#ifndef __APPLE__
+#ifdef CLOCK_REALTIME_COARSE
         pclock_id = CLOCK_REALTIME_COARSE;
 #else
         pclock_id = CLOCK_REALTIME;
@@ -199,7 +236,7 @@ int PS4_SYSV_ABI orbis_clock_gettime(s32 clock_id, struct OrbisKernelTimespec* t
         break;
     case ORBIS_CLOCK_UPTIME_FAST:
     case ORBIS_CLOCK_MONOTONIC_FAST:
-#ifndef __APPLE__
+#ifdef CLOCK_MONOTONIC_COARSE
         pclock_id = CLOCK_MONOTONIC_COARSE;
 #else
         pclock_id = CLOCK_MONOTONIC;
@@ -208,196 +245,226 @@ int PS4_SYSV_ABI orbis_clock_gettime(s32 clock_id, struct OrbisKernelTimespec* t
     case ORBIS_CLOCK_THREAD_CPUTIME_ID:
         pclock_id = CLOCK_THREAD_CPUTIME_ID;
         break;
-    case ORBIS_CLOCK_PROCTIME: {
-        const auto us = sceKernelGetProcessTime();
-        ts->tv_sec = us / 1'000'000;
-        ts->tv_nsec = (us % 1'000'000) * 1000;
-        return 0;
-    }
     case ORBIS_CLOCK_VIRTUAL: {
-#ifdef _WIN64
-        FILETIME ct, et, kt, ut;
-        if (!GetProcessTimes(GetCurrentProcess(), &ct, &et, &kt, &ut)) {
-            return EFAULT;
-        }
-        const u64 ns = FileTimeTo100Ns(ut);
-        ts->tv_sec = ns / 10'000'000;
-        ts->tv_nsec = (ns % 10'000'000) * 100;
-#else
-        struct rusage ru;
+        rusage ru;
         const auto res = getrusage(RUSAGE_SELF, &ru);
         if (res < 0) {
-            return res;
+            SetPosixErrno(EFAULT);
+            return -1;
         }
         ts->tv_sec = ru.ru_utime.tv_sec;
         ts->tv_nsec = ru.ru_utime.tv_usec * 1000;
-#endif
         return 0;
     }
     case ORBIS_CLOCK_PROF: {
-#ifdef _WIN64
-        FILETIME ct, et, kt, ut;
-        if (!GetProcessTimes(GetCurrentProcess(), &ct, &et, &kt, &ut)) {
-            return EFAULT;
-        }
-        const u64 ns = FileTimeTo100Ns(kt);
-        ts->tv_sec = ns / 10'000'000;
-        ts->tv_nsec = (ns % 10'000'000) * 100;
-#else
-        struct rusage ru;
+        rusage ru;
         const auto res = getrusage(RUSAGE_SELF, &ru);
         if (res < 0) {
-            return res;
+            SetPosixErrno(EFAULT);
+            return -1;
         }
         ts->tv_sec = ru.ru_stime.tv_sec;
         ts->tv_nsec = ru.ru_stime.tv_usec * 1000;
-#endif
         return 0;
     }
-    case ORBIS_CLOCK_EXT_NETWORK:
-    case ORBIS_CLOCK_EXT_DEBUG_NETWORK:
-    case ORBIS_CLOCK_EXT_AD_NETWORK:
-    case ORBIS_CLOCK_EXT_RAW_NETWORK:
-        pclock_id = CLOCK_MONOTONIC;
-        LOG_ERROR(Lib_Kernel, "unsupported = {} using CLOCK_MONOTONIC", clock_id);
-        break;
     default:
-        return EINVAL;
+        SetPosixErrno(EFAULT);
+        return -1;
     }
 
     timespec t{};
-    int result = clock_gettime(pclock_id, &t);
+    const auto result = clock_gettime(pclock_id, &t);
     ts->tv_sec = t.tv_sec;
     ts->tv_nsec = t.tv_nsec;
-    return result;
-}
-
-int PS4_SYSV_ABI sceKernelClockGettime(s32 clock_id, OrbisKernelTimespec* tp) {
-    const auto res = orbis_clock_gettime(clock_id, tp);
-    if (res < 0) {
-        return ErrnoToSceKernelError(res);
+    if (result < 0) {
+        SetPosixErrno(errno);
+        return -1;
     }
-    return ORBIS_OK;
-}
-
-int PS4_SYSV_ABI posix_nanosleep(const OrbisKernelTimespec* rqtp, OrbisKernelTimespec* rmtp) {
-    const auto* request = reinterpret_cast<const timespec*>(rqtp);
-    auto* remain = reinterpret_cast<timespec*>(rmtp);
-    return nanosleep(request, remain);
-}
-
-int PS4_SYSV_ABI sceKernelNanosleep(const OrbisKernelTimespec* rqtp, OrbisKernelTimespec* rmtp) {
-    if (!rqtp || !rmtp) {
-        return ORBIS_KERNEL_ERROR_EFAULT;
-    }
-
-    if (rqtp->tv_sec < 0 || rqtp->tv_nsec < 0) {
-        return ORBIS_KERNEL_ERROR_EINVAL;
-    }
-
-    return posix_nanosleep(rqtp, rmtp);
-}
-
-int PS4_SYSV_ABI sceKernelGettimeofday(OrbisKernelTimeval* tp) {
-    if (!tp) {
-        return ORBIS_KERNEL_ERROR_EFAULT;
-    }
-
-#ifdef _WIN64
-    FILETIME filetime;
-    GetSystemTimePreciseAsFileTime(&filetime);
-
-    constexpr u64 UNIX_TIME_START = 0x295E9648864000;
-    constexpr u64 TICKS_PER_SECOND = 1000000;
-
-    u64 ticks = filetime.dwHighDateTime;
-    ticks <<= 32;
-    ticks |= filetime.dwLowDateTime;
-    ticks /= 10;
-    ticks -= UNIX_TIME_START;
-
-    tp->tv_sec = ticks / TICKS_PER_SECOND;
-    tp->tv_usec = ticks % TICKS_PER_SECOND;
-#else
-    timeval tv;
-    gettimeofday(&tv, nullptr);
-    tp->tv_sec = tv.tv_sec;
-    tp->tv_usec = tv.tv_usec;
+    return 0;
 #endif
+}
+
+s32 PS4_SYSV_ABI sceKernelClockGettime(const u32 clock_id, OrbisKernelTimespec* ts) {
+    if (const auto ret = posix_clock_gettime(clock_id, ts); ret < 0) {
+        return ErrnoToSceKernelError(*__Error());
+    }
     return ORBIS_OK;
 }
 
-int PS4_SYSV_ABI gettimeofday(OrbisKernelTimeval* tp, OrbisKernelTimezone* tz) {
-    // FreeBSD docs mention that the kernel generally does not track these values
-    // and they	are usually returned as	zero.
-    if (tz) {
-        tz->tz_minuteswest = 0;
-        tz->tz_dsttime = 0;
-    }
-    return sceKernelGettimeofday(tp);
-}
-
-s32 PS4_SYSV_ABI sceKernelGettimezone(OrbisKernelTimezone* tz) {
-#ifdef _WIN64
-    ASSERT(tz);
-    static int tzflag = 0;
-    if (!tzflag) {
-        _tzset();
-        tzflag++;
-    }
-    tz->tz_minuteswest = _timezone / 60;
-    tz->tz_dsttime = _daylight;
-#else
-    struct timezone tzz;
-    struct timeval tv;
-    gettimeofday(&tv, &tzz);
-    tz->tz_dsttime = tzz.tz_dsttime;
-    tz->tz_minuteswest = tzz.tz_minuteswest;
-#endif
-    return ORBIS_OK;
-}
-
-int PS4_SYSV_ABI posix_clock_getres(u32 clock_id, OrbisKernelTimespec* res) {
+s32 PS4_SYSV_ABI posix_clock_getres(u32 clock_id, OrbisKernelTimespec* res) {
     if (res == nullptr) {
-        return ORBIS_KERNEL_ERROR_EFAULT;
+        SetPosixErrno(EFAULT);
+        return -1;
     }
-    clockid_t pclock_id = CLOCK_REALTIME;
+
+    if (clock_id == ORBIS_CLOCK_EXT_NETWORK || clock_id == ORBIS_CLOCK_EXT_DEBUG_NETWORK ||
+        clock_id == ORBIS_CLOCK_EXT_AD_NETWORK || clock_id == ORBIS_CLOCK_EXT_RAW_NETWORK) {
+        LOG_ERROR(Lib_Kernel, "Unsupported clock type {}, using CLOCK_MONOTONIC", clock_id);
+        clock_id = ORBIS_CLOCK_MONOTONIC;
+    }
+
+#ifdef _WIN32
+    switch (clock_id) {
+    case ORBIS_CLOCK_SECOND:
+    case ORBIS_CLOCK_REALTIME_FAST: {
+        DWORD timeAdjustment;
+        DWORD timeIncrement;
+        BOOL isTimeAdjustmentDisabled;
+        if (!GetSystemTimeAdjustment(&timeAdjustment, &timeIncrement, &isTimeAdjustmentDisabled)) {
+            SetPosixErrno(EFAULT);
+            return -1;
+        }
+        res->tv_sec = 0;
+        res->tv_nsec = timeIncrement * 100;
+        return 0;
+    }
+    case ORBIS_CLOCK_REALTIME:
+    case ORBIS_CLOCK_REALTIME_PRECISE:
+    case ORBIS_CLOCK_UPTIME:
+    case ORBIS_CLOCK_UPTIME_PRECISE:
+    case ORBIS_CLOCK_MONOTONIC:
+    case ORBIS_CLOCK_MONOTONIC_PRECISE:
+    case ORBIS_CLOCK_UPTIME_FAST:
+    case ORBIS_CLOCK_MONOTONIC_FAST: {
+        LARGE_INTEGER pf;
+        if (!QueryPerformanceFrequency(&pf)) {
+            SetPosixErrno(EFAULT);
+            return -1;
+        }
+        res->tv_sec = 0;
+        res->tv_nsec =
+            std::max(static_cast<s32>((1000000000 + (pf.QuadPart >> 1)) / pf.QuadPart), 1);
+        return 0;
+    }
+    default:
+        UNREACHABLE();
+    }
+#else
+    clockid_t pclock_id;
     switch (clock_id) {
     case ORBIS_CLOCK_REALTIME:
     case ORBIS_CLOCK_REALTIME_PRECISE:
-    case ORBIS_CLOCK_REALTIME_FAST:
         pclock_id = CLOCK_REALTIME;
         break;
     case ORBIS_CLOCK_SECOND:
+    case ORBIS_CLOCK_REALTIME_FAST:
+#ifdef CLOCK_REALTIME_COARSE
+        pclock_id = CLOCK_REALTIME_COARSE;
+#else
+        pclock_id = CLOCK_REALTIME;
+#endif
+        break;
+    case ORBIS_CLOCK_UPTIME:
+    case ORBIS_CLOCK_UPTIME_PRECISE:
     case ORBIS_CLOCK_MONOTONIC:
     case ORBIS_CLOCK_MONOTONIC_PRECISE:
-    case ORBIS_CLOCK_MONOTONIC_FAST:
         pclock_id = CLOCK_MONOTONIC;
+        break;
+    case ORBIS_CLOCK_UPTIME_FAST:
+    case ORBIS_CLOCK_MONOTONIC_FAST:
+#ifdef CLOCK_MONOTONIC_COARSE
+        pclock_id = CLOCK_MONOTONIC_COARSE;
+#else
+        pclock_id = CLOCK_MONOTONIC;
+#endif
         break;
     default:
         UNREACHABLE();
     }
 
     timespec t{};
-    int result = clock_getres(pclock_id, &t);
+    const auto result = clock_getres(pclock_id, &t);
     res->tv_sec = t.tv_sec;
     res->tv_nsec = t.tv_nsec;
-    if (result == 0) {
-        return ORBIS_OK;
+    if (result < 0) {
+        SetPosixErrno(errno);
+        return -1;
     }
-    return ORBIS_KERNEL_ERROR_EINVAL;
+    return 0;
+#endif
 }
 
-int PS4_SYSV_ABI sceKernelConvertLocaltimeToUtc(time_t param_1, int64_t param_2, time_t* seconds,
-                                                OrbisKernelTimezone* timezone, int* dst_seconds) {
+s32 PS4_SYSV_ABI sceKernelClockGetres(const u32 clock_id, OrbisKernelTimespec* res) {
+    if (const auto ret = posix_clock_getres(clock_id, res); ret < 0) {
+        return ErrnoToSceKernelError(*__Error());
+    }
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI posix_gettimeofday(OrbisKernelTimeval* tp, OrbisKernelTimezone* tz) {
+#ifdef _WIN64
+    if (tp) {
+        FILETIME filetime;
+        GetSystemTimePreciseAsFileTime(&filetime);
+
+        constexpr u64 UNIX_TIME_START = 0x295E9648864000;
+        constexpr u64 TICKS_PER_SECOND = 1000000;
+
+        u64 ticks = filetime.dwHighDateTime;
+        ticks <<= 32;
+        ticks |= filetime.dwLowDateTime;
+        ticks /= 10;
+        ticks -= UNIX_TIME_START;
+
+        tp->tv_sec = ticks / TICKS_PER_SECOND;
+        tp->tv_usec = ticks % TICKS_PER_SECOND;
+    }
+    if (tz) {
+        static int tzflag = 0;
+        if (!tzflag) {
+            _tzset();
+            tzflag++;
+        }
+        tz->tz_minuteswest = _timezone / 60;
+        tz->tz_dsttime = _daylight;
+    }
+    return 0;
+#else
+    struct timezone tzz;
+    timeval tv;
+    const auto ret = gettimeofday(&tv, &tzz);
+    if (tp) {
+        tp->tv_sec = tv.tv_sec;
+        tp->tv_usec = tv.tv_usec;
+    }
+    if (tz) {
+        tz->tz_dsttime = tzz.tz_dsttime;
+        tz->tz_minuteswest = tzz.tz_minuteswest;
+    }
+    if (ret < 0) {
+        SetPosixErrno(errno);
+        return -1;
+    }
+    return 0;
+#endif
+}
+
+s32 PS4_SYSV_ABI sceKernelGettimeofday(OrbisKernelTimeval* tp) {
+    if (const auto ret = posix_gettimeofday(tp, nullptr); ret < 0) {
+        return ErrnoToSceKernelError(*__Error());
+    }
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceKernelGettimezone(OrbisKernelTimezone* tz) {
+    if (const auto ret = posix_gettimeofday(nullptr, tz); ret < 0) {
+        return ErrnoToSceKernelError(*__Error());
+    }
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceKernelConvertLocaltimeToUtc(time_t param_1, int64_t param_2, time_t* seconds,
+                                                OrbisKernelTimezone* timezone, s32* dst_seconds) {
     LOG_INFO(Kernel, "called");
     if (timezone) {
         sceKernelGettimezone(timezone);
         param_1 -= (timezone->tz_minuteswest + timezone->tz_dsttime) * 60;
-        if (seconds)
+        if (seconds) {
             *seconds = param_1;
-        if (dst_seconds)
+        }
+        if (dst_seconds) {
             *dst_seconds = timezone->tz_dsttime * 60;
+        }
     } else {
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
@@ -415,7 +482,7 @@ Common::NativeClock* GetClock() {
 
 } // namespace Dev
 
-int PS4_SYSV_ABI sceKernelConvertUtcToLocaltime(time_t time, time_t* local_time,
+s32 PS4_SYSV_ABI sceKernelConvertUtcToLocaltime(time_t time, time_t* local_time,
                                                 struct OrbisTimesec* st, u64* dst_sec) {
     LOG_TRACE(Kernel, "Called");
 #ifdef __APPLE__
@@ -444,28 +511,35 @@ int PS4_SYSV_ABI sceKernelConvertUtcToLocaltime(time_t time, time_t* local_time,
 void RegisterTime(Core::Loader::SymbolsResolver* sym) {
     clock = std::make_unique<Common::NativeClock>();
     initial_ptc = clock->GetUptime();
+
+    // POSIX
+    LIB_FUNCTION("yS8U2TGCe1A", "libkernel", 1, "libkernel", 1, 1, posix_nanosleep);
+    LIB_FUNCTION("yS8U2TGCe1A", "libScePosix", 1, "libkernel", 1, 1, posix_nanosleep);
+    LIB_FUNCTION("QcteRwbsnV0", "libkernel", 1, "libkernel", 1, 1, posix_usleep);
+    LIB_FUNCTION("QcteRwbsnV0", "libScePosix", 1, "libkernel", 1, 1, posix_usleep);
+    LIB_FUNCTION("0wu33hunNdE", "libkernel", 1, "libkernel", 1, 1, posix_sleep);
+    LIB_FUNCTION("0wu33hunNdE", "libScePosix", 1, "libkernel", 1, 1, posix_sleep);
+    LIB_FUNCTION("lLMT9vJAck0", "libkernel", 1, "libkernel", 1, 1, posix_clock_gettime);
+    LIB_FUNCTION("lLMT9vJAck0", "libScePosix", 1, "libkernel", 1, 1, posix_clock_gettime);
+    LIB_FUNCTION("smIj7eqzZE8", "libkernel", 1, "libkernel", 1, 1, posix_clock_getres);
+    LIB_FUNCTION("smIj7eqzZE8", "libScePosix", 1, "libkernel", 1, 1, posix_clock_getres);
+    LIB_FUNCTION("n88vx3C5nW8", "libkernel", 1, "libkernel", 1, 1, posix_gettimeofday);
+    LIB_FUNCTION("n88vx3C5nW8", "libScePosix", 1, "libkernel", 1, 1, posix_gettimeofday);
+
+    // Orbis
     LIB_FUNCTION("4J2sUJmuHZQ", "libkernel", 1, "libkernel", 1, 1, sceKernelGetProcessTime);
     LIB_FUNCTION("fgxnMeTNUtY", "libkernel", 1, "libkernel", 1, 1, sceKernelGetProcessTimeCounter);
     LIB_FUNCTION("BNowx2l588E", "libkernel", 1, "libkernel", 1, 1,
                  sceKernelGetProcessTimeCounterFrequency);
     LIB_FUNCTION("-2IRUCO--PM", "libkernel", 1, "libkernel", 1, 1, sceKernelReadTsc);
     LIB_FUNCTION("1j3S3n-tTW4", "libkernel", 1, "libkernel", 1, 1, sceKernelGetTscFrequency);
-    LIB_FUNCTION("ejekcaNQNq0", "libkernel", 1, "libkernel", 1, 1, sceKernelGettimeofday);
-    LIB_FUNCTION("n88vx3C5nW8", "libkernel", 1, "libkernel", 1, 1, gettimeofday);
-    LIB_FUNCTION("n88vx3C5nW8", "libScePosix", 1, "libkernel", 1, 1, gettimeofday);
     LIB_FUNCTION("QvsZxomvUHs", "libkernel", 1, "libkernel", 1, 1, sceKernelNanosleep);
     LIB_FUNCTION("1jfXLRVzisc", "libkernel", 1, "libkernel", 1, 1, sceKernelUsleep);
-    LIB_FUNCTION("QcteRwbsnV0", "libkernel", 1, "libkernel", 1, 1, posix_usleep);
-    LIB_FUNCTION("QcteRwbsnV0", "libScePosix", 1, "libkernel", 1, 1, posix_usleep);
     LIB_FUNCTION("-ZR+hG7aDHw", "libkernel", 1, "libkernel", 1, 1, sceKernelSleep);
-    LIB_FUNCTION("0wu33hunNdE", "libScePosix", 1, "libkernel", 1, 1, sceKernelSleep);
-    LIB_FUNCTION("yS8U2TGCe1A", "libkernel", 1, "libkernel", 1, 1, posix_nanosleep);
-    LIB_FUNCTION("yS8U2TGCe1A", "libScePosix", 1, "libkernel", 1, 1, posix_nanosleep);
     LIB_FUNCTION("QBi7HCK03hw", "libkernel", 1, "libkernel", 1, 1, sceKernelClockGettime);
+    LIB_FUNCTION("wRYVA5Zolso", "libkernel", 1, "libkernel", 1, 1, sceKernelClockGetres);
+    LIB_FUNCTION("ejekcaNQNq0", "libkernel", 1, "libkernel", 1, 1, sceKernelGettimeofday);
     LIB_FUNCTION("kOcnerypnQA", "libkernel", 1, "libkernel", 1, 1, sceKernelGettimezone);
-    LIB_FUNCTION("lLMT9vJAck0", "libkernel", 1, "libkernel", 1, 1, orbis_clock_gettime);
-    LIB_FUNCTION("lLMT9vJAck0", "libScePosix", 1, "libkernel", 1, 1, orbis_clock_gettime);
-    LIB_FUNCTION("smIj7eqzZE8", "libScePosix", 1, "libkernel", 1, 1, posix_clock_getres);
     LIB_FUNCTION("0NTHN1NKONI", "libkernel", 1, "libkernel", 1, 1, sceKernelConvertLocaltimeToUtc);
     LIB_FUNCTION("-o5uEDpN+oY", "libkernel", 1, "libkernel", 1, 1, sceKernelConvertUtcToLocaltime);
 }

--- a/src/core/libraries/kernel/time.h
+++ b/src/core/libraries/kernel/time.h
@@ -75,14 +75,14 @@ u64 PS4_SYSV_ABI sceKernelGetProcessTime();
 u64 PS4_SYSV_ABI sceKernelGetProcessTimeCounter();
 u64 PS4_SYSV_ABI sceKernelGetProcessTimeCounterFrequency();
 u64 PS4_SYSV_ABI sceKernelReadTsc();
-int PS4_SYSV_ABI sceKernelClockGettime(s32 clock_id, OrbisKernelTimespec* tp);
+s32 PS4_SYSV_ABI sceKernelClockGettime(u32 clock_id, OrbisKernelTimespec* tp);
 s32 PS4_SYSV_ABI sceKernelGettimezone(OrbisKernelTimezone* tz);
-int PS4_SYSV_ABI sceKernelConvertLocaltimeToUtc(time_t param_1, int64_t param_2, time_t* seconds,
-                                                OrbisKernelTimezone* timezone, int* dst_seconds);
+s32 PS4_SYSV_ABI sceKernelConvertLocaltimeToUtc(time_t param_1, int64_t param_2, time_t* seconds,
+                                                OrbisKernelTimezone* timezone, s32* dst_seconds);
 
-int PS4_SYSV_ABI sceKernelConvertUtcToLocaltime(time_t time, time_t* local_time, OrbisTimesec* st,
+s32 PS4_SYSV_ABI sceKernelConvertUtcToLocaltime(time_t time, time_t* local_time, OrbisTimesec* st,
                                                 u64* dst_sec);
-int PS4_SYSV_ABI sceKernelUsleep(u32 microseconds);
+s32 PS4_SYSV_ABI sceKernelUsleep(u32 microseconds);
 
 void RegisterTime(Core::Loader::SymbolsResolver* sym);
 


### PR DESCRIPTION
* Split out a new `Common::PreciseSleep` from `Common::AccurateSleep`. This implements an interruptible sleep with high precision, and `AccurateSleep` uses it to implement an uninterruptible sleep like before.
* Reimplement `nanosleep` using the new `PreciseSleep`, and implement other sleep functions in terms of `nanosleep` similar to the real kernel library.
* Provide a fill for `clock_getres` on Windows.
* Remove `winpthreads` as, with these changes, it is no longer used.

Please test on various games for regressions given the new sleep implementations.