### PR TITLE
video_out: SubmitEopFlip adding mutex and lockguard also fixing reject of full flips by adding a wait

### DIFF
--- a/src/core/libraries/videoout/driver.cpp
+++ b/src/core/libraries/videoout/driver.cpp
@@ -311,10 +311,9 @@ void VideoOutDriver::PresentThread(std::stop_token token) {
                 }
             } else {
                 Flip(request);
-                request.port->vo_cv.notify_all();
-                // wake up threads waiting to submit more flips
+                request.port->vo_cv.notify_all(); // wake up threads waiting to submit more flips
+                FRAME_END;
             }
-            FRAME_END;
         }
 
         {

--- a/src/core/libraries/videoout/driver.cpp
+++ b/src/core/libraries/videoout/driver.cpp
@@ -311,7 +311,7 @@ void VideoOutDriver::PresentThread(std::stop_token token) {
                 }
             } else {
                 Flip(request);
-                main_port.vblank_cv.notify_all();
+                request.port->vo_cv.notify_all();
                 // wake up threads waiting to submit more flips
             }
             FRAME_END;

--- a/src/core/libraries/videoout/driver.cpp
+++ b/src/core/libraries/videoout/driver.cpp
@@ -67,7 +67,7 @@ void VideoOutDriver::Close(s32 handle) {
     ASSERT(main_port.flip_events.empty());
 }
 
-VideoOutPort* VideoOutDriver::GetPort(int handle) {
+VideoOutPort* VideoOutDriver::GetPort(s32 handle) {
     if (handle != 1) [[unlikely]] {
         return nullptr;
     }

--- a/src/core/libraries/videoout/driver.h
+++ b/src/core/libraries/videoout/driver.h
@@ -29,8 +29,6 @@ struct VideoOutPort {
     std::vector<Kernel::SceKernelEqueue> vblank_events;
     std::mutex vo_mutex;
     std::mutex port_mutex;
-    std::mutex pending_mutex;
-    std::queue<std::tuple<u32, u32>> pending_flips;
     std::condition_variable vo_cv;
     std::condition_variable vblank_cv;
     int flip_rate = 0;

--- a/src/core/libraries/videoout/driver.h
+++ b/src/core/libraries/videoout/driver.h
@@ -29,6 +29,8 @@ struct VideoOutPort {
     std::vector<Kernel::SceKernelEqueue> vblank_events;
     std::mutex vo_mutex;
     std::mutex port_mutex;
+    std::mutex pending_mutex;
+    std::queue<std::tuple<u32, u32>> pending_flips;
     std::condition_variable vo_cv;
     std::condition_variable vblank_cv;
     int flip_rate = 0;

--- a/src/core/libraries/videoout/video_out.cpp
+++ b/src/core/libraries/videoout/video_out.cpp
@@ -338,11 +338,6 @@ s32 sceVideoOutSubmitEopFlip(s32 handle, u32 buf_id, u32 mode, u32 arg, void** u
     if (!port) {
         return ORBIS_VIDEO_OUT_ERROR_INVALID_HANDLE;
     }
-
-    {
-        std::lock_guard lock(port->pending_mutex);
-        port->pending_flips.emplace(buf_id, arg);
-    }
     Platform::IrqC::Instance()->RegisterOnce(
         Platform::InterruptId::GfxFlip, [=](Platform::InterruptId irq) {
             ASSERT_MSG(irq == Platform::InterruptId::GfxFlip, "Unexpected IRQ");

--- a/src/core/libraries/videoout/video_out.cpp
+++ b/src/core/libraries/videoout/video_out.cpp
@@ -339,13 +339,25 @@ s32 sceVideoOutSubmitEopFlip(s32 handle, u32 buf_id, u32 mode, u32 arg, void** u
         return ORBIS_VIDEO_OUT_ERROR_INVALID_HANDLE;
     }
 
-    Platform::IrqC::Instance()->RegisterOnce(
-        Platform::InterruptId::GfxFlip, [=](Platform::InterruptId irq) {
-            ASSERT_MSG(irq == Platform::InterruptId::GfxFlip, "An unexpected IRQ occured");
-            ASSERT_MSG(port->buffer_labels[buf_id] == 1, "Out of order flip IRQ");
-            const auto result = driver->SubmitFlip(port, buf_id, arg, true);
-            ASSERT_MSG(result, "EOP flip submission failed");
-        });
+    static std::mutex irq_mutex;
+
+    {
+        std::lock_guard<std::mutex> lock(irq_mutex);
+
+        Platform::IrqC::Instance()->RegisterOnce(
+            Platform::InterruptId::GfxFlip, [=](Platform::InterruptId irq) {
+                ASSERT_MSG(irq == Platform::InterruptId::GfxFlip, "Unexpected IRQ occurred");
+                ASSERT_MSG(port->buffer_labels[buf_id] == 1, "Out-of-order flip IRQ");
+
+                const auto result = driver->SubmitFlip(port, buf_id, arg, true);
+                if (!result) {
+                    LOG_ERROR(Lib_VideoOut, "EOP flip submission failed for buffer {}", buf_id);
+                    return;
+                }
+
+                port->buffer_labels[buf_id] = 0;
+            });
+    }
 
     return ORBIS_OK;
 }

--- a/src/core/libraries/videoout/video_out.cpp
+++ b/src/core/libraries/videoout/video_out.cpp
@@ -350,22 +350,8 @@ s32 sceVideoOutSubmitEopFlip(s32 handle, u32 buf_id, u32 mode, u32 arg, void** u
                 LOG_WARNING(Lib_VideoOut, "Ignoring flip IRQ during mode change");
                 return;
             }
-            std::tuple<u32, u32> pending;
-            {
-                std::lock_guard lock(port->pending_mutex);
-                if (port->pending_flips.empty()) {
-                    LOG_ERROR(Lib_VideoOut, "Received GfxFlip IRQ but no flips pending");
-                    return;
-                }
-                pending = port->pending_flips.front();
-                port->pending_flips.pop();
-            }
-            const auto [queued_buf_id, queued_arg] = pending;
-            ASSERT_MSG(queued_buf_id == buf_id,
-                       "Out-of-order flip IRQ (expected buf_id = {}, got = {})", buf_id,
-                       queued_buf_id);
-            const bool result = driver->SubmitFlip(port, queued_buf_id, queued_arg, true);
-            ASSERT_MSG(result, "EOP flip submission failed for buffer {}", queued_buf_id);
+            const bool result = driver->SubmitFlip(port, buf_id, arg, true);
+            ASSERT_MSG(result, "EOP flip submission failed for buffer {}", buf_id);
         });
 
     return ORBIS_OK;


### PR DESCRIPTION
This stops the flip bug we have on video out on my end while testing dark souls 3 fire fades
updating  buffer labels, and adding buffer id for logging on error
let me know if its ok. 

Also fixed a discrepancy on driver.cpp