### PR TITLE
CMakePreset: Specify compiler for Linux

### DIFF
--- a/CMakeLinuxPresets.json
+++ b/CMakeLinuxPresets.json
@@ -12,6 +12,8 @@
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/Build/${presetName}",
       "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
         "CMAKE_INSTALL_PREFIX": "${sourceDir}/Build/${presetName}"
       }
     }


### PR DESCRIPTION
Specify the compiler used in Linux as clang. It was not specified before (and will use the default GCC).

Note that is doesn't specify Clang 19, but uses the default one provided by the distribution.

I could specify "clang-19" insteed of just "clang" (it works on Fedora) but I don't know how other distros manage different Clang versions.