### PR TITLE
Qt: Set Minimum Icon Size List to 48

### DIFF
--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -387,9 +387,9 @@ void MainWindow::CreateConnects() {
     connect(ui->sizeSlider, &QSlider::valueChanged, this, [this](int value) {
         if (isTableList) {
             m_game_list_frame->icon_size =
-                36 + value; // 36 is the minimum icon size to use due to text disappearing.
-            m_game_list_frame->ResizeIcons(36 + value);
-            Config::setIconSize(36 + value);
+                48 + value; // 48 is the minimum icon size to use due to text disappearing.
+            m_game_list_frame->ResizeIcons(48 + value);
+            Config::setIconSize(48 + value);
             Config::setSliderPosition(value);
         } else {
             m_game_grid_frame->icon_size = 69 + value;


### PR DESCRIPTION
When the minimum size is selected, only the image is reduced to 36. The text is at 48, so there is a difference between the size of the icon and the text.


Before (minimum size):
![Before](https://github.com/user-attachments/assets/d4565357-014c-4ac1-94d7-67027899f949)

After (minimum size):
![After](https://github.com/user-attachments/assets/8a87aa05-962e-43ff-8f00-f54b85bf5794)