### PR TITLE
better handling of tiling size, dividing check and assert more specifc

### DIFF
--- a/src/video_core/texture_cache/tile_manager.cpp
+++ b/src/video_core/texture_cache/tile_manager.cpp
@@ -264,7 +264,7 @@ std::pair<vk::Buffer, u32> TileManager::TryDetile(vk::Buffer in_buffer, u32 in_o
                                 set_writes);
 
     DetilerParams params;
-    params.num_levels = (info.resources.levels);
+    params.num_levels = info.resources.levels;
     params.pitch0 = info.pitch >> (info.props.is_block ? 2u : 0u);
     params.height = info.size.height;
 

--- a/src/video_core/texture_cache/tile_manager.cpp
+++ b/src/video_core/texture_cache/tile_manager.cpp
@@ -264,7 +264,7 @@ std::pair<vk::Buffer, u32> TileManager::TryDetile(vk::Buffer in_buffer, u32 in_o
                                 set_writes);
 
     DetilerParams params;
-    params.num_levels = std::min<u32>(7, info.resources.levels);
+    params.num_levels = (info.resources.levels);
     params.pitch0 = info.pitch >> (info.props.is_block ? 2u : 0u);
     params.height = info.size.height;
 


### PR DESCRIPTION
this pr helps handle all tiling sizes under texture, divide the check so display due to shader limitations dosent get overloaded. 
added psucien suggestions,