### PR TITLE
Fix Bugs: src/core/libraries/libc_internal/libc_internal_math.cpp:74:12: error: no member named 'atan2f' in namespace 'std'

### DIFF
--- a/src/core/libraries/libc_internal/libc_internal_math.cpp
+++ b/src/core/libraries/libc_internal/libc_internal_math.cpp
@@ -13,7 +13,7 @@ double PS4_SYSV_ABI internal_sin(double x) {
 }
 
 float PS4_SYSV_ABI internal_sinf(float x) {
-    return std::sinf(x);
+    return sinf(x);
 }
 
 double PS4_SYSV_ABI internal_cos(double x) {
@@ -21,7 +21,7 @@ double PS4_SYSV_ABI internal_cos(double x) {
 }
 
 float PS4_SYSV_ABI internal_cosf(float x) {
-    return std::cosf(x);
+    return cosf(x);
 }
 
 void PS4_SYSV_ABI internal_sincos(double x, double* sinp, double* cosp) {
@@ -30,8 +30,8 @@ void PS4_SYSV_ABI internal_sincos(double x, double* sinp, double* cosp) {
 }
 
 void PS4_SYSV_ABI internal_sincosf(float x, float* sinp, float* cosp) {
-    *sinp = std::sinf(x);
-    *cosp = std::cosf(x);
+    *sinp = sinf(x);
+    *cosp = cosf(x);
 }
 
 double PS4_SYSV_ABI internal_tan(double x) {
@@ -39,7 +39,7 @@ double PS4_SYSV_ABI internal_tan(double x) {
 }
 
 float PS4_SYSV_ABI internal_tanf(float x) {
-    return std::tanf(x);
+    return tanf(x);
 }
 
 double PS4_SYSV_ABI internal_asin(double x) {
@@ -47,7 +47,7 @@ double PS4_SYSV_ABI internal_asin(double x) {
 }
 
 float PS4_SYSV_ABI internal_asinf(float x) {
-    return std::asinf(x);
+    return asinf(x);
 }
 
 double PS4_SYSV_ABI internal_acos(double x) {
@@ -55,7 +55,7 @@ double PS4_SYSV_ABI internal_acos(double x) {
 }
 
 float PS4_SYSV_ABI internal_acosf(float x) {
-    return std::acosf(x);
+    return acosf(x);
 }
 
 double PS4_SYSV_ABI internal_atan(double x) {
@@ -63,7 +63,7 @@ double PS4_SYSV_ABI internal_atan(double x) {
 }
 
 float PS4_SYSV_ABI internal_atanf(float x) {
-    return std::atanf(x);
+    return atanf(x);
 }
 
 double PS4_SYSV_ABI internal_atan2(double y, double x) {
@@ -71,7 +71,7 @@ double PS4_SYSV_ABI internal_atan2(double y, double x) {
 }
 
 float PS4_SYSV_ABI internal_atan2f(float y, float x) {
-    return std::atan2f(y, x);
+    return atan2f(y, x);
 }
 
 double PS4_SYSV_ABI internal_exp(double x) {
@@ -79,7 +79,7 @@ double PS4_SYSV_ABI internal_exp(double x) {
 }
 
 float PS4_SYSV_ABI internal_expf(float x) {
-    return std::expf(x);
+    return expf(x);
 }
 
 double PS4_SYSV_ABI internal_exp2(double x) {
@@ -95,7 +95,7 @@ double PS4_SYSV_ABI internal_pow(double x, double y) {
 }
 
 float PS4_SYSV_ABI internal_powf(float x, float y) {
-    return std::powf(x, y);
+    return powf(x, y);
 }
 
 double PS4_SYSV_ABI internal_log(double x) {
@@ -103,7 +103,7 @@ double PS4_SYSV_ABI internal_log(double x) {
 }
 
 float PS4_SYSV_ABI internal_logf(float x) {
-    return std::logf(x);
+    return logf(x);
 }
 
 double PS4_SYSV_ABI internal_log10(double x) {
@@ -111,7 +111,7 @@ double PS4_SYSV_ABI internal_log10(double x) {
 }
 
 float PS4_SYSV_ABI internal_log10f(float x) {
-    return std::log10f(x);
+    return log10f(x);
 }
 
 void RegisterlibSceLibcInternalMath(Core::Loader::SymbolsResolver* sym) {


### PR DESCRIPTION
In C++, many math functions are overloaded and placed in the std namespace, but not all C functions are namespaced—especially the float-specific versions like atan2f.

Clang version: 18.1.3