### PR TITLE
Core: Memory fixes <insert big Roman numeral here>

### DIFF
--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -194,6 +194,10 @@ int PS4_SYSV_ABI sceKernelMapNamedDirectMemory(void** addr, u64 len, int prot, i
     const auto map_flags = static_cast<Core::MemoryMapFlags>(flags);
 
     auto* memory = Core::Memory::Instance();
+    if (memory->GetTotalDirectSize() < len) {
+        LOG_ERROR(Kernel_Vmm, "Length is too big!");
+        return ORBIS_KERNEL_ERROR_ENOMEM;
+    }
     const auto ret =
         memory->MapMemory(addr, in_addr, len, mem_prot, map_flags, Core::VMAType::Direct, name,
                           false, directMemoryStart, alignment);


### PR DESCRIPTION
Return ENOMEM if len exceeds the available space in sceKernelMapNamedDirectMemory.

This is based on a hardware test, courtesy of a plugin by @StevenMiller123. It fixes a discrepancy found in Driveclub if you use the CLI flag `-increasedrenderplus`, and with this PR, the console and the emulator now crash at the same place.

Klog:
```
<118>(../dmem/source/main.c:49) sceKernelMapDirectMemory called, in_addr = 2000000000, len = fffffffff8a00000, flags = 0, phys_addr = 0, align = 200000
<118>(../dmem/source/main.c:51) sceKernelMapDirectMemory called, out_addr = 2000000000, result = 8002000c
```