### PR TITLE
bit_array: Remove non const operator~

### DIFF
--- a/src/common/bit_array.h
+++ b/src/common/bit_array.h
@@ -361,13 +361,6 @@ public:
         return *this;
     }
 
-    inline constexpr BitArray& operator~() {
-        for (size_t i = 0; i < WORD_COUNT; ++i) {
-            data[i] = ~data[i];
-        }
-        return *this;
-    }
-
     inline constexpr BitArray operator|(const BitArray& other) const {
         BitArray result = *this;
         result |= other;
@@ -388,7 +381,9 @@ public:
 
     inline constexpr BitArray operator~() const {
         BitArray result = *this;
-        result = ~result;
+        for (size_t i = 0; i < WORD_COUNT; ++i) {
+            result.data[i] = ~result.data[i];
+        }
         return result;
     }
 


### PR DESCRIPTION
This operator is never meant to actually operate on the object its prefixed, rather always make a copy.
~~This caused some debug pain trying to port read protects to the new region manager~~