### PR TITLE
Filesystem: Fixes for posix_rename and write

### DIFF
--- a/src/common/io_file.h
+++ b/src/common/io_file.h
@@ -186,7 +186,9 @@ public:
 
     template <typename T>
     size_t WriteRaw(const void* data, size_t size) const {
-        return std::fwrite(data, sizeof(T), size, file);
+        auto bytes = std::fwrite(data, sizeof(T), size, file);
+        std::fflush(file);
+        return bytes;
     }
 
     template <typename T>

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -294,18 +294,9 @@ s64 PS4_SYSV_ABI write(s32 fd, const void* buf, size_t nbytes) {
         return result;
     }
 
-    // Due to a quirk with std::fwrite
-    // we need to validate the returned bytes, and make sure the file size is correct.
-    auto expected_file_size = file->f.GetSize();
     auto bytes_written = file->f.WriteRaw<u8>(buf, nbytes);
-    expected_file_size += bytes_written;
-    auto actual_file_size = file->f.GetSize();
-    if (expected_file_size != actual_file_size) {
-        LOG_WARNING(Kernel_Fs,
-                    "Unexpected behavior from fwrite. Expected size {:#x}, actual size {:#x}",
-                    expected_file_size, actual_file_size);
-        file->f.SetSize(expected_file_size);
-    }
+    // Some written data might be buffered, run Flush to make sure all data is written properly.
+    file->f.Flush();
     return bytes_written;
 }
 

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -294,10 +294,7 @@ s64 PS4_SYSV_ABI write(s32 fd, const void* buf, size_t nbytes) {
         return result;
     }
 
-    auto bytes_written = file->f.WriteRaw<u8>(buf, nbytes);
-    // Some written data might be buffered, run Flush to make sure all data is written properly.
-    file->f.Flush();
-    return bytes_written;
+    return file->f.WriteRaw<u8>(buf, nbytes);
 }
 
 s64 PS4_SYSV_ABI posix_write(s32 fd, const void* buf, size_t nbytes) {

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -751,6 +751,7 @@ s32 PS4_SYSV_ABI posix_rename(const char* from, const char* to) {
         return -1;
     }
     std::filesystem::copy(src_path, dst_path, std::filesystem::copy_options::overwrite_existing);
+    std::filesystem::remove(src_path);
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -293,7 +293,12 @@ s64 PS4_SYSV_ABI write(s32 fd, const void* buf, size_t nbytes) {
         }
         return result;
     }
-    return file->f.WriteRaw<u8>(buf, nbytes);
+    auto written_bytes = file->f.WriteRaw<u8>(buf, nbytes);
+    auto file_size = file->f.GetSize();
+    if (file_size != written_bytes) {
+        file->f.SetSize(written_bytes);
+    }
+    return written_bytes;
 }
 
 s64 PS4_SYSV_ABI posix_write(s32 fd, const void* buf, size_t nbytes) {

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -293,9 +293,10 @@ s64 PS4_SYSV_ABI write(s32 fd, const void* buf, size_t nbytes) {
         }
         return result;
     }
+    auto file_size_before = file->f.GetSize();
     auto written_bytes = file->f.WriteRaw<u8>(buf, nbytes);
     auto file_size = file->f.GetSize();
-    if (file_size != written_bytes) {
+    if (file_size != file_size_before + written_bytes) {
         file->f.SetSize(written_bytes);
     }
     return written_bytes;


### PR DESCRIPTION
On some platforms, `WriteRaw` doesn't write all the data to the file immediately, resulting in `write` returning more bytes than what we actually wrote to the file stream. To fix this, I've added an `std::fflush` call to `WriteRaw`, which ensures all buffered data is written before the function call returns.

Additionally, our `posix_rename` function was only copying files, instead of renaming this. On closer inspection, it seems like this was done to prevent "shared access" errors on Windows devices, which could occur if the file to rename was already open. To work around this, I've added code to close the source file, delete it, then open the "renamed" copy. 

These two fixes solve the savedata errors in DRAGON BALL XENOVERSE (CUSA01341) and DRAGON BALL XENOVERSE 2 (CUSA05350).