### PR TITLE
Log sceKernelAllocateDirectMemory call on error

### DIFF
--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -57,17 +57,17 @@ s32 PS4_SYSV_ABI sceKernelAllocateDirectMemory(s64 searchStart, s64 searchEnd, u
 
     auto* memory = Core::Memory::Instance();
     PAddr phys_addr = memory->Allocate(searchStart, searchEnd, len, alignment, memoryType);
-    if (phys_addr == -1) {
-        return ORBIS_KERNEL_ERROR_EAGAIN;
-    }
-
-    *physAddrOut = static_cast<s64>(phys_addr);
 
     LOG_INFO(Kernel_Vmm,
              "searchStart = {:#x}, searchEnd = {:#x}, len = {:#x}, "
              "alignment = {:#x}, memoryType = {:#x}, physAddrOut = {:#x}",
              searchStart, searchEnd, len, alignment, memoryType, phys_addr);
 
+    if (phys_addr == -1) {
+        return ORBIS_KERNEL_ERROR_EAGAIN;
+    }
+    
+    *physAddrOut = static_cast<s64>(phys_addr);
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -66,7 +66,7 @@ s32 PS4_SYSV_ABI sceKernelAllocateDirectMemory(s64 searchStart, s64 searchEnd, u
     if (phys_addr == -1) {
         return ORBIS_KERNEL_ERROR_EAGAIN;
     }
-    
+
     *physAddrOut = static_cast<s64>(phys_addr);
     return ORBIS_OK;
 }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -214,7 +214,10 @@ PAddr MemoryManager::Allocate(PAddr search_start, PAddr search_end, u64 size, u6
 
     if (dmem_area == dmem_map.end()) {
         // There are no suitable mappings in this range
-        LOG_ERROR(Kernel_Vmm, "Unable to find free direct memory area: size = {:#x}", size);
+        auto exceed = mapping_end - search_end;
+        LOG_ERROR(Kernel_Vmm,
+                  "Unable to find free direct memory area: size = {:#x}, exceed = {:#x}", size,
+                  exceed);
         return -1;
     }
 


### PR DESCRIPTION
If memory allocation failed, there is no logging sceKernelAllocateDirectMemory() call