### PR TITLE
Filesystem: Fix error behavior for close calls on std handles

### DIFF
--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -253,8 +253,8 @@ s32 PS4_SYSV_ABI close(s32 fd) {
         return -1;
     }
     if (fd < 3) {
-        // This is technically possible, but it's usually caused by some stubbed function instead.
-        LOG_WARNING(Kernel_Fs, "called on an std handle, fd = {}", fd);
+        *__Error() = POSIX_EPERM;
+        return -1;
     }
     if (file->type == Core::FileSys::FileType::Regular) {
         file->f.Close();


### PR DESCRIPTION
On real hardware, these calls return EPERM. This reverts an incorrect change I made back in #2554.

Thanks to @red-prig for bringing this to my attention.