### PR TITLE
ci: Work around Qt issue on new Xcode.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,7 +224,10 @@ jobs:
         arch: clang_64
         archives: qtbase qttools
         modules: qtmultimedia
-        
+
+    - name: Workaround Qt <=6.9.1 issue
+      run: sed -i '' '/target_link_libraries(WrapOpenGL::WrapOpenGL INTERFACE ${__opengl_agl_fw_path})/d' ${{env.QT_ROOT_DIR}}/lib/cmake/Qt6/FindWrapOpenGL.cmake
+
     - name: Cache CMake Configuration
       uses: actions/cache@v4 
       env: 


### PR DESCRIPTION
Qt links to a legacy framework, that was removed from the latest Xcode, which it doesn't even use. This issue is fixed for Qt 6.9.2/6.10.0beta2, but until that is released we can work around it by removing the linkage from a CMake file.

Validated in a CI run using the new actions image version: https://github.com/squidbus/shadPS4/actions/runs/15744066321/job/44376325415