### PR TITLE
Implement libusb callbacks with correct ABI

### DIFF
--- a/src/core/libraries/usbd/usbd.cpp
+++ b/src/core/libraries/usbd/usbd.cpp
@@ -10,6 +10,33 @@
 #include <fmt/format.h>
 #include <libusb.h>
 
+#include <unordered_map>
+#include <mutex>
+
+namespace {
+    std::unordered_map<Libraries::Usbd::SceUsbdTransfer*, Libraries::Usbd::SceUsbdTransferCallback> g_transfer_callbacks;
+    std::mutex g_callback_mutex;
+
+    void transfer_abi_callback(libusb_transfer* transfer) {
+        using SysVCallback = void (PS4_SYSV_ABI *)(Libraries::Usbd::SceUsbdTransfer*);
+        SysVCallback callback = nullptr;
+
+        {
+            std::lock_guard<std::mutex> lock(g_callback_mutex);
+            auto it = g_transfer_callbacks.find(transfer);
+            if (it != g_transfer_callbacks.end()) {
+                callback = (SysVCallback)it->second;
+            }
+        }
+
+        if (callback) {
+            callback(transfer);
+        } else {
+            LOG_WARNING(Lib_Usbd, "No registered callback for USB transfer {:p}");
+        }
+    }
+}
+
 namespace Libraries::Usbd {
 
 s32 libusb_to_orbis_error(int retVal) {
@@ -276,6 +303,11 @@ s32 PS4_SYSV_ABI sceUsbdCancelTransfer(SceUsbdTransfer* transfer) {
 void PS4_SYSV_ABI sceUsbdFreeTransfer(SceUsbdTransfer* transfer) {
     LOG_DEBUG(Lib_Usbd, "called");
 
+    {
+        std::lock_guard<std::mutex> lock(g_callback_mutex);
+        g_transfer_callbacks.erase(transfer);
+    }
+
     libusb_free_transfer(transfer);
 }
 
@@ -305,7 +337,12 @@ void PS4_SYSV_ABI sceUsbdFillInterruptTransfer(SceUsbdTransfer* transfer,
                                                u32 timeout) {
     LOG_DEBUG(Lib_Usbd, "called");
 
-    libusb_fill_interrupt_transfer(transfer, dev_handle, endpoint, buffer, length, callback,
+    {
+        std::lock_guard<std::mutex> lock(g_callback_mutex);
+        g_transfer_callbacks[transfer] = callback;
+    }
+
+    libusb_fill_interrupt_transfer(transfer, dev_handle, endpoint, buffer, length, transfer_abi_callback,
                                    user_data, timeout);
 }
 

--- a/src/core/libraries/usbd/usbd.cpp
+++ b/src/core/libraries/usbd/usbd.cpp
@@ -32,7 +32,7 @@ namespace {
         if (callback) {
             callback(transfer);
         } else {
-            LOG_WARNING(Lib_Usbd, "No registered callback for USB transfer {:p}");
+            LOG_WARNING(Lib_Usbd, "No registered callback for USB transfer");
         }
     }
 }


### PR DESCRIPTION
The libusb library executes the emulated callback, but does not respect the PS4's ABI, as such passing the libusb_transfer argument into the RAX register rather than the RDI register.

This pull request introduces a "trampoline" that registers a host-machine callback that then executes the emulated callback with the correct ABI, fixing the issue.

Only tested on Windows.

This now makes LEGO Dimensions enter the game and seems to be fully playable.

To be considered:

- Should this be applied to all types of transfer (i.e. bulk, control, isochronous)
- Is there a better alternative to creating and maintaining a dictionary of transfers?