### PR TITLE
Filesystem: Fix create flag handling in open

### DIFF
--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -118,14 +118,16 @@ s32 PS4_SYSV_ABI open(const char* raw_path, s32 flags, u16 mode) {
             return -1;
         }
 
-        if (read_only) {
-            // Can't create files in a read only directory
-            h->DeleteHandle(handle);
-            *__Error() = POSIX_EROFS;
-            return -1;
+        if (!exists) {
+            if (read_only) {
+                // Can't create files in a read only directory
+                h->DeleteHandle(handle);
+                *__Error() = POSIX_EROFS;
+                return -1;
+            }
+            // Create a file if it doesn't exist
+            Common::FS::IOFile out(file->m_host_name, Common::FS::FileAccessMode::Write);
         }
-        // Create a file if it doesn't exist
-        Common::FS::IOFile out(file->m_host_name, Common::FS::FileAccessMode::Write);
     } else if (!exists) {
         // If we're not creating a file, and it doesn't exist, return ENOENT
         h->DeleteHandle(handle);


### PR DESCRIPTION
If the create flag is specified but the file already exists, then the file should open successfully regardless of permissions. This behavior was validated through hardware testing.

This fixes a crash seen in Phantasy Star Online 2 New Genesis (CUSA29813), bringing the game to bootable status (now crashes from libSceHttp stubs).