### PR TITLE
vk_rasterizer: Improve stencil clears

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -1211,11 +1211,13 @@ void Rasterizer::UpdateDepthStencilState() const {
         } : front_ops;
         dynamic_state.SetStencilOps(front_ops, back_ops);
 
+        const bool stencil_clear = regs.depth_render_control.stencil_clear_enable;
         const auto front = regs.stencil_ref_front;
         const auto back =
             regs.depth_control.backface_enable ? regs.stencil_ref_back : regs.stencil_ref_front;
         dynamic_state.SetStencilReferences(front.stencil_test_val, back.stencil_test_val);
-        dynamic_state.SetStencilWriteMasks(front.stencil_write_mask, back.stencil_write_mask);
+        dynamic_state.SetStencilWriteMasks(!stencil_clear ? front.stencil_write_mask.Value() : 0U,
+                                           !stencil_clear ? back.stencil_write_mask.Value() : 0U);
         dynamic_state.SetStencilCompareMasks(front.stencil_mask, back.stencil_mask);
     }
 }


### PR DESCRIPTION
When stencil fast clear is enabled, mask out any stencil writes from the draw itself as the clear takes priority. This has been done for a while now for depth but not for stencil, which resulted in stencil being cleared to wrong values in certain cases, depending if ref value set matched the clear value in registers.

Fixes the title screen sky in Persona 5 Strikers.

| main | PR |
| ------------- | ------------- |
| <img width="1282" height="719" alt="Screenshot_20250718_154840" src="https://github.com/user-attachments/assets/cb57e2f8-3ec1-4715-b04e-d5c366477518" /> | <img width="1282" height="721" alt="Screenshot_20250717_202321" src="https://github.com/user-attachments/assets/cc129adf-40d6-49c5-a45c-a55abdc0b09e" /> |