### PR TITLE
shader_recompiler: Fix incorrect float type on FPRecip64

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_floating_point.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_floating_point.cpp
@@ -154,7 +154,7 @@ Id EmitFPRecip32(EmitContext& ctx, Id value) {
 }
 
 Id EmitFPRecip64(EmitContext& ctx, Id value) {
-    return ctx.OpFDiv(ctx.F64[1], ctx.Constant(ctx.F64[1], 1.0f), value);
+    return ctx.OpFDiv(ctx.F64[1], ctx.Constant(ctx.F64[1], f64{1.0}), value);
 }
 
 Id EmitFPRecipSqrt32(EmitContext& ctx, Id value) {


### PR DESCRIPTION
Currently erroneously a float is emitted insteed of a double, cusing a SPIR-V validation error.

For example, in InFamous: First Light (shader 0xa71733ca):
```
error: line 256: Invalid word count: OpConstant starting at word 1043 says it has 4 words, but found 5 words instead.
```