### PR TITLE
Qt: Directly install update after downloading

### DIFF
--- a/src/qt_gui/check_update.cpp
+++ b/src/qt_gui/check_update.cpp
@@ -426,8 +426,6 @@ void CheckUpdate::DownloadUpdate(const QString& url) {
         if (file.open(QIODevice::WriteOnly)) {
             file.write(reply->readAll());
             file.close();
-            QMessageBox::information(this, tr("Download Complete"),
-                                     tr("The update has been downloaded, press OK to install."));
             Install();
         } else {
             QMessageBox::warning(


### PR DESCRIPTION
This allows you to install the update directly after downloading it.
This dialog box is useless since there is nothing else you can do except OK.

![image](https://github.com/user-attachments/assets/066c0ffb-cbb7-48d7-a793-bf9777d1e0df)