### PR TITLE
Extend Qt detection to support multiple drives

### DIFF
--- a/cmake/DetectQtInstallation.cmake
+++ b/cmake/DetectQtInstallation.cmake
@@ -1,14 +1,28 @@
 # SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-file(GLOB QT_KITS LIST_DIRECTORIES true "C:/Qt/*/msvc*_64")
-list(SORT QT_KITS COMPARE NATURAL)
-list(REVERSE QT_KITS)
-if(QT_KITS)
-    list(GET QT_KITS 0 QT_PREFIX)
-    set(CMAKE_PREFIX_PATH "${QT_PREFIX}" CACHE PATH "Qt prefix auto‑detected" FORCE)
-    message(STATUS "Auto-detected Qt prefix: ${QT_PREFIX}")
-else()
-    message(STATUS "findQt.cmake: no Qt‑Directory found in C:/Qt – please set CMAKE_PREFIX_PATH manually")
-endif()
+set(highest_version "0")
+set(CANDIDATE_DRIVES A B C D E F G H I J K L M N O P Q R S T U V W X Y Z)
 
+foreach(drive ${CANDIDATE_DRIVES})
+    file(GLOB kits LIST_DIRECTORIES true CONFIGURE_DEPENDS "${drive}:/Qt/*/msvc*_64")
+    foreach(kit IN LISTS kits)
+        get_filename_component(version_dir "${kit}" DIRECTORY)
+        get_filename_component(kit_version "${version_dir}" NAME)
+
+        message(STATUS "DetectQtInstallation.cmake: Detected Qt: ${kit}")
+
+        if (kit_version VERSION_GREATER highest_version)
+            set(highest_version "${kit_version}")
+            set(QT_PREFIX "${kit}")
+
+        endif()
+    endforeach()
+endforeach()
+
+if(QT_PREFIX)
+    set(CMAKE_PREFIX_PATH "${QT_PREFIX}" CACHE PATH "Qt prefix auto‑detected" FORCE)
+    message(STATUS "DetectQtInstallation.cmake: Choose newest Qt: ${QT_PREFIX}")
+else()
+    message(STATUS "DetectQtInstallation.cmake: No Qt‑Directory found in <drive>:/Qt – please set CMAKE_PREFIX_PATH manually")
+endif()


### PR DESCRIPTION
I had hoped I’d never have to touch CMake again, but since there are users who don’t install Qt on C:, I’ve now extended the detection to check all other possible drives as well.
Additionally, it now shows which installations were detected and which one is selected like:
```
[CMake] -- DetectQtInstallation.cmake: Detected Qt: C:/Qt/6.5.3/msvc2019_64
[CMake] -- DetectQtInstallation.cmake: Detected Qt: E:/Qt/6.9.1/msvc2022_64
[CMake] -- DetectQtInstallation.cmake: Choose newest Qt: E:/Qt/6.9.1/msvc2022_64
```