### PR TITLE
More precise buffer size calculation

### DIFF
--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -80,7 +80,15 @@ struct Buffer {
     }
 
     u32 GetSize() const noexcept {
-        return stride == 0 ? num_records : (stride * num_records);
+        if (stride == 0) {
+            return num_records;
+        }
+        auto bits = NumBits(DataFormat(data_format));
+        if (bits <= 0) {
+            return stride * num_records;
+        }
+        auto dfmt_bytes = bits / 8;
+        return stride * (num_records - 1) + dfmt_bytes;
     }
 
     u32 GetIndexStride() const noexcept {


### PR DESCRIPTION
Another attempt at fixing the 'non-GPU memory tracking' errors after #2920. This one tries to make sure that our calculated size does not exceed the total buffer size in case of using buffer offsets.