### PR TITLE
Core: Pthread affinity fixups

### DIFF
--- a/src/core/libraries/kernel/threads/pthread_attr.cpp
+++ b/src/core/libraries/kernel/threads/pthread_attr.cpp
@@ -306,6 +306,8 @@ void RegisterThreadAttr(Core::Loader::SymbolsResolver* sym) {
                  posix_pthread_attr_getdetachstate);
     LIB_FUNCTION("JKyG3SWyA10", "libScePosix", 1, "libkernel", 1, 1,
                  posix_pthread_attr_setguardsize);
+    LIB_FUNCTION("qlk9pSLsUmM", "libScePosix", 1, "libkernel", 1, 1,
+                 posix_pthread_attr_getschedparam);
 
     // Orbis
     LIB_FUNCTION("4+h9EzwKF4I", "libkernel", 1, "libkernel", 1, 1,


### PR DESCRIPTION
In the pthread affinity functions, when `thread != g_curthread`, we should be using `ThrState::FindThread` to get and lock the appropriate thread. Adding this logic fixes a potential crash in `scePthreadSetAffinity`, helping Need for Speed™ Heat (CUSA15081) get slightly further.
I've also added an export for `posix_pthread_attr_getschedparam`, as it's used by Kingdom Come: Deliverance Royal Edition (CUSA15436).