### PR TITLE
controller select crash fix + minor changes

### DIFF
--- a/src/imgui/renderer/imgui_impl_sdl3.cpp
+++ b/src/imgui/renderer/imgui_impl_sdl3.cpp
@@ -9,6 +9,7 @@
 #include "core/memory.h"
 #include "imgui_impl_sdl3.h"
 #include "input/controller.h"
+#include "sdl_window.h"
 
 // SDL
 #include <SDL3/SDL.h>
@@ -502,6 +503,9 @@ bool ProcessEvent(const SDL_Event* event) {
         bd->want_update_gamepads_list = true;
         return true;
     }
+    case SDL_EVENT_CHANGE_CONTROLLER:
+        bd->want_update_gamepads_list = true;
+        return false;
     }
     return false;
 }

--- a/src/imgui/renderer/imgui_impl_sdl3.cpp
+++ b/src/imgui/renderer/imgui_impl_sdl3.cpp
@@ -732,18 +732,15 @@ static void UpdateGamepads() {
     ImGuiIO& io = ImGui::GetIO();
     SdlData* bd = GetBackendData();
 
-    auto memory = Core::Memory::Instance();
     auto controller = Common::Singleton<Input::GameController>::Instance();
     auto engine = controller->GetEngine();
     SDL_Gamepad* SDLGamepad = engine->m_gamepad;
-
-    if (SDLGamepad) {
-        bd->gamepads.push_back(SDLGamepad);
-        bd->want_update_gamepads_list = false;
-    } else {
-        // Update list of gamepads to use
-        if (bd->want_update_gamepads_list &&
-            bd->gamepad_mode != ImGui_ImplSDL3_GamepadMode_Manual) {
+    // Update list of gamepads to use
+    if (bd->want_update_gamepads_list && bd->gamepad_mode != ImGui_ImplSDL3_GamepadMode_Manual) {
+        if (SDLGamepad) {
+            bd->gamepads.push_back(SDLGamepad);
+            bd->want_update_gamepads_list = false;
+        } else {
             CloseGamepads();
             int sdl_gamepads_count = 0;
             const SDL_JoystickID* sdl_gamepads = SDL_GetGamepads(&sdl_gamepads_count);

--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -685,7 +685,6 @@ void ControlSettings::CheckGamePad() {
         gamepad = nullptr;
     }
 
-    SDL_free(gamepads);
     gamepads = SDL_GetGamepads(&gamepad_count);
 
     if (!gamepads) {
@@ -974,6 +973,11 @@ void ControlSettings::processSDLEvents(int Type, int Input, int Value) {
             }
         }
     }
+
+    if (Type == SDL_EVENT_GAMEPAD_ADDED || SDL_EVENT_GAMEPAD_REMOVED) {
+        ui->ActiveGamepadBox->clear();
+        CheckGamePad();
+    }
 }
 
 void ControlSettings::pollSDLEvents() {
@@ -986,11 +990,6 @@ void ControlSettings::pollSDLEvents() {
 
         if (event.type == SDL_EVENT_QUIT) {
             return;
-        }
-
-        if (event.type == SDL_EVENT_GAMEPAD_ADDED) {
-            ui->ActiveGamepadBox->clear();
-            CheckGamePad();
         }
 
         SdlEventWrapper::Wrapper::GetInstance()->Wrapper::ProcessEvent(&event);

--- a/src/qt_gui/control_settings.ui
+++ b/src/qt_gui/control_settings.ui
@@ -253,34 +253,6 @@
             </property>
             <layout class="QHBoxLayout" name="horizontalLayout_13">
              <item>
-              <widget class="QGroupBox" name="gb_l2">
-               <property name="title">
-                <string>L2</string>
-               </property>
-               <layout class="QVBoxLayout" name="gb_l2_layout">
-                <property name="leftMargin">
-                 <number>5</number>
-                </property>
-                <property name="topMargin">
-                 <number>5</number>
-                </property>
-                <property name="rightMargin">
-                 <number>5</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>5</number>
-                </property>
-                <item>
-                 <widget class="QPushButton" name="L2Button">
-                  <property name="text">
-                   <string>unmapped</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
               <widget class="QGroupBox" name="gb_l1">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -306,6 +278,34 @@
                 </property>
                 <item>
                  <widget class="QPushButton" name="L1Button">
+                  <property name="text">
+                   <string>unmapped</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QGroupBox" name="gb_l2">
+               <property name="title">
+                <string>L2</string>
+               </property>
+               <layout class="QVBoxLayout" name="gb_l2_layout">
+                <property name="leftMargin">
+                 <number>5</number>
+                </property>
+                <property name="topMargin">
+                 <number>5</number>
+                </property>
+                <property name="rightMargin">
+                 <number>5</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>5</number>
+                </property>
+                <item>
+                 <widget class="QPushButton" name="L2Button">
                   <property name="text">
                    <string>unmapped</string>
                   </property>
@@ -1343,34 +1343,6 @@
             </property>
             <layout class="QHBoxLayout" name="horizontalLayout_14">
              <item>
-              <widget class="QGroupBox" name="gb_r2">
-               <property name="title">
-                <string>R2</string>
-               </property>
-               <layout class="QVBoxLayout" name="gb_r2_layout">
-                <property name="leftMargin">
-                 <number>5</number>
-                </property>
-                <property name="topMargin">
-                 <number>5</number>
-                </property>
-                <property name="rightMargin">
-                 <number>5</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>5</number>
-                </property>
-                <item>
-                 <widget class="QPushButton" name="R2Button">
-                  <property name="text">
-                   <string>unmapped</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
               <widget class="QGroupBox" name="gb_r1">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -1396,6 +1368,34 @@
                 </property>
                 <item>
                  <widget class="QPushButton" name="R1Button">
+                  <property name="text">
+                   <string>unmapped</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QGroupBox" name="gb_r2">
+               <property name="title">
+                <string>R2</string>
+               </property>
+               <layout class="QVBoxLayout" name="gb_r2_layout">
+                <property name="leftMargin">
+                 <number>5</number>
+                </property>
+                <property name="topMargin">
+                 <number>5</number>
+                </property>
+                <property name="rightMargin">
+                 <number>5</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>5</number>
+                </property>
+                <item>
+                 <widget class="QPushButton" name="R2Button">
                   <property name="text">
                    <string>unmapped</string>
                   </property>

--- a/src/qt_gui/sdl_event_wrapper.cpp
+++ b/src/qt_gui/sdl_event_wrapper.cpp
@@ -24,8 +24,10 @@ bool Wrapper::ProcessEvent(SDL_Event* event) {
     case SDL_EVENT_WINDOW_EXPOSED:
         return false;
     case SDL_EVENT_GAMEPAD_ADDED:
+        emit SDLEvent(SDL_EVENT_GAMEPAD_ADDED, 0, 0);
         return false;
     case SDL_EVENT_GAMEPAD_REMOVED:
+        emit SDLEvent(SDL_EVENT_GAMEPAD_REMOVED, 0, 0);
         return false;
     case SDL_EVENT_QUIT:
         emit SDLEvent(SDL_EVENT_QUIT, 0, 0);


### PR DESCRIPTION
Fixes constructor crash and imgui mistake causing some performance degradation

Also fixes detection of gamepad added/removed, and puts L1/R1 to the left or L2/R2 in the gui

