### PR TITLE
Implement sceAudioOutGetLastOutputTime

### DIFF
--- a/src/core/libraries/audio/audioout.cpp
+++ b/src/core/libraries/audio/audioout.cpp
@@ -171,7 +171,16 @@ int PS4_SYSV_ABI sceAudioOutGetInfoOpenNum() {
 
 int PS4_SYSV_ABI sceAudioOutGetLastOutputTime(s32 handle, u64* output_time) {
     LOG_DEBUG(Lib_AudioOut, "called");
+    if (!output_time) {
+        return ORBIS_AUDIO_OUT_ERROR_INVALID_POINTER;
+    }
+    if (handle >= ports_out.size()) {
+        return ORBIS_AUDIO_OUT_ERROR_INVALID_PORT;
+    }
     auto& port = ports_out.at(handle - 1);
+    if (!port.IsOpen()) {
+        return ORBIS_AUDIO_OUT_ERROR_NOT_OPENED;
+    }
     *output_time = port.last_output_time;
     return ORBIS_OK;
 }

--- a/src/core/libraries/audio/audioout.cpp
+++ b/src/core/libraries/audio/audioout.cpp
@@ -170,7 +170,7 @@ int PS4_SYSV_ABI sceAudioOutGetInfoOpenNum() {
 }
 
 int PS4_SYSV_ABI sceAudioOutGetLastOutputTime(s32 handle, u64* output_time) {
-    LOG_DEBUG(Lib_AudioOut, "called");
+    LOG_DEBUG(Lib_AudioOut, "called, handle: {}, output time: {}", handle, fmt::ptr(output_time));
     if (!output_time) {
         return ORBIS_AUDIO_OUT_ERROR_INVALID_POINTER;
     }

--- a/src/core/libraries/audio/audioout.cpp
+++ b/src/core/libraries/audio/audioout.cpp
@@ -14,6 +14,7 @@
 #include "core/libraries/audio/audioout.h"
 #include "core/libraries/audio/audioout_backend.h"
 #include "core/libraries/audio/audioout_error.h"
+#include "core/libraries/kernel/time.h"
 #include "core/libraries/libs.h"
 
 namespace Libraries::AudioOut {
@@ -168,8 +169,10 @@ int PS4_SYSV_ABI sceAudioOutGetInfoOpenNum() {
     return ORBIS_OK;
 }
 
-int PS4_SYSV_ABI sceAudioOutGetLastOutputTime() {
-    LOG_ERROR(Lib_AudioOut, "(STUBBED) called");
+int PS4_SYSV_ABI sceAudioOutGetLastOutputTime(s32 handle, u64* output_time) {
+    LOG_DEBUG(Lib_AudioOut, "called");
+    auto& port = ports_out.at(handle - 1);
+    *output_time = port.last_output_time;
     return ORBIS_OK;
 }
 
@@ -396,6 +399,7 @@ s32 PS4_SYSV_ABI sceAudioOutOutput(s32 handle, void* ptr) {
         if (ptr != nullptr && port.IsOpen()) {
             std::memcpy(port.output_buffer, ptr, port.BufferSize());
             port.output_ready = true;
+            port.last_output_time = Kernel::sceKernelGetProcessTime();
         }
     }
     port.output_cv.notify_one();

--- a/src/core/libraries/audio/audioout.h
+++ b/src/core/libraries/audio/audioout.h
@@ -96,6 +96,7 @@ struct PortOut {
     AudioFormatInfo format_info;
     u32 sample_rate;
     u32 buffer_frames;
+    u64 last_output_time;
     std::array<s32, 8> volume;
 
     [[nodiscard]] bool IsOpen() const {
@@ -127,7 +128,7 @@ int PS4_SYSV_ABI sceAudioOutGetFocusEnablePid();
 int PS4_SYSV_ABI sceAudioOutGetHandleStatusInfo();
 int PS4_SYSV_ABI sceAudioOutGetInfo();
 int PS4_SYSV_ABI sceAudioOutGetInfoOpenNum();
-int PS4_SYSV_ABI sceAudioOutGetLastOutputTime();
+int PS4_SYSV_ABI sceAudioOutGetLastOutputTime(s32 handle, u64* output_time);
 int PS4_SYSV_ABI sceAudioOutGetPortState(s32 handle, OrbisAudioOutPortState* state);
 int PS4_SYSV_ABI sceAudioOutGetSimulatedBusUsableStatusByBusType();
 int PS4_SYSV_ABI sceAudioOutGetSimulatedHandleStatusInfo();


### PR DESCRIPTION
Implements the titular function seen in https://github.com/shadps4-compatibility/shadps4-game-compatibility/issues/1322 (CUSA04408 - Middle-earth™: Shadow of War™). This is not the source of the hang in the game, and the spam is only a side effect of the fact that the game hangs, while the audio thread doesn't, but since it does look to be working fine I thought I'd PR it anyway.