### PR TITLE
Stub out sceKernelSetGPO and sceKernelGetGPI

### DIFF
--- a/src/core/libraries/kernel/kernel.h
+++ b/src/core/libraries/kernel/kernel.h
@@ -12,10 +12,10 @@ class SymbolsResolver;
 
 namespace Libraries::Kernel {
 
-void ErrSceToPosix(int result);
-int ErrnoToSceKernelError(int e);
-void SetPosixErrno(int e);
-int* PS4_SYSV_ABI __Error();
+void ErrSceToPosix(s32 result);
+s32 ErrnoToSceKernelError(s32 e);
+void SetPosixErrno(s32 e);
+s32* PS4_SYSV_ABI __Error();
 
 template <class F, F f>
 struct OrbisWrapperImpl;
@@ -33,7 +33,7 @@ struct OrbisWrapperImpl<PS4_SYSV_ABI R (*)(Args...), f> {
 
 #define ORBIS(func) (Libraries::Kernel::OrbisWrapperImpl<decltype(&(func)), func>::wrap)
 
-int* PS4_SYSV_ABI __Error();
+s32* PS4_SYSV_ABI __Error();
 
 void RegisterKernel(Core::Loader::SymbolsResolver* sym);
 


### PR DESCRIPTION
Stubs out these two functions that are similarly stubbed on real hardware