### PR TITLE
savedata: Fix missing uses of config based save data dir.

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -154,7 +154,7 @@ bool GetLoadGameSizeEnabled() {
 
 std::filesystem::path GetSaveDataPath() {
     if (save_data_path.empty()) {
-        return Common::FS::GetUserPath(Common::FS::PathType::SaveDataDir);
+        return Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "savedata";
     }
     return save_data_path;
 }

--- a/src/common/path_util.cpp
+++ b/src/common/path_util.cpp
@@ -128,7 +128,6 @@ static auto UserPaths = [] {
     create_path(PathType::LogDir, user_dir / LOG_DIR);
     create_path(PathType::ScreenshotsDir, user_dir / SCREENSHOTS_DIR);
     create_path(PathType::ShaderDir, user_dir / SHADER_DIR);
-    create_path(PathType::SaveDataDir, user_dir / SAVEDATA_DIR);
     create_path(PathType::GameDataDir, user_dir / GAMEDATA_DIR);
     create_path(PathType::TempDataDir, user_dir / TEMPDATA_DIR);
     create_path(PathType::SysModuleDir, user_dir / SYSMODULES_DIR);

--- a/src/common/path_util.h
+++ b/src/common/path_util.h
@@ -18,7 +18,6 @@ enum class PathType {
     LogDir,         // Where log files are stored.
     ScreenshotsDir, // Where screenshots are stored.
     ShaderDir,      // Where shaders are stored.
-    SaveDataDir,    // Where guest save data is stored.
     TempDataDir,    // Where game temp data is stored.
     GameDataDir,    // Where game data is stored.
     SysModuleDir,   // Where system modules are stored.
@@ -36,7 +35,6 @@ constexpr auto PORTABLE_DIR = "user";
 constexpr auto LOG_DIR = "log";
 constexpr auto SCREENSHOTS_DIR = "screenshots";
 constexpr auto SHADER_DIR = "shader";
-constexpr auto SAVEDATA_DIR = "savedata";
 constexpr auto GAMEDATA_DIR = "data";
 constexpr auto TEMPDATA_DIR = "temp";
 constexpr auto SYSMODULES_DIR = "sys_modules";

--- a/src/core/libraries/save_data/savedata.cpp
+++ b/src/core/libraries/save_data/savedata.cpp
@@ -8,6 +8,7 @@
 #include <magic_enum/magic_enum.hpp>
 
 #include "common/assert.h"
+#include "common/config.h"
 #include "common/cstring.h"
 #include "common/elf_info.h"
 #include "common/enum.h"
@@ -438,7 +439,7 @@ static Error saveDataMount(const OrbisSaveDataMount2* mount_info,
             LOG_INFO(Lib_SaveData, "called with invalid block size");
         }
 
-        const auto root_save = Common::FS::GetUserPath(Common::FS::PathType::SaveDataDir);
+        const auto root_save = Config::GetSaveDataPath();
         fs::create_directories(root_save);
         const auto available = fs::space(root_save).available;
 

--- a/src/qt_gui/gui_context_menus.h
+++ b/src/qt_gui/gui_context_menus.h
@@ -156,11 +156,9 @@ public:
         }
 
         if (selected == openSaveDataFolder) {
-            QString userPath;
-            Common::FS::PathToQString(userPath,
-                                      Common::FS::GetUserPath(Common::FS::PathType::UserDir));
-            QString saveDataPath =
-                userPath + "/savedata/1/" + QString::fromStdString(m_games[itemID].save_dir);
+            QString saveDataPath;
+            Common::FS::PathToQString(saveDataPath,
+                                      Config::GetSaveDataPath() / "1" / m_games[itemID].save_dir);
             QDir(saveDataPath).mkpath(saveDataPath);
             QDesktopServices::openUrl(QUrl::fromLocalFile(saveDataPath));
         }
@@ -485,8 +483,7 @@ public:
                 dlc_path, Config::getAddonInstallDir() /
                               Common::FS::PathFromQString(folder_path).parent_path().filename());
             Common::FS::PathToQString(save_data_path,
-                                      Common::FS::GetUserPath(Common::FS::PathType::UserDir) /
-                                          "savedata/1" / m_games[itemID].serial);
+                                      Config::GetSaveDataPath() / "1" / m_games[itemID].save_dir);
 
             Common::FS::PathToQString(trophy_data_path,
                                       Common::FS::GetUserPath(Common::FS::PathType::MetaDataDir) /


### PR DESCRIPTION
* Fix a few places that were using the default save data directory path instead of the one specified by config.
* Fix Qt GUI delete still using game serial instead of correct save data directory name.
* Remove `PathType::SaveDataDir` so it won't be mistakenly use; instead just do same as DLC directory and have the default in the config function.