### PR TITLE
libSceVideodec2: Fix sceVideodec2GetPictureInfo regressions

### DIFF
--- a/src/core/libraries/videodec/videodec2.cpp
+++ b/src/core/libraries/videodec/videodec2.cpp
@@ -171,19 +171,40 @@ s32 PS4_SYSV_ABI sceVideodec2GetPictureInfo(const OrbisVideodec2OutputInfo* outp
         LOG_ERROR(Lib_Vdec2, "Invalid struct size");
         return ORBIS_VIDEODEC2_ERROR_STRUCT_SIZE;
     }
-    if (outputInfo->pictureCount == 0 || gPictureInfos.empty()) {
+    if (outputInfo->pictureCount == 0) {
         LOG_ERROR(Lib_Vdec2, "No picture info available");
         return ORBIS_OK;
     }
 
-    if (p1stPictureInfoOut) {
-        OrbisVideodec2AvcPictureInfo* picInfo =
-            static_cast<OrbisVideodec2AvcPictureInfo*>(p1stPictureInfoOut);
-        if ((picInfo->thisSize | 16) != sizeof(OrbisVideodec2AvcPictureInfo)) {
-            LOG_ERROR(Lib_Vdec2, "Invalid struct size");
-            return ORBIS_VIDEODEC2_ERROR_STRUCT_SIZE;
+    // If the game uses the older Videodec2 structs, we need to accomodate that.
+    if (outputInfo->thisSize != sizeof(OrbisVideodec2OutputInfo)) {
+        if (gLegacyPictureInfos.empty()) {
+            LOG_ERROR(Lib_Vdec2, "No picture info available");
+            return ORBIS_OK;
         }
-        *picInfo = gPictureInfos.back();
+        if (p1stPictureInfoOut) {
+            OrbisVideodec2LegacyAvcPictureInfo* picInfo =
+                static_cast<OrbisVideodec2LegacyAvcPictureInfo*>(p1stPictureInfoOut);
+            if (picInfo->thisSize != sizeof(OrbisVideodec2LegacyAvcPictureInfo)) {
+                LOG_ERROR(Lib_Vdec2, "Invalid struct size");
+                return ORBIS_VIDEODEC2_ERROR_STRUCT_SIZE;
+            }
+            *picInfo = gLegacyPictureInfos.back();
+        }
+    } else {
+        if (gPictureInfos.empty()) {
+            LOG_ERROR(Lib_Vdec2, "No picture info available");
+            return ORBIS_OK;
+        }
+        if (p1stPictureInfoOut) {
+            OrbisVideodec2AvcPictureInfo* picInfo =
+                static_cast<OrbisVideodec2AvcPictureInfo*>(p1stPictureInfoOut);
+            if (picInfo->thisSize != sizeof(OrbisVideodec2AvcPictureInfo)) {
+                LOG_ERROR(Lib_Vdec2, "Invalid struct size");
+                return ORBIS_VIDEODEC2_ERROR_STRUCT_SIZE;
+            }
+            *picInfo = gPictureInfos.back();
+        }
     }
 
     if (outputInfo->pictureCount > 1) {

--- a/src/core/libraries/videodec/videodec2_avc.h
+++ b/src/core/libraries/videodec/videodec2_avc.h
@@ -74,4 +74,57 @@ struct OrbisVideodec2AvcPictureInfo {
 };
 static_assert(sizeof(OrbisVideodec2AvcPictureInfo) == 0x78);
 
+// An older version of the OrbisVideodec2AvcPictureInfo struct
+// Keeping this is needed for compatiblity with older games.
+struct OrbisVideodec2LegacyAvcPictureInfo {
+    u64 thisSize;
+
+    bool isValid;
+
+    u64 ptsData;
+    u64 dtsData;
+    u64 attachedData;
+
+    u8 idrPictureflag;
+
+    u8 profile_idc;
+    u8 level_idc;
+    u32 pic_width_in_mbs_minus1;
+    u32 pic_height_in_map_units_minus1;
+    u8 frame_mbs_only_flag;
+
+    u8 frame_cropping_flag;
+    u32 frameCropLeftOffset;
+    u32 frameCropRightOffset;
+    u32 frameCropTopOffset;
+    u32 frameCropBottomOffset;
+
+    u8 aspect_ratio_info_present_flag;
+    u8 aspect_ratio_idc;
+    u16 sar_width;
+    u16 sar_height;
+
+    u8 video_signal_type_present_flag;
+    u8 video_format;
+    u8 video_full_range_flag;
+    u8 colour_description_present_flag;
+    u8 colour_primaries;
+    u8 transfer_characteristics;
+    u8 matrix_coefficients;
+
+    u8 timing_info_present_flag;
+    u32 num_units_in_tick;
+    u32 time_scale;
+    u8 fixed_frame_rate_flag;
+
+    u8 bitstream_restriction_flag;
+    u8 max_dec_frame_buffering;
+
+    u8 pic_struct_present_flag;
+    u8 pic_struct;
+    u8 field_pic_flag;
+    u8 bottom_field_flag;
+};
+static_assert(sizeof(OrbisVideodec2LegacyAvcPictureInfo) == 0x68);
+
 } // namespace Libraries::Vdec2

--- a/src/core/libraries/videodec/videodec2_impl.cpp
+++ b/src/core/libraries/videodec/videodec2_impl.cpp
@@ -12,6 +12,7 @@
 namespace Libraries::Vdec2 {
 
 std::vector<OrbisVideodec2AvcPictureInfo> gPictureInfos;
+std::vector<OrbisVideodec2LegacyAvcPictureInfo> gLegacyPictureInfos;
 
 static inline void CopyNV12Data(u8* dst, const AVFrame& src) {
     std::memcpy(dst, src.data[0], src.width * src.height);
@@ -117,27 +118,46 @@ s32 VdecDecoder::Decode(const OrbisVideodec2InputData& inputData,
         outputInfo.isErrorFrame = false;
         outputInfo.pictureCount = 1; // TODO: 2 pictures for interlaced video
 
-        // Only set framePitchInBytes if the game uses the newer struct version.
+        // For proper compatibility with older games, check the inputted OutputInfo struct size.
         if (outputInfo.thisSize == sizeof(OrbisVideodec2OutputInfo)) {
+            // framePitchInBytes only exists in the newer struct.
             outputInfo.framePitchInBytes = frame->linesize[0];
-        }
+            if (outputInfo.isValid) {
+                OrbisVideodec2AvcPictureInfo pictureInfo = {};
 
-        if (outputInfo.isValid) {
-            OrbisVideodec2AvcPictureInfo pictureInfo = {};
+                pictureInfo.thisSize = sizeof(OrbisVideodec2AvcPictureInfo);
+                pictureInfo.isValid = true;
 
-            pictureInfo.thisSize = sizeof(OrbisVideodec2AvcPictureInfo);
-            pictureInfo.isValid = true;
+                pictureInfo.ptsData = inputData.ptsData;
+                pictureInfo.dtsData = inputData.dtsData;
+                pictureInfo.attachedData = inputData.attachedData;
 
-            pictureInfo.ptsData = inputData.ptsData;
-            pictureInfo.dtsData = inputData.dtsData;
-            pictureInfo.attachedData = inputData.attachedData;
+                pictureInfo.frameCropLeftOffset = frame->crop_left;
+                pictureInfo.frameCropRightOffset = frame->crop_right;
+                pictureInfo.frameCropTopOffset = frame->crop_top;
+                pictureInfo.frameCropBottomOffset = frame->crop_bottom;
 
-            pictureInfo.frameCropLeftOffset = frame->crop_left;
-            pictureInfo.frameCropRightOffset = frame->crop_right;
-            pictureInfo.frameCropTopOffset = frame->crop_top;
-            pictureInfo.frameCropBottomOffset = frame->crop_bottom;
+                gPictureInfos.push_back(pictureInfo);
+            }
+        } else {
+            if (outputInfo.isValid) {
+                // If the game uses the older struct versions, we need to use it too.
+                OrbisVideodec2LegacyAvcPictureInfo pictureInfo = {};
 
-            gPictureInfos.push_back(pictureInfo);
+                pictureInfo.thisSize = sizeof(OrbisVideodec2LegacyAvcPictureInfo);
+                pictureInfo.isValid = true;
+
+                pictureInfo.ptsData = inputData.ptsData;
+                pictureInfo.dtsData = inputData.dtsData;
+                pictureInfo.attachedData = inputData.attachedData;
+
+                pictureInfo.frameCropLeftOffset = frame->crop_left;
+                pictureInfo.frameCropRightOffset = frame->crop_right;
+                pictureInfo.frameCropTopOffset = frame->crop_top;
+                pictureInfo.frameCropBottomOffset = frame->crop_bottom;
+
+                gLegacyPictureInfos.push_back(pictureInfo);
+            }
         }
     }
 

--- a/src/core/libraries/videodec/videodec2_impl.h
+++ b/src/core/libraries/videodec/videodec2_impl.h
@@ -16,6 +16,7 @@ extern "C" {
 namespace Libraries::Vdec2 {
 
 extern std::vector<OrbisVideodec2AvcPictureInfo> gPictureInfos;
+extern std::vector<OrbisVideodec2LegacyAvcPictureInfo> gLegacyPictureInfos;
 
 class VdecDecoder {
 public:


### PR DESCRIPTION
After #3077 and #3087, it became clear that something was wrong with the outputted AvcPictureInfo in some games. After increasing the struct size, they were no longer able to access the picture data properly.

This PR takes a simple approach to resolving these regressions, keep the old AvcPictureInfo struct, and create a separate vector for storing picture infos using the legacy struct. The necessary struct can be determined using received OrbisVideodec2OutputInfo's thisSize parameter.

This fixes the recent regression in Uncharted: The Nathan Drake Collection™ (CUSA02320)

I'm open to cleaner solutions if anyone has better ideas for solving this, as this is a sort of brute-force solution.