### PR TITLE
Fix shared memory definition when only one type is used

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_shared_memory.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_shared_memory.cpp
@@ -14,8 +14,10 @@ Id EmitLoadSharedU16(EmitContext& ctx, Id offset) {
     const u32 num_elements{Common::DivCeil(ctx.runtime_info.cs_info.shared_memory_size, 2u)};
 
     return AccessBoundsCheck<16>(ctx, index, ctx.ConstU32(num_elements), [&] {
-        const Id pointer =
-            ctx.OpAccessChain(ctx.shared_u16, ctx.shared_memory_u16, ctx.u32_zero_value, index);
+        const Id pointer = std::popcount(static_cast<u32>(ctx.info.shared_types)) > 1
+                               ? ctx.OpAccessChain(ctx.shared_u16, ctx.shared_memory_u16,
+                                                   ctx.u32_zero_value, index)
+                               : ctx.OpAccessChain(ctx.shared_u16, ctx.shared_memory_u16, index);
         return ctx.OpLoad(ctx.U16, pointer);
     });
 }
@@ -26,8 +28,10 @@ Id EmitLoadSharedU32(EmitContext& ctx, Id offset) {
     const u32 num_elements{Common::DivCeil(ctx.runtime_info.cs_info.shared_memory_size, 4u)};
 
     return AccessBoundsCheck<32>(ctx, index, ctx.ConstU32(num_elements), [&] {
-        const Id pointer =
-            ctx.OpAccessChain(ctx.shared_u32, ctx.shared_memory_u32, ctx.u32_zero_value, index);
+        const Id pointer = std::popcount(static_cast<u32>(ctx.info.shared_types)) > 1
+                               ? ctx.OpAccessChain(ctx.shared_u32, ctx.shared_memory_u32,
+                                                   ctx.u32_zero_value, index)
+                               : ctx.OpAccessChain(ctx.shared_u32, ctx.shared_memory_u32, index);
         return ctx.OpLoad(ctx.U32[1], pointer);
     });
 }
@@ -38,8 +42,10 @@ Id EmitLoadSharedU64(EmitContext& ctx, Id offset) {
     const u32 num_elements{Common::DivCeil(ctx.runtime_info.cs_info.shared_memory_size, 8u)};
 
     return AccessBoundsCheck<64>(ctx, index, ctx.ConstU32(num_elements), [&] {
-        const Id pointer{
-            ctx.OpAccessChain(ctx.shared_u64, ctx.shared_memory_u64, ctx.u32_zero_value, index)};
+        const Id pointer = std::popcount(static_cast<u32>(ctx.info.shared_types)) > 1
+                               ? ctx.OpAccessChain(ctx.shared_u64, ctx.shared_memory_u64,
+                                                   ctx.u32_zero_value, index)
+                               : ctx.OpAccessChain(ctx.shared_u64, ctx.shared_memory_u64, index);
         return ctx.OpLoad(ctx.U64, pointer);
     });
 }
@@ -50,8 +56,10 @@ void EmitWriteSharedU16(EmitContext& ctx, Id offset, Id value) {
     const u32 num_elements{Common::DivCeil(ctx.runtime_info.cs_info.shared_memory_size, 2u)};
 
     AccessBoundsCheck<16>(ctx, index, ctx.ConstU32(num_elements), [&] {
-        const Id pointer =
-            ctx.OpAccessChain(ctx.shared_u16, ctx.shared_memory_u16, ctx.u32_zero_value, index);
+        const Id pointer = std::popcount(static_cast<u32>(ctx.info.shared_types)) > 1
+                               ? ctx.OpAccessChain(ctx.shared_u16, ctx.shared_memory_u16,
+                                                   ctx.u32_zero_value, index)
+                               : ctx.OpAccessChain(ctx.shared_u16, ctx.shared_memory_u16, index);
         ctx.OpStore(pointer, value);
         return Id{0};
     });
@@ -63,8 +71,10 @@ void EmitWriteSharedU32(EmitContext& ctx, Id offset, Id value) {
     const u32 num_elements{Common::DivCeil(ctx.runtime_info.cs_info.shared_memory_size, 4u)};
 
     AccessBoundsCheck<32>(ctx, index, ctx.ConstU32(num_elements), [&] {
-        const Id pointer =
-            ctx.OpAccessChain(ctx.shared_u32, ctx.shared_memory_u32, ctx.u32_zero_value, index);
+        const Id pointer = std::popcount(static_cast<u32>(ctx.info.shared_types)) > 1
+                               ? ctx.OpAccessChain(ctx.shared_u32, ctx.shared_memory_u32,
+                                                   ctx.u32_zero_value, index)
+                               : ctx.OpAccessChain(ctx.shared_u32, ctx.shared_memory_u32, index);
         ctx.OpStore(pointer, value);
         return Id{0};
     });
@@ -76,8 +86,10 @@ void EmitWriteSharedU64(EmitContext& ctx, Id offset, Id value) {
     const u32 num_elements{Common::DivCeil(ctx.runtime_info.cs_info.shared_memory_size, 8u)};
 
     AccessBoundsCheck<64>(ctx, index, ctx.ConstU32(num_elements), [&] {
-        const Id pointer{
-            ctx.OpAccessChain(ctx.shared_u64, ctx.shared_memory_u64, ctx.u32_zero_value, index)};
+        const Id pointer = std::popcount(static_cast<u32>(ctx.info.shared_types)) > 1
+                               ? ctx.OpAccessChain(ctx.shared_u64, ctx.shared_memory_u64,
+                                                   ctx.u32_zero_value, index)
+                               : ctx.OpAccessChain(ctx.shared_u64, ctx.shared_memory_u64, index);
         ctx.OpStore(pointer, value);
         return Id{0};
     });


### PR DESCRIPTION
Fixes the validation error
```
[Render.Vulkan] <Error> vk_platform.cpp:56 DebugUtilsCallback: VUID-StandaloneSpirv-None-10684: vkCreateShaderModule(): pCreateInfo->pCode (spirv-val produced an error):
Invalid explicit layout decorations on type for operand '55[%55]'
  %shared_mem_u64 = OpVariable %_ptr_Workgroup__struct_54 Workgroup
The Vulkan spec states: All variables must have valid explicit layout decorations as described in Shader Interfaces (https://docs.vulkan.org/spec/latest/appendices/spirvenv.html#VUID-StandaloneSpirv-None-10684)
```
by removing the struct indirection in shared memory definition if only one shared memory type is used. If explicit memory layout is not declared in the shader, Workgroup cannot be used on structs