### PR TITLE
Enable sampleRateShading

### DIFF
--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -355,6 +355,7 @@ bool Instance::CreateDevice() {
                 .independentBlend = features.independentBlend,
                 .geometryShader = features.geometryShader,
                 .tessellationShader = features.tessellationShader,
+                .sampleRateShading = features.sampleRateShading,
                 .dualSrcBlend = features.dualSrcBlend,
                 .logicOp = features.logicOp,
                 .multiDrawIndirect = features.multiDrawIndirect,


### PR DESCRIPTION
Fixes validation error introduced by https://github.com/shadps4-emu/shadPS4/pull/3103
```
[Render.Vulkan] <Error> vk_platform.cpp:56 DebugUtilsCallback: VUID-VkShaderModuleCreateInfo-pCode-08740: vkCreateShaderModule(): SPIR-V Capability SampleRateShading was declared, but one of the following requirements is required (VkPhysicalDeviceFeatures::sampleRateShading).
The Vulkan spec states: If pCode is a pointer to SPIR-V code, and pCode declares any of the capabilities listed in the SPIR-V Environment appendix, one of the corresponding requirements must be satisfied (https://docs.vulkan.org/spec/latest/chapters/shaders.html#VUID-VkShaderModuleCreateInfo-pCode-08740)
```