### PR TITLE
video_core: Rework tile manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -925,6 +925,8 @@ set(VIDEO_CORE src/video_core/amdgpu/liverpool.cpp
                src/video_core/amdgpu/pm4_cmds.h
                src/video_core/amdgpu/pm4_opcodes.h
                src/video_core/amdgpu/resource.h
+               src/video_core/amdgpu/tiling.cpp
+               src/video_core/amdgpu/tiling.h
                src/video_core/amdgpu/types.h
                src/video_core/amdgpu/default_context.cpp
                src/video_core/buffer_cache/buffer.cpp

--- a/src/core/devtools/widget/reg_popup.cpp
+++ b/src/core/devtools/widget/reg_popup.cpp
@@ -64,7 +64,7 @@ void RegPopup::DrawColorBuffer(const AmdGpu::Liverpool::ColorBuffer& buffer) {
             "NumSamples()",         buffer.NumSamples(),
             "NumSlices()",          buffer.NumSlices(),
             "GetColorSliceSize()",  buffer.GetColorSliceSize(),
-            "GetTilingMode()",      buffer.GetTilingMode(),
+            "GetTileMode()",        buffer.GetTileMode(),
             "IsTiled()",            buffer.IsTiled(),
             "NumFormat()",          buffer.GetNumberFmt()
         );

--- a/src/shader_recompiler/info.h
+++ b/src/shader_recompiler/info.h
@@ -326,12 +326,12 @@ constexpr AmdGpu::Image ImageResource::GetSharp(const Info& info) const noexcept
     }
     if (!image.Valid()) {
         LOG_DEBUG(Render_Vulkan, "Encountered invalid image sharp");
-        image = is_depth ? AmdGpu::Image::NullDepth() : AmdGpu::Image::Null();
+        image = AmdGpu::Image::Null(is_depth);
     } else if (is_depth) {
         const auto data_fmt = image.GetDataFmt();
         if (data_fmt != AmdGpu::DataFormat::Format16 && data_fmt != AmdGpu::DataFormat::Format32) {
             LOG_DEBUG(Render_Vulkan, "Encountered non-depth image used with depth instruction!");
-            image = AmdGpu::Image::NullDepth();
+            image = AmdGpu::Image::Null(true);
         }
     }
     return image;

--- a/src/shader_recompiler/specialization.h
+++ b/src/shader_recompiler/specialization.h
@@ -6,8 +6,8 @@
 #include <bitset>
 
 #include "common/types.h"
-#include "shader_recompiler/frontend/fetch_shader.h"
 #include "shader_recompiler/backend/bindings.h"
+#include "shader_recompiler/frontend/fetch_shader.h"
 #include "shader_recompiler/info.h"
 
 namespace Shader {

--- a/src/shader_recompiler/specialization.h
+++ b/src/shader_recompiler/specialization.h
@@ -6,7 +6,7 @@
 #include <bitset>
 
 #include "common/types.h"
-#include "frontend/fetch_shader.h"
+#include "shader_recompiler/frontend/fetch_shader.h"
 #include "shader_recompiler/backend/bindings.h"
 #include "shader_recompiler/info.h"
 

--- a/src/video_core/amdgpu/pixel_format.cpp
+++ b/src/video_core/amdgpu/pixel_format.cpp
@@ -178,7 +178,7 @@ static constexpr std::array BITS_PER_BLOCK = {
     64,  // 12 Format16_16_16_16
     96,  // 13 Format32_32_32
     128, // 14 Format32_32_32_32
-    0,   // 15
+    -1,  // 15
     16,  // 16 Format5_6_5
     16,  // 17 Format1_5_5_5
     16,  // 18 Format5_5_5_1
@@ -186,15 +186,15 @@ static constexpr std::array BITS_PER_BLOCK = {
     32,  // 20 Format8_24
     32,  // 21 Format24_8
     64,  // 22 FormatX24_8_32
-    0,   // 23
-    0,   // 24
-    0,   // 25
-    0,   // 26
-    0,   // 27
-    0,   // 28
-    0,   // 29
-    0,   // 30
-    0,   // 31
+    -1,  // 23
+    -1,  // 24
+    -1,  // 25
+    -1,  // 26
+    -1,  // 27
+    -1,  // 28
+    -1,  // 29
+    -1,  // 30
+    -1,  // 31
     16,  // 32 FormatGB_GR
     16,  // 33 FormatBG_RG
     32,  // 34 Format5_9_9_9
@@ -211,6 +211,57 @@ u32 NumBitsPerBlock(DataFormat format) {
     const u32 index = static_cast<u32>(format);
     ASSERT_MSG(index < BITS_PER_BLOCK.size(), "Invalid data format = {}", format);
     return BITS_PER_BLOCK[index];
+}
+
+static constexpr std::array BITS_PER_ELEMENT = {
+    0,   //  0 FormatInvalid
+    8,   //  1 Format8
+    16,  //  2 Format16
+    16,  //  3 Format8_8
+    32,  //  4 Format32
+    32,  //  5 Format16_16
+    32,  //  6 Format10_11_11
+    32,  //  7 Format11_11_10
+    32,  //  8 Format10_10_10_2
+    32,  //  9 Format2_10_10_10
+    32,  // 10 Format8_8_8_8
+    64,  // 11 Format32_32
+    64,  // 12 Format16_16_16_16
+    96,  // 13 Format32_32_32
+    128, // 14 Format32_32_32_32
+    -1,  // 15
+    16,  // 16 Format5_6_5
+    16,  // 17 Format1_5_5_5
+    16,  // 18 Format5_5_5_1
+    16,  // 19 Format4_4_4_4
+    32,  // 20 Format8_24
+    32,  // 21 Format24_8
+    64,  // 22 FormatX24_8_32
+    -1,  // 23
+    -1,  // 24
+    -1,  // 25
+    -1,  // 26
+    -1,  // 27
+    -1,  // 28
+    -1,  // 29
+    -1,  // 30
+    -1,  // 31
+    16,  // 32 FormatGB_GR
+    16,  // 33 FormatBG_RG
+    32,  // 34 Format5_9_9_9
+    4,   // 35 FormatBc1
+    8,   // 36 FormatBc2
+    8,   // 37 FormatBc3
+    4,   // 38 FormatBc4
+    8,   // 39 FormatBc5
+    8,   // 40 FormatBc6
+    8,   // 41 FormatBc7
+};
+
+u32 NumBitsPerElement(DataFormat format) {
+    const u32 index = static_cast<u32>(format);
+    ASSERT_MSG(index < BITS_PER_ELEMENT.size(), "Invalid data format = {}", format);
+    return BITS_PER_ELEMENT[index];
 }
 
 } // namespace AmdGpu

--- a/src/video_core/amdgpu/pixel_format.h
+++ b/src/video_core/amdgpu/pixel_format.h
@@ -85,7 +85,7 @@ enum class NumberClass {
     Uint,
 };
 
-enum class CompSwizzle : u8 {
+enum class CompSwizzle : u32 {
     Zero = 0,
     One = 1,
     Red = 4,
@@ -321,6 +321,7 @@ std::string_view NameOf(NumberFormat fmt);
 
 u32 NumComponents(DataFormat format);
 u32 NumBitsPerBlock(DataFormat format);
+u32 NumBitsPerElement(DataFormat format);
 
 } // namespace AmdGpu
 

--- a/src/video_core/amdgpu/pixel_format.h
+++ b/src/video_core/amdgpu/pixel_format.h
@@ -313,7 +313,11 @@ constexpr NumberClass GetNumberClass(const NumberFormat nfmt) {
 }
 
 constexpr bool IsInteger(const NumberFormat nfmt) {
-    return nfmt == AmdGpu::NumberFormat::Sint || nfmt == AmdGpu::NumberFormat::Uint;
+    return nfmt == NumberFormat::Sint || nfmt == NumberFormat::Uint;
+}
+
+constexpr bool IsBlockCoded(DataFormat format) {
+    return format >= DataFormat::FormatBc1 && format <= DataFormat::FormatBc7;
 }
 
 std::string_view NameOf(DataFormat fmt);

--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -276,7 +276,8 @@ struct Image {
     }
 
     bool IsTiled() const {
-        return tiling_index != TileMode::DisplayLinearAligned && tiling_index != TileMode::DisplayLinearGeneral;
+        return tiling_index != TileMode::DisplayLinearAligned &&
+               tiling_index != TileMode::DisplayLinearGeneral;
     }
 
     u32 GetBankSwizzle() const {

--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -280,7 +280,7 @@ struct Image {
                GetTileMode() != TileMode::DisplayLinearGeneral;
     }
 
-    u32 GetBankSwizzle() const {
+    u8 GetBankSwizzle() const {
         const auto tile_mode = GetTileMode();
         const auto array_mode = GetArrayMode(tile_mode);
         const auto dfmt = GetDataFmt();

--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -7,6 +7,7 @@
 #include "common/assert.h"
 #include "common/bit_field.h"
 #include "video_core/amdgpu/pixel_format.h"
+#include "video_core/amdgpu/tiling.h"
 
 namespace AmdGpu {
 
@@ -138,60 +139,29 @@ constexpr std::string_view NameOf(ImageType type) {
     }
 }
 
-enum class TilingMode : u32 {
-    Depth_MacroTiled = 0u,
-    Display_Linear = 0x8u,
-    Display_MicroTiled = 0x9u,
-    Display_MacroTiled = 0xAu,
-    Texture_MicroTiled = 0xDu,
-    Texture_MacroTiled = 0xEu,
-    Texture_Volume = 0x13u,
-};
-
-constexpr std::string_view NameOf(TilingMode type) {
-    switch (type) {
-    case TilingMode::Depth_MacroTiled:
-        return "Depth_MacroTiled";
-    case TilingMode::Display_Linear:
-        return "Display_Linear";
-    case TilingMode::Display_MicroTiled:
-        return "Display_MicroTiled";
-    case TilingMode::Display_MacroTiled:
-        return "Display_MacroTiled";
-    case TilingMode::Texture_MicroTiled:
-        return "Texture_MicroTiled";
-    case TilingMode::Texture_MacroTiled:
-        return "Texture_MacroTiled";
-    case TilingMode::Texture_Volume:
-        return "Texture_Volume";
-    default:
-        return "Unknown";
-    }
-}
-
 struct Image {
     u64 base_address : 38;
     u64 mtype_l2 : 2;
     u64 min_lod : 12;
-    u64 data_format : 6;
-    u64 num_format : 4;
+    DataFormat data_format : 6;
+    NumberFormat num_format : 4;
     u64 mtype : 2;
 
     u64 width : 14;
     u64 height : 14;
     u64 perf_modulation : 3;
     u64 interlaced : 1;
-    u64 dst_sel_x : 3;
-    u64 dst_sel_y : 3;
-    u64 dst_sel_z : 3;
-    u64 dst_sel_w : 3;
+    CompSwizzle dst_sel_x : 3;
+    CompSwizzle dst_sel_y : 3;
+    CompSwizzle dst_sel_z : 3;
+    CompSwizzle dst_sel_w : 3;
     u64 base_level : 4;
     u64 last_level : 4;
-    u64 tiling_index : 5;
+    TileMode tiling_index : 5;
     u64 pow2pad : 1;
     u64 mtype2 : 1;
     u64 atc : 1;
-    u64 type : 4; // overlaps with V# type, so shouldn't be 0 for buffer
+    ImageType type : 4; // overlaps with V# type, so shouldn't be 0 for buffer
 
     u64 depth : 13;
     u64 pitch : 14;
@@ -212,34 +182,21 @@ struct Image {
     u64 alt_tile_mode : 1;
     u64 : 39;
 
-    static constexpr Image Null() {
+    static constexpr Image Null(bool is_depth) {
         Image image{};
-        image.data_format = u64(DataFormat::Format8_8_8_8);
-        image.num_format = u64(NumberFormat::Unorm);
-        image.dst_sel_x = u64(CompSwizzle::Red);
-        image.dst_sel_y = u64(CompSwizzle::Green);
-        image.dst_sel_z = u64(CompSwizzle::Blue);
-        image.dst_sel_w = u64(CompSwizzle::Alpha);
-        image.tiling_index = u64(TilingMode::Texture_MicroTiled);
-        image.type = u64(ImageType::Color2D);
-        return image;
-    }
-
-    static constexpr Image NullDepth() {
-        Image image{};
-        image.data_format = u64(DataFormat::Format32);
-        image.num_format = u64(NumberFormat::Float);
-        image.dst_sel_x = u64(CompSwizzle::Red);
-        image.dst_sel_y = u64(CompSwizzle::Green);
-        image.dst_sel_z = u64(CompSwizzle::Blue);
-        image.dst_sel_w = u64(CompSwizzle::Alpha);
-        image.tiling_index = u64(TilingMode::Texture_MicroTiled);
-        image.type = u64(ImageType::Color2D);
+        image.data_format = is_depth ? DataFormat::Format32 : DataFormat::Format8_8_8_8;
+        image.num_format = is_depth ? NumberFormat::Float : NumberFormat::Unorm;
+        image.dst_sel_x = CompSwizzle::Red;
+        image.dst_sel_y = CompSwizzle::Green;
+        image.dst_sel_z = CompSwizzle::Blue;
+        image.dst_sel_w = CompSwizzle::Alpha;
+        image.tiling_index = TileMode::Thin1DThin;
+        image.type = ImageType::Color2D;
         return image;
     }
 
     bool Valid() const {
-        return (type & 0x8u) != 0;
+        return type != ImageType::Invalid;
     }
 
     VAddr Address() const {
@@ -295,11 +252,11 @@ struct Image {
     }
 
     bool IsCube() const noexcept {
-        return static_cast<ImageType>(type) == ImageType::Cube;
+        return type == ImageType::Cube;
     }
 
     ImageType GetType() const noexcept {
-        return IsCube() ? ImageType::Color2DArray : static_cast<ImageType>(type);
+        return IsCube() ? ImageType::Color2DArray : type;
     }
 
     DataFormat GetDataFmt() const noexcept {
@@ -314,16 +271,24 @@ struct Image {
         return MapNumberConversion(NumberFormat(num_format), DataFormat(data_format));
     }
 
-    TilingMode GetTilingMode() const {
-        if (tiling_index >= 0 && tiling_index <= 7) {
-            return tiling_index == 5 ? TilingMode::Texture_MicroTiled
-                                     : TilingMode::Depth_MacroTiled;
-        }
-        return static_cast<TilingMode>(tiling_index);
+    TileMode GetTileMode() const {
+        return tiling_index;
     }
 
     bool IsTiled() const {
-        return GetTilingMode() != TilingMode::Display_Linear;
+        return tiling_index != TileMode::DisplayLinearAligned && tiling_index != TileMode::DisplayLinearGeneral;
+    }
+
+    u32 GetBankSwizzle() const {
+        const auto array_mode = GetArrayMode(tiling_index);
+        const auto dfmt = GetDataFmt();
+        if (!alt_tile_mode || dfmt == DataFormat::FormatInvalid || !IsMacroTiled(array_mode)) {
+            return 0;
+        }
+        const u32 bpp = NumBitsPerElement(dfmt);
+        const auto macro_tile_mode = CalculateMacrotileMode(tiling_index, bpp, NumSamples());
+        const u32 banks = GetAltNumBanks(macro_tile_mode);
+        return (((banks - 1) << 4) & base_address) >> 4;
     }
 
     bool IsFmask() const noexcept {
@@ -331,7 +296,21 @@ struct Image {
                GetDataFmt() <= DataFormat::FormatFmask64_8;
     }
 
-    [[nodiscard]] ImageType GetViewType(const bool is_array) const noexcept {
+    ImageType GetBaseType() const noexcept {
+        const auto base_type = GetType();
+        if (base_type == ImageType::Color1DArray) {
+            return ImageType::Color1D;
+        }
+        if (base_type == ImageType::Color2DArray) {
+            return ImageType::Color2D;
+        }
+        if (base_type == ImageType::Color2DMsaa || base_type == ImageType::Color2DMsaaArray) {
+            return ImageType::Color2D;
+        }
+        return base_type;
+    }
+
+    ImageType GetViewType(const bool is_array) const noexcept {
         const auto base_type = GetType();
         if (IsCube()) {
             // Cube needs to remain array type regardless of instruction array specifier.
@@ -422,13 +401,7 @@ enum class Filter : u64 {
 };
 
 constexpr bool IsAnisoFilter(const Filter filter) {
-    switch (filter) {
-    case Filter::AnisoPoint:
-    case Filter::AnisoLinear:
-        return true;
-    default:
-        return false;
-    }
+    return filter == Filter::AnisoPoint || filter == Filter::AnisoLinear;
 }
 
 enum class MipFilter : u64 {
@@ -495,7 +468,7 @@ struct Sampler {
     }
 
     float LodBias() const noexcept {
-        return static_cast<float>(static_cast<int16_t>((lod_bias.Value() ^ 0x2000u) - 0x2000u)) /
+        return static_cast<float>(static_cast<s16>((lod_bias.Value() ^ 0x2000u) - 0x2000u)) /
                256.0f;
     }
 

--- a/src/video_core/amdgpu/tiling.cpp
+++ b/src/video_core/amdgpu/tiling.cpp
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
-#pragma clang optimize off
+
 #include "common/assert.h"
 #include "video_core/amdgpu/tiling.h"
 
@@ -529,7 +529,8 @@ u32 GetPipeCount(PipeConfig pipe_cfg) {
 }
 
 MacroTileMode CalculateMacrotileMode(TileMode tile_mode, u32 bpp, u32 num_samples) {
-    ASSERT_MSG(std::has_single_bit(num_samples) && num_samples <= 16, "Invalid sample count {}", num_samples);
+    ASSERT_MSG(std::has_single_bit(num_samples) && num_samples <= 16, "Invalid sample count {}",
+               num_samples);
     ASSERT_MSG(bpp >= 1 && bpp <= 128, "Invalid bpp {}", bpp);
 
     const ArrayMode array_mode = GetArrayMode(tile_mode);
@@ -542,7 +543,8 @@ MacroTileMode CalculateMacrotileMode(TileMode tile_mode, u32 bpp, u32 num_sample
     const u32 tile_thickness = GetMicroTileThickness(array_mode);
     const u32 tile_bytes_1x = bpp * MICROTILE_SIZE * MICROTILE_SIZE * tile_thickness / 8;
     const u32 color_tile_split = std::max(256U, sample_split * tile_bytes_1x);
-    const u32 tile_split = micro_tile_mode == MicroTileMode::Depth ? tile_split_hw : color_tile_split;
+    const u32 tile_split =
+        micro_tile_mode == MicroTileMode::Depth ? tile_split_hw : color_tile_split;
     const u32 tilesplic = std::min(DRAM_ROW_SIZE, tile_split);
     const u32 tile_bytes = std::min(tilesplic, num_samples * tile_bytes_1x);
     const u32 mtm_idx = std::bit_width(tile_bytes / 64) - 1;

--- a/src/video_core/amdgpu/tiling.cpp
+++ b/src/video_core/amdgpu/tiling.cpp
@@ -1,0 +1,552 @@
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma clang optimize off
+#include "common/assert.h"
+#include "video_core/amdgpu/tiling.h"
+
+#include <magic_enum/magic_enum.hpp>
+
+namespace AmdGpu {
+
+static constexpr u32 MICROTILE_SIZE = 8;
+static constexpr u32 DRAM_ROW_SIZE = 1024;
+
+std::string_view NameOf(TileMode tile_mode) {
+    return magic_enum::enum_name(tile_mode);
+}
+
+ArrayMode GetArrayMode(TileMode tile_mode) {
+    switch (tile_mode) {
+    case TileMode::Depth1DThin:
+    case TileMode::Display1DThin:
+    case TileMode::Thin1DThin:
+        return ArrayMode::Array1DTiledThin1;
+    case TileMode::Depth2DThin64:
+    case TileMode::Depth2DThin128:
+    case TileMode::Depth2DThin256:
+    case TileMode::Depth2DThin512:
+    case TileMode::Depth2DThin1K:
+    case TileMode::Display2DThin:
+    case TileMode::Thin2DThin:
+        return ArrayMode::Array2DTiledThin1;
+    case TileMode::DisplayThinPrt:
+    case TileMode::ThinThinPrt:
+        return ArrayMode::ArrayPrtTiledThin1;
+    case TileMode::Depth2DThinPrt256:
+    case TileMode::Depth2DThinPrt1K:
+    case TileMode::Display2DThinPrt:
+    case TileMode::Thin2DThinPrt:
+        return ArrayMode::ArrayPrt2DTiledThin1;
+    case TileMode::Thin3DThin:
+    case TileMode::Thin3DThinPrt:
+        return ArrayMode::Array3DTiledThin1;
+    case TileMode::Thick1DThick:
+        return ArrayMode::Array1DTiledThick;
+    case TileMode::Thick2DThick:
+        return ArrayMode::Array2DTiledThick;
+    case TileMode::Thick3DThick:
+        return ArrayMode::Array3DTiledThick;
+    case TileMode::ThickThickPrt:
+        return ArrayMode::ArrayPrtTiledThick;
+    case TileMode::Thick2DThickPrt:
+        return ArrayMode::ArrayPrt2DTiledThick;
+    case TileMode::Thick3DThickPrt:
+        return ArrayMode::ArrayPrt3DTiledThick;
+    case TileMode::Thick2DXThick:
+        return ArrayMode::Array2DTiledXThick;
+    case TileMode::Thick3DXThick:
+        return ArrayMode::Array3DTiledXThick;
+    case TileMode::DisplayLinearAligned:
+        return ArrayMode::ArrayLinearAligned;
+    case TileMode::DisplayLinearGeneral:
+        return ArrayMode::ArrayLinearGeneral;
+    default:
+        UNREACHABLE_MSG("Unknown tile mode = {}", u32(tile_mode));
+    }
+}
+
+MicroTileMode GetMicroTileMode(TileMode tile_mode) {
+    switch (tile_mode) {
+    case TileMode::Depth2DThin64:
+    case TileMode::Depth2DThin128:
+    case TileMode::Depth2DThin256:
+    case TileMode::Depth2DThin512:
+    case TileMode::Depth2DThin1K:
+    case TileMode::Depth1DThin:
+    case TileMode::Depth2DThinPrt256:
+    case TileMode::Depth2DThinPrt1K:
+        return MicroTileMode::Depth;
+    case TileMode::DisplayLinearAligned:
+    case TileMode::Display1DThin:
+    case TileMode::Display2DThin:
+    case TileMode::DisplayThinPrt:
+    case TileMode::Display2DThinPrt:
+    case TileMode::DisplayLinearGeneral:
+        return MicroTileMode::Display;
+    case TileMode::Thin1DThin:
+    case TileMode::Thin2DThin:
+    case TileMode::Thin3DThin:
+    case TileMode::ThinThinPrt:
+    case TileMode::Thin2DThinPrt:
+    case TileMode::Thin3DThinPrt:
+        return MicroTileMode::Thin;
+    case TileMode::Thick1DThick:
+    case TileMode::Thick2DThick:
+    case TileMode::Thick3DThick:
+    case TileMode::ThickThickPrt:
+    case TileMode::Thick2DThickPrt:
+    case TileMode::Thick3DThickPrt:
+    case TileMode::Thick2DXThick:
+    case TileMode::Thick3DXThick:
+        return MicroTileMode::Thick;
+    default:
+        UNREACHABLE_MSG("Unknown tile mode = {}", u32(tile_mode));
+    }
+}
+
+PipeConfig GetPipeConfig(TileMode tile_mode) {
+    switch (tile_mode) {
+    case TileMode::Depth2DThin64:
+    case TileMode::Depth2DThin128:
+    case TileMode::Depth2DThin256:
+    case TileMode::Depth2DThin512:
+    case TileMode::Depth2DThin1K:
+    case TileMode::Depth1DThin:
+    case TileMode::Depth2DThinPrt256:
+    case TileMode::Depth2DThinPrt1K:
+    case TileMode::DisplayLinearAligned:
+    case TileMode::Display1DThin:
+    case TileMode::Display2DThin:
+    case TileMode::Display2DThinPrt:
+    case TileMode::Thin1DThin:
+    case TileMode::Thin2DThin:
+    case TileMode::Thin2DThinPrt:
+    case TileMode::Thin3DThinPrt:
+    case TileMode::Thick1DThick:
+    case TileMode::Thick2DThick:
+    case TileMode::Thick2DThickPrt:
+    case TileMode::Thick2DXThick:
+        return PipeConfig::P8_32x32_16x16;
+    case TileMode::DisplayThinPrt:
+    case TileMode::Thin3DThin:
+    case TileMode::ThinThinPrt:
+    case TileMode::Thick3DThick:
+    case TileMode::ThickThickPrt:
+    case TileMode::Thick3DThickPrt:
+    case TileMode::Thick3DXThick:
+        return PipeConfig::P8_32x32_8x16;
+    case TileMode::DisplayLinearGeneral:
+        return PipeConfig::P2;
+    default:
+        UNREACHABLE_MSG("Unknown tile mode = {}", u32(tile_mode));
+    }
+}
+
+PipeConfig GetAltPipeConfig(TileMode tile_mode) {
+    switch (tile_mode) {
+    case TileMode::Depth2DThin64:
+    case TileMode::Depth2DThin128:
+    case TileMode::Depth2DThin256:
+    case TileMode::Depth2DThin512:
+    case TileMode::Depth2DThin1K:
+    case TileMode::Depth1DThin:
+    case TileMode::Depth2DThinPrt256:
+    case TileMode::Depth2DThinPrt1K:
+    case TileMode::DisplayLinearAligned:
+    case TileMode::Display1DThin:
+    case TileMode::Display2DThin:
+    case TileMode::DisplayThinPrt:
+    case TileMode::Display2DThinPrt:
+    case TileMode::Thin1DThin:
+    case TileMode::Thin2DThin:
+    case TileMode::Thin3DThin:
+    case TileMode::ThinThinPrt:
+    case TileMode::Thin2DThinPrt:
+    case TileMode::Thin3DThinPrt:
+    case TileMode::Thick1DThick:
+    case TileMode::Thick2DThick:
+    case TileMode::Thick3DThick:
+    case TileMode::ThickThickPrt:
+    case TileMode::Thick2DThickPrt:
+    case TileMode::Thick3DThickPrt:
+    case TileMode::Thick2DXThick:
+    case TileMode::Thick3DXThick:
+        return PipeConfig::P16_32x32_8x16;
+    case TileMode::DisplayLinearGeneral:
+        return PipeConfig::P2;
+    default:
+        UNREACHABLE_MSG("Unknown tile mode = {}", u32(tile_mode));
+    }
+}
+
+u32 GetSampleSplit(TileMode tile_mode) {
+    switch (tile_mode) {
+    case TileMode::Depth2DThin64:
+    case TileMode::Depth2DThin128:
+    case TileMode::Depth2DThin256:
+    case TileMode::Depth2DThin512:
+    case TileMode::Depth2DThin1K:
+    case TileMode::Depth1DThin:
+    case TileMode::Depth2DThinPrt256:
+    case TileMode::Depth2DThinPrt1K:
+    case TileMode::DisplayLinearAligned:
+    case TileMode::Display1DThin:
+    case TileMode::Thin1DThin:
+    case TileMode::Thick1DThick:
+    case TileMode::Thick2DThick:
+    case TileMode::Thick3DThick:
+    case TileMode::ThickThickPrt:
+    case TileMode::Thick2DThickPrt:
+    case TileMode::Thick3DThickPrt:
+    case TileMode::Thick2DXThick:
+    case TileMode::Thick3DXThick:
+    case TileMode::DisplayLinearGeneral:
+        return 1;
+    case TileMode::Display2DThin:
+    case TileMode::DisplayThinPrt:
+    case TileMode::Display2DThinPrt:
+    case TileMode::Thin2DThin:
+    case TileMode::Thin3DThin:
+    case TileMode::ThinThinPrt:
+    case TileMode::Thin2DThinPrt:
+    case TileMode::Thin3DThinPrt:
+        return 2;
+    default:
+        UNREACHABLE_MSG("Unknown tile mode = {}", u32(tile_mode));
+    }
+}
+
+u32 GetTileSplit(TileMode tile_mode) {
+    switch (tile_mode) {
+    case TileMode::Depth2DThin64:
+    case TileMode::Depth1DThin:
+    case TileMode::DisplayLinearAligned:
+    case TileMode::Display1DThin:
+    case TileMode::Display2DThin:
+    case TileMode::DisplayThinPrt:
+    case TileMode::Display2DThinPrt:
+    case TileMode::Thin1DThin:
+    case TileMode::Thin2DThin:
+    case TileMode::Thin3DThin:
+    case TileMode::ThinThinPrt:
+    case TileMode::Thin2DThinPrt:
+    case TileMode::Thin3DThinPrt:
+    case TileMode::Thick1DThick:
+    case TileMode::Thick2DThick:
+    case TileMode::Thick3DThick:
+    case TileMode::ThickThickPrt:
+    case TileMode::Thick2DThickPrt:
+    case TileMode::Thick3DThickPrt:
+    case TileMode::Thick2DXThick:
+    case TileMode::Thick3DXThick:
+    case TileMode::DisplayLinearGeneral:
+        return 64;
+    case TileMode::Depth2DThin128:
+        return 128;
+    case TileMode::Depth2DThin256:
+    case TileMode::Depth2DThinPrt256:
+        return 256;
+    case TileMode::Depth2DThin512:
+        return 512;
+    case TileMode::Depth2DThin1K:
+    case TileMode::Depth2DThinPrt1K:
+        return 1024;
+    default:
+        UNREACHABLE_MSG("Unknown tile mode = {}", u32(tile_mode));
+    }
+}
+
+u32 GetBankWidth(MacroTileMode mode) {
+    switch (mode) {
+    case MacroTileMode::Mode_1x4_16:
+    case MacroTileMode::Mode_1x2_16:
+    case MacroTileMode::Mode_1x1_16:
+    case MacroTileMode::Mode_1x1_16_Dup:
+    case MacroTileMode::Mode_1x1_8:
+    case MacroTileMode::Mode_1x1_4:
+    case MacroTileMode::Mode_1x1_2:
+    case MacroTileMode::Mode_1x1_2_Dup:
+    case MacroTileMode::Mode_1x8_16:
+    case MacroTileMode::Mode_1x4_16_Dup:
+    case MacroTileMode::Mode_1x2_16_Dup:
+    case MacroTileMode::Mode_1x1_16_Dup2:
+    case MacroTileMode::Mode_1x1_8_Dup:
+    case MacroTileMode::Mode_1x1_4_Dup:
+    case MacroTileMode::Mode_1x1_2_Dup2:
+    case MacroTileMode::Mode_1x1_2_Dup3:
+        return 1;
+    default:
+        UNREACHABLE_MSG("Unknown macro tile mode = {}", u32(mode));
+    }
+}
+
+u32 GetBankHeight(MacroTileMode mode) {
+    switch (mode) {
+    case MacroTileMode::Mode_1x1_16:
+    case MacroTileMode::Mode_1x1_16_Dup:
+    case MacroTileMode::Mode_1x1_8:
+    case MacroTileMode::Mode_1x1_4:
+    case MacroTileMode::Mode_1x1_2:
+    case MacroTileMode::Mode_1x1_2_Dup:
+    case MacroTileMode::Mode_1x1_16_Dup2:
+    case MacroTileMode::Mode_1x1_8_Dup:
+    case MacroTileMode::Mode_1x1_4_Dup:
+    case MacroTileMode::Mode_1x1_2_Dup2:
+    case MacroTileMode::Mode_1x1_2_Dup3:
+        return 1;
+    case MacroTileMode::Mode_1x2_16:
+    case MacroTileMode::Mode_1x2_16_Dup:
+        return 2;
+    case MacroTileMode::Mode_1x4_16:
+    case MacroTileMode::Mode_1x4_16_Dup:
+        return 4;
+    case MacroTileMode::Mode_1x8_16:
+        return 8;
+    default:
+        UNREACHABLE_MSG("Unknown macro tile mode = {}", u32(mode));
+    }
+}
+
+u32 GetNumBanks(MacroTileMode mode) {
+    switch (mode) {
+    case MacroTileMode::Mode_1x1_2:
+    case MacroTileMode::Mode_1x1_2_Dup:
+    case MacroTileMode::Mode_1x1_2_Dup2:
+    case MacroTileMode::Mode_1x1_2_Dup3:
+        return 2;
+    case MacroTileMode::Mode_1x1_4:
+    case MacroTileMode::Mode_1x1_4_Dup:
+        return 4;
+    case MacroTileMode::Mode_1x1_8:
+    case MacroTileMode::Mode_1x1_8_Dup:
+        return 8;
+    case MacroTileMode::Mode_1x4_16:
+    case MacroTileMode::Mode_1x2_16:
+    case MacroTileMode::Mode_1x1_16:
+    case MacroTileMode::Mode_1x1_16_Dup:
+    case MacroTileMode::Mode_1x8_16:
+    case MacroTileMode::Mode_1x4_16_Dup:
+    case MacroTileMode::Mode_1x2_16_Dup:
+    case MacroTileMode::Mode_1x1_16_Dup2:
+        return 16;
+    default:
+        UNREACHABLE_MSG("Unknown macro tile mode = {}", u32(mode));
+    }
+}
+
+u32 GetMacrotileAspect(MacroTileMode mode) {
+    switch (mode) {
+    case MacroTileMode::Mode_1x1_8:
+    case MacroTileMode::Mode_1x1_4:
+    case MacroTileMode::Mode_1x1_2:
+    case MacroTileMode::Mode_1x1_2_Dup:
+    case MacroTileMode::Mode_1x1_8_Dup:
+    case MacroTileMode::Mode_1x1_4_Dup:
+    case MacroTileMode::Mode_1x1_2_Dup2:
+    case MacroTileMode::Mode_1x1_2_Dup3:
+        return 1;
+    case MacroTileMode::Mode_1x2_16:
+    case MacroTileMode::Mode_1x1_16:
+    case MacroTileMode::Mode_1x1_16_Dup:
+    case MacroTileMode::Mode_1x2_16_Dup:
+    case MacroTileMode::Mode_1x1_16_Dup2:
+        return 2;
+    case MacroTileMode::Mode_1x4_16:
+    case MacroTileMode::Mode_1x8_16:
+    case MacroTileMode::Mode_1x4_16_Dup:
+        return 4;
+    default:
+        UNREACHABLE_MSG("Unknown macro tile mode = {}", u32(mode));
+    }
+}
+
+u32 GetAltBankHeight(MacroTileMode mode) {
+    switch (mode) {
+    case MacroTileMode::Mode_1x1_8:
+    case MacroTileMode::Mode_1x1_4:
+    case MacroTileMode::Mode_1x1_2:
+    case MacroTileMode::Mode_1x1_2_Dup:
+    case MacroTileMode::Mode_1x1_16_Dup2:
+    case MacroTileMode::Mode_1x1_8_Dup:
+    case MacroTileMode::Mode_1x1_4_Dup:
+    case MacroTileMode::Mode_1x1_2_Dup2:
+    case MacroTileMode::Mode_1x1_2_Dup3:
+        return 1;
+    case MacroTileMode::Mode_1x1_16:
+    case MacroTileMode::Mode_1x1_16_Dup:
+    case MacroTileMode::Mode_1x2_16_Dup:
+        return 2;
+    case MacroTileMode::Mode_1x4_16:
+    case MacroTileMode::Mode_1x2_16:
+    case MacroTileMode::Mode_1x8_16:
+    case MacroTileMode::Mode_1x4_16_Dup:
+        return 4;
+    default:
+        UNREACHABLE_MSG("Unknown macro tile mode = {}", u32(mode));
+    }
+}
+
+u32 GetAltNumBanks(MacroTileMode mode) {
+    switch (mode) {
+    case MacroTileMode::Mode_1x1_2_Dup:
+    case MacroTileMode::Mode_1x1_2_Dup2:
+    case MacroTileMode::Mode_1x1_2_Dup3:
+        return 2;
+    case MacroTileMode::Mode_1x1_2:
+    case MacroTileMode::Mode_1x1_8_Dup:
+    case MacroTileMode::Mode_1x1_4_Dup:
+        return 4;
+    case MacroTileMode::Mode_1x4_16:
+    case MacroTileMode::Mode_1x2_16:
+    case MacroTileMode::Mode_1x1_16:
+    case MacroTileMode::Mode_1x1_16_Dup:
+    case MacroTileMode::Mode_1x1_8:
+    case MacroTileMode::Mode_1x1_4:
+    case MacroTileMode::Mode_1x4_16_Dup:
+    case MacroTileMode::Mode_1x2_16_Dup:
+    case MacroTileMode::Mode_1x1_16_Dup2:
+        return 8;
+    case MacroTileMode::Mode_1x8_16:
+        return 16;
+    default:
+        UNREACHABLE_MSG("Unknown macro tile mode = {}", u32(mode));
+    }
+}
+
+u32 GetAltMacrotileAspect(MacroTileMode mode) {
+    switch (mode) {
+    case MacroTileMode::Mode_1x1_16:
+    case MacroTileMode::Mode_1x1_16_Dup:
+    case MacroTileMode::Mode_1x1_8:
+    case MacroTileMode::Mode_1x1_4:
+    case MacroTileMode::Mode_1x1_2:
+    case MacroTileMode::Mode_1x1_2_Dup:
+    case MacroTileMode::Mode_1x2_16_Dup:
+    case MacroTileMode::Mode_1x1_16_Dup2:
+    case MacroTileMode::Mode_1x1_8_Dup:
+    case MacroTileMode::Mode_1x1_4_Dup:
+    case MacroTileMode::Mode_1x1_2_Dup2:
+    case MacroTileMode::Mode_1x1_2_Dup3:
+        return 1;
+    case MacroTileMode::Mode_1x4_16:
+    case MacroTileMode::Mode_1x2_16:
+    case MacroTileMode::Mode_1x8_16:
+    case MacroTileMode::Mode_1x4_16_Dup:
+        return 2;
+    default:
+        UNREACHABLE_MSG("Unknown macro tile mode = {}", u32(mode));
+    }
+}
+
+bool IsMacroTiled(ArrayMode array_mode) {
+    switch (array_mode) {
+    case ArrayMode::ArrayLinearGeneral:
+    case ArrayMode::ArrayLinearAligned:
+    case ArrayMode::Array1DTiledThin1:
+    case ArrayMode::Array1DTiledThick:
+        return false;
+    case ArrayMode::Array2DTiledThin1:
+    case ArrayMode::ArrayPrtTiledThin1:
+    case ArrayMode::ArrayPrt2DTiledThin1:
+    case ArrayMode::Array2DTiledThick:
+    case ArrayMode::Array2DTiledXThick:
+    case ArrayMode::ArrayPrtTiledThick:
+    case ArrayMode::ArrayPrt2DTiledThick:
+    case ArrayMode::ArrayPrt3DTiledThin1:
+    case ArrayMode::Array3DTiledThin1:
+    case ArrayMode::Array3DTiledThick:
+    case ArrayMode::Array3DTiledXThick:
+    case ArrayMode::ArrayPrt3DTiledThick:
+        return true;
+    default:
+        UNREACHABLE_MSG("Unknown array mode = {}", u32(array_mode));
+    }
+}
+
+bool IsPrt(ArrayMode array_mode) {
+    switch (array_mode) {
+    case ArrayMode::ArrayPrtTiledThin1:
+    case ArrayMode::ArrayPrtTiledThick:
+    case ArrayMode::ArrayPrt2DTiledThin1:
+    case ArrayMode::ArrayPrt2DTiledThick:
+    case ArrayMode::ArrayPrt3DTiledThin1:
+    case ArrayMode::ArrayPrt3DTiledThick:
+        return true;
+    case ArrayMode::ArrayLinearGeneral:
+    case ArrayMode::ArrayLinearAligned:
+    case ArrayMode::Array1DTiledThin1:
+    case ArrayMode::Array1DTiledThick:
+    case ArrayMode::Array2DTiledThin1:
+    case ArrayMode::Array2DTiledThick:
+    case ArrayMode::Array2DTiledXThick:
+    case ArrayMode::Array3DTiledThin1:
+    case ArrayMode::Array3DTiledThick:
+    case ArrayMode::Array3DTiledXThick:
+        return false;
+    default:
+        UNREACHABLE_MSG("Unknown array mode = {}", u32(array_mode));
+    }
+}
+
+u32 GetMicroTileThickness(ArrayMode array_mode) {
+    switch (array_mode) {
+    case ArrayMode::ArrayLinearGeneral:
+    case ArrayMode::ArrayLinearAligned:
+    case ArrayMode::Array1DTiledThin1:
+    case ArrayMode::Array2DTiledThin1:
+    case ArrayMode::ArrayPrtTiledThin1:
+    case ArrayMode::ArrayPrt2DTiledThin1:
+    case ArrayMode::ArrayPrt3DTiledThin1:
+    case ArrayMode::Array3DTiledThin1:
+        return 1;
+    case ArrayMode::Array1DTiledThick:
+    case ArrayMode::Array2DTiledThick:
+    case ArrayMode::Array3DTiledThick:
+    case ArrayMode::ArrayPrtTiledThick:
+    case ArrayMode::ArrayPrt2DTiledThick:
+    case ArrayMode::ArrayPrt3DTiledThick:
+        return 4;
+    case ArrayMode::Array2DTiledXThick:
+    case ArrayMode::Array3DTiledXThick:
+        return 8;
+    default:
+        UNREACHABLE_MSG("Unknown array mode = {}", u32(array_mode));
+    }
+}
+
+u32 GetPipeCount(PipeConfig pipe_cfg) {
+    switch (pipe_cfg) {
+    case PipeConfig::P2:
+        return 2;
+    case PipeConfig::P8_32x32_8x16:
+    case PipeConfig::P8_32x32_16x16:
+        return 8;
+    case PipeConfig::P16_32x32_8x16:
+        return 16;
+    default:
+        UNREACHABLE_MSG("Unknown pipe config = {}", u32(pipe_cfg));
+    }
+}
+
+MacroTileMode CalculateMacrotileMode(TileMode tile_mode, u32 bpp, u32 num_samples) {
+    ASSERT_MSG(std::has_single_bit(num_samples) && num_samples <= 16, "Invalid sample count {}", num_samples);
+    ASSERT_MSG(bpp >= 1 && bpp <= 128, "Invalid bpp {}", bpp);
+
+    const ArrayMode array_mode = GetArrayMode(tile_mode);
+    ASSERT_MSG(IsMacroTiled(array_mode), "Tile mode not macro tiled");
+
+    const MicroTileMode micro_tile_mode = GetMicroTileMode(tile_mode);
+    const u32 sample_split = GetSampleSplit(tile_mode);
+    const u32 tile_split_hw = GetTileSplit(tile_mode);
+
+    const u32 tile_thickness = GetMicroTileThickness(array_mode);
+    const u32 tile_bytes_1x = bpp * MICROTILE_SIZE * MICROTILE_SIZE * tile_thickness / 8;
+    const u32 color_tile_split = std::max(256U, sample_split * tile_bytes_1x);
+    const u32 tile_split = micro_tile_mode == MicroTileMode::Depth ? tile_split_hw : color_tile_split;
+    const u32 tilesplic = std::min(DRAM_ROW_SIZE, tile_split);
+    const u32 tile_bytes = std::min(tilesplic, num_samples * tile_bytes_1x);
+    const u32 mtm_idx = std::bit_width(tile_bytes / 64) - 1;
+    return IsPrt(array_mode) ? MacroTileMode(mtm_idx + 8) : MacroTileMode(mtm_idx);
+}
+
+} // namespace AmdGpu

--- a/src/video_core/amdgpu/tiling.h
+++ b/src/video_core/amdgpu/tiling.h
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <string_view>
+
+#include "common/types.h"
+
+namespace AmdGpu {
+
+struct Image;
+
+static constexpr size_t NUM_TILE_MODES = 32;
+
+enum class PipeConfig : u32 {
+    P2 = 0,
+    P4_8x16 = 4,
+    P4_16x16 = 5,
+    P4_16x32 = 6,
+    P4_32x32 = 7,
+    P8_16x16_8x16 = 8,
+    P8_16x32_8x16 = 9,
+    P8_32x32_8x16 = 10,
+    P8_16x32_16x16 = 11,
+    P8_32x32_16x16 = 12,
+    P8_32x32_16x32 = 13,
+    P8_32x64_32x32 = 14,
+    P16_32x32_8x16 = 16,
+    P16_32x32_16x16 = 17,
+    P16 = 18,
+};
+
+enum class MicroTileMode : u32 {
+    Display = 0,
+    Thin = 1,
+    Depth = 2,
+    Rotated = 3,
+    Thick = 4,
+};
+
+enum class MacroTileMode : u32 {
+    Mode_1x4_16 = 0,
+    Mode_1x2_16 = 1,
+    Mode_1x1_16 = 2,
+    Mode_1x1_16_Dup = 3,
+    Mode_1x1_8 = 4,
+    Mode_1x1_4 = 5,
+    Mode_1x1_2 = 6,
+    Mode_1x1_2_Dup = 7,
+    Mode_1x8_16 = 8,
+    Mode_1x4_16_Dup = 9,
+    Mode_1x2_16_Dup = 10,
+    Mode_1x1_16_Dup2 = 11,
+    Mode_1x1_8_Dup = 12,
+    Mode_1x1_4_Dup = 13,
+    Mode_1x1_2_Dup2 = 14,
+    Mode_1x1_2_Dup3 = 15,
+};
+
+enum class ArrayMode : u32 {
+    ArrayLinearGeneral = 0,
+    ArrayLinearAligned = 1,
+    Array1DTiledThin1 = 2,
+    Array1DTiledThick = 3,
+    Array2DTiledThin1 = 4,
+    ArrayPrtTiledThin1 = 5,
+    ArrayPrt2DTiledThin1 = 6,
+    Array2DTiledThick = 7,
+    Array2DTiledXThick = 8,
+    ArrayPrtTiledThick = 9,
+    ArrayPrt2DTiledThick = 10,
+    ArrayPrt3DTiledThin1 = 11,
+    Array3DTiledThin1 = 12,
+    Array3DTiledThick = 13,
+    Array3DTiledXThick = 14,
+    ArrayPrt3DTiledThick = 15,
+};
+
+enum class TileMode : u32 {
+    Depth2DThin64 = 0,
+    Depth2DThin128 = 1,
+    Depth2DThin256 = 2,
+    Depth2DThin512 = 3,
+    Depth2DThin1K = 4,
+    Depth1DThin = 5,
+    Depth2DThinPrt256 = 6,
+    Depth2DThinPrt1K = 7,
+    DisplayLinearAligned = 8,
+    Display1DThin = 9,
+    Display2DThin = 10,
+    DisplayThinPrt = 11,
+    Display2DThinPrt = 12,
+    Thin1DThin = 13,
+    Thin2DThin = 14,
+    Thin3DThin = 15,
+    ThinThinPrt = 16,
+    Thin2DThinPrt = 17,
+    Thin3DThinPrt = 18,
+    Thick1DThick = 19,
+    Thick2DThick = 20,
+    Thick3DThick = 21,
+    ThickThickPrt = 22,
+    Thick2DThickPrt = 23,
+    Thick3DThickPrt = 24,
+    Thick2DXThick = 25,
+    Thick3DXThick = 26,
+    DisplayLinearGeneral = 31,
+};
+
+std::string_view NameOf(TileMode tile_mode);
+
+ArrayMode GetArrayMode(TileMode tile_mode);
+
+MicroTileMode GetMicroTileMode(TileMode tile_mode);
+
+PipeConfig GetPipeConfig(TileMode tile_mode);
+
+PipeConfig GetAltPipeConfig(TileMode tile_mode);
+
+u32 GetSampleSplit(TileMode tile_mode);
+
+u32 GetTileSplit(TileMode tile_mode);
+
+u32 GetBankWidth(MacroTileMode mode);
+
+u32 GetBankHeight(MacroTileMode mode);
+
+u32 GetNumBanks(MacroTileMode mode);
+
+u32 GetMacrotileAspect(MacroTileMode mode);
+
+u32 GetAltBankHeight(MacroTileMode mode);
+
+u32 GetAltNumBanks(MacroTileMode mode);
+
+u32 GetAltMacrotileAspect(MacroTileMode mode);
+
+bool IsMacroTiled(ArrayMode array_mode);
+
+bool IsPrt(ArrayMode array_mode);
+
+u32 GetMicroTileThickness(ArrayMode array_mode);
+
+u32 GetPipeCount(PipeConfig pipe_cfg);
+
+MacroTileMode CalculateMacrotileMode(TileMode tile_mode, u32 bpp, u32 num_samples);
+
+} // namespace AmdGpu

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -983,7 +983,7 @@ bool BufferCache::SynchronizeBufferFromImage(Buffer& buffer, VAddr device_addr, 
         }
     }
     Image& image = texture_cache.GetImage(image_id);
-    ASSERT_MSG(device_addr == image.info.guest_address && image.info.resources.levels == 1,
+    ASSERT_MSG(device_addr == image.info.guest_address,
                "Texel buffer aliases image subresources {:x} : {:x}", device_addr,
                image.info.guest_address);
     const u32 offset = buffer.Offset(image.info.guest_address);

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -1026,7 +1026,7 @@ bool BufferCache::SynchronizeBufferFromImage(Buffer& buffer, VAddr device_addr, 
     auto barriers =
         image.GetBarriers(vk::ImageLayout::eTransferSrcOptimal, vk::AccessFlagBits2::eTransferRead,
                           vk::PipelineStageFlagBits2::eTransfer, {});
-    const auto cmdbuf = scheduler.CommandBuffer();
+    auto cmdbuf = scheduler.CommandBuffer();
     cmdbuf.pipelineBarrier2(vk::DependencyInfo{
         .dependencyFlags = vk::DependencyFlagBits::eByRegion,
         .bufferMemoryBarrierCount = 1,
@@ -1036,6 +1036,7 @@ bool BufferCache::SynchronizeBufferFromImage(Buffer& buffer, VAddr device_addr, 
     });
     auto& tile_manager = texture_cache.GetTileManager();
     tile_manager.TileImage(image.image, copy, buffer.Handle(), offset, image.info);
+    cmdbuf = scheduler.CommandBuffer();
     cmdbuf.pipelineBarrier2(vk::DependencyInfo{
         .dependencyFlags = vk::DependencyFlagBits::eByRegion,
         .bufferMemoryBarrierCount = 1,

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -963,7 +963,7 @@ bool BufferCache::SynchronizeBufferFromImage(Buffer& buffer, VAddr device_addr, 
         const u32 height = std::max(image.info.size.height >> mip, 1u);
         const u32 depth = std::max(image.info.size.depth >> mip, 1u);
         if (buf_offset + mip_info.offset + mip_info.size > buffer.SizeBytes()) {
-            return false;
+            break;
         }
         buffer_copies.push_back(vk::BufferImageCopy{
             .bufferOffset = mip_info.offset,

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -1023,9 +1023,9 @@ bool BufferCache::SynchronizeBufferFromImage(Buffer& buffer, VAddr device_addr, 
         .offset = offset,
         .size = size,
     };
-    auto barriers = image.GetBarriers(vk::ImageLayout::eTransferSrcOptimal,
-                                      vk::AccessFlagBits2::eTransferRead,
-                                      vk::PipelineStageFlagBits2::eTransfer, {});
+    auto barriers =
+        image.GetBarriers(vk::ImageLayout::eTransferSrcOptimal, vk::AccessFlagBits2::eTransferRead,
+                          vk::PipelineStageFlagBits2::eTransfer, {});
     const auto cmdbuf = scheduler.CommandBuffer();
     cmdbuf.pipelineBarrier2(vk::DependencyInfo{
         .dependencyFlags = vk::DependencyFlagBits::eByRegion,

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -980,6 +980,9 @@ bool BufferCache::SynchronizeBufferFromImage(Buffer& buffer, VAddr device_addr, 
         });
         copy_size += mip_info.size;
     }
+    if (copy_size == 0) {
+        return false;
+    }
     scheduler.EndRendering();
     const vk::BufferMemoryBarrier2 pre_barrier = {
         .srcStageMask = vk::PipelineStageFlagBits2::eAllCommands,

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -102,15 +102,14 @@ public:
 
     /// Retrieves a utility buffer optimized for specified memory usage.
     StreamBuffer& GetUtilityBuffer(MemoryUsage usage) noexcept {
-        switch (usage) {
-        case MemoryUsage::Stream:
+        if (usage == MemoryUsage::Stream) {
             return stream_buffer;
-        case MemoryUsage::Download:
+        } else if (usage == MemoryUsage::Download) {
             return download_buffer;
-        case MemoryUsage::Upload:
-            return staging_buffer;
-        case MemoryUsage::DeviceLocal:
+        } else if (usage == MemoryUsage::DeviceLocal) {
             return device_buffer;
+        } else {
+            return staging_buffer;
         }
     }
 

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -200,7 +200,7 @@ private:
     template <bool insert>
     void ChangeRegister(BufferId buffer_id);
 
-    void SynchronizeBuffer(Buffer& buffer, VAddr device_addr, u32 size, bool is_written,
+    bool SynchronizeBuffer(Buffer& buffer, VAddr device_addr, u32 size, bool is_written,
                            bool is_texel_buffer);
 
     vk::Buffer UploadCopies(Buffer& buffer, std::span<vk::BufferCopy> copies,

--- a/src/video_core/host_shaders/CMakeLists.txt
+++ b/src/video_core/host_shaders/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SHADER_FILES
     fs_tri.vert
     fsr.comp
     post_process.frag
+    tiling.comp
 )
 
 set(SHADER_INCLUDE ${CMAKE_CURRENT_BINARY_DIR}/include)

--- a/src/video_core/host_shaders/tiling.comp
+++ b/src/video_core/host_shaders/tiling.comp
@@ -412,7 +412,7 @@ uint32_t ComputeSurfaceAddrFromCoordMacroTiled(uint32_t x, uint32_t y, uint32_t 
 uint GetMipLevel(inout uint texel) {
     uint mip = 0;
     uint mip_size = info.mips[mip].size / BYTES_PER_PIXEL;
-    while (texel >= mip_size) {
+    while (texel >= mip_size && mip < info.num_mips) {
         texel -= mip_size;
         ++mip;
         mip_size = info.mips[mip].size / BYTES_PER_PIXEL;

--- a/src/video_core/host_shaders/tiling.comp
+++ b/src/video_core/host_shaders/tiling.comp
@@ -90,11 +90,11 @@ struct MipInfo {
 };
 
 layout (set = 0, binding = 0, scalar) buffer InputBuf {
-    BLOCK_TYPE in_data[];
+    BLOCK_TYPE tiled_data[];
 };
 
 layout (set = 0, binding = 1, scalar) buffer OutputBuf {
-    BLOCK_TYPE out_data[];
+    BLOCK_TYPE linear_data[];
 };
 
 layout (set = 0, binding = 2, scalar) uniform TilingInfo {
@@ -433,5 +433,9 @@ void main() {
     tiled_offset += ComputeSurfaceAddrFromCoordMacroTiled(x, y, slice, pitch, height, 0);
 #endif
 
-    out_data[gl_GlobalInvocationID.x] = in_data[tiled_offset / BYTES_PER_PIXEL];
+#ifdef IS_TILER
+    tiled_data[tiled_offset / BYTES_PER_PIXEL] = linear_data[gl_GlobalInvocationID.x];
+#else
+    linear_data[gl_GlobalInvocationID.x] = tiled_data[tiled_offset / BYTES_PER_PIXEL];
+#endif
 }

--- a/src/video_core/host_shaders/tiling.comp
+++ b/src/video_core/host_shaders/tiling.comp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 #version 450 core
 
 #extension GL_GOOGLE_include_directive : require

--- a/src/video_core/host_shaders/tiling.comp
+++ b/src/video_core/host_shaders/tiling.comp
@@ -1,0 +1,437 @@
+#version 450 core
+
+#extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_scalar_block_layout : require
+#extension GL_EXT_shader_explicit_arithmetic_types : require
+
+layout (local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+
+// #define BITS_PER_PIXEL
+// #define NUM_SAMPLES
+// #define MICRO_TILE_MODE
+// #define ARRAY_MODE
+// #define MICRO_TILE_THICKNESS
+// #define PIPE_CONFIG
+// #define BANK_WIDTH
+// #define BANK_HEIGHT
+// #define NUM_BANKS
+// #define NUM_BANK_BITS
+// #define TILE_SPLIT_BYTES
+// #define MACRO_TILE_ASPECT
+
+#define BYTES_PER_PIXEL (BITS_PER_PIXEL / 8)
+
+#if BITS_PER_PIXEL == 8
+#define BLOCK_TYPE uint8_t
+#elif BITS_PER_PIXEL == 16
+#define BLOCK_TYPE uint16_t
+#elif BITS_PER_PIXEL == 32
+#define BLOCK_TYPE uint32_t
+#elif BITS_PER_PIXEL == 64
+#define BLOCK_TYPE u32vec2
+#elif BITS_PER_PIXEL == 96
+#define BLOCK_TYPE u32vec3
+#else
+#define BLOCK_TYPE u32vec4
+#endif
+
+#if PIPE_CONFIG == ADDR_SURF_P2
+#define NUM_PIPES 2
+#define NUM_PIPE_BITS 1
+#else
+#define NUM_PIPES 8
+#define NUM_PIPE_BITS 3
+#endif
+
+#define MICRO_TILE_WIDTH 8
+#define MICRO_TILE_HEIGHT 8
+#define MICRO_TILE_PIXELS (MICRO_TILE_WIDTH * MICRO_TILE_HEIGHT)
+#define MICRO_TILE_BITS (MICRO_TILE_PIXELS * MICRO_TILE_THICKNESS * BITS_PER_PIXEL * NUM_SAMPLES)
+#define MICRO_TILE_BYTES (MICRO_TILE_BITS / 8)
+
+#define NUM_PIPE_INTERLEAVE_BITS 8
+
+#define ADDR_SURF_DISPLAY_MICRO_TILING 0
+#define ADDR_SURF_THIN_MICRO_TILING 1
+#define ADDR_SURF_DEPTH_MICRO_TILING 2
+#define ADDR_SURF_ROTATED_MICRO_TILING 3
+
+#define ARRAY_LINEAR_GENERAL 0
+#define ARRAY_LINEAR_ALIGNED 1
+#define ARRAY_1D_TILED_THIN1 2
+#define ARRAY_1D_TILED_THICK 3
+#define ARRAY_2D_TILED_THIN1 4
+#define ARRAY_PRT_TILED_THIN1 5
+#define ARRAY_PRT_2D_TILED_THIN1 6
+#define ARRAY_2D_TILED_THICK 7
+#define ARRAY_2D_TILED_XTHICK 8
+#define ARRAY_PRT_TILED_THICK 9
+#define ARRAY_PRT_2D_TILED_THICK 10
+#define ARRAY_PRT_3D_TILED_THIN1 11
+#define ARRAY_3D_TILED_THIN1 12
+#define ARRAY_3D_TILED_THICK 13
+#define ARRAY_3D_TILED_XTHICK 14
+#define ARRAY_PRT_3D_TILED_THICK 15
+
+#define	ADDR_SURF_P2 0
+#define	ADDR_SURF_P8_32x32_8x16	10
+#define	ADDR_SURF_P8_32x32_16x16 12
+
+#define BITS_PER_BYTE 8
+#define BITS_TO_BYTES(x) (((x) + (BITS_PER_BYTE-1)) / BITS_PER_BYTE)
+
+#define _BIT(v, b) bitfieldExtract((v), (b), 1)
+
+struct MipInfo {
+    uint size;
+    uint pitch;
+    uint height;
+    uint offset;
+};
+
+layout (set = 0, binding = 0, scalar) buffer InputBuf {
+    BLOCK_TYPE in_data[];
+};
+
+layout (set = 0, binding = 1, scalar) buffer OutputBuf {
+    BLOCK_TYPE out_data[];
+};
+
+layout (set = 0, binding = 2, scalar) uniform TilingInfo {
+    uint bank_swizzle;
+    uint num_slices;
+    uint num_mips;
+    MipInfo mips[16];
+} info;
+
+uint32_t ComputePixelIndexWithinMicroTile(uint32_t x, uint32_t y, uint32_t z) {
+    uint32_t p0 = 0;
+    uint32_t p1 = 0;
+    uint32_t p2 = 0;
+    uint32_t p3 = 0;
+    uint32_t p4 = 0;
+    uint32_t p5 = 0;
+    uint32_t p6 = 0;
+    uint32_t p7 = 0;
+    uint32_t p8 = 0;
+
+    uint32_t x0 = _BIT(x, 0);
+    uint32_t x1 = _BIT(x, 1);
+    uint32_t x2 = _BIT(x, 2);
+    uint32_t y0 = _BIT(y, 0);
+    uint32_t y1 = _BIT(y, 1);
+    uint32_t y2 = _BIT(y, 2);
+    uint32_t z0 = _BIT(z, 0);
+    uint32_t z1 = _BIT(z, 1);
+    uint32_t z2 = _BIT(z, 2);
+
+#if MICRO_TILE_MODE == ADDR_SURF_DISPLAY_MICRO_TILING
+    #if BITS_PER_PIXEL == 8
+        p0 = x0;
+        p1 = x1;
+        p2 = x2;
+        p3 = y1;
+        p4 = y0;
+        p5 = y2;
+    #elif BITS_PER_PIXEL == 16
+        p0 = x0;
+        p1 = x1;
+        p2 = x2;
+        p3 = y0;
+        p4 = y1;
+        p5 = y2;
+    #elif BITS_PER_PIXEL == 32
+        p0 = x0;
+        p1 = x1;
+        p2 = y0;
+        p3 = x2;
+        p4 = y1;
+        p5 = y2;
+    #elif BITS_PER_PIXEL == 64
+        p0 = x0;
+        p1 = y0;
+        p2 = x1;
+        p3 = x2;
+        p4 = y1;
+        p5 = y2;
+    #elif BITS_PER_PIXEL == 128
+        p0 = y0;
+        p1 = x0;
+        p2 = x1;
+        p3 = x2;
+        p4 = y1;
+        p5 = y2;
+    #endif
+#elif MICRO_TILE_MODE == ADDR_SURF_THIN_MICRO_TILING || MICRO_TILE_MODE == ADDR_SURF_DEPTH_MICRO_TILING
+        p0 = x0;
+        p1 = y0;
+        p2 = x1;
+        p3 = y1;
+        p4 = x2;
+        p5 = y2;
+#else
+    #if BITS_PER_PIXEL == 8 || BITS_PER_PIXEL == 16
+        p0 = x0;
+        p1 = y0;
+        p2 = x1;
+        p3 = y1;
+        p4 = z0;
+        p5 = z1;
+    #elif BITS_PER_PIXEL == 32
+        p0 = x0;
+        p1 = y0;
+        p2 = x1;
+        p3 = z0;
+        p4 = y1;
+        p5 = z1;
+    #elif BITS_PER_PIXEL == 64 || BITS_PER_PIXEL == 128
+        p0 = x0;
+        p1 = y0;
+        p2 = z0;
+        p3 = x1;
+        p4 = y1;
+        p5 = z1;
+    #endif
+        p6 = x2;
+        p7 = y2;
+
+    #if MICRO_TILE_THICKNESS == 8
+        p8 = z2;
+    #endif
+#endif
+
+    uint32_t pixel_number =
+        ((p0) | (p1 << 1) | (p2 << 2) | (p3 << 3) | (p4 << 4) |
+         (p5 << 5) | (p6 << 6) | (p7 << 7) | (p8 << 8));
+
+    return pixel_number;
+}
+
+#if ARRAY_MODE == ARRAY_1D_TILED_THIN1 || ARRAY_MODE == ARRAY_1D_TILED_THICK
+uint32_t ComputeSurfaceAddrFromCoordMicroTiled(uint32_t x, uint32_t y, uint32_t slice, uint32_t pitch, uint32_t height, uint32_t sample_index) {
+    uint32_t slice_bytes = BITS_TO_BYTES(pitch * height * MICRO_TILE_THICKNESS * BITS_PER_PIXEL * NUM_SAMPLES);
+
+    uint32_t micro_tiles_per_row = pitch / MICRO_TILE_WIDTH;
+    uint32_t micro_tile_index_x = x / MICRO_TILE_WIDTH;
+    uint32_t micro_tile_index_y = y / MICRO_TILE_HEIGHT;
+    uint32_t micro_tile_index_z = slice / MICRO_TILE_THICKNESS;
+
+    uint32_t slice_offset = micro_tile_index_z * slice_bytes;
+    uint32_t micro_tile_offset = (micro_tile_index_y * micro_tiles_per_row + micro_tile_index_x) * MICRO_TILE_BYTES;
+
+    uint32_t pixel_index = ComputePixelIndexWithinMicroTile(x, y, slice);
+
+    uint32_t sample_offset;
+    uint32_t pixel_offset;
+#if MICRO_TILE_MODE == ADDR_SURF_DEPTH_MICRO_TILING
+    sample_offset = sample_index * BITS_PER_PIXEL;
+    pixel_offset = pixel_index * BITS_PER_PIXEL * NUM_SAMPLES;
+#else
+    sample_offset = sample_index * (MICRO_TILE_BYTES * 8 / NUM_SAMPLES);
+    pixel_offset = pixel_index * BITS_PER_PIXEL;
+#endif
+
+    uint32_t elem_offset = (sample_offset + pixel_offset) / 8;
+    return slice_offset + micro_tile_offset + elem_offset;
+}
+#else
+uint32_t ComputePipeFromCoord(uint32_t x, uint32_t y, uint32_t slice) {
+    uint32_t p0 = 0;
+    uint32_t p1 = 0;
+    uint32_t p2 = 0;
+
+    uint32_t tx = x / MICRO_TILE_WIDTH;
+    uint32_t ty = y / MICRO_TILE_HEIGHT;
+    uint32_t x3 = _BIT(tx, 0);
+    uint32_t x4 = _BIT(tx, 1);
+    uint32_t x5 = _BIT(tx, 2);
+    uint32_t y3 = _BIT(ty, 0);
+    uint32_t y4 = _BIT(ty, 1);
+    uint32_t y5 = _BIT(ty, 2);
+
+#if PIPE_CONFIG == ADDR_SURF_P2
+    p0 = x3 ^ y3;
+#elif PIPE_CONFIG == ADDR_SURF_P8_32x32_8x16
+    p0 = x4 ^ y3 ^ x5;
+    p1 = x3 ^ y4;
+    p2 = x5 ^ y5;
+#elif PIPE_CONFIG == ADDR_SURF_P8_32x32_16x16
+    p0 = x3 ^ y3 ^ x4;
+    p1 = x4 ^ y4;
+    p2 = x5 ^ y5;
+#endif
+
+    uint32_t pipe = p0 | (p1 << 1) | (p2 << 2);
+
+    uint32_t pipe_swizzle = 0;
+#if ARRAY_MODE == ARRAY_3D_TILED_THIN1 || ARRAY_MODE == ARRAY_3D_TILED_THICK || ARRAY_MODE == ARRAY_3D_TILED_XTHICK
+    pipe_swizzle += max(1, NUM_PIPES / 2 - 1) * (slice / MICRO_TILE_THICKNESS);
+#endif
+    pipe_swizzle &= (NUM_PIPES - 1);
+    pipe = pipe ^ pipe_swizzle;
+    return pipe;
+}
+
+uint32_t ComputeBankFromCoord(uint32_t x, uint32_t y, uint32_t slice, uint32_t tile_split_slice) {
+    uint32_t b0 = 0;
+    uint32_t b1 = 0;
+    uint32_t b2 = 0;
+    uint32_t b3 = 0;
+    uint32_t slice_rotation = 0;
+    uint32_t tile_split_rotation = 0;
+
+    uint32_t tx = x / MICRO_TILE_WIDTH / (BANK_WIDTH * NUM_PIPES);
+    uint32_t ty = y / MICRO_TILE_HEIGHT / BANK_HEIGHT;
+
+    uint32_t x3 = _BIT(tx, 0);
+    uint32_t x4 = _BIT(tx, 1);
+    uint32_t x5 = _BIT(tx, 2);
+    uint32_t x6 = _BIT(tx, 3);
+    uint32_t y3 = _BIT(ty, 0);
+    uint32_t y4 = _BIT(ty, 1);
+    uint32_t y5 = _BIT(ty, 2);
+    uint32_t y6 = _BIT(ty, 3);
+
+#if NUM_BANKS == 16
+    b0 = x3 ^ y6;
+    b1 = x4 ^ y5 ^ y6;
+    b2 = x5 ^ y4;
+    b3 = x6 ^ y3;
+#elif NUM_BANKS == 8
+    b0 = x3 ^ y5;
+    b1 = x4 ^ y4 ^ y5;
+    b2 = x5 ^ y3;
+#elif NUM_BANKS == 4
+    b0 = x3 ^ y4;
+    b1 = x4 ^ y3;
+#elif NUM_BANKS == 2
+    b0 = x3 ^ y3;
+#endif
+
+    uint32_t bank = b0 | (b1 << 1) | (b2 << 2) | (b3 << 3);
+
+#if ARRAY_MODE == ARRAY_2D_TILED_THIN1 || ARRAY_MODE == ARRAY_2D_TILED_THICK || ARRAY_MODE == ARRAY_2D_TILED_XTHICK
+    slice_rotation = ((NUM_BANKS / 2) - 1) * (slice / MICRO_TILE_THICKNESS);
+#elif ARRAY_MODE == ARRAY_3D_TILED_THIN1 || ARRAY_MODE == ARRAY_3D_TILED_THICK || ARRAY_MODE == ARRAY_3D_TILED_XTHICK
+    slice_rotation = max(1u, (NUM_PIPES / 2) - 1) * (slice / MICRO_TILE_THICKNESS) / NUM_PIPES;
+#endif
+
+#if ARRAY_MODE == ARRAY_2D_TILED_THIN1 || ARRAY_MODE == ARRAY_3D_TILED_THIN1 || \
+    ARRAY_MODE == ARRAY_PRT_2D_TILED_THIN1 || ARRAY_MODE == ARRAY_PRT_3D_TILED_THIN1
+                                                                tile_split_rotation = ((NUM_BANKS / 2) + 1) * tile_split_slice;
+#endif
+
+    bank ^= info.bank_swizzle + slice_rotation;
+    bank ^= tile_split_rotation;
+    bank &= (NUM_BANKS - 1);
+
+    return bank;
+}
+
+uint32_t ComputeSurfaceAddrFromCoordMacroTiled(uint32_t x, uint32_t y, uint32_t slice, uint32_t pitch, uint32_t height, uint32_t sample_index) {
+    uint32_t pixel_index = ComputePixelIndexWithinMicroTile(x, y, slice);
+
+    uint32_t sample_offset;
+    uint32_t pixel_offset;
+#if MICRO_TILE_MODE == ADDR_SURF_DEPTH_MICRO_TILING
+    sample_offset = sample_index * BITS_PER_PIXEL;
+    pixel_offset = pixel_index * BITS_PER_PIXEL * NUM_SAMPLES;
+#else
+    sample_offset = sample_index * (MICRO_TILE_BITS / NUM_SAMPLES);
+    pixel_offset = pixel_index * BITS_PER_PIXEL;
+#endif
+
+    uint32_t element_offset = (pixel_offset + sample_offset) / 8;
+
+    uint32_t slices_per_tile = 1;
+    uint32_t tile_split_slice = 0;
+#if MICRO_TILE_BYTES > TILE_SPLIT_BYTES && MICRO_TILE_THICKNESS == 1
+    slices_per_tile = MICRO_TILE_BYTES / TILE_SPLIT_BYTES;
+    tile_split_slice = element_offset / TILE_SPLIT_BYTES;
+    element_offset %= TILE_SPLIT_BYTES;
+    #undef MICRO_TILE_BYTES
+    #define MICRO_TILE_BYTES TILE_SPLIT_BYTES
+#endif
+
+    uint32_t macro_tile_pitch = (MICRO_TILE_WIDTH * BANK_WIDTH * NUM_PIPES) * MACRO_TILE_ASPECT;
+    uint32_t macro_tile_height = (MICRO_TILE_HEIGHT * BANK_HEIGHT * NUM_BANKS) / MACRO_TILE_ASPECT;
+
+    uint32_t macro_tile_bytes = MICRO_TILE_BYTES *
+                               (macro_tile_pitch / MICRO_TILE_WIDTH) *
+                               (macro_tile_height / MICRO_TILE_HEIGHT) / (NUM_PIPES * NUM_BANKS);
+
+    uint32_t macro_tiles_per_row = pitch / macro_tile_pitch;
+
+    uint32_t macro_tile_index_x = x / macro_tile_pitch;
+    uint32_t macro_tile_index_y = y / macro_tile_height;
+    uint32_t macro_tile_offset =
+        ((macro_tile_index_y * macro_tiles_per_row) + macro_tile_index_x) * macro_tile_bytes;
+    uint32_t macro_tiles_per_slice = macro_tiles_per_row * (height / macro_tile_height);
+
+    uint32_t slice_bytes = macro_tiles_per_slice * macro_tile_bytes;
+    uint32_t slice_offset =
+        slice_bytes * (tile_split_slice + slices_per_tile * (slice / MICRO_TILE_THICKNESS));
+
+    uint32_t tile_row_index = (y / MICRO_TILE_HEIGHT) % BANK_HEIGHT;
+    uint32_t tile_column_index = ((x / MICRO_TILE_WIDTH) / NUM_PIPES) % BANK_WIDTH;
+    uint32_t tile_index = (tile_row_index * BANK_WIDTH) + tile_column_index;
+    uint32_t tile_offset = tile_index * MICRO_TILE_BYTES;
+
+    uint32_t total_offset = slice_offset + macro_tile_offset + element_offset + tile_offset;
+
+#if ARRAY_MODE == ARRAY_PRT_TILED_THIN1 || ARRAY_MODE == ARRAY_PRT_TILED_THICK || \
+    ARRAY_MODE == ARRAY_PRT_2D_TILED_THIN1 || ARRAY_MODE == ARRAY_PRT_2D_TILED_THICK || \
+    ARRAY_MODE == ARRAY_PRT_3D_TILED_THIN1 || ARRAY_MODE == ARRAY_PRT_3D_TILED_THICK
+    x %= macro_tile_pitch;
+    y %= macro_tile_height;
+#endif
+
+    uint32_t pipe = ComputePipeFromCoord(x, y, slice);
+    uint32_t bank = ComputeBankFromCoord(x, y, slice, tile_split_slice);
+
+    uint32_t pipe_interleave_mask = (1 << NUM_PIPE_INTERLEAVE_BITS) - 1;
+    uint32_t pipe_interleave_offset = total_offset & pipe_interleave_mask;
+    uint32_t offset = total_offset >> NUM_PIPE_INTERLEAVE_BITS;
+
+    uint32_t addr = pipe_interleave_offset;
+    uint32_t pipe_bits = pipe << NUM_PIPE_INTERLEAVE_BITS;
+    uint32_t bank_bits = bank << (NUM_PIPE_INTERLEAVE_BITS + NUM_PIPE_BITS);
+    uint32_t offset_bits = offset << (NUM_PIPE_INTERLEAVE_BITS + NUM_PIPE_BITS + NUM_BANK_BITS);
+
+    addr |= pipe_bits;
+    addr |= bank_bits;
+    addr |= offset_bits;
+
+    return addr;
+}
+#endif
+
+uint GetMipLevel(inout uint texel) {
+    uint mip = 0;
+    uint mip_size = info.mips[mip].size / BYTES_PER_PIXEL;
+    while (texel >= mip_size) {
+        texel -= mip_size;
+        ++mip;
+        mip_size = info.mips[mip].size / BYTES_PER_PIXEL;
+    }
+    return mip;
+}
+
+void main() {
+    uint texel = gl_GlobalInvocationID.x;
+    uint mip = GetMipLevel(texel);
+    uint pitch = info.mips[mip].pitch;
+    uint height = info.mips[mip].height;
+    uint tiled_offset = info.mips[mip].offset;
+    uint x = texel % pitch;
+    uint y = (texel / pitch) % height;
+    uint slice = texel / (pitch * height);
+
+#if ARRAY_MODE == ARRAY_1D_TILED_THIN1 || ARRAY_MODE == ARRAY_1D_TILED_THICK
+    tiled_offset += ComputeSurfaceAddrFromCoordMicroTiled(x, y, slice, pitch, height, 0);
+#else
+    tiled_offset += ComputeSurfaceAddrFromCoordMacroTiled(x, y, slice, pitch, height, 0);
+#endif
+
+    out_data[gl_GlobalInvocationID.x] = in_data[tiled_offset / BYTES_PER_PIXEL];
+}

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -253,6 +253,7 @@ bool Instance::CreateDevice() {
     ASSERT(add_extension(VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME));
 
     // Optional
+    maintenance_8 = add_extension(VK_KHR_MAINTENANCE_8_EXTENSION_NAME);
     depth_range_unrestricted = add_extension(VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME);
     dynamic_state_3 = add_extension(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
     if (dynamic_state_3) {
@@ -459,6 +460,9 @@ bool Instance::CreateDevice() {
         vk::PhysicalDeviceVertexAttributeDivisorFeatures{
             .vertexAttributeInstanceRateDivisor = true,
         },
+        vk::PhysicalDeviceMaintenance8FeaturesKHR{
+            .maintenance8 = true,
+        },
         vk::PhysicalDeviceShaderAtomicFloat2FeaturesEXT{
             .shaderBufferFloat32AtomicMinMax =
                 shader_atomic_float2_features.shaderBufferFloat32AtomicMinMax,
@@ -526,6 +530,9 @@ bool Instance::CreateDevice() {
     }
     if (!provoking_vertex) {
         device_chain.unlink<vk::PhysicalDeviceProvokingVertexFeaturesEXT>();
+    }
+    if (!maintenance_8) {
+        device_chain.unlink<vk::PhysicalDeviceMaintenance8FeaturesKHR>();
     }
     if (!shader_atomic_float2) {
         device_chain.unlink<vk::PhysicalDeviceShaderAtomicFloat2FeaturesEXT>();

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -414,7 +414,6 @@ bool Instance::CreateDevice() {
         },
         vk::PhysicalDeviceVulkan13Features{
             .robustImageAccess = vk13_features.robustImageAccess,
-            .inlineUniformBlock = vk13_features.inlineUniformBlock,
             .shaderDemoteToHelperInvocation = vk13_features.shaderDemoteToHelperInvocation,
             .synchronization2 = vk13_features.synchronization2,
             .dynamicRendering = vk13_features.dynamicRendering,

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -414,6 +414,7 @@ bool Instance::CreateDevice() {
         },
         vk::PhysicalDeviceVulkan13Features{
             .robustImageAccess = vk13_features.robustImageAccess,
+            .inlineUniformBlock = vk13_features.inlineUniformBlock,
             .shaderDemoteToHelperInvocation = vk13_features.shaderDemoteToHelperInvocation,
             .synchronization2 = vk13_features.synchronization2,
             .dynamicRendering = vk13_features.dynamicRendering,

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -109,6 +109,11 @@ public:
         return vk12_features.shaderInt8;
     }
 
+    /// Returns true if VK_KHR_maintenance8 is supported
+    bool IsMaintenance8Supported() const {
+        return maintenance_8;
+    }
+
     /// Returns true when VK_EXT_custom_border_color is supported
     bool IsCustomBorderColorSupported() const {
         return custom_border_color;
@@ -469,6 +474,7 @@ private:
     bool shader_atomic_float2{};
     bool workgroup_memory_explicit_layout{};
     bool portability_subset{};
+    bool maintenance_8{};
     bool supports_memory_budget{};
     u64 total_memory_budget{};
     std::vector<size_t> valid_heaps;

--- a/src/video_core/renderer_vulkan/vk_presenter.h
+++ b/src/video_core/renderer_vulkan/vk_presenter.h
@@ -5,6 +5,7 @@
 
 #include <condition_variable>
 
+#include "core/libraries/videoout/buffer.h"
 #include "imgui/imgui_config.h"
 #include "imgui/imgui_texture.h"
 #include "video_core/amdgpu/liverpool.h"

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -687,7 +687,7 @@ void Rasterizer::BindTextures(const Shader::Info& stage, Shader::Backend::Bindin
             if (image.binding.force_general || image.binding.is_target) {
                 image.Transit(vk::ImageLayout::eGeneral,
                               vk::AccessFlagBits2::eShaderRead |
-                                  (image.info.IsDepthStencil()
+                                  (image.info.props.is_depth
                                        ? vk::AccessFlagBits2::eDepthStencilAttachmentWrite
                                        : vk::AccessFlagBits2::eColorAttachmentWrite),
                               {});
@@ -698,7 +698,7 @@ void Rasterizer::BindTextures(const Shader::Info& stage, Shader::Backend::Bindin
                                       vk::AccessFlagBits2::eShaderWrite,
                                   desc.view_info.range);
                 } else {
-                    const auto new_layout = image.info.IsDepthStencil()
+                    const auto new_layout = image.info.props.is_depth
                                                 ? vk::ImageLayout::eDepthStencilReadOnlyOptimal
                                                 : vk::ImageLayout::eShaderReadOnlyOptimal;
                     image.Transit(new_layout, vk::AccessFlagBits2::eShaderRead,

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -112,6 +112,7 @@ private:
     }
 
     bool IsComputeMetaClear(const Pipeline* pipeline);
+    bool IsComputeImageCopy(const Pipeline* pipeline);
 
 private:
     friend class VideoCore::BufferCache;

--- a/src/video_core/texture_cache/image.cpp
+++ b/src/video_core/texture_cache/image.cpp
@@ -357,13 +357,13 @@ void Image::CopyImage(const Image& src_image) {
 
         image_copy.emplace_back(vk::ImageCopy{
             .srcSubresource{
-                .aspectMask = src_image.aspect_mask,
+                .aspectMask = src_image.aspect_mask & ~vk::ImageAspectFlagBits::eStencil,
                 .mipLevel = m,
                 .baseArrayLayer = 0,
                 .layerCount = src_info.resources.layers,
             },
             .dstSubresource{
-                .aspectMask = src_image.aspect_mask,
+                .aspectMask = src_image.aspect_mask & ~vk::ImageAspectFlagBits::eStencil,
                 .mipLevel = m,
                 .baseArrayLayer = 0,
                 .layerCount = src_info.resources.layers,

--- a/src/video_core/texture_cache/image.cpp
+++ b/src/video_core/texture_cache/image.cpp
@@ -186,8 +186,8 @@ Image::Image(const Vulkan::Instance& instance_, Vulkan::Scheduler& scheduler_,
     image.Create(image_ci);
 
     Vulkan::SetObjectName(instance->GetDevice(), (vk::Image)image, "Image {}x{}x{} {} {:#x}:{:#x}",
-                          info.size.width, info.size.height, info.size.depth, AmdGpu::NameOf(info.tile_mode),
-                          info.guest_address, info.guest_size);
+                          info.size.width, info.size.height, info.size.depth,
+                          AmdGpu::NameOf(info.tile_mode), info.guest_address, info.guest_size);
 }
 
 boost::container::small_vector<vk::ImageMemoryBarrier2, 32> Image::GetBarriers(

--- a/src/video_core/texture_cache/image.cpp
+++ b/src/video_core/texture_cache/image.cpp
@@ -341,8 +341,9 @@ void Image::Upload(vk::Buffer buffer, u64 offset) {
             vk::AccessFlagBits2::eShaderRead | vk::AccessFlagBits2::eTransferRead, {});
 }
 
-void Image::CopyImage(const Image& src_image) {
+void Image::CopyImage(Image& src_image) {
     scheduler->EndRendering();
+    src_image.Transit(vk::ImageLayout::eTransferSrcOptimal, vk::AccessFlagBits2::eTransferRead, {});
     Transit(vk::ImageLayout::eTransferDstOptimal, vk::AccessFlagBits2::eTransferWrite, {});
 
     auto cmdbuf = scheduler->CommandBuffer();
@@ -363,7 +364,7 @@ void Image::CopyImage(const Image& src_image) {
                 .layerCount = src_info.resources.layers,
             },
             .dstSubresource{
-                .aspectMask = src_image.aspect_mask & ~vk::ImageAspectFlagBits::eStencil,
+                .aspectMask = aspect_mask & ~vk::ImageAspectFlagBits::eStencil,
                 .mipLevel = m,
                 .baseArrayLayer = 0,
                 .layerCount = src_info.resources.layers,

--- a/src/video_core/texture_cache/image.h
+++ b/src/video_core/texture_cache/image.h
@@ -103,7 +103,7 @@ struct Image {
                  std::optional<SubresourceRange> range, vk::CommandBuffer cmdbuf = {});
     void Upload(vk::Buffer buffer, u64 offset);
 
-    void CopyImage(const Image& src_image);
+    void CopyImage(Image& src_image);
     void CopyImageWithBuffer(Image& src_image, vk::Buffer buffer, u64 offset);
     void CopyMip(const Image& src_image, u32 mip, u32 slice);
 

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -179,6 +179,10 @@ void ImageInfo::UpdateSize() {
                 ImageSizeMicroTiled(mip_w, mip_h, thickness, num_bits, num_samples);
             break;
         }
+        case AmdGpu::ArrayMode::Array2DTiledThick:
+            thickness = 4;
+            mip_d += (-mip_d) & (thickness - 1);
+            [[fallthrough]];
         case AmdGpu::ArrayMode::Array2DTiledThin1: {
             ASSERT(!props.is_block);
             std::tie(mip_info.pitch, mip_info.height, mip_info.size) = ImageSizeMacroTiled(
@@ -186,7 +190,7 @@ void ImageInfo::UpdateSize() {
             break;
         }
         default: {
-            UNREACHABLE_MSG("Unknown tile mode {}", magic_enum::enum_name(array_mode));
+            UNREACHABLE_MSG("Unknown array mode {}", magic_enum::enum_name(array_mode));
         }
         }
         if (props.is_block) {

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -9,6 +9,8 @@
 #include "video_core/texture_cache/image_info.h"
 #include "video_core/texture_cache/tile.h"
 
+#include <magic_enum/magic_enum.hpp>
+
 namespace VideoCore {
 
 using namespace Vulkan;
@@ -184,7 +186,7 @@ void ImageInfo::UpdateSize() {
             break;
         }
         default: {
-            UNREACHABLE();
+            UNREACHABLE_MSG("Unknown tile mode {}", magic_enum::enum_name(array_mode));
         }
         }
         if (props.is_block) {

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -111,6 +111,7 @@ ImageInfo::ImageInfo(const AmdGpu::Image& image, const Shader::ImageResource& de
     pixel_format = LiverpoolToVK::SurfaceFormat(image.GetDataFmt(), image.GetNumberFmt());
     if (desc.is_depth) {
         pixel_format = LiverpoolToVK::PromoteFormatToDepth(pixel_format);
+        props.is_depth = true;
     }
     type = image.GetBaseType();
     props.is_tiled = image.IsTiled();

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -74,7 +74,7 @@ ImageInfo::ImageInfo(const AmdGpu::Liverpool::ColorBuffer& buffer,
     guest_address = buffer.Address();
     const auto color_slice_sz = buffer.GetColorSliceSize();
     guest_size = color_slice_sz * buffer.NumSlices();
-    mips_layout.emplace_back(color_slice_sz, pitch, buffer.Height(), 0);
+    mips_layout.emplace_back(guest_size, pitch, buffer.Height(), 0);
     alt_tile = Libraries::Kernel::sceKernelIsNeoMode() && buffer.info.alt_tile_mode;
 }
 
@@ -104,7 +104,7 @@ ImageInfo::ImageInfo(const AmdGpu::Liverpool::DepthBuffer& buffer, u32 num_slice
     guest_address = write_buffer ? buffer.DepthWriteAddress() : buffer.DepthAddress();
     const auto depth_slice_sz = buffer.GetDepthSliceSize();
     guest_size = depth_slice_sz * num_slices;
-    mips_layout.emplace_back(depth_slice_sz, pitch, buffer.Height(), 0);
+    mips_layout.emplace_back(guest_size, pitch, buffer.Height(), 0);
 }
 
 ImageInfo::ImageInfo(const AmdGpu::Image& image, const Shader::ImageResource& desc) noexcept {
@@ -131,7 +131,6 @@ ImageInfo::ImageInfo(const AmdGpu::Image& image, const Shader::ImageResource& de
 
     guest_address = image.Address();
 
-    mips_layout.reserve(resources.levels);
     alt_tile = Libraries::Kernel::sceKernelIsNeoMode() && image.alt_tile_mode;
     UpdateSize();
 }

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -128,6 +128,7 @@ ImageInfo::ImageInfo(const AmdGpu::Image& image, const Shader::ImageResource& de
     resources.layers = image.NumLayers();
     num_samples = image.NumSamples();
     num_bits = NumBitsPerBlock(image.GetDataFmt());
+    bank_swizzle = image.GetBankSwizzle();
 
     guest_address = image.Address();
 

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -61,8 +61,8 @@ ImageInfo::ImageInfo(const Libraries::VideoOut::BufferAttributeGroup& group,
                      VAddr cpu_address) noexcept {
     const auto& attrib = group.attrib;
     props.is_tiled = attrib.tiling_mode == TilingMode::Tile;
-    tile_mode = props.is_tiled ? AmdGpu::TileMode::Display2DThin
-                               : AmdGpu::TileMode::DisplayLinearAligned;
+    tile_mode =
+        props.is_tiled ? AmdGpu::TileMode::Display2DThin : AmdGpu::TileMode::DisplayLinearAligned;
     array_mode = AmdGpu::GetArrayMode(tile_mode);
     pixel_format = ConvertPixelFormat(attrib.pixel_format);
     type = AmdGpu::ImageType::Color2D;

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "common/assert.h"
-#include "common/config.h"
 #include "core/libraries/kernel/process.h"
+#include "core/libraries/videoout/buffer.h"
+#include "shader_recompiler/info.h"
 #include "video_core/renderer_vulkan/liverpool_to_vk.h"
 #include "video_core/texture_cache/image_info.h"
 #include "video_core/texture_cache/tile.h"
@@ -32,127 +33,7 @@ static vk::Format ConvertPixelFormat(const VideoOutFormat format) {
     return {};
 }
 
-static vk::ImageType ConvertImageType(AmdGpu::ImageType type) noexcept {
-    switch (type) {
-    case AmdGpu::ImageType::Color1D:
-    case AmdGpu::ImageType::Color1DArray:
-        return vk::ImageType::e1D;
-    case AmdGpu::ImageType::Color2D:
-    case AmdGpu::ImageType::Color2DMsaa:
-    case AmdGpu::ImageType::Color2DArray:
-        return vk::ImageType::e2D;
-    case AmdGpu::ImageType::Color3D:
-        return vk::ImageType::e3D;
-    default:
-        UNREACHABLE();
-    }
-}
-
-ImageInfo::ImageInfo(const Libraries::VideoOut::BufferAttributeGroup& group,
-                     VAddr cpu_address) noexcept {
-    const auto& attrib = group.attrib;
-    props.is_tiled = attrib.tiling_mode == TilingMode::Tile;
-    tiling_mode = props.is_tiled ? AmdGpu::TilingMode::Display_MacroTiled
-                                 : AmdGpu::TilingMode::Display_Linear;
-    pixel_format = ConvertPixelFormat(attrib.pixel_format);
-    type = vk::ImageType::e2D;
-    size.width = attrib.width;
-    size.height = attrib.height;
-    pitch = attrib.tiling_mode == TilingMode::Linear ? size.width : (size.width + 127) & (~127);
-    num_bits = attrib.pixel_format != VideoOutFormat::A16R16G16B16Float ? 32 : 64;
-    ASSERT(num_bits == 32);
-
-    guest_address = cpu_address;
-    if (!props.is_tiled) {
-        guest_size = pitch * size.height * 4;
-    } else {
-        if (Libraries::Kernel::sceKernelIsNeoMode()) {
-            guest_size = pitch * ((size.height + 127) & (~127)) * 4;
-        } else {
-            guest_size = pitch * ((size.height + 63) & (~63)) * 4;
-        }
-    }
-    mips_layout.emplace_back(guest_size, pitch, 0);
-}
-
-ImageInfo::ImageInfo(const AmdGpu::Liverpool::ColorBuffer& buffer,
-                     const AmdGpu::Liverpool::CbDbExtent& hint /*= {}*/) noexcept {
-    props.is_tiled = buffer.IsTiled();
-    tiling_mode = buffer.GetTilingMode();
-    pixel_format = LiverpoolToVK::SurfaceFormat(buffer.GetDataFmt(), buffer.GetNumberFmt());
-    num_samples = buffer.NumSamples();
-    num_bits = NumBitsPerBlock(buffer.GetDataFmt());
-    type = vk::ImageType::e2D;
-    size.width = hint.Valid() ? hint.width : buffer.Pitch();
-    size.height = hint.Valid() ? hint.height : buffer.Height();
-    size.depth = 1;
-    pitch = buffer.Pitch();
-    resources.layers = buffer.NumSlices();
-    meta_info.cmask_addr = buffer.info.fast_clear ? buffer.CmaskAddress() : 0;
-    meta_info.fmask_addr = buffer.info.compression ? buffer.FmaskAddress() : 0;
-
-    guest_address = buffer.Address();
-    const auto color_slice_sz = buffer.GetColorSliceSize();
-    guest_size = color_slice_sz * buffer.NumSlices();
-    mips_layout.emplace_back(color_slice_sz, pitch, 0);
-    tiling_idx = static_cast<u32>(buffer.attrib.tile_mode_index.Value());
-    alt_tile = Libraries::Kernel::sceKernelIsNeoMode() && buffer.info.alt_tile_mode;
-}
-
-ImageInfo::ImageInfo(const AmdGpu::Liverpool::DepthBuffer& buffer, u32 num_slices,
-                     VAddr htile_address, const AmdGpu::Liverpool::CbDbExtent& hint,
-                     bool write_buffer) noexcept {
-    props.is_tiled = false;
-    pixel_format = LiverpoolToVK::DepthFormat(buffer.z_info.format, buffer.stencil_info.format);
-    type = vk::ImageType::e2D;
-    num_samples = buffer.NumSamples();
-    num_bits = buffer.NumBits();
-    size.width = hint.Valid() ? hint.width : buffer.Pitch();
-    size.height = hint.Valid() ? hint.height : buffer.Height();
-    size.depth = 1;
-    pitch = buffer.Pitch();
-    resources.layers = num_slices;
-    meta_info.htile_addr = buffer.z_info.tile_surface_en ? htile_address : 0;
-
-    stencil_addr = write_buffer ? buffer.StencilWriteAddress() : buffer.StencilAddress();
-    stencil_size = pitch * size.height * sizeof(u8);
-
-    guest_address = write_buffer ? buffer.DepthWriteAddress() : buffer.DepthAddress();
-    const auto depth_slice_sz = buffer.GetDepthSliceSize();
-    guest_size = depth_slice_sz * num_slices;
-    mips_layout.emplace_back(depth_slice_sz, pitch, 0);
-}
-
-ImageInfo::ImageInfo(const AmdGpu::Image& image, const Shader::ImageResource& desc) noexcept {
-    tiling_mode = image.GetTilingMode();
-    pixel_format = LiverpoolToVK::SurfaceFormat(image.GetDataFmt(), image.GetNumberFmt());
-    // Override format if image is forced to be a depth target
-    if (desc.is_depth) {
-        pixel_format = LiverpoolToVK::PromoteFormatToDepth(pixel_format);
-    }
-    type = ConvertImageType(image.GetType());
-    props.is_tiled = image.IsTiled();
-    props.is_volume = image.GetType() == AmdGpu::ImageType::Color3D;
-    props.is_pow2 = image.pow2pad;
-    props.is_block = IsBlockCoded();
-    size.width = image.width + 1;
-    size.height = image.height + 1;
-    size.depth = props.is_volume ? image.depth + 1 : 1;
-    pitch = image.Pitch();
-    resources.levels = image.NumLevels();
-    resources.layers = image.NumLayers();
-    num_samples = image.NumSamples();
-    num_bits = NumBitsPerBlock(image.GetDataFmt());
-
-    guest_address = image.Address();
-
-    mips_layout.reserve(resources.levels);
-    tiling_idx = image.tiling_index;
-    alt_tile = Libraries::Kernel::sceKernelIsNeoMode() && image.alt_tile_mode;
-    UpdateSize();
-}
-
-bool ImageInfo::IsBlockCoded() const {
+bool IsBlockCoded(vk::Format pixel_format) {
     switch (pixel_format) {
     case vk::Format::eBc1RgbaSrgbBlock:
     case vk::Format::eBc1RgbaUnormBlock:
@@ -174,6 +55,114 @@ bool ImageInfo::IsBlockCoded() const {
     default:
         return false;
     }
+}
+
+ImageInfo::ImageInfo(const Libraries::VideoOut::BufferAttributeGroup& group,
+                     VAddr cpu_address) noexcept {
+    const auto& attrib = group.attrib;
+    props.is_tiled = attrib.tiling_mode == TilingMode::Tile;
+    tile_mode = props.is_tiled ? AmdGpu::TileMode::Display2DThin
+                               : AmdGpu::TileMode::DisplayLinearAligned;
+    array_mode = AmdGpu::GetArrayMode(tile_mode);
+    pixel_format = ConvertPixelFormat(attrib.pixel_format);
+    type = AmdGpu::ImageType::Color2D;
+    size.width = attrib.width;
+    size.height = attrib.height;
+    pitch = attrib.tiling_mode == TilingMode::Linear ? size.width : (size.width + 127) & (~127);
+    num_bits = attrib.pixel_format != VideoOutFormat::A16R16G16B16Float ? 32 : 64;
+    ASSERT(num_bits == 32);
+
+    guest_address = cpu_address;
+    if (!props.is_tiled) {
+        guest_size = pitch * size.height * 4;
+    } else {
+        if (Libraries::Kernel::sceKernelIsNeoMode()) {
+            guest_size = pitch * ((size.height + 127) & (~127)) * 4;
+        } else {
+            guest_size = pitch * ((size.height + 63) & (~63)) * 4;
+        }
+    }
+    const u32 old_guest_size = guest_size;
+    UpdateSize();
+    ASSERT(old_guest_size == guest_size);
+}
+
+ImageInfo::ImageInfo(const AmdGpu::Liverpool::ColorBuffer& buffer,
+                     const AmdGpu::Liverpool::CbDbExtent& hint /*= {}*/) noexcept {
+    props.is_tiled = buffer.IsTiled();
+    tile_mode = buffer.GetTileMode();
+    array_mode = AmdGpu::GetArrayMode(tile_mode);
+    pixel_format = LiverpoolToVK::SurfaceFormat(buffer.GetDataFmt(), buffer.GetNumberFmt());
+    num_samples = buffer.NumSamples();
+    num_bits = NumBitsPerBlock(buffer.GetDataFmt());
+    type = AmdGpu::ImageType::Color2D;
+    size.width = hint.Valid() ? hint.width : buffer.Pitch();
+    size.height = hint.Valid() ? hint.height : buffer.Height();
+    size.depth = 1;
+    pitch = buffer.Pitch();
+    resources.layers = buffer.NumSlices();
+    meta_info.cmask_addr = buffer.info.fast_clear ? buffer.CmaskAddress() : 0;
+    meta_info.fmask_addr = buffer.info.compression ? buffer.FmaskAddress() : 0;
+
+    guest_address = buffer.Address();
+    const auto color_slice_sz = buffer.GetColorSliceSize();
+    guest_size = color_slice_sz * buffer.NumSlices();
+    mips_layout.emplace_back(color_slice_sz, pitch, buffer.Height(), 0);
+    alt_tile = Libraries::Kernel::sceKernelIsNeoMode() && buffer.info.alt_tile_mode;
+}
+
+ImageInfo::ImageInfo(const AmdGpu::Liverpool::DepthBuffer& buffer, u32 num_slices,
+                     VAddr htile_address, const AmdGpu::Liverpool::CbDbExtent& hint,
+                     bool write_buffer) noexcept {
+    props.is_tiled = buffer.IsTiled();
+    tile_mode = buffer.GetTileMode();
+    array_mode = AmdGpu::GetArrayMode(tile_mode);
+    pixel_format = LiverpoolToVK::DepthFormat(buffer.z_info.format, buffer.stencil_info.format);
+    type = AmdGpu::ImageType::Color2D;
+    num_samples = buffer.NumSamples();
+    num_bits = buffer.NumBits();
+    size.width = hint.Valid() ? hint.width : buffer.Pitch();
+    size.height = hint.Valid() ? hint.height : buffer.Height();
+    size.depth = 1;
+    pitch = buffer.Pitch();
+    resources.layers = num_slices;
+    meta_info.htile_addr = buffer.z_info.tile_surface_en ? htile_address : 0;
+
+    stencil_addr = write_buffer ? buffer.StencilWriteAddress() : buffer.StencilAddress();
+    stencil_size = pitch * size.height * sizeof(u8);
+
+    guest_address = write_buffer ? buffer.DepthWriteAddress() : buffer.DepthAddress();
+    const auto depth_slice_sz = buffer.GetDepthSliceSize();
+    guest_size = depth_slice_sz * num_slices;
+    mips_layout.emplace_back(depth_slice_sz, pitch, buffer.Height(), 0);
+}
+
+ImageInfo::ImageInfo(const AmdGpu::Image& image, const Shader::ImageResource& desc) noexcept {
+    tile_mode = image.GetTileMode();
+    array_mode = AmdGpu::GetArrayMode(tile_mode);
+    pixel_format = LiverpoolToVK::SurfaceFormat(image.GetDataFmt(), image.GetNumberFmt());
+    if (desc.is_depth) {
+        pixel_format = LiverpoolToVK::PromoteFormatToDepth(pixel_format);
+    }
+    type = image.GetBaseType();
+    props.is_tiled = image.IsTiled();
+    props.is_volume = type == AmdGpu::ImageType::Color3D;
+    props.is_pow2 = image.pow2pad;
+    props.is_block = IsBlockCoded(pixel_format);
+    size.width = image.width + 1;
+    size.height = image.height + 1;
+    size.depth = props.is_volume ? image.depth + 1 : 1;
+    pitch = image.Pitch();
+    resources.levels = image.NumLevels();
+    resources.layers = image.NumLayers();
+    num_samples = image.NumSamples();
+    num_bits = NumBitsPerBlock(image.GetDataFmt());
+
+    guest_address = image.Address();
+
+    mips_layout.reserve(resources.levels);
+    alt_tile = Libraries::Kernel::sceKernelIsNeoMode() && image.alt_tile_mode;
+    UpdateSize();
 }
 
 bool ImageInfo::IsDepthStencil() const {
@@ -202,35 +191,21 @@ bool ImageInfo::IsCompatible(const ImageInfo& info) const {
             num_bits == info.num_bits);
 }
 
-bool ImageInfo::IsTilingCompatible(u32 lhs, u32 rhs) const {
-    if (lhs == rhs) {
-        return true;
-    }
-    if (lhs == 0x0e && rhs == 0x0d) {
-        return true;
-    }
-    if (lhs == 0x0d && rhs == 0x0e) {
-        return true;
-    }
-    return false;
-}
-
 void ImageInfo::UpdateSize() {
     mips_layout.clear();
     MipInfo mip_info{};
     guest_size = 0;
-    for (auto mip = 0u; mip < resources.levels; ++mip) {
-        auto bpp = num_bits;
-        auto mip_w = pitch >> mip;
-        auto mip_h = size.height >> mip;
+    for (s32 mip = 0; mip < resources.levels; ++mip) {
+        u32 mip_w = pitch >> mip;
+        u32 mip_h = size.height >> mip;
         if (props.is_block) {
             mip_w = (mip_w + 3) / 4;
             mip_h = (mip_h + 3) / 4;
         }
         mip_w = std::max(mip_w, 1u);
         mip_h = std::max(mip_h, 1u);
-        auto mip_d = std::max(size.depth >> mip, 1u);
-        auto thickness = 1;
+        u32 mip_d = std::max(size.depth >> mip, 1u);
+        u32 thickness = 1;
 
         if (props.is_pow2) {
             mip_w = std::bit_ceil(mip_w);
@@ -238,35 +213,32 @@ void ImageInfo::UpdateSize() {
             mip_d = std::bit_ceil(mip_d);
         }
 
-        switch (tiling_mode) {
-        case AmdGpu::TilingMode::Display_Linear: {
-            std::tie(mip_info.pitch, mip_info.size) =
-                ImageSizeLinearAligned(mip_w, mip_h, bpp, num_samples);
+        switch (array_mode) {
+        case AmdGpu::ArrayMode::ArrayLinearGeneral:
+        case AmdGpu::ArrayMode::ArrayLinearAligned: {
+            std::tie(mip_info.pitch, mip_info.height, mip_info.size) =
+                ImageSizeLinearAligned(mip_w, mip_h, num_bits, num_samples);
             break;
         }
-        case AmdGpu::TilingMode::Texture_Volume:
+        case AmdGpu::ArrayMode::Array1DTiledThick:
             thickness = 4;
             mip_d += (-mip_d) & (thickness - 1);
             [[fallthrough]];
-        case AmdGpu::TilingMode::Display_MicroTiled:
-        case AmdGpu::TilingMode::Texture_MicroTiled: {
-            std::tie(mip_info.pitch, mip_info.size) =
-                ImageSizeMicroTiled(mip_w, mip_h, thickness, bpp, num_samples);
+        case AmdGpu::ArrayMode::Array1DTiledThin1: {
+            std::tie(mip_info.pitch, mip_info.height, mip_info.size) =
+                ImageSizeMicroTiled(mip_w, mip_h, thickness, num_bits, num_samples);
             break;
         }
-        case AmdGpu::TilingMode::Display_MacroTiled:
-        case AmdGpu::TilingMode::Texture_MacroTiled:
-        case AmdGpu::TilingMode::Depth_MacroTiled: {
+        case AmdGpu::ArrayMode::Array2DTiledThin1: {
             ASSERT(!props.is_block);
-            std::tie(mip_info.pitch, mip_info.size) = ImageSizeMacroTiled(
-                mip_w, mip_h, thickness, bpp, num_samples, tiling_idx, mip, alt_tile);
+            std::tie(mip_info.pitch, mip_info.height, mip_info.size) = ImageSizeMacroTiled(
+                mip_w, mip_h, thickness, num_bits, num_samples, tile_mode, mip, alt_tile);
             break;
         }
         default: {
             UNREACHABLE();
         }
         }
-        mip_info.height = mip_h;
         if (props.is_block) {
             mip_info.pitch = std::max(mip_info.pitch * 4, 32u);
             mip_info.height = std::max(mip_info.height * 4, 32u);
@@ -283,7 +255,19 @@ s32 ImageInfo::MipOf(const ImageInfo& info) const {
         return -1;
     }
 
-    if (!IsTilingCompatible(info.tiling_idx, tiling_idx)) {
+    const auto is_compatible = [&](u32 lhs, u32 rhs) {
+        if (lhs == rhs) {
+            return true;
+        }
+        if (lhs == 0x0e && rhs == 0x0d) {
+            return true;
+        }
+        if (lhs == 0x0d && rhs == 0x0e) {
+            return true;
+        }
+        return false;
+    }(u32(info.tile_mode), u32(tile_mode));
+    if (!is_compatible) {
         return -1;
     }
 
@@ -321,7 +305,7 @@ s32 ImageInfo::MipOf(const ImageInfo& info) const {
     }
 
     const auto mip_d = std::max(info.size.depth >> mip, 1u);
-    if (info.type == vk::ImageType::e3D && type == vk::ImageType::e2D) {
+    if (info.type == AmdGpu::ImageType::Color3D && type == AmdGpu::ImageType::Color2D) {
         // In case of 2D array to 3D copy, make sure we have proper number of layers.
         if (resources.layers != mip_d) {
             return -1;

--- a/src/video_core/texture_cache/image_info.h
+++ b/src/video_core/texture_cache/image_info.h
@@ -3,13 +3,24 @@
 
 #pragma once
 
+#include <boost/container/static_vector.hpp>
+
 #include "common/types.h"
-#include "core/libraries/videoout/buffer.h"
-#include "shader_recompiler/info.h"
 #include "video_core/amdgpu/liverpool.h"
+#include "video_core/renderer_vulkan/vk_common.h"
 #include "video_core/texture_cache/types.h"
 
-#include <boost/container/small_vector.hpp>
+namespace AmdGpu {
+enum class ImageType : u64;
+}
+
+namespace Libraries::VideoOut {
+struct BufferAttributeGroup;
+}
+
+namespace Shader {
+struct ImageResource;
+}
 
 namespace VideoCore {
 
@@ -23,14 +34,13 @@ struct ImageInfo {
     ImageInfo(const AmdGpu::Image& image, const Shader::ImageResource& desc) noexcept;
 
     bool IsTiled() const {
-        return tiling_mode != AmdGpu::TilingMode::Display_Linear;
+        return tile_mode != AmdGpu::TileMode::DisplayLinearAligned;
     }
     Extent3D BlockDim() const {
         const u32 shift = props.is_block ? 2 : 0;
         return Extent3D{size.width >> shift, size.height >> shift, size.depth};
     }
 
-    bool IsBlockCoded() const;
     bool IsDepthStencil() const;
     bool HasStencil() const;
 
@@ -38,15 +48,13 @@ struct ImageInfo {
     s32 SliceOf(const ImageInfo& info, s32 mip) const;
 
     bool IsCompatible(const ImageInfo& info) const;
-    bool IsTilingCompatible(u32 lhs, u32 rhs) const;
-
     void UpdateSize();
 
     struct {
         VAddr cmask_addr;
         VAddr fmask_addr;
         VAddr htile_addr;
-        u32 htile_clear_mask{u32(-1)};
+        u32 htile_clear_mask = u32(-1);
     } meta_info{};
 
     struct {
@@ -54,30 +62,31 @@ struct ImageInfo {
         u32 is_tiled : 1;
         u32 is_pow2 : 1;
         u32 is_block : 1;
-    } props{}; // Surface properties with impact on various calculation factors
+        u32 is_depth : 1;
+    } props{};
 
     vk::Format pixel_format = vk::Format::eUndefined;
-    vk::ImageType type = vk::ImageType::e2D;
+    AmdGpu::ImageType type;
     SubresourceExtent resources;
     Extent3D size{1, 1, 1};
     u32 num_bits{};
     u32 num_samples = 1;
-    u32 pitch = 0;
-    AmdGpu::TilingMode tiling_mode{AmdGpu::TilingMode::Display_Linear};
+    u32 pitch{};
+    AmdGpu::TileMode tile_mode = AmdGpu::TileMode::DisplayLinearAligned;
+    AmdGpu::ArrayMode array_mode = AmdGpu::ArrayMode::ArrayLinearAligned;
     struct MipInfo {
         u32 size;
         u32 pitch;
         u32 height;
         u32 offset;
     };
-    boost::container::small_vector<MipInfo, 14> mips_layout;
-    VAddr guest_address{0};
-    u32 guest_size{0};
-    u32 tiling_idx{0}; // TODO: merge with existing!
-    bool alt_tile{false};
+    boost::container::static_vector<MipInfo, 16> mips_layout;
+    VAddr guest_address{};
+    u32 guest_size{};
+    bool alt_tile{};
 
-    VAddr stencil_addr{0};
-    u32 stencil_size{0};
+    VAddr stencil_addr{};
+    u32 stencil_size{};
 };
 
 } // namespace VideoCore

--- a/src/video_core/texture_cache/image_info.h
+++ b/src/video_core/texture_cache/image_info.h
@@ -81,6 +81,7 @@ struct ImageInfo {
     boost::container::static_vector<MipInfo, 16> mips_layout;
     VAddr guest_address{};
     u32 guest_size{};
+    u8 bank_swizzle{};
     bool alt_tile{};
 
     VAddr stencil_addr{};

--- a/src/video_core/texture_cache/image_info.h
+++ b/src/video_core/texture_cache/image_info.h
@@ -24,6 +24,15 @@ struct ImageResource;
 
 namespace VideoCore {
 
+struct ImageProperties {
+    u32 is_volume : 1;
+    u32 is_tiled : 1;
+    u32 is_pow2 : 1;
+    u32 is_block : 1;
+    u32 is_depth : 1;
+    u32 has_stencil : 1;
+};
+
 struct ImageInfo {
     ImageInfo() = default;
     ImageInfo(const Libraries::VideoOut::BufferAttributeGroup& group, VAddr cpu_address) noexcept;
@@ -37,12 +46,8 @@ struct ImageInfo {
         return tile_mode != AmdGpu::TileMode::DisplayLinearAligned;
     }
     Extent3D BlockDim() const {
-        const u32 shift = props.is_block ? 2 : 0;
-        return Extent3D{size.width >> shift, size.height >> shift, size.depth};
+        return props.is_block ? Extent3D{size.width >> 2, size.height >> 2, size.depth} : size;
     }
-
-    bool IsDepthStencil() const;
-    bool HasStencil() const;
 
     s32 MipOf(const ImageInfo& info) const;
     s32 SliceOf(const ImageInfo& info, s32 mip) const;
@@ -57,14 +62,7 @@ struct ImageInfo {
         u32 htile_clear_mask = u32(-1);
     } meta_info{};
 
-    struct {
-        u32 is_volume : 1;
-        u32 is_tiled : 1;
-        u32 is_pow2 : 1;
-        u32 is_block : 1;
-        u32 is_depth : 1;
-    } props{};
-
+    ImageProperties props{};
     vk::Format pixel_format = vk::Format::eUndefined;
     AmdGpu::ImageType type;
     SubresourceExtent resources;

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -29,19 +29,18 @@ vk::ImageViewType ConvertImageViewType(AmdGpu::ImageType type) {
     }
 }
 
-bool IsViewTypeCompatible(vk::ImageViewType view_type, vk::ImageType image_type) {
+bool IsViewTypeCompatible(AmdGpu::ImageType view_type, AmdGpu::ImageType image_type) {
     switch (view_type) {
-    case vk::ImageViewType::e1D:
-    case vk::ImageViewType::e1DArray:
-        return image_type == vk::ImageType::e1D;
-    case vk::ImageViewType::e2D:
-    case vk::ImageViewType::e2DArray:
-        return image_type == vk::ImageType::e2D || image_type == vk::ImageType::e3D;
-    case vk::ImageViewType::eCube:
-    case vk::ImageViewType::eCubeArray:
-        return image_type == vk::ImageType::e2D;
-    case vk::ImageViewType::e3D:
-        return image_type == vk::ImageType::e3D;
+    case AmdGpu::ImageType::Color1D:
+    case AmdGpu::ImageType::Color1DArray:
+        return image_type == AmdGpu::ImageType::Color1D;
+    case AmdGpu::ImageType::Color2D:
+    case AmdGpu::ImageType::Color2DArray:
+    case AmdGpu::ImageType::Color2DMsaa:
+    case AmdGpu::ImageType::Color2DMsaaArray:
+        return image_type == AmdGpu::ImageType::Color2D || image_type == AmdGpu::ImageType::Color3D;
+    case AmdGpu::ImageType::Color3D:
+        return image_type == AmdGpu::ImageType::Color3D;
     default:
         UNREACHABLE();
     }
@@ -63,7 +62,7 @@ ImageViewInfo::ImageViewInfo(const AmdGpu::Image& image, const Shader::ImageReso
     range.base.layer = image.base_array;
     range.extent.levels = image.NumViewLevels(desc.is_array);
     range.extent.layers = image.NumViewLayers(desc.is_array);
-    type = ConvertImageViewType(image.GetViewType(desc.is_array));
+    type = image.GetViewType(desc.is_array);
 
     if (!is_storage) {
         mapping = Vulkan::LiverpoolToVK::ComponentMapping(image.DstSelect());
@@ -73,7 +72,7 @@ ImageViewInfo::ImageViewInfo(const AmdGpu::Image& image, const Shader::ImageReso
 ImageViewInfo::ImageViewInfo(const AmdGpu::Liverpool::ColorBuffer& col_buffer) noexcept {
     range.base.layer = col_buffer.view.slice_start;
     range.extent.layers = col_buffer.NumSlices() - range.base.layer;
-    type = range.extent.layers > 1 ? vk::ImageViewType::e2DArray : vk::ImageViewType::e2D;
+    type = range.extent.layers > 1 ? AmdGpu::ImageType::Color2DArray : AmdGpu::ImageType::Color2D;
     format =
         Vulkan::LiverpoolToVK::SurfaceFormat(col_buffer.GetDataFmt(), col_buffer.GetNumberFmt());
 }
@@ -86,7 +85,7 @@ ImageViewInfo::ImageViewInfo(const AmdGpu::Liverpool::DepthBuffer& depth_buffer,
     is_storage = ctl.depth_write_enable;
     range.base.layer = view.slice_start;
     range.extent.layers = view.NumSlices() - range.base.layer;
-    type = range.extent.layers > 1 ? vk::ImageViewType::e2DArray : vk::ImageViewType::e2D;
+    type = range.extent.layers > 1 ? AmdGpu::ImageType::Color2DArray : AmdGpu::ImageType::Color2D;
 }
 
 ImageView::ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info_, Image& image,
@@ -113,7 +112,7 @@ ImageView::ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info
     const vk::ImageViewCreateInfo image_view_ci = {
         .pNext = &usage_ci,
         .image = image.image,
-        .viewType = info.type,
+        .viewType = ConvertImageViewType(info.type),
         .format = instance.GetSupportedFormat(format, image.format_features),
         .components = info.mapping,
         .subresourceRange{
@@ -124,9 +123,9 @@ ImageView::ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info
             .layerCount = info.range.extent.layers,
         },
     };
-    if (!IsViewTypeCompatible(image_view_ci.viewType, image.info.type)) {
+    if (!IsViewTypeCompatible(info.type, image.info.type)) {
         LOG_ERROR(Render_Vulkan, "image view type {} is incompatible with image type {}",
-                  vk::to_string(image_view_ci.viewType), vk::to_string(image.info.type));
+                  vk::to_string(image_view_ci.viewType), vk::to_string(image_view_ci.viewType));
     }
 
     auto [view_result, view] = instance.GetDevice().createImageViewUnique(image_view_ci);

--- a/src/video_core/texture_cache/image_view.h
+++ b/src/video_core/texture_cache/image_view.h
@@ -23,7 +23,7 @@ struct ImageViewInfo {
     ImageViewInfo(const AmdGpu::Liverpool::DepthBuffer& depth_buffer,
                   AmdGpu::Liverpool::DepthView view, AmdGpu::Liverpool::DepthControl ctl);
 
-    vk::ImageViewType type = vk::ImageViewType::e2D;
+    AmdGpu::ImageType type = AmdGpu::ImageType::Color2D;
     vk::Format format = vk::Format::eR8G8B8A8Unorm;
     SubresourceRange range;
     vk::ComponentMapping mapping{};
@@ -45,9 +45,8 @@ struct ImageView {
     ImageView(ImageView&&) = default;
     ImageView& operator=(ImageView&&) = default;
 
-    ImageId image_id{};
-    Extent3D size{0, 0, 0};
-    ImageViewInfo info{};
+    ImageId image_id;
+    ImageViewInfo info;
     vk::UniqueImageView image_view;
 };
 

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -923,8 +923,8 @@ void TextureCache::RunGarbageCollector() {
         --num_deletions;
         auto& image = slot_images[image_id];
         const bool download = image.SafeToDownload();
-        const bool linear = image.info.tiling_mode == AmdGpu::TilingMode::Display_Linear;
-        if (!linear && download) {
+        const bool tiled = image.info.IsTiled();
+        if (tiled && download) {
             // This is a workaround for now. We can't handle non-linear image downloads.
             return false;
         }

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -25,7 +25,8 @@ static constexpr u64 NumFramesBeforeRemoval = 32;
 TextureCache::TextureCache(const Vulkan::Instance& instance_, Vulkan::Scheduler& scheduler_,
                            BufferCache& buffer_cache_, PageManager& tracker_)
     : instance{instance_}, scheduler{scheduler_}, buffer_cache{buffer_cache_}, tracker{tracker_},
-      blit_helper{instance, scheduler}, tile_manager{instance, scheduler, buffer_cache.GetUtilityBuffer(MemoryUsage::Stream)} {
+      blit_helper{instance, scheduler},
+      tile_manager{instance, scheduler, buffer_cache.GetUtilityBuffer(MemoryUsage::Stream)} {
     // Create basic null image at fixed image ID.
     const auto null_id = GetNullImage(vk::Format::eR8G8B8A8Unorm);
     ASSERT(null_id.index == NULL_IMAGE_ID.index);
@@ -672,7 +673,8 @@ void TextureCache::RefreshImage(Image& image, Vulkan::Scheduler* custom_schedule
         });
     }
 
-    const auto [buffer, offset] = tile_manager.DetileImage(in_buffer->Handle(), in_offset, image.info);
+    const auto [buffer, offset] =
+        tile_manager.DetileImage(in_buffer->Handle(), in_offset, image.info);
     for (auto& copy : image_copy) {
         copy.bufferOffset += offset;
     }

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -513,7 +513,7 @@ ImageView& TextureCache::FindTexture(ImageId image_id, const BaseDesc& desc) {
     Image& image = slot_images[image_id];
     if (desc.type == BindingType::Storage) {
         image.flags |= ImageFlagBits::GpuModified;
-        if (Config::readbackLinearImages() && image.info.props.is_tiled) {
+        if (Config::readbackLinearImages() && !image.info.props.is_tiled) {
             download_images.emplace(image_id);
         }
     }

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -103,6 +103,10 @@ public:
                  BufferCache& buffer_cache, PageManager& tracker);
     ~TextureCache();
 
+    TileManager& GetTileManager() noexcept {
+        return tile_manager;
+    }
+
     /// Invalidates any image in the logical page range.
     void InvalidateMemory(VAddr addr, size_t size);
 

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -39,7 +39,6 @@ class TextureCache {
         static constexpr size_t PageBits = 20;
     };
     using PageTable = MultiLevelPageTable<Traits>;
-    using ImageIds = boost::container::small_vector<ImageId, 8>;
 
 public:
     enum class BindingType : u32 {
@@ -113,7 +112,7 @@ public:
     [[nodiscard]] ImageId FindImage(BaseDesc& desc, bool exact_fmt = false);
 
     /// Retrieves image whose address matches provided
-    [[nodiscard]] ImageId FindImageFromRange(VAddr address, size_t size);
+    [[nodiscard]] ImageId FindImageFromRange(VAddr address, size_t size, bool ensure_valid = true);
 
     /// Retrieves an image view with the properties of the specified image id.
     [[nodiscard]] ImageView& FindTexture(ImageId image_id, const BaseDesc& desc);

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -26,17 +26,6 @@ namespace VideoCore {
 class BufferCache;
 class PageManager;
 
-enum class FindFlags {
-    NoCreate = 1 << 0,  ///< Do not create an image if searching for one fails.
-    RelaxDim = 1 << 1,  ///< Do not check the dimentions of image, only address.
-    RelaxSize = 1 << 2, ///< Do not check that the size matches exactly.
-    RelaxFmt = 1 << 3,  ///< Do not check that format is compatible.
-    ExactFmt = 1 << 4,  ///< Require the format to be exactly the same.
-};
-DECLARE_ENUM_FLAG_OPERATORS(FindFlags)
-
-static constexpr u32 MaxInvalidateDist = 12_MB;
-
 class TextureCache {
     // Default values for garbage collection
     static constexpr s64 DEFAULT_PRESSURE_GC_MEMORY = 1_GB + 512_MB;
@@ -50,6 +39,7 @@ class TextureCache {
         static constexpr size_t PageBits = 20;
     };
     using PageTable = MultiLevelPageTable<Traits>;
+    using ImageIds = boost::container::small_vector<ImageId, 8>;
 
 public:
     enum class BindingType : u32 {
@@ -120,7 +110,10 @@ public:
     void ProcessDownloadImages();
 
     /// Retrieves the image handle of the image with the provided attributes.
-    [[nodiscard]] ImageId FindImage(BaseDesc& desc, FindFlags flags = {});
+    [[nodiscard]] ImageId FindImage(BaseDesc& desc, bool exact_fmt = false);
+
+    /// Retrieves image whose address matches provided
+    [[nodiscard]] ImageId FindImageFromRange(VAddr address, size_t size);
 
     /// Retrieves an image view with the properties of the specified image id.
     [[nodiscard]] ImageView& FindTexture(ImageId image_id, const BaseDesc& desc);
@@ -149,6 +142,7 @@ public:
     [[nodiscard]] ImageId ResolveDepthOverlap(const ImageInfo& requested_info, BindingType binding,
                                               ImageId cache_img_id);
 
+    /// Creates a new image with provided image info and copies subresources from image_id
     [[nodiscard]] ImageId ExpandImage(const ImageInfo& info, ImageId image_id);
 
     /// Reuploads image contents.

--- a/src/video_core/texture_cache/tile.h
+++ b/src/video_core/texture_cache/tile.h
@@ -6,6 +6,10 @@
 #include "common/assert.h"
 #include "common/types.h"
 
+namespace AmdGpu {
+enum class TileMode : u32;
+}
+
 namespace VideoCore {
 
 // clang-format off
@@ -285,17 +289,16 @@ constexpr std::array macro_tile_extents_alt{
 constexpr std::pair micro_tile_extent{8u, 8u};
 constexpr auto hw_pipe_interleave = 256u;
 
-constexpr std::pair<u32, u32> GetMacroTileExtents(u32 tiling_idx, u32 bpp, u32 num_samples,
-                                                  bool alt) {
+constexpr std::pair<u32, u32> GetMacroTileExtents(AmdGpu::TileMode tile_mode, u32 bpp, u32 num_samples, bool alt) {
     ASSERT(num_samples <= 8);
     const auto samples_log = static_cast<u32>(std::log2(num_samples));
-    const auto row = tiling_idx * 5;
+    const auto row = u32(tile_mode) * 5;
     const auto column = std::bit_width(bpp) - 4; // bpps are 8, 16, 32, 64, 128
     return (alt ? macro_tile_extents_alt : macro_tile_extents)[samples_log][row + column];
 }
 
-constexpr std::pair<u32, size_t> ImageSizeLinearAligned(u32 pitch, u32 height, u32 bpp,
-                                                        u32 num_samples) {
+constexpr std::tuple<u32, u32, size_t> ImageSizeLinearAligned(u32 pitch, u32 height, u32 bpp,
+                                                              u32 num_samples) {
     const auto pitch_align = std::max(8u, 64u / ((bpp + 7) / 8));
     auto pitch_aligned = (pitch + pitch_align - 1) & ~(pitch_align - 1);
     const auto height_aligned = height;
@@ -305,11 +308,11 @@ constexpr std::pair<u32, size_t> ImageSizeLinearAligned(u32 pitch, u32 height, u
         pitch_aligned += pitch_align;
         log_sz = pitch_aligned * height_aligned * num_samples;
     }
-    return {pitch_aligned, (log_sz * bpp + 7) / 8};
+    return {pitch_aligned, height_aligned, (log_sz * bpp + 7) / 8};
 }
 
-constexpr std::pair<u32, size_t> ImageSizeMicroTiled(u32 pitch, u32 height, u32 thickness, u32 bpp,
-                                                     u32 num_samples) {
+constexpr std::tuple<u32, u32, size_t> ImageSizeMicroTiled(u32 pitch, u32 height, u32 thickness, u32 bpp,
+                                                           u32 num_samples) {
     const auto& [pitch_align, height_align] = micro_tile_extent;
     auto pitch_aligned = (pitch + pitch_align - 1) & ~(pitch_align - 1);
     const auto height_aligned = (height + height_align - 1) & ~(height_align - 1);
@@ -318,14 +321,13 @@ constexpr std::pair<u32, size_t> ImageSizeMicroTiled(u32 pitch, u32 height, u32 
         pitch_aligned += pitch_align;
         log_sz = (pitch_aligned * height_aligned * bpp * num_samples + 7) / 8;
     }
-    return {pitch_aligned, log_sz};
+    return {pitch_aligned, height_aligned, log_sz};
 }
 
-constexpr std::pair<u32, size_t> ImageSizeMacroTiled(u32 pitch, u32 height, u32 thickness, u32 bpp,
-                                                     u32 num_samples, u32 tiling_idx, u32 mip_n,
-                                                     bool alt) {
-    const auto& [pitch_align, height_align] =
-        GetMacroTileExtents(tiling_idx, bpp, num_samples, alt);
+constexpr std::tuple<u32, u32, size_t> ImageSizeMacroTiled(u32 pitch, u32 height, u32 thickness, u32 bpp,
+                                                           u32 num_samples, AmdGpu::TileMode tile_mode, u32 mip_n,
+                                                           bool alt) {
+    const auto [pitch_align, height_align] = GetMacroTileExtents(tile_mode, bpp, num_samples, alt);
     ASSERT(pitch_align != 0 && height_align != 0);
     bool downgrade_to_micro = false;
     if (mip_n > 0) {
@@ -341,7 +343,7 @@ constexpr std::pair<u32, size_t> ImageSizeMacroTiled(u32 pitch, u32 height, u32 
     const auto pitch_aligned = (pitch + pitch_align - 1) & ~(pitch_align - 1);
     const auto height_aligned = (height + height_align - 1) & ~(height_align - 1);
     const auto log_sz = pitch_aligned * height_aligned * num_samples;
-    return {pitch_aligned, (log_sz * bpp + 7) / 8};
+    return {pitch_aligned, height_aligned, (log_sz * bpp + 7) / 8};
 }
 
 } // namespace VideoCore

--- a/src/video_core/texture_cache/tile.h
+++ b/src/video_core/texture_cache/tile.h
@@ -289,7 +289,8 @@ constexpr std::array macro_tile_extents_alt{
 constexpr std::pair micro_tile_extent{8u, 8u};
 constexpr auto hw_pipe_interleave = 256u;
 
-constexpr std::pair<u32, u32> GetMacroTileExtents(AmdGpu::TileMode tile_mode, u32 bpp, u32 num_samples, bool alt) {
+constexpr std::pair<u32, u32> GetMacroTileExtents(AmdGpu::TileMode tile_mode, u32 bpp,
+                                                  u32 num_samples, bool alt) {
     ASSERT(num_samples <= 8);
     const auto samples_log = static_cast<u32>(std::log2(num_samples));
     const auto row = u32(tile_mode) * 5;
@@ -311,8 +312,8 @@ constexpr std::tuple<u32, u32, size_t> ImageSizeLinearAligned(u32 pitch, u32 hei
     return {pitch_aligned, height_aligned, (log_sz * bpp + 7) / 8};
 }
 
-constexpr std::tuple<u32, u32, size_t> ImageSizeMicroTiled(u32 pitch, u32 height, u32 thickness, u32 bpp,
-                                                           u32 num_samples) {
+constexpr std::tuple<u32, u32, size_t> ImageSizeMicroTiled(u32 pitch, u32 height, u32 thickness,
+                                                           u32 bpp, u32 num_samples) {
     const auto& [pitch_align, height_align] = micro_tile_extent;
     auto pitch_aligned = (pitch + pitch_align - 1) & ~(pitch_align - 1);
     const auto height_aligned = (height + height_align - 1) & ~(height_align - 1);
@@ -324,8 +325,9 @@ constexpr std::tuple<u32, u32, size_t> ImageSizeMicroTiled(u32 pitch, u32 height
     return {pitch_aligned, height_aligned, log_sz};
 }
 
-constexpr std::tuple<u32, u32, size_t> ImageSizeMacroTiled(u32 pitch, u32 height, u32 thickness, u32 bpp,
-                                                           u32 num_samples, AmdGpu::TileMode tile_mode, u32 mip_n,
+constexpr std::tuple<u32, u32, size_t> ImageSizeMacroTiled(u32 pitch, u32 height, u32 thickness,
+                                                           u32 bpp, u32 num_samples,
+                                                           AmdGpu::TileMode tile_mode, u32 mip_n,
                                                            bool alt) {
     const auto [pitch_align, height_align] = GetMacroTileExtents(tile_mode, bpp, num_samples, alt);
     ASSERT(pitch_align != 0 && height_align != 0);

--- a/src/video_core/texture_cache/tile_manager.cpp
+++ b/src/video_core/texture_cache/tile_manager.cpp
@@ -164,6 +164,25 @@ TileManager::Result TileManager::DetileImage(vk::Buffer in_buffer, u32 in_offset
         return {in_buffer, in_offset};
     }
 
+    TilingInfo params{};
+    params.bank_swizzle = 0U;
+    params.num_slices = info.props.is_volume ? info.size.depth : info.resources.layers;
+    params.num_mips = info.resources.levels;
+    for (u32 mip = 0; mip < info.resources.levels; ++mip) {
+        auto& mip_info = params.mips[mip];
+        mip_info = info.mips_layout[mip];
+        if (info.props.is_block) {
+            mip_info.pitch = std::max((mip_info.pitch + 3) / 4, 1U);
+            mip_info.height = std::max((mip_info.height + 3) / 4, 1U);
+        }
+    }
+
+    const vk::DescriptorBufferInfo params_buffer_info{
+        .buffer = stream_buffer.Handle(),
+        .offset = stream_buffer.Copy(&params, sizeof(params), instance.UniformMinAlignment()),
+        .range = sizeof(params),
+    };
+
     const auto [out_buffer, out_allocation] = GetScratchBuffer(info.guest_size);
     scheduler.DeferOperation([this, out_buffer, out_allocation]() {
         vmaDestroyBuffer(instance.GetAllocator(), out_buffer, out_allocation);
@@ -182,25 +201,6 @@ TileManager::Result TileManager::DetileImage(vk::Buffer in_buffer, u32 in_offset
         .buffer = out_buffer,
         .offset = 0,
         .range = info.guest_size,
-    };
-
-    TilingInfo params{};
-    params.bank_swizzle = 0U;
-    params.num_slices = info.props.is_volume ? info.size.depth : info.resources.layers;
-    params.num_mips = info.resources.levels;
-    for (u32 mip = 0; mip < info.resources.levels; ++mip) {
-        auto& mip_info = params.mips[mip];
-        mip_info = info.mips_layout[mip];
-        if (info.props.is_block) {
-            mip_info.pitch = std::max((mip_info.pitch + 3) / 4, 1U);
-            mip_info.height = std::max((mip_info.height + 3) / 4, 1U);
-        }
-    }
-
-    const vk::DescriptorBufferInfo params_buffer_info{
-        .buffer = stream_buffer.Handle(),
-        .offset = stream_buffer.Copy(&params, sizeof(params), instance.UniformMinAlignment()),
-        .range = sizeof(params),
     };
 
     const std::array<vk::WriteDescriptorSet, 3> set_writes = {{
@@ -246,6 +246,25 @@ void TileManager::TileImage(vk::Image in_image, vk::BufferImageCopy in_copy, vk:
         return;
     }
 
+    TilingInfo params{};
+    params.bank_swizzle = 0U;
+    params.num_slices = info.props.is_volume ? info.size.depth : info.resources.layers;
+    params.num_mips = info.resources.levels;
+    for (u32 mip = 0; mip < info.resources.levels; ++mip) {
+        auto& mip_info = params.mips[mip];
+        mip_info = info.mips_layout[mip];
+        if (info.props.is_block) {
+            mip_info.pitch = std::max((mip_info.pitch + 3) / 4, 1U);
+            mip_info.height = std::max((mip_info.height + 3) / 4, 1U);
+        }
+    }
+
+    const vk::DescriptorBufferInfo params_buffer_info{
+        .buffer = stream_buffer.Handle(),
+        .offset = stream_buffer.Copy(&params, sizeof(params), instance.UniformMinAlignment()),
+        .range = sizeof(params),
+    };
+
     const auto [temp_buffer, temp_allocation] = GetScratchBuffer(info.guest_size);
     scheduler.DeferOperation([this, temp_buffer, temp_allocation]() {
         vmaDestroyBuffer(instance.GetAllocator(), temp_buffer, temp_allocation);
@@ -265,25 +284,6 @@ void TileManager::TileImage(vk::Image in_image, vk::BufferImageCopy in_copy, vk:
         .buffer = temp_buffer,
         .offset = 0,
         .range = info.guest_size,
-    };
-
-    TilingInfo params{};
-    params.bank_swizzle = 0U;
-    params.num_slices = info.props.is_volume ? info.size.depth : info.resources.layers;
-    params.num_mips = info.resources.levels;
-    for (u32 mip = 0; mip < info.resources.levels; ++mip) {
-        auto& mip_info = params.mips[mip];
-        mip_info = info.mips_layout[mip];
-        if (info.props.is_block) {
-            mip_info.pitch = std::max((mip_info.pitch + 3) / 4, 1U);
-            mip_info.height = std::max((mip_info.height + 3) / 4, 1U);
-        }
-    }
-
-    const vk::DescriptorBufferInfo params_buffer_info{
-        .buffer = stream_buffer.Handle(),
-        .offset = stream_buffer.Copy(&params, sizeof(params), instance.UniformMinAlignment()),
-        .range = sizeof(params),
     };
 
     const std::array<vk::WriteDescriptorSet, 3> set_writes = {{

--- a/src/video_core/texture_cache/tile_manager.cpp
+++ b/src/video_core/texture_cache/tile_manager.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "video_core/buffer_cache/buffer.h"
 #include "video_core/renderer_vulkan/vk_instance.h"
 #include "video_core/renderer_vulkan/vk_scheduler.h"
 #include "video_core/renderer_vulkan/vk_shader_util.h"
@@ -8,82 +9,25 @@
 #include "video_core/texture_cache/image_view.h"
 #include "video_core/texture_cache/tile_manager.h"
 
-#include "video_core/host_shaders/detilers/display_micro_64bpp_comp.h"
-#include "video_core/host_shaders/detilers/macro_32bpp_comp.h"
-#include "video_core/host_shaders/detilers/macro_64bpp_comp.h"
-#include "video_core/host_shaders/detilers/macro_8bpp_comp.h"
-#include "video_core/host_shaders/detilers/micro_128bpp_comp.h"
-#include "video_core/host_shaders/detilers/micro_16bpp_comp.h"
-#include "video_core/host_shaders/detilers/micro_32bpp_comp.h"
-#include "video_core/host_shaders/detilers/micro_64bpp_comp.h"
-#include "video_core/host_shaders/detilers/micro_8bpp_comp.h"
+#include "video_core/host_shaders/tiling_comp.h"
 
-// #include <boost/container/static_vector.hpp>
 #include <magic_enum/magic_enum.hpp>
 #include <vk_mem_alloc.h>
 
 namespace VideoCore {
 
-const DetilerContext* TileManager::GetDetiler(const ImageInfo& info) const {
-    switch (info.tiling_mode) {
-    case AmdGpu::TilingMode::Texture_MicroTiled:
-        switch (info.num_bits) {
-        case 8:
-            return &detilers[DetilerType::Micro8];
-        case 16:
-            return &detilers[DetilerType::Micro16];
-        case 32:
-            return &detilers[DetilerType::Micro32];
-        case 64:
-            return &detilers[DetilerType::Micro64];
-        case 128:
-            return &detilers[DetilerType::Micro128];
-        default:
-            return nullptr;
-        }
-    case AmdGpu::TilingMode::Texture_Volume:
-        switch (info.num_bits) {
-        case 8:
-            return &detilers[DetilerType::Macro8];
-        case 32:
-            return &detilers[DetilerType::Macro32];
-        case 64:
-            return &detilers[DetilerType::Macro64];
-        default:
-            return nullptr;
-        }
-        break;
-    case AmdGpu::TilingMode::Display_MicroTiled:
-        switch (info.num_bits) {
-        case 64:
-            return &detilers[DetilerType::Display_Micro64];
-        default:
-            return nullptr;
-        }
-        break;
-    default:
-        return nullptr;
-    }
-}
-
-struct DetilerParams {
-    u32 num_levels;
-    u32 pitch0;
-    u32 height;
-    std::array<u32, 16> sizes;
+struct TilingInfo {
+    u32 bank_swizzle;
+    u32 num_slices;
+    u32 num_mips;
+    std::array<ImageInfo::MipInfo, 16> mips;
 };
 
-TileManager::TileManager(const Vulkan::Instance& instance, Vulkan::Scheduler& scheduler)
-    : instance{instance}, scheduler{scheduler} {
-    static const std::array detiler_shaders{
-        HostShaders::MICRO_8BPP_COMP,          HostShaders::MICRO_16BPP_COMP,
-        HostShaders::MICRO_32BPP_COMP,         HostShaders::MICRO_64BPP_COMP,
-        HostShaders::MICRO_128BPP_COMP,        HostShaders::MACRO_8BPP_COMP,
-        HostShaders::MACRO_32BPP_COMP,         HostShaders::MACRO_64BPP_COMP,
-        HostShaders::DISPLAY_MICRO_64BPP_COMP,
-    };
-
-    boost::container::static_vector<vk::DescriptorSetLayoutBinding, 2> bindings{
+TileManager::TileManager(const Vulkan::Instance& instance, Vulkan::Scheduler& scheduler,
+                         StreamBuffer& stream_buffer_)
+    : instance{instance}, scheduler{scheduler}, stream_buffer{stream_buffer_} {
+    const auto device = instance.GetDevice();
+    const std::array<vk::DescriptorSetLayoutBinding, 3> bindings = {{
         {
             .binding = 0,
             .descriptorType = vk::DescriptorType::eStorageBuffer,
@@ -96,88 +40,50 @@ TileManager::TileManager(const Vulkan::Instance& instance, Vulkan::Scheduler& sc
             .descriptorCount = 1,
             .stageFlags = vk::ShaderStageFlagBits::eCompute,
         },
-    };
+        {
+            .binding = 2,
+            .descriptorType = vk::DescriptorType::eUniformBuffer,
+            .descriptorCount = 1,
+            .stageFlags = vk::ShaderStageFlagBits::eCompute,
+        },
+    }};
 
     const vk::DescriptorSetLayoutCreateInfo desc_layout_ci = {
         .flags = vk::DescriptorSetLayoutCreateFlagBits::ePushDescriptorKHR,
         .bindingCount = static_cast<u32>(bindings.size()),
         .pBindings = bindings.data(),
     };
-    auto desc_layout_result = instance.GetDevice().createDescriptorSetLayoutUnique(desc_layout_ci);
+    auto desc_layout_result = device.createDescriptorSetLayoutUnique(desc_layout_ci);
     ASSERT_MSG(desc_layout_result.result == vk::Result::eSuccess,
                "Failed to create descriptor set layout: {}",
                vk::to_string(desc_layout_result.result));
     desc_layout = std::move(desc_layout_result.value);
 
-    const vk::PushConstantRange push_constants = {
-        .stageFlags = vk::ShaderStageFlagBits::eCompute,
-        .offset = 0,
-        .size = sizeof(DetilerParams),
+    const vk::DescriptorSetLayout set_layout = *desc_layout;
+    const vk::PipelineLayoutCreateInfo layout_info = {
+        .setLayoutCount = 1U,
+        .pSetLayouts = &set_layout,
+        .pushConstantRangeCount = 0U,
+        .pPushConstantRanges = nullptr,
     };
-
-    for (int pl_id = 0; pl_id < DetilerType::Max; ++pl_id) {
-        auto& ctx = detilers[pl_id];
-
-        const auto& module = Vulkan::Compile(
-            detiler_shaders[pl_id], vk::ShaderStageFlagBits::eCompute, instance.GetDevice());
-
-        // Set module debug name
-        auto module_name = magic_enum::enum_name(static_cast<DetilerType>(pl_id));
-        Vulkan::SetObjectName(instance.GetDevice(), module, module_name);
-
-        const vk::PipelineShaderStageCreateInfo shader_ci = {
-            .stage = vk::ShaderStageFlagBits::eCompute,
-            .module = module,
-            .pName = "main",
-        };
-
-        const vk::DescriptorSetLayout set_layout = *desc_layout;
-        const vk::PipelineLayoutCreateInfo layout_info = {
-            .setLayoutCount = 1U,
-            .pSetLayouts = &set_layout,
-            .pushConstantRangeCount = 1,
-            .pPushConstantRanges = &push_constants,
-        };
-        auto [layout_result, layout] = instance.GetDevice().createPipelineLayoutUnique(layout_info);
-        ASSERT_MSG(layout_result == vk::Result::eSuccess, "Failed to create pipeline layout: {}",
-                   vk::to_string(layout_result));
-        ctx.pl_layout = std::move(layout);
-
-        const vk::ComputePipelineCreateInfo compute_pipeline_ci = {
-            .stage = shader_ci,
-            .layout = *ctx.pl_layout,
-        };
-        auto result = instance.GetDevice().createComputePipelineUnique(
-            /*pipeline_cache*/ {}, compute_pipeline_ci);
-        if (result.result == vk::Result::eSuccess) {
-            ctx.pl = std::move(result.value);
-        } else {
-            UNREACHABLE_MSG("Detiler pipeline creation failed!");
-        }
-
-        // Once pipeline is compiled, we don't need the shader module anymore
-        instance.GetDevice().destroyShaderModule(module);
-    }
+    auto [layout_result, layout] = device.createPipelineLayoutUnique(layout_info);
+    ASSERT_MSG(layout_result == vk::Result::eSuccess, "Failed to create pipeline layout: {}",
+               vk::to_string(layout_result));
+    pl_layout = std::move(layout);
 }
 
 TileManager::~TileManager() = default;
 
-TileManager::ScratchBuffer TileManager::AllocBuffer(u32 size, bool is_storage /*= false*/) {
-    const auto usage = vk::BufferUsageFlagBits::eStorageBuffer |
-                       (is_storage ? vk::BufferUsageFlagBits::eTransferSrc
-                                   : vk::BufferUsageFlagBits::eTransferDst);
-    const vk::BufferCreateInfo buffer_ci{
+TileManager::ScratchBuffer TileManager::GetScratchBuffer(u32 size) {
+    constexpr auto usage = vk::BufferUsageFlagBits::eUniformBuffer | vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eTransferSrc;
+
+    const vk::BufferCreateInfo buffer_ci = {
         .size = size,
         .usage = usage,
     };
 
-    VmaAllocationCreateInfo alloc_info{
-        .flags = !is_storage ? VMA_ALLOCATION_CREATE_HOST_ACCESS_ALLOW_TRANSFER_INSTEAD_BIT |
-                                   VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT
-                             : static_cast<VmaAllocationCreateFlags>(0),
+    const VmaAllocationCreateInfo alloc_info{
         .usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE,
-        .requiredFlags = !is_storage ? VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT
-                                     : static_cast<VkMemoryPropertyFlags>(0),
     };
 
     VkBuffer buffer;
@@ -189,60 +95,100 @@ TileManager::ScratchBuffer TileManager::AllocBuffer(u32 size, bool is_storage /*
     return {buffer, allocation};
 }
 
-void TileManager::Upload(ScratchBuffer buffer, const void* data, size_t size) {
-    VmaAllocationInfo alloc_info{};
-    vmaGetAllocationInfo(instance.GetAllocator(), buffer.second, &alloc_info);
-    ASSERT(size <= alloc_info.size);
-    void* ptr{};
-    const auto result = vmaMapMemory(instance.GetAllocator(), buffer.second, &ptr);
-    ASSERT(result == VK_SUCCESS);
-    std::memcpy(ptr, data, size);
-    vmaUnmapMemory(instance.GetAllocator(), buffer.second);
+vk::Pipeline TileManager::GetDetiler(const ImageInfo& info) {
+    const u32 pl_id = u32(info.tile_mode) * NUM_BPPS + std::bit_width(info.num_bits) - 4;
+    if (auto pipeline = *detilers[pl_id]; pipeline != VK_NULL_HANDLE) {
+        return pipeline;
+    }
+
+    const auto device = instance.GetDevice();
+    std::vector<std::string> defines = {
+        fmt::format("BITS_PER_PIXEL={}", info.num_bits),
+        fmt::format("NUM_SAMPLES={}", info.num_samples),
+        fmt::format("ARRAY_MODE={}", u32(info.array_mode)),
+        fmt::format("MICRO_TILE_MODE={}", u32(AmdGpu::GetMicroTileMode(info.tile_mode))),
+        fmt::format("MICRO_TILE_THICKNESS={}", AmdGpu::GetMicroTileThickness(info.array_mode)),
+    };
+    if (AmdGpu::IsMacroTiled(info.array_mode)) {
+        const auto macro_tile_mode = AmdGpu::CalculateMacrotileMode(info.tile_mode, info.num_bits, info.num_samples);
+        const u32 num_banks = AmdGpu::GetNumBanks(macro_tile_mode);
+        defines.emplace_back(fmt::format("PIPE_CONFIG={}", u32(AmdGpu::GetPipeConfig(info.tile_mode))));
+        defines.emplace_back(fmt::format("BANK_WIDTH={}", AmdGpu::GetBankWidth(macro_tile_mode)));
+        defines.emplace_back(fmt::format("BANK_HEIGHT={}", AmdGpu::GetBankHeight(macro_tile_mode)));
+        defines.emplace_back(fmt::format("NUM_BANKS={}", num_banks));
+        defines.emplace_back(fmt::format("NUM_BANK_BITS={}", std::bit_width(num_banks) - 1));
+        defines.emplace_back(fmt::format("TILE_SPLIT_BYTES={}", AmdGpu::GetTileSplit(info.tile_mode)));
+        defines.emplace_back(fmt::format("MACRO_TILE_ASPECT={}", AmdGpu::GetMacrotileAspect(macro_tile_mode)));
+    }
+
+    const auto& module = Vulkan::Compile(HostShaders::TILING_COMP, vk::ShaderStageFlagBits::eCompute, device, defines);
+    const auto module_name = fmt::format("{}_{}", magic_enum::enum_name(info.tile_mode), info.num_bits);
+    LOG_WARNING(Render_Vulkan, "Compiling shader {}", module_name);
+    for (const auto& def : defines) {
+        LOG_WARNING(Render_Vulkan, "#define {}", def);
+    }
+    Vulkan::SetObjectName(device, module, module_name);
+    const vk::PipelineShaderStageCreateInfo shader_ci = {
+        .stage = vk::ShaderStageFlagBits::eCompute,
+        .module = module,
+        .pName = "main",
+    };
+    const vk::ComputePipelineCreateInfo compute_pipeline_ci = {
+        .stage = shader_ci,
+        .layout = *pl_layout,
+    };
+    auto [result, pipeline] = device.createComputePipelineUnique(VK_NULL_HANDLE, compute_pipeline_ci);
+    ASSERT_MSG(result == vk::Result::eSuccess, "Detiler pipeline creation failed {}", vk::to_string(result));
+    detilers[pl_id] = std::move(pipeline);
+    device.destroyShaderModule(module);
+    return *detilers[pl_id];
 }
 
-void TileManager::FreeBuffer(ScratchBuffer buffer) {
-    vmaDestroyBuffer(instance.GetAllocator(), buffer.first, buffer.second);
-}
-
-std::pair<vk::Buffer, u32> TileManager::TryDetile(vk::Buffer in_buffer, u32 in_offset,
-                                                  const ImageInfo& info) {
+std::pair<vk::Buffer, u32> TileManager::TryDetile(vk::Buffer in_buffer, u32 in_offset, const ImageInfo& info) {
     if (!info.props.is_tiled) {
         return {in_buffer, in_offset};
     }
 
-    const auto* detiler = GetDetiler(info);
-    if (!detiler) {
-        if (info.tiling_mode != AmdGpu::TilingMode::Texture_MacroTiled &&
-            info.tiling_mode != AmdGpu::TilingMode::Display_MacroTiled &&
-            info.tiling_mode != AmdGpu::TilingMode::Depth_MacroTiled) {
-            LOG_ERROR(Render_Vulkan, "Unsupported tiled image: {} ({})",
-                      vk::to_string(info.pixel_format), NameOf(info.tiling_mode));
-        }
-        return {in_buffer, in_offset};
-    }
+    const auto [out_buffer, out_allocation] = GetScratchBuffer(info.guest_size);
+    scheduler.DeferOperation([this, out_buffer, out_allocation]() {
+        vmaDestroyBuffer(instance.GetAllocator(), out_buffer, out_allocation);
+    });
 
-    const u32 image_size = info.guest_size;
-
-    // Prepare output buffer
-    auto out_buffer = AllocBuffer(image_size, true);
-    scheduler.DeferOperation([=, this]() { FreeBuffer(out_buffer); });
-
-    auto cmdbuf = scheduler.CommandBuffer();
-    cmdbuf.bindPipeline(vk::PipelineBindPoint::eCompute, *detiler->pl);
+    const auto cmdbuf = scheduler.CommandBuffer();
+    cmdbuf.bindPipeline(vk::PipelineBindPoint::eCompute, GetDetiler(info));
 
     const vk::DescriptorBufferInfo input_buffer_info{
         .buffer = in_buffer,
         .offset = in_offset,
-        .range = image_size,
+        .range = info.guest_size,
     };
 
     const vk::DescriptorBufferInfo output_buffer_info{
-        .buffer = out_buffer.first,
+        .buffer = out_buffer,
         .offset = 0,
-        .range = image_size,
+        .range = info.guest_size,
     };
 
-    std::vector<vk::WriteDescriptorSet> set_writes{
+    TilingInfo params{};
+    params.bank_swizzle = 0U;
+    params.num_slices = info.props.is_volume ? info.size.depth : info.resources.layers;
+    params.num_mips = info.resources.levels;
+    for (u32 mip = 0; mip < info.resources.levels; ++mip) {
+        auto& mip_info = params.mips[mip];
+        mip_info = info.mips_layout[mip];
+        if (info.props.is_block) {
+            mip_info.pitch = std::max((mip_info.pitch + 3) / 4, 1U);
+            mip_info.height = std::max((mip_info.height + 3) / 4, 1U);
+        }
+    }
+
+    const vk::DescriptorBufferInfo params_buffer_info{
+        .buffer = stream_buffer.Handle(),
+        .offset = stream_buffer.Copy(&params, sizeof(params), instance.UniformMinAlignment()),
+        .range = sizeof(params),
+    };
+
+    const std::array<vk::WriteDescriptorSet, 3> set_writes = {{
         {
             .dstSet = VK_NULL_HANDLE,
             .dstBinding = 0,
@@ -259,39 +205,21 @@ std::pair<vk::Buffer, u32> TileManager::TryDetile(vk::Buffer in_buffer, u32 in_o
             .descriptorType = vk::DescriptorType::eStorageBuffer,
             .pBufferInfo = &output_buffer_info,
         },
-    };
-    cmdbuf.pushDescriptorSetKHR(vk::PipelineBindPoint::eCompute, *detiler->pl_layout, 0,
-                                set_writes);
+        {
+            .dstSet = VK_NULL_HANDLE,
+            .dstBinding = 2,
+            .dstArrayElement = 0,
+            .descriptorCount = 1,
+            .descriptorType = vk::DescriptorType::eUniformBuffer,
+            .pBufferInfo = &params_buffer_info,
+        },
+    }};
+    cmdbuf.pushDescriptorSetKHR(vk::PipelineBindPoint::eCompute, *pl_layout, 0, set_writes);
 
-    DetilerParams params;
-    params.num_levels = info.resources.levels;
-    params.pitch0 = info.pitch >> (info.props.is_block ? 2u : 0u);
-    params.height = info.size.height;
-    if (info.tiling_mode == AmdGpu::TilingMode::Texture_Volume ||
-        info.tiling_mode == AmdGpu::TilingMode::Display_MicroTiled) {
-        if (info.resources.levels != 1) {
-            LOG_ERROR(Render_Vulkan, "Unexpected mipmaps for volume and display tilings {}",
-                      info.resources.levels);
-        }
-        const auto tiles_per_row = info.pitch / 8u;
-        const auto tiles_per_slice = tiles_per_row * ((info.size.height + 7u) / 8u);
-        params.sizes[0] = tiles_per_row;
-        params.sizes[1] = tiles_per_slice;
-    } else {
-        ASSERT(info.resources.levels <= params.sizes.size());
-        std::memset(&params.sizes, 0, sizeof(params.sizes));
-        for (int m = 0; m < info.resources.levels; ++m) {
-            params.sizes[m] = info.mips_layout[m].size + (m > 0 ? params.sizes[m - 1] : 0);
-        }
-    }
-
-    cmdbuf.pushConstants(*detiler->pl_layout, vk::ShaderStageFlagBits::eCompute, 0u, sizeof(params),
-                         &params);
-
-    ASSERT((image_size % 64) == 0);
-    const auto num_tiles = image_size / (64 * (info.num_bits / 8));
-    cmdbuf.dispatch(num_tiles, 1, 1);
-    return {out_buffer.first, 0};
+    const auto dim_x = (info.guest_size / (info.num_bits / 8)) / 64;
+    LOG_ERROR(Render, "guest_size = {:#x}, num_bytes = {}, dim_x = {}", info.guest_size, info.num_bits / 8, dim_x);
+    cmdbuf.dispatch(dim_x, 1, 1);
+    return {out_buffer, 0};
 }
 
 } // namespace VideoCore

--- a/src/video_core/texture_cache/tile_manager.h
+++ b/src/video_core/texture_cache/tile_manager.h
@@ -17,17 +17,20 @@ class TileManager {
 
 public:
     using ScratchBuffer = std::pair<vk::Buffer, VmaAllocation>;
+    using Result = std::pair<vk::Buffer, u32>;
 
     explicit TileManager(const Vulkan::Instance& instance, Vulkan::Scheduler& scheduler,
                          StreamBuffer& stream_buffer);
     ~TileManager();
 
-    std::pair<vk::Buffer, u32> TryDetile(vk::Buffer in_buffer, u32 in_offset,
-                                         const ImageInfo& info);
+    void TileImage(vk::Image in_image, vk::BufferImageCopy in_copy,
+                   vk::Buffer out_buffer, u32 out_offset, const ImageInfo& info);
+
+    Result DetileImage(vk::Buffer in_buffer, u32 in_offset, const ImageInfo& info);
 
 private:
+    vk::Pipeline GetTilingPipeline(const ImageInfo& info, bool is_tiler);
     ScratchBuffer GetScratchBuffer(u32 size);
-    vk::Pipeline GetDetiler(const ImageInfo& info);
 
 private:
     const Vulkan::Instance& instance;
@@ -36,6 +39,7 @@ private:
     vk::UniqueDescriptorSetLayout desc_layout;
     vk::UniquePipelineLayout pl_layout;
     std::array<vk::UniquePipeline, AmdGpu::NUM_TILE_MODES * NUM_BPPS> detilers{};
+    std::array<vk::UniquePipeline, AmdGpu::NUM_TILE_MODES * NUM_BPPS> tilers{};
 };
 
 } // namespace VideoCore

--- a/src/video_core/texture_cache/tile_manager.h
+++ b/src/video_core/texture_cache/tile_manager.h
@@ -4,56 +4,38 @@
 #pragma once
 
 #include "common/types.h"
+#include "video_core/amdgpu/tiling.h"
 #include "video_core/buffer_cache/buffer.h"
 
 namespace VideoCore {
 
-class TextureCache;
 struct ImageInfo;
-
-enum DetilerType : u32 {
-    Micro8,
-    Micro16,
-    Micro32,
-    Micro64,
-    Micro128,
-
-    Macro8,
-    Macro32,
-    Macro64,
-
-    Display_Micro64,
-
-    Max
-};
-
-struct DetilerContext {
-    vk::UniquePipeline pl;
-    vk::UniquePipelineLayout pl_layout;
-};
+class StreamBuffer;
 
 class TileManager {
+    static constexpr size_t NUM_BPPS = 5;
+
 public:
     using ScratchBuffer = std::pair<vk::Buffer, VmaAllocation>;
 
-    TileManager(const Vulkan::Instance& instance, Vulkan::Scheduler& scheduler);
+    explicit TileManager(const Vulkan::Instance& instance, Vulkan::Scheduler& scheduler,
+                         StreamBuffer& stream_buffer);
     ~TileManager();
 
     std::pair<vk::Buffer, u32> TryDetile(vk::Buffer in_buffer, u32 in_offset,
                                          const ImageInfo& info);
 
-    ScratchBuffer AllocBuffer(u32 size, bool is_storage = false);
-    void Upload(ScratchBuffer buffer, const void* data, size_t size);
-    void FreeBuffer(ScratchBuffer buffer);
-
 private:
-    const DetilerContext* GetDetiler(const ImageInfo& info) const;
+    ScratchBuffer GetScratchBuffer(u32 size);
+    vk::Pipeline GetDetiler(const ImageInfo& info);
 
 private:
     const Vulkan::Instance& instance;
     Vulkan::Scheduler& scheduler;
+    StreamBuffer& stream_buffer;
     vk::UniqueDescriptorSetLayout desc_layout;
-    std::array<DetilerContext, DetilerType::Max> detilers;
+    vk::UniquePipelineLayout pl_layout;
+    std::array<vk::UniquePipeline, AmdGpu::NUM_TILE_MODES * NUM_BPPS> detilers{};
 };
 
 } // namespace VideoCore

--- a/src/video_core/texture_cache/tile_manager.h
+++ b/src/video_core/texture_cache/tile_manager.h
@@ -23,8 +23,8 @@ public:
                          StreamBuffer& stream_buffer);
     ~TileManager();
 
-    void TileImage(vk::Image in_image, vk::BufferImageCopy in_copy,
-                   vk::Buffer out_buffer, u32 out_offset, const ImageInfo& info);
+    void TileImage(vk::Image in_image, vk::BufferImageCopy in_copy, vk::Buffer out_buffer,
+                   u32 out_offset, const ImageInfo& info);
 
     Result DetileImage(vk::Buffer in_buffer, u32 in_offset, const ImageInfo& info);
 

--- a/src/video_core/texture_cache/tile_manager.h
+++ b/src/video_core/texture_cache/tile_manager.h
@@ -23,8 +23,8 @@ public:
                          StreamBuffer& stream_buffer);
     ~TileManager();
 
-    void TileImage(vk::Image in_image, vk::BufferImageCopy in_copy, vk::Buffer out_buffer,
-                   u32 out_offset, const ImageInfo& info);
+    void TileImage(vk::Image in_image, std::span<vk::BufferImageCopy> buffer_copies,
+                   vk::Buffer out_buffer, u32 out_offset, const ImageInfo& info);
 
     Result DetileImage(vk::Buffer in_buffer, u32 in_offset, const ImageInfo& info);
 


### PR DESCRIPTION
This started with the goal of supporting Texture_Macrotiled detiling and turned into a rework of the tiling system

## General changes

* Fleshed out the tiling mode enum and added more tiling properties from GB_TILE_MODE such as pipe config, array mode, micro tile mode
* MipInfo structure is now consistent in terms of padding. On main the pitch is padded by the ImageSize functions but the height was not, now it also returns the padded height.
* Replaced some vulkan types in ImageInfo with appropriate AmdGpu types, helps with decoupling it from the vulkan backend
* Properly query tile mode for depth buffer as well, on main all depth buffer image infos had been left with linear tiling
* Property queries from image info now consistently use the props member instead of functions that decide on the pixel format

## Tile manager changes

* Replaced the numerous detile shaders with a single unified tiling shader based on r800 addrlib, which supports all tile modes of the guest hardware. Most of the parameters of the shader are pre-processor macros to avoid overhead. In the most common case of 1D thin tiling it produces the following code which is basically generating the LUT values at runtime and should not be much slower

```glsl
_260.out_data[_402] = _265.in_data[((((_402 / (_404 * _405)) * ((((_240 * _405) * 32u) + 7u) / 8u)) + ((((_229 / 8u) * (_240 / 8u)) + (_223 / 8u)) * 256u)) + (((((((bitfieldExtract(_223, 0, 1) | (bitfieldExtract(_229, 0, 1) << uint(1))) | (bitfieldExtract(_223, 1, 1) << uint(2))) | (bitfieldExtract(_229, 1, 1) << uint(3))) | (bitfieldExtract(_223, 2, 1) << uint(4))) | (bitfieldExtract(_229, 2, 1) << uint(5))) * 32u) / 8u)) / 4u];
```
* Detilers are now consistent in terms of padding. On main, 1D thin detilers would produce padded output, while volume detilers would produce packed output, because the latter would index the output buffer instead of input (side note, but on main the volume detiler is named macro which seems incorrect from my research, as volume textures are 1D thick not 2D tiled). Padded output was chosen because it is more convenient, as it allows to offset the linear surface using the mip info structures generated during image size calculation and removes the need for address bounds checking in shader (number of texels processed is always multiple of 64)

* Support for tiling has been added as well with a simple macro parameter. This is used for macrotile handling (read below)

* Textures with bpp < 32 now have better GPU occupancy during detiling as it can use the full subgroup length on AMD GPUs

## Macrotile support changes

Since the original goal was this, support for detiling macrotile images is also added and I've verified it works from Knack, which uses Texture_Macrotile image for its fonts. However this isn't as simple because this path is also used by image copies with compute and it implicitly relies on the detiling failing (SynchronizeBufferFromImage copies the linear image data to buffers without any tiling). This is where tile shader comes in, now the buffer cache will tile the image data before copying it to the buffer, so texture cache can allow detiling of macrotile images. This adds some overhead so before merging I will add a fast path that detects image copies and uses vkCmdCopyImage but it's also more accurate to real hardware.

Note: This still doesn't handle degrading of macro tile mode to micro tile for mipmaps, but it should be easier to implement now

This fixes the font in Knack

| main  | PR |
| ------------- | ------------- |
| <img width="1282" height="719" alt="knack_bad" src="https://github.com/user-attachments/assets/86847458-05f7-4d67-8213-5dd4ea3147a7" /> | <img width="1280" height="721" alt="knack_good" src="https://github.com/user-attachments/assets/fb79e91e-b23f-4b41-befc-377cbd845abd" />|

TODO
- [x] Add fast path for image copies
- [x] Hookup bank swizzle to tile manager