### PR TITLE
buffer_cache: Bump device local staging buffer size

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -23,7 +23,7 @@ static constexpr size_t DataShareBufferSize = 64_KB;
 static constexpr size_t StagingBufferSize = 512_MB;
 static constexpr size_t UboStreamBufferSize = 128_MB;
 static constexpr size_t DownloadBufferSize = 128_MB;
-static constexpr size_t DeviceBufferSize = 16_MB;
+static constexpr size_t DeviceBufferSize = 128_MB;
 static constexpr size_t MaxPageFaults = 1024;
 
 BufferCache::BufferCache(const Vulkan::Instance& instance_, Vulkan::Scheduler& scheduler_,


### PR DESCRIPTION
Fix for https://github.com/shadps4-emu/shadPS4/pull/3079#issuecomment-2964660112
Game is trying to copy a 4096x4096 depth buffer and needs 4096 * 4096 * 4 = 67108864 which didn't fit the buffer