### PR TITLE
Log user CPU, total RAM, and OS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -111,4 +111,4 @@
 	url = https://github.com/jiixyj/epoll-shim.git
 [submodule "externals/hwinfo"]
 	path = externals/hwinfo
-	url = https://github.com/lfreist/hwinfo
+	url = https://github.com/rainmakerv3/hwinfo

--- a/.gitmodules
+++ b/.gitmodules
@@ -111,5 +111,5 @@
 	url = https://github.com/jiixyj/epoll-shim.git
 [submodule "externals/hwinfo"]
 	path = externals/hwinfo
-	url = https://github.com/rainmakerv3/hwinfo
+	url = https://github.com/shadps4-emu/ext-hwinfo
 	shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -112,3 +112,4 @@
 [submodule "externals/hwinfo"]
 	path = externals/hwinfo
 	url = https://github.com/rainmakerv3/hwinfo
+	shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -109,3 +109,6 @@
 [submodule "externals/epoll-shim"]
 	path = externals/epoll-shim
 	url = https://github.com/jiixyj/epoll-shim.git
+[submodule "externals/hwinfo"]
+	path = externals/hwinfo
+	url = https://github.com/lfreist/hwinfo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1126,7 +1126,7 @@ endif()
 create_target_directory_groups(shadps4)
 
 target_link_libraries(shadps4 PRIVATE magic_enum::magic_enum fmt::fmt toml11::toml11 tsl::robin_map xbyak::xbyak Tracy::TracyClient RenderDoc::API FFmpeg::ffmpeg Dear_ImGui gcn half::half ZLIB::ZLIB PNG::PNG)
-target_link_libraries(shadps4 PRIVATE Boost::headers GPUOpen::VulkanMemoryAllocator LibAtrac9 sirit Vulkan::Headers xxHash::xxhash Zydis::Zydis glslang::glslang SDL3::SDL3 pugixml::pugixml stb::headers libusb::usb)
+target_link_libraries(shadps4 PRIVATE Boost::headers GPUOpen::VulkanMemoryAllocator LibAtrac9 sirit Vulkan::Headers xxHash::xxhash Zydis::Zydis glslang::glslang SDL3::SDL3 pugixml::pugixml stb::headers libusb::usb lfreist-hwinfo::hwinfo)
 
 target_compile_definitions(shadps4 PRIVATE IMGUI_USER_CONFIG="imgui/imgui_config.h")
 target_compile_definitions(Dear_ImGui PRIVATE IMGUI_USER_CONFIG="${PROJECT_SOURCE_DIR}/src/imgui/imgui_config.h")

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -217,6 +217,7 @@ if (NOT TARGET stb::headers)
 endif()
 
 # hwinfo
+set(HWINFO_STATIC ON)
 add_subdirectory(hwinfo)
 
 # Apple-only dependencies

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -216,6 +216,9 @@ if (NOT TARGET stb::headers)
     add_library(stb::headers ALIAS stb)
 endif()
 
+# hwinfo
+add_subdirectory(hwinfo)
+
 # Apple-only dependencies
 if (APPLE)
     # date

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -153,12 +153,14 @@ void Emulator::Run(std::filesystem::path file, const std::vector<std::string> ar
     LOG_INFO(Config, "Vulkan rdocEnable: {}", Config::isRdocEnabled());
 
     hwinfo::Memory ram;
+    hwinfo::OS os;
     const auto cpus = hwinfo::getAllCPUs();
     for (const auto& cpu : cpus) {
         LOG_INFO(Config, "CPU Name: {}", cpu.modelName());
         LOG_INFO(Config, "CPU Cores: {}", cpu.numPhysicalCores());
     }
-    LOG_INFO(Config, "RAM [GB]: {}", ram.total_Bytes() / pow(1024, 3));
+    LOG_INFO(Config, "RAM: {}GB", ram.total_Bytes() / pow(1024, 3));
+    LOG_INFO(Config, "Operating System: {}", os.name());
 
     if (param_sfo_exists) {
         LOG_INFO(Loader, "Game id: {} Title: {}", id, title);

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -159,7 +159,7 @@ void Emulator::Run(std::filesystem::path file, const std::vector<std::string> ar
         LOG_INFO(Config, "CPU Name: {}", cpu.modelName());
         LOG_INFO(Config, "CPU Cores: {}", cpu.numPhysicalCores());
     }
-    LOG_INFO(Config, "RAM: {}GB", ram.total_Bytes() / pow(1024, 3));
+    LOG_INFO(Config, "Total RAM: {} GB", std::round(ram.total_Bytes() / pow(1024, 3)));
     LOG_INFO(Config, "Operating System: {}", os.name());
 
     if (param_sfo_exists) {

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -156,8 +156,9 @@ void Emulator::Run(std::filesystem::path file, const std::vector<std::string> ar
     hwinfo::OS os;
     const auto cpus = hwinfo::getAllCPUs();
     for (const auto& cpu : cpus) {
-        LOG_INFO(Config, "CPU Name: {}", cpu.modelName());
-        LOG_INFO(Config, "CPU Cores: {}", cpu.numPhysicalCores());
+        LOG_INFO(Config, "CPU Model: {}", cpu.modelName());
+        LOG_INFO(Config, "CPU Physical Cores: {}, Logical Cores: {}", cpu.numPhysicalCores(),
+                 cpu.numLogicalCores());
     }
     LOG_INFO(Config, "Total RAM: {} GB", std::round(ram.total_Bytes() / pow(1024, 3)));
     LOG_INFO(Config, "Operating System: {}", os.name());

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <set>
 #include <fmt/core.h>
+#include <hwinfo/hwinfo.h>
 
 #include "common/config.h"
 #include "common/debug.h"
@@ -150,6 +151,14 @@ void Emulator::Run(std::filesystem::path file, const std::vector<std::string> ar
     LOG_INFO(Config, "Vulkan hostMarkers: {}", Config::getVkHostMarkersEnabled());
     LOG_INFO(Config, "Vulkan guestMarkers: {}", Config::getVkGuestMarkersEnabled());
     LOG_INFO(Config, "Vulkan rdocEnable: {}", Config::isRdocEnabled());
+
+    hwinfo::Memory ram;
+    const auto cpus = hwinfo::getAllCPUs();
+    for (const auto& cpu : cpus) {
+        LOG_INFO(Config, "CPU Name: {}", cpu.modelName());
+        LOG_INFO(Config, "CPU Cores: {}", cpu.numPhysicalCores());
+    }
+    LOG_INFO(Config, "RAM [GB]: {}", ram.total_Bytes() / pow(1024, 3));
 
     if (param_sfo_exists) {
         LOG_INFO(Loader, "Game id: {} Title: {}", id, title);


### PR DESCRIPTION
Closes https://github.com/shadps4-emu/shadPS4/issues/3401

This logs the CPU, RAM, and OS on emulator startup with this submodule: https://github.com/lfreist/hwinfo

<img width="818" height="86" alt="image" src="https://github.com/user-attachments/assets/2f8c6728-1e68-4ec4-841a-4e8d331d019a" />

Having spent a bunch of time in bloodborne-chat, I can agree that this bit of logging actually helps quite a bit for those trying to provide help.

Mac build error is because of the submodule (seems like just a missing include?). If this is otherwise okay, can someone fork the submodule to add it in? 