### PR TITLE
shader_recompiler: Fix handling unbound depth image.

### DIFF
--- a/src/shader_recompiler/info.h
+++ b/src/shader_recompiler/info.h
@@ -308,17 +308,17 @@ constexpr AmdGpu::Image ImageResource::GetSharp(const Info& info) const noexcept
     if (!is_r128) {
         image = info.ReadUdSharp<AmdGpu::Image>(sharp_idx);
     } else {
-        AmdGpu::Buffer buf = info.ReadUdSharp<AmdGpu::Buffer>(sharp_idx);
+        const auto buf = info.ReadUdSharp<AmdGpu::Buffer>(sharp_idx);
         memcpy(&image, &buf, sizeof(buf));
     }
     if (!image.Valid()) {
         // Fall back to null image if unbound.
-        return AmdGpu::Image::Null();
-    }
-    const auto data_fmt = image.GetDataFmt();
-    if (is_depth && data_fmt != AmdGpu::DataFormat::Format16 &&
-        data_fmt != AmdGpu::DataFormat::Format32) {
-        return AmdGpu::Image::NullDepth();
+        image = is_depth ? AmdGpu::Image::NullDepth() : AmdGpu::Image::Null();
+    } else if (is_depth) {
+        const auto data_fmt = image.GetDataFmt();
+        if (data_fmt != AmdGpu::DataFormat::Format16 && data_fmt != AmdGpu::DataFormat::Format32) {
+            image = AmdGpu::Image::NullDepth();
+        }
     }
     return image;
 }

--- a/src/shader_recompiler/info.h
+++ b/src/shader_recompiler/info.h
@@ -313,10 +313,12 @@ constexpr AmdGpu::Image ImageResource::GetSharp(const Info& info) const noexcept
     }
     if (!image.Valid()) {
         // Fall back to null image if unbound.
+        LOG_DEBUG(Render_Vulkan, "Encountered unbound image!");
         image = is_depth ? AmdGpu::Image::NullDepth() : AmdGpu::Image::Null();
     } else if (is_depth) {
         const auto data_fmt = image.GetDataFmt();
         if (data_fmt != AmdGpu::DataFormat::Format16 && data_fmt != AmdGpu::DataFormat::Format32) {
+            LOG_DEBUG(Render_Vulkan, "Encountered non-depth image used with depth instruction!");
             image = AmdGpu::Image::NullDepth();
         }
     }

--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -369,13 +369,14 @@ void PatchImageSharp(IR::Block& block, IR::Inst& inst, Info& info, Descriptors& 
     auto image = info.ReadUdSharp<AmdGpu::Image>(tsharp);
     if (!image.Valid()) {
         LOG_ERROR(Render_Vulkan, "Shader compiled with unbound image!");
-        image = AmdGpu::Image::Null();
-    }
-    const auto data_fmt = image.GetDataFmt();
-    if (inst_info.is_depth && data_fmt != AmdGpu::DataFormat::Format16 &&
-        data_fmt != AmdGpu::DataFormat::Format32) {
-        LOG_ERROR(Render_Vulkan, "Shader compiled using non-depth image with depth instruction!");
-        image = AmdGpu::Image::NullDepth();
+        image = inst_info.is_depth ? AmdGpu::Image::NullDepth() : AmdGpu::Image::Null();
+    } else if (inst_info.is_depth) {
+        const auto data_fmt = image.GetDataFmt();
+        if (data_fmt != AmdGpu::DataFormat::Format16 && data_fmt != AmdGpu::DataFormat::Format32) {
+            LOG_ERROR(Render_Vulkan,
+                      "Shader compiled using non-depth image with depth instruction!");
+            image = AmdGpu::Image::NullDepth();
+        }
     }
     ASSERT(image.GetType() != AmdGpu::ImageType::Invalid);
     const bool is_written = inst.GetOpcode() == IR::Opcode::ImageWrite;

--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -366,20 +366,17 @@ void PatchImageSharp(IR::Block& block, IR::Inst& inst, Info& info, Descriptors& 
     // Read image sharp.
     const auto tsharp = TrackSharp(tsharp_handle, info);
     const auto inst_info = inst.Flags<IR::TextureInstInfo>();
-    auto image = info.ReadUdSharp<AmdGpu::Image>(tsharp);
-    if (!image.Valid()) {
-        LOG_ERROR(Render_Vulkan, "Shader compiled with unbound image!");
-        image = inst_info.is_depth ? AmdGpu::Image::NullDepth() : AmdGpu::Image::Null();
-    } else if (inst_info.is_depth) {
-        const auto data_fmt = image.GetDataFmt();
-        if (data_fmt != AmdGpu::DataFormat::Format16 && data_fmt != AmdGpu::DataFormat::Format32) {
-            LOG_ERROR(Render_Vulkan,
-                      "Shader compiled using non-depth image with depth instruction!");
-            image = AmdGpu::Image::NullDepth();
-        }
-    }
-    ASSERT(image.GetType() != AmdGpu::ImageType::Invalid);
     const bool is_written = inst.GetOpcode() == IR::Opcode::ImageWrite;
+    const ImageResource image_res = {
+        .sharp_idx = tsharp,
+        .is_depth = bool(inst_info.is_depth),
+        .is_atomic = IsImageAtomicInstruction(inst),
+        .is_array = bool(inst_info.is_array),
+        .is_written = is_written,
+        .is_r128 = bool(inst_info.is_r128),
+    };
+    auto image = image_res.GetSharp(info);
+    ASSERT(image.GetType() != AmdGpu::ImageType::Invalid);
 
     // Patch image instruction if image is FMask.
     if (image.IsFmask()) {
@@ -414,14 +411,7 @@ void PatchImageSharp(IR::Block& block, IR::Inst& inst, Info& info, Descriptors& 
         }
     }
 
-    u32 image_binding = descriptors.Add(ImageResource{
-        .sharp_idx = tsharp,
-        .is_depth = bool(inst_info.is_depth),
-        .is_atomic = IsImageAtomicInstruction(inst),
-        .is_array = bool(inst_info.is_array),
-        .is_written = is_written,
-        .is_r128 = bool(inst_info.is_r128),
-    });
+    u32 image_binding = descriptors.Add(image_res);
 
     IR::IREmitter ir{block, IR::Block::InstructionList::s_iterator_to(inst)};
 


### PR DESCRIPTION
When an unbound image is detected, make sure to use the null depth image for depth instructions instead of the regular null image. Should avoid some confusing messaging where the unbound null image is detected as an improper depth image.