### PR TITLE
Equeue: fix WaitEqueue assert on nullptr

### DIFF
--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -266,23 +266,16 @@ int PS4_SYSV_ABI sceKernelWaitEqueue(SceKernelEqueue eq, SceKernelEvent* ev, int
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
 
+    // When the timeout is nullptr, we wait indefinitely
     if (eq->HasSmallTimer()) {
-        ASSERT(timo && *timo);
-        *out = eq->WaitForSmallTimer(ev, num, *timo);
+        *out = eq->WaitForSmallTimer(ev, num, (timo != nullptr) ? *timo : 0);
     } else {
-        if (timo == nullptr) { // wait until an event arrives without timing out
-            *out = eq->WaitForEvents(ev, num, 0);
-        }
-
-        if (timo != nullptr) {
+        if (*timo == 0) {
             // Only events that have already arrived at the time of this function call can be
             // received
-            if (*timo == 0) {
-                *out = eq->GetTriggeredEvents(ev, num);
-            } else {
-                // Wait until an event arrives with timing out
-                *out = eq->WaitForEvents(ev, num, *timo);
-            }
+            *out = eq->GetTriggeredEvents(ev, num);
+        } else {
+            *out = eq->WaitForEvents(ev, num, (timo != nullptr) ? *timo : 0);
         }
     }
 

--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -279,6 +279,8 @@ int PS4_SYSV_ABI sceKernelWaitEqueue(SceKernelEqueue eq, SceKernelEvent* ev, int
         if (timo == nullptr) {
             *out = eq->WaitForEvents(ev, num, 0);
         } else if (*timo == 0) {
+            // Only events that have already arrived at the time of this function call can be
+            // received
             *out = eq->GetTriggeredEvents(ev, num);
         } else {
             *out = eq->WaitForEvents(ev, num, *timo);

--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -271,6 +271,10 @@ int PS4_SYSV_ABI sceKernelWaitEqueue(SceKernelEqueue eq, SceKernelEvent* ev, int
     if (eq->HasSmallTimer()) {
         if (timo == nullptr) {
             *out = eq->WaitForSmallTimer(ev, num, 0);
+        } else if (*timo == 0) {
+            // Only events that have already arrived at the time of this function call can be
+            // received
+            *out = eq->GetTriggeredEvents(ev, num);
         } else {
             ASSERT(*timo);
             *out = eq->WaitForSmallTimer(ev, num, *timo);

--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -187,7 +187,8 @@ int EqueueInternal::WaitForSmallTimer(SceKernelEvent* ev, int num, u32 micros) {
     ASSERT(num == 1);
 
     auto curr_clock = std::chrono::steady_clock::now();
-    const auto wait_end_us = curr_clock + std::chrono::microseconds{micros};
+    const auto wait_end_us = (micros == 0) ? std::chrono::steady_clock::time_point::max()
+                                           : curr_clock + std::chrono::microseconds{micros};
 
     do {
         curr_clock = std::chrono::steady_clock::now();

--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -269,14 +269,19 @@ int PS4_SYSV_ABI sceKernelWaitEqueue(SceKernelEqueue eq, SceKernelEvent* ev, int
 
     // When the timeout is nullptr, we wait indefinitely
     if (eq->HasSmallTimer()) {
-        *out = eq->WaitForSmallTimer(ev, num, (timo != nullptr) ? *timo : 0);
+        if (timo == nullptr) {
+            *out = eq->WaitForSmallTimer(ev, num, 0);
+        } else {
+            ASSERT(*timo);
+            *out = eq->WaitForSmallTimer(ev, num, *timo);
+        }
     } else {
-        if (*timo == 0) {
-            // Only events that have already arrived at the time of this function call can be
-            // received
+        if (timo == nullptr) {
+            *out = eq->WaitForEvents(ev, num, 0);
+        } else if (*timo == 0) {
             *out = eq->GetTriggeredEvents(ev, num);
         } else {
-            *out = eq->WaitForEvents(ev, num, (timo != nullptr) ? *timo : 0);
+            *out = eq->WaitForEvents(ev, num, *timo);
         }
     }
 

--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -276,7 +276,6 @@ int PS4_SYSV_ABI sceKernelWaitEqueue(SceKernelEqueue eq, SceKernelEvent* ev, int
             // received
             *out = eq->GetTriggeredEvents(ev, num);
         } else {
-            ASSERT(*timo);
             *out = eq->WaitForSmallTimer(ev, num, *timo);
         }
     } else {


### PR DESCRIPTION
On real hardware nullptr is not a problem and based on RE WaitEqueue simply passes 0 to kqueue if timeout is nullptr

Pls test again before merge