### PR TITLE
Update template hyperlink to the wiki instead of the compatibility list

### DIFF
--- a/.github/ISSUE_TEMPLATE/game-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/game-bug-report.yaml
@@ -35,7 +35,7 @@ body:
           required: true
         - label: I have disabled all patches and cheats and the issue is still present.
           required: true
-        - label: I have all the required [system modules](https://github.com/shadps4-emu/shadps4-game-compatibility?tab=readme-ov-file#informations) installed.
+        - label: I have all the required [system modules](https://github.com/shadps4-emu/shadPS4/wiki/I.-Quick-start-%5BUsers%5D#4-adding-modules) installed.
           required: true
   - type: textarea
     id: desc


### PR DESCRIPTION
Updating the GAME BUG template hyperlink to the wiki instead of the compatibility list, could also redirect to the README in the emulator's repo instead but I thought redirecting to the Wiki would give users more info.