### PR TITLE
video_core: Page manager and memory tracker improvenets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -679,6 +679,7 @@ set(COMMON src/common/logging/backend.cpp
            src/common/path_util.h
            src/common/object_pool.h
            src/common/polyfill_thread.h
+           src/common/range_lock.h
            src/common/rdtsc.cpp
            src/common/rdtsc.h
            src/common/recursive_lock.cpp

--- a/src/common/adaptive_mutex.h
+++ b/src/common/adaptive_mutex.h
@@ -18,6 +18,9 @@ public:
     void unlock() {
         pthread_mutex_unlock(&mutex);
     }
+    [[nodiscard]] bool try_lock() {
+        return pthread_mutex_trylock(&mutex) == 0;
+    }
 
 private:
     pthread_mutex_t mutex = PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP;

--- a/src/common/range_lock.h
+++ b/src/common/range_lock.h
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <iterator>
+#include <mutex>
+
+namespace Common {
+
+// From boost thread locking
+
+template <typename Iterator>
+struct RangeLockGuard {
+    Iterator begin;
+    Iterator end;
+
+    RangeLockGuard(Iterator begin_, Iterator end_) : begin(begin_), end(end_) {
+        LockRange(begin, end);
+    }
+
+    void release() {
+        begin = end;
+    }
+
+    ~RangeLockGuard() {
+        for (; begin != end; ++begin) {
+            begin->unlock();
+        }
+    }
+};
+
+template <typename Iterator>
+Iterator TryLockRange(Iterator begin, Iterator end) {
+    using LockType = typename std::iterator_traits<Iterator>::value_type;
+
+    if (begin == end) {
+        return end;
+    }
+
+    std::unique_lock<LockType> guard(*begin, std::try_to_lock);
+    if (!guard.owns_lock()) {
+        return begin;
+    }
+
+    Iterator failed = TryLockRange(++begin, end);
+    if (failed == end) {
+        guard.release();
+    }
+
+    return failed;
+}
+
+template <typename Iterator>
+void LockRange(Iterator begin, Iterator end) {
+    using LockType = typename std::iterator_traits<Iterator>::value_type;
+
+    if (begin == end) {
+        return;
+    }
+    
+    bool start_with_begin = true;
+    Iterator second = begin;
+    ++second;
+    Iterator next = second;
+
+    while (true) {
+        std::unique_lock<LockType> begin_lock(*begin, std::defer_lock);
+        if (start_with_begin) {
+            begin_lock.lock();
+
+            const Iterator failed_lock = TryLockRange(next, end);
+            if (failed_lock == end) {
+                begin_lock.release();
+                return;
+            }
+
+            start_with_begin = false;
+            next = failed_lock;
+        } else {
+            RangeLockGuard<Iterator> guard(next, end);
+
+            if (begin_lock.try_lock()) {
+                const Iterator failed_lock = TryLockRange(second, next);
+                if (failed_lock == next) {
+                    begin_lock.release();
+                    guard.release();
+                    return;
+                }
+                
+                start_with_begin = false;
+                next = failed_lock;
+            } else {
+                start_with_begin = true;
+                next = second;
+            }
+        }
+    }
+}
+
+} // namespace Common

--- a/src/common/range_lock.h
+++ b/src/common/range_lock.h
@@ -58,7 +58,7 @@ void LockRange(Iterator begin, Iterator end) {
     if (begin == end) {
         return;
     }
-    
+
     bool start_with_begin = true;
     Iterator second = begin;
     ++second;
@@ -87,7 +87,7 @@ void LockRange(Iterator begin, Iterator end) {
                     guard.release();
                     return;
                 }
-                
+
                 start_with_begin = false;
                 next = failed_lock;
             } else {

--- a/src/video_core/buffer_cache/memory_tracker.h
+++ b/src/video_core/buffer_cache/memory_tracker.h
@@ -16,7 +16,7 @@ namespace VideoCore {
 class MemoryTracker {
 public:
     static constexpr size_t MAX_CPU_PAGE_BITS = 40;
-    static constexpr size_t NUM_HIGH_PAGES = 1ULL << (MAX_CPU_PAGE_BITS - HIGHER_PAGE_BITS);
+    static constexpr size_t NUM_HIGH_PAGES = 1ULL << (MAX_CPU_PAGE_BITS - TRACKER_HIGHER_PAGE_BITS);
     static constexpr size_t MANAGER_POOL_SIZE = 32;
 
 public:
@@ -90,11 +90,11 @@ private:
         using FuncReturn = typename std::invoke_result<Func, RegionManager*, u64, size_t>::type;
         static constexpr bool BOOL_BREAK = std::is_same_v<FuncReturn, bool>;
         std::size_t remaining_size{size};
-        std::size_t page_index{cpu_address >> HIGHER_PAGE_BITS};
-        u64 page_offset{cpu_address & HIGHER_PAGE_MASK};
+        std::size_t page_index{cpu_address >> TRACKER_HIGHER_PAGE_BITS};
+        u64 page_offset{cpu_address & TRACKER_HIGHER_PAGE_MASK};
         while (remaining_size > 0) {
             const std::size_t copy_amount{
-                std::min<std::size_t>(HIGHER_PAGE_SIZE - page_offset, remaining_size)};
+                std::min<std::size_t>(TRACKER_HIGHER_PAGE_SIZE - page_offset, remaining_size)};
             auto* manager{top_tier[page_index]};
             if (manager) {
                 if constexpr (BOOL_BREAK) {
@@ -123,7 +123,7 @@ private:
     }
 
     void CreateRegion(std::size_t page_index) {
-        const VAddr base_cpu_addr = page_index << HIGHER_PAGE_BITS;
+        const VAddr base_cpu_addr = page_index << TRACKER_HIGHER_PAGE_BITS;
         if (free_managers.empty()) {
             manager_pool.emplace_back();
             auto& last_pool = manager_pool.back();

--- a/src/video_core/buffer_cache/region_definitions.h
+++ b/src/video_core/buffer_cache/region_definitions.h
@@ -9,13 +9,13 @@
 
 namespace VideoCore {
 
-constexpr u64 PAGES_PER_WORD = 64;
-constexpr u64 BYTES_PER_PAGE = 4_KB;
+constexpr u64 TRACKER_PAGE_BITS = 12; // 4K pages
+constexpr u64 TRACKER_BYTES_PER_PAGE = 1ULL << TRACKER_PAGE_BITS;
 
-constexpr u64 HIGHER_PAGE_BITS = 22;
-constexpr u64 HIGHER_PAGE_SIZE = 1ULL << HIGHER_PAGE_BITS;
-constexpr u64 HIGHER_PAGE_MASK = HIGHER_PAGE_SIZE - 1ULL;
-constexpr u64 NUM_REGION_PAGES = HIGHER_PAGE_SIZE / BYTES_PER_PAGE;
+constexpr u64 TRACKER_HIGHER_PAGE_BITS = 24; // each region is 16MB
+constexpr u64 TRACKER_HIGHER_PAGE_SIZE = 1ULL << TRACKER_HIGHER_PAGE_BITS;
+constexpr u64 TRACKER_HIGHER_PAGE_MASK = TRACKER_HIGHER_PAGE_SIZE - 1ULL;
+constexpr u64 NUM_PAGES_PER_REGION = TRACKER_HIGHER_PAGE_SIZE / TRACKER_BYTES_PER_PAGE;
 
 enum class Type {
     CPU,
@@ -23,6 +23,6 @@ enum class Type {
     Writeable,
 };
 
-using RegionBits = Common::BitArray<NUM_REGION_PAGES>;
+using RegionBits = Common::BitArray<NUM_PAGES_PER_REGION>;
 
 } // namespace VideoCore

--- a/src/video_core/buffer_cache/region_manager.h
+++ b/src/video_core/buffer_cache/region_manager.h
@@ -84,7 +84,8 @@ public:
         RENDERER_TRACE;
         const size_t offset = dirty_addr - cpu_addr;
         const size_t start_page = SanitizeAddress(offset) / TRACKER_BYTES_PER_PAGE;
-        const size_t end_page = Common::DivCeil(SanitizeAddress(offset + size), TRACKER_BYTES_PER_PAGE);
+        const size_t end_page =
+            Common::DivCeil(SanitizeAddress(offset + size), TRACKER_BYTES_PER_PAGE);
         if (start_page >= NUM_PAGES_PER_REGION || end_page <= start_page) {
             return;
         }
@@ -115,7 +116,8 @@ public:
         RENDERER_TRACE;
         const size_t offset = query_cpu_range - cpu_addr;
         const size_t start_page = SanitizeAddress(offset) / TRACKER_BYTES_PER_PAGE;
-        const size_t end_page = Common::DivCeil(SanitizeAddress(offset + size), TRACKER_BYTES_PER_PAGE);
+        const size_t end_page =
+            Common::DivCeil(SanitizeAddress(offset + size), TRACKER_BYTES_PER_PAGE);
         if (start_page >= NUM_PAGES_PER_REGION || end_page <= start_page) {
             return;
         }
@@ -152,7 +154,8 @@ public:
     [[nodiscard]] bool IsRegionModified(u64 offset, u64 size) const noexcept {
         RENDERER_TRACE;
         const size_t start_page = SanitizeAddress(offset) / TRACKER_BYTES_PER_PAGE;
-        const size_t end_page = Common::DivCeil(SanitizeAddress(offset + size), TRACKER_BYTES_PER_PAGE);
+        const size_t end_page =
+            Common::DivCeil(SanitizeAddress(offset + size), TRACKER_BYTES_PER_PAGE);
         if (start_page >= NUM_PAGES_PER_REGION || end_page <= start_page) {
             return false;
         }

--- a/src/video_core/buffer_cache/region_manager.h
+++ b/src/video_core/buffer_cache/region_manager.h
@@ -83,9 +83,9 @@ public:
     void ChangeRegionState(u64 dirty_addr, u64 size) noexcept(type == Type::GPU) {
         RENDERER_TRACE;
         const size_t offset = dirty_addr - cpu_addr;
-        const size_t start_page = SanitizeAddress(offset) / BYTES_PER_PAGE;
-        const size_t end_page = Common::DivCeil(SanitizeAddress(offset + size), BYTES_PER_PAGE);
-        if (start_page >= NUM_REGION_PAGES || end_page <= start_page) {
+        const size_t start_page = SanitizeAddress(offset) / TRACKER_BYTES_PER_PAGE;
+        const size_t end_page = Common::DivCeil(SanitizeAddress(offset + size), TRACKER_BYTES_PER_PAGE);
+        if (start_page >= NUM_PAGES_PER_REGION || end_page <= start_page) {
             return;
         }
         std::scoped_lock lk{lock};
@@ -114,9 +114,9 @@ public:
     void ForEachModifiedRange(VAddr query_cpu_range, s64 size, auto&& func) {
         RENDERER_TRACE;
         const size_t offset = query_cpu_range - cpu_addr;
-        const size_t start_page = SanitizeAddress(offset) / BYTES_PER_PAGE;
-        const size_t end_page = Common::DivCeil(SanitizeAddress(offset + size), BYTES_PER_PAGE);
-        if (start_page >= NUM_REGION_PAGES || end_page <= start_page) {
+        const size_t start_page = SanitizeAddress(offset) / TRACKER_BYTES_PER_PAGE;
+        const size_t end_page = Common::DivCeil(SanitizeAddress(offset + size), TRACKER_BYTES_PER_PAGE);
+        if (start_page >= NUM_PAGES_PER_REGION || end_page <= start_page) {
             return;
         }
         std::scoped_lock lk{lock};
@@ -131,7 +131,7 @@ public:
         }
 
         for (const auto& [start, end] : mask) {
-            func(cpu_addr + start * BYTES_PER_PAGE, (end - start) * BYTES_PER_PAGE);
+            func(cpu_addr + start * TRACKER_BYTES_PER_PAGE, (end - start) * TRACKER_BYTES_PER_PAGE);
         }
 
         if constexpr (clear) {
@@ -151,9 +151,9 @@ public:
     template <Type type>
     [[nodiscard]] bool IsRegionModified(u64 offset, u64 size) const noexcept {
         RENDERER_TRACE;
-        const size_t start_page = SanitizeAddress(offset) / BYTES_PER_PAGE;
-        const size_t end_page = Common::DivCeil(SanitizeAddress(offset + size), BYTES_PER_PAGE);
-        if (start_page >= NUM_REGION_PAGES || end_page <= start_page) {
+        const size_t start_page = SanitizeAddress(offset) / TRACKER_BYTES_PER_PAGE;
+        const size_t end_page = Common::DivCeil(SanitizeAddress(offset + size), TRACKER_BYTES_PER_PAGE);
+        if (start_page >= NUM_PAGES_PER_REGION || end_page <= start_page) {
             return false;
         }
         // std::scoped_lock lk{lock}; // Is this needed?

--- a/src/video_core/page_manager.cpp
+++ b/src/video_core/page_manager.cpp
@@ -190,10 +190,10 @@ struct PageManager::Impl {
     template <bool track>
     void UpdatePageWatchers(VAddr addr, u64 size) {
         RENDERER_TRACE;
-        
+
         size_t page = addr >> PAGE_BITS;
         const u64 page_end = Common::DivCeil(addr + size, PAGE_SIZE);
-        
+
         const size_t lock_start = page / PAGES_PER_LOCK;
         const size_t lock_end = Common::DivCeil(page_end, PAGES_PER_LOCK);
         for (size_t i = lock_start; i < lock_end; ++i) {
@@ -214,7 +214,6 @@ struct PageManager::Impl {
                 potential_range_bytes = 0;
             }
         };
-
 
         // Iterate requested pages
         const u64 aligned_addr = page << PAGE_BITS;
@@ -273,7 +272,7 @@ struct PageManager::Impl {
             UpdatePageWatchers<track>(start_addr, size);
             return;
         }
-        
+
         size_t base_page = (base_addr >> PAGE_BITS);
         ASSERT(base_page % PAGES_PER_LOCK == 0);
         std::scoped_lock lk(locks[base_page / PAGES_PER_LOCK]);

--- a/src/video_core/page_manager.h
+++ b/src/video_core/page_manager.h
@@ -15,8 +15,13 @@ class Rasterizer;
 namespace VideoCore {
 
 class PageManager {
-    static constexpr size_t PAGE_BITS = 12;
-    static constexpr size_t PAGE_SIZE = 1ULL << PAGE_BITS;
+    // Use the same page size as the tracker.
+    static constexpr size_t PAGE_BITS = TRACKER_PAGE_BITS;
+    static constexpr size_t PAGE_SIZE = TRACKER_BYTES_PER_PAGE;
+
+    // Keep the lock granularity the same as region granularity. (since each regions has
+    // itself a lock)
+    static constexpr size_t PAGES_PER_LOCK = NUM_PAGES_PER_REGION;
 
 public:
     explicit PageManager(Vulkan::Rasterizer* rasterizer);


### PR DESCRIPTION
This adds some improvements to the page manager and memory tracker:
* Better calculation of what memory pages to (un)protect
* Increese region manager from 4 MB to 16 MB
* Regional locking in page manager. Currently in main, a single mutex is used to lock all watcher updates, creating a bottleneck every time memory is tracked or untracked. This creates a lock for every 1024 pages (16 MB). This is currently the same as memory tracker, I don't think it makes sense for it to be more granular.