### PR TITLE
video_core: Page manager/region manager optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -653,6 +653,7 @@ set(COMMON src/common/logging/backend.cpp
            src/common/arch.h
            src/common/assert.cpp
            src/common/assert.h
+           src/common/bit_array.h
            src/common/bit_field.h
            src/common/bounded_threadsafe_queue.h
            src/common/concepts.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -914,9 +914,10 @@ set(VIDEO_CORE src/video_core/amdgpu/liverpool.cpp
                src/video_core/buffer_cache/buffer.h
                src/video_core/buffer_cache/buffer_cache.cpp
                src/video_core/buffer_cache/buffer_cache.h
-               src/video_core/buffer_cache/memory_tracker_base.h
+               src/video_core/buffer_cache/memory_tracker.h
                src/video_core/buffer_cache/range_set.h
-               src/video_core/buffer_cache/word_manager.h
+               src/video_core/buffer_cache/region_definitions.h
+               src/video_core/buffer_cache/region_manager.h
                src/video_core/renderer_vulkan/liverpool_to_vk.cpp
                src/video_core/renderer_vulkan/liverpool_to_vk.h
                src/video_core/renderer_vulkan/vk_common.cpp

--- a/src/common/bit_array.h
+++ b/src/common/bit_array.h
@@ -262,9 +262,9 @@ public:
             }
             return Range{find_start_bit(index - 1), end_bit};
         };
-        const size_t end_word = (end - 1) / BITS_PER_WORD;
+        const size_t end_word = ((end - 1) / BITS_PER_WORD) + 1;
         const size_t end_bit = (end - 1) % BITS_PER_WORD;
-        u64 masked_last = data[end_word];
+        u64 masked_last = data[end_word - 1];
         if (end_bit < BITS_PER_WORD - 1) {
             masked_last &= (1ULL << (end_bit + 1)) - 1;
         }

--- a/src/common/bit_array.h
+++ b/src/common/bit_array.h
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include "common/types.h"
+
+#ifdef __AVX2__
+#define BIT_ARRAY_USE_AVX
+#include <immintrin.h>
+#endif
+
+namespace Common {
+
+template <size_t N>
+class BitArray {
+    static_assert(N % 64 == 0, "BitArray size must be a multiple of 64 bits.");
+
+    static constexpr size_t BITS_PER_WORD = 64;
+    static constexpr size_t WORD_COUNT = N / BITS_PER_WORD;
+    static constexpr size_t WORDS_PER_AVX = 4;
+    static constexpr size_t AVX_WORD_COUNT = WORD_COUNT / WORDS_PER_AVX;
+
+public:
+    using Range = std::pair<size_t, size_t>;
+
+    inline constexpr void Set(size_t idx) {
+        data[idx / BITS_PER_WORD] |= (1ULL << (idx % BITS_PER_WORD));
+    }
+
+    inline constexpr void Unset(size_t idx) {
+        data[idx / BITS_PER_WORD] &= ~(1ULL << (idx % BITS_PER_WORD));
+    }
+
+    inline constexpr bool Get(size_t idx) const {
+        return (data[idx / BITS_PER_WORD] & (1ULL << (idx % BITS_PER_WORD))) != 0;
+    }
+
+    inline constexpr void SetRange(size_t start, size_t end) {
+        if (start >= end || end > N) {
+            return;
+        }
+        const size_t first_word = start / BITS_PER_WORD;
+        const size_t last_word = (end - 1) / BITS_PER_WORD;
+        const size_t start_bit = start % BITS_PER_WORD;
+        const size_t end_bit = (end - 1) % BITS_PER_WORD;
+        const u64 start_mask = ~((1ULL << start_bit) - 1);
+        const u64 end_mask = end_bit == BITS_PER_WORD - 1 ? ~0ULL : (1ULL << (end_bit + 1)) - 1;
+        if (first_word == last_word) {
+            data[first_word] |= start_mask & end_mask;
+        } else {
+            data[first_word] |= start_mask;
+            size_t i = first_word + 1;
+#ifdef BIT_ARRAY_USE_AVX
+            const __m256i value = _mm256_set1_epi64x(~1);
+            for (; i + WORDS_PER_AVX <= last_word; i += WORDS_PER_AVX) {
+                _mm256_storeu_si256(reinterpret_cast<__m256i*>(&data[i]), value);
+            }
+#endif
+            for (; i < last_word; ++i) {
+                data[i] = ~0ULL;
+            }
+            data[last_word] |= end_mask;
+        }
+    }
+
+    inline constexpr void UnsetRange(size_t start, size_t end) {
+        if (start >= end || end > N) {
+            return;
+        }
+        size_t first_word = start / BITS_PER_WORD;
+        const size_t last_word = (end - 1) / BITS_PER_WORD;
+        const size_t start_bit = start % BITS_PER_WORD;
+        const size_t end_bit = (end - 1) % BITS_PER_WORD;
+        const u64 start_mask = (1ULL << start_bit) - 1;
+        const u64 end_mask = end_bit == BITS_PER_WORD - 1 ? 0ULL : ~((1ULL << (end_bit + 1)) - 1);
+        if (first_word == last_word) {
+            data[first_word] &= start_mask | end_mask;
+        } else {
+            data[first_word] &= start_mask;
+            size_t i = first_word + 1;
+#ifdef BIT_ARRAY_USE_AVX
+            const __m256i value = _mm256_setzero_si256();
+            for (; i + WORDS_PER_AVX <= last_word; i += WORDS_PER_AVX) {
+                _mm256_storeu_si256(reinterpret_cast<__m256i*>(&data[i]), value);
+            }
+#endif
+            for (; i < last_word; ++i) {
+                data[i] = 0ULL;
+            }
+            data[last_word] &= end_mask;
+        }
+    }
+
+    inline constexpr void SetRange(const Range& range) {
+        SetRange(range.first, range.second);
+    }
+
+    inline constexpr void UnsetRange(const Range& range) {
+        UnsetRange(range.first, range.second);
+    }
+
+    inline constexpr void Clear() {
+        data.fill(0);
+    }
+
+    inline constexpr bool None() const {
+        u64 result = 0;
+        for (const auto& word : data) {
+            result |= word;
+        }
+        return result == 0;
+    }
+
+    inline constexpr bool Any() const {
+        return !None();
+    }
+
+    inline constexpr Range FirstSetFrom(size_t start) const {
+        if (start >= N) {
+            return {N, N};
+        }
+        const auto find_end_bit = [&](size_t word) {
+#ifdef BIT_ARRAY_USE_AVX
+            const __m256i all_one = _mm256_set1_epi64x(-1);
+            for (; word + WORDS_PER_AVX <= WORD_COUNT; word += WORDS_PER_AVX) {
+                const __m256i current =
+                    _mm256_loadu_si256(reinterpret_cast<const __m256i*>(&data[word]));
+                const __m256i cmp = _mm256_cmpeq_epi64(current, all_one);
+                if (_mm256_movemask_epi8(cmp) != 0xFFFFFFFF) {
+                    break;
+                }
+            }
+#endif
+            for (; word < WORD_COUNT; ++word) {
+                if (data[word] != ~0ULL) {
+                    return (word * BITS_PER_WORD) + std::countr_one(data[word]);
+                }
+            }
+            return N;
+        };
+
+        const auto word_bits = [&](size_t index, u64 word) {
+            const int empty_bits = std::countr_zero(word);
+            const int ones_count = std::countr_one(word >> empty_bits);
+            const size_t start_bit = index * BITS_PER_WORD + empty_bits;
+            if (ones_count + empty_bits < BITS_PER_WORD) {
+                return Range{start_bit, start_bit + ones_count};
+            }
+            return Range{start_bit, find_end_bit(index + 1)};
+        };
+
+        const size_t start_word = start / BITS_PER_WORD;
+        const size_t start_bit = start % BITS_PER_WORD;
+        const u64 masked_first = data[start_word] & (~((1ULL << start_bit) - 1));
+        if (masked_first) {
+            return word_bits(start_word, masked_first);
+        }
+
+        size_t word = start_word + 1;
+#ifdef BIT_ARRAY_USE_AVX
+        for (; word + WORDS_PER_AVX <= WORD_COUNT; word += WORDS_PER_AVX) {
+            const __m256i current =
+                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(&data[word]));
+            if (!_mm256_testz_si256(current, current)) {
+                break;
+            }
+        }
+#endif
+        for (; word < WORD_COUNT; ++word) {
+            if (data[word] != 0) {
+                return word_bits(word, data[word]);
+            }
+        }
+        return {N, N};
+    }
+
+private:
+    std::array<u64, WORD_COUNT> data{};
+};
+
+} // namespace Common

--- a/src/common/bit_array.h
+++ b/src/common/bit_array.h
@@ -152,6 +152,10 @@ public:
         data.fill(0);
     }
 
+    inline constexpr void Fill() {
+        data.fill(~0ULL);
+    }
+
     inline constexpr bool None() const {
         u64 result = 0;
         for (const auto& word : data) {

--- a/src/common/bit_array.h
+++ b/src/common/bit_array.h
@@ -38,7 +38,7 @@ public:
         return (data[idx / BITS_PER_WORD] & (1ULL << (idx % BITS_PER_WORD))) != 0;
     }
 
-    inline void SetRange(size_t start, size_t end) {
+    void SetRange(size_t start, size_t end) {
         if (start >= end || end > N) {
             return;
         }
@@ -54,7 +54,7 @@ public:
             data[first_word] |= start_mask;
             size_t i = first_word + 1;
 #ifdef BIT_ARRAY_USE_AVX
-            const __m256i value = _mm256_set1_epi64x(~1);
+            const __m256i value = _mm256_set1_epi64x(-1);
             for (; i + WORDS_PER_AVX <= last_word; i += WORDS_PER_AVX) {
                 _mm256_storeu_si256(reinterpret_cast<__m256i*>(&data[i]), value);
             }
@@ -66,7 +66,7 @@ public:
         }
     }
 
-    inline void UnsetRange(size_t start, size_t end) {
+    void UnsetRange(size_t start, size_t end) {
         if (start >= end || end > N) {
             return;
         }
@@ -118,7 +118,7 @@ public:
         return !None();
     }
 
-    inline Range FirstSetFrom(size_t start) const {
+    Range FirstSetFrom(size_t start) const {
         if (start >= N) {
             return {N, N};
         }

--- a/src/common/bit_array.h
+++ b/src/common/bit_array.h
@@ -38,7 +38,7 @@ public:
         return (data[idx / BITS_PER_WORD] & (1ULL << (idx % BITS_PER_WORD))) != 0;
     }
 
-    inline constexpr void SetRange(size_t start, size_t end) {
+    inline void SetRange(size_t start, size_t end) {
         if (start >= end || end > N) {
             return;
         }
@@ -66,7 +66,7 @@ public:
         }
     }
 
-    inline constexpr void UnsetRange(size_t start, size_t end) {
+    inline void UnsetRange(size_t start, size_t end) {
         if (start >= end || end > N) {
             return;
         }
@@ -118,7 +118,7 @@ public:
         return !None();
     }
 
-    inline constexpr Range FirstSetFrom(size_t start) const {
+    inline Range FirstSetFrom(size_t start) const {
         if (start >= N) {
             return {N, N};
         }

--- a/src/common/bit_array.h
+++ b/src/common/bit_array.h
@@ -227,7 +227,7 @@ public:
         return FirstRangeFrom(0);
     }
 
-    Range LastRegionFrom(size_t end) const {
+    Range LastRangeFrom(size_t end) const {
         if (end == 0) {
             return {0, 0};
         }
@@ -289,8 +289,8 @@ public:
         return {0, 0};
     }
 
-    inline constexpr Range LastRegion() const {
-        return LastRegionFrom(N);
+    inline constexpr Range LastRaange() const {
+        return LastRangeFrom(N);
     }
 
     inline constexpr size_t Size() const {

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -9,7 +9,7 @@
 #include "common/slot_vector.h"
 #include "common/types.h"
 #include "video_core/buffer_cache/buffer.h"
-#include "video_core/buffer_cache/memory_tracker_base.h"
+#include "video_core/buffer_cache/memory_tracker.h"
 #include "video_core/buffer_cache/range_set.h"
 #include "video_core/multi_level_page_table.h"
 

--- a/src/video_core/buffer_cache/memory_tracker.h
+++ b/src/video_core/buffer_cache/memory_tracker.h
@@ -9,7 +9,7 @@
 #include <vector>
 #include "common/debug.h"
 #include "common/types.h"
-#include "video_core/buffer_cache/word_manager.h"
+#include "video_core/buffer_cache/region_manager.h"
 
 namespace VideoCore {
 

--- a/src/video_core/buffer_cache/region_definitions.h
+++ b/src/video_core/buffer_cache/region_definitions.h
@@ -20,7 +20,7 @@ constexpr u64 NUM_REGION_PAGES = HIGHER_PAGE_SIZE / BYTES_PER_PAGE;
 enum class Type {
     CPU,
     GPU,
-    Untracked,
+    Writeable,
 };
 
 using RegionBits = Common::BitArray<NUM_REGION_PAGES>;

--- a/src/video_core/buffer_cache/region_definitions.h
+++ b/src/video_core/buffer_cache/region_definitions.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <array>
+#include "common/bit_array.h"
+#include "common/types.h"
+
+namespace VideoCore {
+
+constexpr u64 PAGES_PER_WORD = 64;
+constexpr u64 BYTES_PER_PAGE = 4_KB;
+constexpr u64 BYTES_PER_WORD = PAGES_PER_WORD * BYTES_PER_PAGE;
+
+constexpr u64 HIGHER_PAGE_BITS = 22;
+constexpr u64 HIGHER_PAGE_SIZE = 1ULL << HIGHER_PAGE_BITS;
+constexpr u64 HIGHER_PAGE_MASK = HIGHER_PAGE_SIZE - 1ULL;
+constexpr u64 NUM_REGION_WORDS = HIGHER_PAGE_SIZE / BYTES_PER_WORD;
+
+enum class Type {
+    CPU,
+    GPU,
+    Untracked,
+};
+
+using WordsArray = std::array<u64, NUM_REGION_WORDS>;
+// TODO: use this insteed of WordsArray once it is ready
+using RegionBits = Common::BitArray<NUM_REGION_WORDS * PAGES_PER_WORD>;
+
+} // namespace VideoCore

--- a/src/video_core/buffer_cache/region_definitions.h
+++ b/src/video_core/buffer_cache/region_definitions.h
@@ -11,12 +11,11 @@ namespace VideoCore {
 
 constexpr u64 PAGES_PER_WORD = 64;
 constexpr u64 BYTES_PER_PAGE = 4_KB;
-constexpr u64 BYTES_PER_WORD = PAGES_PER_WORD * BYTES_PER_PAGE;
 
 constexpr u64 HIGHER_PAGE_BITS = 22;
 constexpr u64 HIGHER_PAGE_SIZE = 1ULL << HIGHER_PAGE_BITS;
 constexpr u64 HIGHER_PAGE_MASK = HIGHER_PAGE_SIZE - 1ULL;
-constexpr u64 NUM_REGION_WORDS = HIGHER_PAGE_SIZE / BYTES_PER_WORD;
+constexpr u64 NUM_REGION_PAGES = HIGHER_PAGE_SIZE / BYTES_PER_PAGE;
 
 enum class Type {
     CPU,
@@ -24,8 +23,6 @@ enum class Type {
     Untracked,
 };
 
-using WordsArray = std::array<u64, NUM_REGION_WORDS>;
-// TODO: use this insteed of WordsArray once it is ready
-using RegionBits = Common::BitArray<NUM_REGION_WORDS * PAGES_PER_WORD>;
+using RegionBits = Common::BitArray<NUM_REGION_PAGES>;
 
 } // namespace VideoCore

--- a/src/video_core/buffer_cache/region_manager.h
+++ b/src/video_core/buffer_cache/region_manager.h
@@ -188,7 +188,7 @@ private:
         if (mask.None()) {
             return; // No changes to the CPU tracking state
         }
-        
+
         writeable = cpu;
         tracker->UpdatePageWatchersForRegion<add_to_tracker>(cpu_addr, mask);
     }

--- a/src/video_core/buffer_cache/region_manager.h
+++ b/src/video_core/buffer_cache/region_manager.h
@@ -184,8 +184,13 @@ private:
     void UpdateProtection() {
         RENDERER_TRACE;
         RegionBits mask = cpu ^ writeable;
+
+        if (mask.None()) {
+            return; // No changes to the CPU tracking state
+        }
+        
         writeable = cpu;
-        tracker->UpdatePageWatchersMasked<add_to_tracker>(cpu_addr, mask);
+        tracker->UpdatePageWatchersForRegion<add_to_tracker>(cpu_addr, mask);
     }
 
 #ifdef PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP

--- a/src/video_core/buffer_cache/region_manager.h
+++ b/src/video_core/buffer_cache/region_manager.h
@@ -130,19 +130,15 @@ public:
         }
         mask &= bits;
 
+        for (const auto& [start, end] : mask) {
+            func(cpu_addr + start * BYTES_PER_PAGE, (end - start) * BYTES_PER_PAGE);
+        }
+
         if constexpr (clear) {
             bits.UnsetRange(start_page, end_page);
             if constexpr (type == Type::CPU) {
                 UpdateProtection<true>(std::move(lk));
-            } else {
-                lk.unlock();
             }
-        } else {
-            lk.unlock();
-        }
-
-        for (const auto& [start, end] : mask) {
-            func(cpu_addr + start * BYTES_PER_PAGE, (end - start) * BYTES_PER_PAGE);
         }
     }
 

--- a/src/video_core/buffer_cache/region_manager.h
+++ b/src/video_core/buffer_cache/region_manager.h
@@ -125,6 +125,11 @@ public:
         RegionBits& bits = GetRegionBits<type>();
         RegionBits mask(bits, start_page, end_page);
 
+        // TODO: this will not be needed once we handle readbacks
+        if constexpr (type == Type::GPU) {
+            mask &= ~writeable;
+        }
+
         for (const auto& [start, end] : mask) {
             func(cpu_addr + start * BYTES_PER_PAGE, (end - start) * BYTES_PER_PAGE);
         }
@@ -156,6 +161,12 @@ public:
 
         const RegionBits& bits = GetRegionBits<type>();
         RegionBits test(bits, start_page, end_page);
+
+        // TODO: this will not be needed once we handle readbacks
+        if constexpr (type == Type::GPU) {
+            test &= ~writeable;
+        }
+
         return test.Any();
     }
 

--- a/src/video_core/buffer_cache/region_manager.h
+++ b/src/video_core/buffer_cache/region_manager.h
@@ -123,12 +123,7 @@ public:
         static_assert(type != Type::Writeable);
 
         RegionBits& bits = GetRegionBits<type>();
-        RegionBits mask{};
-        mask.SetRange(start_page, end_page);
-        if constexpr (type == Type::GPU) {
-            mask &= ~writeable;
-        }
-        mask &= bits;
+        RegionBits mask(bits, start_page, end_page);
 
         for (const auto& [start, end] : mask) {
             func(cpu_addr + start * BYTES_PER_PAGE, (end - start) * BYTES_PER_PAGE);
@@ -160,12 +155,7 @@ public:
         static_assert(type != Type::Writeable);
 
         const RegionBits& bits = GetRegionBits<type>();
-        RegionBits test{};
-        test.SetRange(start_page, end_page);
-        if constexpr (type == Type::GPU) {
-            test &= ~writeable;
-        }
-        test &= bits;
+        RegionBits test(bits, start_page, end_page);
         return test.Any();
     }
 

--- a/src/video_core/page_manager.cpp
+++ b/src/video_core/page_manager.cpp
@@ -189,12 +189,12 @@ struct PageManager::Impl {
     template <bool track>
     void UpdatePageWatchers(VAddr addr, u64 size) {
         RENDERER_TRACE;
-        
+
         size_t page = addr >> PAGE_BITS;
         auto perms = cached_pages[page].Perm();
         u64 range_begin = 0;
         u64 range_bytes = 0;
-        
+
         const auto release_pending = [&] {
             if (range_bytes > 0) {
                 RENDERER_TRACE;
@@ -203,7 +203,7 @@ struct PageManager::Impl {
                 range_bytes = 0;
             }
         };
-        
+
         std::scoped_lock lk(lock);
 
         // Iterate requested pages
@@ -211,8 +211,8 @@ struct PageManager::Impl {
         const u64 aligned_addr = page << PAGE_BITS;
         const u64 aligned_end = page_end << PAGE_BITS;
         ASSERT_MSG(rasterizer->IsMapped(aligned_addr, aligned_end - aligned_addr),
-                    "Attempted to track non-GPU memory at address {:#x}, size {:#x}.",
-                    aligned_addr, aligned_end - aligned_addr);
+                   "Attempted to track non-GPU memory at address {:#x}, size {:#x}.", aligned_addr,
+                   aligned_end - aligned_addr);
 
         for (; page != page_end; ++page) {
             PageState& state = cached_pages[page];
@@ -254,12 +254,12 @@ struct PageManager::Impl {
             UpdatePageWatchers<track>(start_addr, size);
             return;
         }
-        
+
         size_t base_page = (base_addr >> PAGE_BITS);
         auto perms = cached_pages[base_page + start_range.first].Perm();
         u64 range_begin = 0;
         u64 range_bytes = 0;
-        
+
         const auto release_pending = [&] {
             if (range_bytes > 0) {
                 RENDERER_TRACE;
@@ -268,7 +268,7 @@ struct PageManager::Impl {
                 range_bytes = 0;
             }
         };
-        
+
         std::scoped_lock lk(lock);
 
         // Iterate pages
@@ -277,8 +277,7 @@ struct PageManager::Impl {
             const bool update = mask.Get(page);
 
             // Apply the change to the page state
-            const u8 new_count =
-                update ? state.AddDelta<track ? 1 : -1>() : state.AddDelta<0>();
+            const u8 new_count = update ? state.AddDelta<track ? 1 : -1>() : state.AddDelta<0>();
 
             if (auto new_perms = state.Perm(); new_perms != perms) [[unlikely]] {
                 // If the protection changed add pending (un)protect action

--- a/src/video_core/page_manager.cpp
+++ b/src/video_core/page_manager.cpp
@@ -337,7 +337,9 @@ void PageManager::UpdatePageWatchersForRegion(VAddr base_addr, RegionBits& mask)
 
 template void PageManager::UpdatePageWatchers<true>(VAddr addr, u64 size) const;
 template void PageManager::UpdatePageWatchers<false>(VAddr addr, u64 size) const;
-template void PageManager::UpdatePageWatchersForRegion<true>(VAddr base_addr, RegionBits& mask) const;
-template void PageManager::UpdatePageWatchersForRegion<false>(VAddr base_addr, RegionBits& mask) const;
+template void PageManager::UpdatePageWatchersForRegion<true>(VAddr base_addr,
+                                                             RegionBits& mask) const;
+template void PageManager::UpdatePageWatchersForRegion<false>(VAddr base_addr,
+                                                              RegionBits& mask) const;
 
 } // namespace VideoCore

--- a/src/video_core/page_manager.cpp
+++ b/src/video_core/page_manager.cpp
@@ -241,7 +241,7 @@ struct PageManager::Impl {
     }
 
     template <bool track>
-    void UpdatePageWatchersMasked(VAddr base_addr, RegionBits& mask) {
+    void UpdatePageWatchersForRegion(VAddr base_addr, RegionBits& mask) {
         RENDERER_TRACE;
         auto start_range = mask.FirstRange();
         auto end_range = mask.LastRange();
@@ -331,13 +331,13 @@ void PageManager::UpdatePageWatchers(VAddr addr, u64 size) const {
 }
 
 template <bool track>
-void PageManager::UpdatePageWatchersMasked(VAddr base_addr, RegionBits& mask) const {
-    impl->UpdatePageWatchersMasked<track>(base_addr, mask);
+void PageManager::UpdatePageWatchersForRegion(VAddr base_addr, RegionBits& mask) const {
+    impl->UpdatePageWatchersForRegion<track>(base_addr, mask);
 }
 
 template void PageManager::UpdatePageWatchers<true>(VAddr addr, u64 size) const;
 template void PageManager::UpdatePageWatchers<false>(VAddr addr, u64 size) const;
-template void PageManager::UpdatePageWatchersMasked<true>(VAddr base_addr, RegionBits& mask) const;
-template void PageManager::UpdatePageWatchersMasked<false>(VAddr base_addr, RegionBits& mask) const;
+template void PageManager::UpdatePageWatchersForRegion<true>(VAddr base_addr, RegionBits& mask) const;
+template void PageManager::UpdatePageWatchersForRegion<false>(VAddr base_addr, RegionBits& mask) const;
 
 } // namespace VideoCore

--- a/src/video_core/page_manager.cpp
+++ b/src/video_core/page_manager.cpp
@@ -225,7 +225,7 @@ struct PageManager::Impl {
                 PageState& state = cached_pages[page];
 
                 // Apply the change to the page state
-                const u8 new_count = state.AddDelta<track ? 1 : -1> ();
+                const u8 new_count = state.AddDelta<track ? 1 : -1>();
 
                 if (auto new_perms = state.Perm(); new_perms != perms) [[unlikely]] {
                     // If the protection changed add pending (un)protect action
@@ -293,7 +293,7 @@ struct PageManager::Impl {
 
                 // Apply the change to the page state
                 const u8 new_count =
-                    update ? state.AddDelta<track ? 1 : -1> () : state.AddDelta<0>();
+                    update ? state.AddDelta<track ? 1 : -1>() : state.AddDelta<0>();
 
                 if (auto new_perms = state.Perm(); new_perms != perms) [[unlikely]] {
                     // If the protection changed add pending (un)protect action

--- a/src/video_core/page_manager.cpp
+++ b/src/video_core/page_manager.cpp
@@ -225,7 +225,7 @@ struct PageManager::Impl {
                 PageState& state = cached_pages[page];
 
                 // Apply the change to the page state
-                const u8 new_count = state.AddDelta<track ? 1 : -1 > ();
+                const u8 new_count = state.AddDelta<track ? 1 : -1> ();
 
                 if (auto new_perms = state.Perm(); new_perms != perms) [[unlikely]] {
                     // If the protection changed add pending (un)protect action
@@ -293,7 +293,7 @@ struct PageManager::Impl {
 
                 // Apply the change to the page state
                 const u8 new_count =
-                    update ? state.AddDelta<track ? 1 : -1 > () : state.AddDelta<0>();
+                    update ? state.AddDelta<track ? 1 : -1> () : state.AddDelta<0>();
 
                 if (auto new_perms = state.Perm(); new_perms != perms) [[unlikely]] {
                     // If the protection changed add pending (un)protect action

--- a/src/video_core/page_manager.cpp
+++ b/src/video_core/page_manager.cpp
@@ -225,7 +225,7 @@ struct PageManager::Impl {
                 PageState& state = cached_pages[page];
 
                 // Apply the change to the page state
-                const u8 new_count = state.AddDelta < track ? 1 : -1 > ();
+                const u8 new_count = state.AddDelta< track ? 1 : -1 > ();
 
                 if (auto new_perms = state.Perm(); new_perms != perms) [[unlikely]] {
                     // If the protection changed add pending (un)protect action
@@ -293,7 +293,7 @@ struct PageManager::Impl {
 
                 // Apply the change to the page state
                 const u8 new_count =
-                    update ? state.AddDelta < track ? 1 : -1 > () : state.AddDelta<0>();
+                    update ? state.AddDelta< track ? 1 : -1 > () : state.AddDelta<0>();
 
                 if (auto new_perms = state.Perm(); new_perms != perms) [[unlikely]] {
                     // If the protection changed add pending (un)protect action

--- a/src/video_core/page_manager.cpp
+++ b/src/video_core/page_manager.cpp
@@ -259,7 +259,7 @@ struct PageManager::Impl {
         boost::container::small_vector<UpdateProtectRange, 16> update_ranges;
 
         auto start_range = mask.FirstRange();
-        auto end_range = mask.LastRaange();
+        auto end_range = mask.LastRange();
 
         if (start_range.second == end_range.second) {
             // Optimization: if all pages are contiguous, use the regular UpdatePageWatchers

--- a/src/video_core/page_manager.cpp
+++ b/src/video_core/page_manager.cpp
@@ -225,7 +225,7 @@ struct PageManager::Impl {
                 PageState& state = cached_pages[page];
 
                 // Apply the change to the page state
-                const u8 new_count = state.AddDelta< track ? 1 : -1 > ();
+                const u8 new_count = state.AddDelta<track ? 1 : -1 > ();
 
                 if (auto new_perms = state.Perm(); new_perms != perms) [[unlikely]] {
                     // If the protection changed add pending (un)protect action
@@ -287,13 +287,13 @@ struct PageManager::Impl {
                 }
             };
 
-            for (size_t page = start_range.first; page <= end_range.second; ++page) {
+            for (size_t page = start_range.first; page < end_range.second; ++page) {
                 PageState& state = cached_pages[base_page + page];
                 const bool update = mask.Get(page);
 
                 // Apply the change to the page state
                 const u8 new_count =
-                    update ? state.AddDelta< track ? 1 : -1 > () : state.AddDelta<0>();
+                    update ? state.AddDelta<track ? 1 : -1 > () : state.AddDelta<0>();
 
                 if (auto new_perms = state.Perm(); new_perms != perms) [[unlikely]] {
                     // If the protection changed add pending (un)protect action

--- a/src/video_core/page_manager.h
+++ b/src/video_core/page_manager.h
@@ -35,7 +35,7 @@ public:
     /// Updates watches in the pages touching the specified region
     /// using a mask.
     template <bool track>
-    void UpdatePageWatchersMasked(VAddr base_addr, RegionBits& mask) const;
+    void UpdatePageWatchersForRegion(VAddr base_addr, RegionBits& mask) const;
 
     /// Returns page aligned address.
     static constexpr VAddr GetPageAddr(VAddr addr) {

--- a/src/video_core/page_manager.h
+++ b/src/video_core/page_manager.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include "common/alignment.h"
 #include "common/types.h"
+#include "video_core/buffer_cache//region_definitions.h"
 
 namespace Vulkan {
 class Rasterizer;
@@ -28,8 +29,13 @@ public:
     void OnGpuUnmap(VAddr address, size_t size);
 
     /// Updates watches in the pages touching the specified region.
-    template <s32 delta>
+    template <bool track>
     void UpdatePageWatchers(VAddr addr, u64 size) const;
+
+    /// Updates watches in the pages touching the specified region
+    /// using a mask.
+    template <bool track>
+    void UpdatePageWatchersMasked(VAddr addr, RegionBits& mask) const;
 
     /// Returns page aligned address.
     static constexpr VAddr GetPageAddr(VAddr addr) {

--- a/src/video_core/page_manager.h
+++ b/src/video_core/page_manager.h
@@ -35,7 +35,7 @@ public:
     /// Updates watches in the pages touching the specified region
     /// using a mask.
     template <bool track>
-    void UpdatePageWatchersMasked(VAddr addr, RegionBits& mask) const;
+    void UpdatePageWatchersMasked(VAddr base_addr, RegionBits& mask) const;
 
     /// Returns page aligned address.
     static constexpr VAddr GetPageAddr(VAddr addr) {

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -761,7 +761,7 @@ void TextureCache::UntrackImage(ImageId image_id) {
     image.track_addr = 0;
     image.track_addr_end = 0;
     if (size != 0) {
-        tracker.UpdatePageWatchers<-1>(addr, size);
+        tracker.UpdatePageWatchers<false>(addr, size);
     }
 }
 
@@ -780,7 +780,7 @@ void TextureCache::UntrackImageHead(ImageId image_id) {
         // Cehck its hash later.
         MarkAsMaybeDirty(image_id, image);
     }
-    tracker.UpdatePageWatchers<-1>(image_begin, size);
+    tracker.UpdatePageWatchers<false>(image_begin, size);
 }
 
 void TextureCache::UntrackImageTail(ImageId image_id) {
@@ -799,7 +799,7 @@ void TextureCache::UntrackImageTail(ImageId image_id) {
         // Cehck its hash later.
         MarkAsMaybeDirty(image_id, image);
     }
-    tracker.UpdatePageWatchers<-1>(addr, size);
+    tracker.UpdatePageWatchers<false>(addr, size);
 }
 
 void TextureCache::DeleteImage(ImageId image_id) {


### PR DESCRIPTION
Rewrite parts of the page manager and region manager to be faster

Use a bit array that uses AVX to accelerate.
Also tries to batch mprotects in the same region (another pr is needed to take advantage of this)

I have done zero testing right now with this and i rewrote parts of the memory tracker so there is a very high chance I broke something.

This is part of a series of PR with the hope of improving performance of games that use DMA, since it is currently quite slow (mainly because the ammount of memory protections and synced buffers).