### PR TITLE
libSceNpTrophy: Change initial context and handle values

### DIFF
--- a/src/core/libraries/np_trophy/np_trophy.cpp
+++ b/src/core/libraries/np_trophy/np_trophy.cpp
@@ -212,7 +212,7 @@ s32 PS4_SYSV_ABI sceNpTrophyDestroyHandle(OrbisNpTrophyHandle handle) {
 
     s32 handle_index = handle - 1;
     if (handle_index >= trophy_handles.size()) {
-        LOG_ERROR(Lib_NpTrophy, "Invalid handle {}", handle_index);
+        LOG_ERROR(Lib_NpTrophy, "Invalid handle {}", handle);
         return ORBIS_NP_TROPHY_ERROR_INVALID_HANDLE;
     }
 

--- a/src/core/libraries/np_trophy/np_trophy.cpp
+++ b/src/core/libraries/np_trophy/np_trophy.cpp
@@ -164,10 +164,12 @@ s32 PS4_SYSV_ABI sceNpTrophyCreateContext(OrbisNpTrophyContext* context, int32_t
     }
 
     const auto ctx_id = trophy_contexts.insert(user_id, service_label);
-    contexts_internal[key].context_id = ctx_id.index;
-    LOG_INFO(Lib_NpTrophy, "New context = {}, user_id = {} service label = {}", ctx_id.index,
-             user_id, service_label);
-    *context = ctx_id.index;
+
+    *context = ctx_id.index + 1;
+    contexts_internal[key].context_id = *context;
+    LOG_INFO(Lib_NpTrophy, "New context = {}, user_id = {} service label = {}", *context, user_id,
+             service_label);
+
     return ORBIS_OK;
 }
 
@@ -179,21 +181,23 @@ s32 PS4_SYSV_ABI sceNpTrophyCreateHandle(OrbisNpTrophyHandle* handle) {
     if (trophy_handles.size() >= MaxTrophyHandles) {
         return ORBIS_NP_TROPHY_ERROR_HANDLE_EXCEEDS_MAX;
     }
-    const auto handle_id = trophy_handles.insert();
-    LOG_INFO(Lib_NpTrophy, "New handle = {}", handle_id.index);
 
-    *handle = handle_id.index;
+    const auto handle_id = trophy_handles.insert();
+
+    *handle = handle_id.index + 1;
+    LOG_INFO(Lib_NpTrophy, "New handle = {}", *handle);
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceNpTrophyDestroyContext(OrbisNpTrophyContext context) {
     LOG_INFO(Lib_NpTrophy, "Destroyed Context {}", context);
 
-    if (context == ORBIS_NP_TROPHY_INVALID_CONTEXT)
+    if (context == ORBIS_NP_TROPHY_INVALID_CONTEXT) {
         return ORBIS_NP_TROPHY_ERROR_INVALID_CONTEXT;
+    }
 
     Common::SlotId contextId;
-    contextId.index = context;
+    contextId.index = context - 1;
 
     ContextKey contextkey = trophy_contexts[contextId];
     trophy_contexts.erase(contextId);
@@ -206,15 +210,17 @@ s32 PS4_SYSV_ABI sceNpTrophyDestroyHandle(OrbisNpTrophyHandle handle) {
     if (handle == ORBIS_NP_TROPHY_INVALID_HANDLE)
         return ORBIS_NP_TROPHY_ERROR_INVALID_HANDLE;
 
-    if (handle >= trophy_handles.size()) {
-        LOG_ERROR(Lib_NpTrophy, "Invalid handle {}", handle);
-        return ORBIS_NP_TROPHY_ERROR_INVALID_HANDLE;
-    }
-    if (!trophy_handles.is_allocated({static_cast<u32>(handle)})) {
+    s32 handle_index = handle - 1;
+    if (handle_index >= trophy_handles.size()) {
+        LOG_ERROR(Lib_NpTrophy, "Invalid handle {}", handle_index);
         return ORBIS_NP_TROPHY_ERROR_INVALID_HANDLE;
     }
 
-    trophy_handles.erase({static_cast<u32>(handle)});
+    if (!trophy_handles.is_allocated({static_cast<u32>(handle_index)})) {
+        return ORBIS_NP_TROPHY_ERROR_INVALID_HANDLE;
+    }
+
+    trophy_handles.erase({static_cast<u32>(handle_index)});
     LOG_INFO(Lib_NpTrophy, "Handle {} destroyed", handle);
     return ORBIS_OK;
 }


### PR DESCRIPTION
libSceNpToolkit internally uses context/handle values of zero to indicate that libSceNpTrophy calls failed. This PR sets handle and context values as index + 1 instead, avoiding any internal libSceNpToolkit issues a context or handle of zero may cause.

This fixes one of many issues related to the current crash in SWORD ART ONLINE: HOLLOW REALIZATION (CUSA05125). Now it crashes because we've stubbed sceNpTrophyGetGameIcon though.