### PR TITLE
Trophy fix

### DIFF
--- a/src/core/libraries/np_trophy/np_trophy.cpp
+++ b/src/core/libraries/np_trophy/np_trophy.cpp
@@ -203,7 +203,6 @@ int PS4_SYSV_ABI sceNpTrophyDestroyContext(OrbisNpTrophyContext context) {
 }
 
 s32 PS4_SYSV_ABI sceNpTrophyDestroyHandle(OrbisNpTrophyHandle handle) {
-    LOG_INFO(Lib_NpTrophy, "Destroyed handle {}", handle);
     if (handle == ORBIS_NP_TROPHY_INVALID_HANDLE)
         return ORBIS_NP_TROPHY_ERROR_INVALID_HANDLE;
 

--- a/src/core/libraries/np_trophy/np_trophy.cpp
+++ b/src/core/libraries/np_trophy/np_trophy.cpp
@@ -203,9 +203,14 @@ int PS4_SYSV_ABI sceNpTrophyDestroyContext(OrbisNpTrophyContext context) {
 }
 
 s32 PS4_SYSV_ABI sceNpTrophyDestroyHandle(OrbisNpTrophyHandle handle) {
+    LOG_INFO(Lib_NpTrophy, "Destroyed handle {}", handle);
     if (handle == ORBIS_NP_TROPHY_INVALID_HANDLE)
         return ORBIS_NP_TROPHY_ERROR_INVALID_HANDLE;
 
+    if (handle >= trophy_handles.size()) {
+        LOG_ERROR(Lib_NpTrophy, "Invalid handle {}", handle);
+        return ORBIS_NP_TROPHY_ERROR_INVALID_HANDLE;
+    }
     if (!trophy_handles.is_allocated({static_cast<u32>(handle)})) {
         return ORBIS_NP_TROPHY_ERROR_INVALID_HANDLE;
     }


### PR DESCRIPTION
CUSA00051 - Injustice: Gods Among Us Ultimate Edition does the following sequence

[Lib.NpTrophy] <Info> np_trophy.cpp:183 sceNpTrophyCreateHandle: New handle = 0
[Lib.NpTrophy] <Info> np_trophy.cpp:169 sceNpTrophyCreateContext: New context = 0, user_id = 1 service label = 0
[Lib.NpTrophy] <Info> np_trophy.cpp:206 sceNpTrophyDestroyHandle: Destroyed handle 34801564

So although it creates handle =0 tries to destroy handle 34801564 . That is probably an issue somewhere else but just to make sure we check if the size of trophy handles isn't smaller than handler