### PR TITLE
Handle pipelines with mixed samples counts

### DIFF
--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -109,7 +109,7 @@ GraphicsPipeline::GraphicsPipeline(
 
     const vk::PipelineMultisampleStateCreateInfo multisampling = {
         .rasterizationSamples =
-            LiverpoolToVK::NumSamples(key.num_samples, instance.GetFramebufferSampleCounts()),
+            instance.IsMixedSamplesSupported() ? vk::SampleCountFlagBits::e1 : key.num_samples,
         .sampleShadingEnable = false,
     };
 
@@ -212,7 +212,14 @@ GraphicsPipeline::GraphicsPipeline(
         });
     }
 
+    const vk::AttachmentSampleCountInfoAMD mixed_samples = {
+        .colorAttachmentCount = key.num_color_attachments,
+        .pColorAttachmentSamples = key.color_samples.data(),
+        .depthStencilAttachmentSamples = key.depth_samples,
+    };
+
     const vk::PipelineRenderingCreateInfo pipeline_rendering_ci = {
+        .pNext = instance.IsMixedSamplesSupported() ? &mixed_samples : nullptr,
         .colorAttachmentCount = key.num_color_attachments,
         .pColorAttachmentFormats = key.color_formats.data(),
         .depthAttachmentFormat = key.depth_format,

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -39,7 +39,9 @@ struct GraphicsPipelineKey {
     vk::Format depth_format;
     vk::Format stencil_format;
 
-    u32 num_samples;
+    vk::SampleCountFlagBits num_samples;
+    std::array<vk::SampleCountFlagBits, Liverpool::NumColorBuffers> color_samples;
+    vk::SampleCountFlagBits depth_samples;
     u32 mrt_mask;
     AmdGpu::PrimitiveType prim_type;
     Liverpool::PolygonMode polygon_mode;

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -283,6 +283,8 @@ bool Instance::CreateDevice() {
         LOG_INFO(Render_Vulkan, "- shaderImageFloat32AtomicMinMax: {}",
                  shader_atomic_float2_features.shaderImageFloat32AtomicMinMax);
     }
+    nv_framebuffer_mixed_samples = add_extension(VK_NV_FRAMEBUFFER_MIXED_SAMPLES_EXTENSION_NAME);
+    amd_mixed_attachment_samples = add_extension(VK_AMD_MIXED_ATTACHMENT_SAMPLES_EXTENSION_NAME);
     const bool calibrated_timestamps =
         TRACY_GPU_ENABLED ? add_extension(VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME) : false;
 

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -171,6 +171,12 @@ public:
         return shader_atomic_float2 && shader_atomic_float2_features.shaderImageFloat32AtomicMinMax;
     }
 
+    /// Returns true if VK_NV_framebuffer_mixed_samples or
+    /// VK_AMD_mixed_attachment_samples is supported
+    bool IsMixedSamplesSupported() const {
+        return nv_framebuffer_mixed_samples || amd_mixed_attachment_samples;
+    }
+
     /// Returns true when geometry shaders are supported by the device
     bool IsGeometryStageSupported() const {
         return features.geometryShader;
@@ -374,6 +380,8 @@ private:
     bool amd_gcn_shader{};
     bool amd_shader_trinary_minmax{};
     bool shader_atomic_float2{};
+    bool nv_framebuffer_mixed_samples{};
+    bool amd_mixed_attachment_samples{};
     bool portability_subset{};
 };
 


### PR DESCRIPTION
Fixes a Device lost error encountered in WIPEOUT: Omega Collection and HEAVY RAIN:
```
[Render.Vulkan] <Error> vk_platform.cpp:56 DebugUtilsCallback: VUID-vkCmdDrawIndexed-multisampledRenderToSingleSampled-07285: Validation Error: [ VUID-vkCmdDrawIndexed-multisampledRenderToSingleSampled-07285 ] Object 0: handle = 0xfa17400, name = CommandPool: Command Buffer 0, type = VK_OBJECT_TYPE_COMMAND_BUFFER; Object 1: handle = 0xe9b2ee0000000094, name = Graphics Pipeline fs_0x000000004f6cc41b,vs_0x000000002012d5ea, type = VK_OBJECT_TYPE_PIPELINE; | MessageID = 0xf4b969ec | vkCmdDrawIndexed(): Color attachment (0) sample count (VK_SAMPLE_COUNT_1_BIT) must match corresponding VkPipelineMultisampleStateCreateInfo sample count (VK_SAMPLE_COUNT_4_BIT).
The Vulkan spec states: If the bound pipeline was created without a VkAttachmentSampleCountInfoAMD or VkAttachmentSampleCountInfoNV structure, and the multisampledRenderToSingleSampled feature is not enabled, and the current render pass instance was begun with vkCmdBeginRendering with a VkRenderingInfo::colorAttachmentCount parameter greater than 0, then each element of the VkRenderingInfo::pColorAttachments array with a imageView not equal to VK_NULL_HANDLE must have been created with a sample count equal to the value of rasterizationSamples for the bound graphics pipeline (https://vulkan.lunarg.com/doc/view/1.4.304.1/windows/antora/spec/latest/chapters/drawing.html#VUID-vkCmdDrawIndexed-multisampledRenderToSingleSampled-07285)
```

According to gpuinfo, `multisampledRenderToSingleSampled` is supported by only a handful of mobile GPUs, while the other two are supported by most modern cards from the respective company.