### PR TITLE
control_flow_graph: Treat empty conditional branch as noop

### DIFF
--- a/src/shader_recompiler/frontend/control_flow_graph.cpp
+++ b/src/shader_recompiler/frontend/control_flow_graph.cpp
@@ -141,8 +141,10 @@ void CFG::EmitLabels() {
         } else if (inst.IsConditionalBranch()) {
             const u32 true_label = inst.BranchTarget(pc);
             const u32 false_label = pc + inst.length;
-            AddLabel(true_label);
-            AddLabel(false_label);
+            if (true_label != false_label) {
+                AddLabel(true_label);
+                AddLabel(false_label);
+            }
         } else if (inst.opcode == Opcode::S_ENDPGM) {
             const u32 next_label = pc + inst.length;
             AddLabel(next_label);


### PR DESCRIPTION
This fixes the motion blur in Driveclub (CUSA00093)

In the offending shader the AMD compiler appears to have had a derp moment and emitted an empty branch. It wants to check if s28 <= v5, but instead of doing it directly, it checks s28 > v5, does an empty branch, reverses the condition and then does the actual branch. This confuses the structurization passes (not exactly sure yet though) and causes the branch to be s28 > v5. Avoid this by not ending a block on such no-op branches, so the reversing of condition is also part of the branch

```
v_cmp_gt_f32    vcc, s28, v5
s_and_saveexec_b64 s[24:25], vcc
s_cbranch_execz .L596_0
.L596_0:
s_andn2_b64     exec, s[24:25], exec
s_cbranch_execz .L1048_0
```