### PR TITLE
Initialize system handle in HLE Ngs2 library

### DIFF
--- a/src/core/libraries/ngs2/ngs2_impl.cpp
+++ b/src/core/libraries/ngs2/ngs2_impl.cpp
@@ -100,6 +100,11 @@ s32 SystemSetupCore(StackBuffer* stackBuffer, const OrbisNgs2SystemOption* optio
         return ORBIS_NGS2_ERROR_INVALID_SAMPLE_RATE;
     }
 
+    if (outSystem) {
+        // dummy handle
+        outSystem->systemHandle = 1;
+    }
+
     return ORBIS_OK;
 }
 


### PR DESCRIPTION
Allows Gravity Rush Remastered to once again boot without LLE system modules.