### PR TITLE
Changed package name to openal-soft-devel

### DIFF
--- a/documents/building-linux.md
+++ b/documents/building-linux.md
@@ -25,7 +25,7 @@ sudo apt install build-essential clang git cmake libasound2-dev \
 
 ```bash
 sudo dnf install clang git cmake libatomic alsa-lib-devel \
-    pipewire-jack-audio-connection-kit-devel openal-devel \
+    pipewire-jack-audio-connection-kit-devel openal-soft-devel \
     openssl-devel libevdev-devel libudev-devel libXext-devel \
     qt6-qtbase-devel qt6-qtbase-private-devel \
     qt6-qtmultimedia-devel qt6-qtsvg-devel qt6-qttools-devel \


### PR DESCRIPTION
Fedora repos have change the openal-devel package to openal-soft-devel. As you can find here:
![image](https://github.com/user-attachments/assets/04435a30-0eec-41f3-9c84-3084b4eaa541)

https://packages.fedoraproject.org/search?query=openal-devel


 I have tested building with this package and it will now successfully build again. 