### PR TITLE
texture_cache: Do not modify mip height for copy in volume texture.

### DIFF
--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -619,8 +619,10 @@ void TextureCache::RefreshImage(Image& image, Vulkan::Scheduler* custom_schedule
 
         const u32 extent_width = mip_pitch ? std::min(mip_pitch, width) : width;
         const u32 extent_height = mip_height ? std::min(mip_height, height) : height;
-        const u32 height_aligned =
-            mip_height && image.info.IsTiled() ? std::max(mip_height, 8U) : mip_height;
+        const bool is_volume = image.info.tiling_mode == AmdGpu::TilingMode::Texture_Volume;
+        const u32 height_aligned = mip_height && image.info.IsTiled() && !is_volume
+                                       ? std::max(mip_height, 8U)
+                                       : mip_height;
 
         image_copy.push_back({
             .bufferOffset = mip_offset,


### PR DESCRIPTION
As noted with TLG in https://github.com/shadps4-emu/shadPS4/pull/3261, the change to `mip_height` when refreshing textures may not be aligned correctly for volume textures. It seems this was fixed for TLG by using `max(mip_height, 8)` instead of aligning, but this is still an issue for at least Sakura Wars.

For now at least, excluding volume textures from this alignment.