### PR TITLE
vulkan: Fix two validation errors introduced by shared memory changes.

### DIFF
--- a/src/shader_recompiler/ir/passes/shared_memory_to_storage_pass.cpp
+++ b/src/shader_recompiler/ir/passes/shared_memory_to_storage_pass.cpp
@@ -34,11 +34,11 @@ void SharedMemoryToStoragePass(IR::Program& program, const RuntimeInfo& runtime_
     if (program.info.stage != Stage::Compute) {
         return;
     }
-    // Only perform the transform if the host shared memory is insufficient
-    // or the device does not support VK_KHR_workgroup_memory_explicit_layout
+    // Only perform the transform if there is shared memory and either host shared memory is
+    // insufficient or the device does not support VK_KHR_workgroup_memory_explicit_layout
     const u32 shared_memory_size = runtime_info.cs_info.shared_memory_size;
-    if (shared_memory_size <= profile.max_shared_memory_size &&
-        profile.supports_workgroup_explicit_memory_layout) {
+    if (shared_memory_size == 0 || (shared_memory_size <= profile.max_shared_memory_size &&
+                                    profile.supports_workgroup_explicit_memory_layout)) {
         return;
     }
     // Add buffer binding for shared memory storage buffer.

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -445,7 +445,25 @@ bool Instance::CreateDevice() {
                 workgroup_memory_explicit_layout_features.workgroupMemoryExplicitLayout16BitAccess,
         },
 #ifdef __APPLE__
-        portability_features,
+        vk::PhysicalDevicePortabilitySubsetFeaturesKHR{
+            .constantAlphaColorBlendFactors = portability_features.constantAlphaColorBlendFactors,
+            .events = portability_features.events,
+            .imageViewFormatReinterpretation = portability_features.imageViewFormatReinterpretation,
+            .imageViewFormatSwizzle = portability_features.imageViewFormatSwizzle,
+            .imageView2DOn3DImage = portability_features.imageView2DOn3DImage,
+            .multisampleArrayImage = portability_features.multisampleArrayImage,
+            .mutableComparisonSamplers = portability_features.mutableComparisonSamplers,
+            .pointPolygons = portability_features.pointPolygons,
+            .samplerMipLodBias = portability_features.samplerMipLodBias,
+            .separateStencilMaskRef = portability_features.separateStencilMaskRef,
+            .shaderSampleRateInterpolationFunctions =
+                portability_features.shaderSampleRateInterpolationFunctions,
+            .tessellationIsolines = portability_features.tessellationIsolines,
+            .tessellationPointMode = portability_features.tessellationPointMode,
+            .triangleFans = portability_features.triangleFans,
+            .vertexAttributeAccessBeyondStride =
+                portability_features.vertexAttributeAccessBeyondStride,
+        },
 #endif
     };
 


### PR DESCRIPTION
* Fix LDS buffer of size 0 being bound when shared memory is not needed by a shader and `VK_KHR_workgroup_memory_explicit_layout` is not supported.
* Fix extra feature structs being included in device create chain due to re-using portability subset feature instance without it being last in the get chain.