### PR TITLE
build: Target x86-64-v3 CPU architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,9 +54,9 @@ else()
 endif()
 
 if (ARCHITECTURE STREQUAL "x86_64")
-    # Target the same CPU architecture as the PS4, to maintain the same level of compatibility.
-    # Exclude SSE4a as it is only available on AMD CPUs.
-    add_compile_options(-march=btver2 -mtune=generic -mno-sse4a)
+    # Target x86-64-v3 CPU architecture as this is a good balance between supporting performance critical
+    # instructions like AVX2 and maintaining support for older CPUs.
+    add_compile_options(-march=x86-64-v3)
 endif()
 
 if (APPLE AND ARCHITECTURE STREQUAL "x86_64" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")

--- a/documents/Quickstart/Quickstart.md
+++ b/documents/Quickstart/Quickstart.md
@@ -21,9 +21,9 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 - A processor with at least 4 cores and 6 threads
 - Above 2.5 GHz frequency
-- A CPU supporting the following instruction sets: MMX, SSE, SSE2, SSE3, SSSE3, SSE4.1, SSE4.2, AVX, F16C, CLMUL, AES, BMI1, MOVBE, XSAVE, ABM
+- A CPU supporting the x86-64-v3 baseline.
   - **Intel**: Haswell generation or newer
-  - **AMD**: Jaguar generation or newer
+  - **AMD**: Excavator generation or newer
   - **Apple**: Rosetta 2 on macOS 15.4 or newer
 
 ### GPU


### PR DESCRIPTION
As discussed in #2819 the usage of AVX2 ops could improve performance quite significantly in a lot of cases which is why this PR sets `-march=x86-64-v3` as the target CPU architecture. This strikes a good balance between enabling performance-critical instructions (e.g., AVX2) and maintaining compatibility with relatively older systems.

The x86-64-v3 target corresponds to Intel's Haswell era architectures. Haswell was introduced in 2014. The vast majority of users today have CPUs that are significantly newer. Systems with pre-Haswell CPUs are unlikely to meet the performance requirements for PS4 emulation, making support for them impractical.

As `-march=x86-64-v3` also implies `-mtune=x86-64-v3`, the mtune part was removed.