### PR TITLE
ir_passes: Fold readlane with ff1 pattern

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
@@ -529,7 +529,7 @@ Id EmitLaneId(EmitContext& ctx);
 Id EmitWarpId(EmitContext& ctx);
 Id EmitQuadShuffle(EmitContext& ctx, Id value, Id index);
 Id EmitReadFirstLane(EmitContext& ctx, Id value);
-Id EmitReadLane(EmitContext& ctx, Id value, u32 lane);
+Id EmitReadLane(EmitContext& ctx, Id value, Id lane);
 Id EmitWriteLane(EmitContext& ctx, Id value, Id write_value, u32 lane);
 Id EmitDataAppend(EmitContext& ctx, u32 gds_addr, u32 binding);
 Id EmitDataConsume(EmitContext& ctx, u32 gds_addr, u32 binding);

--- a/src/shader_recompiler/backend/spirv/emit_spirv_warp.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_warp.cpp
@@ -26,9 +26,8 @@ Id EmitReadFirstLane(EmitContext& ctx, Id value) {
     return ctx.OpGroupNonUniformBroadcastFirst(ctx.U32[1], SubgroupScope(ctx), value);
 }
 
-Id EmitReadLane(EmitContext& ctx, Id value, u32 lane) {
-    return ctx.OpGroupNonUniformBroadcast(ctx.U32[1], SubgroupScope(ctx), value,
-                                          ctx.ConstU32(lane));
+Id EmitReadLane(EmitContext& ctx, Id value, Id lane) {
+    return ctx.OpGroupNonUniformBroadcast(ctx.U32[1], SubgroupScope(ctx), value, lane);
 }
 
 Id EmitWriteLane(EmitContext& ctx, Id value, Id write_value, u32 lane) {


### PR DESCRIPTION
I've recently spotted the following shader pattern, used in some waterfall loops, which is essentially a we-have-v_readfirstlane_b32-at-home

```
/*00000000000c*/ s_mov_b64       s[16:17], exec
...
.LOOP
/*000000000028*/ s_ff1_i32_b64   s18, s[16:17]
/*00000000002c*/ v_readlane_b32  s25, v3, s18
```

Which on main gets translated to
```glsl
subgroupBroadcast(uint(gl_InstanceIndex), 3305621016u);
```

There are 2 issues here. First EmitReadLane assumes the lane id is a constant u32, which is not always the case (the large number here is because that's a pointer stored in the Opaque IR::Value). Second is that s_ff1_i32_b64 is implemented with GetSrc64 instead of thread bits. This instruction should probably be swapped to thread bits but because I don't remember the original usecase, which could have been 64-bit, I won't change it in this PR.

To solve this issue, the readlane elimination pass will detect when readlane has an non immediate lane coming from FindILSB64 and substitute it with ReadFirstLane