### PR TITLE
Fix brace elision for designated initializer warning

### DIFF
--- a/src/core/libraries/ime/ime_dialog_ui.cpp
+++ b/src/core/libraries/ime/ime_dialog_ui.cpp
@@ -379,7 +379,7 @@ int ImeDialogUi::InputTextCallback(ImGuiInputTextCallbackData* data) {
                                                   // the current language?)
         .user_id = ui->state->user_id,
         .resource_id = 0,
-        .timestamp = 0,
+        .timestamp = {0},
     };
 
     if (!ui->state->ConvertUTF8ToOrbis(event_char, 4, &src_keycode.character, 1)) {


### PR DESCRIPTION
The following warning was introduced by #3207:
```
ime_dialog_ui.cpp:382:22: warning: brace elision for designated initializer is a C99 extension [-Wc99-designator]
  382 |         .timestamp = 0,
      |                      ^
      |                      {}
1 warning generated.
```
