### PR TITLE
Core: More Memory Cleanup & Fixes

### DIFF
--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -574,7 +574,7 @@ void* PS4_SYSV_ABI posix_mmap(void* addr, u64 len, s32 prot, s32 flags, s32 fd, 
     const auto mem_prot = static_cast<Core::MemoryProt>(prot);
     const auto mem_flags = static_cast<Core::MemoryMapFlags>(flags);
 
-    s32 result = 0;
+    s32 result = ORBIS_OK;
     if (fd == -1) {
         result = memory->MapMemory(&addr_out, std::bit_cast<VAddr>(addr), len, mem_prot, mem_flags,
                                    Core::VMAType::Flexible);
@@ -583,7 +583,7 @@ void* PS4_SYSV_ABI posix_mmap(void* addr, u64 len, s32 prot, s32 flags, s32 fd, 
                                  fd, phys_addr);
     }
 
-    if (result < 0) {
+    if (result != ORBIS_OK) {
         // If the memory mappings fail, mmap sets errno to the appropriate error code,
         // then returns (void*)-1;
         ErrSceToPosix(result);
@@ -605,7 +605,7 @@ s32 PS4_SYSV_ABI sceKernelMmap(void* addr, u64 len, s32 prot, s32 flags, s32 fd,
 
     // Set the outputted address
     *res = addr_out;
-    return 0;
+    return ORBIS_OK;
 }
 
 s32 PS4_SYSV_ABI sceKernelConfiguredFlexibleMemorySize(u64* sizeOut) {

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -389,7 +389,7 @@ s32 PS4_SYSV_ABI sceKernelBatchMap2(OrbisKernelBatchMapEntry* entries, int numEn
     return result;
 }
 
-s32 PS4_SYSV_ABI sceKernelSetVirtualRangeName(const void* addr, size_t len, const char* name) {
+s32 PS4_SYSV_ABI sceKernelSetVirtualRangeName(const void* addr, u64 len, const char* name) {
     if (name == nullptr) {
         LOG_ERROR(Kernel_Vmm, "name is invalid!");
         return ORBIS_KERNEL_ERROR_EFAULT;

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -396,8 +396,8 @@ s32 PS4_SYSV_ABI sceKernelSetVirtualRangeName(const void* addr, size_t len, cons
     return ORBIS_OK;
 }
 
-s32 PS4_SYSV_ABI sceKernelMemoryPoolExpand(u64 searchStart, u64 searchEnd, u64 len,
-                                           u64 alignment, u64* physAddrOut) {
+s32 PS4_SYSV_ABI sceKernelMemoryPoolExpand(u64 searchStart, u64 searchEnd, u64 len, u64 alignment,
+                                           u64* physAddrOut) {
     if (searchStart < 0 || searchEnd <= searchStart) {
         LOG_ERROR(Kernel_Vmm, "Provided address range is invalid!");
         return ORBIS_KERNEL_ERROR_EINVAL;

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -152,7 +152,7 @@ s32 PS4_SYSV_ABI sceKernelReserveVirtualRange(void** addr, u64 len, int flags, u
     const auto map_flags = static_cast<Core::MemoryMapFlags>(flags);
 
     s32 result = memory->MapMemory(addr, in_addr, len, Core::MemoryProt::NoAccess, map_flags,
-                                   Core::VMAType::Reserved);
+                                   Core::VMAType::Reserved, "anon", false, -1, alignment);
     if (result == 0) {
         LOG_INFO(Kernel_Vmm, "out_addr = {}", fmt::ptr(*addr));
     }
@@ -458,9 +458,11 @@ s32 PS4_SYSV_ABI sceKernelMemoryPoolReserve(void* addr_in, u64 len, u64 alignmen
     auto* memory = Core::Memory::Instance();
     const VAddr in_addr = reinterpret_cast<VAddr>(addr_in);
     const auto map_flags = static_cast<Core::MemoryMapFlags>(flags);
+    u64 map_alignment = alignment == 0 ? 2_MB : alignment;
 
     return memory->MapMemory(addr_out, std::bit_cast<VAddr>(addr_in), len,
-                             Core::MemoryProt::NoAccess, map_flags, Core::VMAType::PoolReserved);
+                             Core::MemoryProt::NoAccess, map_flags, Core::VMAType::PoolReserved,
+                             "anon", false, -1, map_alignment);
 }
 
 s32 PS4_SYSV_ABI sceKernelMemoryPoolCommit(void* addr, u64 len, s32 type, s32 prot, s32 flags) {

--- a/src/core/libraries/kernel/memory.h
+++ b/src/core/libraries/kernel/memory.h
@@ -167,12 +167,12 @@ s32 PS4_SYSV_ABI sceKernelBatchMap2(OrbisKernelBatchMapEntry* entries, int numEn
 
 s32 PS4_SYSV_ABI sceKernelSetVirtualRangeName(const void* addr, size_t len, const char* name);
 
-s32 PS4_SYSV_ABI sceKernelMemoryPoolExpand(u64 searchStart, u64 searchEnd, size_t len,
-                                           size_t alignment, u64* physAddrOut);
-s32 PS4_SYSV_ABI sceKernelMemoryPoolReserve(void* addrIn, size_t len, size_t alignment, int flags,
-                                            void** addrOut);
-s32 PS4_SYSV_ABI sceKernelMemoryPoolCommit(void* addr, size_t len, int type, int prot, int flags);
-s32 PS4_SYSV_ABI sceKernelMemoryPoolDecommit(void* addr, size_t len, int flags);
+s32 PS4_SYSV_ABI sceKernelMemoryPoolExpand(u64 searchStart, u64 searchEnd, u64 len,
+                                           u64 alignment, u64* physAddrOut);
+s32 PS4_SYSV_ABI sceKernelMemoryPoolReserve(void* addr_in, u64 len, u64 alignment, s32 flags,
+                                            void** addr_out);
+s32 PS4_SYSV_ABI sceKernelMemoryPoolCommit(void* addr, u64 len, s32 type, s32 prot, s32 flags);
+s32 PS4_SYSV_ABI sceKernelMemoryPoolDecommit(void* addr, u64 len, s32 flags);
 s32 PS4_SYSV_ABI sceKernelMemoryPoolBatch(const OrbisKernelMemoryPoolBatchEntry* entries, s32 count,
                                           s32* num_processed, s32 flags);
 

--- a/src/core/libraries/kernel/memory.h
+++ b/src/core/libraries/kernel/memory.h
@@ -167,8 +167,8 @@ s32 PS4_SYSV_ABI sceKernelBatchMap2(OrbisKernelBatchMapEntry* entries, int numEn
 
 s32 PS4_SYSV_ABI sceKernelSetVirtualRangeName(const void* addr, size_t len, const char* name);
 
-s32 PS4_SYSV_ABI sceKernelMemoryPoolExpand(u64 searchStart, u64 searchEnd, u64 len,
-                                           u64 alignment, u64* physAddrOut);
+s32 PS4_SYSV_ABI sceKernelMemoryPoolExpand(u64 searchStart, u64 searchEnd, u64 len, u64 alignment,
+                                           u64* physAddrOut);
 s32 PS4_SYSV_ABI sceKernelMemoryPoolReserve(void* addr_in, u64 len, u64 alignment, s32 flags,
                                             void** addr_out);
 s32 PS4_SYSV_ABI sceKernelMemoryPoolCommit(void* addr, u64 len, s32 type, s32 prot, s32 flags);

--- a/src/core/libraries/kernel/memory.h
+++ b/src/core/libraries/kernel/memory.h
@@ -147,9 +147,9 @@ s32 PS4_SYSV_ABI sceKernelMapFlexibleMemory(void** addr_in_out, std::size_t len,
                                             int flags);
 int PS4_SYSV_ABI sceKernelQueryMemoryProtection(void* addr, void** start, void** end, u32* prot);
 
-int PS4_SYSV_ABI sceKernelMProtect(const void* addr, size_t size, int prot);
+s32 PS4_SYSV_ABI sceKernelMprotect(const void* addr, u64 size, s32 prot);
 
-int PS4_SYSV_ABI sceKernelMTypeProtect(const void* addr, size_t size, int mtype, int prot);
+s32 PS4_SYSV_ABI sceKernelMtypeprotect(const void* addr, u64 size, s32 mtype, s32 prot);
 
 int PS4_SYSV_ABI sceKernelDirectMemoryQuery(u64 offset, int flags, OrbisQueryInfo* query_info,
                                             size_t infoSize);

--- a/src/core/libraries/kernel/memory.h
+++ b/src/core/libraries/kernel/memory.h
@@ -165,7 +165,7 @@ s32 PS4_SYSV_ABI sceKernelBatchMap(OrbisKernelBatchMapEntry* entries, int numEnt
 s32 PS4_SYSV_ABI sceKernelBatchMap2(OrbisKernelBatchMapEntry* entries, int numEntries,
                                     int* numEntriesOut, int flags);
 
-s32 PS4_SYSV_ABI sceKernelSetVirtualRangeName(const void* addr, size_t len, const char* name);
+s32 PS4_SYSV_ABI sceKernelSetVirtualRangeName(const void* addr, u64 len, const char* name);
 
 s32 PS4_SYSV_ABI sceKernelMemoryPoolExpand(u64 searchStart, u64 searchEnd, u64 len, u64 alignment,
                                            u64* physAddrOut);

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -314,7 +314,7 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
         // When MemoryMapFlags::Fixed is not specified, and mapped_addr is 0,
         // search from address 0x200000000 instead.
         alignment = alignment > 0 ? alignment : 16_KB;
-        mapped_addr = mapped_addr == 0 ? 0x200000000 : mapped_addr;
+        mapped_addr = virtual_addr == 0 ? 0x200000000 : mapped_addr;
         mapped_addr = SearchFree(mapped_addr, size, alignment);
         if (mapped_addr == -1) {
             // No suitable memory areas to map to

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -400,10 +400,7 @@ s32 MemoryManager::MapFile(void** out_addr, VAddr virtual_addr, u64 size, Memory
     impl.MapFile(mapped_addr, size_aligned, phys_addr, std::bit_cast<u32>(prot), handle);
 
     if (prot >= MemoryProt::GpuRead) {
-        // PS4s only map to GPU memory when the protection includes GPU access.
-        // If the address to map to is too high, PS4s throw a page fault and crash.
-        ASSERT_MSG(IsValidGpuMapping(mapped_addr, size_aligned), "Invalid address for GPU mapping");
-        rasterizer->MapMemory(mapped_addr, size_aligned);
+        ASSERT_MSG(false, "Files cannot be mapped to GPU memory");
     }
 
     // Add virtual memory area

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -396,7 +396,7 @@ s32 MemoryManager::MapFile(void** out_addr, VAddr virtual_addr, u64 size, Memory
 
     const auto handle = file->f.GetFileMapping();
 
-    impl.MapFile(mapped_addr, size_aligned, phys_addr, std::bit_cast<u32>(prot), fd);
+    impl.MapFile(mapped_addr, size_aligned, phys_addr, std::bit_cast<u32>(prot), handle);
 
     if (prot >= MemoryProt::GpuRead) {
         // PS4s only map to GPU memory when the protection includes GPU access.

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -563,8 +563,9 @@ s64 MemoryManager::ProtectBytes(VAddr addr, VirtualMemoryArea vma_base, size_t s
         vma_base.size - start_in_vma < size ? vma_base.size - start_in_vma : size;
 
     if (vma_base.type == VMAType::Free) {
-        LOG_ERROR(Kernel_Vmm, "Cannot change protection on free memory region");
-        return ORBIS_KERNEL_ERROR_EINVAL;
+        // On PS4, protecting freed memory does nothing.
+        LOG_WARNING(Kernel_Vmm, "Attempting to protect free memory");
+        return adjusted_size;
     }
 
     // Validate protection flags

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -797,14 +797,14 @@ VAddr MemoryManager::SearchFree(VAddr virtual_addr, size_t size, u32 alignment) 
     virtual_addr = Common::AlignUp(virtual_addr, alignment);
     auto it = FindVMA(virtual_addr);
 
-    // If the VMA is free and contains the requested mapping we are done.
-    if (it->second.IsFree() && it->second.Contains(virtual_addr, size)) {
+    // If the VMA is not mapped and contains the requested mapping, we are done.
+    if (!it->second.IsMapped() && it->second.Contains(virtual_addr, size)) {
         return virtual_addr;
     }
 
     // Search for the first free VMA that fits our mapping.
     while (it != vma_map.end()) {
-        if (!it->second.IsFree()) {
+        if (it->second.IsMapped()) {
             it++;
             continue;
         }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -182,6 +182,7 @@ PAddr MemoryManager::Allocate(PAddr search_start, PAddr search_end, size_t size,
     auto& area = CarveDmemArea(mapping_start, size)->second;
     area.memory_type = memory_type;
     area.is_free = false;
+    MergeAdjacent(dmem_map, dmem_area);
     return mapping_start;
 }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -335,7 +335,7 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
     new_vma.prot = prot;
     new_vma.name = name;
     new_vma.type = type;
-    new_vma.phys_base = phys_addr;
+    new_vma.phys_base = phys_addr == -1 ? 0 : phys_addr;
     new_vma.is_exec = is_exec;
 
     if (type == VMAType::Reserved) {

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -561,7 +561,6 @@ s64 MemoryManager::ProtectBytes(VAddr addr, VirtualMemoryArea vma_base, size_t s
 
     if (vma_base.type == VMAType::Free) {
         // On PS4, protecting freed memory does nothing.
-        LOG_WARNING(Kernel_Vmm, "Attempting to protect free memory");
         return adjusted_size;
     }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -797,14 +797,14 @@ VAddr MemoryManager::SearchFree(VAddr virtual_addr, size_t size, u32 alignment) 
     virtual_addr = Common::AlignUp(virtual_addr, alignment);
     auto it = FindVMA(virtual_addr);
 
-    // If the VMA is not mapped and contains the requested mapping, we are done.
-    if (!it->second.IsMapped() && it->second.Contains(virtual_addr, size)) {
+    // If the VMA is free and contains the requested mapping we are done.
+    if (it->second.IsFree() && it->second.Contains(virtual_addr, size)) {
         return virtual_addr;
     }
 
     // Search for the first free VMA that fits our mapping.
     while (it != vma_map.end()) {
-        if (it->second.IsMapped()) {
+        if (!it->second.IsFree()) {
             it++;
             continue;
         }

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -195,8 +195,8 @@ public:
                   MemoryMapFlags flags, VMAType type, std::string_view name = "anon",
                   bool is_exec = false, PAddr phys_addr = -1, u64 alignment = 0);
 
-    int MapFile(void** out_addr, VAddr virtual_addr, size_t size, MemoryProt prot,
-                MemoryMapFlags flags, uintptr_t fd, size_t offset);
+    s32 MapFile(void** out_addr, VAddr virtual_addr, u64 size, MemoryProt prot,
+                MemoryMapFlags flags, s32 fd, s64 phys_addr);
 
     s32 PoolDecommit(VAddr virtual_addr, size_t size);
 

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -183,15 +183,9 @@ public:
 
     void Free(PAddr phys_addr, size_t size);
 
-    int PoolReserve(void** out_addr, VAddr virtual_addr, size_t size, MemoryMapFlags flags,
-                    u64 alignment = 0);
-
-    int Reserve(void** out_addr, VAddr virtual_addr, size_t size, MemoryMapFlags flags,
-                u64 alignment = 0);
-
     int PoolCommit(VAddr virtual_addr, size_t size, MemoryProt prot);
 
-    int MapMemory(void** out_addr, VAddr virtual_addr, size_t size, MemoryProt prot,
+    s32 MapMemory(void** out_addr, VAddr virtual_addr, u64 size, MemoryProt prot,
                   MemoryMapFlags flags, VMAType type, std::string_view name = "anon",
                   bool is_exec = false, PAddr phys_addr = -1, u64 alignment = 0);
 

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -215,7 +215,7 @@ public:
 
     s32 SetDirectMemoryType(s64 phys_addr, s32 memory_type);
 
-    void NameVirtualRange(VAddr virtual_addr, size_t size, std::string_view name);
+    void NameVirtualRange(VAddr virtual_addr, u64 size, std::string_view name);
 
     void InvalidateMemory(VAddr addr, u64 size) const;
 


### PR DESCRIPTION
The main change of this PR is completely removing our `PoolReserve` and `Reserve` functions in `Core::Memory`. Both of these functions were effectively re-implementations of `MapMemory` with minor changes, since all three functions are different uses of the `mmap` syscall.
Instead of constantly updating all three separately, it's easier to group all behavior in one function with additional checks where we need to behave slightly differently.

I've also added proper error handling in `posix_mmap`, added proper conditional rasterizer memory mapping logic based on protection values, and fixed a few other edge cases I've noticed in testing.

I'm opening this as a draft for now, as I need to make some more minor cleanup/style commits, and these changes need proper testing before any merges.