### PR TITLE
libSceVideoOut: Proper sceVideoOutGetResolutionStatus error behavior

### DIFF
--- a/src/core/libraries/videoout/video_out.cpp
+++ b/src/core/libraries/videoout/video_out.cpp
@@ -282,7 +282,12 @@ s32 PS4_SYSV_ABI sceVideoOutGetVblankStatus(int handle, SceVideoOutVblankStatus*
 
 s32 PS4_SYSV_ABI sceVideoOutGetResolutionStatus(s32 handle, SceVideoOutResolutionStatus* status) {
     LOG_INFO(Lib_VideoOut, "called");
-    *status = driver->GetPort(handle)->resolution;
+    auto* port = driver->GetPort(handle);
+    if (!port || !port->is_open) {
+        return ORBIS_VIDEO_OUT_ERROR_INVALID_HANDLE;
+    }
+
+    *status = port->resolution;
     return ORBIS_OK;
 }
 


### PR DESCRIPTION
When the provided VideoOut port hasn't been opened, `sceVideoOutGetResolutionStatus` should return `ORBIS_VIDEO_OUT_ERROR_INVALID_HANDLE`.

Handling this properly fixes a crash in The Sims 4 (CUSA09216).