### PR TITLE
amdgpu: Implement 0x5u for Depth_MicroTiled.

### DIFF
--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -152,6 +152,8 @@ enum class TilingMode : u32 {
 
 constexpr std::string_view NameOf(TilingMode type) {
     switch (type) {
+    case TilingMode::Depth_MicroTiled:
+        return "Depth_MicroTiled";
     case TilingMode::Depth_MacroTiled:
         return "Depth_MacroTiled";
     case TilingMode::Display_Linear:
@@ -318,8 +320,7 @@ struct Image {
 
     TilingMode GetTilingMode() const {
         if (tiling_index >= 0 && tiling_index <= 7) {
-            return tiling_index == 5 ? TilingMode::Texture_MicroTiled
-                                     : TilingMode::Depth_MacroTiled;
+        return tiling_index == 5 ? TilingMode::Depth_MicroTiled : TilingMode::Depth_MacroTiled;
         }
         return static_cast<TilingMode>(tiling_index);
     }

--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -320,7 +320,7 @@ struct Image {
 
     TilingMode GetTilingMode() const {
         if (tiling_index >= 0 && tiling_index <= 7) {
-        return tiling_index == 5 ? TilingMode::Depth_MicroTiled : TilingMode::Depth_MacroTiled;
+         return tiling_index == 5 ? TilingMode::Depth_MicroTiled : TilingMode::Depth_MacroTiled;
         }
         return static_cast<TilingMode>(tiling_index);
     }

--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -141,6 +141,7 @@ constexpr std::string_view NameOf(ImageType type) {
 
 enum class TilingMode : u32 {
     Depth_MacroTiled = 0u,
+    Depth_MicroTiled = 0x5u,
     Display_Linear = 0x8u,
     Display_MicroTiled = 0x9u,
     Display_MacroTiled = 0xAu,

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -186,14 +186,13 @@ void ImageInfo::UpdateSize() {
             thickness = 4;
             mip_d += (-mip_d) & (thickness - 1);
             [[fallthrough]];
+        case AmdGpu::TilingMode::Depth_MicroTiled:
         case AmdGpu::TilingMode::Display_MicroTiled:
         case AmdGpu::TilingMode::Texture_MicroTiled: {
             std::tie(mip_info.pitch, mip_info.size) =
                 ImageSizeMicroTiled(mip_w, mip_h, thickness, bpp, num_samples);
             break;
         }
-        case AmdGpu::TilingMode::Depth_MicroTiled:        
-        case AmdGpu::TilingMode::Display_MicroTiled:
         case AmdGpu::TilingMode::Display_MacroTiled:
         case AmdGpu::TilingMode::Texture_MacroTiled:
         case AmdGpu::TilingMode::Depth_MacroTiled: {

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -192,6 +192,8 @@ void ImageInfo::UpdateSize() {
                 ImageSizeMicroTiled(mip_w, mip_h, thickness, bpp, num_samples);
             break;
         }
+        case AmdGpu::TilingMode::Depth_MicroTiled:        
+        case AmdGpu::TilingMode::Display_MicroTiled:
         case AmdGpu::TilingMode::Display_MacroTiled:
         case AmdGpu::TilingMode::Texture_MacroTiled:
         case AmdGpu::TilingMode::Depth_MacroTiled: {

--- a/src/video_core/texture_cache/tile_manager.cpp
+++ b/src/video_core/texture_cache/tile_manager.cpp
@@ -28,7 +28,6 @@ const DetilerContext* TileManager::GetDetiler(const ImageInfo& info) const {
     const auto bpp = info.num_bits * (info.props.is_block ? 16 : 1);
     switch (info.tiling_mode) {
     case AmdGpu::TilingMode::Depth_MicroTiled:
-    case AmdGpu::TilingMode::Display_MicroTiled:
     case AmdGpu::TilingMode::Texture_MicroTiled:
         switch (bpp) {
         case 8:

--- a/src/video_core/texture_cache/tile_manager.cpp
+++ b/src/video_core/texture_cache/tile_manager.cpp
@@ -27,6 +27,8 @@ namespace VideoCore {
 const DetilerContext* TileManager::GetDetiler(const ImageInfo& info) const {
     const auto bpp = info.num_bits * (info.props.is_block ? 16 : 1);
     switch (info.tiling_mode) {
+    case AmdGpu::TilingMode::Depth_MicroTiled:
+    case AmdGpu::TilingMode::Display_MicroTiled:
     case AmdGpu::TilingMode::Texture_MicroTiled:
         switch (bpp) {
         case 8:


### PR DESCRIPTION
Used by KNACK (CUSA00068).
Spotted by Niko on the shadPS4 Discord development channel.