### PR TITLE
Fix incorrect base orientation due to incorrect initialization

### DIFF
--- a/src/core/libraries/pad/pad.cpp
+++ b/src/core/libraries/pad/pad.cpp
@@ -272,7 +272,8 @@ int PS4_SYSV_ABI scePadOpen(s32 userId, s32 type, s32 index, const OrbisPadOpenP
     }
     LOG_INFO(Lib_Pad, "(DUMMY) called user_id = {} type = {} index = {}", userId, type, index);
     g_opened = true;
-    scePadResetLightBar(1);
+    scePadResetLightBar(userId);
+    scePadResetOrientation(userId);
     return 1; // dummy
 }
 


### PR DESCRIPTION
Fixes driving with motion controls in Driveclub, among other things, by setting the current orientation of the controller as the default base orientation when scePadOpen is called.