### PR TITLE
qt: fix gui emulatorLanguage

### DIFF
--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -437,7 +437,7 @@ void SettingsDialog::LoadValuesFromConfig() {
                                 toml::find_or<int>(data, "Settings", "consoleLanguage", 6))) %
         languageIndexes.size());
     ui->emulatorLanguageComboBox->setCurrentIndex(
-        languages[toml::find_or<std::string>(data, "GUI", "emulatorLanguage", "en_US")]);
+        languages[m_gui_settings->GetValue(gui::gen_guiLanguage).toString().toStdString()]);
     ui->hideCursorComboBox->setCurrentIndex(toml::find_or<int>(data, "Input", "cursorState", 1));
     OnCursorStateChanged(toml::find_or<int>(data, "Input", "cursorState", 1));
     ui->idleTimeoutSpinBox->setValue(toml::find_or<int>(data, "Input", "cursorHideTimeout", 5));


### PR DESCRIPTION
Although the language was correct, English always appeared in the emulator's language selection option/menu,

In the example image, I am using Brazilian Portuguese, but when I open the menu the English option is always selected.
<img width="382" height="374" alt="image" src="https://github.com/user-attachments/assets/c0845071-08d3-45c5-a2c8-ebe5fe106f7e" />
