### PR TITLE
remove the accidental backslash in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The following firmware modules are supported and must be placed in shadPS4's `sy
 </div>
 
 > [!Caution]
-> The above modules are required to run the games properly and must be extracted from your PlayStation 4.\
+> The above modules are required to run the games properly and must be extracted from your PlayStation 4.
 
 
 


### PR DESCRIPTION
Removes the backslash that was(seemingly) added on accident in the README file. Here's a before and after comparison:
![image](https://github.com/user-attachments/assets/745fe2ef-4cd8-4c4e-871f-50cd887e80f1)
![image](https://github.com/user-attachments/assets/43943cf9-4018-4470-9478-7c323816a52b)
