### PR TITLE
Implement sceKernelMapDirectMemory2

### DIFF
--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -211,41 +211,13 @@ int PS4_SYSV_ABI sceKernelMapDirectMemory(void** addr, u64 len, int prot, int fl
 
 s32 PS4_SYSV_ABI sceKernelMapDirectMemory2(void** addr, u64 len, s32 type, s32 prot, s32 flags,
                                            s64 phys_addr, u64 alignment) {
-    LOG_INFO(Kernel_Vmm,
-             "in_addr = {}, len = {:#x}, type = {:#x}, prot = {:#x}, flags = {:#x}, "
-             "phys_addr = {:#x}, alignment = {:#x}",
-             fmt::ptr(*addr), len, type, prot, flags, phys_addr, alignment);
-
-    if (len == 0 || !Common::Is16KBAligned(len)) {
-        LOG_ERROR(Kernel_Vmm, "Map size is either zero or not 16KB aligned!");
-        return ORBIS_KERNEL_ERROR_EINVAL;
-    }
-
-    if (!Common::Is16KBAligned(phys_addr)) {
-        LOG_ERROR(Kernel_Vmm, "Start address is not 16KB aligned!");
-        return ORBIS_KERNEL_ERROR_EINVAL;
-    }
-
-    if (alignment != 0) {
-        if ((!std::has_single_bit(alignment) && !Common::Is16KBAligned(alignment))) {
-            LOG_ERROR(Kernel_Vmm, "Alignment value is invalid!");
-            return ORBIS_KERNEL_ERROR_EINVAL;
-        }
-    }
-
-    const VAddr in_addr = reinterpret_cast<VAddr>(*addr);
-    const auto mem_prot = static_cast<Core::MemoryProt>(prot);
-    const auto map_flags = static_cast<Core::MemoryMapFlags>(flags);
-
-    auto* memory = Core::Memory::Instance();
-    const auto ret = memory->MapMemory(addr, in_addr, len, mem_prot, map_flags,
-                                       Core::VMAType::Direct, "anon", false, phys_addr, alignment);
-
+    LOG_INFO(Kernel_Vmm, "called, redirected to sceKernelMapNamedDirectMemory");
+    const s32 ret = sceKernelMapNamedDirectMemory(addr, len, prot, flags, phys_addr, alignment, "anon");
+    
     if (ret == 0) {
+        auto* memory = Core::Memory::Instance();
         memory->SetDirectMemoryType(phys_addr, type);
     }
-
-    LOG_INFO(Kernel_Vmm, "out_addr = {}", fmt::ptr(*addr));
     return ret;
 }
 

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -212,8 +212,9 @@ int PS4_SYSV_ABI sceKernelMapDirectMemory(void** addr, u64 len, int prot, int fl
 s32 PS4_SYSV_ABI sceKernelMapDirectMemory2(void** addr, u64 len, s32 type, s32 prot, s32 flags,
                                            s64 phys_addr, u64 alignment) {
     LOG_INFO(Kernel_Vmm, "called, redirected to sceKernelMapNamedDirectMemory");
-    const s32 ret = sceKernelMapNamedDirectMemory(addr, len, prot, flags, phys_addr, alignment, "anon");
-    
+    const s32 ret =
+        sceKernelMapNamedDirectMemory(addr, len, prot, flags, phys_addr, alignment, "anon");
+
     if (ret == 0) {
         auto* memory = Core::Memory::Instance();
         memory->SetDirectMemoryType(phys_addr, type);

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -783,6 +783,19 @@ int MemoryManager::DirectQueryAvailable(PAddr search_start, PAddr search_end, si
     return ORBIS_OK;
 }
 
+s32 MemoryManager::SetDirectMemoryType(s64 phys_addr, s32 memory_type) {
+    std::scoped_lock lk{mutex};
+
+    auto& dmem_area = FindDmemArea(phys_addr)->second;
+
+    ASSERT_MSG(phys_addr <= dmem_area.GetEnd() && !dmem_area.is_free,
+               "Direct memory area is not mapped");
+
+    dmem_area.memory_type = memory_type;
+
+    return ORBIS_OK;
+}
+
 void MemoryManager::NameVirtualRange(VAddr virtual_addr, size_t size, std::string_view name) {
     auto it = FindVMA(virtual_addr);
 

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -219,6 +219,8 @@ public:
     int GetDirectMemoryType(PAddr addr, int* directMemoryTypeOut, void** directMemoryStartOut,
                             void** directMemoryEndOut);
 
+    s32 SetDirectMemoryType(s64 phys_addr, s32 memory_type);
+
     void NameVirtualRange(VAddr virtual_addr, size_t size, std::string_view name);
 
     void InvalidateMemory(VAddr addr, u64 size) const;


### PR DESCRIPTION
Behaves similarly to sceKernelMapDirectMemory, but supplies a memory type parameter.
To handle this, I've added a SetDirectMemoryType function to our MemoryManager.

I believe this has shown up in logs before, but I don't recall what specific titles used it.