### PR TITLE
IME fixes

### DIFF
--- a/src/core/libraries/ime/ime.h
+++ b/src/core/libraries/ime/ime.h
@@ -13,72 +13,6 @@ class SymbolsResolver;
 
 namespace Libraries::Ime {
 
-constexpr u32 ORBIS_IME_MAX_TEXT_LENGTH = 2048;
-
-enum class OrbisImeKeyboardOption : u32 {
-    Default = 0,
-    Repeat = 1,
-    RepeatEachKey = 2,
-    AddOsk = 4,
-    EffectiveWithIme = 8,
-    DisableResume = 16,
-    DisableCapslockWithoutShift = 32,
-};
-DECLARE_ENUM_FLAG_OPERATORS(OrbisImeKeyboardOption)
-
-enum class OrbisImeOption : u32 {
-    DEFAULT = 0,
-    MULTILINE = 1,
-    NO_AUTO_CAPITALIZATION = 2,
-    PASSWORD = 4,
-    LANGUAGES_FORCED = 8,
-    EXT_KEYBOARD = 16,
-    NO_LEARNING = 32,
-    FIXED_POSITION = 64,
-    DISABLE_RESUME = 256,
-    DISABLE_AUTO_SPACE = 512,
-    DISABLE_POSITION_ADJUSTMENT = 2048,
-    EXPANDED_PREEDIT_BUFFER = 4096,
-    USE_JAPANESE_EISUU_KEY_AS_CAPSLOCK = 8192,
-    USE_2K_COORDINATES = 16384,
-};
-DECLARE_ENUM_FLAG_OPERATORS(OrbisImeOption)
-
-struct OrbisImeKeyboardParam {
-    OrbisImeKeyboardOption option;
-    s8 reserved1[4];
-    void* arg;
-    OrbisImeEventHandler handler;
-    s8 reserved2[8];
-};
-
-struct OrbisImeParam {
-    s32 user_id;
-    OrbisImeType type;
-    u64 supported_languages;
-    OrbisImeEnterLabel enter_label;
-    OrbisImeInputMethod input_method;
-    OrbisImeTextFilter filter;
-    OrbisImeOption option;
-    u32 maxTextLength;
-    char16_t* inputTextBuffer;
-    float posx;
-    float posy;
-    OrbisImeHorizontalAlignment horizontal_alignment;
-    OrbisImeVerticalAlignment vertical_alignment;
-    void* work;
-    void* arg;
-    OrbisImeEventHandler handler;
-    s8 reserved[8];
-};
-
-struct OrbisImeCaret {
-    f32 x;
-    f32 y;
-    u32 height;
-    u32 index;
-};
-
 int PS4_SYSV_ABI FinalizeImeModule();
 int PS4_SYSV_ABI InitializeImeModule();
 int PS4_SYSV_ABI sceImeCheckFilterText();
@@ -98,22 +32,22 @@ int PS4_SYSV_ABI sceImeDisableController();
 int PS4_SYSV_ABI sceImeFilterText();
 int PS4_SYSV_ABI sceImeForTestFunction();
 int PS4_SYSV_ABI sceImeGetPanelPositionAndForm();
-s32 PS4_SYSV_ABI sceImeGetPanelSize(const OrbisImeParam* param, u32* width, u32* height);
-s32 PS4_SYSV_ABI sceImeKeyboardClose(s32 userId);
+Error PS4_SYSV_ABI sceImeGetPanelSize(const OrbisImeParam* param, u32* width, u32* height);
+Error PS4_SYSV_ABI sceImeKeyboardClose(s32 userId);
 int PS4_SYSV_ABI sceImeKeyboardGetInfo();
 int PS4_SYSV_ABI sceImeKeyboardGetResourceId();
-s32 PS4_SYSV_ABI sceImeKeyboardOpen(s32 userId, const OrbisImeKeyboardParam* param);
+Error PS4_SYSV_ABI sceImeKeyboardOpen(s32 userId, const OrbisImeKeyboardParam* param);
 int PS4_SYSV_ABI sceImeKeyboardOpenInternal();
 int PS4_SYSV_ABI sceImeKeyboardSetMode();
 int PS4_SYSV_ABI sceImeKeyboardUpdate();
-s32 PS4_SYSV_ABI sceImeOpen(const OrbisImeParam* param, const void* extended);
+Error PS4_SYSV_ABI sceImeOpen(const OrbisImeParam* param, const OrbisImeParamExtended* extended);
 int PS4_SYSV_ABI sceImeOpenInternal();
 void PS4_SYSV_ABI sceImeParamInit(OrbisImeParam* param);
 int PS4_SYSV_ABI sceImeSetCandidateIndex();
-s32 PS4_SYSV_ABI sceImeSetCaret(const OrbisImeCaret* caret);
-s32 PS4_SYSV_ABI sceImeSetText(const char16_t* text, u32 length);
+Error PS4_SYSV_ABI sceImeSetCaret(const OrbisImeCaret* caret);
+Error PS4_SYSV_ABI sceImeSetText(const char16_t* text, u32 length);
 int PS4_SYSV_ABI sceImeSetTextGeometry();
-s32 PS4_SYSV_ABI sceImeUpdate(OrbisImeEventHandler handler);
+Error PS4_SYSV_ABI sceImeUpdate(OrbisImeEventHandler handler);
 int PS4_SYSV_ABI sceImeVshClearPreedit();
 int PS4_SYSV_ABI sceImeVshClose();
 int PS4_SYSV_ABI sceImeVshConfirmPreedit();

--- a/src/core/libraries/ime/ime_dialog.h
+++ b/src/core/libraries/ime/ime_dialog.h
@@ -13,50 +13,6 @@ class SymbolsResolver;
 
 namespace Libraries::ImeDialog {
 
-constexpr u32 ORBIS_IME_DIALOG_MAX_TEXT_LENGTH = 2048;
-
-enum class Error : u32 {
-    OK = 0x0,
-    BUSY = 0x80bc0001,
-    NOT_OPENED = 0x80bc0002,
-    NO_MEMORY = 0x80bc0003,
-    CONNECTION_FAILED = 0x80bc0004,
-    TOO_MANY_REQUESTS = 0x80bc0005,
-    INVALID_TEXT = 0x80bc0006,
-    EVENT_OVERFLOW = 0x80bc0007,
-    NOT_ACTIVE = 0x80bc0008,
-    IME_SUSPENDING = 0x80bc0009,
-    DEVICE_IN_USE = 0x80bc000a,
-    INVALID_USER_ID = 0x80bc0010,
-    INVALID_TYPE = 0x80bc0011,
-    INVALID_SUPPORTED_LANGUAGES = 0x80bc0012,
-    INVALID_ENTER_LABEL = 0x80bc0013,
-    INVALID_INPUT_METHOD = 0x80bc0014,
-    INVALID_OPTION = 0x80bc0015,
-    INVALID_MAX_TEXT_LENGTH = 0x80bc0016,
-    INVALID_INPUT_TEXT_BUFFER = 0x80bc0017,
-    INVALID_POSX = 0x80bc0018,
-    INVALID_POSY = 0x80bc0019,
-    INVALID_HORIZONTALIGNMENT = 0x80bc001a,
-    INVALID_VERTICALALIGNMENT = 0x80bc001b,
-    INVALID_EXTENDED = 0x80bc001c,
-    INVALID_KEYBOARD_TYPE = 0x80bc001d,
-    INVALID_WORK = 0x80bc0020,
-    INVALID_ARG = 0x80bc0021,
-    INVALID_HANDLER = 0x80bc0022,
-    NO_RESOURCE_ID = 0x80bc0023,
-    INVALID_MODE = 0x80bc0024,
-    INVALID_PARAM = 0x80bc0030,
-    INVALID_ADDRESS = 0x80bc0031,
-    INVALID_RESERVED = 0x80bc0032,
-    INVALID_TIMING = 0x80bc0033,
-    INTERNAL = 0x80bc00ff,
-    DIALOG_INVALID_TITLE = 0x80bc0101,
-    DIALOG_NOT_RUNNING = 0x80bc0105,
-    DIALOG_NOT_FINISHED = 0x80bc0106,
-    DIALOG_NOT_IN_USE = 0x80bc0107,
-};
-
 enum class OrbisImeDialogStatus : u32 {
     None = 0,
     Running = 1,
@@ -69,85 +25,9 @@ enum class OrbisImeDialogEndStatus : u32 {
     Aborted = 2,
 };
 
-enum class OrbisImeDialogOption : u32 {
-    Default = 0,
-    Multiline = 1,
-    NoAutoCorrection = 2,
-    NoAutoCompletion = 4,
-    // TODO: Document missing options
-    LargeResolution = 1024,
-};
-DECLARE_ENUM_FLAG_OPERATORS(OrbisImeDialogOption)
-
-enum class OrbisImePanelPriority : u32 {
-    Default = 0,
-    Alphabet = 1,
-    Symbol = 2,
-    Accent = 3,
-};
-
-struct OrbisImeColor {
-    u8 r;
-    u8 g;
-    u8 b;
-    u8 a;
-};
-
 struct OrbisImeDialogResult {
     OrbisImeDialogEndStatus endstatus;
     s32 reserved[12];
-};
-
-struct OrbisImeKeycode {
-    u16 keycode;
-    char16_t character;
-    u32 status;
-    OrbisImeKeyboardType type;
-    s32 user_id;
-    u32 resource_id;
-    u64 timestamp;
-};
-
-using OrbisImeExtKeyboardFilter = PS4_SYSV_ABI int (*)(const OrbisImeKeycode* srcKeycode,
-                                                       u16* outKeycode, u32* outStatus,
-                                                       void* reserved);
-
-struct OrbisImeDialogParam {
-    s32 user_id;
-    OrbisImeType type;
-    u64 supported_languages;
-    OrbisImeEnterLabel enter_label;
-    OrbisImeInputMethod input_method;
-    OrbisImeTextFilter filter;
-    OrbisImeDialogOption option;
-    u32 max_text_length;
-    char16_t* input_text_buffer;
-    float posx;
-    float posy;
-    OrbisImeHorizontalAlignment horizontal_alignment;
-    OrbisImeVerticalAlignment vertical_alignment;
-    const char16_t* placeholder;
-    const char16_t* title;
-    s8 reserved[16];
-};
-
-struct OrbisImeParamExtended {
-    u32 option; // OrbisImeDialogOptionExtended
-    OrbisImeColor color_base;
-    OrbisImeColor color_line;
-    OrbisImeColor color_text_field;
-    OrbisImeColor color_preedit;
-    OrbisImeColor color_button_default;
-    OrbisImeColor color_button_function;
-    OrbisImeColor color_button_symbol;
-    OrbisImeColor color_text;
-    OrbisImeColor color_special;
-    OrbisImePanelPriority priority;
-    char* additional_dictionary_path;
-    OrbisImeExtKeyboardFilter ext_keyboard_filter;
-    uint32_t disable_device;
-    uint32_t ext_keyboard_mode;
-    int8_t reserved[60];
 };
 
 Error PS4_SYSV_ABI sceImeDialogAbort();

--- a/src/core/libraries/ime/ime_ui.cpp
+++ b/src/core/libraries/ime/ime_ui.cpp
@@ -199,7 +199,7 @@ int ImeUi::InputTextCallback(ImGuiInputTextCallbackData* data) {
         eventParam.caret_index = data->CursorPos;
         eventParam.area_num = 1;
 
-        eventParam.text_area[0].mode = 1; // Edit mode
+        eventParam.text_area[0].mode = OrbisImeTextAreaMode::Edit;
         eventParam.text_area[0].index = data->CursorPos;
         eventParam.text_area[0].length = data->BufTextLen;
 


### PR DESCRIPTION
- Moved enums, flags, and structs to ime_common.h to simplify usage with Ime and ImeDialog
- Updated Ime to use an enum as the return type, consistent with ImeDialog
- Removed duplicate definition of OrbisImeKeycode
- Added OrbisImeLanguage as a flags enum
- Added missing options to OrbisImeOption
- Removed OrbisImeDialogOption; OrbisImeOption should be used instead
- Added OrbisImeTextAreaMode
- Updated OrbisImeTextAreaProperty
- Fixed OrbisImeEventParam by adding the missing member OrbisImePanelType panel_type
- Updated the sceImeOpen declaration to use extended parameters (not yet implemented) 
- Fixed Diablo III (CUSA00434) assertion failure on ImeDialog initialization