### PR TITLE
Emulate motion controls with a mouse

### DIFF
--- a/src/core/libraries/pad/pad.cpp
+++ b/src/core/libraries/pad/pad.cpp
@@ -447,21 +447,18 @@ int PS4_SYSV_ABI scePadReadState(s32 handle, OrbisPadData* pData) {
 
     // Only do this on handle 1 for now
     if (engine && handle == 1) {
-        const auto gyro_poll_rate = engine->GetAccelPollRate();
-        if (gyro_poll_rate != 0.0f) {
             auto now = std::chrono::steady_clock::now();
-            float deltaTime = std::chrono::duration_cast<std::chrono::microseconds>(
-                                  now - controller->GetLastUpdate())
+        float deltaTime =
+            std::chrono::duration_cast<std::chrono::microseconds>(now - controller->GetLastUpdate())
                                   .count() /
                               1000000.0f;
             controller->SetLastUpdate(now);
             Libraries::Pad::OrbisFQuaternion lastOrientation = controller->GetLastOrientation();
             Libraries::Pad::OrbisFQuaternion outputOrientation = {0.0f, 0.0f, 0.0f, 1.0f};
-            GameController::CalculateOrientation(pData->acceleration, pData->angularVelocity,
-                                                 deltaTime, lastOrientation, outputOrientation);
+        GameController::CalculateOrientation(pData->acceleration, pData->angularVelocity, deltaTime,
+                                             lastOrientation, outputOrientation);
             pData->orientation = outputOrientation;
             controller->SetLastOrientation(outputOrientation);
-        }
     }
     pData->touchData.touchNum =
         (state.touchpad[0].state ? 1 : 0) + (state.touchpad[1].state ? 1 : 0);

--- a/src/core/libraries/pad/pad.cpp
+++ b/src/core/libraries/pad/pad.cpp
@@ -447,18 +447,18 @@ int PS4_SYSV_ABI scePadReadState(s32 handle, OrbisPadData* pData) {
 
     // Only do this on handle 1 for now
     if (engine && handle == 1) {
-            auto now = std::chrono::steady_clock::now();
+        auto now = std::chrono::steady_clock::now();
         float deltaTime =
             std::chrono::duration_cast<std::chrono::microseconds>(now - controller->GetLastUpdate())
-                                  .count() /
-                              1000000.0f;
-            controller->SetLastUpdate(now);
-            Libraries::Pad::OrbisFQuaternion lastOrientation = controller->GetLastOrientation();
-            Libraries::Pad::OrbisFQuaternion outputOrientation = {0.0f, 0.0f, 0.0f, 1.0f};
+                .count() /
+            1000000.0f;
+        controller->SetLastUpdate(now);
+        Libraries::Pad::OrbisFQuaternion lastOrientation = controller->GetLastOrientation();
+        Libraries::Pad::OrbisFQuaternion outputOrientation = {0.0f, 0.0f, 0.0f, 1.0f};
         GameController::CalculateOrientation(pData->acceleration, pData->angularVelocity, deltaTime,
                                              lastOrientation, outputOrientation);
-            pData->orientation = outputOrientation;
-            controller->SetLastOrientation(outputOrientation);
+        pData->orientation = outputOrientation;
+        controller->SetLastOrientation(outputOrientation);
     }
     pData->touchData.touchNum =
         (state.touchpad[0].state ? 1 : 0) + (state.touchpad[1].state ? 1 : 0);

--- a/src/input/input_handler.cpp
+++ b/src/input/input_handler.cpp
@@ -66,6 +66,7 @@ auto output_array = std::array{
     ControllerOutput(LEFTJOYSTICK_HALFMODE),
     ControllerOutput(RIGHTJOYSTICK_HALFMODE),
     ControllerOutput(KEY_TOGGLE),
+    ControllerOutput(MOUSE_GYRO_ROLL_MODE),
 
     // Button mappings
     ControllerOutput(SDL_GAMEPAD_BUTTON_NORTH),           // Triangle
@@ -534,6 +535,9 @@ void ControllerOutput::FinalizeUpdate() {
         // to do it, and it would be inconvenient to force it here, when AddUpdate does the job just
         // fine, and a toggle doesn't have to checked against every input that's bound to it, it's
         // enough that one is pressed
+        case MOUSE_GYRO_ROLL_MODE:
+            SetMouseGyroRollMode(new_button_state);
+            break;
         default: // is a normal key (hopefully)
             controller->CheckButton(0, SDLGamepadToOrbisButton(button), new_button_state);
             break;

--- a/src/input/input_handler.h
+++ b/src/input/input_handler.h
@@ -35,6 +35,7 @@
 #define BACK_BUTTON 0x00040000
 
 #define KEY_TOGGLE 0x00200000
+#define MOUSE_GYRO_ROLL_MODE 0x00400000
 
 #define SDL_UNMAPPED UINT32_MAX - 1
 
@@ -114,6 +115,7 @@ const std::map<std::string, u32> string_to_cbutton_map = {
     {"lpaddle_low", SDL_GAMEPAD_BUTTON_LEFT_PADDLE2},
     {"rpaddle_high", SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1},
     {"rpaddle_low", SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2},
+    {"mouse_gyro_roll_mode", MOUSE_GYRO_ROLL_MODE},
 };
 
 const std::map<std::string, AxisMapping> string_to_axis_map = {

--- a/src/input/input_mouse.cpp
+++ b/src/input/input_mouse.cpp
@@ -73,8 +73,14 @@ void EmulateJoystick(GameController* controller, u32 interval) {
     }
 }
 
+constexpr float constant_down_accel[3] = {0.0f, 10.0f, 0.0f};
 void EmulateGyro(GameController* controller, u32 interval) {
-    LOG_INFO(Input, "todo gyro");
+    // LOG_INFO(Input, "todo gyro");
+    float d_x = 0, d_y = 0;
+    SDL_GetRelativeMouseState(&d_x, &d_y);
+    controller->Acceleration(1, constant_down_accel);
+    float gyro_from_mouse[3] = {-d_y / 100, -d_x / 100, 0.0f};
+    controller->Gyro(1, gyro_from_mouse);
 }
 
 Uint32 MousePolling(void* param, Uint32 id, Uint32 interval) {

--- a/src/input/input_mouse.cpp
+++ b/src/input/input_mouse.cpp
@@ -3,8 +3,8 @@
 
 #include <cmath>
 
-#include "common/types.h"
 #include "common/assert.h"
+#include "common/types.h"
 #include "input/controller.h"
 #include "input_mouse.h"
 
@@ -20,7 +20,7 @@ MouseMode mouse_mode = MouseMode::Off;
 // Switches mouse to a set mode or turns mouse emulation off if it was already in that mode.
 // Returns whether the mode is turned on.
 bool ToggleMouseModeTo(MouseMode m) {
-    if(mouse_mode == m) {
+    if (mouse_mode == m) {
         mouse_mode = MouseMode::Off;
     } else {
         mouse_mode = m;
@@ -85,15 +85,14 @@ void EmulateGyro(GameController* controller, u32 interval) {
 
 Uint32 MousePolling(void* param, Uint32 id, Uint32 interval) {
     auto* controller = (GameController*)param;
-    switch (mouse_mode)
-    {
+    switch (mouse_mode) {
     case MouseMode::Joystick:
         EmulateJoystick(controller, interval);
         break;
     case MouseMode::Gyro:
         EmulateGyro(controller, interval);
         break;
-    
+
     default:
         break;
     }

--- a/src/input/input_mouse.cpp
+++ b/src/input/input_mouse.cpp
@@ -14,6 +14,7 @@ namespace Input {
 
 int mouse_joystick_binding = 0;
 float mouse_deadzone_offset = 0.5, mouse_speed = 1, mouse_speed_offset = 0.1250;
+bool mouse_gyro_roll_mode = false;
 Uint32 mouse_polling_id = 0;
 MouseMode mouse_mode = MouseMode::Off;
 
@@ -36,6 +37,10 @@ void SetMouseParams(float mdo, float ms, float mso) {
     mouse_deadzone_offset = mdo;
     mouse_speed = ms;
     mouse_speed_offset = mso;
+}
+
+void SetMouseGyroRollMode(bool mode) {
+    mouse_gyro_roll_mode = mode;
 }
 
 void EmulateJoystick(GameController* controller, u32 interval) {
@@ -80,6 +85,10 @@ void EmulateGyro(GameController* controller, u32 interval) {
     SDL_GetRelativeMouseState(&d_x, &d_y);
     controller->Acceleration(1, constant_down_accel);
     float gyro_from_mouse[3] = {-d_y / 100, -d_x / 100, 0.0f};
+    if (mouse_gyro_roll_mode) {
+        gyro_from_mouse[1] = 0.0f;
+        gyro_from_mouse[2] = -d_x / 100;
+    }
     controller->Gyro(1, gyro_from_mouse);
 }
 

--- a/src/input/input_mouse.h
+++ b/src/input/input_mouse.h
@@ -17,6 +17,7 @@ enum MouseMode {
 bool ToggleMouseModeTo(MouseMode m);
 void SetMouseToJoystick(int joystick);
 void SetMouseParams(float mouse_deadzone_offset, float mouse_speed, float mouse_speed_offset);
+void SetMouseGyroRollMode(bool mode);
 
 void EmulateJoystick(GameController* controller, u32 interval);
 void EmulateGyro(GameController* controller, u32 interval);

--- a/src/input/input_mouse.h
+++ b/src/input/input_mouse.h
@@ -8,11 +8,20 @@
 
 namespace Input {
 
-void ToggleMouseEnabled();
+enum MouseMode {
+    Off = 0,
+    Joystick,
+    Gyro,
+};
+
+bool ToggleMouseModeTo(MouseMode m);
 void SetMouseToJoystick(int joystick);
 void SetMouseParams(float mouse_deadzone_offset, float mouse_speed, float mouse_speed_offset);
 
-// Polls the mouse for changes, and simulates joystick movement from it.
+void EmulateJoystick(GameController* controller, u32 interval);
+void EmulateGyro(GameController* controller, u32 interval);
+
+// Polls the mouse for changes
 Uint32 MousePolling(void* param, Uint32 id, Uint32 interval);
 
 } // namespace Input

--- a/src/qt_gui/kbm_help_dialog.h
+++ b/src/qt_gui/kbm_help_dialog.h
@@ -60,7 +60,8 @@ A: -F12: Triggers Renderdoc capture
 -Ctrl F10: Open the debug menu
 -F9: Pauses emultor, if the debug menu is open
 -F8: Reparses the config file while in-game
--F7: Toggles mouse capture and mouse input
+-F7: Toggles mouse-to-joystick emulation
+-F6: Toggles mouse-to-gyro emulation
 
 Q: How do I change between mouse and controller joystick input, and why is it even required?
 A: You can switch between them with F7, and it is required, because mouse input is done with polling, which means mouse movement is checked every frame, and if it didn't move, the code manually sets the emulator's virtual controller to 0 (back to the center), even if other input devices would update it.
@@ -175,6 +176,8 @@ You can find these here, with detailed comments, examples and suggestions for mo
     Values go from 1 to 127 (no deadzone to max deadzone), first is the inner, second is the outer deadzone
     If you only want inner or outer deadzone, set the other to 1 or 127, respectively
     Devices: leftjoystick, rightjoystick, l2, r2
+'mouse_gyro_roll_mode':
+    Controls whether moving the mouse sideways causes a panning or a rolling motion while mouse-to-gyro emulation is active.
 )";
     }
 };

--- a/src/sdl_window.cpp
+++ b/src/sdl_window.cpp
@@ -481,7 +481,7 @@ void WindowSDL::OnKeyboardMouseInput(const SDL_Event* event) {
             return;
         }
         // Toggle mouse capture and gyro input emulation
-        else if (input_id == SDLK_F7) {
+        else if (input_id == SDLK_F6) {
             SDL_SetWindowRelativeMouseMode(this->GetSDLWindow(),
                                            Input::ToggleMouseModeTo(Input::MouseMode::Gyro));
             return;

--- a/src/sdl_window.cpp
+++ b/src/sdl_window.cpp
@@ -474,11 +474,16 @@ void WindowSDL::OnKeyboardMouseInput(const SDL_Event* event) {
             Input::ParseInputConfig(std::string(Common::ElfInfo::Instance().GameSerial()));
             return;
         }
-        // Toggle mouse capture and movement input
+        // Toggle mouse capture and joystick input emulation
         else if (input_id == SDLK_F7) {
-            Input::ToggleMouseEnabled();
             SDL_SetWindowRelativeMouseMode(this->GetSDLWindow(),
-                                           !SDL_GetWindowRelativeMouseMode(this->GetSDLWindow()));
+                                           Input::ToggleMouseModeTo(Input::MouseMode::Joystick));
+            return;
+        }
+        // Toggle mouse capture and gyro input emulation
+        else if (input_id == SDLK_F7) {
+            SDL_SetWindowRelativeMouseMode(this->GetSDLWindow(),
+                                           Input::ToggleMouseModeTo(Input::MouseMode::Gyro));
             return;
         }
         // Toggle fullscreen


### PR DESCRIPTION
Adds the ability to emulate motion control inputs via a mouse. Since a gyroscope is a three-dimensional sensor, while a mouse is only two-dimensional, the full range of controls is achieved by having a (rebindable) toggle key to switch the behaviour of moving the mouse sideways between panning and rolling. While this is active, acceleration is spoofed to a constant downwards direction.

To enable it, press F6. You can also seamlessly switch between joystick and gyro emulation, if you select one while the other is active, it will cleanly switch modes, and if you press the toggle for the currently active mode, it will turn off.

The name for the keybind that switches between panning and rolling is `mouse_gyro_roll_mode`.

This is only the backend code and since this seems to be true for almost every PR I make, I think it will stay that way and I will pass off integrating it into the frontend to someone else.

Since it's using the same setup as joystick emulation, this is also conflicting with gyro data coming from a connected controller the same way joystick data does.

I only tested it with Gravity Rush 2, so further testing is very welcome.