### PR TITLE
Qt: remapping Guis - more minor fixes

### DIFF
--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -859,61 +859,66 @@ bool ControlSettings::eventFilter(QObject* obj, QEvent* event) {
 
 void ControlSettings::processSDLEvents(int Type, int Input, int Value) {
     if (EnableButtonMapping) {
+
+        if (pressedButtons.size() >= 3) {
+            return;
+        }
+
         if (Type == SDL_EVENT_GAMEPAD_BUTTON_DOWN) {
             switch (Input) {
             case SDL_GAMEPAD_BUTTON_SOUTH:
-                pressedButtons.insert("cross");
+                pressedButtons.insert(5, "cross");
                 break;
             case SDL_GAMEPAD_BUTTON_EAST:
-                pressedButtons.insert("circle");
+                pressedButtons.insert(6, "circle");
                 break;
             case SDL_GAMEPAD_BUTTON_NORTH:
-                pressedButtons.insert("triangle");
+                pressedButtons.insert(7, "triangle");
                 break;
             case SDL_GAMEPAD_BUTTON_WEST:
-                pressedButtons.insert("square");
+                pressedButtons.insert(8, "square");
                 break;
             case SDL_GAMEPAD_BUTTON_LEFT_SHOULDER:
-                pressedButtons.insert("l1");
+                pressedButtons.insert(3, "l1");
                 break;
             case SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER:
-                pressedButtons.insert("r1");
+                pressedButtons.insert(4, "r1");
                 break;
             case SDL_GAMEPAD_BUTTON_LEFT_STICK:
-                pressedButtons.insert("l3");
+                pressedButtons.insert(9, "l3");
                 break;
             case SDL_GAMEPAD_BUTTON_RIGHT_STICK:
-                pressedButtons.insert("r3");
+                pressedButtons.insert(10, "r3");
                 break;
             case SDL_GAMEPAD_BUTTON_DPAD_UP:
-                pressedButtons.insert("pad_up");
+                pressedButtons.insert(13, "pad_up");
                 break;
             case SDL_GAMEPAD_BUTTON_DPAD_DOWN:
-                pressedButtons.insert("pad_down");
+                pressedButtons.insert(14, "pad_down");
                 break;
             case SDL_GAMEPAD_BUTTON_DPAD_LEFT:
-                pressedButtons.insert("pad_left");
+                pressedButtons.insert(15, "pad_left");
                 break;
             case SDL_GAMEPAD_BUTTON_DPAD_RIGHT:
-                pressedButtons.insert("pad_right");
+                pressedButtons.insert(16, "pad_right");
                 break;
             case SDL_GAMEPAD_BUTTON_BACK:
-                pressedButtons.insert("back");
+                pressedButtons.insert(11, "back");
                 break;
             case SDL_GAMEPAD_BUTTON_LEFT_PADDLE1:
-                pressedButtons.insert("lpaddle_high");
+                pressedButtons.insert(17, "lpaddle_high");
                 break;
             case SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1:
-                pressedButtons.insert("rpaddle_high");
+                pressedButtons.insert(18, "rpaddle_high");
                 break;
             case SDL_GAMEPAD_BUTTON_LEFT_PADDLE2:
-                pressedButtons.insert("lpaddle_low");
+                pressedButtons.insert(19, "lpaddle_low");
                 break;
             case SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2:
-                pressedButtons.insert("rpaddle_low");
+                pressedButtons.insert(20, "rpaddle_low");
                 break;
             case SDL_GAMEPAD_BUTTON_START:
-                pressedButtons.insert("options");
+                pressedButtons.insert(12, "options");
                 break;
             default:
                 break;
@@ -926,19 +931,19 @@ void ControlSettings::processSDLEvents(int Type, int Input, int Value) {
             switch (Input) {
             case SDL_GAMEPAD_AXIS_LEFT_TRIGGER:
                 if (Value > 16000) {
-                    pressedButtons.insert("l2");
+                    pressedButtons.insert(1, "l2");
                     L2Pressed = true;
                 } else if (Value < 5000) {
-                    if (L2Pressed)
+                    if (L2Pressed && !R2Pressed)
                         emit PushGamepadEvent();
                 }
                 break;
             case SDL_GAMEPAD_AXIS_RIGHT_TRIGGER:
                 if (Value > 16000) {
-                    pressedButtons.insert("r2");
+                    pressedButtons.insert(2, "r2");
                     R2Pressed = true;
                 } else if (Value < 5000) {
-                    if (R2Pressed)
+                    if (R2Pressed && !L2Pressed)
                         emit PushGamepadEvent();
                 }
                 break;

--- a/src/qt_gui/control_settings.h
+++ b/src/qt_gui/control_settings.h
@@ -47,9 +47,10 @@ private:
     void EnableMappingButtons();
     void Cleanup();
 
+    // use QMap instead of QSet to maintain order of inserted strings
+    QMap<int, QString> pressedButtons;
     QList<QPushButton*> ButtonsList;
     QList<QPushButton*> AxisList;
-    QSet<QString> pressedButtons;
 
     std::string RunningGameSerial;
     bool GameRunning;

--- a/src/qt_gui/kbm_gui.cpp
+++ b/src/qt_gui/kbm_gui.cpp
@@ -234,7 +234,7 @@ void KBMSettings::SaveKBMConfig(bool close_on_save) {
 
     lines.push_back("");
 
-    add_mapping(ui->MouseJoystickBox->currentText(), "mouse_to_joystick");
+    lines.push_back("mouse_to_joystick = " + ui->MouseJoystickBox->currentText().toStdString());
     add_mapping(ui->LHalfButton->text(), "leftjoystick_halfmode");
     add_mapping(ui->RHalfButton->text(), "rightjoystick_halfmode");
 


### PR DESCRIPTION
1) fixes saving when mouse to joystick and another mapping are set to "right"
2) Use indexed qmap instead of qset to store controller bindings to enforce a certain order inserting strings for multiple inputs
3) Add the missing restriction to force only maximum 3 input strings for controller