### PR TITLE
Add support for game folder and fail early if eboot.bin is missing or corrupt

### DIFF
--- a/src/emulator.h
+++ b/src/emulator.h
@@ -25,7 +25,7 @@ public:
     Emulator();
     ~Emulator();
 
-    void Run(const std::filesystem::path& file, const std::vector<std::string> args = {});
+    void Run(std::filesystem::path file, const std::vector<std::string> args = {});
     void UpdatePlayTime(const std::string& serial);
 
 private:


### PR DESCRIPTION
Now you can run `.\shadPS4.exe --game "E:\PS4\Games\CUSA09243"` and the emulator will resolve the path to the eboot.
When loading of eboot fails it will throw an error message and stop instead of crash 