### PR TITLE
Core: Fix read-only file unmaps on Windows

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -555,7 +555,8 @@ u64 MemoryManager::UnmapBytesFromEntry(VAddr virtual_addr, VirtualMemoryArea vma
     vma.phys_base = 0;
     vma.disallow_merge = false;
     vma.name = "";
-    const auto post_merge_it = MergeAdjacent(vma_map, new_it);
+    MergeAdjacent(vma_map, new_it);
+
     if (type != VMAType::Reserved && type != VMAType::PoolReserved) {
         // If this mapping has GPU access, unmap from GPU.
         if (IsValidGpuMapping(virtual_addr, size)) {

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -537,6 +537,7 @@ u64 MemoryManager::UnmapBytesFromEntry(VAddr virtual_addr, VirtualMemoryArea vma
         vma_base_size - start_in_vma < size ? vma_base_size - start_in_vma : size;
     const bool has_backing = type == VMAType::Direct || type == VMAType::File;
     const auto prot = vma_base.prot;
+    const bool readonly_file = prot == MemoryProt::CpuRead && type == VMAType::File;
 
     if (type == VMAType::Free) {
         return adjusted_size;
@@ -555,8 +556,6 @@ u64 MemoryManager::UnmapBytesFromEntry(VAddr virtual_addr, VirtualMemoryArea vma
     vma.disallow_merge = false;
     vma.name = "";
     const auto post_merge_it = MergeAdjacent(vma_map, new_it);
-    auto& post_merge_vma = post_merge_it->second;
-    bool readonly_file = post_merge_vma.prot == MemoryProt::CpuRead && type == VMAType::File;
     if (type != VMAType::Reserved && type != VMAType::PoolReserved) {
         // If this mapping has GPU access, unmap from GPU.
         if (IsValidGpuMapping(virtual_addr, size)) {


### PR DESCRIPTION
By using the created `post_merge_vma` to check protections, `readonly_file` would always be false since the created VMA has prot `MemoryProt::NoAccess`. In games that try unmapping a read-only file, this would cause a crash for Windows users since we don't have a proper file mapping at that address.

Fixes Genshin Impact (CUSA23681) crashing on a memory error on boot. It doesn't get much further though, since it needs alertable event flag waits.