### PR TITLE
Fix sceVoiceGetPortInfo

### DIFF
--- a/src/core/libraries/voice/voice.cpp
+++ b/src/core/libraries/voice/voice.cpp
@@ -52,7 +52,7 @@ s32 PS4_SYSV_ABI sceVoiceGetPortAttr() {
 s32 PS4_SYSV_ABI sceVoiceGetPortInfo(u32 port_id, OrbisVoicePortInfo* info) {
     LOG_ERROR(Lib_Voice, "(STUBBED) called");
     info->port_type = 0;
-    info->state = 3;
+    info->state = 0;
     info->byte_count = 0;
     info->frame_size = 1;
     info->edge_count = 0;


### PR DESCRIPTION
The VoicePortInfo 'state' was changed from 3-RUNNING to 0-IDLE. This prevents it from getting into a loop.