### PR TITLE
QT: AutoUpdate - Fix Changelog Error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -494,7 +494,7 @@ jobs:
       with:
         token: ${{ secrets.SHADPS4_TOKEN_REPO }}
         name: "Pre-release-shadPS4-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}"
-        tag: "Pre-release-shadPS4-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}"
+        tag: "Pre-release-shadPS4-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.fullhash }}"
         draft: false
         prerelease: true
         body: "Full Changelog: [${{ env.last_release_tag }}...${{ needs.get-info.outputs.shorthash }}](https://github.com/shadps4-emu/shadPS4/compare/${{ env.last_release_tag }}...${{ needs.get-info.outputs.fullhash }})"
@@ -530,14 +530,14 @@ jobs:
 
           # Check if release already exists and get ID
           release_id=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-            "https://api.github.com/repos/$REPO/releases/tags/Pre-release-shadPS4-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}" | jq -r '.id')
+            "https://api.github.com/repos/$REPO/releases/tags/Pre-release-shadPS4-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.fullhash }}" | jq -r '.id')
 
           if [[ "$release_id" == "null" ]]; then
             echo "Creating release in $REPO for $filename"
             release_id=$(curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" \
               -H "Accept: application/vnd.github.v3+json" \
               -d '{
-                "tag_name": "Pre-release-shadPS4-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}",
+                "tag_name": "Pre-release-shadPS4-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.fullhash }}",
                 "name": "Pre-release-shadPS4-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}",
                 "draft": false,
                 "prerelease": true,

--- a/src/qt_gui/check_update.cpp
+++ b/src/qt_gui/check_update.cpp
@@ -137,7 +137,7 @@ tr("The Auto Updater allows up to 60 update checks per hour.\\nYou have reached 
             }
         }
 
-        latestRev = latestVersion.right(7);
+        latestRev = latestVersion.right(40);
         latestDate = jsonObj["published_at"].toString();
 
         QJsonArray assets = jsonObj["assets"].toArray();
@@ -167,7 +167,7 @@ tr("The Auto Updater allows up to 60 update checks per hour.\\nYou have reached 
         QDateTime dateTime = QDateTime::fromString(latestDate, Qt::ISODate);
         latestDate = dateTime.isValid() ? dateTime.toString("yyyy-MM-dd HH:mm:ss") : "Unknown date";
 
-        if (latestRev == currentRev.left(7)) {
+        if (latestRev == currentRev) {
             if (showMessage) {
                 QMessageBox::information(this, tr("Auto Updater"),
                                          tr("Your version is already up to date!"));
@@ -215,7 +215,7 @@ void CheckUpdate::setupUI(const QString& downloadUrl, const QString& latestDate,
                                  "<td>%3</td>"
                                  "<td>(%4)</td>"
                                  "</tr></table></p>")
-                             .arg(currentRev.left(7), currentDate, latestRev, latestDate);
+                             .arg(currentRev.left(7), currentDate, latestRev.left(7), latestDate);
 
     QLabel* updateLabel = new QLabel(updateText, this);
     layout->addWidget(updateLabel);


### PR DESCRIPTION
Sometimes when trying to show the changelog, this print error appears, this PR fixes it

![image](https://github.com/user-attachments/assets/57c6aa01-7512-4850-a191-ef84c3e0ddfe)

----

Technically speaking, two hashes were compared:
the hash of the executable:           `88f6cb4d4197748c2dde637e3c9340823193228c`

and
the hash of the latest pre-release: `23710f3`

 but the pre-release only had the simplified hash with 7 characters, and the executable had the full hash of 41 characters.
 And sometimes GitHub simply couldn't make this comparison using the short hash.

Now the 'Tags' of the pre-release will contain the full hash, as in the image below:

![image](https://github.com/user-attachments/assets/15640151-e51e-4842-ad16-f6c2fddfeafe)

I didn't change the 'name' of the pre-release, just the 'Tags', as this is the information that the github api returns.

