### PR TITLE
libSceZlib: Fix Queues

### DIFF
--- a/src/core/libraries/zlib/zlib.cpp
+++ b/src/core/libraries/zlib/zlib.cpp
@@ -51,7 +51,7 @@ void ZlibTaskThread(const std::stop_token& stop) {
             if (!task_queue_cv.wait(lock, stop, [&] { return !task_queue.empty(); })) {
                 break;
             }
-            task = task_queue.back();
+            task = task_queue.front();
             task_queue.pop();
         }
 
@@ -136,7 +136,7 @@ s32 PS4_SYSV_ABI sceZlibWaitForDone(u64* request_id, const u32* timeout) {
         } else {
             done_queue_cv.wait(lock, pred);
         }
-        *request_id = done_queue.back();
+        *request_id = done_queue.front();
         done_queue.pop();
     }
     return ORBIS_OK;


### PR DESCRIPTION
Queues are a FIFO data structure, so pop() removes the front, not the end. Therefore, we should be getting from the front of a queue before calling pop(), not the back.

Fixing this issue fixes a strange memory issue observed in Rise of the Tomb Raider (CUSA09193), though the game doesn't get much further yet.