### PR TITLE
Fix deprecated localtime warning in savedata dialog

### DIFF
--- a/src/core/libraries/save_data/dialog/savedatadialog_ui.cpp
+++ b/src/core/libraries/save_data/dialog/savedatadialog_ui.cpp
@@ -96,8 +96,14 @@ SaveDialogState::SaveDialogState(const OrbisSaveDataDialogParam& param) {
             param_sfo.Open(param_sfo_path);
 
             auto last_write = param_sfo.GetLastWrite();
+            #ifdef __APPLE__
+            std::string date_str =
+                fmt::format("{:%d %b, %Y %R}",
+                            fmt::localtime(std::chrono::system_clock::to_time_t(last_write)));
+            #else
             auto sys_time = std::chrono::clock_cast<std::chrono::system_clock>(last_write);
             std::string date_str = fmt::format("{:%d %b, %Y %R}", sys_time);
+            #endif
 
             size_t size = Common::FS::GetDirectorySize(dir_path);
             std::string size_str = SpaceSizeToString(size);

--- a/src/core/libraries/save_data/dialog/savedatadialog_ui.cpp
+++ b/src/core/libraries/save_data/dialog/savedatadialog_ui.cpp
@@ -96,14 +96,14 @@ SaveDialogState::SaveDialogState(const OrbisSaveDataDialogParam& param) {
             param_sfo.Open(param_sfo_path);
 
             auto last_write = param_sfo.GetLastWrite();
-            #ifdef __APPLE__
+#ifdef __APPLE__
             std::string date_str =
                 fmt::format("{:%d %b, %Y %R}",
                             fmt::localtime(std::chrono::system_clock::to_time_t(last_write)));
-            #else
+#else
             auto sys_time = std::chrono::clock_cast<std::chrono::system_clock>(last_write);
             std::string date_str = fmt::format("{:%d %b, %Y %R}", sys_time);
-            #endif
+#endif
 
             size_t size = Common::FS::GetDirectorySize(dir_path);
             std::string size_str = SpaceSizeToString(size);

--- a/src/core/libraries/save_data/dialog/savedatadialog_ui.cpp
+++ b/src/core/libraries/save_data/dialog/savedatadialog_ui.cpp
@@ -96,9 +96,8 @@ SaveDialogState::SaveDialogState(const OrbisSaveDataDialogParam& param) {
             param_sfo.Open(param_sfo_path);
 
             auto last_write = param_sfo.GetLastWrite();
-            std::string date_str =
-                fmt::format("{:%d %b, %Y %R}",
-                            fmt::localtime(std::chrono::system_clock::to_time_t(last_write)));
+            auto sys_time = std::chrono::clock_cast<std::chrono::system_clock>(last_write);
+            std::string date_str = fmt::format("{:%d %b, %Y %R}", sys_time);
 
             size_t size = Common::FS::GetDirectorySize(dir_path);
             std::string size_str = SpaceSizeToString(size);


### PR DESCRIPTION
### What
This PR replaces fmt::localtime(std::chrono::system_clock::to_time_t(...)) with direct std::chrono formatting

### Why
It should be possible to compile without deprecation warnings

![image](https://github.com/user-attachments/assets/ed8d2708-010c-431b-81e6-2dd5d0a0e574)

### How
The change is purely technical (no functionality change)

- Output format remains identical (%d %b, %Y %R)
- Uses more modern C++ best practices
- Requires C++17 (but project already uses it)

Further improvements; This fixes Windows and Linux builds, MacOS is still built the old way.