### PR TITLE
libkernel: Add missing mprotect export

### DIFF
--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -711,6 +711,7 @@ void RegisterMemory(Core::Loader::SymbolsResolver* sym) {
                  sceKernelConfiguredFlexibleMemorySize);
 
     LIB_FUNCTION("vSMAm3cxYTY", "libkernel", 1, "libkernel", 1, 1, sceKernelMprotect);
+    LIB_FUNCTION("YQOfxL4QfeU", "libkernel", 1, "libkernel", 1, 1, posix_mprotect);
     LIB_FUNCTION("YQOfxL4QfeU", "libScePosix", 1, "libkernel", 1, 1, posix_mprotect);
     LIB_FUNCTION("9bfdLIyuwCY", "libkernel", 1, "libkernel", 1, 1, sceKernelMtypeprotect);
 


### PR DESCRIPTION
@mikusp ran into this when testing some homebrew.