### PR TITLE
vk_instance: Remove usage of depth clamp control

### DIFF
--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -140,30 +140,13 @@ GraphicsPipeline::GraphicsPipeline(
         .sampleShadingEnable = false,
     };
 
-    const vk::DepthClampRangeEXT depth_clamp_range = {
-        .minDepthClamp = key.min_depth_clamp,
-        .maxDepthClamp = key.max_depth_clamp,
+    const vk::PipelineViewportDepthClipControlCreateInfoEXT clip_control = {
+        .negativeOneToOne = key.clip_space == Liverpool::ClipSpace::MinusWToW,
     };
 
-    vk::StructureChain viewport_chain = {
-        vk::PipelineViewportStateCreateInfo{},
-        vk::PipelineViewportDepthClipControlCreateInfoEXT{
-            .negativeOneToOne = key.clip_space == Liverpool::ClipSpace::MinusWToW,
-        },
-        vk::PipelineViewportDepthClampControlCreateInfoEXT{
-            .depthClampMode = key.depth_clamp_user_defined_range
-                                  ? vk::DepthClampModeEXT::eUserDefinedRange
-                                  : vk::DepthClampModeEXT::eViewportRange,
-            .pDepthClampRange = &depth_clamp_range,
-        },
+    const vk::PipelineViewportStateCreateInfo viewport_info = {
+        .pNext = instance.IsDepthClipControlSupported() ? &clip_control : nullptr,
     };
-
-    if (!instance.IsDepthClampControlSupported()) {
-        viewport_chain.unlink<vk::PipelineViewportDepthClampControlCreateInfoEXT>();
-    }
-    if (!instance.IsDepthClipControlSupported()) {
-        viewport_chain.unlink<vk::PipelineViewportDepthClipControlCreateInfoEXT>();
-    }
 
     boost::container::static_vector<vk::DynamicState, 32> dynamic_states = {
         vk::DynamicState::eViewportWithCount,  vk::DynamicState::eScissorWithCount,
@@ -339,7 +322,7 @@ GraphicsPipeline::GraphicsPipeline(
         .pVertexInputState = !instance.IsVertexInputDynamicState() ? &vertex_input_info : nullptr,
         .pInputAssemblyState = &input_assembly,
         .pTessellationState = &tessellation_state,
-        .pViewportState = &viewport_chain.get(),
+        .pViewportState = &viewport_info,
         .pRasterizationState = &raster_chain.get(),
         .pMultisampleState = &multisampling,
         .pColorBlendState = &color_blending,

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -48,9 +48,6 @@ struct GraphicsPipelineKey {
         Liverpool::DepthBuffer::ZFormat z_format : 2;
         Liverpool::DepthBuffer::StencilFormat stencil_format : 1;
         u32 depth_clamp_enable : 1;
-        u32 depth_clamp_user_defined_range : 1;
-        float min_depth_clamp;
-        float max_depth_clamp;
     };
     struct {
         AmdGpu::PrimitiveType prim_type : 5;

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -271,7 +271,6 @@ bool Instance::CreateDevice() {
     custom_border_color = add_extension(VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
     depth_clip_control = add_extension(VK_EXT_DEPTH_CLIP_CONTROL_EXTENSION_NAME);
     depth_clip_enable = add_extension(VK_EXT_DEPTH_CLIP_ENABLE_EXTENSION_NAME);
-    depth_clamp_control = add_extension(VK_EXT_DEPTH_CLAMP_CONTROL_EXTENSION_NAME);
     vertex_input_dynamic_state = add_extension(VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
     list_restart = add_extension(VK_EXT_PRIMITIVE_TOPOLOGY_LIST_RESTART_EXTENSION_NAME);
     fragment_shader_barycentric = add_extension(VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME);
@@ -426,9 +425,6 @@ bool Instance::CreateDevice() {
         vk::PhysicalDeviceDepthClipEnableFeaturesEXT{
             .depthClipEnable = true,
         },
-        vk::PhysicalDeviceDepthClampControlFeaturesEXT{
-            .depthClampControl = true,
-        },
         vk::PhysicalDeviceRobustness2FeaturesEXT{
             .robustBufferAccess2 = robustness2_features.robustBufferAccess2,
             .robustImageAccess2 = robustness2_features.robustImageAccess2,
@@ -503,9 +499,6 @@ bool Instance::CreateDevice() {
     }
     if (!depth_clip_enable) {
         device_chain.unlink<vk::PhysicalDeviceDepthClipEnableFeaturesEXT>();
-    }
-    if (!depth_clamp_control) {
-        device_chain.unlink<vk::PhysicalDeviceDepthClampControlFeaturesEXT>();
     }
     if (!robustness2) {
         device_chain.unlink<vk::PhysicalDeviceRobustness2FeaturesEXT>();

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -114,11 +114,6 @@ public:
         return depth_clip_enable;
     }
 
-    /// Returns true when VK_EXT_depth_clamp_control is supported
-    bool IsDepthClampControlSupported() const {
-        return depth_clamp_control;
-    }
-
     /// Returns true when VK_EXT_depth_range_unrestricted is supported
     bool IsDepthRangeUnrestrictedSupported() const {
         return depth_range_unrestricted;
@@ -420,7 +415,6 @@ private:
     bool fragment_shader_barycentric{};
     bool depth_clip_control{};
     bool depth_clip_enable{};
-    bool depth_clamp_control{};
     bool depth_range_unrestricted{};
     bool dynamic_state_3{};
     bool vertex_input_dynamic_state{};

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -290,6 +290,7 @@ bool PipelineCache::RefreshGraphicsKey() {
     key.stencil_format = regs.depth_buffer.StencilValid()
                              ? regs.depth_buffer.stencil_info.format.Value()
                              : Liverpool::DepthBuffer::StencilFormat::Invalid;
+    key.depth_clamp_enable = !regs.depth_render_override.disable_viewport_clamp;
     key.depth_clip_enable = regs.clipper_control.ZclipEnable();
     key.clip_space = regs.clipper_control.clip_space;
     key.provoking_vtx_last = regs.polygon_control.provoking_vtx_last;
@@ -297,8 +298,6 @@ bool PipelineCache::RefreshGraphicsKey() {
     key.polygon_mode = regs.polygon_control.PolyMode();
     key.logic_op = regs.color_control.rop3;
     key.num_samples = regs.NumSamples();
-
-    RefreshDepthClampRange();
 
     const bool skip_cb_binding =
         regs.color_control.mode == AmdGpu::Liverpool::ColorControl::OperationMode::Disable;
@@ -486,62 +485,6 @@ bool PipelineCache::RefreshGraphicsKey() {
     }
 
     return true;
-}
-
-void PipelineCache::RefreshDepthClampRange() {
-    auto& regs = liverpool->regs;
-    auto& key = graphics_key;
-
-    key.depth_clamp_enable = !regs.depth_render_override.disable_viewport_clamp;
-    if (key.z_format == Liverpool::DepthBuffer::ZFormat::Invalid || !key.depth_clamp_enable) {
-        return;
-    }
-
-    bool depth_clamp_can_use_viewport_range = true;
-    bool depth_clamp_is_same_on_all_viewports = true;
-    float zmin = std::numeric_limits<float>::max();
-    float zmax = std::numeric_limits<float>::max();
-    const auto& vp_ctl = regs.viewport_control;
-    for (u32 i = 0; i < Liverpool::NumViewports; i++) {
-        const auto& vp = regs.viewports[i];
-        const auto& vp_d = regs.viewport_depths[i];
-        if (vp.xscale == 0) {
-            continue;
-        }
-        const auto zoffset = vp_ctl.zoffset_enable ? vp.zoffset : 0.f;
-        const auto zscale = vp_ctl.zscale_enable ? vp.zscale : 1.f;
-
-        float min_depth;
-        float max_depth;
-        if (regs.clipper_control.clip_space == AmdGpu::Liverpool::ClipSpace::MinusWToW) {
-            min_depth = zoffset - zscale;
-            max_depth = zoffset + zscale;
-        } else {
-            min_depth = zoffset;
-            max_depth = zoffset + zscale;
-        }
-        if (zmin == std::numeric_limits<float>::max()) {
-            zmin = vp_d.zmin;
-            zmax = vp_d.zmax;
-        }
-        depth_clamp_is_same_on_all_viewports &= (zmin == vp_d.zmin && zmax == vp_d.zmax);
-        depth_clamp_can_use_viewport_range &= (min_depth == vp_d.zmin && max_depth == vp_d.zmax);
-    }
-
-    if (zmin == std::numeric_limits<float>::max()) {
-        return;
-    }
-
-    if (!depth_clamp_can_use_viewport_range && !depth_clamp_is_same_on_all_viewports) {
-        LOG_ERROR(Render_Vulkan,
-                  "Viewport depth clamping configuration cannot be accurately emulated");
-    }
-
-    key.depth_clamp_user_defined_range = !depth_clamp_can_use_viewport_range;
-    if (key.depth_clamp_user_defined_range) {
-        key.min_depth_clamp = zmin;
-        key.max_depth_clamp = zmax;
-    }
 }
 
 bool PipelineCache::RefreshComputeKey() {

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.h
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.h
@@ -76,8 +76,6 @@ private:
     bool RefreshGraphicsKey();
     bool RefreshComputeKey();
 
-    void RefreshDepthClampRange();
-
     void DumpShader(std::span<const u32> code, u64 hash, Shader::Stage stage, size_t perm_idx,
                     std::string_view ext);
     std::optional<std::vector<u32>> GetShaderPatch(u64 hash, Shader::Stage stage, size_t perm_idx,


### PR DESCRIPTION
AMD proprietary driver doesn't seem to properly implement the extension, not sure what the issue is as I can only test RADV which is fine

@StevenMiller123 Check if this fixes the regression, otherwise the extension itself might need to be excluded