### PR TITLE
texture_cache: Change depth resolve new image back to max of resources.

### DIFF
--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -169,7 +169,7 @@ ImageId TextureCache::ResolveDepthOverlap(const ImageInfo& requested_info, Bindi
 
     if (recreate) {
         auto new_info = requested_info;
-        new_info.resources = std::min(requested_info.resources, cache_image.info.resources);
+        new_info.resources = std::max(requested_info.resources, cache_image.info.resources);
         const auto new_image_id = slot_images.insert(instance, scheduler, new_info);
         RegisterImage(new_image_id);
 


### PR DESCRIPTION
https://github.com/shadps4-emu/shadPS4/pull/3079 changed the resource count for the re-created depth overlap image to the minimum of requested and cached resources instead of the max. This resulted in spam of the following in at least CUSA16404:

```
[Render.Vulkan] <Warning> texture_cache.cpp:405 FindImage: Image overlap resolve failed
```

It's not clear to me why this was changed to `std::min` as usually resource overlaps would resolve to the greatest number of sub-resources rather than the least. When the number of resources in the resolved image is less than requested the code is set up to always fail the resolve.

Proposing changing this back as a PR as the short comment thread on this in the previous PR did not gain traction. With this change the game in question still works and no longer spams overlap failures.