### PR TITLE
Fix image extent in buffer copy to image

### DIFF
--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -538,10 +538,16 @@ void TextureCache::RefreshImage(Image& image, Vulkan::Scheduler* custom_schedule
             image.mip_hashes[m] = hash;
         }
 
+        auto mip_pitch = static_cast<u32>(mip.pitch);
+        auto mip_height = static_cast<u32>(mip.height);
+
+        auto image_extent_width = mip_pitch ? std::min(mip_pitch, width) : width;
+        auto image_extent_height = mip_height ? std::min(mip_height, height) : height;
+
         image_copy.push_back({
             .bufferOffset = mip.offset,
-            .bufferRowLength = static_cast<u32>(mip.pitch),
-            .bufferImageHeight = static_cast<u32>(mip.height),
+            .bufferRowLength = mip_pitch,
+            .bufferImageHeight = mip_height,
             .imageSubresource{
                 .aspectMask = image.aspect_mask & ~vk::ImageAspectFlagBits::eStencil,
                 .mipLevel = m,
@@ -549,7 +555,7 @@ void TextureCache::RefreshImage(Image& image, Vulkan::Scheduler* custom_schedule
                 .layerCount = num_layers,
             },
             .imageOffset = {0, 0, 0},
-            .imageExtent = {width, height, depth},
+            .imageExtent = {image_extent_width, image_extent_height, depth},
         });
     }
 


### PR DESCRIPTION
Fixes a Vulkan validation error hit by AKIBA'S BEAT [CUSA07108]:

```
[Render.Vulkan] <Error> vk_platform.cpp:56 DebugUtilsCallback: VUID-VkBufferImageCopy-bufferRowLength-09101: vkCmdCopyBufferToImage(): pRegions[0].bufferRowLength (1920) must be zero or greater-than-or-equal-to imageExtent.width (2048).
The Vulkan spec states: bufferRowLength must be 0, or greater than or equal to the width member of imageExtent (https://docs.vulkan.org/spec/latest/chapters/copies.html#VUID-VkBufferImageCopy-bufferRowLength-09101)
```

Previously it crashed after showing logos with a device lost error, now it shows the intro movies correctly and gets ingame.

![Screenshot From 2025-05-20 18-01-00](https://github.com/user-attachments/assets/9ad49e68-ec5e-4842-8304-81a6b65fa880)
![Screenshot From 2025-05-20 18-01-16](https://github.com/user-attachments/assets/3b931b95-7861-4937-a7d8-e1a7bd7c7cda)
![Screenshot From 2025-05-20 18-01-36](https://github.com/user-attachments/assets/f915a529-9448-4603-82b7-18971409e1b9)