### PR TITLE
Qt: If duplicate unique inputs found, show which buttons have duplicates

### DIFF
--- a/src/qt_gui/kbm_gui.cpp
+++ b/src/qt_gui/kbm_gui.cpp
@@ -372,12 +372,30 @@ void KBMSettings::SaveKBMConfig(bool CloseOnSave) {
     file.close();
 
     // Prevent duplicate inputs for KBM as this breaks the engine
+    bool duplicateFound = false;
+    QSet<QString> duplicateInputs;
     for (auto it = inputs.begin(); it != inputs.end(); ++it) {
         if (std::find(it + 1, inputs.end(), *it) != inputs.end()) {
-            QMessageBox::information(this, tr("Unable to Save"),
-                                     tr("Cannot bind any unique input more than once"));
-            return;
+            duplicateFound = true;
+            duplicateInputs.insert(QString::fromStdString(*it));
         }
+    }
+
+    if (duplicateFound) {
+        QStringList DuplicateButtons;
+        for (QString i : duplicateInputs) {
+            for (const auto& j : ButtonsList) {
+                if (j->text() == i)
+                    DuplicateButtons.append(j->objectName() + " - " + i);
+            }
+        }
+        QString DuplicateList = DuplicateButtons.join("\n");
+        QMessageBox::information(
+            this, tr("Unable to Save"),
+            QString(tr("Cannot bind any unique input more than once. "
+                       "Duplicate inputs mapped to the following buttons:\n\n%1")
+                        .arg(DuplicateList)));
+        return;
     }
 
     std::vector<std::string> save;

--- a/src/qt_gui/kbm_gui.cpp
+++ b/src/qt_gui/kbm_gui.cpp
@@ -391,9 +391,9 @@ void KBMSettings::SaveKBMConfig(bool CloseOnSave) {
         }
         QMessageBox::information(
             this, tr("Unable to Save"),
-            QString(tr("Cannot bind any unique input more than once. "
-                       "Duplicate inputs mapped to the following buttons:\n\n%1")
-                        .arg(duplicatesList.join("\n"))));
+            // clang-format off
+QString(tr("Cannot bind any unique input more than once. Duplicate inputs mapped to the following buttons:\n\n%1").arg(duplicatesList.join("\n"))));
+        // clang-format on
         return;
     }
 

--- a/src/qt_gui/kbm_gui.cpp
+++ b/src/qt_gui/kbm_gui.cpp
@@ -33,13 +33,13 @@ KBMSettings::KBMSettings(std::shared_ptr<GameInfoClass> game_info_get, QWidget* 
     }
 
     ButtonsList = {
-        ui->CrossButton,       ui->CircleButton,   ui->TriangleButton,   ui->SquareButton,
-        ui->L1Button,          ui->R1Button,       ui->L2Button,         ui->R2Button,
-        ui->L3Button,          ui->R3Button,       ui->TouchpadButton,   ui->OptionsButton,
-        ui->TouchpadButton,    ui->DpadUpButton,   ui->DpadDownButton,   ui->DpadLeftButton,
-        ui->DpadRightButton,   ui->LStickUpButton, ui->LStickDownButton, ui->LStickLeftButton,
-        ui->LStickRightButton, ui->RStickUpButton, ui->RStickDownButton, ui->RStickLeftButton,
-        ui->RStickRightButton, ui->LHalfButton,    ui->RHalfButton};
+        ui->CrossButton,    ui->CircleButton,     ui->TriangleButton,   ui->SquareButton,
+        ui->L1Button,       ui->R1Button,         ui->L2Button,         ui->R2Button,
+        ui->L3Button,       ui->R3Button,         ui->OptionsButton,    ui->TouchpadButton,
+        ui->DpadUpButton,   ui->DpadDownButton,   ui->DpadLeftButton,   ui->DpadRightButton,
+        ui->LStickUpButton, ui->LStickDownButton, ui->LStickLeftButton, ui->LStickRightButton,
+        ui->RStickUpButton, ui->RStickDownButton, ui->RStickLeftButton, ui->RStickRightButton,
+        ui->LHalfButton,    ui->RHalfButton};
 
     ButtonConnects();
     SetUIValuestoMappings("default");

--- a/src/qt_gui/kbm_gui.cpp
+++ b/src/qt_gui/kbm_gui.cpp
@@ -373,28 +373,27 @@ void KBMSettings::SaveKBMConfig(bool CloseOnSave) {
 
     // Prevent duplicate inputs for KBM as this breaks the engine
     bool duplicateFound = false;
-    QSet<QString> duplicateInputs;
+    QSet<QString> duplicateMappings;
     for (auto it = inputs.begin(); it != inputs.end(); ++it) {
         if (std::find(it + 1, inputs.end(), *it) != inputs.end()) {
             duplicateFound = true;
-            duplicateInputs.insert(QString::fromStdString(*it));
+            duplicateMappings.insert(QString::fromStdString(*it));
         }
     }
 
     if (duplicateFound) {
-        QStringList DuplicateButtons;
-        for (QString i : duplicateInputs) {
-            for (const auto& j : ButtonsList) {
-                if (j->text() == i)
-                    DuplicateButtons.append(j->objectName() + " - " + i);
+        QStringList duplicatesList;
+        for (const QString mapping : duplicateMappings) {
+            for (const auto& button : ButtonsList) {
+                if (button->text() == mapping)
+                    duplicatesList.append(button->objectName() + " - " + mapping);
             }
         }
-        QString DuplicateList = DuplicateButtons.join("\n");
         QMessageBox::information(
             this, tr("Unable to Save"),
             QString(tr("Cannot bind any unique input more than once. "
                        "Duplicate inputs mapped to the following buttons:\n\n%1")
-                        .arg(DuplicateList)));
+                        .arg(duplicatesList.join("\n"))));
         return;
     }
 


### PR DESCRIPTION
The KBM GUI does not allow the same unique input to be used for multiple outputs (this breaks the input engine). However, currently it does not show which particular inputs have duplicate mappings so the user may have a difficult time trying to find them.

This PR, upon detecting duplicate inputs, gets the button names and duplicate input strings and displays them in the corresponding error message:

Also removes a duplicated entry in the buttons QList

PR:
![image](https://github.com/user-attachments/assets/3a5a7cec-d473-4993-8fce-237f7f15a275)

Main:
![image](https://github.com/user-attachments/assets/64819b12-1e84-4d5a-8388-7269bda46f18)
