### PR TITLE
Dev Tools: Fix Module Viewer HLE detection

### DIFF
--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -331,7 +331,6 @@ bool Linker::Resolve(const std::string& name, Loader::SymbolType sym_type, Modul
     sr.module_version_minor = module->version_minor;
     sr.type = sym_type;
 
-
     const auto* record = m_hle_symbols.FindSymbol(sr);
     if (record) {
         *return_info = *record;

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -331,20 +331,22 @@ bool Linker::Resolve(const std::string& name, Loader::SymbolType sym_type, Modul
     sr.module_version_minor = module->version_minor;
     sr.type = sym_type;
 
+
     const auto* record = m_hle_symbols.FindSymbol(sr);
-    if (!record) {
-        // Check if it an export function
-        const auto* p = FindExportedModule(*module, *library);
-        if (p && p->export_sym.GetSize() > 0) {
-            record = p->export_sym.FindSymbol(sr);
-        }
-    }
     if (record) {
         *return_info = *record;
-
         Core::Devtools::Widget::ModuleList::AddModule(sr.library);
-
         return true;
+    }
+
+    // Check if it an export function
+    const auto* p = FindExportedModule(*module, *library);
+    if (p && p->export_sym.GetSize() > 0) {
+        record = p->export_sym.FindSymbol(sr);
+        if (record) {
+            *return_info = *record;
+            return true;
+        }
     }
 
     const auto aeronid = AeroLib::FindByNid(sr.name.c_str());


### PR DESCRIPTION
The check before was wrong, it detected all LLE also as HLE
![image](https://github.com/user-attachments/assets/f818ef3b-2a66-4f8e-82ec-9587009e9735)

Now fixed its like this:
![image](https://github.com/user-attachments/assets/021ad508-702d-498c-b691-920879a328a6)
