### PR TITLE
Small typo fix for avplayer assert

### DIFF
--- a/src/core/libraries/avplayer/avplayer_source.h
+++ b/src/core/libraries/avplayer/avplayer_source.h
@@ -40,7 +40,7 @@ public:
     FrameBuffer(const SceAvPlayerMemAllocator& memory_replacement, u32 align, u32 size) noexcept
         : m_memory_replacement(memory_replacement),
           m_data(Allocate(memory_replacement, align, size)) {
-        ASSERT_MSG(m_data, "Could not allocated frame buffer.");
+        ASSERT_MSG(m_data, "Could not allocate frame buffer.");
     }
 
     ~FrameBuffer() {


### PR DESCRIPTION
Found that this assert message was typoed when running Knack 2 through a debugger.