### PR TITLE
qt: Update save data dir open to use name from PSF.

### DIFF
--- a/src/qt_gui/game_info.h
+++ b/src/qt_gui/game_info.h
@@ -79,6 +79,11 @@ public:
             if (const auto play_time = psf.GetString("PLAY_TIME"); play_time.has_value()) {
                 game.play_time = *play_time;
             }
+            if (const auto save_dir = psf.GetString("INSTALL_DIR_SAVEDATA"); save_dir.has_value()) {
+                game.save_dir = *save_dir;
+            } else {
+                game.save_dir = game.serial;
+            }
         }
         return game;
     }

--- a/src/qt_gui/game_list_utils.h
+++ b/src/qt_gui/game_list_utils.h
@@ -25,6 +25,7 @@ struct GameInfo {
     std::string version = "Unknown";
     std::string region = "Unknown";
     std::string fw = "Unknown";
+    std::string save_dir = "Unknown";
 
     std::string play_time = "Unknown";
     CompatibilityEntry compatibility = CompatibilityEntry{CompatibilityStatus::Unknown};

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -160,7 +160,7 @@ public:
             Common::FS::PathToQString(userPath,
                                       Common::FS::GetUserPath(Common::FS::PathType::UserDir));
             QString saveDataPath =
-                userPath + "/savedata/1/" + QString::fromStdString(m_games[itemID].serial);
+                userPath + "/savedata/1/" + QString::fromStdString(m_games[itemID].save_dir);
             QDir(saveDataPath).mkpath(saveDataPath);
             QDesktopServices::openUrl(QUrl::fromLocalFile(saveDataPath));
         }


### PR DESCRIPTION
Updates the UI option to open save data directory to reflect the recent save data change to use the `INSTALL_DIR_SAVEDATA` for the directory name.