### PR TITLE
attribute: Correct bary coord function

### DIFF
--- a/src/shader_recompiler/ir/attribute.h
+++ b/src/shader_recompiler/ir/attribute.h
@@ -110,7 +110,8 @@ constexpr bool IsMrt(Attribute attribute) noexcept {
 }
 
 constexpr bool IsBarycentricCoord(Attribute attribute) noexcept {
-    return attribute >= Attribute::BaryCoordSmooth && attribute <= Attribute::BaryCoordSmoothSample;
+    return attribute >= Attribute::BaryCoordNoPersp &&
+           attribute <= Attribute::BaryCoordSmoothSample;
 }
 
 [[nodiscard]] std::string NameOf(Attribute attribute);


### PR DESCRIPTION
This caused nopersp barycentrics to not get correctly remapped