### PR TITLE
fix patches - Different AppVer

### DIFF
--- a/src/common/memory_patcher.cpp
+++ b/src/common/memory_patcher.cpp
@@ -276,7 +276,7 @@ void OnGameLoaded() {
                             isEnabled = (attr.value().toString() == "true");
                         }
                     }
-                    if (appVer != app_version)
+                    if (appVer.toStdString() != app_version)
                         isEnabled = false;
                 } else if (xmlReader.name() == QStringLiteral("PatchList")) {
                     QJsonArray linesArray;

--- a/src/qt_gui/cheats_patches.cpp
+++ b/src/qt_gui/cheats_patches.cpp
@@ -378,14 +378,12 @@ void CheatsPatches::onSaveButtonClicked() {
     xmlWriter.writeStartDocument();
 
     QXmlStreamReader xmlReader(xmlData);
-    bool insideMetadata = false;
 
     while (!xmlReader.atEnd()) {
         xmlReader.readNext();
 
         if (xmlReader.isStartElement()) {
             if (xmlReader.name() == QStringLiteral("Metadata")) {
-                insideMetadata = true;
                 xmlWriter.writeStartElement(xmlReader.name().toString());
 
                 QString name = xmlReader.attributes().value("Name").toString();
@@ -432,9 +430,6 @@ void CheatsPatches::onSaveButtonClicked() {
                 }
             }
         } else if (xmlReader.isEndElement()) {
-            if (xmlReader.name() == QStringLiteral("Metadata")) {
-                insideMetadata = false;
-            }
             xmlWriter.writeEndElement();
         } else if (xmlReader.isCharacters() && !xmlReader.isWhitespace()) {
             xmlWriter.writeCharacters(xmlReader.text().toString());


### PR DESCRIPTION
This fixes the issue where patches from other enabled AppVers were being applied even when they were from different versions.
