### PR TITLE
liverpool_to_vk: Don't use remapped format for clear value

### DIFF
--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -1009,7 +1009,6 @@ struct Liverpool {
             return RemapSwizzle(info.format, mrt_swizzle);
         }
 
-    private:
         [[nodiscard]] NumberFormat GetFixedNumberFormat() const {
             // There is a small difference between T# and CB number types, account for it.
             return info.number_type == NumberFormat::SnormNz ? NumberFormat::Srgb

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -807,8 +807,8 @@ vk::Format DepthFormat(DepthBuffer::ZFormat z_format, DepthBuffer::StencilFormat
 
 vk::ClearValue ColorBufferClearValue(const AmdGpu::Liverpool::ColorBuffer& color_buffer) {
     const auto comp_swizzle = color_buffer.Swizzle();
-    const auto format = color_buffer.GetDataFmt();
-    const auto number_type = color_buffer.GetNumberFmt();
+    const auto format = color_buffer.info.format.Value();
+    const auto number_type = color_buffer.GetFixedNumberFormat();
 
     const auto& c0 = color_buffer.clear_word0;
     const auto& c1 = color_buffer.clear_word1;


### PR DESCRIPTION
Decoding of clear color value should follow the original format not the remaps

Combined with second commit of https://github.com/shadps4-emu/shadPS4/pull/3252 seems to fix graphical issues reported in https://github.com/shadps4-emu/shadps4-game-compatibility/issues/930