### PR TITLE
Define S_TRAP as InstCategory::FlowControl and stub it

### DIFF
--- a/src/shader_recompiler/frontend/format.cpp
+++ b/src/shader_recompiler/frontend/format.cpp
@@ -397,7 +397,7 @@ constexpr std::array<InstFormat, 27> InstructionFormatSOPP = {{
     // 17 = S_SENDMSGHALT
     {InstClass::ScalarProgFlow, InstCategory::FlowControl, 0, 1, ScalarType::Any, ScalarType::Any},
     // 18 = S_TRAP
-    {InstClass::Undefined, InstCategory::Undefined, 0, 1, ScalarType::Any, ScalarType::Any},
+    {InstClass::Undefined, InstCategory::FlowControl, 0, 1, ScalarType::Any, ScalarType::Any},
     // 19 = S_ICACHE_INV
     {InstClass::ScalarCache, InstCategory::FlowControl, 0, 1, ScalarType::Any, ScalarType::Any},
     // 20 = S_INCPERFLEVEL

--- a/src/shader_recompiler/frontend/translate/scalar_flow.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_flow.cpp
@@ -16,6 +16,9 @@ void Translator::EmitFlowControl(u32 pc, const GcnInst& inst) {
     case Opcode::S_SETPRIO:
         LOG_WARNING(Render_Vulkan, "S_SETPRIO instruction!");
         return;
+    case Opcode::S_TRAP:
+        LOG_WARNING(Render_Vulkan, "S_TRAP instruction!");
+        return;
     case Opcode::S_GETPC_B64:
         return S_GETPC_B64(pc, inst);
     case Opcode::S_SETPC_B64:


### PR DESCRIPTION
One of the shaders in SotC uses this, and it being undefined lead to an unreachable at translate.cpp:608 previously.