### PR TITLE
Lower stack size to clear from 13 to 12 KB

### DIFF
--- a/src/core/tls.h
+++ b/src/core/tls.h
@@ -53,7 +53,7 @@ template <class ReturnType, class... FuncArgs, class... CallArgs>
 ReturnType ExecuteGuest(PS4_SYSV_ABI ReturnType (*func)(FuncArgs...), CallArgs&&... args) {
     EnsureThreadInitialized();
     // clear stack to avoid trash from EnsureThreadInitialized
-    ClearStack<13_KB>();
+    ClearStack<12_KB>();
     return func(std::forward<CallArgs>(args)...);
 }
 


### PR DESCRIPTION
Fixes Gravity Rush 2 crashing on a stack error on boot.