### PR TITLE
Silence unmapped keybind mappings and add XBox paddles

### DIFF
--- a/src/input/input_handler.h
+++ b/src/input/input_handler.h
@@ -32,6 +32,8 @@
 
 #define KEY_TOGGLE 0x00200000
 
+#define SDL_UNMAPPED UINT32_MAX - 1
+
 namespace Input {
 using Input::Axis;
 using Libraries::Pad::OrbisPadButtonDataOffset;
@@ -102,6 +104,10 @@ const std::map<std::string, u32> string_to_cbutton_map = {
 
     // this is only for input
     {"back", SDL_GAMEPAD_BUTTON_BACK},
+    {"lpaddle_high", SDL_GAMEPAD_BUTTON_LEFT_PADDLE1},
+    {"lpaddle_low", SDL_GAMEPAD_BUTTON_LEFT_PADDLE2},
+    {"rpaddle_high", SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1},
+    {"rpaddle_low", SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2},
 };
 
 const std::map<std::string, AxisMapping> string_to_axis_map = {
@@ -225,6 +231,7 @@ const std::map<std::string, u32> string_to_keyboard_key_map = {
     {"kpenter", SDLK_KP_ENTER},
     {"kpequals", SDLK_KP_EQUALS},
     {"capslock", SDLK_CAPSLOCK},
+    {"unmapped", SDL_UNMAPPED},
 };
 
 void ParseInputConfig(const std::string game_id);

--- a/src/qt_gui/kbm_help_dialog.h
+++ b/src/qt_gui/kbm_help_dialog.h
@@ -129,8 +129,10 @@ Controller:
     If you have a controller that has different names for buttons, it will still work, just look up what are the equivalent names for that controller
     The same left-right rule still applies here.
     Buttons:
-        'triangle', 'circle', 'cross', 'square', 'l1', 'l3',
-        'options', touchpad', 'up', 'down', 'left', 'right'
+            'triangle', 'circle', 'cross', 'square', 'l1', 'l3',
+            'options', touchpad', 'up', 'down', 'left', 'right'
+        Input-only:
+            'lpaddle_low', 'lpaddle_high'
     Axes if you bind them to a button input:
         'axis_left_x_plus', 'axis_left_x_minus', 'axis_left_y_plus', 'axis_left_y_minus',
         'axis_right_x_plus', ..., 'axis_right_y_minus',


### PR DESCRIPTION
Removes the invalid mapping warning from the log by defining "unmapped" as an unused SDL ID, and adds Xbox paddles as another thing that can be rebound natively, which was a user request from a few weeks ago, but the guy who asked for it couldn't figure out how Github works and never ended up trying it out and I haven't heard from them since