### PR TITLE
Added back the "Attempted to track non-GPU memory" assert.

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -668,7 +668,7 @@ void BufferCache::ProcessFaultBuffer() {
             const VAddr fault_end = fault + CACHING_PAGESIZE; // This can be adjusted
             fault_ranges +=
                 boost::icl::interval_set<VAddr>::interval_type::right_open(fault, fault_end);
-            LOG_INFO(Render_Vulkan, "Accessed non-GPU mapped memory at {:#x}", fault);
+            LOG_INFO(Render_Vulkan, "Accessed non-GPU cached memory at {:#x}", fault);
         }
         for (const auto& range : fault_ranges) {
             const VAddr start = range.lower();

--- a/src/video_core/page_manager.cpp
+++ b/src/video_core/page_manager.cpp
@@ -213,6 +213,12 @@ struct PageManager::Impl {
 
             // Iterate requested pages
             const u64 page_end = Common::DivCeil(addr + size, PAGE_SIZE);
+            const u64 aligned_addr = page << PAGE_BITS;
+            const u64 aligned_end = page_end << PAGE_BITS;
+            ASSERT_MSG(rasterizer->IsMapped(aligned_addr, aligned_end - aligned_addr),
+                       "Attempted to track non-GPU memory at address {:#x}, size {:#x}.",
+                       aligned_addr, aligned_end - aligned_addr);
+
             for (; page != page_end; ++page) {
                 PageState& state = cached_pages[page];
 


### PR DESCRIPTION
Bring back the assert that I removed when rewritting part of the page_manager.

Please test this before in case the assert is too strct.