### PR TITLE
shader_recompiler: Fix some shared memory accesses when workgroup struct is omitted.

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_atomic.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_atomic.cpp
@@ -19,8 +19,7 @@ Id SharedAtomicU32(EmitContext& ctx, Id offset, Id value,
     const Id shift_id{ctx.ConstU32(2U)};
     const Id index{ctx.OpShiftRightLogical(ctx.U32[1], offset, shift_id)};
     const u32 num_elements{Common::DivCeil(ctx.runtime_info.cs_info.shared_memory_size, 4u)};
-    const Id pointer{
-        ctx.OpAccessChain(ctx.shared_u32, ctx.shared_memory_u32, ctx.u32_zero_value, index)};
+    const Id pointer{ctx.EmitSharedMemoryAccess(ctx.shared_u32, ctx.shared_memory_u32, index)};
     const auto [scope, semantics]{AtomicArgs(ctx)};
     return AccessBoundsCheck<32>(ctx, index, ctx.ConstU32(num_elements), [&] {
         return (ctx.*atomic_func)(ctx.U32[1], pointer, scope, semantics, value);
@@ -32,8 +31,7 @@ Id SharedAtomicU32IncDec(EmitContext& ctx, Id offset,
     const Id shift_id{ctx.ConstU32(2U)};
     const Id index{ctx.OpShiftRightLogical(ctx.U32[1], offset, shift_id)};
     const u32 num_elements{Common::DivCeil(ctx.runtime_info.cs_info.shared_memory_size, 4u)};
-    const Id pointer{
-        ctx.OpAccessChain(ctx.shared_u32, ctx.shared_memory_u32, ctx.u32_zero_value, index)};
+    const Id pointer{ctx.EmitSharedMemoryAccess(ctx.shared_u32, ctx.shared_memory_u32, index)};
     const auto [scope, semantics]{AtomicArgs(ctx)};
     return AccessBoundsCheck<32>(ctx, index, ctx.ConstU32(num_elements), [&] {
         return (ctx.*atomic_func)(ctx.U32[1], pointer, scope, semantics);
@@ -45,8 +43,7 @@ Id SharedAtomicU64(EmitContext& ctx, Id offset, Id value,
     const Id shift_id{ctx.ConstU32(3U)};
     const Id index{ctx.OpShiftRightLogical(ctx.U32[1], offset, shift_id)};
     const u32 num_elements{Common::DivCeil(ctx.runtime_info.cs_info.shared_memory_size, 8u)};
-    const Id pointer{
-        ctx.OpAccessChain(ctx.shared_u64, ctx.shared_memory_u64, ctx.u32_zero_value, index)};
+    const Id pointer{ctx.EmitSharedMemoryAccess(ctx.shared_u64, ctx.shared_memory_u64, index)};
     const auto [scope, semantics]{AtomicArgs(ctx)};
     return AccessBoundsCheck<64>(ctx, index, ctx.ConstU32(num_elements), [&] {
         return (ctx.*atomic_func)(ctx.U64, pointer, scope, semantics, value);

--- a/src/shader_recompiler/backend/spirv/emit_spirv_shared_memory.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_shared_memory.cpp
@@ -14,10 +14,7 @@ Id EmitLoadSharedU16(EmitContext& ctx, Id offset) {
     const u32 num_elements{Common::DivCeil(ctx.runtime_info.cs_info.shared_memory_size, 2u)};
 
     return AccessBoundsCheck<16>(ctx, index, ctx.ConstU32(num_elements), [&] {
-        const Id pointer = std::popcount(static_cast<u32>(ctx.info.shared_types)) > 1
-                               ? ctx.OpAccessChain(ctx.shared_u16, ctx.shared_memory_u16,
-                                                   ctx.u32_zero_value, index)
-                               : ctx.OpAccessChain(ctx.shared_u16, ctx.shared_memory_u16, index);
+        const Id pointer = ctx.EmitSharedMemoryAccess(ctx.shared_u16, ctx.shared_memory_u16, index);
         return ctx.OpLoad(ctx.U16, pointer);
     });
 }
@@ -28,10 +25,7 @@ Id EmitLoadSharedU32(EmitContext& ctx, Id offset) {
     const u32 num_elements{Common::DivCeil(ctx.runtime_info.cs_info.shared_memory_size, 4u)};
 
     return AccessBoundsCheck<32>(ctx, index, ctx.ConstU32(num_elements), [&] {
-        const Id pointer = std::popcount(static_cast<u32>(ctx.info.shared_types)) > 1
-                               ? ctx.OpAccessChain(ctx.shared_u32, ctx.shared_memory_u32,
-                                                   ctx.u32_zero_value, index)
-                               : ctx.OpAccessChain(ctx.shared_u32, ctx.shared_memory_u32, index);
+        const Id pointer = ctx.EmitSharedMemoryAccess(ctx.shared_u32, ctx.shared_memory_u32, index);
         return ctx.OpLoad(ctx.U32[1], pointer);
     });
 }
@@ -42,10 +36,7 @@ Id EmitLoadSharedU64(EmitContext& ctx, Id offset) {
     const u32 num_elements{Common::DivCeil(ctx.runtime_info.cs_info.shared_memory_size, 8u)};
 
     return AccessBoundsCheck<64>(ctx, index, ctx.ConstU32(num_elements), [&] {
-        const Id pointer = std::popcount(static_cast<u32>(ctx.info.shared_types)) > 1
-                               ? ctx.OpAccessChain(ctx.shared_u64, ctx.shared_memory_u64,
-                                                   ctx.u32_zero_value, index)
-                               : ctx.OpAccessChain(ctx.shared_u64, ctx.shared_memory_u64, index);
+        const Id pointer = ctx.EmitSharedMemoryAccess(ctx.shared_u64, ctx.shared_memory_u64, index);
         return ctx.OpLoad(ctx.U64, pointer);
     });
 }
@@ -56,10 +47,7 @@ void EmitWriteSharedU16(EmitContext& ctx, Id offset, Id value) {
     const u32 num_elements{Common::DivCeil(ctx.runtime_info.cs_info.shared_memory_size, 2u)};
 
     AccessBoundsCheck<16>(ctx, index, ctx.ConstU32(num_elements), [&] {
-        const Id pointer = std::popcount(static_cast<u32>(ctx.info.shared_types)) > 1
-                               ? ctx.OpAccessChain(ctx.shared_u16, ctx.shared_memory_u16,
-                                                   ctx.u32_zero_value, index)
-                               : ctx.OpAccessChain(ctx.shared_u16, ctx.shared_memory_u16, index);
+        const Id pointer = ctx.EmitSharedMemoryAccess(ctx.shared_u16, ctx.shared_memory_u16, index);
         ctx.OpStore(pointer, value);
         return Id{0};
     });
@@ -71,10 +59,7 @@ void EmitWriteSharedU32(EmitContext& ctx, Id offset, Id value) {
     const u32 num_elements{Common::DivCeil(ctx.runtime_info.cs_info.shared_memory_size, 4u)};
 
     AccessBoundsCheck<32>(ctx, index, ctx.ConstU32(num_elements), [&] {
-        const Id pointer = std::popcount(static_cast<u32>(ctx.info.shared_types)) > 1
-                               ? ctx.OpAccessChain(ctx.shared_u32, ctx.shared_memory_u32,
-                                                   ctx.u32_zero_value, index)
-                               : ctx.OpAccessChain(ctx.shared_u32, ctx.shared_memory_u32, index);
+        const Id pointer = ctx.EmitSharedMemoryAccess(ctx.shared_u32, ctx.shared_memory_u32, index);
         ctx.OpStore(pointer, value);
         return Id{0};
     });
@@ -86,10 +71,7 @@ void EmitWriteSharedU64(EmitContext& ctx, Id offset, Id value) {
     const u32 num_elements{Common::DivCeil(ctx.runtime_info.cs_info.shared_memory_size, 8u)};
 
     AccessBoundsCheck<64>(ctx, index, ctx.ConstU32(num_elements), [&] {
-        const Id pointer = std::popcount(static_cast<u32>(ctx.info.shared_types)) > 1
-                               ? ctx.OpAccessChain(ctx.shared_u64, ctx.shared_memory_u64,
-                                                   ctx.u32_zero_value, index)
-                               : ctx.OpAccessChain(ctx.shared_u64, ctx.shared_memory_u64, index);
+        const Id pointer = ctx.EmitSharedMemoryAccess(ctx.shared_u64, ctx.shared_memory_u64, index);
         ctx.OpStore(pointer, value);
         return Id{0};
     });

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -203,6 +203,14 @@ public:
         return final_result;
     }
 
+    Id EmitSharedMemoryAccess(const Id result_type, const Id shared_mem, const Id index) {
+        if (std::popcount(static_cast<u32>(info.shared_types)) > 1) {
+            return OpAccessChain(result_type, shared_mem, u32_zero_value, index);
+        }
+        // Workgroup layout struct omitted.
+        return OpAccessChain(result_type, shared_mem, index);
+    }
+
     Info& info;
     const RuntimeInfo& runtime_info;
     const Profile& profile;


### PR DESCRIPTION
Fix-up on https://github.com/shadps4-emu/shadPS4/pull/3106:
* Some places were missed for updating the shared memory access chains.
* Consolidated shared access emit into one helper function to reduce duplication.