### PR TITLE
Make remote link verification for disabling the autoupdater case-independent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,7 +214,8 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/common/scm_rev.cpp.in" "${CMAKE_
 
 message("-- end git things, remote: ${GIT_REMOTE_NAME}, branch: ${GIT_BRANCH}, link: ${GIT_REMOTE_URL}")
 
-if(NOT GIT_REMOTE_URL MATCHES "shadps4-emu/shadPS4" OR NOT GIT_BRANCH STREQUAL "main")
+string(TOLOWER "${GIT_REMOTE_URL}" GIT_REMOTE_URL_LOWER)
+if(NOT GIT_REMOTE_URL_LOWER MATCHES "shadps4-emu/shadps4" OR NOT GIT_BRANCH STREQUAL "main")
     message(STATUS "not main, disabling auto update")
     set(ENABLE_UPDATER OFF)
 endif()


### PR DESCRIPTION
This fixes an issue that only me and no one else in the entire world has, my remote link is https://github.com/shadps4-emu/shadps4 instead of https://github.com/shadps4-emu/shadPS4 which apparently failed this check