### PR TITLE
Avoid clearing depth on partial HTILE writes

### DIFF
--- a/src/shader_recompiler/info.h
+++ b/src/shader_recompiler/info.h
@@ -58,6 +58,7 @@ struct BufferResource {
     BufferType buffer_type;
     u8 instance_attrib{};
     bool is_written{};
+    bool is_read{};
     bool is_formatted{};
 
     bool IsSpecial() const noexcept {

--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -413,11 +413,12 @@ void PatchImageSharp(IR::Block& block, IR::Inst& inst, Info& info, Descriptors& 
     // Read image sharp.
     const auto tsharp = TrackSharp(tsharp_handle, info);
     const auto inst_info = inst.Flags<IR::TextureInstInfo>();
-    const bool is_written = inst.GetOpcode() == IR::Opcode::ImageWrite;
+    const bool is_atomic = IsImageAtomicInstruction(inst);
+    const bool is_written = inst.GetOpcode() == IR::Opcode::ImageWrite || is_atomic;
     const ImageResource image_res = {
         .sharp_idx = tsharp,
         .is_depth = bool(inst_info.is_depth),
-        .is_atomic = IsImageAtomicInstruction(inst),
+        .is_atomic = is_atomic,
         .is_array = bool(inst_info.is_array),
         .is_written = is_written,
         .is_r128 = bool(inst_info.is_r128),

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -511,7 +511,8 @@ bool Rasterizer::IsComputeMetaClear(const Pipeline* pipeline) {
     // will need its full emulation anyways.
     for (const auto& desc : info.buffers) {
         const VAddr address = desc.GetSharp(info).base_address;
-        if (!desc.IsSpecial() && desc.is_written && texture_cache.ClearMeta(address)) {
+        if (!desc.IsSpecial() && desc.is_written && !desc.is_read &&
+            texture_cache.ClearMeta(address)) {
             // Assume all slices were updates
             LOG_TRACE(Render_Vulkan, "Metadata update skipped");
             return true;

--- a/src/video_core/texture_cache/image.h
+++ b/src/video_core/texture_cache/image.h
@@ -27,10 +27,9 @@ enum ImageFlagBits : u32 {
     CpuDirty = 1 << 1,      ///< Contents have been modified from the CPU
     GpuDirty = 1 << 2, ///< Contents have been modified from the GPU (valid data in buffer cache)
     Dirty = MaybeCpuDirty | CpuDirty | GpuDirty,
-    GpuModified = 1 << 3,    ///< Contents have been modified from the GPU
-    Registered = 1 << 6,     ///< True when the image is registered
-    Picked = 1 << 7,         ///< Temporary flag to mark the image as picked
-    MetaRegistered = 1 << 8, ///< True when metadata for this surface is known and registered
+    GpuModified = 1 << 3, ///< Contents have been modified from the GPU
+    Registered = 1 << 6,  ///< True when the image is registered
+    Picked = 1 << 7,      ///< Temporary flag to mark the image as picked
 };
 DECLARE_ENUM_FLAG_OPERATORS(ImageFlagBits)
 

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -451,20 +451,16 @@ ImageView& TextureCache::FindRenderTarget(BaseDesc& desc) {
     UpdateImage(image_id);
 
     // Register meta data for this color buffer
-    if (!(image.flags & ImageFlagBits::MetaRegistered)) {
-        if (desc.info.meta_info.cmask_addr) {
-            surface_metas.emplace(desc.info.meta_info.cmask_addr,
-                                  MetaDataInfo{.type = MetaDataInfo::Type::CMask});
-            image.info.meta_info.cmask_addr = desc.info.meta_info.cmask_addr;
-            image.flags |= ImageFlagBits::MetaRegistered;
-        }
+    if (desc.info.meta_info.cmask_addr) {
+        surface_metas.emplace(desc.info.meta_info.cmask_addr,
+                              MetaDataInfo{.type = MetaDataInfo::Type::CMask});
+        image.info.meta_info.cmask_addr = desc.info.meta_info.cmask_addr;
+    }
 
-        if (desc.info.meta_info.fmask_addr) {
-            surface_metas.emplace(desc.info.meta_info.fmask_addr,
-                                  MetaDataInfo{.type = MetaDataInfo::Type::FMask});
-            image.info.meta_info.fmask_addr = desc.info.meta_info.fmask_addr;
-            image.flags |= ImageFlagBits::MetaRegistered;
-        }
+    if (desc.info.meta_info.fmask_addr) {
+        surface_metas.emplace(desc.info.meta_info.fmask_addr,
+                              MetaDataInfo{.type = MetaDataInfo::Type::FMask});
+        image.info.meta_info.fmask_addr = desc.info.meta_info.fmask_addr;
     }
 
     return RegisterImageView(image_id, desc.view_info);
@@ -479,15 +475,11 @@ ImageView& TextureCache::FindDepthTarget(BaseDesc& desc) {
     UpdateImage(image_id);
 
     // Register meta data for this depth buffer
-    if (!(image.flags & ImageFlagBits::MetaRegistered)) {
-        if (desc.info.meta_info.htile_addr) {
-            surface_metas.emplace(
-                desc.info.meta_info.htile_addr,
-                MetaDataInfo{.type = MetaDataInfo::Type::HTile,
-                             .clear_mask = image.info.meta_info.htile_clear_mask});
-            image.info.meta_info.htile_addr = desc.info.meta_info.htile_addr;
-            image.flags |= ImageFlagBits::MetaRegistered;
-        }
+    if (desc.info.meta_info.htile_addr) {
+        surface_metas.emplace(desc.info.meta_info.htile_addr,
+                              MetaDataInfo{.type = MetaDataInfo::Type::HTile,
+                                           .clear_mask = image.info.meta_info.htile_clear_mask});
+        image.info.meta_info.htile_addr = desc.info.meta_info.htile_addr;
     }
 
     // If there is a stencil attachment, link depth and stencil.


### PR DESCRIPTION
This fixes the shadows on Driveclub (CUSA00093)

| main  | PR |
| ------------- | ------------- |
| ![bad_shadows3](https://github.com/user-attachments/assets/3cd59c17-c260-4e92-93ac-44f678cd50d8) | ![proper_shadows4](https://github.com/user-attachments/assets/66f654f6-0ea0-4e40-904e-3c28f601c142) |


There is a shader that performs some bit operations on HTILE, but not a full clear which got mis-recognized as a clear. According to [mesa](https://github.com/chaotic-cx/mesa-mirror/blob/646977348ba49630515f0da1542b77ef4919d68e/src/amd/vulkan/meta/radv_meta_clear.c#L661) this fetches the upper bit of SR1 and clears/sets zmask depending on that bit. I'm not sure what it is, but doesn't appear to be a depth or stencil clear as it leaves zmin/zmax and sr0/sr1 untouched.

```glsl
htile | ((1u & (~bitfieldExtract(htile, 7, 1))) * 15))
```