### PR TITLE
Core: Reduce GPU memory clamping threshold

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -68,7 +68,7 @@ void MemoryManager::SetupMemoryRegions(u64 flexible_size, bool use_extended_mem1
 }
 
 u64 MemoryManager::ClampRangeSize(VAddr virtual_addr, u64 size) {
-    static constexpr u64 MinSizeToClamp = 512_MB;
+    static constexpr u64 MinSizeToClamp = 2_MB;
     // Dont bother with clamping if the size is small so we dont pay a map lookup on every buffer.
     if (size < MinSizeToClamp) {
         return size;


### PR DESCRIPTION
A proposed alternative to #2950, which works around the non-GPU memory asserts seen in RESIDENT EVIL 2 (CUSA09193) without breaking games that already work.
This brings the game further in menus (though with broken rendering), where it ends up crashing on this:
```
[Debug] <Critical> vector_memory.cpp:182 operator(): Assertion Failed!
Non immediate offset not supported
```
![image](https://github.com/user-attachments/assets/0e264d2f-7f9b-4c32-bb48-d5fcc8f246c6)
[shad_log.txt](https://github.com/user-attachments/files/20580432/shad_log.txt)
