### PR TITLE
Change companion util stub to return NO_EVENT

### DIFF
--- a/src/core/libraries/companion/companion_util.cpp
+++ b/src/core/libraries/companion/companion_util.cpp
@@ -29,10 +29,9 @@ u32 PS4_SYSV_ABI getEvent(sceCompanionUtilContext* ctx, sceCompanionUtilEvent* o
 }
 
 s32 PS4_SYSV_ABI sceCompanionUtilGetEvent(sceCompanionUtilEvent* outEvent) {
-    sceCompanionUtilContext* ctx = nullptr;
-    u32 ret = getEvent(ctx, outEvent, 1);
+    u32 ret = ORBIS_COMPANION_UTIL_NO_EVENT;
 
-    LOG_DEBUG(Lib_CompanionUtil, "(STUBBED) called ret: {}", ret);
+    LOG_DEBUG(Lib_CompanionUtil, "(STUBBED) called ret: {:#x}", ret);
     return ret;
 }
 


### PR DESCRIPTION
Some games, like Battlefield 1, really don't like getting an unexpected error here. Simply returning no event allows them to go further.