### PR TITLE
shader_recompiler: Use VM bit for conditional discard

### DIFF
--- a/src/shader_recompiler/frontend/control_flow_graph.cpp
+++ b/src/shader_recompiler/frontend/control_flow_graph.cpp
@@ -319,8 +319,6 @@ void CFG::LinkBlocks() {
         // need to link with the next block.
         if (!end_inst.IsTerminateInstruction()) {
             auto* next_block = get_block(block.end);
-            ++next_block->num_predecessors;
-
             block.branch_true = next_block;
             block.end_class = EndClass::Branch;
             continue;
@@ -343,17 +341,11 @@ void CFG::LinkBlocks() {
 
         if (end_inst.IsUnconditionalBranch()) {
             auto* target_block = get_block(target_pc);
-            ++target_block->num_predecessors;
-
             block.branch_true = target_block;
             block.end_class = EndClass::Branch;
         } else if (end_inst.IsConditionalBranch()) {
             auto* target_block = get_block(target_pc);
-            ++target_block->num_predecessors;
-
             auto* end_block = get_block(block.end);
-            ++end_block->num_predecessors;
-
             block.branch_true = target_block;
             block.branch_false = end_block;
             block.end_class = EndClass::Branch;

--- a/src/shader_recompiler/frontend/control_flow_graph.h
+++ b/src/shader_recompiler/frontend/control_flow_graph.h
@@ -38,7 +38,6 @@ struct Block : Hook {
     u32 end;
     u32 begin_index;
     u32 end_index;
-    u32 num_predecessors{};
     IR::Condition cond{};
     GcnInst end_inst{};
     EndClass end_class{};

--- a/src/shader_recompiler/frontend/structured_control_flow.cpp
+++ b/src/shader_recompiler/frontend/structured_control_flow.cpp
@@ -635,7 +635,6 @@ private:
             case StatementType::Code: {
                 ensure_block();
                 if (!stmt.block->is_dummy) {
-                    current_block->has_multiple_predecessors = stmt.block->num_predecessors > 1;
                     const u32 start = stmt.block->begin_index;
                     const u32 size = stmt.block->end_index - start + 1;
                     translator.Translate(current_block, stmt.block->begin,

--- a/src/shader_recompiler/frontend/translate/export.cpp
+++ b/src/shader_recompiler/frontend/translate/export.cpp
@@ -133,7 +133,7 @@ void Translator::ExportUncompressed(IR::Attribute attribute, u32 comp, const IR:
 }
 
 void Translator::EmitExport(const GcnInst& inst) {
-    if (ir.block->has_multiple_predecessors && info.stage == Stage::Fragment) {
+    if (info.stage == Stage::Fragment && inst.control.exp.vm) {
         ir.Discard(ir.LogicalNot(ir.GetExec()));
     }
 

--- a/src/shader_recompiler/ir/basic_block.h
+++ b/src/shader_recompiler/ir/basic_block.h
@@ -150,8 +150,6 @@ public:
     std::array<Value, NumScalarRegs> ssa_sbit_values;
     std::array<Value, NumVectorRegs> ssa_vreg_values;
 
-    bool has_multiple_predecessors{false};
-
 private:
     /// Memory pool for instruction list
     Common::ObjectPool<Inst>* inst_pool;


### PR DESCRIPTION
Shader export instructions have 2 special bits, the DONE bit is set for the last export instruction in the shader and can be safely ignored. The VM bit is also set on a single export and makes that export responsible for informing the color buffer which pixels are valid and which have been discarded. So use that to insert the conditional discard instead of guessing from the number of predecessors.

This fixes the blocky shadows in Driveclub, the fragment shader used for rendering tree shadows read the alpha value from the texture and did a conditional discard based on it. But because there was no control flow, the predecessor check failed, resulting in the whole shader being eliminated as dead code.