### PR TITLE
liverpool: Flush buffer cache on rewind packet and async download of small buffers

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -138,7 +138,7 @@ void MemoryManager::CopySparseMemory(VAddr virtual_addr, u8* dest, u64 size) {
 bool MemoryManager::TryWriteBacking(void* address, const void* data, u32 num_bytes) {
     const VAddr virtual_addr = std::bit_cast<VAddr>(address);
     const auto& vma = FindVMA(virtual_addr)->second;
-    ASSERT_MSG(vma.Contains(virtual_addr, 0),
+    ASSERT_MSG(vma.Contains(virtual_addr, num_bytes),
                "Attempting to access out of bounds memory at address {:#x}", virtual_addr);
     if (vma.type != VMAType::Direct) {
         return false;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -135,16 +135,25 @@ void MemoryManager::CopySparseMemory(VAddr virtual_addr, u8* dest, u64 size) {
     }
 }
 
-bool MemoryManager::TryWriteBacking(void* address, const void* data, u32 num_bytes) {
-    const VAddr virtual_addr = std::bit_cast<VAddr>(address);
-    const auto& vma = FindVMA(virtual_addr)->second;
-    ASSERT_MSG(vma.Contains(virtual_addr, num_bytes),
+bool MemoryManager::TryWriteBacking(void* address, const void* data, u32 size) {
+    VAddr virtual_addr = std::bit_cast<VAddr>(address);
+    const u8* src_data = std::bit_cast<const u8*>(data);
+    auto vma = FindVMA(virtual_addr);
+    ASSERT_MSG(vma->second.Contains(virtual_addr, 0),
                "Attempting to access out of bounds memory at address {:#x}", virtual_addr);
-    if (vma.type != VMAType::Direct) {
-        return false;
+    while (size) {
+        if (vma->second.type != VMAType::Direct) {
+            return false;
+        }
+        const u64 offset_in_vma = virtual_addr - vma->first;
+        u64 copy_size = std::min<u64>(vma->second.size - offset_in_vma, size);
+        u8* backing = impl.BackingBase() + vma->second.phys_base + offset_in_vma;
+        std::memcpy(backing, src_data, copy_size);
+        size -= copy_size;
+        virtual_addr += copy_size;
+        src_data += copy_size;
+        ++vma;
     }
-    u8* backing = impl.BackingBase() + vma.phys_base + (virtual_addr - vma.base);
-    memcpy(backing, data, num_bytes);
     return true;
 }
 

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -166,14 +166,21 @@ void EmitGetGotoVariable(EmitContext&) {
 using PointerType = EmitContext::PointerType;
 
 Id EmitReadConst(EmitContext& ctx, IR::Inst* inst, Id addr, Id offset) {
-    const u32 flatbuf_off_dw = inst->Flags<u32>();
+    const u32 flatbuf_offset = inst->Flags<u32>();
+    const auto& flatbuf_buffer{ctx.buffers.back()};
+    ASSERT(flatbuf_buffer.binding >= 0 && flatbuf_buffer.buffer_type == BufferType::Flatbuf);
+    const auto [flatbuf_buffer_id, flatbuf_pointer_type] = flatbuf_buffer[PointerType::U32];
+    const auto ptr{ctx.OpAccessChain(flatbuf_pointer_type, flatbuf_buffer_id, ctx.u32_zero_value,
+                                     ctx.ConstU32(flatbuf_offset))};
+    return ctx.OpLoad(ctx.U32[1], ptr);
+
     // We can only provide a fallback for immediate offsets.
-    if (flatbuf_off_dw == 0) {
-        return ctx.OpFunctionCall(ctx.U32[1], ctx.read_const_dynamic, addr, offset);
-    } else {
-        return ctx.OpFunctionCall(ctx.U32[1], ctx.read_const, addr, offset,
-                                  ctx.ConstU32(flatbuf_off_dw));
-    }
+    // if (flatbuf_off_dw == 0) {
+    //    return ctx.OpFunctionCall(ctx.U32[1], ctx.read_const_dynamic, addr, offset);
+    //} else {
+    //    return ctx.OpFunctionCall(ctx.U32[1], ctx.read_const, addr, offset,
+    //                              ctx.ConstU32(flatbuf_off_dw));
+    //}
 }
 
 template <PointerType type>

--- a/src/shader_recompiler/ir/passes/shader_info_collection_pass.cpp
+++ b/src/shader_recompiler/ir/passes/shader_info_collection_pass.cpp
@@ -136,6 +136,10 @@ void CollectShaderInfoPass(IR::Program& program) {
         }
     }
 
+    program.info.readconst_types = Info::ReadConstType::None;
+    program.info.dma_types = IR::Type::Void;
+    return;
+
     if (program.info.dma_types != IR::Type::Void) {
         program.info.buffers.push_back({
             .used_types = IR::Type::U64,

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -627,10 +627,10 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
             }
             case PM4ItOpcode::EventWriteEop: {
                 const auto* event_eop = reinterpret_cast<const PM4CmdEventWriteEop*>(header);
-                if (rasterizer) {
+                if (rasterizer && event_eop->event_type != EventType::BottomOfPipeTs) {
                     rasterizer->CommitPendingDownloads();
+                    ++fence_tick;
                 }
-                ++fence_tick;
                 event_eop->SignalFence([](void* address, u64 data, u32 num_bytes) {
                     auto* memory = Core::Memory::Instance();
                     if (!memory->TryWriteBacking(address, &data, num_bytes)) {
@@ -1024,9 +1024,9 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
         }
         case PM4ItOpcode::ReleaseMem: {
             const auto* release_mem = reinterpret_cast<const PM4CmdReleaseMem*>(header);
-            ++fence_tick;
             if (rasterizer) {
                 rasterizer->CommitPendingDownloads();
+                ++fence_tick;
             }
             release_mem->SignalFence(static_cast<Platform::InterruptId>(queue.pipe_id));
             break;

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -17,6 +17,8 @@
 #include "video_core/renderer_vulkan/vk_rasterizer.h"
 #include "video_core/renderer_vulkan/vk_scheduler.h"
 
+std::thread::id gpu_id;
+
 namespace AmdGpu {
 
 static const char* dcb_task_name{"DCB_TASK"};
@@ -89,7 +91,7 @@ void Liverpool::ProcessCommands() {
 
 void Liverpool::Process(std::stop_token stoken) {
     Common::SetCurrentThreadName("shadPS4:GpuCommandProcessor");
-
+    gpu_id = std::this_thread::get_id();
     while (!stoken.stop_requested()) {
         {
             std::unique_lock lk{submit_mutex};

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -708,9 +708,7 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
             }
             case PM4ItOpcode::Rewind: {
                 if (rasterizer) {
-                    const VAddr flush_addr = VAddr(reinterpret_cast<const u32*>(header));
-                    const u32 flush_size = dcb.size_bytes();
-                    rasterizer->ReadMemory(flush_addr, flush_size);
+                    rasterizer->CommitPendingDownloads(true);
                 }
                 const PM4CmdRewind* rewind = reinterpret_cast<const PM4CmdRewind*>(header);
                 while (!rewind->Valid()) {
@@ -915,9 +913,7 @@ Liverpool::Task Liverpool::ProcessCompute(const u32* acb, u32 acb_dwords, u32 vq
         }
         case PM4ItOpcode::Rewind: {
             if (rasterizer) {
-                const VAddr flush_addr = VAddr(reinterpret_cast<const u32*>(header));
-                const u32 flush_size = acb_dwords * sizeof(u32);
-                rasterizer->ReadMemory(flush_addr, flush_size);
+                rasterizer->CommitPendingDownloads(true);
             }
             const PM4CmdRewind* rewind = reinterpret_cast<const PM4CmdRewind*>(header);
             while (!rewind->Valid()) {

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -882,8 +882,7 @@ Liverpool::Task Liverpool::ProcessCompute(const u32* acb, u32 acb_dwords, u32 vq
                 break;
             }
             if (dma_data->src_sel == DmaDataSrc::Data && dma_data->dst_sel == DmaDataDst::Gds) {
-                rasterizer->InlineData(dma_data->dst_addr_lo, &dma_data->data, sizeof(u32),
-                                       true);
+                rasterizer->InlineData(dma_data->dst_addr_lo, &dma_data->data, sizeof(u32), true);
             } else if ((dma_data->src_sel == DmaDataSrc::Memory ||
                         dma_data->src_sel == DmaDataSrc::MemoryUsingL2) &&
                        dma_data->dst_sel == DmaDataDst::Gds) {
@@ -892,8 +891,8 @@ Liverpool::Task Liverpool::ProcessCompute(const u32* acb, u32 acb_dwords, u32 vq
             } else if (dma_data->src_sel == DmaDataSrc::Data &&
                        (dma_data->dst_sel == DmaDataDst::Memory ||
                         dma_data->dst_sel == DmaDataDst::MemoryUsingL2)) {
-                rasterizer->InlineData(dma_data->DstAddress<VAddr>(), &dma_data->data,
-                                       sizeof(u32), false);
+                rasterizer->InlineData(dma_data->DstAddress<VAddr>(), &dma_data->data, sizeof(u32),
+                                       false);
             } else if (dma_data->src_sel == DmaDataSrc::Gds &&
                        (dma_data->dst_sel == DmaDataDst::Memory ||
                         dma_data->dst_sel == DmaDataDst::MemoryUsingL2)) {
@@ -903,9 +902,8 @@ Liverpool::Task Liverpool::ProcessCompute(const u32* acb, u32 acb_dwords, u32 vq
                         dma_data->src_sel == DmaDataSrc::MemoryUsingL2) &&
                        (dma_data->dst_sel == DmaDataDst::Memory ||
                         dma_data->dst_sel == DmaDataDst::MemoryUsingL2)) {
-                rasterizer->CopyBuffer(dma_data->DstAddress<VAddr>(),
-                                       dma_data->SrcAddress<VAddr>(), dma_data->NumBytes(),
-                                       false, false);
+                rasterizer->CopyBuffer(dma_data->DstAddress<VAddr>(), dma_data->SrcAddress<VAddr>(),
+                                       dma_data->NumBytes(), false, false);
             } else {
                 UNREACHABLE_MSG("WriteData src_sel = {}, dst_sel = {}",
                                 u32(dma_data->src_sel.Value()), u32(dma_data->dst_sel.Value()));

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -831,7 +831,8 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
         if (queue.tmp_dwords > 0) [[unlikely]] {
             header = reinterpret_cast<const PM4Header*>(queue.tmp_packet.data());
             next_dw_off = header->type3.NumWords() + 1 - queue.tmp_dwords;
-            std::memcpy(queue.tmp_packet.data() + queue.tmp_dwords, acb.data(), next_dw_off * sizeof(u32));
+            std::memcpy(queue.tmp_packet.data() + queue.tmp_dwords, acb.data(),
+                        next_dw_off * sizeof(u32));
             queue.tmp_dwords = 0;
         }
 
@@ -872,8 +873,8 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
         }
         case PM4ItOpcode::IndirectBuffer: {
             const auto* indirect_buffer = reinterpret_cast<const PM4CmdIndirectBuffer*>(header);
-            auto task = ProcessCompute<true>({indirect_buffer->Address<const u32>(),
-                                             indirect_buffer->ib_size}, vqid);
+            auto task = ProcessCompute<true>(
+                {indirect_buffer->Address<const u32>(), indirect_buffer->ib_size}, vqid);
             RESUME_ASC(task, vqid);
 
             while (!task.handle.done()) {

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -816,31 +816,31 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
 }
 
 template <bool is_indirect>
-Liverpool::Task Liverpool::ProcessCompute(const u32* acb, u32 acb_dwords, u32 vqid) {
+Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
     FIBER_ENTER(acb_task_name[vqid]);
     auto& queue = asc_queues[{vqid}];
 
-    auto base_addr = reinterpret_cast<VAddr>(acb);
-    while (acb_dwords > 0) {
+    auto base_addr = reinterpret_cast<VAddr>(acb.data());
+    while (!acb.empty()) {
         ProcessCommands();
 
-        auto* header = reinterpret_cast<const PM4Header*>(acb);
+        auto* header = reinterpret_cast<const PM4Header*>(acb.data());
         u32 next_dw_off = header->type3.NumWords() + 1;
 
         // If we have a buffered packet, use it.
         if (queue.tmp_dwords > 0) [[unlikely]] {
             header = reinterpret_cast<const PM4Header*>(queue.tmp_packet.data());
             next_dw_off = header->type3.NumWords() + 1 - queue.tmp_dwords;
-            std::memcpy(queue.tmp_packet.data() + queue.tmp_dwords, acb, next_dw_off * sizeof(u32));
+            std::memcpy(queue.tmp_packet.data() + queue.tmp_dwords, acb.data(), next_dw_off * sizeof(u32));
             queue.tmp_dwords = 0;
         }
 
         // If the packet is split across ring boundary, buffer until next submission
-        if (next_dw_off > acb_dwords) [[unlikely]] {
-            std::memcpy(queue.tmp_packet.data(), acb, acb_dwords * sizeof(u32));
-            queue.tmp_dwords = acb_dwords;
+        if (next_dw_off > acb.size()) [[unlikely]] {
+            std::memcpy(queue.tmp_packet.data(), acb.data(), acb.size_bytes());
+            queue.tmp_dwords = acb.size();
             if constexpr (!is_indirect) {
-                *queue.read_addr += acb_dwords;
+                *queue.read_addr += acb.size();
                 *queue.read_addr %= queue.ring_size_dw;
             }
             break;
@@ -849,8 +849,7 @@ Liverpool::Task Liverpool::ProcessCompute(const u32* acb, u32 acb_dwords, u32 vq
         if (header->type == 2) {
             // Type-2 packet are used for padding purposes
             next_dw_off = 1;
-            acb += next_dw_off;
-            acb_dwords -= next_dw_off;
+            acb = NextPacket(acb, next_dw_off);
 
             if constexpr (!is_indirect) {
                 *queue.read_addr += next_dw_off;
@@ -873,8 +872,8 @@ Liverpool::Task Liverpool::ProcessCompute(const u32* acb, u32 acb_dwords, u32 vq
         }
         case PM4ItOpcode::IndirectBuffer: {
             const auto* indirect_buffer = reinterpret_cast<const PM4CmdIndirectBuffer*>(header);
-            auto task = ProcessCompute<true>(indirect_buffer->Address<const u32>(),
-                                             indirect_buffer->ib_size, vqid);
+            auto task = ProcessCompute<true>({indirect_buffer->Address<const u32>(),
+                                             indirect_buffer->ib_size}, vqid);
             RESUME_ASC(task, vqid);
 
             while (!task.handle.done()) {
@@ -1040,8 +1039,7 @@ Liverpool::Task Liverpool::ProcessCompute(const u32* acb, u32 acb_dwords, u32 vq
                             static_cast<u32>(opcode), header->type3.NumWords());
         }
 
-        acb += next_dw_off;
-        acb_dwords -= next_dw_off;
+        acb = NextPacket(acb, next_dw_off);
 
         if constexpr (!is_indirect) {
             *queue.read_addr += next_dw_off;
@@ -1111,7 +1109,7 @@ void Liverpool::SubmitAsc(u32 gnm_vqid, std::span<const u32> acb) {
     auto& queue = mapped_queues[gnm_vqid];
 
     const auto vqid = gnm_vqid - 1;
-    const auto& task = ProcessCompute(acb.data(), acb.size(), vqid);
+    const auto& task = ProcessCompute(acb, vqid);
     {
         std::scoped_lock lock{queue.m_access};
         queue.submits.emplace(task.handle);

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -621,7 +621,7 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
             case PM4ItOpcode::EventWriteEop: {
                 const auto* event_eop = reinterpret_cast<const PM4CmdEventWriteEop*>(header);
                 if (rasterizer) {
-                    rasterizer->CommitAsyncFlushes();
+                    rasterizer->CommitPendingDownloads();
                 }
                 ++fence_tick;
                 event_eop->SignalFence([](void* address, u64 data, u32 num_bytes) {
@@ -1023,7 +1023,7 @@ Liverpool::Task Liverpool::ProcessCompute(const u32* acb, u32 acb_dwords, u32 vq
             const auto* release_mem = reinterpret_cast<const PM4CmdReleaseMem*>(header);
             ++fence_tick;
             if (rasterizer) {
-                rasterizer->CommitAsyncFlushes();
+                rasterizer->CommitPendingDownloads();
             }
             release_mem->SignalFence(static_cast<Platform::InterruptId>(queue.pipe_id));
             break;

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -1587,6 +1587,7 @@ private:
     template <bool is_indirect = false>
     Task ProcessCompute(const u32* acb, u32 acb_dwords, u32 vqid);
 
+    void ProcessCommands();
     void Process(std::stop_token stoken);
 
     struct GpuQueue {

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -1532,6 +1532,10 @@ public:
         return mapped_queues[curr_qid].cs_state;
     }
 
+    inline u64 GetFenceTick() const {
+        return fence_tick;
+    }
+
     struct AscQueueInfo {
         static constexpr size_t Pm4BufferSize = 1024;
         VAddr map_addr;
@@ -1627,6 +1631,7 @@ private:
     std::condition_variable_any submit_cv;
     std::queue<Common::UniqueFunction<void>> command_queue{};
     int curr_qid{-1};
+    u64 fence_tick{0};
 };
 
 static_assert(GFX6_3D_REG_INDEX(ps_program) == 0x2C08);

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -1585,7 +1585,7 @@ private:
     Task ProcessGraphics(std::span<const u32> dcb, std::span<const u32> ccb);
     Task ProcessCeUpdate(std::span<const u32> ccb);
     template <bool is_indirect = false>
-    Task ProcessCompute(const u32* acb, u32 acb_dwords, u32 vqid);
+    Task ProcessCompute(std::span<const u32> acb, u32 vqid);
 
     void ProcessCommands();
     void Process(std::stop_token stoken);

--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -421,7 +421,7 @@ struct PM4CmdEventWriteEop {
     PM4Type3Header header;
     union {
         u32 event_control;
-        BitField<0, 6, u32> event_type;  ///< Event type written to VGT_EVENT_INITIATOR
+        BitField<0, 6, EventType> event_type;  ///< Event type written to VGT_EVENT_INITIATOR
         BitField<8, 4, u32> event_index; ///< Event index
     };
     u32 address_lo;

--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -421,8 +421,8 @@ struct PM4CmdEventWriteEop {
     PM4Type3Header header;
     union {
         u32 event_control;
-        BitField<0, 6, EventType> event_type;  ///< Event type written to VGT_EVENT_INITIATOR
-        BitField<8, 4, u32> event_index; ///< Event index
+        BitField<0, 6, EventType> event_type; ///< Event type written to VGT_EVENT_INITIATOR
+        BitField<8, 4, u32> event_index;      ///< Event index
     };
     u32 address_lo;
     union {

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -140,14 +140,22 @@ void BufferCache::InvalidateMemory(VAddr device_addr, u64 size) {
 }
 
 void BufferCache::ReadMemory(VAddr device_addr, u64 size) {
-    ForEachBufferInRange(device_addr, size, [this, device_addr, size](BufferId buffer_id, Buffer& buffer) {
-        const VAddr buffer_start = buffer.CpuAddr();
-        const VAddr buffer_end = buffer_start + buffer.SizeBytes();
-        const VAddr download_start = std::max(buffer_start, device_addr);
-        const VAddr download_end = std::min(buffer_end, device_addr + size);
-        const u64 download_size = download_end - download_start;
-        DownloadBufferMemory(buffer, download_start, download_size);
+    if (!memory_tracker.IsRegionGpuModified(device_addr, size)) {
+        return;
+    }
+    std::binary_semaphore sem{0};
+    liverpool->SendCommand([this, &sem, device_addr, size] {
+        ForEachBufferInRange(device_addr, size, [this, device_addr, size](BufferId buffer_id, Buffer& buffer) {
+            const VAddr buffer_start = buffer.CpuAddr();
+            const VAddr buffer_end = buffer_start + buffer.SizeBytes();
+            const VAddr download_start = std::max(buffer_start, device_addr);
+            const VAddr download_end = std::min(buffer_end, device_addr + size);
+            const u64 download_size = download_end - download_start;
+            DownloadBufferMemory(buffer, download_start, download_size);
+        });
+        sem.release();
     });
+    sem.acquire();
 }
 
 void BufferCache::DownloadBufferMemory(const Buffer& buffer, VAddr device_addr, u64 size) {

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -282,8 +282,8 @@ bool BufferCache::CommitPendingDownloads(bool wait_done) {
                 const u64 dst_offset = copy.dstOffset - offset;
                 if (!memory->TryWriteBacking(std::bit_cast<u8*>(copy_device_addr),
                                              download + dst_offset, copy.size)) {
-                    std::memcpy(std::bit_cast<u8*>(copy_device_addr), download + dst_offset,
-                                copy.size);
+                    //std::memcpy(std::bit_cast<u8*>(copy_device_addr), download + dst_offset,
+                    //            copy.size);
                 }
             }
         }

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -240,7 +240,7 @@ bool BufferCache::CommitPendingDownloads() {
         Buffer& buffer = slot_buffers[buffer_id];
         cmdbuf.copyBuffer(buffer.Handle(), download_buffer.Handle(), buffer_copies);
     }
-    scheduler.DeferOperation([this, download, offset, copies = std::move(copies)]() {
+    scheduler.DeferOperation([this, download, offset, copies]() {
         auto* memory = Core::Memory::Instance();
         for (auto it = copies.begin(); it != copies.end(); ++it) {
             auto& buffer_copies = it.value();

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -288,13 +288,13 @@ bool BufferCache::CommitPendingDownloads(bool wait_done) {
             }
         }
     };
+    const u64 wait_tick = scheduler.CurrentTick();
+    scheduler.Flush();
     {
         std::scoped_lock lk{queue_mutex};
-        async_downloads.emplace(std::move(writeback_host), scheduler.CurrentTick(),
-                                current_download_tick);
+        async_downloads.emplace(std::move(writeback_host), wait_tick, current_download_tick);
     }
     queue_cv.notify_one();
-    scheduler.Flush();
     if (wait_done) {
         WaitForTargetTick(current_download_tick);
     }

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -27,7 +27,7 @@ static constexpr size_t UboStreamBufferSize = 128_MB;
 static constexpr size_t DownloadBufferSize = 128_MB;
 static constexpr size_t DeviceBufferSize = 128_MB;
 static constexpr size_t MaxPageFaults = 1024;
-static constexpr size_t DownloadSizeThreshold = 2_MB;
+static constexpr size_t DownloadSizeThreshold = 1_MB;
 
 BufferCache::BufferCache(const Vulkan::Instance& instance_, Vulkan::Scheduler& scheduler_,
                          AmdGpu::Liverpool* liverpool_, TextureCache& texture_cache_,
@@ -188,7 +188,7 @@ void BufferCache::DownloadBufferMemory(const Buffer& buffer, VAddr device_addr, 
     }
 }
 
-bool BufferCache::CommitPendingDownloads() {
+bool BufferCache::CommitPendingDownloads(bool wait_done) {
     if (pending_download_ranges.Empty()) {
         return false;
     }
@@ -254,7 +254,11 @@ bool BufferCache::CommitPendingDownloads() {
             }
         }
     });
-    scheduler.Flush();
+    if (wait_done) {
+        scheduler.Finish();
+    } else {
+        scheduler.Flush();
+    }
     return true;
 }
 

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -30,7 +30,8 @@ static constexpr size_t MaxPageFaults = 1024;
 static constexpr size_t DownloadSizeThreshold = 2_MB;
 
 BufferCache::BufferCache(const Vulkan::Instance& instance_, Vulkan::Scheduler& scheduler_,
-                         AmdGpu::Liverpool* liverpool_, TextureCache& texture_cache_, PageManager& tracker_)
+                         AmdGpu::Liverpool* liverpool_, TextureCache& texture_cache_,
+                         PageManager& tracker_)
     : instance{instance_}, scheduler{scheduler_}, liverpool{liverpool_},
       memory{Core::Memory::Instance()}, texture_cache{texture_cache_}, tracker{tracker_},
       staging_buffer{instance, scheduler, MemoryUsage::Upload, StagingBufferSize},
@@ -182,8 +183,8 @@ void BufferCache::DownloadBufferMemory(const Buffer& buffer, VAddr device_addr, 
     for (const auto& copy : copies) {
         const VAddr copy_device_addr = buffer.CpuAddr() + copy.srcOffset;
         const u64 dst_offset = copy.dstOffset - offset;
-        ASSERT(memory->TryWriteBacking(std::bit_cast<u8*>(copy_device_addr),
-                                       download + dst_offset, copy.size));
+        ASSERT(memory->TryWriteBacking(std::bit_cast<u8*>(copy_device_addr), download + dst_offset,
+                                       copy.size));
     }
 }
 
@@ -400,7 +401,8 @@ void BufferCache::CopyBuffer(VAddr dst, VAddr src, u32 num_bytes, bool dst_gds, 
             return;
         } else if (!dst_gds) {
             // Write to backing memory to bypass memory protection.
-            ASSERT(memory->TryWriteBacking(std::bit_cast<void*>(dst), std::bit_cast<void*>(src), num_bytes));
+            ASSERT(memory->TryWriteBacking(std::bit_cast<void*>(dst), std::bit_cast<void*>(src),
+                                           num_bytes));
         }
         // Without a readback there's nothing we can do with this
         // Fallback to creating dst buffer on GPU to at least have this data there

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -71,7 +71,8 @@ public:
 
 public:
     explicit BufferCache(const Vulkan::Instance& instance, Vulkan::Scheduler& scheduler,
-                         AmdGpu::Liverpool* liverpool, TextureCache& texture_cache, PageManager& tracker);
+                         AmdGpu::Liverpool* liverpool, TextureCache& texture_cache,
+                         PageManager& tracker);
     ~BufferCache();
 
     /// Returns a pointer to GDS device local buffer.

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -190,7 +190,7 @@ private:
     template <bool insert>
     void ChangeRegister(BufferId buffer_id);
 
-    void SynchronizeBuffer(Buffer& buffer, VAddr device_addr, u32 size, bool is_texel_buffer);
+    bool SynchronizeBuffer(Buffer& buffer, VAddr device_addr, u32 size, bool is_texel_buffer);
 
     bool SynchronizeBufferFromImage(Buffer& buffer, VAddr device_addr, u32 size);
 

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -128,7 +128,7 @@ public:
     void CopyBuffer(VAddr dst, VAddr src, u32 num_bytes, bool dst_gds, bool src_gds);
 
     /// Schedules pending GPU modified ranges since last commit to be copied back the host memory.
-    bool CommitPendingDownloads();
+    bool CommitPendingDownloads(bool wait_done);
 
     /// Obtains a buffer for the specified region.
     [[nodiscard]] std::pair<Buffer*, u32> ObtainBuffer(VAddr gpu_addr, u32 size, bool is_written,

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -126,8 +126,8 @@ public:
     /// Performs buffer to buffer data copy on the GPU.
     void CopyBuffer(VAddr dst, VAddr src, u32 num_bytes, bool dst_gds, bool src_gds);
 
-    /// Schedules all GPU modified ranges since last commit to be copied back the host memory.
-    bool CommitAsyncFlushes();
+    /// Schedules pending GPU modified ranges since last commit to be copied back the host memory.
+    bool CommitPendingDownloads();
 
     /// Obtains a buffer for the specified region.
     [[nodiscard]] std::pair<Buffer*, u32> ObtainBuffer(VAddr gpu_addr, u32 size, bool is_written,

--- a/src/video_core/buffer_cache/memory_tracker.h
+++ b/src/video_core/buffer_cache/memory_tracker.h
@@ -57,6 +57,15 @@ public:
                             });
     }
 
+    /// Unmark region as modified from the host GPU
+    void UnmarkRegionAsGpuModified(VAddr dirty_cpu_addr, u64 query_size) noexcept {
+        IteratePages<true>(dirty_cpu_addr, query_size,
+                           [](RegionManager* manager, u64 offset, size_t size) {
+                               manager->template ChangeRegionState<Type::GPU, false>(
+                                   manager->GetCpuAddr() + offset, size);
+                           });
+    }
+
     /// Call 'func' for each CPU modified range and unmark those pages as CPU modified
     void ForEachUploadRange(VAddr query_cpu_range, u64 query_size, auto&& func) {
         IteratePages<true>(query_cpu_range, query_size,

--- a/src/video_core/buffer_cache/range_set.h
+++ b/src/video_core/buffer_cache/range_set.h
@@ -45,6 +45,10 @@ struct RangeSet {
         m_ranges_set.clear();
     }
 
+    bool Empty() const {
+        return m_ranges_set.empty();
+    }
+
     bool Contains(VAddr base_address, size_t size) const {
         const VAddr end_address = base_address + size;
         IntervalType interval{base_address, end_address};
@@ -110,6 +114,7 @@ struct RangeSet {
         }
     }
 
+private:
     IntervalSet m_ranges_set;
 };
 

--- a/src/video_core/page_manager.cpp
+++ b/src/video_core/page_manager.cpp
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
-
+#pragma clang optimize off
 #include <boost/container/small_vector.hpp>
 #include "common/assert.h"
 #include "common/debug.h"

--- a/src/video_core/page_manager.cpp
+++ b/src/video_core/page_manager.cpp
@@ -3,8 +3,8 @@
 
 #include <boost/container/small_vector.hpp>
 #include "common/assert.h"
-#include "common/div_ceil.h"
 #include "common/debug.h"
+#include "common/div_ceil.h"
 #include "common/signal_context.h"
 #include "core/memory.h"
 #include "core/signals.h"

--- a/src/video_core/page_manager.cpp
+++ b/src/video_core/page_manager.cpp
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
-#pragma clang optimize off
+
 #include <boost/container/small_vector.hpp>
 #include "common/assert.h"
+#include "common/div_ceil.h"
 #include "common/debug.h"
 #include "common/signal_context.h"
 #include "core/memory.h"

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -60,9 +60,9 @@ void Rasterizer::CpSync() {
                            vk::DependencyFlagBits::eByRegion, ib_barrier, {}, {});
 }
 
-bool Rasterizer::CommitAsyncFlushes() {
+bool Rasterizer::CommitPendingDownloads() {
     scheduler.PopPendingOperations();
-    return buffer_cache.CommitAsyncFlushes();
+    return buffer_cache.CommitPendingDownloads();
 }
 
 bool Rasterizer::FilterDraw() {

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -60,6 +60,11 @@ void Rasterizer::CpSync() {
                            vk::DependencyFlagBits::eByRegion, ib_barrier, {}, {});
 }
 
+bool Rasterizer::CommitAsyncFlushes() {
+    scheduler.PopPendingOperations();
+    return buffer_cache.CommitAsyncFlushes();
+}
+
 bool Rasterizer::FilterDraw() {
     const auto& regs = liverpool->regs;
     // There are several cases (e.g. FCE, FMask/HTile decompression) where we don't need to do an
@@ -272,6 +277,8 @@ void Rasterizer::EliminateFastClear() {
 void Rasterizer::Draw(bool is_indexed, u32 index_offset) {
     RENDERER_TRACE;
 
+    scheduler.PopPendingOperations();
+
     if (!FilterDraw()) {
         return;
     }
@@ -316,6 +323,8 @@ void Rasterizer::Draw(bool is_indexed, u32 index_offset) {
 void Rasterizer::DrawIndirect(bool is_indexed, VAddr arg_address, u32 offset, u32 stride,
                               u32 max_count, VAddr count_address) {
     RENDERER_TRACE;
+
+    scheduler.PopPendingOperations();
 
     if (!FilterDraw()) {
         return;
@@ -380,6 +389,8 @@ void Rasterizer::DrawIndirect(bool is_indexed, VAddr arg_address, u32 offset, u3
 void Rasterizer::DispatchDirect() {
     RENDERER_TRACE;
 
+    scheduler.PopPendingOperations();
+
     const auto& cs_program = liverpool->GetCsRegs();
     const ComputePipeline* pipeline = pipeline_cache.GetComputePipeline();
     if (!pipeline) {
@@ -406,6 +417,8 @@ void Rasterizer::DispatchDirect() {
 
 void Rasterizer::DispatchIndirect(VAddr address, u32 offset, u32 size) {
     RENDERER_TRACE;
+
+    scheduler.PopPendingOperations();
 
     const auto& cs_program = liverpool->GetCsRegs();
     const ComputePipeline* pipeline = pipeline_cache.GetComputePipeline();

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -3,8 +3,8 @@
 
 #include "common/config.h"
 #include "common/debug.h"
-#include "core/memory.h"
 #include "common/scope_exit.h"
+#include "core/memory.h"
 #include "shader_recompiler/runtime_info.h"
 #include "video_core/amdgpu/liverpool.h"
 #include "video_core/renderer_vulkan/vk_instance.h"

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -488,7 +488,7 @@ bool Rasterizer::BindResources(const Pipeline* pipeline) {
         uses_dma |= stage->dma_types != Shader::IR::Type::Void;
     }
 
-    if (uses_dma && !fault_process_pending) {
+    if (uses_dma) {
         // We only use fault buffer for DMA right now.
         {
             // TODO: GPU might have written to memory (for example with EVENT_WRITE_EOP)

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -60,9 +60,9 @@ void Rasterizer::CpSync() {
                            vk::DependencyFlagBits::eByRegion, ib_barrier, {}, {});
 }
 
-bool Rasterizer::CommitPendingDownloads() {
+bool Rasterizer::CommitPendingDownloads(bool wait_done) {
     scheduler.PopPendingOperations();
-    return buffer_cache.CommitPendingDownloads();
+    return buffer_cache.CommitPendingDownloads(wait_done);
 }
 
 bool Rasterizer::FilterDraw() {

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -36,7 +36,7 @@ static Shader::PushData MakeUserData(const AmdGpu::Liverpool::Regs& regs) {
 Rasterizer::Rasterizer(const Instance& instance_, Scheduler& scheduler_,
                        AmdGpu::Liverpool* liverpool_)
     : instance{instance_}, scheduler{scheduler_}, page_manager{this},
-      buffer_cache{instance, scheduler, *this, liverpool_, texture_cache, page_manager},
+      buffer_cache{instance, scheduler, liverpool_, texture_cache, page_manager},
       texture_cache{instance, scheduler, buffer_cache, page_manager}, liverpool{liverpool_},
       memory{Core::Memory::Instance()}, pipeline_cache{instance, scheduler, liverpool} {
     if (!Config::nullGpu()) {
@@ -947,6 +947,10 @@ void Rasterizer::InlineData(VAddr address, const void* value, u32 num_bytes, boo
     buffer_cache.InlineData(address, value, num_bytes, is_gds);
 }
 
+void Rasterizer::CopyBuffer(VAddr dst, VAddr src, u32 num_bytes, bool dst_gds, bool src_gds) {
+    buffer_cache.CopyBuffer(dst, src, num_bytes, dst_gds, src_gds);
+}
+
 u32 Rasterizer::ReadDataFromGds(u32 gds_offset) {
     auto* gds_buf = buffer_cache.GetGdsBuffer();
     u32 value;
@@ -959,8 +963,17 @@ bool Rasterizer::InvalidateMemory(VAddr addr, u64 size) {
         // Not GPU mapped memory, can skip invalidation logic entirely.
         return false;
     }
-    buffer_cache.InvalidateMemory(addr, size, false);
+    buffer_cache.InvalidateMemory(addr, size);
     texture_cache.InvalidateMemory(addr, size);
+    return true;
+}
+
+bool Rasterizer::ReadMemory(VAddr addr, u64 size) {
+    if (!IsMapped(addr, size)) {
+        // Not GPU mapped memory, can skip invalidation logic entirely.
+        return false;
+    }
+    buffer_cache.ReadMemory(addr, size);
     return true;
 }
 
@@ -984,7 +997,7 @@ void Rasterizer::MapMemory(VAddr addr, u64 size) {
 }
 
 void Rasterizer::UnmapMemory(VAddr addr, u64 size) {
-    buffer_cache.InvalidateMemory(addr, size, true);
+    buffer_cache.ReadMemory(addr, size);
     texture_cache.UnmapMemory(addr, size);
     page_manager.OnGpuUnmap(addr, size);
     {

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -488,7 +488,7 @@ bool Rasterizer::BindResources(const Pipeline* pipeline) {
         uses_dma |= stage->dma_types != Shader::IR::Type::Void;
     }
 
-    if (uses_dma) {
+    if (uses_dma && !fault_process_pending) {
         // We only use fault buffer for DMA right now.
         {
             // TODO: GPU might have written to memory (for example with EVENT_WRITE_EOP)

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -62,9 +62,6 @@ void Rasterizer::CpSync() {
 }
 
 bool Rasterizer::CommitPendingDownloads(bool wait_done) {
-    SCOPE_EXIT {
-        scheduler.PopPendingOperations();
-    };
     return buffer_cache.CommitPendingDownloads(wait_done);
 }
 

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -56,8 +56,10 @@ public:
                                  bool from_guest = false);
 
     void InlineData(VAddr address, const void* value, u32 num_bytes, bool is_gds);
+    void CopyBuffer(VAddr dst, VAddr src, u32 num_bytes, bool dst_gds, bool src_gds);
     u32 ReadDataFromGds(u32 gsd_offset);
     bool InvalidateMemory(VAddr addr, u64 size);
+    bool ReadMemory(VAddr addr, u64 size);
     bool IsMapped(VAddr addr, u64 size);
     void MapMemory(VAddr addr, u64 size);
     void UnmapMemory(VAddr addr, u64 size);

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -65,7 +65,7 @@ public:
     void UnmapMemory(VAddr addr, u64 size);
 
     void CpSync();
-    bool CommitPendingDownloads();
+    bool CommitPendingDownloads(bool wait_done = false);
     u64 Flush();
     void Finish();
     void ProcessFaults();

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -65,6 +65,7 @@ public:
     void UnmapMemory(VAddr addr, u64 size);
 
     void CpSync();
+    bool CommitAsyncFlushes();
     u64 Flush();
     void Finish();
     void ProcessFaults();

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -65,7 +65,7 @@ public:
     void UnmapMemory(VAddr addr, u64 size);
 
     void CpSync();
-    bool CommitAsyncFlushes();
+    bool CommitPendingDownloads();
     u64 Flush();
     void Finish();
     void ProcessFaults();

--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -98,12 +98,6 @@ void Scheduler::Wait(u64 tick) {
         Flush(info);
     }
     master_semaphore.Wait(tick);
-
-    // CAUTION: This can introduce unexpected variation in the wait time.
-    // We don't currently sync the GPU, and some games are very sensitive to this.
-    // If this becomes a problem, it can be commented out.
-    // Idealy we would implement proper gpu sync.
-    PopPendingOperations();
 }
 
 void Scheduler::AllocateWorkerCommandBuffers() {

--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -8,6 +8,8 @@
 #include "video_core/renderer_vulkan/vk_instance.h"
 #include "video_core/renderer_vulkan/vk_scheduler.h"
 
+extern std::thread::id gpu_id;
+
 namespace Vulkan {
 
 std::mutex Scheduler::submit_mutex;
@@ -68,6 +70,7 @@ void Scheduler::EndRendering() {
 void Scheduler::PopPendingOperations() {
     master_semaphore.Refresh();
     while (!pending_ops.empty() && master_semaphore.IsFree(pending_ops.front().gpu_tick)) {
+        ASSERT(gpu_id == std::this_thread::get_id());
         ASSERT(op_scope == 0);
         ++op_scope;
         pending_ops.front().callback();

--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -68,7 +68,10 @@ void Scheduler::EndRendering() {
 void Scheduler::PopPendingOperations() {
     master_semaphore.Refresh();
     while (!pending_ops.empty() && master_semaphore.IsFree(pending_ops.front().gpu_tick)) {
+        ASSERT(op_scope == 0);
+        ++op_scope;
         pending_ops.front().callback();
+        --op_scope;
         pending_ops.pop();
     }
 }

--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -65,6 +65,14 @@ void Scheduler::EndRendering() {
     current_cmdbuf.endRendering();
 }
 
+void Scheduler::PopPendingOperations() {
+    master_semaphore.Refresh();
+    while (!pending_ops.empty() && master_semaphore.IsFree(pending_ops.front().gpu_tick)) {
+        pending_ops.front().callback();
+        pending_ops.pop();
+    }
+}
+
 void Scheduler::Flush(SubmitInfo& info) {
     // When flushing, we only send data to the driver; no waiting is necessary.
     SubmitExecution(info);
@@ -95,10 +103,7 @@ void Scheduler::Wait(u64 tick) {
     // We don't currently sync the GPU, and some games are very sensitive to this.
     // If this becomes a problem, it can be commented out.
     // Idealy we would implement proper gpu sync.
-    while (!pending_ops.empty() && pending_ops.front().gpu_tick <= tick) {
-        pending_ops.front().callback();
-        pending_ops.pop();
-    }
+    PopPendingOperations();
 }
 
 void Scheduler::AllocateWorkerCommandBuffers() {
@@ -174,11 +179,7 @@ void Scheduler::SubmitExecution(SubmitInfo& info) {
     master_semaphore.Refresh();
     AllocateWorkerCommandBuffers();
 
-    // Apply pending operations
-    while (!pending_ops.empty() && IsFree(pending_ops.front().gpu_tick)) {
-        pending_ops.front().callback();
-        pending_ops.pop();
-    }
+    PopPendingOperations();
 }
 
 void DynamicState::Commit(const Instance& instance, const vk::CommandBuffer& cmdbuf) {

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -379,6 +379,7 @@ private:
         u64 gpu_tick;
     };
     std::queue<PendingOp> pending_ops;
+    u32 op_scope{};
     RenderState render_state;
     DynamicState dynamic_state;
     bool is_rendering = false;

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -323,6 +323,9 @@ public:
     /// Ends current rendering scope.
     void EndRendering();
 
+    /// Attempts to execute pending operations whose tick the GPU has caught up with.
+    void PopPendingOperations();
+
     /// Returns the current render state.
     const RenderState& GetRenderState() const {
         return render_state;
@@ -354,8 +357,8 @@ public:
     }
 
     /// Defers an operation until the gpu has reached the current cpu tick.
-    void DeferOperation(Common::UniqueFunction<void>&& func) {
-        pending_ops.emplace(std::move(func), CurrentTick());
+    void DeferOperation(Common::UniqueFunction<void>&& func, bool prev_tick = false) {
+        pending_ops.emplace(std::move(func), prev_tick ? CurrentTick() - 1 : CurrentTick());
     }
 
     static std::mutex submit_mutex;

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -357,8 +357,8 @@ public:
     }
 
     /// Defers an operation until the gpu has reached the current cpu tick.
-    void DeferOperation(Common::UniqueFunction<void>&& func, bool prev_tick = false) {
-        pending_ops.emplace(std::move(func), prev_tick ? CurrentTick() - 1 : CurrentTick());
+    void DeferOperation(Common::UniqueFunction<void>&& func) {
+        pending_ops.emplace(std::move(func), CurrentTick());
     }
 
     static std::mutex submit_mutex;


### PR DESCRIPTION
This is essentially a readbacks-lite, which tries to give most of the benefits of readbacks without the steep performance cost. It also appears to fix the brightness problems in Driveclub.

It's still highly WIP and prone to instability so opening as draft. Also @LNDF your PR seems to break something in the region manager when messing with GPU bits, so I have your PR reverted here until its fixed.