### PR TITLE
Fix V_ADDC_U32 carry-out edge cases

### DIFF
--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -623,12 +623,13 @@ void Translator::V_ADDC_U32(const GcnInst& inst) {
     const IR::U32 src0{GetSrc(inst.src[0])};
     const IR::U32 src1{GetSrc(inst.src[1])};
     const IR::U32 carry{GetCarryIn(inst)};
-    const IR::U32 result{ir.IAdd(ir.IAdd(src0, src1), carry)};
+    const IR::U32 temp{ir.IAdd(src0, src1)};
+    const IR::U32 result{ir.IAdd(temp, carry)};
     SetDst(inst.dst[0], result);
 
-    const IR::U1 less_src0{ir.ILessThan(result, src0, false)};
-    const IR::U1 less_src1{ir.ILessThan(result, src1, false)};
-    const IR::U1 did_overflow{ir.LogicalOr(less_src0, less_src1)};
+    const IR::U1 less_1{ir.ILessThan(temp, src0, false)};
+    const IR::U1 less_2{ir.ILessThan(result, carry, false)};
+    const IR::U1 did_overflow{ir.LogicalOr(less_1, less_2)};
     SetCarryOut(inst, did_overflow);
 }
 

--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -623,13 +623,15 @@ void Translator::V_ADDC_U32(const GcnInst& inst) {
     const IR::U32 src0{GetSrc(inst.src[0])};
     const IR::U32 src1{GetSrc(inst.src[1])};
     const IR::U32 carry{GetCarryIn(inst)};
-    const IR::U32 temp{ir.IAdd(src0, src1)};
-    const IR::U32 result{ir.IAdd(temp, carry)};
-    SetDst(inst.dst[0], result);
+    const IR::Value tmp1{ir.IAddCary(src0, src1)};
+    const IR::U32 result1{ir.CompositeExtract(tmp1, 0)};
+    const IR::U32 carry_out1{ir.CompositeExtract(tmp1, 1)};
+    const IR::Value tmp2{ir.IAddCary(result1, carry)};
+    const IR::U32 result2{ir.CompositeExtract(tmp2, 0)};
+    const IR::U32 carry_out2{ir.CompositeExtract(tmp2, 1)};
+    SetDst(inst.dst[0], result2);
 
-    const IR::U1 less_1{ir.ILessThan(temp, src0, false)};
-    const IR::U1 less_2{ir.ILessThan(result, carry, false)};
-    const IR::U1 did_overflow{ir.LogicalOr(less_1, less_2)};
+    const IR::U1 did_overflow{ir.INotEqual(ir.BitwiseOr(carry_out1, carry_out2), ir.Imm32(0))};
     SetCarryOut(inst, did_overflow);
 }
 


### PR DESCRIPTION
Carry calculations in unsigned numbers work like this:
```
carry = result < src
```
It doesn't matter which of the two sources you check, because in unsigned addition when there's an overflow the result will be smaller than both sources, never just one.

---

In the case of add with carry, you need to check whether src1 + src2 overflows and whether (src1+src) + cf overflows separately.

The current implementation does `result < src1 || result < src2`. This doesn't check separately for the intermediate result of src1+src2 and only checks if the final result overflowed. This fails in cases where the intermediate result overflows but the final result doesn't.

---

Example where old implementation can fail:

src0 = 0xFFFF'FFFF
src1 = 0xFFFF'FFFF
carry_in = 1

result = 0xFFFF'FFFF + 0xFFFF'FFFF + 1 = 0xFFFF'FFFF

This previous implementation would check `result < src0 (false)` || `result < src1 (false)` and carry_out would be false