### PR TITLE
Initialize the heap API and add new memory functions in HLE LibcInternal

### DIFF
--- a/src/core/libraries/libc_internal/libc_internal_memory.cpp
+++ b/src/core/libraries/libc_internal/libc_internal_memory.cpp
@@ -67,6 +67,14 @@ int PS4_SYSV_ABI internal_posix_memalign(void** ptr, size_t alignment, size_t si
 #endif
 }
 
+void* PS4_SYSV_ABI internal_calloc(size_t num, size_t size) {
+    return std::calloc(num, size);
+}
+
+void* PS4_SYSV_ABI internal_realloc(void* ptr, size_t new_size) {
+    return std::realloc(ptr, new_size);
+}
+
 void RegisterlibSceLibcInternalMemory(Core::Loader::SymbolsResolver* sym) {
 
     LIB_FUNCTION("NFLs+dRJGNg", "libSceLibcInternal", 1, "libSceLibcInternal", 1, 1,

--- a/src/core/libraries/libc_internal/libc_internal_memory.h
+++ b/src/core/libraries/libc_internal/libc_internal_memory.h
@@ -29,5 +29,9 @@ void PS4_SYSV_ABI internal_operator_delete(void* ptr);
 
 int PS4_SYSV_ABI internal_posix_memalign(void** ptr, size_t alignment, size_t size);
 
+void* PS4_SYSV_ABI internal_calloc(size_t num, size_t size);
+
+void* PS4_SYSV_ABI internal_realloc(void* ptr, size_t new_size);
+
 void RegisterlibSceLibcInternalMemory(Core::Loader::SymbolsResolver* sym);
 } // namespace Libraries::LibcInternal

--- a/src/core/libraries/libc_internal/libc_internal_memory.h
+++ b/src/core/libraries/libc_internal/libc_internal_memory.h
@@ -10,5 +10,24 @@ class SymbolsResolver;
 }
 
 namespace Libraries::LibcInternal {
+
+void* PS4_SYSV_ABI internal_memset(void* s, int c, size_t n);
+
+void* PS4_SYSV_ABI internal_memcpy(void* dest, const void* src, size_t n);
+
+s32 PS4_SYSV_ABI internal_memcpy_s(void* dest, size_t destsz, const void* src, size_t count);
+
+s32 PS4_SYSV_ABI internal_memcmp(const void* s1, const void* s2, size_t n);
+
+void* PS4_SYSV_ABI internal_malloc(size_t size);
+
+void PS4_SYSV_ABI internal_free(void* ptr);
+
+void* PS4_SYSV_ABI internal_operator_new(size_t size);
+
+void PS4_SYSV_ABI internal_operator_delete(void* ptr);
+
+int PS4_SYSV_ABI internal_posix_memalign(void** ptr, size_t alignment, size_t size);
+
 void RegisterlibSceLibcInternalMemory(Core::Loader::SymbolsResolver* sym);
 } // namespace Libraries::LibcInternal

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -15,6 +15,7 @@
 #include "core/devtools/widget/module_list.h"
 #include "core/libraries/kernel/memory.h"
 #include "core/libraries/kernel/threads.h"
+#include "core/libraries/libc_internal/libc_internal_memory.h"
 #include "core/linker.h"
 #include "core/memory.h"
 #include "core/tls.h"
@@ -50,12 +51,12 @@ static PS4_SYSV_ABI void* RunMainEntry [[noreturn]] (EntryParams* params) {
 #endif
 
 Linker::Linker()
-    : memory{Memory::Instance()}, heap_api{new HeapAPI{.heap_malloc = &std::malloc,
-                                                       .heap_free = &std::free,
-                                                       .heap_calloc = &std::calloc,
-                                                       .heap_realloc = &std::realloc,
+    : memory{Memory::Instance()}, heap_api{new HeapAPI{.heap_malloc = &Libraries::LibcInternal::internal_malloc,
+                                                       .heap_free = &Libraries::LibcInternal::internal_free,
+                                                       .heap_calloc = &Libraries::LibcInternal::internal_calloc,
+                                                       .heap_realloc = &Libraries::LibcInternal::internal_realloc,
                                                        .heap_memalign = nullptr,
-                                                       .heap_posix_memalign = nullptr,
+                                                       .heap_posix_memalign = Libraries::LibcInternal::internal_posix_memalign,
                                                        .heap_reallocalign = nullptr,
                                                        .heap_malloc_stats = nullptr,
                                                        .heap_malloc_usable_size = nullptr}} {}

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -49,7 +49,16 @@ static PS4_SYSV_ABI void* RunMainEntry [[noreturn]] (EntryParams* params) {
 }
 #endif
 
-Linker::Linker() : memory{Memory::Instance()} {}
+Linker::Linker()
+    : memory{Memory::Instance()}, heap_api{new HeapAPI{.heap_malloc = &std::malloc,
+                                                       .heap_free = &std::free,
+                                                       .heap_calloc = &std::calloc,
+                                                       .heap_realloc = &std::realloc,
+                                                       .heap_memalign = nullptr,
+                                                       .heap_posix_memalign = nullptr,
+                                                       .heap_reallocalign = nullptr,
+                                                       .heap_malloc_stats = nullptr,
+                                                       .heap_malloc_usable_size = nullptr}} {}
 
 Linker::~Linker() = default;
 

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -51,15 +51,16 @@ static PS4_SYSV_ABI void* RunMainEntry [[noreturn]] (EntryParams* params) {
 #endif
 
 Linker::Linker()
-    : memory{Memory::Instance()}, heap_api{new HeapAPI{.heap_malloc = &Libraries::LibcInternal::internal_malloc,
-                                                       .heap_free = &Libraries::LibcInternal::internal_free,
-                                                       .heap_calloc = &Libraries::LibcInternal::internal_calloc,
-                                                       .heap_realloc = &Libraries::LibcInternal::internal_realloc,
-                                                       .heap_memalign = nullptr,
-                                                       .heap_posix_memalign = Libraries::LibcInternal::internal_posix_memalign,
-                                                       .heap_reallocalign = nullptr,
-                                                       .heap_malloc_stats = nullptr,
-                                                       .heap_malloc_usable_size = nullptr}} {}
+    : memory{Memory::Instance()},
+      heap_api{new HeapAPI{.heap_malloc = &Libraries::LibcInternal::internal_malloc,
+                           .heap_free = &Libraries::LibcInternal::internal_free,
+                           .heap_calloc = &Libraries::LibcInternal::internal_calloc,
+                           .heap_realloc = &Libraries::LibcInternal::internal_realloc,
+                           .heap_memalign = nullptr,
+                           .heap_posix_memalign = Libraries::LibcInternal::internal_posix_memalign,
+                           .heap_reallocalign = nullptr,
+                           .heap_malloc_stats = nullptr,
+                           .heap_malloc_usable_size = nullptr}} {}
 
 Linker::~Linker() = default;
 


### PR DESCRIPTION
Applications that do not use their own libc.prx and instead rely on libSceLibcInternal will not initialize this, and will crash on the first call of any of these functions. This PR initializes the heap API so there's at least something for these apps to work with. I tested it with NPXS20001, and it seems to work, by comparing its behaviour to when I put a libc.prx from one of my games to its sce_module folder. However, since I'm not too knowledgeable on this topic, I'll open it as a draft for now.