### PR TITLE
libSceAppContent: Use last 16 characters of DLC folder to determine entitlement label

### DIFF
--- a/src/core/libraries/app_content/app_content.cpp
+++ b/src/core/libraries/app_content/app_content.cpp
@@ -261,7 +261,7 @@ int PS4_SYSV_ABI sceAppContentInitialize(const OrbisAppContentInitParam* initPar
             auto& info = addcont_info[addcont_count++];
             info.status = OrbisAppContentAddcontDownloadStatus::Installed;
 
-            // Most DLC dumping methods prepend the folder name with the game serial
+            // Our recommended dumping method prepends the folder name with the game serial
             // Since they end the folder name with the entitlement label, copy from the end instead.
             entitlement_label.copy(info.entitlement_label, sizeof(info.entitlement_label),
                                    entitlement_label.length() -

--- a/src/core/libraries/app_content/app_content.cpp
+++ b/src/core/libraries/app_content/app_content.cpp
@@ -260,11 +260,12 @@ int PS4_SYSV_ABI sceAppContentInitialize(const OrbisAppContentInitParam* initPar
             auto entitlement_label = entry.path().filename().string();
             auto& info = addcont_info[addcont_count++];
             info.status = OrbisAppContentAddcontDownloadStatus::Installed;
-            
+
             // Most DLC dumping methods prepend the folder name with the game serial
             // Since they end the folder name with the entitlement label, copy from the end instead.
             entitlement_label.copy(info.entitlement_label, sizeof(info.entitlement_label),
-                                   entitlement_label.length() - ORBIS_NP_UNIFIED_ENTITLEMENT_LABEL_SIZE + 1);
+                                   entitlement_label.length() -
+                                       ORBIS_NP_UNIFIED_ENTITLEMENT_LABEL_SIZE + 1);
         }
     }
 

--- a/src/core/libraries/app_content/app_content.cpp
+++ b/src/core/libraries/app_content/app_content.cpp
@@ -260,7 +260,11 @@ int PS4_SYSV_ABI sceAppContentInitialize(const OrbisAppContentInitParam* initPar
             auto entitlement_label = entry.path().filename().string();
             auto& info = addcont_info[addcont_count++];
             info.status = OrbisAppContentAddcontDownloadStatus::Installed;
-            entitlement_label.copy(info.entitlement_label, sizeof(info.entitlement_label));
+            
+            // Most DLC dumping methods prepend the folder name with the game serial
+            // Since they end the folder name with the entitlement label, copy from the end instead.
+            entitlement_label.copy(info.entitlement_label, sizeof(info.entitlement_label),
+                                   entitlement_label.length() - ORBIS_NP_UNIFIED_ENTITLEMENT_LABEL_SIZE + 1);
         }
     }
 


### PR DESCRIPTION
Between game dumping methods, there isn't a widely accepted name format for dumped additional content files. However, our recommended dumping method, the Itemzflow Games Manager homebrew, ends each DLC folder with the entitlement label (For example, one of the DLC from Hatsune Miku: Project DIVA Future Tone (CUSA06093) dumps with the folder name "CUSA06093-DLC-DIVAFT39FUTURE00").

To make the DLC installation process easier, this PR changes the additional content loading process to get the entitlement label name from the end of the dumped folder name, instead of the start. Anyone who modified their dumped folders to get them recognized under the previous code should see no difference over previous builds.

To install DLC dumped through Itemzflow Games Manager with this PR:
1. Go to your shadPS4 additional content folder (which must be manually set though GUI or config.toml)
2. Create a folder in there with your game's serial number (starts with CUSA, followed by five digits)
3. Copy all dumped DLC folders into your created folder.