### PR TITLE
Fork detection fixes VII

### DIFF
--- a/src/common/scm_rev.cpp.in
+++ b/src/common/scm_rev.cpp.in
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <string>
+
 #include "common/scm_rev.h"
 
 namespace Common {
@@ -14,6 +16,27 @@ constexpr char g_scm_desc[]        = "@GIT_DESC@";
 constexpr char g_scm_remote_name[] = "@GIT_REMOTE_NAME@";
 constexpr char g_scm_remote_url[]  = "@GIT_REMOTE_URL@";
 constexpr char g_scm_date[]        = "@BUILD_DATE@";
+
+const std::string GetRemoteNameFromLink() {
+    std::string remote_url(Common::g_scm_remote_url);
+    std::string remote_host;
+    try {
+        if (remote_url.starts_with("http")) {
+            if (*remote_url.rbegin() == '/') {
+                remote_url.pop_back();
+            }
+            remote_host = remote_url.substr(19, remote_url.rfind('/') - 19);
+        } else if (remote_url.starts_with("git@")) {
+            auto after_comma_pos = remote_url.find(':') + 1, slash_pos = remote_url.find('/');
+            remote_host = remote_url.substr(after_comma_pos, slash_pos - after_comma_pos);
+        } else {
+            remote_host = "unknown";
+        }
+    } catch (...) {
+        remote_host = "unknown";
+    }
+    return remote_host;
+}
 
 } // namespace
 

--- a/src/common/scm_rev.h
+++ b/src/common/scm_rev.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <string>
+
 namespace Common {
 
 extern const char g_version[];
@@ -14,5 +16,7 @@ extern const char g_scm_desc[];
 extern const char g_scm_remote_name[];
 extern const char g_scm_remote_url[];
 extern const char g_scm_date[];
+
+const std::string GetRemoteNameFromLink();
 
 } // namespace Common

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -194,15 +194,7 @@ void Emulator::Run(const std::filesystem::path& file, const std::vector<std::str
     std::string game_title = fmt::format("{} - {} <{}>", id, title, app_version);
     std::string window_title = "";
     std::string remote_url(Common::g_scm_remote_url);
-    std::string remote_host;
-    try {
-        if (*remote_url.rbegin() == '/') {
-            remote_url.pop_back();
-        }
-        remote_host = remote_url.substr(19, remote_url.rfind('/') - 19);
-    } catch (...) {
-        remote_host = "unknown";
-    }
+    std::string remote_host = Common::GetRemoteNameFromLink();
     if (Common::g_is_release) {
         if (remote_host == "shadps4-emu" || remote_url.length() == 0) {
             window_title = fmt::format("shadPS4 v{} | {}", Common::g_version, game_title);

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -56,15 +56,7 @@ bool MainWindow::Init() {
     setMinimumSize(720, 405);
     std::string window_title = "";
     std::string remote_url(Common::g_scm_remote_url);
-    std::string remote_host;
-    try {
-        if (*remote_url.rbegin() == '/') {
-            remote_url.pop_back();
-        }
-        remote_host = remote_url.substr(19, remote_url.rfind('/') - 19);
-    } catch (...) {
-        remote_host = "unknown";
-    }
+    std::string remote_host = Common::GetRemoteNameFromLink();
     if (Common::g_is_release) {
         if (remote_host == "shadps4-emu" || remote_url.length() == 0) {
             window_title = fmt::format("shadPS4 v{}", Common::g_version);


### PR DESCRIPTION
The sole reason for this PR is so @StevenMiller123 and the ~3 other people who use SSH remotes can have their remote names formatted correctly in the window titles. As this is only a formatting change, it shouldn't affect anything important.

Image of the issue:
![image](https://github.com/user-attachments/assets/2695990d-57ca-4e47-a6bd-5f95ee8715fa)
