### PR TITLE
vk_rasterizer: Set render area to window scissor when no framebuffers are bound

### DIFF
--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -324,9 +324,19 @@ public:
         return properties.limits.maxViewportDimensions[0];
     }
 
-    ///  Returns the maximum viewport height.
+    /// Returns the maximum viewport height.
     u32 GetMaxViewportHeight() const {
         return properties.limits.maxViewportDimensions[1];
+    }
+
+    /// Returns the maximum render area width.
+    u32 GetMaxFramebufferWidth() const {
+        return properties.limits.maxFramebufferWidth;
+    }
+
+    /// Returns the maximum render area height.
+    u32 GetMaxFramebufferHeight() const {
+        return properties.limits.maxFramebufferHeight;
     }
 
     /// Returns the sample count flags supported by framebuffers.

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -113,6 +113,8 @@ RenderState Rasterizer::PrepareRenderState(u32 mrt_mask) {
     // Prefetch color and depth buffers to let texture cache handle possible overlaps with bound
     // textures (e.g. mipgen)
     RenderState state;
+    state.width = instance.GetMaxFramebufferWidth();
+    state.height = instance.GetMaxFramebufferHeight();
 
     cb_descs.clear();
     db_desc.reset();

--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -34,16 +34,11 @@ void Scheduler::BeginRendering(const RenderState& new_state) {
     is_rendering = true;
     render_state = new_state;
 
-    const auto width =
-        render_state.width != std::numeric_limits<u32>::max() ? render_state.width : 1;
-    const auto height =
-        render_state.height != std::numeric_limits<u32>::max() ? render_state.height : 1;
-
     const vk::RenderingInfo rendering_info = {
         .renderArea =
             {
                 .offset = {0, 0},
-                .extent = {width, height},
+                .extent = {render_state.width, render_state.height},
             },
         .layerCount = 1,
         .colorAttachmentCount = render_state.num_color_attachments,

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -26,8 +26,8 @@ struct RenderState {
     u32 num_color_attachments{};
     bool has_depth{};
     bool has_stencil{};
-    u32 width = std::numeric_limits<u32>::max();
-    u32 height = std::numeric_limits<u32>::max();
+    u32 width{};
+    u32 height{};
 
     bool operator==(const RenderState& other) const noexcept {
         return std::memcmp(this, &other, sizeof(RenderState)) == 0;


### PR DESCRIPTION
It is possible to have a draw call without any framebuffers attached, but still rely on all invocations inside scissor area being invoked (for example writing to storage image with gl_FragCoord coodinates). On main render area would be set to 1 in that case, replace that with the maximum render area, so it covers all of scissor rect

I vaguely remember Knack doing this but not sure