### PR TITLE
qt: Save button label setting

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -180,10 +180,6 @@ bool getShowLabelsUnderIcons() {
     return showLabelsUnderIcons;
 }
 
-bool setShowLabelsUnderIcons() {
-    return false;
-}
-
 std::string getFullscreenMode() {
     return fullscreenMode;
 }
@@ -431,7 +427,8 @@ void setVblankDiv(u32 value) {
 void setIsFullscreen(bool enable) {
     isFullscreen = enable;
 }
-static void setShowLabelsUnderIcons(bool enable) {
+
+void setShowLabelsUnderIcons(bool enable) {
     showLabelsUnderIcons = enable;
 }
 
@@ -882,6 +879,7 @@ void load(const std::filesystem::path& path) {
         emulator_language = toml::find_or<std::string>(gui, "emulatorLanguage", "en_US");
         backgroundImageOpacity = toml::find_or<int>(gui, "backgroundImageOpacity", 50);
         showBackgroundImage = toml::find_or<bool>(gui, "showBackgroundImage", true);
+        showLabelsUnderIcons = toml::find_or<bool>(gui, "showLabels", true);
     }
 
     if (data.contains("Settings")) {
@@ -1096,6 +1094,7 @@ void saveMainWindow(const std::filesystem::path& path) {
     data["GUI"]["geometry_h"] = main_window_geometry_h;
     data["GUI"]["elfDirs"] = m_elf_viewer;
     data["GUI"]["recentFiles"] = m_recent_files;
+    data["GUI"]["showLabels"] = showLabelsUnderIcons;
 
     // Sorting of TOML sections
     sortTomlSections(data);

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -27,7 +27,6 @@ std::filesystem::path GetSaveDataPath();
 void setLoadGameSizeEnabled(bool enable);
 bool getIsFullscreen();
 bool getShowLabelsUnderIcons();
-bool setShowLabelsUnderIcons();
 std::string getFullscreenMode();
 bool isNeoModeConsole();
 bool isDevKitConsole();
@@ -157,6 +156,7 @@ void setMainWindowHeight(u32 height);
 void setElfViewer(const std::vector<std::string>& elfList);
 void setRecentFiles(const std::vector<std::string>& recentFiles);
 void setEmulatorLanguage(std::string language);
+void setShowLabelsUnderIcons(bool enable);
 
 u32 getMainWindowGeometryX();
 u32 getMainWindowGeometryY();

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -138,9 +138,8 @@ void MainWindow::PauseGame() {
 }
 
 void MainWindow::toggleLabelsUnderIcons() {
-    bool showLabels = ui->toggleLabelsAct->isChecked();
-    Config::setShowLabelsUnderIcons();
-    UpdateToolbarLabels();
+    Config::setShowLabelsUnderIcons(ui->toggleLabelsAct->isChecked());
+    AddUiWidgets();
     if (isGameRunning) {
         UpdateToolbarButtons();
     }
@@ -187,7 +186,7 @@ void MainWindow::AddUiWidgets() {
     // add toolbar widgets
     QApplication::setStyle("Fusion");
 
-    bool showLabels = ui->toggleLabelsAct->isChecked();
+    bool showLabels = Config::getShowLabelsUnderIcons();
     ui->toolBar->clear();
 
     ui->toolBar->addWidget(createSpacer(this));
@@ -278,10 +277,6 @@ void MainWindow::UpdateToolbarButtons() {
             pauseButtonLabel->setVisible(true);
         }
     }
-}
-
-void MainWindow::UpdateToolbarLabels() {
-    AddUiWidgets();
 }
 
 void MainWindow::CreateDockWindows() {

--- a/src/qt_gui/main_window.h
+++ b/src/qt_gui/main_window.h
@@ -52,7 +52,6 @@ private Q_SLOTS:
 private:
     Ui_MainWindow* ui;
     void AddUiWidgets();
-    void UpdateToolbarLabels();
     void UpdateToolbarButtons();
     QWidget* createButtonWithLabel(QPushButton* button, const QString& labelText, bool showLabel);
     void CreateActions();


### PR DESCRIPTION
Corrects the config functions/calls related to the button label GUI setting (View->show labels under icons) and add the corresponding reads/writes to the config file to allow saving the setting across sessions