### PR TITLE
Implement sceKernelGetSystemSwVersion

### DIFF
--- a/src/core/libraries/kernel/kernel.cpp
+++ b/src/core/libraries/kernel/kernel.cpp
@@ -243,6 +243,19 @@ s32 PS4_SYSV_ABI sceKernelSetGPO() {
     return ORBIS_OK;
 }
 
+s32 PS4_SYSV_ABI sceKernelGetSystemSwVersion(SwVersionStruct* ret) {
+    if (ret == nullptr) {
+        return ORBIS_OK; // but why?
+    }
+    ASSERT(ret->struct_size == 40);
+    u32 fake_fw = 0x09990000; // chosen arbitrarily, it doesn't matter much
+    ret->hex_representation = fake_fw;
+    std::snprintf(ret->text_representation, 28, "%2x.%03x.%03x", fake_fw >> 0x18,
+                  fake_fw >> 0xc & 0xfff, fake_fw & 0xfff); // why %2x?
+    LOG_INFO(Lib_Kernel, "called, returned sw version: {}", ret->text_representation);
+    return ORBIS_OK;
+}
+
 void RegisterKernel(Core::Loader::SymbolsResolver* sym) {
     service_thread = std::jthread{KernelServiceThread};
 
@@ -258,6 +271,7 @@ void RegisterKernel(Core::Loader::SymbolsResolver* sym) {
     Libraries::Kernel::RegisterDebug(sym);
 
     LIB_OBJ("f7uOxY9mM1U", "libkernel", 1, "libkernel", 1, 1, &g_stack_chk_guard);
+    LIB_FUNCTION("Mv1zUObHvXI", "libkernel", 1, "libkernel", 1, 1, sceKernelGetSystemSwVersion);
     LIB_FUNCTION("PfccT7qURYE", "libkernel", 1, "libkernel", 1, 1, kernel_ioctl);
     LIB_FUNCTION("JGfTMBOdUJo", "libkernel", 1, "libkernel", 1, 1, sceKernelGetFsSandboxRandomWord);
     LIB_FUNCTION("6xVpy0Fdq+I", "libkernel", 1, "libkernel", 1, 1, _sigprocmask);

--- a/src/core/libraries/kernel/kernel.cpp
+++ b/src/core/libraries/kernel/kernel.cpp
@@ -6,6 +6,7 @@
 
 #include "common/assert.h"
 #include "common/debug.h"
+#include "common/elf_info.h"
 #include "common/logging/log.h"
 #include "common/polyfill_thread.h"
 #include "common/thread.h"
@@ -248,7 +249,7 @@ s32 PS4_SYSV_ABI sceKernelGetSystemSwVersion(SwVersionStruct* ret) {
         return ORBIS_OK; // but why?
     }
     ASSERT(ret->struct_size == 40);
-    u32 fake_fw = 0x09990000; // chosen arbitrarily, it doesn't matter much
+    u32 fake_fw = Common::ElfInfo::Instance().RawFirmwareVer();
     ret->hex_representation = fake_fw;
     std::snprintf(ret->text_representation, 28, "%2x.%03x.%03x", fake_fw >> 0x18,
                   fake_fw >> 0xc & 0xfff, fake_fw & 0xfff); // why %2x?

--- a/src/core/libraries/kernel/kernel.h
+++ b/src/core/libraries/kernel/kernel.h
@@ -35,6 +35,12 @@ struct OrbisWrapperImpl<PS4_SYSV_ABI R (*)(Args...), f> {
 
 s32* PS4_SYSV_ABI __Error();
 
+struct SwVersionStruct {
+    u64 struct_size;
+    char text_representation[0x1c];
+    u32 hex_representation;
+};
+
 void RegisterKernel(Core::Loader::SymbolsResolver* sym);
 
 } // namespace Libraries::Kernel


### PR DESCRIPTION
This function is used by LLE HTTP. From comparing the behaviour on console and on the emulator with Driveclub on mikusp's network PR + some hacks + hardcoded values to get it to connect to my local server, it appears to be working fine.
The LLE library still works without this function, it would simply use whatever memory garbage was in the return struct pointer's address instead.