### PR TITLE
shader_recompiler: Replace buffer pulling with attribute divisor for instance step rates

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -52,7 +52,7 @@ Id VsOutputAttrPointer(EmitContext& ctx, VsOutput output) {
 Id OutputAttrPointer(EmitContext& ctx, IR::Attribute attr, u32 element) {
     if (IR::IsParam(attr)) {
         const u32 attr_index{u32(attr) - u32(IR::Attribute::Param0)};
-        if (ctx.stage == Stage::Local && ctx.runtime_info.ls_info.links_with_tcs) {
+        if (ctx.stage == Stage::Local) {
             const auto component_ptr = ctx.TypePointer(spv::StorageClass::Output, ctx.F32[1]);
             return ctx.OpAccessChain(component_ptr, ctx.output_attr_array, ctx.ConstU32(attr_index),
                                      ctx.ConstU32(element));
@@ -94,13 +94,9 @@ Id OutputAttrPointer(EmitContext& ctx, IR::Attribute attr, u32 element) {
 
 std::pair<Id, bool> OutputAttrComponentType(EmitContext& ctx, IR::Attribute attr) {
     if (IR::IsParam(attr)) {
-        if (ctx.stage == Stage::Local && ctx.runtime_info.ls_info.links_with_tcs) {
-            return {ctx.F32[1], false};
-        } else {
-            const u32 index{u32(attr) - u32(IR::Attribute::Param0)};
-            const auto& info{ctx.output_params.at(index)};
-            return {info.component_type, info.is_integer};
-        }
+        const u32 index{u32(attr) - u32(IR::Attribute::Param0)};
+        const auto& info{ctx.output_params.at(index)};
+        return {info.component_type, info.is_integer};
     }
     if (IR::IsMrt(attr)) {
         const u32 index{u32(attr) - u32(IR::Attribute::RenderTarget0)};

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -148,25 +148,19 @@ Id EmitReadConst(EmitContext& ctx, IR::Inst* inst, Id addr, Id offset) {
     }
 }
 
-template <PointerType type>
-Id ReadConstBuffer(EmitContext& ctx, u32 handle, Id index) {
+Id EmitReadConstBuffer(EmitContext& ctx, u32 handle, Id index) {
     const auto& buffer = ctx.buffers[handle];
     if (const Id offset = buffer.Offset(PointerSize::B32); Sirit::ValidId(offset)) {
         index = ctx.OpIAdd(ctx.U32[1], index, offset);
     }
-    const auto [id, pointer_type] = buffer.Alias(type);
-    const auto value_type = type == PointerType::U32 ? ctx.U32[1] : ctx.F32[1];
+    const auto [id, pointer_type] = buffer.Alias(PointerType::U32);
     const Id ptr{ctx.OpAccessChain(pointer_type, id, ctx.u32_zero_value, index)};
-    const Id result{ctx.OpLoad(value_type, ptr)};
+    const Id result{ctx.OpLoad(ctx.U32[1], ptr)};
     if (const Id size = buffer.Size(PointerSize::B32); Sirit::ValidId(size)) {
         const Id in_bounds = ctx.OpULessThan(ctx.U1[1], index, size);
-        return ctx.OpSelect(value_type, in_bounds, result, ctx.u32_zero_value);
+        return ctx.OpSelect(ctx.U32[1], in_bounds, result, ctx.u32_zero_value);
     }
     return result;
-}
-
-Id EmitReadConstBuffer(EmitContext& ctx, u32 handle, Id index) {
-    return ReadConstBuffer<PointerType::U32>(ctx, handle, index);
 }
 
 static Id EmitGetAttributeForGeometry(EmitContext& ctx, IR::Attribute attr, u32 comp, u32 index) {

--- a/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
@@ -108,7 +108,7 @@ Id EmitBufferAtomicXor32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id addres
 Id EmitBufferAtomicSwap32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address, Id value);
 Id EmitBufferAtomicCmpSwap32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address, Id value,
                              Id cmp_value);
-Id EmitGetAttribute(EmitContext& ctx, IR::Attribute attr, u32 comp, Id index);
+Id EmitGetAttribute(EmitContext& ctx, IR::Attribute attr, u32 comp, u32 index);
 Id EmitGetAttributeU32(EmitContext& ctx, IR::Attribute attr, u32 comp);
 void EmitSetAttribute(EmitContext& ctx, IR::Attribute attr, Id value, u32 comp);
 Id EmitGetTessGenericAttribute(EmitContext& ctx, Id vertex_index, Id attr_index, Id comp_index);

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -377,35 +377,13 @@ void EmitContext::DefineInputs() {
             ASSERT(attrib.semantic < IR::NumParams);
             const auto sharp = attrib.GetSharp(info);
             const Id type{GetAttributeType(*this, sharp.GetNumberFmt())[4]};
-            if (attrib.UsesStepRates()) {
-                const u32 rate_idx =
-                    attrib.GetStepRate() == Gcn::VertexAttribute::InstanceIdType::OverStepRate0 ? 0
-                                                                                                : 1;
-                const u32 num_components = AmdGpu::NumComponents(sharp.GetDataFmt());
-                const auto buffer =
-                    std::ranges::find_if(info.buffers, [&attrib](const auto& buffer) {
-                        return buffer.instance_attrib == attrib.semantic;
-                    });
-                // Note that we pass index rather than Id
-                input_params[attrib.semantic] = SpirvAttribute{
-                    .id = {rate_idx},
-                    .pointer_type = input_u32,
-                    .component_type = U32[1],
-                    .num_components = std::min<u16>(attrib.num_elements, num_components),
-                    .is_integer = true,
-                    .is_loaded = false,
-                    .buffer_handle = int(buffer - info.buffers.begin()),
-                };
+            Id id{DefineInput(type, attrib.semantic)};
+            if (attrib.GetStepRate() == Gcn::VertexAttribute::InstanceIdType::Plain) {
+                Name(id, fmt::format("vs_instance_attr{}", attrib.semantic));
             } else {
-                Id id{DefineInput(type, attrib.semantic)};
-                if (attrib.GetStepRate() == Gcn::VertexAttribute::InstanceIdType::Plain) {
-                    Name(id, fmt::format("vs_instance_attr{}", attrib.semantic));
-                } else {
-                    Name(id, fmt::format("vs_in_attr{}", attrib.semantic));
-                }
-                input_params[attrib.semantic] =
-                    GetAttributeInfo(sharp.GetNumberFmt(), id, 4, false);
+                Name(id, fmt::format("vs_in_attr{}", attrib.semantic));
             }
+            input_params[attrib.semantic] = GetAttributeInfo(sharp.GetNumberFmt(), id, 4, false);
         }
         break;
     }
@@ -700,12 +678,10 @@ void EmitContext::DefineOutputs() {
 
 void EmitContext::DefinePushDataBlock() {
     // Create push constants block for instance steps rates
-    const Id struct_type{Name(TypeStruct(U32[1], U32[1], F32[1], F32[1], F32[1], F32[1], U32[4],
-                                         U32[4], U32[4], U32[4], U32[4], U32[4], U32[2]),
+    const Id struct_type{Name(TypeStruct(F32[1], F32[1], F32[1], F32[1], U32[4], U32[4], U32[4],
+                                         U32[4], U32[4], U32[4], U32[2]),
                               "AuxData")};
     Decorate(struct_type, spv::Decoration::Block);
-    MemberName(struct_type, PushData::Step0Index, "sr0");
-    MemberName(struct_type, PushData::Step1Index, "sr1");
     MemberName(struct_type, PushData::XOffsetIndex, "xoffset");
     MemberName(struct_type, PushData::YOffsetIndex, "yoffset");
     MemberName(struct_type, PushData::XScaleIndex, "xscale");
@@ -717,19 +693,17 @@ void EmitContext::DefinePushDataBlock() {
     MemberName(struct_type, PushData::BufOffsetIndex + 0, "buf_offsets0");
     MemberName(struct_type, PushData::BufOffsetIndex + 1, "buf_offsets1");
     MemberName(struct_type, PushData::BufOffsetIndex + 2, "buf_offsets2");
-    MemberDecorate(struct_type, PushData::Step0Index, spv::Decoration::Offset, 0U);
-    MemberDecorate(struct_type, PushData::Step1Index, spv::Decoration::Offset, 4U);
-    MemberDecorate(struct_type, PushData::XOffsetIndex, spv::Decoration::Offset, 8U);
-    MemberDecorate(struct_type, PushData::YOffsetIndex, spv::Decoration::Offset, 12U);
-    MemberDecorate(struct_type, PushData::XScaleIndex, spv::Decoration::Offset, 16U);
-    MemberDecorate(struct_type, PushData::YScaleIndex, spv::Decoration::Offset, 20U);
-    MemberDecorate(struct_type, PushData::UdRegsIndex + 0, spv::Decoration::Offset, 24U);
-    MemberDecorate(struct_type, PushData::UdRegsIndex + 1, spv::Decoration::Offset, 40U);
-    MemberDecorate(struct_type, PushData::UdRegsIndex + 2, spv::Decoration::Offset, 56U);
-    MemberDecorate(struct_type, PushData::UdRegsIndex + 3, spv::Decoration::Offset, 72U);
-    MemberDecorate(struct_type, PushData::BufOffsetIndex + 0, spv::Decoration::Offset, 88U);
-    MemberDecorate(struct_type, PushData::BufOffsetIndex + 1, spv::Decoration::Offset, 104U);
-    MemberDecorate(struct_type, PushData::BufOffsetIndex + 2, spv::Decoration::Offset, 120U);
+    MemberDecorate(struct_type, PushData::XOffsetIndex, spv::Decoration::Offset, 0U);
+    MemberDecorate(struct_type, PushData::YOffsetIndex, spv::Decoration::Offset, 4U);
+    MemberDecorate(struct_type, PushData::XScaleIndex, spv::Decoration::Offset, 8U);
+    MemberDecorate(struct_type, PushData::YScaleIndex, spv::Decoration::Offset, 12U);
+    MemberDecorate(struct_type, PushData::UdRegsIndex + 0, spv::Decoration::Offset, 16U);
+    MemberDecorate(struct_type, PushData::UdRegsIndex + 1, spv::Decoration::Offset, 32U);
+    MemberDecorate(struct_type, PushData::UdRegsIndex + 2, spv::Decoration::Offset, 48U);
+    MemberDecorate(struct_type, PushData::UdRegsIndex + 3, spv::Decoration::Offset, 64U);
+    MemberDecorate(struct_type, PushData::BufOffsetIndex + 0, spv::Decoration::Offset, 80U);
+    MemberDecorate(struct_type, PushData::BufOffsetIndex + 1, spv::Decoration::Offset, 96U);
+    MemberDecorate(struct_type, PushData::BufOffsetIndex + 2, spv::Decoration::Offset, 112U);
     push_data_block = DefineVar(struct_type, spv::StorageClass::PushConstant);
     Name(push_data_block, "push_data");
     interfaces.push_back(push_data_block);

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -551,7 +551,7 @@ void EmitContext::DefineOutputs() {
             cull_distances =
                 DefineVariable(type, spv::BuiltIn::CullDistance, spv::StorageClass::Output);
         }
-        if (stage == Shader::Stage::Local && runtime_info.ls_info.links_with_tcs) {
+        if (stage == Stage::Local) {
             const u32 num_attrs = Common::AlignUp(runtime_info.ls_info.ls_stride, 16) >> 4;
             if (num_attrs > 0) {
                 const Id type{TypeArray(F32[4], ConstU32(num_attrs))};
@@ -737,19 +737,19 @@ EmitContext::BufferSpv EmitContext::DefineBuffer(bool is_storage, bool is_writte
         Decorate(id, spv::Decoration::NonWritable);
     }
     switch (buffer_type) {
-    case Shader::BufferType::GdsBuffer:
+    case BufferType::GdsBuffer:
         Name(id, "gds_buffer");
         break;
-    case Shader::BufferType::Flatbuf:
+    case BufferType::Flatbuf:
         Name(id, "srt_flatbuf");
         break;
-    case Shader::BufferType::BdaPagetable:
+    case BufferType::BdaPagetable:
         Name(id, "bda_pagetable");
         break;
-    case Shader::BufferType::FaultBuffer:
+    case BufferType::FaultBuffer:
         Name(id, "fault_buffer");
         break;
-    case Shader::BufferType::SharedMemory:
+    case BufferType::SharedMemory:
         Name(id, "ssbo_shmem");
         break;
     default:

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -378,7 +378,7 @@ void EmitContext::DefineInputs() {
             const auto sharp = attrib.GetSharp(info);
             const Id type{GetAttributeType(*this, sharp.GetNumberFmt())[4]};
             Id id{DefineInput(type, attrib.semantic)};
-            if (attrib.GetStepRate() == Gcn::VertexAttribute::InstanceIdType::Plain) {
+            if (attrib.GetStepRate() != Gcn::VertexAttribute::InstanceIdType::None) {
                 Name(id, fmt::format("vs_instance_attr{}", attrib.semantic));
             } else {
                 Name(id, fmt::format("vs_in_attr{}", attrib.semantic));

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -361,7 +361,6 @@ public:
         u32 num_components;
         bool is_integer{};
         bool is_loaded{};
-        s32 buffer_handle{-1};
     };
     Id input_attr_array;
     Id output_attr_array;

--- a/src/shader_recompiler/frontend/fetch_shader.h
+++ b/src/shader_recompiler/frontend/fetch_shader.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <ranges>
 #include <vector>
 #include "common/types.h"
 #include "shader_recompiler/info.h"
@@ -29,11 +28,6 @@ struct VertexAttribute {
         return static_cast<InstanceIdType>(instance_data);
     }
 
-    [[nodiscard]] bool UsesStepRates() const {
-        const auto step_rate = GetStepRate();
-        return step_rate == OverStepRate0 || step_rate == OverStepRate1;
-    }
-
     [[nodiscard]] constexpr AmdGpu::Buffer GetSharp(const Shader::Info& info) const noexcept {
         return info.ReadUdReg<AmdGpu::Buffer>(sgpr_base, dword_offset);
     }
@@ -51,12 +45,6 @@ struct FetchShaderData {
     std::vector<VertexAttribute> attributes;
     s8 vertex_offset_sgpr = -1;   ///< SGPR of vertex offset from VADDR
     s8 instance_offset_sgpr = -1; ///< SGPR of instance offset from VADDR
-
-    [[nodiscard]] bool UsesStepRates() const {
-        return std::ranges::find_if(attributes, [](const VertexAttribute& attribute) {
-                   return attribute.UsesStepRates();
-               }) != attributes.end();
-    }
 
     bool operator==(const FetchShaderData& other) const {
         return attributes == other.attributes && vertex_offset_sgpr == other.vertex_offset_sgpr &&

--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -92,11 +92,21 @@ void Translator::EmitPrologue(IR::Block* first_block) {
         ir.SetVectorReg(dst_vreg++, ir.GetAttributeU32(IR::Attribute::VertexId));
         // v1: instance ID, step rate 0
         if (runtime_info.num_input_vgprs > 0) {
-            ir.SetVectorReg(dst_vreg++, ir.GetAttributeU32(IR::Attribute::InstanceId0));
+            if (runtime_info.vs_info.step_rate_0 != 0) {
+                ir.SetVectorReg(dst_vreg++, ir.IDiv(ir.GetAttributeU32(IR::Attribute::InstanceId),
+                                                    ir.Imm32(runtime_info.vs_info.step_rate_0)));
+            } else {
+                ir.SetVectorReg(dst_vreg++, ir.Imm32(0));
+            }
         }
         // v2: instance ID, step rate 1
         if (runtime_info.num_input_vgprs > 1) {
-            ir.SetVectorReg(dst_vreg++, ir.GetAttributeU32(IR::Attribute::InstanceId1));
+            if (runtime_info.vs_info.step_rate_1 != 0) {
+                ir.SetVectorReg(dst_vreg++, ir.IDiv(ir.GetAttributeU32(IR::Attribute::InstanceId),
+                                                    ir.Imm32(runtime_info.vs_info.step_rate_1)));
+            } else {
+                ir.SetVectorReg(dst_vreg++, ir.Imm32(0));
+            }
         }
         // v3: instance ID, plain
         if (runtime_info.num_input_vgprs > 2) {
@@ -183,10 +193,8 @@ void Translator::EmitPrologue(IR::Block* first_block) {
         switch (runtime_info.gs_info.out_primitive[0]) {
         case AmdGpu::GsOutputPrimitiveType::TriangleStrip:
             ir.SetVectorReg(IR::VectorReg::V3, ir.Imm32(2u)); // vertex 2
-            [[fallthrough]];
         case AmdGpu::GsOutputPrimitiveType::LineStrip:
             ir.SetVectorReg(IR::VectorReg::V1, ir.Imm32(1u)); // vertex 1
-            [[fallthrough]];
         default:
             ir.SetVectorReg(IR::VectorReg::V0, ir.Imm32(0u)); // vertex 0
             break;

--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -90,27 +90,40 @@ void Translator::EmitPrologue(IR::Block* first_block) {
     case LogicalStage::Vertex:
         // v0: vertex ID, always present
         ir.SetVectorReg(dst_vreg++, ir.GetAttributeU32(IR::Attribute::VertexId));
-        // v1: instance ID, step rate 0
-        if (runtime_info.num_input_vgprs > 0) {
-            if (runtime_info.vs_info.step_rate_0 != 0) {
-                ir.SetVectorReg(dst_vreg++, ir.IDiv(ir.GetAttributeU32(IR::Attribute::InstanceId),
-                                                    ir.Imm32(runtime_info.vs_info.step_rate_0)));
-            } else {
+        if (info.stage == Stage::Local) {
+            // v1: rel patch ID
+            if (runtime_info.num_input_vgprs > 0) {
                 ir.SetVectorReg(dst_vreg++, ir.Imm32(0));
             }
-        }
-        // v2: instance ID, step rate 1
-        if (runtime_info.num_input_vgprs > 1) {
-            if (runtime_info.vs_info.step_rate_1 != 0) {
-                ir.SetVectorReg(dst_vreg++, ir.IDiv(ir.GetAttributeU32(IR::Attribute::InstanceId),
-                                                    ir.Imm32(runtime_info.vs_info.step_rate_1)));
-            } else {
-                ir.SetVectorReg(dst_vreg++, ir.Imm32(0));
+            // v2: instance ID
+            if (runtime_info.num_input_vgprs > 1) {
+                ir.SetVectorReg(dst_vreg++, ir.GetAttributeU32(IR::Attribute::InstanceId));
             }
-        }
-        // v3: instance ID, plain
-        if (runtime_info.num_input_vgprs > 2) {
-            ir.SetVectorReg(dst_vreg++, ir.GetAttributeU32(IR::Attribute::InstanceId));
+        } else {
+            // v1: instance ID, step rate 0
+            if (runtime_info.num_input_vgprs > 0) {
+                if (runtime_info.vs_info.step_rate_0 != 0) {
+                    ir.SetVectorReg(dst_vreg++,
+                                    ir.IDiv(ir.GetAttributeU32(IR::Attribute::InstanceId),
+                                            ir.Imm32(runtime_info.vs_info.step_rate_0)));
+                } else {
+                    ir.SetVectorReg(dst_vreg++, ir.Imm32(0));
+                }
+            }
+            // v2: instance ID, step rate 1
+            if (runtime_info.num_input_vgprs > 1) {
+                if (runtime_info.vs_info.step_rate_1 != 0) {
+                    ir.SetVectorReg(dst_vreg++,
+                                    ir.IDiv(ir.GetAttributeU32(IR::Attribute::InstanceId),
+                                            ir.Imm32(runtime_info.vs_info.step_rate_1)));
+                } else {
+                    ir.SetVectorReg(dst_vreg++, ir.Imm32(0));
+                }
+            }
+            // v3: instance ID, plain
+            if (runtime_info.num_input_vgprs > 2) {
+                ir.SetVectorReg(dst_vreg++, ir.GetAttributeU32(IR::Attribute::InstanceId));
+            }
         }
         break;
     case LogicalStage::Fragment:

--- a/src/shader_recompiler/info.h
+++ b/src/shader_recompiler/info.h
@@ -113,17 +113,13 @@ struct FMaskResource {
 using FMaskResourceList = boost::container::small_vector<FMaskResource, NumFMasks>;
 
 struct PushData {
-    static constexpr u32 Step0Index = 0;
-    static constexpr u32 Step1Index = 1;
-    static constexpr u32 XOffsetIndex = 2;
-    static constexpr u32 YOffsetIndex = 3;
-    static constexpr u32 XScaleIndex = 4;
-    static constexpr u32 YScaleIndex = 5;
-    static constexpr u32 UdRegsIndex = 6;
+    static constexpr u32 XOffsetIndex = 0;
+    static constexpr u32 YOffsetIndex = 1;
+    static constexpr u32 XScaleIndex = 2;
+    static constexpr u32 YScaleIndex = 3;
+    static constexpr u32 UdRegsIndex = 4;
     static constexpr u32 BufOffsetIndex = UdRegsIndex + NumUserDataRegs / 4;
 
-    u32 step0;
-    u32 step1;
     float xoffset;
     float yoffset;
     float xscale;

--- a/src/shader_recompiler/ir/attribute.cpp
+++ b/src/shader_recompiler/ir/attribute.cpp
@@ -100,22 +100,40 @@ std::string NameOf(Attribute attribute) {
         return "Param30";
     case Attribute::Param31:
         return "Param31";
+    case Attribute::ClipDistance:
+        return "ClipDistanace";
+    case Attribute::CullDistance:
+        return "CullDistance";
+    case Attribute::RenderTargetId:
+        return "RenderTargetId";
+    case Attribute::ViewportId:
+        return "ViewportId";
     case Attribute::VertexId:
         return "VertexId";
-    case Attribute::InstanceId:
-        return "InstanceId";
     case Attribute::PrimitiveId:
         return "PrimitiveId";
-    case Attribute::FragCoord:
-        return "FragCoord";
+    case Attribute::InstanceId:
+        return "InstanceId";
     case Attribute::IsFrontFace:
         return "IsFrontFace";
+    case Attribute::SampleIndex:
+        return "SampleIndex";
+    case Attribute::GlobalInvocationId:
+        return "GlobalInvocationId";
     case Attribute::WorkgroupId:
         return "WorkgroupId";
+    case Attribute::WorkgroupIndex:
+        return "WorkgroupIndex";
     case Attribute::LocalInvocationId:
         return "LocalInvocationId";
     case Attribute::LocalInvocationIndex:
         return "LocalInvocationIndex";
+    case Attribute::FragCoord:
+        return "FragCoord";
+    case Attribute::InstanceId0:
+        return "InstanceId0";
+    case Attribute::InstanceId1:
+        return "InstanceId1";
     case Attribute::InvocationId:
         return "InvocationId";
     case Attribute::PatchVertices:

--- a/src/shader_recompiler/ir/attribute.cpp
+++ b/src/shader_recompiler/ir/attribute.cpp
@@ -130,10 +130,6 @@ std::string NameOf(Attribute attribute) {
         return "LocalInvocationIndex";
     case Attribute::FragCoord:
         return "FragCoord";
-    case Attribute::InstanceId0:
-        return "InstanceId0";
-    case Attribute::InstanceId1:
-        return "InstanceId1";
     case Attribute::InvocationId:
         return "InvocationId";
     case Attribute::PatchVertices:

--- a/src/shader_recompiler/ir/attribute.h
+++ b/src/shader_recompiler/ir/attribute.h
@@ -73,8 +73,6 @@ enum class Attribute : u64 {
     LocalInvocationId = 76,
     LocalInvocationIndex = 77,
     FragCoord = 78,
-    InstanceId0 = 79,  // step rate 0
-    InstanceId1 = 80,  // step rate 1
     InvocationId = 81, // TCS id in output patch and instanced geometry shader id
     PatchVertices = 82,
     TessellationEvaluationPointU = 83,

--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -255,8 +255,8 @@ void IREmitter::SetM0(const U32& value) {
     Inst(Opcode::SetM0, value);
 }
 
-F32 IREmitter::GetAttribute(IR::Attribute attribute, u32 comp, IR::Value index) {
-    return Inst<F32>(Opcode::GetAttribute, attribute, Imm32(comp), index);
+F32 IREmitter::GetAttribute(IR::Attribute attribute, u32 comp, u32 index) {
+    return Inst<F32>(Opcode::GetAttribute, attribute, Imm32(comp), Imm32(index));
 }
 
 U32 IREmitter::GetAttributeU32(IR::Attribute attribute, u32 comp) {

--- a/src/shader_recompiler/ir/ir_emitter.h
+++ b/src/shader_recompiler/ir/ir_emitter.h
@@ -81,8 +81,7 @@ public:
 
     [[nodiscard]] U1 Condition(IR::Condition cond);
 
-    [[nodiscard]] F32 GetAttribute(Attribute attribute, u32 comp = 0,
-                                   IR::Value index = IR::Value(u32(0u)));
+    [[nodiscard]] F32 GetAttribute(Attribute attribute, u32 comp = 0, u32 index = 0);
     [[nodiscard]] U32 GetAttributeU32(Attribute attribute, u32 comp = 0);
     void SetAttribute(Attribute attribute, const F32& value, u32 comp = 0);
 

--- a/src/shader_recompiler/ir/passes/ring_access_elimination.cpp
+++ b/src/shader_recompiler/ir/passes/ring_access_elimination.cpp
@@ -33,12 +33,9 @@ void RingAccessElimination(const IR::Program& program, const RuntimeInfo& runtim
                 bool is_composite = opcode == IR::Opcode::WriteSharedU64;
                 u32 num_components = opcode == IR::Opcode::WriteSharedU32 ? 1 : 2;
 
-                u32 offset = 0;
-                const auto* addr = inst.Arg(0).InstRecursive();
-                if (addr->GetOpcode() == IR::Opcode::IAdd32) {
-                    ASSERT(addr->Arg(1).IsImmediate());
-                    offset = addr->Arg(1).U32();
-                }
+                ASSERT(inst.Arg(0).IsImmediate());
+
+                u32 offset = inst.Arg(0).U32();
                 IR::Value data = is_composite ? ir.UnpackUint2x32(IR::U64{inst.Arg(1).Resolve()})
                                               : inst.Arg(1).Resolve();
                 for (s32 i = 0; i < num_components; i++) {

--- a/src/shader_recompiler/ir/passes/ring_access_elimination.cpp
+++ b/src/shader_recompiler/ir/passes/ring_access_elimination.cpp
@@ -116,7 +116,7 @@ void RingAccessElimination(const IR::Program& program, const RuntimeInfo& runtim
                 }
 
                 const auto shl_inst = inst.Arg(1).TryInstRecursive();
-                const auto vertex_id = ir.Imm32(shl_inst->Arg(0).Resolve().U32() >> 2);
+                const auto vertex_id = shl_inst->Arg(0).Resolve().U32() >> 2;
                 const auto offset = inst.Arg(1).TryInstRecursive()->Arg(1);
                 const auto bucket = offset.Resolve().U32() / 256u;
                 const auto attrib = bucket < 4 ? IR::Attribute::Position0

--- a/src/shader_recompiler/ir/passes/srt.h
+++ b/src/shader_recompiler/ir/passes/srt.h
@@ -20,18 +20,7 @@ struct PersistentSrtInfo {
     };
 
     PFN_SrtWalker walker_func{};
-    boost::container::small_vector<SrtSharpReservation, 2> srt_reservations;
     u32 flattened_bufsize_dw = 16; // NumUserDataRegs
-
-    // Special case for fetch shaders because we don't generate IR to read from step rate buffers,
-    // so we won't see usage with GetUserData/ReadConst.
-    // Reserve space in the flattened buffer for a sharp ahead of time
-    u32 ReserveSharp(u32 sgpr_base, u32 dword_offset, u32 num_dwords) {
-        u32 rv = flattened_bufsize_dw;
-        srt_reservations.emplace_back(sgpr_base, dword_offset, num_dwords);
-        flattened_bufsize_dw += num_dwords;
-        return rv;
-    }
 };
 
 } // namespace Shader

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -85,6 +85,8 @@ struct VertexRuntimeInfo {
     std::array<VsOutputMap, 3> outputs;
     bool emulate_depth_negative_one_to_one{};
     bool clip_disable{};
+    u32 step_rate_0;
+    u32 step_rate_1;
     // Domain
     AmdGpu::TessellationType tess_type;
     AmdGpu::TessellationTopology tess_topology;

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -42,7 +42,6 @@ constexpr u32 MaxStageTypes = static_cast<u32>(LogicalStage::NumLogicalStages);
 
 struct LocalRuntimeInfo {
     u32 ls_stride;
-    bool links_with_tcs;
 
     auto operator<=>(const LocalRuntimeInfo&) const noexcept = default;
 };

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -98,7 +98,8 @@ struct VertexRuntimeInfo {
                clip_disable == other.clip_disable && tess_type == other.tess_type &&
                tess_topology == other.tess_topology &&
                tess_partitioning == other.tess_partitioning &&
-               hs_output_cp_stride == other.hs_output_cp_stride;
+               hs_output_cp_stride == other.hs_output_cp_stride &&
+               step_rate_0 == other.step_rate_0 && step_rate_1 == other.step_rate_1;
     }
 
     void InitFromTessConstants(Shader::TessellationDataConstantBuffer& tess_constants) {

--- a/src/shader_recompiler/specialization.h
+++ b/src/shader_recompiler/specialization.h
@@ -13,7 +13,6 @@
 namespace Shader {
 
 struct VsAttribSpecialization {
-    s32 num_components{};
     u32 divisor{};
     AmdGpu::NumberClass num_class{};
     AmdGpu::CompMapping dst_select{};
@@ -96,7 +95,6 @@ struct StageSpecialization {
             // Specialize shader on VS input number types to follow spec.
             ForEachSharp(vs_attribs, fetch_shader_data->attributes,
                          [&profile_, this](auto& spec, const auto& desc, AmdGpu::Buffer sharp) {
-                             spec.num_components = AmdGpu::NumComponents(sharp.GetDataFmt());
                              using InstanceIdType = Shader::Gcn::VertexAttribute::InstanceIdType;
                              if (const auto step_rate = desc.GetStepRate();
                                  step_rate != InstanceIdType::None) {

--- a/src/shader_recompiler/specialization.h
+++ b/src/shader_recompiler/specialization.h
@@ -14,6 +14,7 @@ namespace Shader {
 
 struct VsAttribSpecialization {
     s32 num_components{};
+    u32 divisor{};
     AmdGpu::NumberClass num_class{};
     AmdGpu::CompMapping dst_select{};
 
@@ -74,13 +75,13 @@ struct SamplerSpecialization {
  * after the first compilation of a module.
  */
 struct StageSpecialization {
-    static constexpr size_t MaxStageResources = 64;
+    static constexpr size_t MaxStageResources = 128;
 
     const Shader::Info* info;
     RuntimeInfo runtime_info;
+    std::bitset<MaxStageResources> bitset{};
     std::optional<Gcn::FetchShaderData> fetch_shader_data{};
     boost::container::small_vector<VsAttribSpecialization, 32> vs_attribs;
-    std::bitset<MaxStageResources> bitset{};
     boost::container::small_vector<BufferSpecialization, 16> buffers;
     boost::container::small_vector<ImageSpecialization, 16> images;
     boost::container::small_vector<FMaskSpecialization, 8> fmasks;
@@ -94,10 +95,17 @@ struct StageSpecialization {
         if (info_.stage == Stage::Vertex && fetch_shader_data) {
             // Specialize shader on VS input number types to follow spec.
             ForEachSharp(vs_attribs, fetch_shader_data->attributes,
-                         [&profile_](auto& spec, const auto& desc, AmdGpu::Buffer sharp) {
-                             spec.num_components = desc.UsesStepRates()
-                                                       ? AmdGpu::NumComponents(sharp.GetDataFmt())
-                                                       : 0;
+                         [&profile_, this](auto& spec, const auto& desc, AmdGpu::Buffer sharp) {
+                             spec.num_components = AmdGpu::NumComponents(sharp.GetDataFmt());
+                             using InstanceIdType = Shader::Gcn::VertexAttribute::InstanceIdType;
+                             if (const auto step_rate = desc.GetStepRate();
+                                 step_rate != InstanceIdType::None) {
+                                 spec.divisor = step_rate == InstanceIdType::OverStepRate0
+                                                    ? runtime_info.vs_info.step_rate_0
+                                                    : (step_rate == InstanceIdType::OverStepRate1
+                                                           ? runtime_info.vs_info.step_rate_1
+                                                           : 1);
+                             }
                              spec.num_class = profile_.support_legacy_vertex_attributes
                                                   ? AmdGpu::NumberClass{}
                                                   : AmdGpu::GetNumberClass(sharp.GetNumberFmt());

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -198,10 +198,13 @@ void BufferCache::DownloadBufferMemory(Buffer& buffer, VAddr device_addr, u64 si
 }
 
 void BufferCache::BindVertexBuffers(const Vulkan::GraphicsPipeline& pipeline) {
+    const auto& regs = liverpool->regs;
     Vulkan::VertexInputs<vk::VertexInputAttributeDescription2EXT> attributes;
     Vulkan::VertexInputs<vk::VertexInputBindingDescription2EXT> bindings;
+    Vulkan::VertexInputs<vk::VertexInputBindingDivisorDescriptionEXT> divisors;
     Vulkan::VertexInputs<AmdGpu::Buffer> guest_buffers;
-    pipeline.GetVertexInputs(attributes, bindings, guest_buffers);
+    pipeline.GetVertexInputs(attributes, bindings, divisors, guest_buffers,
+                             regs.vgt_instance_step_rate_0, regs.vgt_instance_step_rate_1);
 
     if (instance.IsVertexInputDynamicState()) {
         // Update current vertex inputs.

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -72,12 +72,21 @@ GraphicsPipeline::GraphicsPipeline(
 
     VertexInputs<vk::VertexInputAttributeDescription> vertex_attributes;
     VertexInputs<vk::VertexInputBindingDescription> vertex_bindings;
+    VertexInputs<vk::VertexInputBindingDivisorDescriptionEXT> divisors;
     VertexInputs<AmdGpu::Buffer> guest_buffers;
     if (!instance.IsVertexInputDynamicState()) {
-        GetVertexInputs(vertex_attributes, vertex_bindings, guest_buffers);
+        const auto& vs_info = runtime_infos[u32(Shader::LogicalStage::Vertex)].vs_info;
+        GetVertexInputs(vertex_attributes, vertex_bindings, divisors, guest_buffers,
+                        vs_info.step_rate_0, vs_info.step_rate_1);
     }
 
+    const vk::PipelineVertexInputDivisorStateCreateInfo divisor_state = {
+        .vertexBindingDivisorCount = static_cast<u32>(divisors.size()),
+        .pVertexBindingDivisors = divisors.data(),
+    };
+
     const vk::PipelineVertexInputStateCreateInfo vertex_input_info = {
+        .pNext = &divisor_state,
         .vertexBindingDescriptionCount = static_cast<u32>(vertex_bindings.size()),
         .pVertexBindingDescriptions = vertex_bindings.data(),
         .vertexAttributeDescriptionCount = static_cast<u32>(vertex_attributes.size()),
@@ -304,19 +313,16 @@ GraphicsPipeline::GraphicsPipeline(
 GraphicsPipeline::~GraphicsPipeline() = default;
 
 template <typename Attribute, typename Binding>
-void GraphicsPipeline::GetVertexInputs(VertexInputs<Attribute>& attributes,
-                                       VertexInputs<Binding>& bindings,
-                                       VertexInputs<AmdGpu::Buffer>& guest_buffers) const {
+void GraphicsPipeline::GetVertexInputs(
+    VertexInputs<Attribute>& attributes, VertexInputs<Binding>& bindings,
+    VertexInputs<vk::VertexInputBindingDivisorDescriptionEXT>& divisors,
+    VertexInputs<AmdGpu::Buffer>& guest_buffers, u32 step_rate_0, u32 step_rate_1) const {
+    using InstanceIdType = Shader::Gcn::VertexAttribute::InstanceIdType;
     if (!fetch_shader || fetch_shader->attributes.empty()) {
         return;
     }
     const auto& vs_info = GetStage(Shader::LogicalStage::Vertex);
     for (const auto& attrib : fetch_shader->attributes) {
-        if (attrib.UsesStepRates()) {
-            // Skip attribute binding as the data will be pulled by shader.
-            continue;
-        }
-
         const auto& buffer = attrib.GetSharp(vs_info);
         attributes.push_back(Attribute{
             .location = attrib.semantic,
@@ -327,12 +333,21 @@ void GraphicsPipeline::GetVertexInputs(VertexInputs<Attribute>& attributes,
         bindings.push_back(Binding{
             .binding = attrib.semantic,
             .stride = buffer.GetStride(),
-            .inputRate = attrib.GetStepRate() == Shader::Gcn::VertexAttribute::InstanceIdType::None
+            .inputRate = attrib.GetStepRate() == InstanceIdType::None
                              ? vk::VertexInputRate::eVertex
                              : vk::VertexInputRate::eInstance,
         });
+        const u32 divisor =
+            attrib.GetStepRate() == InstanceIdType::OverStepRate0
+                ? step_rate_0
+                : (attrib.GetStepRate() == InstanceIdType::OverStepRate1 ? step_rate_1 : 1);
         if constexpr (std::is_same_v<Binding, vk::VertexInputBindingDescription2EXT>) {
-            bindings.back().divisor = 1;
+            bindings.back().divisor = divisor;
+        } else {
+            divisors.push_back(vk::VertexInputBindingDivisorDescriptionEXT{
+                .binding = attrib.semantic,
+                .divisor = divisor,
+            });
         }
         guest_buffers.emplace_back(buffer);
     }
@@ -342,11 +357,13 @@ void GraphicsPipeline::GetVertexInputs(VertexInputs<Attribute>& attributes,
 template void GraphicsPipeline::GetVertexInputs(
     VertexInputs<vk::VertexInputAttributeDescription>& attributes,
     VertexInputs<vk::VertexInputBindingDescription>& bindings,
-    VertexInputs<AmdGpu::Buffer>& guest_buffers) const;
+    VertexInputs<vk::VertexInputBindingDivisorDescriptionEXT>& divisors,
+    VertexInputs<AmdGpu::Buffer>& guest_buffers, u32 step_rate_0, u32 step_rate_1) const;
 template void GraphicsPipeline::GetVertexInputs(
     VertexInputs<vk::VertexInputAttributeDescription2EXT>& attributes,
     VertexInputs<vk::VertexInputBindingDescription2EXT>& bindings,
-    VertexInputs<AmdGpu::Buffer>& guest_buffers) const;
+    VertexInputs<vk::VertexInputBindingDivisorDescriptionEXT>& divisors,
+    VertexInputs<AmdGpu::Buffer>& guest_buffers, u32 step_rate_0, u32 step_rate_1) const;
 
 void GraphicsPipeline::BuildDescSetLayout() {
     boost::container::small_vector<vk::DescriptorSetLayoutBinding, 32> bindings;

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -81,7 +81,9 @@ public:
     /// Gets the attributes and bindings for vertex inputs.
     template <typename Attribute, typename Binding>
     void GetVertexInputs(VertexInputs<Attribute>& attributes, VertexInputs<Binding>& bindings,
-                         VertexInputs<AmdGpu::Buffer>& guest_buffers) const;
+                         VertexInputs<vk::VertexInputBindingDivisorDescriptionEXT>& divisors,
+                         VertexInputs<AmdGpu::Buffer>& guest_buffers, u32 step_rate_0,
+                         u32 step_rate_1) const;
 
 private:
     void BuildDescSetLayout();

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -277,6 +277,7 @@ bool Instance::CreateDevice() {
     image_load_store_lod = add_extension(VK_AMD_SHADER_IMAGE_LOAD_STORE_LOD_EXTENSION_NAME);
     amd_gcn_shader = add_extension(VK_AMD_GCN_SHADER_EXTENSION_NAME);
     amd_shader_trinary_minmax = add_extension(VK_AMD_SHADER_TRINARY_MINMAX_EXTENSION_NAME);
+    vertex_attribute_divisor = add_extension(VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME);
     shader_atomic_float2 = add_extension(VK_EXT_SHADER_ATOMIC_FLOAT_2_EXTENSION_NAME);
     if (shader_atomic_float2) {
         shader_atomic_float2_features =
@@ -436,6 +437,9 @@ bool Instance::CreateDevice() {
         vk::PhysicalDeviceLegacyVertexAttributesFeaturesEXT{
             .legacyVertexAttributes = true,
         },
+        vk::PhysicalDeviceVertexAttributeDivisorFeatures{
+            .vertexAttributeInstanceRateDivisor = true,
+        },
         vk::PhysicalDeviceShaderAtomicFloat2FeaturesEXT{
             .shaderBufferFloat32AtomicMinMax =
                 shader_atomic_float2_features.shaderBufferFloat32AtomicMinMax,
@@ -497,6 +501,9 @@ bool Instance::CreateDevice() {
     }
     if (!legacy_vertex_attributes) {
         device_chain.unlink<vk::PhysicalDeviceLegacyVertexAttributesFeaturesEXT>();
+    }
+    if (!vertex_attribute_divisor) {
+        device_chain.unlink<vk::PhysicalDeviceVertexAttributeDivisorFeatures>();
     }
     if (!shader_atomic_float2) {
         device_chain.unlink<vk::PhysicalDeviceShaderAtomicFloat2FeaturesEXT>();

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -248,6 +248,7 @@ bool Instance::CreateDevice() {
     // Required
     ASSERT(add_extension(VK_KHR_SWAPCHAIN_EXTENSION_NAME));
     ASSERT(add_extension(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME));
+    ASSERT(add_extension(VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME));
 
     // Optional
     depth_range_unrestricted = add_extension(VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME);
@@ -277,7 +278,6 @@ bool Instance::CreateDevice() {
     image_load_store_lod = add_extension(VK_AMD_SHADER_IMAGE_LOAD_STORE_LOD_EXTENSION_NAME);
     amd_gcn_shader = add_extension(VK_AMD_GCN_SHADER_EXTENSION_NAME);
     amd_shader_trinary_minmax = add_extension(VK_AMD_SHADER_TRINARY_MINMAX_EXTENSION_NAME);
-    vertex_attribute_divisor = add_extension(VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME);
     shader_atomic_float2 = add_extension(VK_EXT_SHADER_ATOMIC_FLOAT_2_EXTENSION_NAME);
     if (shader_atomic_float2) {
         shader_atomic_float2_features =
@@ -501,9 +501,6 @@ bool Instance::CreateDevice() {
     }
     if (!legacy_vertex_attributes) {
         device_chain.unlink<vk::PhysicalDeviceLegacyVertexAttributesFeaturesEXT>();
-    }
-    if (!vertex_attribute_divisor) {
-        device_chain.unlink<vk::PhysicalDeviceVertexAttributeDivisorFeatures>();
     }
     if (!shader_atomic_float2) {
         device_chain.unlink<vk::PhysicalDeviceShaderAtomicFloat2FeaturesEXT>();

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -150,6 +150,11 @@ public:
         return legacy_vertex_attributes;
     }
 
+    /// Returns true when VK_EXT_vertex_attribute_divisor is supported.
+    bool IsVertexAttributeDivisorSupported() const {
+        return vertex_attribute_divisor;
+    }
+
     /// Returns true when VK_AMD_shader_image_load_store_lod is supported.
     bool IsImageLoadStoreLodSupported() const {
         return image_load_store_lod;
@@ -398,6 +403,7 @@ private:
     u32 queue_family_index{0};
     bool custom_border_color{};
     bool fragment_shader_barycentric{};
+    bool vertex_attribute_divisor{};
     bool depth_clip_control{};
     bool depth_range_unrestricted{};
     bool dynamic_state_3{};

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -150,11 +150,6 @@ public:
         return legacy_vertex_attributes;
     }
 
-    /// Returns true when VK_EXT_vertex_attribute_divisor is supported.
-    bool IsVertexAttributeDivisorSupported() const {
-        return vertex_attribute_divisor;
-    }
-
     /// Returns true when VK_AMD_shader_image_load_store_lod is supported.
     bool IsImageLoadStoreLodSupported() const {
         return image_load_store_lod;
@@ -403,7 +398,6 @@ private:
     u32 queue_family_index{0};
     bool custom_border_color{};
     bool fragment_shader_barycentric{};
-    bool vertex_attribute_divisor{};
     bool depth_clip_control{};
     bool depth_range_unrestricted{};
     bool dynamic_state_3{};

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -122,6 +122,8 @@ const Shader::RuntimeInfo& PipelineCache::BuildRuntimeInfo(Stage stage, LogicalS
     case Stage::Vertex: {
         BuildCommon(regs.vs_program);
         GatherVertexOutputs(info.vs_info, regs.vs_output_control);
+        info.vs_info.step_rate_0 = regs.vgt_instance_step_rate_0;
+        info.vs_info.step_rate_1 = regs.vgt_instance_step_rate_1;
         info.vs_info.emulate_depth_negative_one_to_one =
             !instance.IsDepthClipControlSupported() &&
             regs.clipper_control.clip_space == Liverpool::ClipSpace::MinusWToW;
@@ -460,10 +462,6 @@ bool PipelineCache::RefreshGraphicsKey() {
         // Stride will still be handled outside the pipeline using dynamic state.
         u32 vertex_binding = 0;
         for (const auto& attrib : fetch_shader->attributes) {
-            if (attrib.UsesStepRates()) {
-                // Skip attribute binding as the data will be pulled by shader.
-                continue;
-            }
             const auto& buffer = attrib.GetSharp(*vs_info);
             ASSERT(vertex_binding < MaxVertexBufferCount);
             key.vertex_buffer_formats[vertex_binding++] =

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -94,15 +94,10 @@ const Shader::RuntimeInfo& PipelineCache::BuildRuntimeInfo(Stage stage, LogicalS
     switch (stage) {
     case Stage::Local: {
         BuildCommon(regs.ls_program);
-        if (regs.stage_enable.IsStageEnabled(static_cast<u32>(Stage::Hull))) {
-            info.ls_info.links_with_tcs = true;
-            Shader::TessellationDataConstantBuffer tess_constants;
-            const auto* pgm = regs.ProgramForStage(static_cast<u32>(Stage::Hull));
-            const auto params = Liverpool::GetParams(*pgm);
-            const auto& hull_info = program_cache.at(params.hash)->info;
-            hull_info.ReadTessConstantBuffer(tess_constants);
-            info.ls_info.ls_stride = tess_constants.ls_stride;
-        }
+        Shader::TessellationDataConstantBuffer tess_constants;
+        const auto* hull_info = infos[u32(Shader::LogicalStage::TessellationControl)];
+        hull_info->ReadTessConstantBuffer(tess_constants);
+        info.ls_info.ls_stride = tess_constants.ls_stride;
         break;
     }
     case Stage::Hull: {

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -20,12 +20,9 @@
 namespace Vulkan {
 
 static Shader::PushData MakeUserData(const AmdGpu::Liverpool::Regs& regs) {
-    Shader::PushData push_data{};
-    push_data.step0 = regs.vgt_instance_step_rate_0;
-    push_data.step1 = regs.vgt_instance_step_rate_1;
-
     // TODO(roamic): Add support for multiple viewports and geometry shaders when ViewportIndex
     // is encountered and implemented in the recompiler.
+    Shader::PushData push_data{};
     push_data.xoffset = regs.viewport_control.xoffset_enable ? regs.viewports[0].xoffset : 0.f;
     push_data.xscale = regs.viewport_control.xscale_enable ? regs.viewports[0].xscale : 1.f;
     push_data.yoffset = regs.viewport_control.yoffset_enable ? regs.viewports[0].yoffset : 0.f;


### PR DESCRIPTION
This is first part of trying to cleanup the attribute code in recompiler before I can implement what I want, as it has suffered from a bit of scope creep.

In this PR the code for manually pulling buffers for emulating instance step rates is removed in favor of  using VK_EXT_vertex_attribute_divisor. That extension is quite old and ubiquitously supported on all platforms so the benefit of code simplification is worth it. Also added divisor into specialization for checking both input rate and step rate, on main the former wasn't checked (is it even possible for an attribute to go from vertex to instance rate with same shader?) and removed code in backend for handling InstanceId0-1 as it seemed wrong; if those vgprs are used for as index for buffer loads shouldn't they be InstanceId / step_rate_0-1 instead of just step rate? Can be checked now when their assertion hits