### PR TITLE
shader_recompiler: Optimize general case of buffer addressing

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv.cpp
@@ -300,7 +300,7 @@ void SetupCapabilities(const Info& info, const Profile& profile, EmitContext& ct
     if (stage == LogicalStage::TessellationControl || stage == LogicalStage::TessellationEval) {
         ctx.AddCapability(spv::Capability::Tessellation);
     }
-    if (info.dma_types != IR::Type::Void) {
+    if (info.uses_dma) {
         ctx.AddCapability(spv::Capability::PhysicalStorageBufferAddresses);
         ctx.AddExtension("SPV_KHR_physical_storage_buffer");
     }

--- a/src/shader_recompiler/backend/spirv/emit_spirv_atomic.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_atomic.cpp
@@ -7,7 +7,11 @@
 #include "shader_recompiler/backend/spirv/spirv_emit_context.h"
 
 namespace Shader::Backend::SPIRV {
+
 namespace {
+using PointerType = EmitContext::PointerType;
+using PointerSize = EmitContext::PointerSize;
+
 std::pair<Id, Id> AtomicArgs(EmitContext& ctx) {
     const Id scope{ctx.ConstU32(static_cast<u32>(spv::Scope::Device))};
     const Id semantics{ctx.u32_zero_value};
@@ -61,14 +65,13 @@ Id BufferAtomicU32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address, Id 
             return ctx.U32[1];
         }
     }();
-    if (Sirit::ValidId(buffer.offset)) {
-        address = ctx.OpIAdd(ctx.U32[1], address, buffer.offset);
+    if (const Id offset = buffer.Offset(PointerSize::B32); Sirit::ValidId(offset)) {
+        address = ctx.OpIAdd(ctx.U32[1], address, offset);
     }
-    const Id index = ctx.OpShiftRightLogical(ctx.U32[1], address, ctx.ConstU32(2u));
-    const auto [id, pointer_type] = buffer[EmitContext::PointerType::U32];
-    const Id ptr = ctx.OpAccessChain(pointer_type, id, ctx.u32_zero_value, index);
+    const auto [id, pointer_type] = buffer.Alias(PointerType::U32);
+    const Id ptr = ctx.OpAccessChain(pointer_type, id, ctx.u32_zero_value, address);
     const auto [scope, semantics]{AtomicArgs(ctx)};
-    return AccessBoundsCheck<32, 1, is_float>(ctx, index, buffer.size_dwords, [&] {
+    return AccessBoundsCheck<32, 1, is_float>(ctx, address, buffer.Size(PointerSize::B32), [&] {
         return (ctx.*atomic_func)(type, ptr, scope, semantics, value);
     });
 }
@@ -76,14 +79,13 @@ Id BufferAtomicU32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address, Id 
 Id BufferAtomicU32IncDec(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address,
                          Id (Sirit::Module::*atomic_func)(Id, Id, Id, Id)) {
     const auto& buffer = ctx.buffers[handle];
-    if (Sirit::ValidId(buffer.offset)) {
-        address = ctx.OpIAdd(ctx.U32[1], address, buffer.offset);
+    if (const Id offset = buffer.Offset(PointerSize::B32); Sirit::ValidId(offset)) {
+        address = ctx.OpIAdd(ctx.U32[1], address, offset);
     }
-    const Id index = ctx.OpShiftRightLogical(ctx.U32[1], address, ctx.ConstU32(2u));
-    const auto [id, pointer_type] = buffer[EmitContext::PointerType::U32];
-    const Id ptr = ctx.OpAccessChain(pointer_type, id, ctx.u32_zero_value, index);
+    const auto [id, pointer_type] = buffer.Alias(PointerType::U32);
+    const Id ptr = ctx.OpAccessChain(pointer_type, id, ctx.u32_zero_value, address);
     const auto [scope, semantics]{AtomicArgs(ctx)};
-    return AccessBoundsCheck<32>(ctx, index, buffer.size_dwords, [&] {
+    return AccessBoundsCheck<32>(ctx, address, buffer.Size(PointerSize::B32), [&] {
         return (ctx.*atomic_func)(ctx.U32[1], ptr, scope, semantics);
     });
 }
@@ -92,14 +94,13 @@ Id BufferAtomicU32CmpSwap(EmitContext& ctx, IR::Inst* inst, u32 handle, Id addre
                           Id cmp_value,
                           Id (Sirit::Module::*atomic_func)(Id, Id, Id, Id, Id, Id, Id)) {
     const auto& buffer = ctx.buffers[handle];
-    if (Sirit::ValidId(buffer.offset)) {
-        address = ctx.OpIAdd(ctx.U32[1], address, buffer.offset);
+    if (const Id offset = buffer.Offset(PointerSize::B32); Sirit::ValidId(offset)) {
+        address = ctx.OpIAdd(ctx.U32[1], address, offset);
     }
-    const Id index = ctx.OpShiftRightLogical(ctx.U32[1], address, ctx.ConstU32(2u));
-    const auto [id, pointer_type] = buffer[EmitContext::PointerType::U32];
-    const Id ptr = ctx.OpAccessChain(pointer_type, id, ctx.u32_zero_value, index);
+    const auto [id, pointer_type] = buffer.Alias(PointerType::U32);
+    const Id ptr = ctx.OpAccessChain(pointer_type, id, ctx.u32_zero_value, address);
     const auto [scope, semantics]{AtomicArgs(ctx)};
-    return AccessBoundsCheck<32>(ctx, index, buffer.size_dwords, [&] {
+    return AccessBoundsCheck<32>(ctx, address, buffer.Size(PointerSize::B32), [&] {
         return (ctx.*atomic_func)(ctx.U32[1], ptr, scope, semantics, semantics, value, cmp_value);
     });
 }
@@ -107,14 +108,13 @@ Id BufferAtomicU32CmpSwap(EmitContext& ctx, IR::Inst* inst, u32 handle, Id addre
 Id BufferAtomicU64(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address, Id value,
                    Id (Sirit::Module::*atomic_func)(Id, Id, Id, Id, Id)) {
     const auto& buffer = ctx.buffers[handle];
-    if (Sirit::ValidId(buffer.offset)) {
-        address = ctx.OpIAdd(ctx.U32[1], address, buffer.offset);
+    if (const Id offset = buffer.Offset(PointerSize::B64); Sirit::ValidId(offset)) {
+        address = ctx.OpIAdd(ctx.U32[1], address, offset);
     }
-    const Id index = ctx.OpShiftRightLogical(ctx.U32[1], address, ctx.ConstU32(3u));
-    const auto [id, pointer_type] = buffer[EmitContext::PointerType::U64];
-    const Id ptr = ctx.OpAccessChain(pointer_type, id, ctx.u32_zero_value, index);
+    const auto [id, pointer_type] = buffer.Alias(PointerType::U64);
+    const Id ptr = ctx.OpAccessChain(pointer_type, id, ctx.u32_zero_value, address);
     const auto [scope, semantics]{AtomicArgs(ctx)};
-    return AccessBoundsCheck<64>(ctx, index, buffer.size_qwords, [&] {
+    return AccessBoundsCheck<64>(ctx, address, buffer.Size(PointerSize::B64), [&] {
         return (ctx.*atomic_func)(ctx.U64, ptr, scope, semantics, value);
     });
 }
@@ -360,7 +360,7 @@ Id EmitImageAtomicExchange32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id co
 
 Id EmitDataAppend(EmitContext& ctx, u32 gds_addr, u32 binding) {
     const auto& buffer = ctx.buffers[binding];
-    const auto [id, pointer_type] = buffer[EmitContext::PointerType::U32];
+    const auto [id, pointer_type] = buffer.Alias(PointerType::U32);
     const Id ptr = ctx.OpAccessChain(pointer_type, id, ctx.u32_zero_value, ctx.ConstU32(gds_addr));
     const auto [scope, semantics]{AtomicArgs(ctx)};
     return ctx.OpAtomicIIncrement(ctx.U32[1], ptr, scope, semantics);
@@ -368,7 +368,7 @@ Id EmitDataAppend(EmitContext& ctx, u32 gds_addr, u32 binding) {
 
 Id EmitDataConsume(EmitContext& ctx, u32 gds_addr, u32 binding) {
     const auto& buffer = ctx.buffers[binding];
-    const auto [id, pointer_type] = buffer[EmitContext::PointerType::U32];
+    const auto [id, pointer_type] = buffer.Alias(PointerType::U32);
     const Id ptr = ctx.OpAccessChain(pointer_type, id, ctx.u32_zero_value, ctx.ConstU32(gds_addr));
     const auto [scope, semantics]{AtomicArgs(ctx)};
     return ctx.OpAtomicIDecrement(ctx.U32[1], ptr, scope, semantics);

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -3,6 +3,7 @@
 
 #include "common/assert.h"
 #include "common/logging/log.h"
+#include "shader_recompiler/backend/spirv/emit_spirv_bounds.h"
 #include "shader_recompiler/backend/spirv/emit_spirv_instructions.h"
 #include "shader_recompiler/backend/spirv/spirv_emit_context.h"
 #include "shader_recompiler/ir/attribute.h"
@@ -10,8 +11,6 @@
 #include "shader_recompiler/runtime_info.h"
 
 #include <magic_enum/magic_enum.hpp>
-
-#include "emit_spirv_bounds.h"
 
 namespace Shader::Backend::SPIRV {
 namespace {
@@ -164,6 +163,7 @@ void EmitGetGotoVariable(EmitContext&) {
 }
 
 using PointerType = EmitContext::PointerType;
+using PointerSize = EmitContext::PointerSize;
 
 Id EmitReadConst(EmitContext& ctx, IR::Inst* inst, Id addr, Id offset) {
     const u32 flatbuf_off_dw = inst->Flags<u32>();
@@ -179,14 +179,15 @@ Id EmitReadConst(EmitContext& ctx, IR::Inst* inst, Id addr, Id offset) {
 template <PointerType type>
 Id ReadConstBuffer(EmitContext& ctx, u32 handle, Id index) {
     const auto& buffer = ctx.buffers[handle];
-    index = ctx.OpIAdd(ctx.U32[1], index, buffer.offset_dwords);
-    const auto [id, pointer_type] = buffer[type];
+    if (const Id offset = buffer.Offset(PointerSize::B32); Sirit::ValidId(offset)) {
+        index = ctx.OpIAdd(ctx.U32[1], index, offset);
+    }
+    const auto [id, pointer_type] = buffer.Alias(type);
     const auto value_type = type == PointerType::U32 ? ctx.U32[1] : ctx.F32[1];
     const Id ptr{ctx.OpAccessChain(pointer_type, id, ctx.u32_zero_value, index)};
     const Id result{ctx.OpLoad(value_type, ptr)};
-
-    if (Sirit::ValidId(buffer.size_dwords)) {
-        const Id in_bounds = ctx.OpULessThan(ctx.U1[1], index, buffer.size_dwords);
+    if (const Id size = buffer.Size(PointerSize::B32); Sirit::ValidId(size)) {
+        const Id in_bounds = ctx.OpULessThan(ctx.U1[1], index, size);
         return ctx.OpSelect(value_type, in_bounds, result, ctx.u32_zero_value);
     }
     return result;
@@ -419,25 +420,24 @@ void EmitSetPatch(EmitContext& ctx, IR::Patch patch, Id value) {
 
 template <u32 N, PointerType alias>
 static Id EmitLoadBufferB32xN(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address) {
+    constexpr bool is_float = alias == PointerType::F32;
     const auto flags = inst->Flags<IR::BufferInstInfo>();
     const auto& spv_buffer = ctx.buffers[handle];
-    if (Sirit::ValidId(spv_buffer.offset)) {
-        address = ctx.OpIAdd(ctx.U32[1], address, spv_buffer.offset);
+    if (const Id offset = spv_buffer.Offset(PointerSize::B32); Sirit::ValidId(offset)) {
+        address = ctx.OpIAdd(ctx.U32[1], address, offset);
     }
-    const Id index = ctx.OpShiftRightLogical(ctx.U32[1], address, ctx.ConstU32(2u));
     const auto& data_types = alias == PointerType::U32 ? ctx.U32 : ctx.F32;
-    const auto [id, pointer_type] = spv_buffer[alias];
+    const auto [id, pointer_type] = spv_buffer.Alias(alias);
 
     boost::container::static_vector<Id, N> ids;
     for (u32 i = 0; i < N; i++) {
-        const Id index_i = i == 0 ? index : ctx.OpIAdd(ctx.U32[1], index, ctx.ConstU32(i));
+        const Id index_i = i == 0 ? address : ctx.OpIAdd(ctx.U32[1], address, ctx.ConstU32(i));
         const Id ptr_i = ctx.OpAccessChain(pointer_type, id, ctx.u32_zero_value, index_i);
         const Id result_i = ctx.OpLoad(data_types[1], ptr_i);
         if (!flags.typed) {
             // Untyped loads have bounds checking per-component.
-            ids.push_back(LoadAccessBoundsCheck < 32, 1,
-                          alias ==
-                              PointerType::F32 > (ctx, index_i, spv_buffer.size_dwords, result_i));
+            ids.push_back(LoadAccessBoundsCheck<32, 1, is_float>(
+                ctx, index_i, spv_buffer.Size(PointerSize::B32), result_i));
         } else {
             ids.push_back(result_i);
         }
@@ -446,33 +446,32 @@ static Id EmitLoadBufferB32xN(EmitContext& ctx, IR::Inst* inst, u32 handle, Id a
     const Id result = N == 1 ? ids[0] : ctx.OpCompositeConstruct(data_types[N], ids);
     if (flags.typed) {
         // Typed loads have single bounds check for the whole load.
-        return LoadAccessBoundsCheck < 32, N,
-               alias == PointerType::F32 > (ctx, index, spv_buffer.size_dwords, result);
+        return LoadAccessBoundsCheck<32, N, is_float>(ctx, address,
+                                                      spv_buffer.Size(PointerSize::B32), result);
     }
     return result;
 }
 
 Id EmitLoadBufferU8(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address) {
     const auto& spv_buffer = ctx.buffers[handle];
-    if (Sirit::ValidId(spv_buffer.offset)) {
-        address = ctx.OpIAdd(ctx.U32[1], address, spv_buffer.offset);
+    if (const Id offset = spv_buffer.Offset(PointerSize::B8); Sirit::ValidId(offset)) {
+        address = ctx.OpIAdd(ctx.U32[1], address, offset);
     }
-    const auto [id, pointer_type] = spv_buffer[PointerType::U8];
+    const auto [id, pointer_type] = spv_buffer.Alias(PointerType::U8);
     const Id ptr{ctx.OpAccessChain(pointer_type, id, ctx.u32_zero_value, address)};
     const Id result{ctx.OpLoad(ctx.U8, ptr)};
-    return LoadAccessBoundsCheck<8>(ctx, address, spv_buffer.size, result);
+    return LoadAccessBoundsCheck<8>(ctx, address, spv_buffer.Size(PointerSize::B8), result);
 }
 
 Id EmitLoadBufferU16(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address) {
     const auto& spv_buffer = ctx.buffers[handle];
-    if (Sirit::ValidId(spv_buffer.offset)) {
-        address = ctx.OpIAdd(ctx.U32[1], address, spv_buffer.offset);
+    if (const Id offset = spv_buffer.Offset(PointerSize::B16); Sirit::ValidId(offset)) {
+        address = ctx.OpIAdd(ctx.U32[1], address, offset);
     }
-    const auto [id, pointer_type] = spv_buffer[PointerType::U16];
-    const Id index = ctx.OpShiftRightLogical(ctx.U32[1], address, ctx.ConstU32(1u));
-    const Id ptr{ctx.OpAccessChain(pointer_type, id, ctx.u32_zero_value, index)};
+    const auto [id, pointer_type] = spv_buffer.Alias(PointerType::U16);
+    const Id ptr{ctx.OpAccessChain(pointer_type, id, ctx.u32_zero_value, address)};
     const Id result{ctx.OpLoad(ctx.U16, ptr)};
-    return LoadAccessBoundsCheck<16>(ctx, index, spv_buffer.size_shorts, result);
+    return LoadAccessBoundsCheck<16>(ctx, address, spv_buffer.Size(PointerSize::B16), result);
 }
 
 Id EmitLoadBufferU32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address) {
@@ -493,14 +492,13 @@ Id EmitLoadBufferU32x4(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address)
 
 Id EmitLoadBufferU64(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address) {
     const auto& spv_buffer = ctx.buffers[handle];
-    if (Sirit::ValidId(spv_buffer.offset)) {
-        address = ctx.OpIAdd(ctx.U32[1], address, spv_buffer.offset);
+    if (const Id offset = spv_buffer.Offset(PointerSize::B64); Sirit::ValidId(offset)) {
+        address = ctx.OpIAdd(ctx.U32[1], address, offset);
     }
-    const auto [id, pointer_type] = spv_buffer[PointerType::U64];
-    const Id index = ctx.OpShiftRightLogical(ctx.U32[1], address, ctx.ConstU32(3u));
-    const Id ptr{ctx.OpAccessChain(pointer_type, id, ctx.u64_zero_value, index)};
+    const auto [id, pointer_type] = spv_buffer.Alias(PointerType::U64);
+    const Id ptr{ctx.OpAccessChain(pointer_type, id, ctx.u64_zero_value, address)};
     const Id result{ctx.OpLoad(ctx.U64, ptr)};
-    return LoadAccessBoundsCheck<64>(ctx, index, spv_buffer.size_qwords, result);
+    return LoadAccessBoundsCheck<64>(ctx, address, spv_buffer.Size(PointerSize::B64), result);
 }
 
 Id EmitLoadBufferF32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address) {
@@ -526,18 +524,18 @@ Id EmitLoadBufferFormatF32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id addr
 template <u32 N, PointerType alias>
 static void EmitStoreBufferB32xN(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address,
                                  Id value) {
+    constexpr bool is_float = alias == PointerType::F32;
     const auto flags = inst->Flags<IR::BufferInstInfo>();
     const auto& spv_buffer = ctx.buffers[handle];
-    if (Sirit::ValidId(spv_buffer.offset)) {
-        address = ctx.OpIAdd(ctx.U32[1], address, spv_buffer.offset);
+    if (const Id offset = spv_buffer.Offset(PointerSize::B32); Sirit::ValidId(offset)) {
+        address = ctx.OpIAdd(ctx.U32[1], address, offset);
     }
-    const Id index = ctx.OpShiftRightLogical(ctx.U32[1], address, ctx.ConstU32(2u));
     const auto& data_types = alias == PointerType::U32 ? ctx.U32 : ctx.F32;
-    const auto [id, pointer_type] = spv_buffer[alias];
+    const auto [id, pointer_type] = spv_buffer.Alias(alias);
 
     auto store = [&] {
         for (u32 i = 0; i < N; i++) {
-            const Id index_i = i == 0 ? index : ctx.OpIAdd(ctx.U32[1], index, ctx.ConstU32(i));
+            const Id index_i = i == 0 ? address : ctx.OpIAdd(ctx.U32[1], address, ctx.ConstU32(i));
             const Id ptr_i = ctx.OpAccessChain(pointer_type, id, ctx.u32_zero_value, index_i);
             const Id value_i = N == 1 ? value : ctx.OpCompositeExtract(data_types[1], value, i);
             auto store_i = [&] {
@@ -546,8 +544,8 @@ static void EmitStoreBufferB32xN(EmitContext& ctx, IR::Inst* inst, u32 handle, I
             };
             if (!flags.typed) {
                 // Untyped stores have bounds checking per-component.
-                AccessBoundsCheck<32, 1, alias == PointerType::F32>(
-                    ctx, index_i, spv_buffer.size_dwords, store_i);
+                AccessBoundsCheck<32, 1, is_float>(ctx, index_i, spv_buffer.Size(PointerSize::B32),
+                                                   store_i);
             } else {
                 store_i();
             }
@@ -557,8 +555,7 @@ static void EmitStoreBufferB32xN(EmitContext& ctx, IR::Inst* inst, u32 handle, I
 
     if (flags.typed) {
         // Typed stores have single bounds check for the whole store.
-        AccessBoundsCheck<32, N, alias == PointerType::F32>(ctx, index, spv_buffer.size_dwords,
-                                                            store);
+        AccessBoundsCheck<32, N, is_float>(ctx, address, spv_buffer.Size(PointerSize::B32), store);
     } else {
         store();
     }
@@ -566,12 +563,12 @@ static void EmitStoreBufferB32xN(EmitContext& ctx, IR::Inst* inst, u32 handle, I
 
 void EmitStoreBufferU8(EmitContext& ctx, IR::Inst*, u32 handle, Id address, Id value) {
     const auto& spv_buffer = ctx.buffers[handle];
-    if (Sirit::ValidId(spv_buffer.offset)) {
-        address = ctx.OpIAdd(ctx.U32[1], address, spv_buffer.offset);
+    if (const Id offset = spv_buffer.Offset(PointerSize::B8); Sirit::ValidId(offset)) {
+        address = ctx.OpIAdd(ctx.U32[1], address, offset);
     }
-    const auto [id, pointer_type] = spv_buffer[PointerType::U8];
+    const auto [id, pointer_type] = spv_buffer.Alias(PointerType::U8);
     const Id ptr{ctx.OpAccessChain(pointer_type, id, ctx.u32_zero_value, address)};
-    AccessBoundsCheck<8>(ctx, address, spv_buffer.size, [&] {
+    AccessBoundsCheck<8>(ctx, address, spv_buffer.Size(PointerSize::B8), [&] {
         ctx.OpStore(ptr, value);
         return Id{};
     });
@@ -579,13 +576,12 @@ void EmitStoreBufferU8(EmitContext& ctx, IR::Inst*, u32 handle, Id address, Id v
 
 void EmitStoreBufferU16(EmitContext& ctx, IR::Inst*, u32 handle, Id address, Id value) {
     const auto& spv_buffer = ctx.buffers[handle];
-    if (Sirit::ValidId(spv_buffer.offset)) {
-        address = ctx.OpIAdd(ctx.U32[1], address, spv_buffer.offset);
+    if (const Id offset = spv_buffer.Offset(PointerSize::B16); Sirit::ValidId(offset)) {
+        address = ctx.OpIAdd(ctx.U32[1], address, offset);
     }
-    const auto [id, pointer_type] = spv_buffer[PointerType::U16];
-    const Id index = ctx.OpShiftRightLogical(ctx.U32[1], address, ctx.ConstU32(1u));
-    const Id ptr{ctx.OpAccessChain(pointer_type, id, ctx.u32_zero_value, index)};
-    AccessBoundsCheck<16>(ctx, index, spv_buffer.size_shorts, [&] {
+    const auto [id, pointer_type] = spv_buffer.Alias(PointerType::U16);
+    const Id ptr{ctx.OpAccessChain(pointer_type, id, ctx.u32_zero_value, address)};
+    AccessBoundsCheck<16>(ctx, address, spv_buffer.Size(PointerSize::B16), [&] {
         ctx.OpStore(ptr, value);
         return Id{};
     });
@@ -609,13 +605,12 @@ void EmitStoreBufferU32x4(EmitContext& ctx, IR::Inst* inst, u32 handle, Id addre
 
 void EmitStoreBufferU64(EmitContext& ctx, IR::Inst*, u32 handle, Id address, Id value) {
     const auto& spv_buffer = ctx.buffers[handle];
-    if (Sirit::ValidId(spv_buffer.offset)) {
-        address = ctx.OpIAdd(ctx.U32[1], address, spv_buffer.offset);
+    if (const Id offset = spv_buffer.Offset(PointerSize::B64); Sirit::ValidId(offset)) {
+        address = ctx.OpIAdd(ctx.U32[1], address, offset);
     }
-    const auto [id, pointer_type] = spv_buffer[PointerType::U64];
-    const Id index = ctx.OpShiftRightLogical(ctx.U32[1], address, ctx.ConstU32(3u));
-    const Id ptr{ctx.OpAccessChain(pointer_type, id, ctx.u64_zero_value, index)};
-    AccessBoundsCheck<64>(ctx, index, spv_buffer.size_qwords, [&] {
+    const auto [id, pointer_type] = spv_buffer.Alias(PointerType::U64);
+    const Id ptr{ctx.OpAccessChain(pointer_type, id, ctx.u64_zero_value, address)};
+    AccessBoundsCheck<64>(ctx, address, spv_buffer.Size(PointerSize::B64), [&] {
         ctx.OpStore(ptr, value);
         return Id{};
     });

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -1170,14 +1170,14 @@ Id EmitContext::DefineGetBdaPointer() {
     // First time acces, mark as fault
     AddLabel(fault_label);
     const auto& fault_buffer{buffers[fault_buffer_index]};
-    const auto [fault_buffer_id, fault_pointer_type] = fault_buffer.Alias(PointerType::U8);
-    const auto page_div8{OpShiftRightLogical(U32[1], page32, ConstU32(3U))};
-    const auto page_mod8{OpBitwiseAnd(U32[1], page32, ConstU32(7U))};
-    const auto page_mask{OpShiftLeftLogical(U8, u8_one_value, page_mod8)};
+    const auto [fault_buffer_id, fault_pointer_type] = fault_buffer.Alias(PointerType::U32);
+    const auto page_div32{OpShiftRightLogical(U32[1], page32, ConstU32(5U))};
+    const auto page_mod32{OpBitwiseAnd(U32[1], page32, ConstU32(31U))};
+    const auto page_mask{OpShiftLeftLogical(U32[1], u32_one_value, page_mod32)};
     const auto fault_ptr{
-        OpAccessChain(fault_pointer_type, fault_buffer_id, u32_zero_value, page_div8)};
-    const auto fault_value{OpLoad(U8, fault_ptr)};
-    const auto fault_value_masked{OpBitwiseOr(U8, fault_value, page_mask)};
+        OpAccessChain(fault_pointer_type, fault_buffer_id, u32_zero_value, page_div32)};
+    const auto fault_value{OpLoad(U32[1], fault_ptr)};
+    const auto fault_value_masked{OpBitwiseOr(U32[1], fault_value, page_mask)};
     OpStore(fault_ptr, fault_value_masked);
 
     // Return null pointer

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -42,17 +42,6 @@ public:
                          Bindings& binding);
     ~EmitContext();
 
-    enum class PointerType : u32 {
-        U8,
-        U16,
-        F16,
-        U32,
-        F32,
-        U64,
-        F64,
-        NumAlias,
-    };
-
     Id Def(const IR::Value& value);
 
     void DefineBufferProperties();
@@ -294,6 +283,24 @@ public:
         bool is_storage = false;
     };
 
+    enum class PointerType : u32 {
+        U8,
+        U16,
+        U32,
+        F32,
+        U64,
+        F64,
+        NumAlias,
+    };
+
+    enum class PointerSize : u32 {
+        B8,
+        B16,
+        B32,
+        B64,
+        NumClass,
+    };
+
     struct BufferSpv {
         Id id;
         Id pointer_type;
@@ -302,20 +309,23 @@ public:
     struct BufferDefinition {
         u32 binding;
         BufferType buffer_type;
-        Id offset;
-        Id offset_dwords;
-        Id size;
-        Id size_shorts;
-        Id size_dwords;
-        Id size_qwords;
+        std::array<Id, u32(PointerSize::NumClass)> offsets;
+        std::array<Id, u32(PointerSize::NumClass)> sizes;
         std::array<BufferSpv, u32(PointerType::NumAlias)> aliases;
 
-        const BufferSpv& operator[](PointerType alias) const {
-            return aliases[u32(alias)];
+        template <class Self>
+        auto& Alias(this Self& self, PointerType alias) {
+            return self.aliases[u32(alias)];
         }
 
-        BufferSpv& operator[](PointerType alias) {
-            return aliases[u32(alias)];
+        template <class Self>
+        auto& Offset(this Self& self, PointerSize size) {
+            return self.offsets[u32(size)];
+        }
+
+        template <class Self>
+        auto& Size(this Self& self, PointerSize size) {
+            return self.sizes[u32(size)];
         }
     };
 

--- a/src/shader_recompiler/frontend/translate/scalar_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_alu.cpp
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include <bit>
 #include "common/assert.h"
 #include "shader_recompiler/frontend/translate/translate.h"
 

--- a/src/shader_recompiler/info.h
+++ b/src/shader_recompiler/info.h
@@ -238,7 +238,7 @@ struct Info {
         Dynamic = 1 << 1,
     };
     ReadConstType readconst_types{};
-    IR::Type dma_types{IR::Type::Void};
+    bool uses_dma{false};
 
     explicit Info(Stage stage_, LogicalStage l_stage_, ShaderParams params)
         : stage{stage_}, l_stage{l_stage_}, pgm_hash{params.hash}, pgm_base{params.Base()},

--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -119,9 +119,26 @@ u32 BufferAddressShift(const IR::Inst& inst, AmdGpu::DataFormat data_format) {
         return 3;
     case IR::Opcode::LoadBufferFormatF32:
     case IR::Opcode::StoreBufferFormatF32: {
-        const auto num_comps = AmdGpu::NumComponents(data_format);
-        const auto num_bytes = (AmdGpu::NumBitsPerBlock(data_format) >> 3) / num_comps;
-        return std::bit_width(num_bytes) - 1;
+        switch (data_format) {
+        case AmdGpu::DataFormat::Format8:
+            return 0;
+        case AmdGpu::DataFormat::Format8_8:
+        case AmdGpu::DataFormat::Format16:
+            return 1;
+        case AmdGpu::DataFormat::Format8_8_8_8:
+        case AmdGpu::DataFormat::Format16_16:
+        case AmdGpu::DataFormat::Format10_11_11:
+        case AmdGpu::DataFormat::Format2_10_10_10:
+        case AmdGpu::DataFormat::Format16_16_16_16:
+        case AmdGpu::DataFormat::Format32:
+        case AmdGpu::DataFormat::Format32_32:
+        case AmdGpu::DataFormat::Format32_32_32:
+        case AmdGpu::DataFormat::Format32_32_32_32:
+            return 2;
+        default:
+            return 0;
+        }
+        break;
     }
     case IR::Opcode::ReadConstBuffer:
         // Provided address is already in dwords

--- a/src/shader_recompiler/ir/passes/shader_info_collection_pass.cpp
+++ b/src/shader_recompiler/ir/passes/shader_info_collection_pass.cpp
@@ -145,7 +145,7 @@ void CollectShaderInfoPass(IR::Program& program) {
             .is_written = true,
         });
         info.buffers.push_back({
-            .used_types = IR::Type::U8,
+            .used_types = IR::Type::U32,
             .inline_cbuf = AmdGpu::Buffer::Placeholder(VideoCore::BufferCache::FAULT_BUFFER_SIZE),
             .buffer_type = BufferType::FaultBuffer,
             .is_written = true,

--- a/src/shader_recompiler/ir/passes/shader_info_collection_pass.cpp
+++ b/src/shader_recompiler/ir/passes/shader_info_collection_pass.cpp
@@ -102,7 +102,7 @@ void Visit(Info& info, const IR::Inst& inst) {
         info.uses_lane_id = true;
         break;
     case IR::Opcode::ReadConst:
-        if (info.readconst_types == Info::ReadConstType::None) {
+        if (!info.uses_dma) {
             info.buffers.push_back({
                 .used_types = IR::Type::U32,
                 // We can't guarantee that flatbuf will not grow past UBO
@@ -116,7 +116,7 @@ void Visit(Info& info, const IR::Inst& inst) {
         } else {
             info.readconst_types |= Info::ReadConstType::Dynamic;
         }
-        info.dma_types |= IR::Type::U32;
+        info.uses_dma = true;
         break;
     case IR::Opcode::PackUfloat10_11_11:
         info.uses_pack_10_11_11 = true;
@@ -130,20 +130,21 @@ void Visit(Info& info, const IR::Inst& inst) {
 }
 
 void CollectShaderInfoPass(IR::Program& program) {
+    auto& info = program.info;
     for (IR::Block* const block : program.post_order_blocks) {
         for (IR::Inst& inst : block->Instructions()) {
-            Visit(program.info, inst);
+            Visit(info, inst);
         }
     }
 
-    if (program.info.dma_types != IR::Type::Void) {
-        program.info.buffers.push_back({
+    if (info.uses_dma) {
+        info.buffers.push_back({
             .used_types = IR::Type::U64,
             .inline_cbuf = AmdGpu::Buffer::Placeholder(VideoCore::BufferCache::BDA_PAGETABLE_SIZE),
             .buffer_type = BufferType::BdaPagetable,
             .is_written = true,
         });
-        program.info.buffers.push_back({
+        info.buffers.push_back({
             .used_types = IR::Type::U8,
             .inline_cbuf = AmdGpu::Buffer::Placeholder(VideoCore::BufferCache::FAULT_BUFFER_SIZE),
             .buffer_type = BufferType::FaultBuffer,

--- a/src/shader_recompiler/profile.h
+++ b/src/shader_recompiler/profile.h
@@ -35,7 +35,7 @@ struct Profile {
     bool lower_left_origin_mode{};
     bool needs_manual_interpolation{};
     bool needs_lds_barriers{};
-    u64 min_ssbo_alignment{};
+    bool needs_buffer_offsets{};
     u64 max_ubo_size{};
     u32 max_viewport_width{};
     u32 max_viewport_height{};

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -225,6 +225,7 @@ PipelineCache::PipelineCache(const Instance& instance_, Scheduler& scheduler_,
                                       instance.GetDriverID() == vk::DriverId::eNvidiaProprietary,
         .needs_lds_barriers = instance.GetDriverID() == vk::DriverId::eNvidiaProprietary ||
                               instance.GetDriverID() == vk::DriverId::eMoltenvk,
+        .needs_buffer_offsets = instance.StorageMinAlignment() > 4,
         // When binding a UBO, we calculate its size considering the offset in the larger buffer
         // cache underlying resource. In some cases, it may produce sizes exceeding the system
         // maximum allowed UBO range, so we need to reduce the threshold to prevent issues.


### PR DESCRIPTION
Buffer instructions have always had a strange API where regardless of their element size, they would receive a byte address from IR, add the offset in bytes and shift the address to get the array index. This makes buffer reads harder to read and has additional overhead in the form of a shift operation. For example:

```glsl
uint _118 = (((_113 * 64u) + 32u) >> 2u) + buf0_dword_off;
uint _120 = ssbo_1_1.data[_118];
``` 

With this PR buffer instruction now directly accept the array index of the buffer and add the correctly sized offset. By doing the shift in IR the most common buffer addressing mode can be detected and optimize away the shift by directly shifting the constants instead.

```glsl
uint _116 = ((_113 * 16u) + 8u) + buf0_dword_off;
uint _118 = ssbo_1_1.data[_116];
```

On platforms where minStorageBufferOffsetAlignment = 4 (AMD, Intel) we can go a step further and eliminate the buffer offset addition, saving another ALU operation per access

```glsl
uint _87 = (_83 * 16u) + 8u;
uint _89 = ssbo_1_1.data[_87];
```

This might have some impact on GPU performance especially if many shaders do many buffer accesses, as the saved ALU ops can add up