### PR TITLE
Handle immediate inline samplers

### DIFF
--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -972,7 +972,12 @@ void EmitContext::DefineImagesAndSamplers() {
         const Id id{AddGlobalVariable(sampler_pointer_type, spv::StorageClass::UniformConstant)};
         Decorate(id, spv::Decoration::Binding, binding.unified++);
         Decorate(id, spv::Decoration::DescriptorSet, 0U);
-        Name(id, fmt::format("{}_{}{}", stage, "samp", samp_desc.sharp_idx));
+        auto sharp_desc = std::holds_alternative<u32>(samp_desc.sampler)
+                              ? fmt::format("sgpr:{}", std::get<u32>(samp_desc.sampler))
+                              : fmt::format("inline:{:#x}:{:#x}",
+                                            std::get<AmdGpu::Sampler>(samp_desc.sampler).raw0,
+                                            std::get<AmdGpu::Sampler>(samp_desc.sampler).raw1);
+        Name(id, fmt::format("{}_{}{}", stage, "samp", sharp_desc));
         samplers.push_back(id);
         interfaces.push_back(id);
     }

--- a/src/shader_recompiler/frontend/translate/vector_memory.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_memory.cpp
@@ -531,8 +531,7 @@ IR::Value EmitImageSample(IR::IREmitter& ir, const GcnInst& inst, const IR::Scal
     // Load first dword of T# and S#. We will use them as the handle that will guide resource
     // tracking pass where to read the sharps. This will later also get patched to the SPIRV texture
     // binding index.
-    const IR::Value handle =
-        ir.CompositeConstruct(ir.GetScalarReg(tsharp_reg), ir.GetScalarReg(sampler_reg));
+    const IR::Value handle = ir.GetScalarReg(tsharp_reg);
     const IR::Value inline_sampler =
         ir.CompositeConstruct(ir.GetScalarReg(sampler_reg), ir.GetScalarReg(sampler_reg + 1),
                               ir.GetScalarReg(sampler_reg + 2), ir.GetScalarReg(sampler_reg + 3));

--- a/src/shader_recompiler/frontend/translate/vector_memory.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_memory.cpp
@@ -533,6 +533,9 @@ IR::Value EmitImageSample(IR::IREmitter& ir, const GcnInst& inst, const IR::Scal
     // binding index.
     const IR::Value handle =
         ir.CompositeConstruct(ir.GetScalarReg(tsharp_reg), ir.GetScalarReg(sampler_reg));
+    const IR::Value inline_sampler =
+        ir.CompositeConstruct(ir.GetScalarReg(sampler_reg), ir.GetScalarReg(sampler_reg + 1),
+                              ir.GetScalarReg(sampler_reg + 2), ir.GetScalarReg(sampler_reg + 3));
 
     // Determine how many address registers need to be passed.
     // The image type is unknown, so add all 4 possible base registers and resolve later.
@@ -568,7 +571,8 @@ IR::Value EmitImageSample(IR::IREmitter& ir, const GcnInst& inst, const IR::Scal
     const IR::Value address4 = get_addr_reg(12);
 
     // Issue the placeholder IR instruction.
-    IR::Value texel = ir.ImageSampleRaw(handle, address1, address2, address3, address4, info);
+    IR::Value texel =
+        ir.ImageSampleRaw(handle, address1, address2, address3, address4, inline_sampler, info);
     if (info.is_depth && !gather) {
         // For non-gather depth sampling, only return a single value.
         texel = ir.CompositeExtract(texel, 0);

--- a/src/shader_recompiler/info.h
+++ b/src/shader_recompiler/info.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <span>
+#include <variant>
 #include <vector>
 #include <boost/container/small_vector.hpp>
 #include <boost/container/static_vector.hpp>

--- a/src/shader_recompiler/info.h
+++ b/src/shader_recompiler/info.h
@@ -91,10 +91,14 @@ struct ImageResource {
 using ImageResourceList = boost::container::small_vector<ImageResource, NumImages>;
 
 struct SamplerResource {
-    u32 sharp_idx;
-    AmdGpu::Sampler inline_sampler{};
+    std::variant<u32, AmdGpu::Sampler> sampler;
     u32 associated_image : 4;
     u32 disable_aniso : 1;
+
+    SamplerResource(u32 sharp_idx, u32 associated_image_, bool disable_aniso_)
+        : sampler{sharp_idx}, associated_image{associated_image_}, disable_aniso{disable_aniso_} {}
+    SamplerResource(AmdGpu::Sampler sampler_)
+        : sampler{sampler_}, associated_image{0}, disable_aniso(0) {}
 
     constexpr AmdGpu::Sampler GetSharp(const Info& info) const noexcept;
 };
@@ -318,7 +322,9 @@ constexpr AmdGpu::Image ImageResource::GetSharp(const Info& info) const noexcept
 }
 
 constexpr AmdGpu::Sampler SamplerResource::GetSharp(const Info& info) const noexcept {
-    return inline_sampler ? inline_sampler : info.ReadUdSharp<AmdGpu::Sampler>(sharp_idx);
+    return std::holds_alternative<AmdGpu::Sampler>(sampler)
+               ? std::get<AmdGpu::Sampler>(sampler)
+               : info.ReadUdSharp<AmdGpu::Sampler>(std::get<u32>(sampler));
 }
 
 constexpr AmdGpu::Image FMaskResource::GetSharp(const Info& info) const noexcept {

--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -1964,9 +1964,9 @@ Value IREmitter::ImageAtomicExchange(const Value& handle, const Value& coords, c
 
 Value IREmitter::ImageSampleRaw(const Value& handle, const Value& address1, const Value& address2,
                                 const Value& address3, const Value& address4,
-                                TextureInstInfo info) {
-    return Inst(Opcode::ImageSampleRaw, Flags{info}, handle, address1, address2, address3,
-                address4);
+                                const Value& inline_sampler, TextureInstInfo info) {
+    return Inst(Opcode::ImageSampleRaw, Flags{info}, handle, address1, address2, address3, address4,
+                inline_sampler);
 }
 
 Value IREmitter::ImageSampleImplicitLod(const Value& handle, const Value& coords, const F32& bias,

--- a/src/shader_recompiler/ir/ir_emitter.h
+++ b/src/shader_recompiler/ir/ir_emitter.h
@@ -349,7 +349,8 @@ public:
 
     [[nodiscard]] Value ImageSampleRaw(const Value& handle, const Value& address1,
                                        const Value& address2, const Value& address3,
-                                       const Value& address4, TextureInstInfo info);
+                                       const Value& address4, const Value& inline_sampler,
+                                       TextureInstInfo info);
 
     [[nodiscard]] Value ImageSampleImplicitLod(const Value& handle, const Value& body,
                                                const F32& bias, const Value& offset,

--- a/src/shader_recompiler/ir/opcodes.inc
+++ b/src/shader_recompiler/ir/opcodes.inc
@@ -412,7 +412,7 @@ OPCODE(ConvertU8U32,                                        U8,             U32,
 OPCODE(ConvertU32U8,                                        U32,            U8,                                                                             )
 
 // Image operations
-OPCODE(ImageSampleRaw,                                      F32x4,          Opaque,         F32x4,          F32x4,          F32x4,          F32,            )
+OPCODE(ImageSampleRaw,                                      F32x4,          Opaque,         F32x4,          F32x4,          F32x4,          F32,            Opaque,      )
 OPCODE(ImageSampleImplicitLod,                              F32x4,          Opaque,         F32x4,          F32,            Opaque,                         )
 OPCODE(ImageSampleExplicitLod,                              F32x4,          Opaque,         Opaque,         F32,            Opaque,                         )
 OPCODE(ImageSampleDrefImplicitLod,                          F32x4,          Opaque,         Opaque,         F32,            F32,            Opaque,         )

--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -351,8 +351,7 @@ void PatchBufferSharp(IR::Block& block, IR::Inst& inst, Info& info, Descriptors&
 void PatchImageSharp(IR::Block& block, IR::Inst& inst, Info& info, Descriptors& descriptors) {
     const auto pred = [](const IR::Inst* inst) -> std::optional<const IR::Inst*> {
         const auto opcode = inst->GetOpcode();
-        if (opcode == IR::Opcode::CompositeConstructU32x2 || // IMAGE_SAMPLE (image+sampler)
-            opcode == IR::Opcode::ReadConst ||               // IMAGE_LOAD (image only)
+        if (opcode == IR::Opcode::ReadConst || // IMAGE_LOAD (image only)
             opcode == IR::Opcode::GetUserData) {
             return inst;
         }
@@ -360,9 +359,7 @@ void PatchImageSharp(IR::Block& block, IR::Inst& inst, Info& info, Descriptors& 
     };
     const auto result = IR::BreadthFirstSearch(&inst, pred);
     ASSERT_MSG(result, "Unable to find image sharp source");
-    const IR::Inst* producer = result.value();
-    const bool has_sampler = producer->GetOpcode() == IR::Opcode::CompositeConstructU32x2;
-    const auto tsharp_handle = has_sampler ? producer->Arg(0).InstRecursive() : producer;
+    const IR::Inst* tsharp_handle = result.value();
 
     // Read image sharp.
     const auto tsharp = TrackSharp(tsharp_handle, info);
@@ -428,28 +425,14 @@ void PatchImageSharp(IR::Block& block, IR::Inst& inst, Info& info, Descriptors& 
     if (inst.GetOpcode() == IR::Opcode::ImageSampleRaw) {
         // Read sampler sharp.
         const auto sampler_binding = [&] -> u32 {
-            ASSERT(producer->GetOpcode() == IR::Opcode::CompositeConstructU32x2);
-            const IR::Value& handle = producer->Arg(1);
+            const auto sampler = inst.Arg(5).InstRecursive();
+            ASSERT(sampler && sampler->GetOpcode() == IR::Opcode::CompositeConstructU32x4);
+            const auto handle = sampler->Arg(0);
             // Inline sampler resource.
             if (handle.IsImmediate()) {
-                LOG_WARNING(Render_Vulkan, "Inline sampler detected");
-                const auto inline_sampler_arg = inst.Arg(5).InstRecursive();
-                const auto pred = [](const IR::Inst* inst) -> std::optional<const IR::Inst*> {
-                    const auto opcode = inst->GetOpcode();
-                    if (opcode == IR::Opcode::CompositeConstructU32x4) {
-                        return inst;
-                    }
-                    return std::nullopt;
-                };
-                const auto result = IR::BreadthFirstSearch(inline_sampler_arg, pred);
-                ASSERT_MSG(result, "Unable to find immediate sampler");
-                const IR::Inst* inline_producer = result.value();
-                ASSERT(inline_producer &&
-                       inline_producer->GetOpcode() == IR::Opcode::CompositeConstructU32x4);
-
+                LOG_DEBUG(Render_Vulkan, "Inline sampler detected");
                 const auto [s1, s2, s3, s4] =
-                    std::tuple{inline_producer->Arg(0), inline_producer->Arg(1),
-                               inline_producer->Arg(2), inline_producer->Arg(3)};
+                    std::tuple{sampler->Arg(0), sampler->Arg(1), sampler->Arg(2), sampler->Arg(3)};
                 ASSERT(s1.IsImmediate() && s2.IsImmediate() && s3.IsImmediate() &&
                        s4.IsImmediate());
                 const auto inline_sampler = AmdGpu::Sampler{
@@ -458,14 +441,15 @@ void PatchImageSharp(IR::Block& block, IR::Inst& inst, Info& info, Descriptors& 
                 };
                 const auto binding = descriptors.Add(SamplerResource{inline_sampler});
                 return binding;
+            } else {
+                // Normal sampler resource.
+                const auto ssharp_handle = handle.InstRecursive();
+                const auto& [ssharp_ud, disable_aniso] = TryDisableAnisoLod0(ssharp_handle);
+                const auto ssharp = TrackSharp(ssharp_ud, info);
+                const auto binding =
+                    descriptors.Add(SamplerResource{ssharp, image_binding, disable_aniso});
+                return binding;
             }
-            // Normal sampler resource.
-            const auto ssharp_handle = handle.InstRecursive();
-            const auto& [ssharp_ud, disable_aniso] = TryDisableAnisoLod0(ssharp_handle);
-            const auto ssharp = TrackSharp(ssharp_ud, info);
-            const auto binding =
-                descriptors.Add(SamplerResource{ssharp, image_binding, disable_aniso});
-            return binding;
         }();
         // Patch image and sampler handle.
         inst.SetArg(0, ir.Imm32(image_binding | sampler_binding << 16));


### PR DESCRIPTION
Previously inline samplers were initialized from a single u32, leaving the other 96 bits zeroed. This PR aims to recover the whole S#. I have no idea what I'm doing in the shader recompiler but it seems to work and allows Dishonored 2 to get past intro.