### PR TITLE
Stop and restart function added

### DIFF
--- a/src/core/devtools/layer.cpp
+++ b/src/core/devtools/layer.cpp
@@ -3,7 +3,7 @@
 
 #include "layer.h"
 
-#include <imgui.h>
+#include "SDL3/SDL_events.h"
 
 #include "SDL3/SDL_log.h"
 #include "common/config.h"
@@ -30,7 +30,7 @@ static bool show_simple_fps = false;
 static bool visibility_toggled = false;
 
 static bool show_fullscreen_tip = true;
-static float fullscreen_tip_timer = 5.0f;
+static float fullscreen_tip_timer = 8.0f;
 
 static float fps_scale = 1.0f;
 static int dump_frame_count = 1;
@@ -362,6 +362,11 @@ void L::SetupSettings() {
 void L::Draw() {
     const auto io = GetIO();
     PushID("DevtoolsLayer");
+    if (IsKeyPressed(ImGuiKey_F4, false)) {
+        SDL_Event quitEvent;
+        quitEvent.type = SDL_EVENT_QUIT;
+        SDL_PushEvent(&quitEvent);
+    }
 
     if (show_fullscreen_tip) {
         fullscreen_tip_timer -= io.DeltaTime;
@@ -371,8 +376,10 @@ void L::Draw() {
             // Display the fullscreen tip near the top-left corner, below pause message if needed
             ImVec2 pos(10, 30); // adjust Y so it doesn't overlap pause text at y=10
             ImU32 color = IM_COL32(255, 255, 255, 255);
-            ImGui::GetForegroundDrawList()->AddText(
-                pos, color, "Press F11 to toggle FullScreen and F9 to Pause Emulation");
+            ImGui::GetForegroundDrawList()->AddText(pos, color,
+                                                    "Press F11 to toggle FullScreen\n"
+                                                    "F9 to Pause Emulation\n"
+                                                    "F4 to Stop Game");
         }
     }
     if (!DebugState.IsGuestThreadsPaused()) {

--- a/src/core/devtools/layer.cpp
+++ b/src/core/devtools/layer.cpp
@@ -29,6 +29,9 @@ using L = ::Core::Devtools::Layer;
 static bool show_simple_fps = false;
 static bool visibility_toggled = false;
 
+static bool show_fullscreen_tip = true;
+static float fullscreen_tip_timer = 5.0f;
+
 static float fps_scale = 1.0f;
 static int dump_frame_count = 1;
 
@@ -360,6 +363,18 @@ void L::Draw() {
     const auto io = GetIO();
     PushID("DevtoolsLayer");
 
+    if (show_fullscreen_tip) {
+        fullscreen_tip_timer -= io.DeltaTime;
+        if (fullscreen_tip_timer <= 0.0f) {
+            show_fullscreen_tip = false;
+        } else {
+            // Display the fullscreen tip near the top-left corner, below pause message if needed
+            ImVec2 pos(10, 30); // adjust Y so it doesn't overlap pause text at y=10
+            ImU32 color = IM_COL32(255, 255, 255, 255);
+            ImGui::GetForegroundDrawList()->AddText(
+                pos, color, "Press F11 to toggle FullScreen and F9 to Pause Emulation");
+        }
+    }
     if (!DebugState.IsGuestThreadsPaused()) {
         const auto fn = DebugState.flip_frame_count.load();
         frame_graph.AddFrame(fn, DebugState.FrameDeltaTime);

--- a/src/qt_gui/main_window.cpp
+++ b/src/qt_gui/main_window.cpp
@@ -801,6 +801,12 @@ void MainWindow::CreateConnects() {
 }
 
 void MainWindow::StartGame() {
+    if (isGameRunning) {
+        QMessageBox::critical(nullptr, tr("Run Game"), tr("Game is already running!"));
+        return;
+    }
+
+    isGameRunning = false;
     BackgroundMusicPlayer::getInstance().stopMusic();
     QString gamePath = "";
     int table_mode = m_gui_settings->GetValue(gui::gl_mode).toInt();

--- a/src/qt_gui/main_window.h
+++ b/src/qt_gui/main_window.h
@@ -37,9 +37,15 @@ public:
     bool Init();
     void InstallDirectory();
     void StartGame();
+    void StartGameWithPath(const QString&);
     void PauseGame();
     bool showLabels;
-
+    void StopGame();
+    void RestartGame();
+    std::unique_ptr<Core::Emulator> emulator;
+    bool pendingRestart = false;
+    qint64 detachedGamePid = -1;
+    bool isDetachedLaunch = false;
 private Q_SLOTS:
     void ConfigureGuiFromSettings();
     void SaveWindowState();
@@ -66,6 +72,10 @@ private:
     void CheckUpdateMain(bool checkSave);
 #endif
     void CreateConnects();
+#ifdef ENABLE_QT_GUI
+    QString getLastEbootPath();
+    QString lastGamePath;
+#endif
     void SetLastUsedTheme();
     void SetLastIconSizeBullet();
     void SetUiIcons(bool isWhite);

--- a/src/qt_gui/main_window.h
+++ b/src/qt_gui/main_window.h
@@ -38,7 +38,6 @@ public:
     void InstallDirectory();
     void StartGame();
     void StartGameWithPath(const QString&);
-    void PauseGame();
     bool showLabels;
     void StopGame();
     void RestartGame();
@@ -63,7 +62,6 @@ private:
     void UpdateToolbarButtons();
     QWidget* createButtonWithLabel(QPushButton* button, const QString& labelText, bool showLabel);
     void CreateActions();
-    void toggleFullscreen();
     void CreateRecentGameActions();
     void CreateDockWindows();
     void LoadGameLists();

--- a/src/qt_gui/main_window_ui.h
+++ b/src/qt_gui/main_window_ui.h
@@ -43,13 +43,11 @@ public:
     QWidget* centralWidget;
     QLineEdit* mw_searchbar;
     QPushButton* playButton;
-    QPushButton* pauseButton;
     QPushButton* stopButton;
     QPushButton* refreshButton;
     QPushButton* settingsButton;
     QPushButton* controllerButton;
     QPushButton* keyboardButton;
-    QPushButton* fullscreenButton;
     QPushButton* restartButton;
 
     QWidget* sizeSliderContainer;
@@ -200,10 +198,6 @@ public:
         playButton->setFlat(true);
         playButton->setIcon(QIcon(":images/play_icon.png"));
         playButton->setIconSize(QSize(40, 40));
-        pauseButton = new QPushButton(centralWidget);
-        pauseButton->setFlat(true);
-        pauseButton->setIcon(QIcon(":images/pause_icon.png"));
-        pauseButton->setIconSize(QSize(40, 40));
         stopButton = new QPushButton(centralWidget);
         stopButton->setFlat(true);
         stopButton->setIcon(QIcon(":images/stop_icon.png"));
@@ -212,10 +206,6 @@ public:
         refreshButton->setFlat(true);
         refreshButton->setIcon(QIcon(":images/refreshlist_icon.png"));
         refreshButton->setIconSize(QSize(40, 40));
-        fullscreenButton = new QPushButton(centralWidget);
-        fullscreenButton->setFlat(true);
-        fullscreenButton->setIcon(QIcon(":images/fullscreen_icon.png"));
-        fullscreenButton->setIconSize(QSize(38, 38));
         settingsButton = new QPushButton(centralWidget);
         settingsButton->setFlat(true);
         settingsButton->setIcon(QIcon(":images/settings_icon.png"));


### PR DESCRIPTION
Adding proper stopgame and restart game functions, removing pause and fullscreen buttons as they arent working anymore with these changes, but added a tip when booting a game that shows for 5 seconds when u can still pause and fullscreen from keyboard
<img width="426" height="149" alt="image" src="https://github.com/user-attachments/assets/07e7215b-d5e6-47a8-a393-cbb743973d05" />
