### PR TITLE
video_core: use shared first mutex (reader priority shared mutex) to resolve deadlock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -689,6 +689,7 @@ set(COMMON src/common/logging/backend.cpp
            src/common/recursive_lock.cpp
            src/common/recursive_lock.h
            src/common/sha1.h
+           src/common/shared_first_mutex.h
            src/common/signal_context.h
            src/common/signal_context.cpp
            src/common/singleton.h

--- a/src/common/shared_first_mutex.h
+++ b/src/common/shared_first_mutex.h
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+
+namespace Common {
+
+// Like std::shared_mutex, but reader has priority over writer.
+class SharedFirstMutex {
+public:
+    void lock() {
+        std::unique_lock<std::mutex> lock(mtx);
+        cv.wait(lock, [this]() { return !writer_active && readers == 0; });
+        writer_active = true;
+    }
+
+    void unlock() {
+        std::lock_guard<std::mutex> lock(mtx);
+        writer_active = false;
+        cv.notify_all();
+    }
+
+    void lock_shared() {
+        std::unique_lock<std::mutex> lock(mtx);
+        cv.wait(lock, [this]() { return !writer_active; });
+        ++readers;
+    }
+
+    void unlock_shared() {
+        std::lock_guard<std::mutex> lock(mtx);
+        if (--readers == 0) {
+            cv.notify_all();
+        }
+    }
+
+private:
+    std::mutex mtx;
+    std::condition_variable cv;
+    int readers = 0;
+    bool writer_active = false;
+};
+
+} // namespace Common

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -5,6 +5,7 @@
 
 #include <shared_mutex>
 #include "common/recursive_lock.h"
+#include "common/shared_first_mutex.h"
 #include "video_core/buffer_cache/buffer_cache.h"
 #include "video_core/page_manager.h"
 #include "video_core/renderer_vulkan/vk_pipeline_cache.h"
@@ -122,7 +123,7 @@ private:
     AmdGpu::Liverpool* liverpool;
     Core::MemoryManager* memory;
     boost::icl::interval_set<VAddr> mapped_ranges;
-    std::shared_mutex mapped_ranges_mutex;
+    Common::SharedFirstMutex mapped_ranges_mutex;
     PipelineCache pipeline_cache;
 
     boost::container::static_vector<


### PR DESCRIPTION
From the discord:

> Just checked and the lock that I thought was exclusive was already a shared lock. 
> What is currently happening is:
> thread a (gpucommand) locks the mapped_range mutex (shared lock)
> thread b (the mapmemory thread)  waits to lock the mapped_range mutex (exclusive lock)
> thread c (the one invalidating memory) waits to lock the mapped_range mutex (shared lock)
>
> The logic says to me that, if thread a and c have shared locks, they could both acquire the lock. But apparently, if thread b tries to acquire exclusive lock before thread c tries to acquire a shared lock, exclusive lock takes preference and all other shared locks need to wait untile thread b releases the lock (causing a deadlock in this instance). To solve that I will have to implement custom mutex that doesn't have this behaviour.

I can change the name of the mutex if you think is not descriptive enough

@StevenMiller123 