### PR TITLE
Return the number of samples enqueued in AudioOut

### DIFF
--- a/src/core/libraries/audio/audioout.cpp
+++ b/src/core/libraries/audio/audioout.cpp
@@ -398,6 +398,7 @@ s32 PS4_SYSV_ABI sceAudioOutOutput(s32 handle, void* ptr) {
         return ORBIS_AUDIO_OUT_ERROR_INVALID_PORT;
     }
 
+    auto samples_sent = 0;
     auto& port = ports_out.at(handle - 1);
     {
         std::unique_lock lock{port.mutex};
@@ -409,10 +410,11 @@ s32 PS4_SYSV_ABI sceAudioOutOutput(s32 handle, void* ptr) {
             std::memcpy(port.output_buffer, ptr, port.BufferSize());
             port.output_ready = true;
             port.last_output_time = Kernel::sceKernelGetProcessTime();
+            samples_sent = port.buffer_frames * port.format_info.num_channels;
         }
     }
     port.output_cv.notify_one();
-    return ORBIS_OK;
+    return samples_sent;
 }
 
 int PS4_SYSV_ABI sceAudioOutOutputs(OrbisAudioOutOutputParam* param, u32 num) {


### PR DESCRIPTION
Another one for Agents of Mayhem CUSA03067. The game calls sceAudioOutOutput and checks if the result is larger than 0, meaning that the audio data has been properly enqueued. If it is zero (as it was before), the game deliberately crashes 🐸  RE suggests that it returns the number of samples provided.