### PR TITLE
Zero top bits in INSERTQ/EXTRQ

### DIFF
--- a/src/core/cpu_patches.cpp
+++ b/src/core/cpu_patches.cpp
@@ -177,7 +177,8 @@ static void GenerateEXTRQ(void* /* address */, const ZydisDecodedOperand* operan
         c.mov(scratch2, mask);
         c.and_(scratch1, scratch2);
 
-        // Writeback to xmm register, extrq instruction says top 64-bits are undefined but zeroed on AMD CPUs
+        // Writeback to xmm register, extrq instruction says top 64-bits are undefined but zeroed on
+        // AMD CPUs
         c.vmovq(xmm_dst, scratch1);
 
         c.pop(scratch2);
@@ -306,7 +307,8 @@ static void GenerateINSERTQ(void* /* address */, const ZydisDecodedOperand* oper
         // dst |= src
         c.or_(scratch2, scratch1);
 
-        // Insert scratch2 into low 64 bits of dst, upper 64 bits are undefined but zeroed on AMD CPUs
+        // Insert scratch2 into low 64 bits of dst, upper 64 bits are undefined but zeroed on AMD
+        // CPUs
         c.vmovq(xmm_dst, scratch2);
 
         c.pop(mask);

--- a/src/core/cpu_patches.cpp
+++ b/src/core/cpu_patches.cpp
@@ -163,7 +163,9 @@ static void GenerateEXTRQ(void* /* address */, const ZydisDecodedOperand* operan
             mask = (1ULL << length) - 1;
         }
 
-        ASSERT_MSG(length + index <= 64, "length + index must be less than or equal to 64.");
+        if (length + index > 64) {
+            mask = 0xFFFF'FFFF'FFFF'FFFF;
+        }
 
         // Get lower qword from xmm register
         c.vmovq(scratch1, xmm_dst);
@@ -287,7 +289,9 @@ static void GenerateINSERTQ(void* /* address */, const ZydisDecodedOperand* oper
             mask_value = (1ULL << length) - 1;
         }
 
-        ASSERT_MSG(length + index <= 64, "length + index must be less than or equal to 64.");
+        if (length + index > 64) {
+            mask_value = 0xFFFF'FFFF'FFFF'FFFF;
+        }
 
         c.vmovq(scratch1, xmm_src);
         c.vmovq(scratch2, xmm_dst);


### PR DESCRIPTION
AMD manual says the value of these bits is undefined but AMD CPUs seem to zero them