### PR TITLE
Core: Only update configs when using a different build.

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -107,8 +107,8 @@ u32 m_language = 1; // english
 // Keys
 static std::string trophyKey = "";
 
-// Expected number of items in the config file
-static constexpr u64 total_entries = 55;
+// Config version, used to determine if a user's config file is outdated.
+static constexpr u64 config_version = 1;
 
 int getVolumeSlider() {
     return volumeSlider;
@@ -623,8 +623,6 @@ void load(const std::filesystem::path& path) {
         return;
     }
 
-    u64 entry_count = 0;
-
     if (data.contains("General")) {
         const toml::value& general = data.at("General");
 
@@ -646,8 +644,6 @@ void load(const std::filesystem::path& path) {
         checkCompatibilityOnStartup = toml::find_or<bool>(general, "checkCompatibilityOnStartup",
                                                           checkCompatibilityOnStartup);
         chooseHomeTab = toml::find_or<std::string>(general, "chooseHomeTab", chooseHomeTab);
-
-        entry_count += general.size();
     }
 
     if (data.contains("Input")) {
@@ -662,8 +658,6 @@ void load(const std::filesystem::path& path) {
         useUnifiedInputConfig =
             toml::find_or<bool>(input, "useUnifiedInputConfig", useUnifiedInputConfig);
         micDevice = toml::find_or<std::string>(input, "micDevice", micDevice);
-
-        entry_count += input.size();
     }
 
     if (data.contains("GPU")) {
@@ -687,8 +681,6 @@ void load(const std::filesystem::path& path) {
         isFullscreen = toml::find_or<bool>(gpu, "Fullscreen", isFullscreen);
         fullscreenMode = toml::find_or<std::string>(gpu, "FullscreenMode", fullscreenMode);
         isHDRAllowed = toml::find_or<bool>(gpu, "allowHDR", isHDRAllowed);
-
-        entry_count += gpu.size();
     }
 
     if (data.contains("Vulkan")) {
@@ -702,10 +694,9 @@ void load(const std::filesystem::path& path) {
         vkHostMarkers = toml::find_or<bool>(vk, "hostMarkers", vkHostMarkers);
         vkGuestMarkers = toml::find_or<bool>(vk, "guestMarkers", vkGuestMarkers);
         rdocEnable = toml::find_or<bool>(vk, "rdocEnable", rdocEnable);
-
-        entry_count += vk.size();
     }
 
+    u32 current_version = 0;
     if (data.contains("Debug")) {
         const toml::value& debug = data.at("Debug");
 
@@ -714,8 +705,7 @@ void load(const std::filesystem::path& path) {
             toml::find_or<bool>(debug, "isSeparateLogFilesEnabled", isSeparateLogFilesEnabled);
         isShaderDebug = toml::find_or<bool>(debug, "CollectShader", isShaderDebug);
         isFpsColor = toml::find_or<bool>(debug, "FPSColor", isFpsColor);
-
-        entry_count += debug.size();
+        current_version = toml::find_or<u32>(debug, "ConfigVersion", current_version);
     }
 
     if (data.contains("GUI")) {
@@ -747,26 +737,20 @@ void load(const std::filesystem::path& path) {
 
         settings_addon_install_dir =
             toml::find_fs_path_or(gui, "addonInstallDir", settings_addon_install_dir);
-
-        entry_count += gui.size();
     }
 
     if (data.contains("Settings")) {
         const toml::value& settings = data.at("Settings");
         m_language = toml::find_or<int>(settings, "consoleLanguage", m_language);
-
-        entry_count += settings.size();
     }
 
     if (data.contains("Keys")) {
         const toml::value& keys = data.at("Keys");
         trophyKey = toml::find_or<std::string>(keys, "TrophyKey", trophyKey);
-
-        entry_count += keys.size();
     }
 
     // Run save after loading to generate any missing fields with default values.
-    if (entry_count != total_entries) {
+    if (config_version != current_version) {
         fmt::print("Outdated config detected, updating config file.\n");
         save(path);
     }
@@ -874,6 +858,7 @@ void save(const std::filesystem::path& path) {
     data["Debug"]["CollectShader"] = isShaderDebug;
     data["Debug"]["isSeparateLogFilesEnabled"] = isSeparateLogFilesEnabled;
     data["Debug"]["FPSColor"] = isFpsColor;
+    data["Debug"]["ConfigVersion"] = config_version;
     data["Keys"]["TrophyKey"] = trophyKey;
 
     std::vector<std::string> install_dirs;

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -108,7 +108,7 @@ u32 m_language = 1; // english
 static std::string trophyKey = "";
 
 // Config version, used to determine if a user's config file is outdated.
-static constexpr u64 config_version = 1;
+static std::string config_version = Common::g_scm_rev;
 
 int getVolumeSlider() {
     return volumeSlider;
@@ -696,7 +696,7 @@ void load(const std::filesystem::path& path) {
         rdocEnable = toml::find_or<bool>(vk, "rdocEnable", rdocEnable);
     }
 
-    u32 current_version = 0;
+    std::string current_version = {};
     if (data.contains("Debug")) {
         const toml::value& debug = data.at("Debug");
 
@@ -705,7 +705,7 @@ void load(const std::filesystem::path& path) {
             toml::find_or<bool>(debug, "isSeparateLogFilesEnabled", isSeparateLogFilesEnabled);
         isShaderDebug = toml::find_or<bool>(debug, "CollectShader", isShaderDebug);
         isFpsColor = toml::find_or<bool>(debug, "FPSColor", isFpsColor);
-        current_version = toml::find_or<u32>(debug, "ConfigVersion", current_version);
+        current_version = toml::find_or<std::string>(debug, "ConfigVersion", current_version);
     }
 
     if (data.contains("GUI")) {


### PR DESCRIPTION
This PR adds the currently used emulator revision to the config file, and if there's a mismatch between the current revision and the stored revision, a config update will be triggered.

Using this logic addresses the issue where configs with additional entries would trigger a config update on each emulator boot, and removes the requirement for PR authors to increment a constant every time they add a new config entry.

Outside of rewriting config logic to check for the existance of each individual option, I don't see a better solution at this time. I'm also still opting not to clear old/unused config entries, since doing so could interfere with some people's PR/fork testing, though it comes with the downside of cluttering the config file.