### PR TITLE
Handle mixed samples attachments during draws

### DIFF
--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -108,6 +108,7 @@ GraphicsPipeline::GraphicsPipeline(
     };
 
     const vk::PipelineMultisampleStateCreateInfo multisampling = {
+        // if dynamic rasterization samples state is enabled, this field is ignored
         .rasterizationSamples =
             LiverpoolToVK::NumSamples(key.num_samples, instance.GetFramebufferSampleCounts()),
         .sampleShadingEnable = false,
@@ -121,7 +122,7 @@ GraphicsPipeline::GraphicsPipeline(
         .pNext = instance.IsDepthClipControlSupported() ? &clip_control : nullptr,
     };
 
-    boost::container::static_vector<vk::DynamicState, 20> dynamic_states = {
+    boost::container::static_vector<vk::DynamicState, 22> dynamic_states = {
         vk::DynamicState::eViewportWithCount,  vk::DynamicState::eScissorWithCount,
         vk::DynamicState::eBlendConstants,     vk::DynamicState::eDepthTestEnable,
         vk::DynamicState::eDepthWriteEnable,   vk::DynamicState::eDepthCompareOp,
@@ -146,6 +147,9 @@ GraphicsPipeline::GraphicsPipeline(
         dynamic_states.push_back(vk::DynamicState::eVertexInputEXT);
     } else if (!vertex_bindings.empty()) {
         dynamic_states.push_back(vk::DynamicState::eVertexInputBindingStride);
+    }
+    if (instance.IsDynamicRasterizationSamplesSupported()) {
+        dynamic_states.push_back(vk::DynamicState::eRasterizationSamplesEXT);
     }
 
     const vk::PipelineDynamicStateCreateInfo dynamic_info = {

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -39,7 +39,7 @@ struct GraphicsPipelineKey {
     vk::Format depth_format;
     vk::Format stencil_format;
 
-    u32 num_samples;
+    u32 num_samples{};
     u32 mrt_mask;
     AmdGpu::PrimitiveType prim_type;
     Liverpool::PolygonMode polygon_mode;

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -213,7 +213,8 @@ bool Instance::CreateDevice() {
                           vk::PhysicalDevicePrimitiveTopologyListRestartFeaturesEXT,
                           vk::PhysicalDevicePortabilitySubsetFeaturesKHR,
                           vk::PhysicalDeviceShaderAtomicFloat2FeaturesEXT,
-                          vk::PhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>();
+                          vk::PhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR,
+                          vk::PhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT>();
     features = feature_chain.get().features;
 
     const vk::StructureChain properties_chain = physical_device.getProperties2<
@@ -257,6 +258,8 @@ bool Instance::CreateDevice() {
             feature_chain.get<vk::PhysicalDeviceExtendedDynamicState3FeaturesEXT>();
         LOG_INFO(Render_Vulkan, "- extendedDynamicState3ColorWriteMask: {}",
                  dynamic_state_3_features.extendedDynamicState3ColorWriteMask);
+        LOG_INFO(Render_Vulkan, "- extendedDynamicState3RasterizationSamples: {}",
+                 dynamic_state_3_features.extendedDynamicState3RasterizationSamples);
     }
     robustness2 = add_extension(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
     if (robustness2) {
@@ -300,6 +303,8 @@ bool Instance::CreateDevice() {
             Render_Vulkan, "- workgroupMemoryExplicitLayout16BitAccess: {}",
             workgroup_memory_explicit_layout_features.workgroupMemoryExplicitLayout16BitAccess);
     }
+    dynamic_rendering_unused_attachments =
+        add_extension(VK_EXT_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_EXTENSION_NAME);
     const bool calibrated_timestamps =
         TRACY_GPU_ENABLED ? add_extension(VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME) : false;
 
@@ -409,6 +414,8 @@ bool Instance::CreateDevice() {
             .customBorderColorWithoutFormat = true,
         },
         vk::PhysicalDeviceExtendedDynamicState3FeaturesEXT{
+            .extendedDynamicState3RasterizationSamples =
+                dynamic_state_3_features.extendedDynamicState3RasterizationSamples,
             .extendedDynamicState3ColorWriteMask =
                 dynamic_state_3_features.extendedDynamicState3ColorWriteMask,
         },
@@ -448,6 +455,9 @@ bool Instance::CreateDevice() {
                     .workgroupMemoryExplicitLayoutScalarBlockLayout,
             .workgroupMemoryExplicitLayout16BitAccess =
                 workgroup_memory_explicit_layout_features.workgroupMemoryExplicitLayout16BitAccess,
+        },
+        vk::PhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT{
+            .dynamicRenderingUnusedAttachments = true,
         },
 #ifdef __APPLE__
         vk::PhysicalDevicePortabilitySubsetFeaturesKHR{
@@ -501,6 +511,9 @@ bool Instance::CreateDevice() {
     }
     if (!workgroup_memory_explicit_layout) {
         device_chain.unlink<vk::PhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>();
+    }
+    if (!dynamic_rendering_unused_attachments) {
+        device_chain.unlink<vk::PhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT>();
     }
 
     auto [device_result, dev] = physical_device.createDeviceUnique(device_chain.get());

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -114,6 +114,13 @@ public:
         return depth_range_unrestricted;
     }
 
+    /// Returns true when the extendedDynamicState3RasterizationSamples feature of
+    /// VK_EXT_extended_dynamic_state3 is supported.
+    bool IsDynamicRasterizationSamplesSupported() const {
+        return dynamic_state_3 &&
+               dynamic_state_3_features.extendedDynamicState3RasterizationSamples;
+    }
+
     /// Returns true when the extendedDynamicState3ColorWriteMask feature of
     /// VK_EXT_extended_dynamic_state3 is supported.
     bool IsDynamicColorWriteMaskSupported() const {
@@ -390,6 +397,7 @@ private:
     bool amd_shader_trinary_minmax{};
     bool shader_atomic_float2{};
     bool workgroup_memory_explicit_layout{};
+    bool dynamic_rendering_unused_attachments{};
     bool portability_subset{};
 };
 

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -303,7 +303,7 @@ bool PipelineCache::RefreshGraphicsKey() {
     key.prim_type = regs.primitive_type;
     key.polygon_mode = regs.polygon_control.PolyMode();
     key.clip_space = regs.clipper_control.clip_space;
-    key.num_samples = regs.NumSamples();
+    key.num_samples = instance.IsDynamicRasterizationSamplesSupported() ? 1 : regs.NumSamples();
 
     const bool skip_cb_binding =
         regs.color_control.mode == AmdGpu::Liverpool::ColorControl::OperationMode::Disable;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -86,8 +86,10 @@ private:
     void Resolve();
     void DepthStencilCopy(bool is_depth, bool is_stencil);
     void EliminateFastClear();
+    std::vector<u32> UniqueSampleCounts() const;
 
-    void UpdateDynamicState(const GraphicsPipeline& pipeline) const;
+    void UpdateDynamicState(const GraphicsPipeline& pipeline,
+                            vk::SampleCountFlagBits sample_count) const;
     void UpdateViewportScissorState() const;
     void UpdateDepthStencilState() const;
     void UpdatePrimitiveState() const;

--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -326,6 +326,12 @@ void DynamicState::Commit(const Instance& instance, const vk::CommandBuffer& cmd
             cmdbuf.setColorWriteMaskEXT(0, color_write_masks);
         }
     }
+    if (dirty_state.rasterization_samples) {
+        dirty_state.rasterization_samples = false;
+        if (instance.IsDynamicRasterizationSamplesSupported()) {
+            cmdbuf.setRasterizationSamplesEXT(rasterization_samples);
+        }
+    }
 }
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -101,6 +101,7 @@ struct DynamicState {
 
         bool blend_constants : 1;
         bool color_write_masks : 1;
+        bool rasterization_samples : 1;
     } dirty_state{};
 
     Viewports viewports{};
@@ -135,6 +136,7 @@ struct DynamicState {
 
     float blend_constants[4]{};
     ColorWriteMasks color_write_masks{};
+    vk::SampleCountFlagBits rasterization_samples{};
 
     /// Commits the dynamic state to the provided command buffer.
     void Commit(const Instance& instance, const vk::CommandBuffer& cmdbuf);
@@ -294,6 +296,13 @@ struct DynamicState {
         if (!std::ranges::equal(color_write_masks, color_write_masks_)) {
             color_write_masks = color_write_masks_;
             dirty_state.color_write_masks = true;
+        }
+    }
+
+    void SetRasterizationSamples(const vk::SampleCountFlagBits rasterization_samples_) {
+        if (rasterization_samples != rasterization_samples_) {
+            rasterization_samples = rasterization_samples_;
+            dirty_state.rasterization_samples = true;
         }
     }
 };


### PR DESCRIPTION
Another shot at fixing the issue mentioned in https://github.com/shadps4-emu/shadPS4/pull/3020, when a game tries to do a draw into multiple color attachments that differ in their sample counts.

No longer requires VK_AMD/NV_* extension as the previous one, but VK_EXT_dynamic_rendering_unused_attachments and extendedDynamicState3RasterizationSamples - both handled by three major GPU vendors. Not supported by MoltenVK, that would need to wait for another PR. Now it gets ingame with HEAVY RAIN and renders the whole framebuffer
![Screenshot From 2025-06-13 19-33-44](https://github.com/user-attachments/assets/4d916184-3765-431b-b790-9699855deda9)
