### PR TITLE
shader_recompiler: Better handling of geometry shader scenario G

### DIFF
--- a/src/shader_recompiler/frontend/copy_shader.cpp
+++ b/src/shader_recompiler/frontend/copy_shader.cpp
@@ -67,6 +67,9 @@ CopyShaderData ParseCopyShader(std::span<const u32> code) {
 
     if (last_attr != IR::Attribute::Position0) {
         data.num_attrs = static_cast<u32>(last_attr) - static_cast<u32>(IR::Attribute::Param0) + 1;
+        const auto it = data.attr_map.begin();
+        const u32 comp_stride = std::next(it)->first - it->first;
+        data.output_vertices = comp_stride / 64;
     }
 
     return data;

--- a/src/shader_recompiler/frontend/copy_shader.h
+++ b/src/shader_recompiler/frontend/copy_shader.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
+#include <map>
 #include <span>
-#include <unordered_map>
 
 #include "common/types.h"
 #include "shader_recompiler/ir/attribute.h"
@@ -12,8 +12,9 @@
 namespace Shader {
 
 struct CopyShaderData {
-    std::unordered_map<u32, std::pair<Shader::IR::Attribute, u32>> attr_map;
+    std::map<u32, std::pair<Shader::IR::Attribute, u32>> attr_map;
     u32 num_attrs{0};
+    u32 output_vertices{0};
 };
 
 CopyShaderData ParseCopyShader(std::span<const u32> code);

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <span>
+#include <unordered_map>
 #include "shader_recompiler/frontend/instruction.h"
 #include "shader_recompiler/info.h"
 #include "shader_recompiler/ir/basic_block.h"

--- a/src/shader_recompiler/ir/passes/readlane_elimination_pass.cpp
+++ b/src/shader_recompiler/ir/passes/readlane_elimination_pass.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <unordered_map>
 #include "shader_recompiler/ir/program.h"
 
 namespace Shader::Optimization {

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -149,6 +149,7 @@ struct GeometryRuntimeInfo {
     u32 out_vertex_data_size{};
     AmdGpu::PrimitiveType in_primitive;
     GsOutputPrimTypes out_primitive;
+    AmdGpu::Liverpool::GsMode::Mode mode;
     std::span<const u32> vs_copy;
     u64 vs_copy_hash;
 

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -1179,8 +1179,16 @@ struct Liverpool {
     };
 
     union GsMode {
+        enum class Mode : u32 {
+            Off = 0,
+            ScenarioA = 1,
+            ScenarioB = 2,
+            ScenarioG = 3,
+            ScenarioC = 4,
+        };
+
         u32 raw;
-        BitField<0, 3, u32> mode;
+        BitField<0, 3, Mode> mode;
         BitField<3, 2, u32> cut_mode;
         BitField<22, 2, u32> onchip;
     };

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -146,6 +146,7 @@ const Shader::RuntimeInfo& PipelineCache::BuildRuntimeInfo(Stage stage, LogicalS
         }
         gs_info.in_vertex_data_size = regs.vgt_esgs_ring_itemsize;
         gs_info.out_vertex_data_size = regs.vgt_gs_vert_itemsize[0];
+        gs_info.mode = regs.vgt_gs_mode.mode;
         const auto params_vc = Liverpool::GetParams(regs.vs_program);
         gs_info.vs_copy = params_vc.code;
         gs_info.vs_copy_hash = params_vc.hash;


### PR DESCRIPTION
The sea islands register reference mentions 2 different behaviors for VGT_GS_MAX_VERT_OUT. For Scenario C it represents the actual amount of output vertices a GS will make. For Scenario G on the other hand it represents the maximum, so it can't always be used for mapping offset to attribute, as the actual component stride might be smaller.

This fixes a crash when compiling a geometry shader in Driveclub (CUSA00093) which "lies" about the number of vertices it outputs. While the actual number is 4, the register reports a much larger number (44). Instead attempt to compute the output vertices from the copy shader and if they mismatch do some validation checks and use that instead. I've also added a warning in case this regresses any other geoshaders, so it can be seen easily

~~Oops wrong branch~~