### PR TITLE
Libraries: Implement sceAudio3dTerminate

### DIFF
--- a/src/core/libraries/audio3d/audio3d.cpp
+++ b/src/core/libraries/audio3d/audio3d.cpp
@@ -526,7 +526,11 @@ s32 PS4_SYSV_ABI sceAudio3dStrError() {
 }
 
 s32 PS4_SYSV_ABI sceAudio3dTerminate() {
-    LOG_ERROR(Lib_Audio3d, "(STUBBED) called");
+    LOG_INFO(Lib_Audio3d, "called");
+    if (!state) {
+        return ORBIS_AUDIO3D_ERROR_NOT_READY;
+    }
+    state.release();
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/audio3d/audio3d.cpp
+++ b/src/core/libraries/audio3d/audio3d.cpp
@@ -530,6 +530,9 @@ s32 PS4_SYSV_ABI sceAudio3dTerminate() {
     if (!state) {
         return ORBIS_AUDIO3D_ERROR_NOT_READY;
     }
+
+    AudioOut::sceAudioOutOutput(state->audio_out_handle, nullptr);
+    AudioOut::sceAudioOutClose(state->audio_out_handle);
     state.release();
     return ORBIS_OK;
 }


### PR DESCRIPTION
My First Gran Turismo® (CUSA49696) uses this while initializing it's audio system. Not handling this results in sceAudio3dInitialize error spam, and would probably cause other issues if the game got further.