### PR TITLE
Fixed green artifacts in movies/animations (ffmpeg)

### DIFF
--- a/src/core/libraries/videodec/videodec2_impl.cpp
+++ b/src/core/libraries/videodec/videodec2_impl.cpp
@@ -42,8 +42,6 @@ VdecDecoder::VdecDecoder(const OrbisVideodec2DecoderConfigInfo& configInfo,
     mCodecContext->width = configInfo.maxFrameWidth;
     mCodecContext->height = configInfo.maxFrameHeight;
 
-    // mMemoryAlignment = memoryInfo.frameBufferAlignment;
-
     avcodec_open2(mCodecContext, codec, nullptr);
 }
 

--- a/src/core/libraries/videodec/videodec2_impl.h
+++ b/src/core/libraries/videodec/videodec2_impl.h
@@ -33,6 +33,7 @@ private:
     AVFrame* ConvertNV12Frame(AVFrame& frame);
 
 private:
+    //u32 mMemoryAlignment = 0;
     AVCodecContext* mCodecContext = nullptr;
     SwsContext* mSwsContext = nullptr;
 };

--- a/src/core/libraries/videodec/videodec2_impl.h
+++ b/src/core/libraries/videodec/videodec2_impl.h
@@ -33,7 +33,6 @@ private:
     AVFrame* ConvertNV12Frame(AVFrame& frame);
 
 private:
-    //u32 mMemoryAlignment = 0;
     AVCodecContext* mCodecContext = nullptr;
     SwsContext* mSwsContext = nullptr;
 };


### PR DESCRIPTION
### Reason  
Green artifacts in some movies/embedded scenes. This bug affects following, but not limited to, games: Catherine Full Body, Burnout Paradise (allegedly).  

### Fix  
FFMPEG dynamically allocates buffer, which may or may not have the same width as target media. Dumping raw frames shows additional padding (green), but Orbis can't handle differing widths resulting in broken images (mismatched chroma layer, green patches, noise).  
Copying data as-is caused padding to be included. Now it's not.  

Before:
<img width="400" height="350" alt="obraz" src="https://github.com/user-attachments/assets/11cd1669-c060-49d6-bd7f-d1c62d36c5f1" />
<img width="400" height="350" alt="obraz" src="https://github.com/user-attachments/assets/4b4ecd04-2b58-4314-9755-80946df9fc90" />

After:
<img width="400" height="300" alt="obraz" src="https://github.com/user-attachments/assets/9d3556b5-ca51-4e10-b84e-f7f17d2a0fe8" />
