### PR TITLE
buffer_cache: Inline data to cpu unless gpu modified

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -293,7 +293,7 @@ void BufferCache::BindIndexBuffer(u32 index_offset) {
 
 void BufferCache::InlineData(VAddr address, const void* value, u32 num_bytes, bool is_gds) {
     ASSERT_MSG(address % 4 == 0, "GDS offset must be dword aligned");
-    if (!is_gds && !IsRegionRegistered(address, num_bytes)) {
+    if (!is_gds && !IsRegionGpuModified(address, num_bytes)) {
         memcpy(std::bit_cast<void*>(address), value, num_bytes);
         return;
     }


### PR DESCRIPTION
The sea islands register reference mentions 2 different behaviors for VGT_GS_MAX_VERT_OUT. For Scenario C it represents the actual amount of output vertices a GS will make. For Scenario G on the other hand it represents the maximum, so it can't always be used for mapping offset to attribute, as the actual component stride might be smaller.

This fixes a crash when compiling a geometry shader in Driveclub (CUSA00093) which "lies" about its output vertex size. While the actual number is 4, the register reports a much larger number (44). Instead attempt to compute the output vertices from the copy shader and if they mismatch do some validation checks and use that instead. I've also added a warning in case this regresses any other geoshaders, so it can be seen easily