### PR TITLE
texture_cache: Basic handling of partially resident images

### DIFF
--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -660,6 +660,9 @@ int PS4_SYSV_ABI sceKernelSetPrtAperture(int id, VAddr address, size_t size) {
                 "PRT aperture id = {}, address = {:#x}, size = {:#x} is set but not used", id,
                 address, size);
 
+    auto* memory = Core::Memory::Instance();
+    memory->SetPrtArea(id, address, size);
+
     PrtApertures[id] = {address, size};
     return ORBIS_OK;
 }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -95,6 +95,46 @@ u64 MemoryManager::ClampRangeSize(VAddr virtual_addr, u64 size) {
     return clamped_size;
 }
 
+void MemoryManager::SetPrtArea(u32 id, VAddr address, u64 size) {
+    PrtArea& area = prt_areas[id];
+    if (area.mapped) {
+        rasterizer->UnmapMemory(area.start, area.end - area.start);
+    }
+
+    area.start = address;
+    area.end = address + size;
+    area.mapped = true;
+
+    // Pretend the entire PRT area is mapped to avoid GPU tracking errors.
+    // The caches will use CopySparseMemory to fetch data which avoids unmapped areas.
+    rasterizer->MapMemory(address, size);
+}
+
+void MemoryManager::CopySparseMemory(VAddr virtual_addr, u8* dest, u64 size) {
+    const bool is_sparse = std::ranges::any_of(
+        prt_areas, [&](const PrtArea& area) { return area.Overlaps(virtual_addr, size); });
+    if (!is_sparse) {
+        std::memcpy(dest, std::bit_cast<const u8*>(virtual_addr), size);
+        return;
+    }
+
+    auto vma = FindVMA(virtual_addr);
+    ASSERT_MSG(vma->second.Contains(virtual_addr, 0),
+               "Attempted to access invalid GPU address {:#x}", virtual_addr);
+    while (size) {
+        u64 copy_size = std::min(vma->second.size - (virtual_addr - vma->first), size);
+        if (vma->second.IsFree()) {
+            std::memset(dest, 0, copy_size);
+        } else {
+            std::memcpy(dest, std::bit_cast<const u8*>(virtual_addr), copy_size);
+        }
+        size -= copy_size;
+        virtual_addr += copy_size;
+        dest += copy_size;
+        ++vma;
+    }
+}
+
 bool MemoryManager::TryWriteBacking(void* address, const void* data, u32 num_bytes) {
     const VAddr virtual_addr = std::bit_cast<VAddr>(address);
     const auto& vma = FindVMA(virtual_addr)->second;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -122,7 +122,7 @@ void MemoryManager::CopySparseMemory(VAddr virtual_addr, u8* dest, u64 size) {
     ASSERT_MSG(vma->second.Contains(virtual_addr, 0),
                "Attempted to access invalid GPU address {:#x}", virtual_addr);
     while (size) {
-        u64 copy_size = std::min(vma->second.size - (virtual_addr - vma->first), size);
+        u64 copy_size = std::min<u64>(vma->second.size - (virtual_addr - vma->first), size);
         if (vma->second.IsFree()) {
             std::memset(dest, 0, copy_size);
         } else {

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -172,6 +172,10 @@ public:
 
     u64 ClampRangeSize(VAddr virtual_addr, u64 size);
 
+    void SetPrtArea(u32 id, VAddr address, u64 size);
+
+    void CopySparseMemory(VAddr source, u8* dest, u64 size);
+
     bool TryWriteBacking(void* address, const void* data, u32 num_bytes);
 
     void SetupMemoryRegions(u64 flexible_size, bool use_extended_mem1, bool use_extended_mem2);
@@ -274,6 +278,18 @@ private:
     size_t flexible_usage{};
     size_t pool_budget{};
     Vulkan::Rasterizer* rasterizer{};
+
+    struct PrtArea {
+        VAddr start;
+        VAddr end;
+        bool mapped;
+
+        bool Overlaps(VAddr test_address, u64 test_size) const {
+            const VAddr overlap_end = test_address + test_size;
+            return start < overlap_end && test_address < end;
+        }
+    };
+    std::array<PrtArea, 3> prt_areas{};
 
     friend class ::Core::Devtools::Widget::MemoryMapViewer;
 };

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -17,6 +17,10 @@ namespace AmdGpu {
 struct Liverpool;
 }
 
+namespace Core {
+class MemoryManager;
+}
+
 namespace Shader {
 namespace Gcn {
 struct FetchShaderData;
@@ -183,6 +187,7 @@ private:
     Vulkan::Scheduler& scheduler;
     Vulkan::Rasterizer& rasterizer;
     AmdGpu::Liverpool* liverpool;
+    Core::MemoryManager* memory;
     TextureCache& texture_cache;
     PageManager& tracker;
     StreamBuffer staging_buffer;

--- a/src/video_core/texture_cache/tile_manager.cpp
+++ b/src/video_core/texture_cache/tile_manager.cpp
@@ -269,7 +269,10 @@ std::pair<vk::Buffer, u32> TileManager::TryDetile(vk::Buffer in_buffer, u32 in_o
     params.height = info.size.height;
     if (info.tiling_mode == AmdGpu::TilingMode::Texture_Volume ||
         info.tiling_mode == AmdGpu::TilingMode::Display_MicroTiled) {
-        ASSERT(info.resources.levels == 1);
+        if (info.resources.levels != 1) {
+            LOG_ERROR(Render_Vulkan, "Unexpected mipmaps for volume and display tilings {}",
+                      info.resources.levels);
+        }
         const auto tiles_per_row = info.pitch / 8u;
         const auto tiles_per_slice = tiles_per_row * ((info.size.height + 7u) / 8u);
         params.sizes[0] = tiles_per_row;


### PR DESCRIPTION
This allows Driveclub (CUSA00093) to go in-game without any hacks.

The game setups a PRT area, maps only some pages inside it and creates a render target covering all of it causing a gpu tracking assert to kick in. To avoid this the memory manager will register active PRT areas and map those areas to gpu, so the page manager can track any image inside the region. Meanwhile access to cpu memory will be handled via a new function CopySparseMemory which behaves the same as a memcpy, except when source address is a PRT area, where it will copy only mapped regions, while zeroing unmapped areas.

Using host sparse feature would be ideal, but its very inconvenient as host sparse page size and alignment might differ a lot from the guest. So its a lot easier to eat the extra memory cost of creating the non sparse version of the full image. This can also be expanded in the future with subresource uploads, on every gpu map we can invalidate the texture cache and reupload parts of PRT that were mapped. This isn't done here as that would trash the entire thing (due to unimplemented subres upload) and DC uses it as a render target