### PR TITLE
If CONTENT_ID is empty in param.sfo, try using TITLE_ID as fallback

### DIFF
--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -100,8 +100,12 @@ void Emulator::Run(std::filesystem::path file, const std::vector<std::string> ar
 
         const auto content_id = param_sfo->GetString("CONTENT_ID");
         ASSERT_MSG(content_id.has_value(), "Failed to get CONTENT_ID");
-
-        id = std::string(*content_id, 7, 9);
+        const auto title_id = param_sfo->GetString("TITLE_ID");
+        if (!content_id->empty()) {
+            id = std::string(*content_id, 7, 9);
+        } else if (content_id.has_value()) {
+            id = *title_id;
+        }
         title = param_sfo->GetString("TITLE").value_or("Unknown title");
         fw_version = param_sfo->GetInteger("SYSTEM_VER").value_or(0x4700000);
         app_version = param_sfo->GetString("APP_VER").value_or("Unknown version");

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -99,11 +99,10 @@ void Emulator::Run(std::filesystem::path file, const std::vector<std::string> ar
         ASSERT_MSG(param_sfo->Open(param_sfo_path), "Failed to open param.sfo");
 
         const auto content_id = param_sfo->GetString("CONTENT_ID");
-        ASSERT_MSG(content_id.has_value(), "Failed to get CONTENT_ID");
         const auto title_id = param_sfo->GetString("TITLE_ID");
-        if (!content_id->empty()) {
+        if (content_id.has_value() && !content_id->empty()) {
             id = std::string(*content_id, 7, 9);
-        } else if (content_id.has_value()) {
+        } else if (title_id.has_value()) {
             id = *title_id;
         }
         title = param_sfo->GetString("TITLE").value_or("Unknown title");


### PR DESCRIPTION
Honestly I have no idea why CONTENT_ID is used here in the first place, TITLE_ID is literally just the exact same thing except there's no need to use substring
Fixes a crash when trying to open firmware apps whose CONTENT_IDs are empty