### PR TITLE
Fix passing user data in user-triggered equeue events

### DIFF
--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -145,6 +145,8 @@ bool EqueueInternal::TriggerEvent(u64 ident, s16 filter, void* trigger_data) {
             if (event.event.ident == ident && event.event.filter == filter) {
                 if (filter == SceKernelEvent::Filter::VideoOut) {
                     event.TriggerDisplay(trigger_data);
+                } else if (filter == SceKernelEvent::Filter::User) {
+                    event.TriggerUser(trigger_data);
                 } else {
                     event.Trigger(trigger_data);
                 }

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -98,6 +98,12 @@ struct EqueueEvent {
         event.data = reinterpret_cast<uintptr_t>(data);
     }
 
+    void TriggerUser(void* data) {
+        is_triggered = true;
+        event.fflags++;
+        event.udata = data;
+    }
+
     void TriggerDisplay(void* data) {
         is_triggered = true;
         if (data != nullptr) {


### PR DESCRIPTION
RE2 calls sceKernelTriggerUserEvent and then expects the .udata field to contain the provided data