### PR TITLE
Controller Remapping GUI v2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1068,6 +1068,8 @@ set(QT_GUI src/qt_gui/about_dialog.cpp
            src/qt_gui/gui_settings.h
            src/qt_gui/settings.cpp
            src/qt_gui/settings.h
+           src/qt_gui/sdl_event_wrapper.cpp
+           src/qt_gui/sdl_event_wrapper.h
            ${EMULATOR}
            ${RESOURCE_FILES}
            ${TRANSLATIONS}

--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -752,6 +752,8 @@ void ControlSettings::CheckMapping(QPushButton*& button) {
         button->setText(mapping);
         EnableButtonMapping = false;
         EnableAxisMapping = false;
+        L2Pressed = false;
+        R2Pressed = false;
         EnableMappingButtons();
         timer->stop();
     }
@@ -844,19 +846,32 @@ void ControlSettings::processSDLEvents(int Type, int Input, int Value) {
         if (Type == SDL_EVENT_GAMEPAD_AXIS_MOTION) {
             // SDL trigger axis values range from 0 to 32000, set mapping on half movement
             // Set zone for trigger release signal arbitrarily at 5000
-            if (Value > 16000) {
-                switch (Input) {
-                case SDL_GAMEPAD_AXIS_LEFT_TRIGGER:
+            switch (Input) {
+            case SDL_GAMEPAD_AXIS_LEFT_TRIGGER:
+                if (Value > 16000) {
                     pressedButtons.insert("l2");
-                    break;
-                case SDL_GAMEPAD_AXIS_RIGHT_TRIGGER:
-                    pressedButtons.insert("r2");
-                    break;
-                default:
-                    break;
+                    L2Pressed = true;
+                } else if (Value < 5000) {
+                    if (L2Pressed)
+                        emit PushGamepadEvent();
                 }
+                break;
+            case SDL_GAMEPAD_AXIS_RIGHT_TRIGGER:
+                if (Value > 16000) {
+                    pressedButtons.insert("r2");
+                    R2Pressed = true;
+                } else if (Value < 5000) {
+                    if (R2Pressed)
+                        emit PushGamepadEvent();
+                }
+                break;
+            default:
+                break;
             }
         }
+
+        if (Type == SDL_EVENT_GAMEPAD_BUTTON_UP)
+            emit PushGamepadEvent();
 
     } else if (EnableAxisMapping) {
         if (Type == SDL_EVENT_GAMEPAD_AXIS_MOTION) {

--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -918,7 +918,7 @@ void ControlSettings::pollSDLEvents() {
     }
 }
 
-void ControlSettings::cleanup() {
+void ControlSettings::Cleanup() {
     SdlEventWrapper::Wrapper::wrapperActive = false;
     if (gamepad)
         SDL_CloseGamepad(gamepad);

--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <QMessageBox>
 #include <QPushButton>
+#include "common/logging/log.h"
 #include "common/path_util.h"
 #include "control_settings.h"
 #include "ui_control_settings.h"
@@ -12,11 +13,49 @@ ControlSettings::ControlSettings(std::shared_ptr<GameInfoClass> game_info_get, Q
     : QDialog(parent), m_game_info(game_info_get), ui(new Ui::ControlSettings) {
 
     ui->setupUi(this);
-    ui->PerGameCheckBox->setChecked(!Config::GetUseUnifiedInputConfig());
+
+    SDL_InitSubSystem(SDL_INIT_GAMEPAD);
+    SDL_InitSubSystem(SDL_INIT_EVENTS);
+
+    CheckGamePad();
+    QFuture<void> future = QtConcurrent::run(&ControlSettings::pollSDLEvents, this);
 
     AddBoxItems();
     SetUIValuestoMappings();
     UpdateLightbarColor();
+
+    ButtonsList = {ui->CrossButton,
+                   ui->CircleButton,
+                   ui->TriangleButton,
+                   ui->SquareButton,
+                   ui->L1Button,
+                   ui->R1Button,
+                   ui->L2Button,
+                   ui->R2Button,
+                   ui->L3Button,
+                   ui->R3Button,
+                   ui->OptionsButton,
+                   ui->TouchpadLeftButton,
+                   ui->TouchpadCenterButton,
+                   ui->TouchpadRightButton,
+                   ui->DpadUpButton,
+                   ui->DpadDownButton,
+                   ui->DpadLeftButton,
+                   ui->DpadRightButton};
+
+    AxisList = {ui->LStickUpButton,    ui->LStickDownButton, ui->LStickLeftButton,
+                ui->LStickRightButton, ui->RStickUpButton,   ui->RStickDownButton,
+                ui->RStickLeftButton,  ui->RStickRightButton};
+
+    for (auto& button : ButtonsList) {
+        connect(button, &QPushButton::clicked, this,
+                [this, &button]() { StartTimer(button, true); });
+    }
+
+    for (auto& button : AxisList) {
+        connect(button, &QPushButton::clicked, this,
+                [this, &button]() { StartTimer(button, false); });
+    }
 
     connect(ui->buttonBox, &QDialogButtonBox::clicked, this, [this](QAbstractButton* button) {
         if (button == ui->buttonBox->button(QDialogButtonBox::Save)) {
@@ -33,6 +72,8 @@ ControlSettings::ControlSettings(std::shared_ptr<GameInfoClass> game_info_get, Q
     ui->buttonBox->button(QDialogButtonBox::RestoreDefaults)->setText(tr("Restore Defaults"));
     ui->buttonBox->button(QDialogButtonBox::Cancel)->setText(tr("Cancel"));
 
+    ui->PerGameCheckBox->setChecked(!Config::GetUseUnifiedInputConfig());
+
     connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &QWidget::close);
 
     connect(ui->ProfileComboBox, &QComboBox::currentTextChanged, this, [this] {
@@ -44,24 +85,6 @@ ControlSettings::ControlSettings(std::shared_ptr<GameInfoClass> game_info_get, Q
             [this](int value) { ui->LeftDeadzoneValue->setText(QString::number(value)); });
     connect(ui->RightDeadzoneSlider, &QSlider::valueChanged, this,
             [this](int value) { ui->RightDeadzoneValue->setText(QString::number(value)); });
-
-    connect(ui->LStickUpBox, &QComboBox::currentIndexChanged, this,
-            [this](int value) { ui->LStickDownBox->setCurrentIndex(value); });
-    connect(ui->LStickDownBox, &QComboBox::currentIndexChanged, this,
-            [this](int value) { ui->LStickUpBox->setCurrentIndex(value); });
-    connect(ui->LStickRightBox, &QComboBox::currentIndexChanged, this,
-            [this](int value) { ui->LStickLeftBox->setCurrentIndex(value); });
-    connect(ui->LStickLeftBox, &QComboBox::currentIndexChanged, this,
-            [this](int value) { ui->LStickRightBox->setCurrentIndex(value); });
-
-    connect(ui->RStickUpBox, &QComboBox::currentIndexChanged, this,
-            [this](int value) { ui->RStickDownBox->setCurrentIndex(value); });
-    connect(ui->RStickDownBox, &QComboBox::currentIndexChanged, this,
-            [this](int value) { ui->RStickUpBox->setCurrentIndex(value); });
-    connect(ui->RStickRightBox, &QComboBox::currentIndexChanged, this,
-            [this](int value) { ui->RStickLeftBox->setCurrentIndex(value); });
-    connect(ui->RStickLeftBox, &QComboBox::currentIndexChanged, this,
-            [this](int value) { ui->RStickRightBox->setCurrentIndex(value); });
 
     connect(ui->RSlider, &QSlider::valueChanged, this, [this](int value) {
         QString RedValue = QString("%1").arg(value, 3, 10, QChar('0'));
@@ -83,30 +106,35 @@ ControlSettings::ControlSettings(std::shared_ptr<GameInfoClass> game_info_get, Q
         ui->BLabel->setText(BValue);
         UpdateLightbarColor();
     });
+
+    connect(this, &ControlSettings::gamepadInputEvent, this,
+            [this]() { CheckMapping(MappingButton); });
+    connect(this, &ControlSettings::AxisChanged, this,
+            [this]() { ConnectAxisInputs(MappingButton); });
 }
 
 void ControlSettings::SaveControllerConfig(bool CloseOnSave) {
-    QList<QComboBox*> list;
-    list << ui->RStickUpBox << ui->RStickRightBox << ui->LStickUpBox << ui->LStickRightBox;
+    QList<QPushButton*> list;
+    list << ui->RStickUpButton << ui->RStickRightButton << ui->LStickUpButton
+         << ui->LStickRightButton;
     int count_axis_left_x = 0, count_axis_left_y = 0, count_axis_right_x = 0,
         count_axis_right_y = 0;
     for (const auto& i : list) {
-        if (i->currentText() == "axis_left_x") {
+        if (i->text() == "axis_left_x") {
             count_axis_left_x = count_axis_left_x + 1;
-        } else if (i->currentText() == "axis_left_y") {
+        } else if (i->text() == "axis_left_y") {
             count_axis_left_y = count_axis_left_y + 1;
-        } else if (i->currentText() == "axis_right_x") {
+        } else if (i->text() == "axis_right_x") {
             count_axis_right_x = count_axis_right_x + 1;
-        } else if (i->currentText() == "axis_right_y") {
+        } else if (i->text() == "axis_right_y") {
             count_axis_right_y = count_axis_right_y + 1;
         }
     }
 
     if (count_axis_left_x > 1 | count_axis_left_y > 1 | count_axis_right_x > 1 |
         count_axis_right_y > 1) {
-        QMessageBox::StandardButton nosave;
-        nosave = QMessageBox::information(this, tr("Unable to Save"),
-                                          tr("Cannot bind axis values more than once"));
+        QMessageBox::information(this, tr("Unable to Save"),
+                                 tr("Cannot bind axis values more than once"));
         return;
     }
 
@@ -118,7 +146,7 @@ void ControlSettings::SaveControllerConfig(bool CloseOnSave) {
 
     int lineCount = 0;
     std::string line;
-    std::vector<std::string> lines;
+    std::vector<std::string> lines, inputs;
     std::string output_string = "", input_string = "";
     std::fstream file(config_file);
 
@@ -152,92 +180,60 @@ void ControlSettings::SaveControllerConfig(bool CloseOnSave) {
 
     file.close();
 
-    input_string = "cross";
-    output_string = ui->ABox->currentText().toStdString();
-    lines.push_back(output_string + " = " + input_string);
+    // Lambda to reduce repetitive code for mapping buttons to config lines
+    auto add_mapping = [&](const QString& buttonText, const std::string& output_name) {
+        input_string = buttonText.toStdString();
+        output_string = output_name;
+        if (input_string != "unmapped") {
+            lines.push_back(output_string + " = " + input_string);
+            inputs.push_back(input_string);
+        }
+    };
 
-    input_string = "circle";
-    output_string = ui->BBox->currentText().toStdString();
-    lines.push_back(output_string + " = " + input_string);
-
-    input_string = "square";
-    output_string = ui->XBox->currentText().toStdString();
-    lines.push_back(output_string + " = " + input_string);
-
-    input_string = "triangle";
-    output_string = ui->YBox->currentText().toStdString();
-    lines.push_back(output_string + " = " + input_string);
-
-    lines.push_back("");
-
-    input_string = "l1";
-    output_string = ui->LBBox->currentText().toStdString();
-    lines.push_back(output_string + " = " + input_string);
-
-    input_string = "r1";
-    output_string = ui->RBBox->currentText().toStdString();
-    lines.push_back(output_string + " = " + input_string);
-
-    input_string = "l2";
-    output_string = ui->LTBox->currentText().toStdString();
-    lines.push_back(output_string + " = " + input_string);
-
-    input_string = "r2";
-    output_string = ui->RTBox->currentText().toStdString();
-    lines.push_back(output_string + " = " + input_string);
-
-    input_string = "l3";
-    output_string = ui->LClickBox->currentText().toStdString();
-    lines.push_back(output_string + " = " + input_string);
-
-    input_string = "r3";
-    output_string = ui->RClickBox->currentText().toStdString();
-    lines.push_back(output_string + " = " + input_string);
+    add_mapping(ui->CrossButton->text(), "cross");
+    add_mapping(ui->CircleButton->text(), "circle");
+    add_mapping(ui->SquareButton->text(), "square");
+    add_mapping(ui->TriangleButton->text(), "triangle");
 
     lines.push_back("");
 
-    input_string = "back";
-    output_string = ui->BackBox->currentText().toStdString();
-    lines.push_back(output_string + " = " + input_string);
-
-    input_string = "options";
-    output_string = ui->StartBox->currentText().toStdString();
-    lines.push_back(output_string + " = " + input_string);
-
-    lines.push_back("");
-
-    input_string = "pad_up";
-    output_string = ui->DpadUpBox->currentText().toStdString();
-    lines.push_back(output_string + " = " + input_string);
-
-    input_string = "pad_down";
-    output_string = ui->DpadDownBox->currentText().toStdString();
-    lines.push_back(output_string + " = " + input_string);
-
-    input_string = "pad_left";
-    output_string = ui->DpadLeftBox->currentText().toStdString();
-    lines.push_back(output_string + " = " + input_string);
-
-    input_string = "pad_right";
-    output_string = ui->DpadRightBox->currentText().toStdString();
-    lines.push_back(output_string + " = " + input_string);
+    add_mapping(ui->L1Button->text(), "l1");
+    add_mapping(ui->R1Button->text(), "r1");
+    add_mapping(ui->L2Button->text(), "l2");
+    add_mapping(ui->R2Button->text(), "r2");
+    add_mapping(ui->L3Button->text(), "l3");
+    add_mapping(ui->R3Button->text(), "r3");
 
     lines.push_back("");
 
-    input_string = "axis_left_x";
-    output_string = ui->LStickRightBox->currentText().toStdString();
+    add_mapping(ui->TouchpadLeftButton->text(), "touchpad_left");
+    add_mapping(ui->TouchpadCenterButton->text(), "touchpad_center");
+    add_mapping(ui->TouchpadRightButton->text(), "touchpad_right");
+    add_mapping(ui->OptionsButton->text(), "options");
+
+    lines.push_back("");
+
+    add_mapping(ui->DpadUpButton->text(), "pad_up");
+    add_mapping(ui->DpadDownButton->text(), "pad_down");
+    add_mapping(ui->DpadLeftButton->text(), "pad_left");
+    add_mapping(ui->DpadRightButton->text(), "pad_right");
+
+    lines.push_back("");
+
+    output_string = "axis_left_x";
+    input_string = ui->LStickRightButton->text().toStdString();
     lines.push_back(output_string + " = " + input_string);
 
-    input_string = "axis_left_y";
-    output_string = ui->LStickUpBox->currentText().toStdString();
+    output_string = "axis_left_y";
+    input_string = ui->LStickUpButton->text().toStdString();
     lines.push_back(output_string + " = " + input_string);
 
-    input_string = "axis_right_x";
-    output_string = ui->RStickRightBox->currentText().toStdString();
+    output_string = "axis_right_x";
+    input_string = ui->RStickRightButton->text().toStdString();
     lines.push_back(output_string + " = " + input_string);
 
-    input_string = "axis_right_y";
-    output_string = ui->RStickUpBox->currentText().toStdString();
+    output_string = "axis_right_y";
+    input_string = ui->RStickUpButton->text().toStdString();
     lines.push_back(output_string + " = " + input_string);
 
     lines.push_back("");
@@ -256,6 +252,33 @@ void ControlSettings::SaveControllerConfig(bool CloseOnSave) {
     std::string LightBarB = std::to_string(ui->BSlider->value());
     lines.push_back("override_controller_color = " + OverrideLB + ", " + LightBarR + ", " +
                     LightBarG + ", " + LightBarB);
+
+    // Prevent duplicate inputs that break the input engine
+    bool duplicateFound = false;
+    QSet<QString> duplicateMappings;
+
+    for (auto it = inputs.begin(); it != inputs.end(); ++it) {
+        if (std::find(it + 1, inputs.end(), *it) != inputs.end()) {
+            duplicateFound = true;
+            duplicateMappings.insert(QString::fromStdString(*it));
+        }
+    }
+
+    if (duplicateFound) {
+        QStringList duplicatesList;
+        for (const QString mapping : duplicateMappings) {
+            for (const auto& button : ButtonsList) {
+                if (button->text() == mapping)
+                    duplicatesList.append(button->objectName() + " - " + mapping);
+            }
+        }
+        QMessageBox::information(
+            this, tr("Unable to Save"),
+            // clang-format off
+            QString(tr("Cannot bind any unique input more than once. Duplicate inputs mapped to the following buttons:\n\n%1").arg(duplicatesList.join("\n"))));
+        // clang-format on
+        return;
+    }
 
     std::vector<std::string> save;
     bool CurrentLineEmpty = false, LastLineEmpty = false;
@@ -283,31 +306,33 @@ void ControlSettings::SaveControllerConfig(bool CloseOnSave) {
 }
 
 void ControlSettings::SetDefault() {
-    ui->ABox->setCurrentIndex(0);
-    ui->BBox->setCurrentIndex(1);
-    ui->XBox->setCurrentIndex(2);
-    ui->YBox->setCurrentIndex(3);
-    ui->DpadUpBox->setCurrentIndex(11);
-    ui->DpadDownBox->setCurrentIndex(12);
-    ui->DpadLeftBox->setCurrentIndex(13);
-    ui->DpadRightBox->setCurrentIndex(14);
-    ui->LClickBox->setCurrentIndex(8);
-    ui->RClickBox->setCurrentIndex(9);
-    ui->LBBox->setCurrentIndex(4);
-    ui->RBBox->setCurrentIndex(5);
-    ui->LTBox->setCurrentIndex(6);
-    ui->RTBox->setCurrentIndex(7);
-    ui->StartBox->setCurrentIndex(10);
-    ui->BackBox->setCurrentIndex(15);
+    ui->CrossButton->setText("cross");
+    ui->CircleButton->setText("circle");
+    ui->SquareButton->setText("square");
+    ui->TriangleButton->setText("triangle");
+    ui->DpadUpButton->setText("pad_up");
+    ui->DpadDownButton->setText("pad_down");
+    ui->DpadLeftButton->setText("pad_left");
+    ui->DpadRightButton->setText("pad_right");
+    ui->L3Button->setText("l3");
+    ui->R3Button->setText("r3");
+    ui->L1Button->setText("l1");
+    ui->R1Button->setText("r1");
+    ui->L2Button->setText("l2");
+    ui->R2Button->setText("r2");
+    ui->OptionsButton->setText("options");
+    ui->TouchpadLeftButton->setText("back");
+    ui->TouchpadCenterButton->setText("unmapped");
+    ui->TouchpadRightButton->setText("unmapped");
 
-    ui->LStickUpBox->setCurrentIndex(1);
-    ui->LStickDownBox->setCurrentIndex(1);
-    ui->LStickLeftBox->setCurrentIndex(0);
-    ui->LStickRightBox->setCurrentIndex(0);
-    ui->RStickUpBox->setCurrentIndex(3);
-    ui->RStickDownBox->setCurrentIndex(3);
-    ui->RStickLeftBox->setCurrentIndex(2);
-    ui->RStickRightBox->setCurrentIndex(2);
+    ui->LStickUpButton->setText("axis_left_y");
+    ui->LStickDownButton->setText("axis_left_y");
+    ui->LStickLeftButton->setText("axis_left_x");
+    ui->LStickRightButton->setText("axis_left_x");
+    ui->RStickUpButton->setText("axis_right_y");
+    ui->RStickDownButton->setText("axis_right_y");
+    ui->RStickLeftButton->setText("axis_right_x");
+    ui->RStickRightButton->setText("axis_right_x");
 
     ui->LeftDeadzoneSlider->setValue(2);
     ui->RightDeadzoneSlider->setValue(2);
@@ -320,32 +345,6 @@ void ControlSettings::SetDefault() {
 }
 
 void ControlSettings::AddBoxItems() {
-    ui->DpadUpBox->addItems(ButtonOutputs);
-    ui->DpadDownBox->addItems(ButtonOutputs);
-    ui->DpadLeftBox->addItems(ButtonOutputs);
-    ui->DpadRightBox->addItems(ButtonOutputs);
-    ui->LBBox->addItems(ButtonOutputs);
-    ui->RBBox->addItems(ButtonOutputs);
-    ui->LTBox->addItems(ButtonOutputs);
-    ui->RTBox->addItems(ButtonOutputs);
-    ui->RClickBox->addItems(ButtonOutputs);
-    ui->LClickBox->addItems(ButtonOutputs);
-    ui->StartBox->addItems(ButtonOutputs);
-    ui->ABox->addItems(ButtonOutputs);
-    ui->BBox->addItems(ButtonOutputs);
-    ui->XBox->addItems(ButtonOutputs);
-    ui->YBox->addItems(ButtonOutputs);
-    ui->BackBox->addItems(ButtonOutputs);
-
-    ui->LStickUpBox->addItems(StickOutputs);
-    ui->LStickDownBox->addItems(StickOutputs);
-    ui->LStickLeftBox->addItems(StickOutputs);
-    ui->LStickRightBox->addItems(StickOutputs);
-    ui->RStickUpBox->addItems(StickOutputs);
-    ui->RStickDownBox->addItems(StickOutputs);
-    ui->RStickLeftBox->addItems(StickOutputs);
-    ui->RStickRightBox->addItems(StickOutputs);
-
     ui->ProfileComboBox->addItem("Common Config");
     for (int i = 0; i < m_game_info->m_games.size(); i++) {
         ui->ProfileComboBox->addItem(QString::fromStdString(m_game_info->m_games[i].serial));
@@ -355,6 +354,7 @@ void ControlSettings::AddBoxItems() {
 }
 
 void ControlSettings::SetUIValuestoMappings() {
+
     std::string config_id;
     config_id = (ui->ProfileComboBox->currentText() == "Common Config")
                     ? "default"
@@ -366,7 +366,8 @@ void ControlSettings::SetUIValuestoMappings() {
     bool CrossExists = false, CircleExists = false, SquareExists = false, TriangleExists = false,
          L1Exists = false, L2Exists = false, L3Exists = false, R1Exists = false, R2Exists = false,
          R3Exists = false, DPadUpExists = false, DPadDownExists = false, DPadLeftExists = false,
-         DPadRightExists = false, StartExists = false, BackExists = false, LStickXExists = false,
+         DPadRightExists = false, OptionsExists = false, TouchpadLeftExists = false,
+         TouchpadCenterExists = false, TouchpadRightExists = false, LStickXExists = false,
          LStickYExists = false, RStickXExists = false, RStickYExists = false;
     int lineCount = 0;
     std::string line = "";
@@ -391,69 +392,75 @@ void ControlSettings::SetUIValuestoMappings() {
         if (std::find(ControllerInputs.begin(), ControllerInputs.end(), input_string) !=
                 ControllerInputs.end() ||
             output_string == "analog_deadzone" || output_string == "override_controller_color") {
-            if (input_string == "cross") {
-                ui->ABox->setCurrentText(QString::fromStdString(output_string));
+            if (output_string == "cross") {
+                ui->CrossButton->setText(QString::fromStdString(input_string));
                 CrossExists = true;
-            } else if (input_string == "circle") {
-                ui->BBox->setCurrentText(QString::fromStdString(output_string));
+            } else if (output_string == "circle") {
+                ui->CircleButton->setText(QString::fromStdString(input_string));
                 CircleExists = true;
-            } else if (input_string == "square") {
-                ui->XBox->setCurrentText(QString::fromStdString(output_string));
+            } else if (output_string == "square") {
+                ui->SquareButton->setText(QString::fromStdString(input_string));
                 SquareExists = true;
-            } else if (input_string == "triangle") {
-                ui->YBox->setCurrentText(QString::fromStdString(output_string));
+            } else if (output_string == "triangle") {
+                ui->TriangleButton->setText(QString::fromStdString(input_string));
                 TriangleExists = true;
-            } else if (input_string == "l1") {
-                ui->LBBox->setCurrentText(QString::fromStdString(output_string));
+            } else if (output_string == "l1") {
+                ui->L1Button->setText(QString::fromStdString(input_string));
                 L1Exists = true;
-            } else if (input_string == "l2") {
-                ui->LTBox->setCurrentText(QString::fromStdString(output_string));
+            } else if (output_string == "l2") {
+                ui->L2Button->setText(QString::fromStdString(input_string));
                 L2Exists = true;
-            } else if (input_string == "r1") {
-                ui->RBBox->setCurrentText(QString::fromStdString(output_string));
+            } else if (output_string == "r1") {
+                ui->R1Button->setText(QString::fromStdString(input_string));
                 R1Exists = true;
-            } else if (input_string == "r2") {
-                ui->RTBox->setCurrentText(QString::fromStdString(output_string));
+            } else if (output_string == "r2") {
+                ui->R2Button->setText(QString::fromStdString(input_string));
                 R2Exists = true;
-            } else if (input_string == "l3") {
-                ui->LClickBox->setCurrentText(QString::fromStdString(output_string));
+            } else if (output_string == "l3") {
+                ui->L3Button->setText(QString::fromStdString(input_string));
                 L3Exists = true;
-            } else if (input_string == "r3") {
-                ui->RClickBox->setCurrentText(QString::fromStdString(output_string));
+            } else if (output_string == "r3") {
+                ui->R3Button->setText(QString::fromStdString(input_string));
                 R3Exists = true;
-            } else if (input_string == "pad_up") {
-                ui->DpadUpBox->setCurrentText(QString::fromStdString(output_string));
+            } else if (output_string == "pad_up") {
+                ui->DpadUpButton->setText(QString::fromStdString(input_string));
                 DPadUpExists = true;
-            } else if (input_string == "pad_down") {
-                ui->DpadDownBox->setCurrentText(QString::fromStdString(output_string));
+            } else if (output_string == "pad_down") {
+                ui->DpadDownButton->setText(QString::fromStdString(input_string));
                 DPadDownExists = true;
-            } else if (input_string == "pad_left") {
-                ui->DpadLeftBox->setCurrentText(QString::fromStdString(output_string));
+            } else if (output_string == "pad_left") {
+                ui->DpadLeftButton->setText(QString::fromStdString(input_string));
                 DPadLeftExists = true;
-            } else if (input_string == "pad_right") {
-                ui->DpadRightBox->setCurrentText(QString::fromStdString(output_string));
+            } else if (output_string == "pad_right") {
+                ui->DpadRightButton->setText(QString::fromStdString(input_string));
                 DPadRightExists = true;
-            } else if (input_string == "options") {
-                ui->StartBox->setCurrentText(QString::fromStdString(output_string));
-                StartExists = true;
-            } else if (input_string == "back") {
-                ui->BackBox->setCurrentText(QString::fromStdString(output_string));
-                BackExists = true;
-            } else if (input_string == "axis_left_x") {
-                ui->LStickRightBox->setCurrentText(QString::fromStdString(output_string));
-                ui->LStickLeftBox->setCurrentText(QString::fromStdString(output_string));
+            } else if (output_string == "options") {
+                ui->OptionsButton->setText(QString::fromStdString(input_string));
+                OptionsExists = true;
+            } else if (output_string == "touchpad_left") {
+                ui->TouchpadLeftButton->setText(QString::fromStdString(input_string));
+                TouchpadLeftExists = true;
+            } else if (output_string == "touchpad_center") {
+                ui->TouchpadCenterButton->setText(QString::fromStdString(input_string));
+                TouchpadCenterExists = true;
+            } else if (output_string == "touchpad_right") {
+                ui->TouchpadRightButton->setText(QString::fromStdString(input_string));
+                TouchpadRightExists = true;
+            } else if (output_string == "axis_left_x") {
+                ui->LStickRightButton->setText(QString::fromStdString(input_string));
+                ui->LStickLeftButton->setText(QString::fromStdString(input_string));
                 LStickXExists = true;
-            } else if (input_string == "axis_left_y") {
-                ui->LStickUpBox->setCurrentText(QString::fromStdString(output_string));
-                ui->LStickDownBox->setCurrentText(QString::fromStdString(output_string));
+            } else if (output_string == "axis_left_y") {
+                ui->LStickUpButton->setText(QString::fromStdString(input_string));
+                ui->LStickDownButton->setText(QString::fromStdString(input_string));
                 LStickYExists = true;
-            } else if (input_string == "axis_right_x") {
-                ui->RStickRightBox->setCurrentText(QString::fromStdString(output_string));
-                ui->RStickLeftBox->setCurrentText(QString::fromStdString(output_string));
+            } else if (output_string == "axis_right_x") {
+                ui->RStickRightButton->setText(QString::fromStdString(input_string));
+                ui->RStickLeftButton->setText(QString::fromStdString(input_string));
                 RStickXExists = true;
-            } else if (input_string == "axis_right_y") {
-                ui->RStickUpBox->setCurrentText(QString::fromStdString(output_string));
-                ui->RStickDownBox->setCurrentText(QString::fromStdString(output_string));
+            } else if (output_string == "axis_right_y") {
+                ui->RStickUpButton->setText(QString::fromStdString(input_string));
+                ui->RStickDownButton->setText(QString::fromStdString(input_string));
                 RStickYExists = true;
             } else if (input_string.contains("leftjoystick")) {
                 std::size_t comma_pos = line.find(',');
@@ -517,53 +524,57 @@ void ControlSettings::SetUIValuestoMappings() {
 
     // If an entry does not exist in the config file, we assume the user wants it unmapped
     if (!CrossExists)
-        ui->ABox->setCurrentText("unmapped");
+        ui->CrossButton->setText("unmapped");
     if (!CircleExists)
-        ui->BBox->setCurrentText("unmapped");
+        ui->CircleButton->setText("unmapped");
     if (!SquareExists)
-        ui->XBox->setCurrentText("unmapped");
+        ui->SquareButton->setText("unmapped");
     if (!TriangleExists)
-        ui->YBox->setCurrentText("unmapped");
+        ui->TriangleButton->setText("unmapped");
     if (!L1Exists)
-        ui->LBBox->setCurrentText("unmapped");
+        ui->L1Button->setText("unmapped");
     if (!L2Exists)
-        ui->LTBox->setCurrentText("unmapped");
+        ui->L2Button->setText("unmapped");
     if (!L3Exists)
-        ui->LClickBox->setCurrentText("unmapped");
+        ui->L3Button->setText("unmapped");
     if (!R1Exists)
-        ui->RBBox->setCurrentText("unmapped");
+        ui->R1Button->setText("unmapped");
     if (!R2Exists)
-        ui->RTBox->setCurrentText("unmapped");
+        ui->R2Button->setText("unmapped");
     if (!R3Exists)
-        ui->RClickBox->setCurrentText("unmapped");
+        ui->R3Button->setText("unmapped");
     if (!DPadUpExists)
-        ui->DpadUpBox->setCurrentText("unmapped");
+        ui->DpadUpButton->setText("unmapped");
     if (!DPadDownExists)
-        ui->DpadDownBox->setCurrentText("unmapped");
+        ui->DpadDownButton->setText("unmapped");
     if (!DPadLeftExists)
-        ui->DpadLeftBox->setCurrentText("unmapped");
+        ui->DpadLeftButton->setText("unmapped");
     if (!DPadRightExists)
-        ui->DpadRightBox->setCurrentText("unmapped");
-    if (!BackExists)
-        ui->BackBox->setCurrentText("unmapped");
-    if (!StartExists)
-        ui->StartBox->setCurrentText("unmapped");
+        ui->DpadRightButton->setText("unmapped");
+    if (!TouchpadLeftExists)
+        ui->TouchpadLeftButton->setText("unmapped");
+    if (!TouchpadCenterExists)
+        ui->TouchpadCenterButton->setText("unmapped");
+    if (!TouchpadRightExists)
+        ui->TouchpadRightButton->setText("unmapped");
+    if (!OptionsExists)
+        ui->OptionsButton->setText("unmapped");
 
     if (!LStickXExists) {
-        ui->LStickRightBox->setCurrentText("unmapped");
-        ui->LStickLeftBox->setCurrentText("unmapped");
+        ui->LStickRightButton->setText("unmapped");
+        ui->LStickLeftButton->setText("unmapped");
     }
     if (!LStickYExists) {
-        ui->LStickUpBox->setCurrentText("unmapped");
-        ui->LStickDownBox->setCurrentText("unmapped");
+        ui->LStickUpButton->setText("unmapped");
+        ui->LStickDownButton->setText("unmapped");
     }
     if (!RStickXExists) {
-        ui->RStickRightBox->setCurrentText("unmapped");
-        ui->RStickLeftBox->setCurrentText("unmapped");
+        ui->RStickRightButton->setText("unmapped");
+        ui->RStickLeftButton->setText("unmapped");
     }
     if (!RStickYExists) {
-        ui->RStickUpBox->setCurrentText("unmapped");
-        ui->RStickDownBox->setCurrentText("unmapped");
+        ui->RStickUpButton->setText("unmapped");
+        ui->RStickDownButton->setText("unmapped");
     }
 }
 
@@ -587,6 +598,244 @@ void ControlSettings::UpdateLightbarColor() {
     QString BValue = QString::number(ui->BSlider->value());
     QString colorstring = "background-color: rgb(" + RValue + "," + GValue + "," + BValue + ")";
     ui->LightbarColorFrame->setStyleSheet(colorstring);
+}
+
+void ControlSettings::CheckGamePad() {
+    if (m_gamepad) {
+        SDL_CloseGamepad(m_gamepad);
+        m_gamepad = nullptr;
+    }
+
+    int gamepad_count;
+    SDL_JoystickID* gamepads = SDL_GetGamepads(&gamepad_count);
+
+    if (!gamepads) {
+        LOG_ERROR(Input, "Cannot get gamepad list: {}", SDL_GetError());
+        return;
+    }
+
+    if (gamepad_count == 0) {
+        LOG_INFO(Input, "No gamepad found!");
+        SDL_free(gamepads);
+        return;
+    }
+
+    LOG_INFO(Input, "Got {} gamepads. Opening the first one.", gamepad_count);
+    m_gamepad = SDL_OpenGamepad(gamepads[0]);
+
+    if (!m_gamepad) {
+        LOG_ERROR(Input, "Failed to open gamepad 0: {}", SDL_GetError());
+        SDL_free(gamepads);
+        return;
+    }
+
+    SDL_free(gamepads);
+}
+
+void ControlSettings::DisableMappingButtons() {
+    for (const auto& i : ButtonsList) {
+        i->setEnabled(false);
+    }
+
+    for (const auto& i : AxisList) {
+        i->setEnabled(false);
+    }
+}
+
+void ControlSettings::EnableMappingButtons() {
+    for (const auto& i : ButtonsList) {
+        i->setEnabled(true);
+    }
+
+    for (const auto& i : AxisList) {
+        i->setEnabled(true);
+    }
+}
+
+void ControlSettings::ConnectAxisInputs(QPushButton*& button) {
+    QString input = button->text();
+    if (button == ui->LStickUpButton) {
+        ui->LStickDownButton->setText(input);
+    } else if (button == ui->LStickDownButton) {
+        ui->LStickUpButton->setText(input);
+    } else if (button == ui->LStickLeftButton) {
+        ui->LStickRightButton->setText(input);
+    } else if (button == ui->LStickRightButton) {
+        ui->LStickLeftButton->setText(input);
+    } else if (button == ui->RStickUpButton) {
+        ui->RStickDownButton->setText(input);
+    } else if (button == ui->RStickDownButton) {
+        ui->RStickUpButton->setText(input);
+    } else if (button == ui->RStickLeftButton) {
+        ui->RStickRightButton->setText(input);
+    } else if (button == ui->RStickRightButton) {
+        ui->RStickLeftButton->setText(input);
+    }
+}
+
+void ControlSettings::StartTimer(QPushButton*& button, bool isButton) {
+    MappingTimer = 3;
+    isButton ? EnableButtonMapping = true : EnableAxisMapping = true;
+    MappingCompleted = false;
+    mapping = button->text();
+    DisableMappingButtons();
+
+    EnableButtonMapping
+        ? button->setText(tr("Press a button") + " [" + QString::number(MappingTimer) + "]")
+        : button->setText(tr("Move analog stick") + " [" + QString::number(MappingTimer) + "]");
+
+    timer = new QTimer(this);
+    MappingButton = button;
+    timer->start(1000);
+    connect(timer, &QTimer::timeout, this, [this]() { CheckMapping(MappingButton); });
+}
+
+void ControlSettings::CheckMapping(QPushButton*& button) {
+    MappingTimer -= 1;
+    EnableButtonMapping
+        ? button->setText(tr("Press a button") + " [" + QString::number(MappingTimer) + "]")
+        : button->setText(tr("Move analog stick") + " [" + QString::number(MappingTimer) + "]");
+
+    if (MappingCompleted || MappingTimer <= 0) {
+        button->setText(mapping);
+        EnableButtonMapping = false;
+        EnableAxisMapping = false;
+        EnableMappingButtons();
+        timer->stop();
+    }
+}
+
+void ControlSettings::pollSDLEvents() {
+    SDL_Event event;
+
+    auto SetMapping = [&](const QString& input) {
+        mapping = input;
+        MappingCompleted = true;
+        emit gamepadInputEvent();
+        if (EnableAxisMapping)
+            emit AxisChanged();
+    };
+
+    while (isRunning) {
+        if (!SDL_WaitEvent(&event)) {
+            return;
+        }
+
+        while (SDL_WaitEvent(&event)) {
+            if (event.type == SDL_EVENT_QUIT) {
+                isRunning = false;
+                SDL_QuitSubSystem(SDL_INIT_GAMEPAD);
+                SDL_QuitSubSystem(SDL_INIT_EVENTS);
+                SDL_Quit();
+            }
+
+            if (event.type == SDL_EVENT_GAMEPAD_ADDED)
+                CheckGamePad();
+
+            if (EnableButtonMapping) {
+                if (event.type == SDL_EVENT_GAMEPAD_BUTTON_DOWN) {
+                    switch (event.gbutton.button) {
+
+                    case SDL_GAMEPAD_BUTTON_SOUTH:
+                        SetMapping("cross");
+                        break;
+                    case SDL_GAMEPAD_BUTTON_EAST:
+                        SetMapping("circle");
+                        break;
+                    case SDL_GAMEPAD_BUTTON_NORTH:
+                        SetMapping("triangle");
+                        break;
+                    case SDL_GAMEPAD_BUTTON_WEST:
+                        SetMapping("square");
+                        break;
+                    case SDL_GAMEPAD_BUTTON_LEFT_SHOULDER:
+                        SetMapping("l1");
+                        break;
+                    case SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER:
+                        SetMapping("r1");
+                        break;
+                    case SDL_GAMEPAD_BUTTON_LEFT_STICK:
+                        SetMapping("l3");
+                        break;
+                    case SDL_GAMEPAD_BUTTON_RIGHT_STICK:
+                        SetMapping("r3");
+                        break;
+                    case SDL_GAMEPAD_BUTTON_DPAD_UP:
+                        SetMapping("pad_up");
+                        break;
+                    case SDL_GAMEPAD_BUTTON_DPAD_DOWN:
+                        SetMapping("pad_down");
+                        break;
+                    case SDL_GAMEPAD_BUTTON_DPAD_LEFT:
+                        SetMapping("pad_left");
+                        break;
+                    case SDL_GAMEPAD_BUTTON_DPAD_RIGHT:
+                        SetMapping("pad_right");
+                        break;
+                    case SDL_GAMEPAD_BUTTON_BACK:
+                        SetMapping("back");
+                        break;
+                    case SDL_GAMEPAD_BUTTON_LEFT_PADDLE1:
+                        SetMapping("lpaddle_high");
+                        break;
+                    case SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1:
+                        SetMapping("rpaddle_high");
+                        break;
+                    case SDL_GAMEPAD_BUTTON_LEFT_PADDLE2:
+                        SetMapping("lpaddle_low");
+                        break;
+                    case SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2:
+                        SetMapping("rpaddle_low");
+                        break;
+                    case SDL_GAMEPAD_BUTTON_START:
+                        SetMapping("options");
+                        break;
+                    default:
+                        break;
+                    }
+                }
+
+                if (event.type == SDL_EVENT_GAMEPAD_AXIS_MOTION) {
+                    // SDL trigger axis values range from 0-32000, set mapping on half movement
+                    if (event.gaxis.value > 16000) {
+                        switch (event.gaxis.axis) {
+                        case SDL_GAMEPAD_AXIS_LEFT_TRIGGER:
+                            SetMapping("l2");
+                            break;
+                        case SDL_GAMEPAD_AXIS_RIGHT_TRIGGER:
+                            SetMapping("r2");
+                            break;
+                        default:
+                            break;
+                        }
+                    }
+                }
+
+            } else if (EnableAxisMapping) {
+                if (event.type == SDL_EVENT_GAMEPAD_AXIS_MOTION) {
+                    // SDL stick axis values range from -32000-32000, set mapping on half movement
+                    if (event.gaxis.value > 16000 || event.gaxis.value < -16000) {
+                        switch (event.gaxis.axis) {
+                        case SDL_GAMEPAD_AXIS_LEFTX:
+                            SetMapping("axis_left_x");
+                            break;
+                        case SDL_GAMEPAD_AXIS_LEFTY:
+                            SetMapping("axis_left_y");
+                            break;
+                        case SDL_GAMEPAD_AXIS_RIGHTX:
+                            SetMapping("axis_right_x");
+                            break;
+                        case SDL_GAMEPAD_AXIS_RIGHTY:
+                            SetMapping("axis_right_y");
+                            break;
+                        default:
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 ControlSettings::~ControlSettings() {}

--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -779,11 +779,6 @@ bool ControlSettings::eventFilter(QObject* obj, QEvent* event) {
 }
 
 void ControlSettings::processSDLEvents(int Type, int Input, int Value) {
-    if (Type == SDL_EVENT_GAMEPAD_ADDED) {
-        if (!GameRunning)
-            CheckGamePad();
-    }
-
     if (EnableButtonMapping) {
         if (Type == SDL_EVENT_GAMEPAD_BUTTON_DOWN) {
             switch (Input) {
@@ -891,8 +886,17 @@ void ControlSettings::processSDLEvents(int Type, int Input, int Value) {
 void ControlSettings::pollSDLEvents() {
     SDL_Event event;
     while (SdlEventWrapper::Wrapper::wrapperActive) {
+
         if (!SDL_WaitEvent(&event)) {
             return;
+        }
+
+        if (event.type == SDL_EVENT_QUIT) {
+            return;
+        }
+
+        if (event.type == SDL_EVENT_GAMEPAD_ADDED) {
+            CheckGamePad();
         }
 
         SdlEventWrapper::Wrapper::GetInstance()->Wrapper::ProcessEvent(&event);

--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -124,8 +124,9 @@ ControlSettings::ControlSettings(std::shared_ptr<GameInfoClass> game_info_get, b
     QObject::connect(RemapWrapper, &SdlEventWrapper::Wrapper::SDLEvent, this,
                      &ControlSettings::processSDLEvents);
 
-    if (!GameRunning)
-        QFuture<void> future = QtConcurrent::run(&ControlSettings::pollSDLEvents, this);
+    if (!GameRunning) {
+        Polling = QtConcurrent::run(&ControlSettings::pollSDLEvents, this);
+    }
 }
 
 void ControlSettings::SaveControllerConfig(bool CloseOnSave) {
@@ -926,6 +927,11 @@ void ControlSettings::Cleanup() {
         SDL_CloseGamepad(gamepad);
 
     if (!GameRunning) {
+        SDL_Event quitLoop{};
+        quitLoop.type = SDL_EVENT_QUIT;
+        SDL_PushEvent(&quitLoop);
+        Polling.waitForFinished();
+
         SDL_QuitSubSystem(SDL_INIT_GAMEPAD);
         SDL_QuitSubSystem(SDL_INIT_EVENTS);
         SDL_Quit();

--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -21,6 +21,7 @@ ControlSettings::ControlSettings(std::shared_ptr<GameInfoClass> game_info_get, b
     if (!GameRunning) {
         SDL_InitSubSystem(SDL_INIT_GAMEPAD);
         SDL_InitSubSystem(SDL_INIT_EVENTS);
+        CheckGamePad();
     } else {
         SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
         SDL_Event pauseGame{};
@@ -28,7 +29,6 @@ ControlSettings::ControlSettings(std::shared_ptr<GameInfoClass> game_info_get, b
         SDL_PushEvent(&pauseGame);
     }
 
-    CheckGamePad();
     AddBoxItems();
     SetUIValuestoMappings();
     UpdateLightbarColor();

--- a/src/qt_gui/control_settings.h
+++ b/src/qt_gui/control_settings.h
@@ -44,6 +44,7 @@ private:
     void SetMapping(QString input);
     void DisableMappingButtons();
     void EnableMappingButtons();
+    void cleanup();
 
     QList<QPushButton*> ButtonsList;
     QList<QPushButton*> AxisList;
@@ -73,8 +74,6 @@ private:
 
 protected:
     void closeEvent(QCloseEvent* event) override {
-        SDL_Event quitLoop{};
-        quitLoop.type = SDL_EVENT_QUIT;
-        SDL_PushEvent(&quitLoop);
+        cleanup();
     }
 };

--- a/src/qt_gui/control_settings.h
+++ b/src/qt_gui/control_settings.h
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include <QComboBox>
 #include <QDialog>
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_gamepad.h>
 #include "game_info.h"
+#include "sdl_event_wrapper.h"
 
 namespace Ui {
 class ControlSettings;
@@ -14,7 +14,7 @@ class ControlSettings;
 class ControlSettings : public QDialog {
     Q_OBJECT
 public:
-    explicit ControlSettings(std::shared_ptr<GameInfoClass> game_info_get,
+    explicit ControlSettings(std::shared_ptr<GameInfoClass> game_info_get, bool GameRunning,
                              QWidget* parent = nullptr);
     ~ControlSettings();
 
@@ -39,6 +39,7 @@ private:
     void SetUIValuestoMappings();
     void GetGameTitle();
     void CheckGamePad();
+    void processSDLEvents(int Type, int Input, int Value);
     void pollSDLEvents();
     void SetMapping(QString input);
     void DisableMappingButtons();
@@ -48,8 +49,7 @@ private:
     QList<QPushButton*> AxisList;
     QSet<QString> pressedButtons;
 
-    bool isRunning = true;
-    bool triggerWasPressed = false;
+    bool GameRunning;
     bool EnableButtonMapping = false;
     bool EnableAxisMapping = false;
     bool MappingCompleted = false;
@@ -57,7 +57,8 @@ private:
     int MappingTimer;
     QTimer* timer;
     QPushButton* MappingButton;
-    SDL_Gamepad* m_gamepad = nullptr;
+    SDL_Gamepad* gamepad = nullptr;
+    SdlEventWrapper::Wrapper* RemapWrapper;
 
     const std::vector<std::string> ControllerInputs = {
         "cross",        "circle",    "square",      "triangle",    "l1",

--- a/src/qt_gui/control_settings.h
+++ b/src/qt_gui/control_settings.h
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <QComboBox>
 #include <QDialog>
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_gamepad.h>
 #include "game_info.h"
 
 namespace Ui {
@@ -15,10 +18,17 @@ public:
                              QWidget* parent = nullptr);
     ~ControlSettings();
 
+signals:
+    void gamepadInputEvent();
+    void AxisChanged();
+
 private Q_SLOTS:
     void SaveControllerConfig(bool CloseOnSave);
     void SetDefault();
     void UpdateLightbarColor();
+    void CheckMapping(QPushButton*& button);
+    void StartTimer(QPushButton*& button, bool isButton);
+    void ConnectAxisInputs(QPushButton*& button);
 
 private:
     std::unique_ptr<Ui::ControlSettings> ui;
@@ -27,6 +37,23 @@ private:
     void AddBoxItems();
     void SetUIValuestoMappings();
     void GetGameTitle();
+    void CheckGamePad();
+    void pollSDLEvents();
+    void DisableMappingButtons();
+    void EnableMappingButtons();
+
+    QList<QPushButton*> ButtonsList;
+    QList<QPushButton*> AxisList;
+
+    bool isRunning = true;
+    bool EnableButtonMapping = false;
+    bool EnableAxisMapping = false;
+    bool MappingCompleted = false;
+    QString mapping;
+    int MappingTimer;
+    QTimer* timer;
+    QPushButton* MappingButton;
+    SDL_Gamepad* m_gamepad = nullptr;
 
     const std::vector<std::string> ControllerInputs = {
         "cross",        "circle",    "square",      "triangle",    "l1",
@@ -39,29 +66,10 @@ private:
         "pad_left",     "pad_right", "axis_left_x", "axis_left_y", "axis_right_x",
         "axis_right_y", "back"};
 
-    const QStringList ButtonOutputs = {"cross",
-                                       "circle",
-                                       "square",
-                                       "triangle",
-                                       "l1",
-                                       "r1",
-                                       "l2",
-                                       "r2",
-                                       "l3",
-
-                                       "r3",
-                                       "options",
-                                       "pad_up",
-
-                                       "pad_down",
-
-                                       "pad_left",
-                                       "pad_right",
-                                       "touchpad_left",
-                                       "touchpad_center",
-                                       "touchpad_right",
-                                       "unmapped"};
-
-    const QStringList StickOutputs = {"axis_left_x", "axis_left_y", "axis_right_x", "axis_right_y",
-                                      "unmapped"};
+protected:
+    void closeEvent(QCloseEvent* event) override {
+        SDL_Event quitLoop{};
+        quitLoop.type = SDL_EVENT_QUIT;
+        SDL_PushEvent(&quitLoop);
+    }
 };

--- a/src/qt_gui/control_settings.h
+++ b/src/qt_gui/control_settings.h
@@ -19,7 +19,7 @@ public:
     ~ControlSettings();
 
 signals:
-    void gamepadInputEvent();
+    void PushGamepadEvent();
     void AxisChanged();
 
 private Q_SLOTS:
@@ -46,8 +46,10 @@ private:
 
     QList<QPushButton*> ButtonsList;
     QList<QPushButton*> AxisList;
+    QSet<QString> pressedButtons;
 
     bool isRunning = true;
+    bool triggerWasPressed = false;
     bool EnableButtonMapping = false;
     bool EnableAxisMapping = false;
     bool MappingCompleted = false;

--- a/src/qt_gui/control_settings.h
+++ b/src/qt_gui/control_settings.h
@@ -44,7 +44,7 @@ private:
     void SetMapping(QString input);
     void DisableMappingButtons();
     void EnableMappingButtons();
-    void cleanup();
+    void Cleanup();
 
     QList<QPushButton*> ButtonsList;
     QList<QPushButton*> AxisList;
@@ -76,6 +76,6 @@ private:
 
 protected:
     void closeEvent(QCloseEvent* event) override {
-        cleanup();
+        Cleanup();
     }
 };

--- a/src/qt_gui/control_settings.h
+++ b/src/qt_gui/control_settings.h
@@ -51,6 +51,8 @@ private:
     QSet<QString> pressedButtons;
 
     bool GameRunning;
+    bool L2Pressed = false;
+    bool R2Pressed = false;
     bool EnableButtonMapping = false;
     bool EnableAxisMapping = false;
     bool MappingCompleted = false;

--- a/src/qt_gui/control_settings.h
+++ b/src/qt_gui/control_settings.h
@@ -34,11 +34,13 @@ private:
     std::unique_ptr<Ui::ControlSettings> ui;
     std::shared_ptr<GameInfoClass> m_game_info;
 
+    bool eventFilter(QObject* obj, QEvent* event) override;
     void AddBoxItems();
     void SetUIValuestoMappings();
     void GetGameTitle();
     void CheckGamePad();
     void pollSDLEvents();
+    void SetMapping(QString input);
     void DisableMappingButtons();
     void EnableMappingButtons();
 

--- a/src/qt_gui/control_settings.h
+++ b/src/qt_gui/control_settings.h
@@ -63,6 +63,7 @@ private:
     QPushButton* MappingButton;
     SDL_Gamepad* gamepad = nullptr;
     SdlEventWrapper::Wrapper* RemapWrapper;
+    QFuture<void> Polling;
 
     const std::vector<std::string> ControllerInputs = {
         "cross",        "circle",    "square",      "triangle",    "l1",

--- a/src/qt_gui/control_settings.h
+++ b/src/qt_gui/control_settings.h
@@ -15,7 +15,7 @@ class ControlSettings : public QDialog {
     Q_OBJECT
 public:
     explicit ControlSettings(std::shared_ptr<GameInfoClass> game_info_get, bool GameRunning,
-                             QWidget* parent = nullptr);
+                             std::string GameRunningSerial, QWidget* parent = nullptr);
     ~ControlSettings();
 
 signals:
@@ -50,6 +50,7 @@ private:
     QList<QPushButton*> AxisList;
     QSet<QString> pressedButtons;
 
+    std::string RunningGameSerial;
     bool GameRunning;
     bool L2Pressed = false;
     bool R2Pressed = false;

--- a/src/qt_gui/control_settings.ui
+++ b/src/qt_gui/control_settings.ui
@@ -11,8 +11,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1043</width>
-    <height>792</height>
+    <width>1114</width>
+    <height>794</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -33,8 +33,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>1019</width>
-        <height>732</height>
+        <width>1094</width>
+        <height>744</height>
        </rect>
       </property>
       <widget class="QWidget" name="layoutWidget">
@@ -42,8 +42,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>1021</width>
-         <height>731</height>
+         <width>1091</width>
+         <height>741</height>
         </rect>
        </property>
        <layout class="QHBoxLayout" name="RemapLayout">
@@ -110,7 +110,7 @@
                  <widget class="QGroupBox" name="gb_dpad_up">
                   <property name="minimumSize">
                    <size>
-                    <width>124</width>
+                    <width>152</width>
                     <height>0</height>
                    </size>
                   </property>
@@ -125,12 +125,9 @@
                   </property>
                   <layout class="QHBoxLayout" name="horizontalLayout_4">
                    <item>
-                    <widget class="QComboBox" name="DpadUpBox">
-                     <property name="editable">
-                      <bool>false</bool>
-                     </property>
-                     <property name="sizeAdjustPolicy">
-                      <enum>QComboBox::SizeAdjustPolicy::AdjustToContents</enum>
+                    <widget class="QPushButton" name="DpadUpButton">
+                     <property name="text">
+                      <string>unmapped</string>
                      </property>
                     </widget>
                    </item>
@@ -161,7 +158,11 @@
                    <number>5</number>
                   </property>
                   <item>
-                   <widget class="QComboBox" name="DpadLeftBox"/>
+                   <widget class="QPushButton" name="DpadLeftButton">
+                    <property name="text">
+                     <string>unmapped</string>
+                    </property>
+                   </widget>
                   </item>
                  </layout>
                 </widget>
@@ -185,9 +186,9 @@
                    <number>5</number>
                   </property>
                   <item>
-                   <widget class="QComboBox" name="DpadRightBox">
-                    <property name="editable">
-                     <bool>false</bool>
+                   <widget class="QPushButton" name="DpadRightButton">
+                    <property name="text">
+                     <string>unmapped</string>
                     </property>
                    </widget>
                   </item>
@@ -213,6 +214,12 @@
                 </property>
                 <item>
                  <widget class="QGroupBox" name="gb_dpad_down">
+                  <property name="minimumSize">
+                   <size>
+                    <width>152</width>
+                    <height>0</height>
+                   </size>
+                  </property>
                   <property name="maximumSize">
                    <size>
                     <width>124</width>
@@ -224,21 +231,9 @@
                   </property>
                   <layout class="QHBoxLayout" name="horizontalLayout_3">
                    <item>
-                    <widget class="QComboBox" name="DpadDownBox">
-                     <property name="enabled">
-                      <bool>true</bool>
-                     </property>
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="minimumSize">
-                      <size>
-                       <width>0</width>
-                       <height>0</height>
-                      </size>
+                    <widget class="QPushButton" name="DpadDownButton">
+                     <property name="text">
+                      <string>unmapped</string>
                      </property>
                     </widget>
                    </item>
@@ -378,7 +373,7 @@
                   </property>
                   <property name="maximumSize">
                    <size>
-                    <width>124</width>
+                    <width>152</width>
                     <height>16777215</height>
                    </size>
                   </property>
@@ -387,9 +382,9 @@
                   </property>
                   <layout class="QVBoxLayout" name="verticalLayout_10">
                    <item>
-                    <widget class="QComboBox" name="LStickUpBox">
-                     <property name="enabled">
-                      <bool>true</bool>
+                    <widget class="QPushButton" name="LStickUpButton">
+                     <property name="text">
+                      <string>unmapped</string>
                      </property>
                     </widget>
                    </item>
@@ -420,9 +415,9 @@
                    <number>5</number>
                   </property>
                   <item>
-                   <widget class="QComboBox" name="LStickLeftBox">
-                    <property name="enabled">
-                     <bool>true</bool>
+                   <widget class="QPushButton" name="LStickLeftButton">
+                    <property name="text">
+                     <string>unmapped</string>
                     </property>
                    </widget>
                   </item>
@@ -454,9 +449,9 @@
                    <number>5</number>
                   </property>
                   <item>
-                   <widget class="QComboBox" name="LStickRightBox">
-                    <property name="enabled">
-                     <bool>true</bool>
+                   <widget class="QPushButton" name="LStickRightButton">
+                    <property name="text">
+                     <string>unmapped</string>
                     </property>
                    </widget>
                   </item>
@@ -484,7 +479,7 @@
                  <widget class="QGroupBox" name="gb_left_stick_down">
                   <property name="minimumSize">
                    <size>
-                    <width>124</width>
+                    <width>152</width>
                     <height>0</height>
                    </size>
                   </property>
@@ -499,15 +494,9 @@
                   </property>
                   <layout class="QVBoxLayout" name="verticalLayout_8">
                    <item>
-                    <widget class="QComboBox" name="LStickDownBox">
-                     <property name="enabled">
-                      <bool>true</bool>
-                     </property>
-                     <property name="editable">
-                      <bool>false</bool>
-                     </property>
-                     <property name="frame">
-                      <bool>false</bool>
+                    <widget class="QPushButton" name="LStickDownButton">
+                     <property name="text">
+                      <string>unmapped</string>
                      </property>
                     </widget>
                    </item>
@@ -618,145 +607,186 @@
              <number>0</number>
             </property>
             <item>
-             <layout class="QVBoxLayout" name="layout_l1_l2">
-              <item>
-               <widget class="QGroupBox" name="gb_l1">
-                <property name="title">
-                 <string>L1 / LB</string>
-                </property>
-                <layout class="QVBoxLayout" name="gb_l1_layout">
-                 <property name="leftMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>5</number>
-                 </property>
-                 <item>
-                  <widget class="QComboBox" name="LBBox"/>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="gb_l2">
-                <property name="title">
-                 <string>L2 / LT</string>
-                </property>
-                <layout class="QVBoxLayout" name="gb_l2_layout">
-                 <property name="leftMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>5</number>
-                 </property>
-                 <item>
-                  <widget class="QComboBox" name="LTBox"/>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item>
              <layout class="QVBoxLayout" name="layout_system_buttons">
               <item>
-               <spacer name="verticalSpacer_3">
-                <property name="orientation">
-                 <enum>Qt::Orientation::Vertical</enum>
-                </property>
-                <property name="sizeType">
-                 <enum>QSizePolicy::Policy::Preferred</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>40</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item>
                <layout class="QVBoxLayout" name="verticalLayout_4">
-                <property name="spacing">
-                 <number>10</number>
-                </property>
                 <item>
-                 <widget class="QGroupBox" name="groupBox_2">
-                  <property name="title">
-                   <string>Back</string>
-                  </property>
-                  <layout class="QVBoxLayout" name="verticalLayout_9">
-                   <item>
-                    <widget class="QComboBox" name="BackBox"/>
-                   </item>
-                  </layout>
-                 </widget>
+                 <layout class="QHBoxLayout" name="horizontalLayout_13">
+                  <item>
+                   <widget class="QGroupBox" name="gb_l1">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="title">
+                     <string>L1</string>
+                    </property>
+                    <layout class="QVBoxLayout" name="gb_l1_layout">
+                     <property name="leftMargin">
+                      <number>5</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>5</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>5</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>5</number>
+                     </property>
+                     <item>
+                      <widget class="QPushButton" name="L1Button">
+                       <property name="text">
+                        <string>unmapped</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="horizontalSpacer_2">
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Horizontal</enum>
+                    </property>
+                    <property name="sizeType">
+                     <enum>QSizePolicy::Policy::Fixed</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>133</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="gb_r1">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="title">
+                     <string>R1</string>
+                    </property>
+                    <layout class="QVBoxLayout" name="gb_r1_layout">
+                     <property name="leftMargin">
+                      <number>5</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>5</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>5</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>5</number>
+                     </property>
+                     <item>
+                      <widget class="QPushButton" name="R1Button">
+                       <property name="text">
+                        <string>unmapped</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                 </layout>
+                </item>
+                <item>
+                 <layout class="QHBoxLayout" name="horizontalLayout_14">
+                  <item>
+                   <widget class="QGroupBox" name="gb_l2">
+                    <property name="title">
+                     <string>L2</string>
+                    </property>
+                    <layout class="QVBoxLayout" name="gb_l2_layout">
+                     <property name="leftMargin">
+                      <number>5</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>5</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>5</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>5</number>
+                     </property>
+                     <item>
+                      <widget class="QPushButton" name="L2Button">
+                       <property name="text">
+                        <string>unmapped</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="gb_start">
+                    <property name="title">
+                     <string>Options</string>
+                    </property>
+                    <layout class="QVBoxLayout" name="gb_start_layout">
+                     <property name="leftMargin">
+                      <number>5</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>5</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>5</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>5</number>
+                     </property>
+                     <item>
+                      <widget class="QPushButton" name="OptionsButton">
+                       <property name="text">
+                        <string>unmapped</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="gb_r2">
+                    <property name="title">
+                     <string>R2</string>
+                    </property>
+                    <layout class="QVBoxLayout" name="gb_r2_layout">
+                     <property name="leftMargin">
+                      <number>5</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>5</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>5</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>5</number>
+                     </property>
+                     <item>
+                      <widget class="QPushButton" name="R2Button">
+                       <property name="text">
+                        <string>unmapped</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                 </layout>
                 </item>
                </layout>
-              </item>
-             </layout>
-            </item>
-            <item>
-             <layout class="QVBoxLayout" name="layout_r1_r2">
-              <item>
-               <widget class="QGroupBox" name="gb_r1">
-                <property name="title">
-                 <string>R1 / RB</string>
-                </property>
-                <layout class="QVBoxLayout" name="gb_r1_layout">
-                 <property name="leftMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>5</number>
-                 </property>
-                 <item>
-                  <widget class="QComboBox" name="RBBox"/>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="gb_r2">
-                <property name="title">
-                 <string>R2 / RT</string>
-                </property>
-                <layout class="QVBoxLayout" name="gb_r2_layout">
-                 <property name="leftMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>5</number>
-                 </property>
-                 <item>
-                  <widget class="QComboBox" name="RTBox"/>
-                 </item>
-                </layout>
-               </widget>
               </item>
              </layout>
             </item>
@@ -806,7 +836,7 @@
            </widget>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="layout_middle_bottom">
+           <layout class="QVBoxLayout" name="verticalLayout_9">
             <property name="spacing">
              <number>10</number>
             </property>
@@ -814,76 +844,144 @@
              <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
             </property>
             <item>
-             <widget class="QGroupBox" name="gb_l3">
-              <property name="title">
-               <string>L3</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_l3_layout">
-               <property name="leftMargin">
-                <number>5</number>
-               </property>
-               <property name="topMargin">
-                <number>5</number>
-               </property>
-               <property name="rightMargin">
-                <number>5</number>
-               </property>
-               <property name="bottomMargin">
-                <number>5</number>
-               </property>
-               <item>
-                <widget class="QComboBox" name="LClickBox"/>
-               </item>
-              </layout>
-             </widget>
+             <layout class="QHBoxLayout" name="horizontalLayout">
+              <item>
+               <widget class="QGroupBox" name="gb_l3">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="title">
+                 <string>L3</string>
+                </property>
+                <layout class="QVBoxLayout" name="gb_l3_layout">
+                 <property name="leftMargin">
+                  <number>5</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>5</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>5</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>5</number>
+                 </property>
+                 <item>
+                  <widget class="QPushButton" name="L3Button">
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer">
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Policy::Fixed</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>133</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QGroupBox" name="gb_r3">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="title">
+                 <string>R3</string>
+                </property>
+                <layout class="QVBoxLayout" name="gb_r3_layout">
+                 <property name="leftMargin">
+                  <number>5</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>5</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>5</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>5</number>
+                 </property>
+                 <item>
+                  <widget class="QPushButton" name="R3Button">
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+             </layout>
             </item>
             <item>
-             <widget class="QGroupBox" name="gb_start">
-              <property name="title">
-               <string>Options / Start</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_start_layout">
-               <property name="leftMargin">
-                <number>5</number>
-               </property>
-               <property name="topMargin">
-                <number>5</number>
-               </property>
-               <property name="rightMargin">
-                <number>5</number>
-               </property>
-               <property name="bottomMargin">
-                <number>5</number>
-               </property>
-               <item>
-                <widget class="QComboBox" name="StartBox"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_r3">
-              <property name="title">
-               <string>R3</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_r3_layout">
-               <property name="leftMargin">
-                <number>5</number>
-               </property>
-               <property name="topMargin">
-                <number>5</number>
-               </property>
-               <property name="rightMargin">
-                <number>5</number>
-               </property>
-               <property name="bottomMargin">
-                <number>5</number>
-               </property>
-               <item>
-                <widget class="QComboBox" name="RClickBox"/>
-               </item>
-              </layout>
-             </widget>
+             <layout class="QHBoxLayout" name="horizontalLayout_2">
+              <item>
+               <widget class="QGroupBox" name="gb_touchleft">
+                <property name="title">
+                 <string>Touchpad Left</string>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_5">
+                 <item>
+                  <widget class="QPushButton" name="TouchpadLeftButton">
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QGroupBox" name="gb_touchcenter">
+                <property name="title">
+                 <string>Touchpad Center</string>
+                </property>
+                <layout class="QVBoxLayout" name="verticalLayout_11">
+                 <item>
+                  <widget class="QPushButton" name="TouchpadCenterButton">
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QGroupBox" name="gb_touchright">
+                <property name="title">
+                 <string>Touchpad Right</string>
+                </property>
+                <layout class="QVBoxLayout" name="verticalLayout_12">
+                 <item>
+                  <widget class="QPushButton" name="TouchpadRightButton">
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+             </layout>
             </item>
            </layout>
           </item>
@@ -1104,7 +1202,7 @@
                   </property>
                   <property name="minimumSize">
                    <size>
-                    <width>124</width>
+                    <width>152</width>
                     <height>0</height>
                    </size>
                   </property>
@@ -1115,19 +1213,13 @@
                    </size>
                   </property>
                   <property name="title">
-                   <string>Triangle / Y</string>
+                   <string>Triangle</string>
                   </property>
                   <layout class="QVBoxLayout" name="verticalLayout_3">
                    <item>
-                    <widget class="QComboBox" name="YBox">
-                     <property name="enabled">
-                      <bool>true</bool>
-                     </property>
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
+                    <widget class="QPushButton" name="TriangleButton">
+                     <property name="text">
+                      <string>unmapped</string>
                      </property>
                     </widget>
                    </item>
@@ -1142,7 +1234,7 @@
                <item>
                 <widget class="QGroupBox" name="gb_square">
                  <property name="title">
-                  <string>Square / X</string>
+                  <string>Square</string>
                  </property>
                  <layout class="QVBoxLayout" name="gb_square_layout">
                   <property name="leftMargin">
@@ -1158,7 +1250,11 @@
                    <number>5</number>
                   </property>
                   <item>
-                   <widget class="QComboBox" name="XBox"/>
+                   <widget class="QPushButton" name="SquareButton">
+                    <property name="text">
+                     <string>unmapped</string>
+                    </property>
+                   </widget>
                   </item>
                  </layout>
                 </widget>
@@ -1166,7 +1262,7 @@
                <item>
                 <widget class="QGroupBox" name="gb_circle">
                  <property name="title">
-                  <string>Circle / B</string>
+                  <string>Circle</string>
                  </property>
                  <layout class="QVBoxLayout" name="gb_circle_layout">
                   <property name="leftMargin">
@@ -1182,7 +1278,11 @@
                    <number>5</number>
                   </property>
                   <item>
-                   <widget class="QComboBox" name="BBox"/>
+                   <widget class="QPushButton" name="CircleButton">
+                    <property name="text">
+                     <string>unmapped</string>
+                    </property>
+                   </widget>
                   </item>
                  </layout>
                 </widget>
@@ -1208,7 +1308,7 @@
                  <widget class="QGroupBox" name="gb_cross">
                   <property name="minimumSize">
                    <size>
-                    <width>124</width>
+                    <width>152</width>
                     <height>0</height>
                    </size>
                   </property>
@@ -1219,11 +1319,15 @@
                    </size>
                   </property>
                   <property name="title">
-                   <string>Cross / A</string>
+                   <string>Cross</string>
                   </property>
                   <layout class="QVBoxLayout" name="verticalLayout_5">
                    <item>
-                    <widget class="QComboBox" name="ABox"/>
+                    <widget class="QPushButton" name="CrossButton">
+                     <property name="text">
+                      <string>unmapped</string>
+                     </property>
+                    </widget>
                    </item>
                   </layout>
                  </widget>
@@ -1361,7 +1465,7 @@
                   </property>
                   <property name="maximumSize">
                    <size>
-                    <width>124</width>
+                    <width>152</width>
                     <height>1231321</height>
                    </size>
                   </property>
@@ -1370,9 +1474,9 @@
                   </property>
                   <layout class="QVBoxLayout" name="verticalLayout_7">
                    <item>
-                    <widget class="QComboBox" name="RStickUpBox">
-                     <property name="enabled">
-                      <bool>true</bool>
+                    <widget class="QPushButton" name="RStickUpButton">
+                     <property name="text">
+                      <string>unmapped</string>
                      </property>
                     </widget>
                    </item>
@@ -1403,9 +1507,9 @@
                    <number>5</number>
                   </property>
                   <item>
-                   <widget class="QComboBox" name="RStickLeftBox">
-                    <property name="enabled">
-                     <bool>true</bool>
+                   <widget class="QPushButton" name="RStickLeftButton">
+                    <property name="text">
+                     <string>unmapped</string>
                     </property>
                    </widget>
                   </item>
@@ -1431,7 +1535,11 @@
                    <number>5</number>
                   </property>
                   <item>
-                   <widget class="QComboBox" name="RStickRightBox"/>
+                   <widget class="QPushButton" name="RStickRightButton">
+                    <property name="text">
+                     <string>unmapped</string>
+                    </property>
+                   </widget>
                   </item>
                  </layout>
                 </widget>
@@ -1457,7 +1565,7 @@
                  <widget class="QGroupBox" name="gb_right_stick_down">
                   <property name="minimumSize">
                    <size>
-                    <width>124</width>
+                    <width>152</width>
                     <height>0</height>
                    </size>
                   </property>
@@ -1472,9 +1580,9 @@
                   </property>
                   <layout class="QVBoxLayout" name="verticalLayout_6">
                    <item>
-                    <widget class="QComboBox" name="RStickDownBox">
-                     <property name="enabled">
-                      <bool>true</bool>
+                    <widget class="QPushButton" name="RStickDownButton">
+                     <property name="text">
+                      <string>unmapped</string>
                      </property>
                     </widget>
                    </item>

--- a/src/qt_gui/kbm_gui.cpp
+++ b/src/qt_gui/kbm_gui.cpp
@@ -7,21 +7,31 @@
 #include <QMouseEvent>
 #include <QPushButton>
 #include <QWheelEvent>
+#include <SDL3/SDL_events.h>
 
 #include "common/path_util.h"
 #include "kbm_config_dialog.h"
 #include "kbm_gui.h"
 #include "kbm_help_dialog.h"
+#include "sdl_window.h"
 #include "ui_kbm_gui.h"
 
 HelpDialog* HelpWindow;
-KBMSettings::KBMSettings(std::shared_ptr<GameInfoClass> game_info_get, QWidget* parent)
-    : QDialog(parent), m_game_info(game_info_get), ui(new Ui::KBMSettings) {
+KBMSettings::KBMSettings(std::shared_ptr<GameInfoClass> game_info_get, bool isGameRunning,
+                         QWidget* parent)
+    : QDialog(parent), m_game_info(game_info_get), GameRunning(isGameRunning),
+      ui(new Ui::KBMSettings) {
 
     ui->setupUi(this);
     ui->PerGameCheckBox->setChecked(!Config::GetUseUnifiedInputConfig());
     ui->TextEditorButton->setFocus();
     this->setFocusPolicy(Qt::StrongFocus);
+
+    if (GameRunning) {
+        SDL_Event pauseGame{};
+        pauseGame.type = SDL_EVENT_TOGGLE_PAUSE;
+        SDL_PushEvent(&pauseGame);
+    }
 
     ui->MouseJoystickBox->addItem("none");
     ui->MouseJoystickBox->addItem("right");
@@ -998,8 +1008,15 @@ bool KBMSettings::eventFilter(QObject* obj, QEvent* event) {
             }
         }
     }
-
     return QDialog::eventFilter(obj, event);
+}
+
+void KBMSettings::Cleanup() {
+    if (GameRunning) {
+        SDL_Event resumeGame{};
+        resumeGame.type = SDL_EVENT_TOGGLE_PAUSE;
+        SDL_PushEvent(&resumeGame);
+    }
 }
 
 KBMSettings::~KBMSettings() {}

--- a/src/qt_gui/kbm_gui.cpp
+++ b/src/qt_gui/kbm_gui.cpp
@@ -269,9 +269,17 @@ void KBMSettings::SaveKBMConfig(bool close_on_save) {
         output_string = line.substr(0, equal_pos - 1);
         input_string = line.substr(equal_pos + 2);
 
-        if (std::find(ControllerInputs.begin(), ControllerInputs.end(), input_string) !=
-                ControllerInputs.end() ||
-            output_string == "analog_deadzone" || output_string == "override_controller_color") {
+        bool controllerInputdetected = false;
+        for (std::string input : ControllerInputs) {
+            // Needed to avoid detecting backspace while detecting back
+            if (input_string.contains(input) && !input_string.contains("backspace")) {
+                controllerInputdetected = true;
+                break;
+            }
+        }
+
+        if (controllerInputdetected || output_string == "analog_deadzone" ||
+            output_string == "override_controller_color") {
             lines.push_back(line);
         }
     }
@@ -388,8 +396,16 @@ void KBMSettings::SetUIValuestoMappings(std::string config_id) {
         std::string output_string = line.substr(0, equal_pos - 1);
         std::string input_string = line.substr(equal_pos + 2);
 
-        if (std::find(ControllerInputs.begin(), ControllerInputs.end(), input_string) ==
-            ControllerInputs.end()) {
+        bool controllerInputdetected = false;
+        for (std::string input : ControllerInputs) {
+            // Needed to avoid detecting backspace while detecting back
+            if (input_string.contains(input) && !input_string.contains("backspace")) {
+                controllerInputdetected = true;
+                break;
+            }
+        }
+
+        if (!controllerInputdetected) {
             if (output_string == "cross") {
                 ui->CrossButton->setText(QString::fromStdString(input_string));
             } else if (output_string == "circle") {

--- a/src/qt_gui/kbm_gui.h
+++ b/src/qt_gui/kbm_gui.h
@@ -23,7 +23,8 @@ class KBMSettings;
 class KBMSettings : public QDialog {
     Q_OBJECT
 public:
-    explicit KBMSettings(std::shared_ptr<GameInfoClass> game_info_get, QWidget* parent = nullptr);
+    explicit KBMSettings(std::shared_ptr<GameInfoClass> game_info_get, bool GameRunning,
+                         QWidget* parent = nullptr);
     ~KBMSettings();
 
 private Q_SLOTS:
@@ -44,8 +45,10 @@ private:
     void DisableMappingButtons();
     void EnableMappingButtons();
     void SetMapping(QString input);
+    void Cleanup();
 
     QSet<QString> pressedKeys;
+    bool GameRunning;
     bool EnableMapping = false;
     bool MappingCompleted = false;
     bool HelpWindowOpen = false;
@@ -66,4 +69,9 @@ private:
 
         "pad_left",     "pad_right", "axis_left_x", "axis_left_y", "axis_right_x",
         "axis_right_y", "back"};
+
+protected:
+    void closeEvent(QCloseEvent* event) override {
+        Cleanup();
+    }
 };

--- a/src/qt_gui/kbm_gui.h
+++ b/src/qt_gui/kbm_gui.h
@@ -24,7 +24,7 @@ class KBMSettings : public QDialog {
     Q_OBJECT
 public:
     explicit KBMSettings(std::shared_ptr<GameInfoClass> game_info_get, bool GameRunning,
-                         QWidget* parent = nullptr);
+                         std::string GameRunningSerial, QWidget* parent = nullptr);
     ~KBMSettings();
 
 private Q_SLOTS:
@@ -47,6 +47,7 @@ private:
     void SetMapping(QString input);
     void Cleanup();
 
+    std::string RunningGameSerial;
     QSet<QString> pressedKeys;
     bool GameRunning;
     bool EnableMapping = false;
@@ -69,9 +70,4 @@ private:
 
         "pad_left",     "pad_right", "axis_left_x", "axis_left_y", "axis_right_x",
         "axis_right_y", "back"};
-
-protected:
-    void closeEvent(QCloseEvent* event) override {
-        Cleanup();
-    }
 };

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -478,7 +478,7 @@ void MainWindow::CreateConnects() {
     });
 
     connect(ui->keyboardButton, &QPushButton::clicked, this, [this]() {
-        auto kbmWindow = new KBMSettings(m_game_info, this);
+        auto kbmWindow = new KBMSettings(m_game_info, isGameRunning, this);
         kbmWindow->exec();
     });
 

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -473,12 +473,13 @@ void MainWindow::CreateConnects() {
     });
 
     connect(ui->controllerButton, &QPushButton::clicked, this, [this]() {
-        ControlSettings* remapWindow = new ControlSettings(m_game_info, isGameRunning, this);
+        ControlSettings* remapWindow =
+            new ControlSettings(m_game_info, isGameRunning, runningGameSerial, this);
         remapWindow->exec();
     });
 
     connect(ui->keyboardButton, &QPushButton::clicked, this, [this]() {
-        auto kbmWindow = new KBMSettings(m_game_info, isGameRunning, this);
+        auto kbmWindow = new KBMSettings(m_game_info, isGameRunning, runningGameSerial, this);
         kbmWindow->exec();
     });
 
@@ -846,12 +847,14 @@ void MainWindow::StartGame() {
         if (m_game_list_frame->currentItem()) {
             int itemID = m_game_list_frame->currentItem()->row();
             Common::FS::PathToQString(gamePath, m_game_info->m_games[itemID].path / "eboot.bin");
+            runningGameSerial = m_game_info->m_games[itemID].serial;
         }
     } else if (table_mode == 1) {
         if (m_game_grid_frame->cellClicked) {
             int itemID = (m_game_grid_frame->crtRow * m_game_grid_frame->columnCnt) +
                          m_game_grid_frame->crtColumn;
             Common::FS::PathToQString(gamePath, m_game_info->m_games[itemID].path / "eboot.bin");
+            runningGameSerial = m_game_info->m_games[itemID].serial;
         }
     } else {
         if (m_elf_viewer->currentItem()) {

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -473,13 +473,8 @@ void MainWindow::CreateConnects() {
     });
 
     connect(ui->controllerButton, &QPushButton::clicked, this, [this]() {
-        if (!isGameRunning) {
-            auto configWindow = new ControlSettings(m_game_info, this);
-            configWindow->exec();
-        } else {
-            QMessageBox::information(this, tr("Remapping not available"),
-                                     tr("Cannot remap controller while game is running"));
-        }
+        ControlSettings* remapWindow = new ControlSettings(m_game_info, isGameRunning, this);
+        remapWindow->exec();
     });
 
     connect(ui->keyboardButton, &QPushButton::clicked, this, [this]() {

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -473,8 +473,13 @@ void MainWindow::CreateConnects() {
     });
 
     connect(ui->controllerButton, &QPushButton::clicked, this, [this]() {
-        auto configWindow = new ControlSettings(m_game_info, this);
-        configWindow->exec();
+        if (!isGameRunning) {
+            auto configWindow = new ControlSettings(m_game_info, this);
+            configWindow->exec();
+        } else {
+            QMessageBox::information(this, tr("Remapping not available"),
+                                     tr("Cannot remap controller while game is running"));
+        }
     });
 
     connect(ui->keyboardButton, &QPushButton::clicked, this, [this]() {

--- a/src/qt_gui/main_window.h
+++ b/src/qt_gui/main_window.h
@@ -75,11 +75,13 @@ private:
     void PlayBackgroundMusic();
     QIcon RecolorIcon(const QIcon& icon, bool isWhite);
     void StartEmulator(std::filesystem::path);
+
     bool isIconBlack = false;
     bool isTableList = true;
     bool isGameRunning = false;
     bool isWhite = false;
     bool is_paused = false;
+    std::string runningGameSerial = "";
 
     QActionGroup* m_icon_size_act_group = nullptr;
     QActionGroup* m_list_mode_act_group = nullptr;

--- a/src/qt_gui/sdl_event_wrapper.cpp
+++ b/src/qt_gui/sdl_event_wrapper.cpp
@@ -22,9 +22,6 @@ bool Wrapper::ProcessEvent(SDL_Event* event) {
     case SDL_EVENT_QUIT:
         emit SDLEvent(SDL_EVENT_QUIT, 0, 0);
         return true;
-    case SDL_EVENT_GAMEPAD_ADDED:
-        emit SDLEvent(SDL_EVENT_GAMEPAD_ADDED, 0, 0);
-        return true;
     case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
         emit SDLEvent(SDL_EVENT_GAMEPAD_BUTTON_DOWN, event->gbutton.button, 0);
         return true;

--- a/src/qt_gui/sdl_event_wrapper.cpp
+++ b/src/qt_gui/sdl_event_wrapper.cpp
@@ -19,6 +19,10 @@ Wrapper* Wrapper::GetInstance() {
 
 bool Wrapper::ProcessEvent(SDL_Event* event) {
     switch (event->type) {
+    case SDL_EVENT_WINDOW_RESTORED:
+        return false;
+    case SDL_EVENT_WINDOW_EXPOSED:
+        return false;
     case SDL_EVENT_GAMEPAD_ADDED:
         return false;
     case SDL_EVENT_GAMEPAD_REMOVED:

--- a/src/qt_gui/sdl_event_wrapper.cpp
+++ b/src/qt_gui/sdl_event_wrapper.cpp
@@ -18,9 +18,6 @@ Wrapper* Wrapper::GetInstance() {
 }
 
 bool Wrapper::ProcessEvent(SDL_Event* event) {
-    if (!wrapperActive)
-        return false;
-
     switch (event->type) {
     case SDL_EVENT_QUIT:
         emit SDLEvent(SDL_EVENT_QUIT, 0, 0);

--- a/src/qt_gui/sdl_event_wrapper.cpp
+++ b/src/qt_gui/sdl_event_wrapper.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "sdl_event_wrapper.h"
+
+using namespace SdlEventWrapper;
+
+Wrapper* Wrapper::WrapperInstance = nullptr;
+bool Wrapper::wrapperActive = false;
+
+Wrapper::Wrapper(QObject* parent) : QObject(parent) {}
+
+Wrapper* Wrapper::GetInstance() {
+    if (WrapperInstance == nullptr) {
+        WrapperInstance = new Wrapper();
+    }
+    return WrapperInstance;
+}
+
+bool Wrapper::ProcessEvent(SDL_Event* event) {
+    if (!wrapperActive)
+        return false;
+
+    switch (event->type) {
+    case SDL_EVENT_QUIT:
+        emit SDLEvent(SDL_EVENT_QUIT, 0, 0);
+        return true;
+    case SDL_EVENT_GAMEPAD_ADDED:
+        emit SDLEvent(SDL_EVENT_GAMEPAD_ADDED, 0, 0);
+        return true;
+    case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
+        emit SDLEvent(SDL_EVENT_GAMEPAD_BUTTON_DOWN, event->gbutton.button, 0);
+        return true;
+    case SDL_EVENT_GAMEPAD_BUTTON_UP:
+        emit SDLEvent(SDL_EVENT_GAMEPAD_BUTTON_UP, event->gbutton.button, 0);
+        return true;
+    case SDL_EVENT_GAMEPAD_AXIS_MOTION:
+        emit SDLEvent(SDL_EVENT_GAMEPAD_AXIS_MOTION, event->gaxis.axis, event->gaxis.value);
+        return true;
+    default:
+        return false;
+    }
+}
+Wrapper::~Wrapper() {}

--- a/src/qt_gui/sdl_event_wrapper.cpp
+++ b/src/qt_gui/sdl_event_wrapper.cpp
@@ -19,6 +19,10 @@ Wrapper* Wrapper::GetInstance() {
 
 bool Wrapper::ProcessEvent(SDL_Event* event) {
     switch (event->type) {
+    case SDL_EVENT_GAMEPAD_ADDED:
+        return false;
+    case SDL_EVENT_GAMEPAD_REMOVED:
+        return false;
     case SDL_EVENT_QUIT:
         emit SDLEvent(SDL_EVENT_QUIT, 0, 0);
         return true;
@@ -31,8 +35,9 @@ bool Wrapper::ProcessEvent(SDL_Event* event) {
     case SDL_EVENT_GAMEPAD_AXIS_MOTION:
         emit SDLEvent(SDL_EVENT_GAMEPAD_AXIS_MOTION, event->gaxis.axis, event->gaxis.value);
         return true;
+    // block all other SDL events while wrapper is active
     default:
-        return false;
+        return true;
     }
 }
 Wrapper::~Wrapper() {}

--- a/src/qt_gui/sdl_event_wrapper.h
+++ b/src/qt_gui/sdl_event_wrapper.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+#include <QObject>
+#include <SDL3/SDL_events.h>
+
+namespace SdlEventWrapper {
+
+class Wrapper : public QObject {
+    Q_OBJECT
+
+public:
+    explicit Wrapper(QObject* parent = nullptr);
+    ~Wrapper();
+    bool ProcessEvent(SDL_Event* event);
+    static Wrapper* GetInstance();
+    static bool wrapperActive;
+    static Wrapper* WrapperInstance;
+
+signals:
+    void SDLEvent(int Type, int Input, int Value);
+};
+
+} // namespace SdlEventWrapper

--- a/src/sdl_window.cpp
+++ b/src/sdl_window.cpp
@@ -20,6 +20,10 @@
 #include "sdl_window.h"
 #include "video_core/renderdoc.h"
 
+#ifdef ENABLE_QT_GUI
+#include "qt_gui/sdl_event_wrapper.h"
+#endif
+
 #ifdef __APPLE__
 #include "SDL3/SDL_metal.h"
 #endif
@@ -339,6 +343,13 @@ void WindowSDL::WaitEvent() {
     if (!SDL_WaitEvent(&event)) {
         return;
     }
+
+#ifdef ENABLE_QT_GUI
+    if (SdlEventWrapper::Wrapper::wrapperActive) {
+        if (SdlEventWrapper::Wrapper::GetInstance()->ProcessEvent(&event))
+            return;
+    }
+#endif
 
     if (ImGui::Core::ProcessEvent(&event)) {
         return;


### PR DESCRIPTION
Re-did the controller remapping GUI to be similar to the KBM GUI, it now listens for controller inputs instead of choosing items from a drop-down box.

Also to make it more consistent with the KBM GUI, the selections now represent inputs instead of outputs.

For now, controller only be remapped while a game in not running (so as to simplify SDL event loop handling).

Have not been able to test a lot, would be good to get a couple testers.