### PR TITLE
Proper error handling for MapMemory errors

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -386,7 +386,7 @@ int MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, size_t size, M
         vma = FindVMA(mapped_addr)->second;
         remaining_size = vma.base + vma.size - mapped_addr;
         if (vma.IsMapped() || remaining_size < size) {
-            LOG_ERROR(Kernel_Vmm, "Not enough memory to map {:#x} bytes at address {:#x}", size,
+            LOG_ERROR(Kernel_Vmm, "Unable to map {:#x} bytes at address {:#x}", size,
                       mapped_addr);
             return ORBIS_KERNEL_ERROR_ENOMEM;
         }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -383,12 +383,13 @@ int MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, size_t size, M
             vma = FindVMA(unmap_addr)->second;
         }
 
-        // This should return SCE_KERNEL_ERROR_ENOMEM but rarely happens.
         vma = FindVMA(mapped_addr)->second;
         remaining_size = vma.base + vma.size - mapped_addr;
-        ASSERT_MSG(!vma.IsMapped() && remaining_size >= size,
-                   "Memory region {:#x} to {:#x} isn't free enough to map region {:#x} to {:#x}",
-                   vma.base, vma.base + vma.size, virtual_addr, virtual_addr + size);
+        if (vma.IsMapped() || remaining_size < size) {
+            LOG_ERROR(Kernel_Vmm, "Not enough memory to map {:#x} bytes at address {:#x}", size,
+                      mapped_addr);
+            return ORBIS_KERNEL_ERROR_ENOMEM;
+        }
     }
 
     // Find the first free area starting with provided virtual address.

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -376,8 +376,8 @@ int MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, size_t size, M
         // To account for this, unmap any reserved areas within this mapping range first.
         auto unmap_addr = mapped_addr;
         auto unmap_size = size;
-        // If flag NoOverwrite is provided, allow overwriting mapped VMAs.
-        // Otherwise, we can only overwrite unmapped or reserved VMAs.
+        // If flag NoOverwrite is provided, don't overwrite mapped VMAs.
+        // When it isn't provided, VMAs can be overwritten regardless of if they're mapped.
         auto should_overwrite = False(flags & MemoryMapFlags::NoOverwrite) || !vma.IsMapped();
         while (should_overwrite && unmap_addr < mapped_addr + size && remaining_size < size) {
             auto unmapped = UnmapBytesFromEntry(unmap_addr, vma, unmap_size);

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -378,15 +378,12 @@ int MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, size_t size, M
         auto unmap_size = size;
         // If flag NoOverwrite is provided, don't overwrite mapped VMAs.
         // When it isn't provided, VMAs can be overwritten regardless of if they're mapped.
-        auto should_overwrite = False(flags & MemoryMapFlags::NoOverwrite) || !vma.IsMapped();
-        while (should_overwrite && unmap_addr < mapped_addr + size && remaining_size < size) {
+        while ((False(flags & MemoryMapFlags::NoOverwrite) || !vma.IsMapped()) &&
+               unmap_addr < mapped_addr + size && remaining_size < size) {
             auto unmapped = UnmapBytesFromEntry(unmap_addr, vma, unmap_size);
             unmap_addr += unmapped;
             unmap_size -= unmapped;
-            // Unmap addr should be the address of the next VMA
-            // if the previous VMA is fully unmapped.
             vma = FindVMA(unmap_addr)->second;
-            should_overwrite = False(flags & MemoryMapFlags::NoOverwrite) || !vma.IsMapped();
         }
 
         vma = FindVMA(mapped_addr)->second;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -386,8 +386,7 @@ int MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, size_t size, M
         vma = FindVMA(mapped_addr)->second;
         remaining_size = vma.base + vma.size - mapped_addr;
         if (vma.IsMapped() || remaining_size < size) {
-            LOG_ERROR(Kernel_Vmm, "Unable to map {:#x} bytes at address {:#x}", size,
-                      mapped_addr);
+            LOG_ERROR(Kernel_Vmm, "Unable to map {:#x} bytes at address {:#x}", size, mapped_addr);
             return ORBIS_KERNEL_ERROR_ENOMEM;
         }
     }


### PR DESCRIPTION
On real hardware, most functions we've attached to MapMemory will return ENOMEM if they've got flag `MAP_FIXED` and try mapping to already mapped addresses.

Handling this error case properly is necessary for Assassin's Creed® Unity (CUSA00663) and Need for Speed™ Heat (CUSA15081) to progress further.

Once this is merged, I'll probably start an aggregate issue for tracking known memory issues, as this will make it harder to identify them.