### PR TITLE
libSceNpParty: Stub out functions with not-in-party behavior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -591,6 +591,7 @@ set(NP_LIBS src/core/libraries/np_common/np_common.cpp
             src/core/libraries/np_web_api/np_web_api.h
             src/core/libraries/np_party/np_party.cpp
             src/core/libraries/np_party/np_party.h
+            src/core/libraries/np_party/np_party_error.h
             src/core/libraries/np_auth/np_auth.cpp
             src/core/libraries/np_auth/np_auth.h
 )

--- a/src/core/libraries/np_party/np_party.cpp
+++ b/src/core/libraries/np_party/np_party.cpp
@@ -5,6 +5,7 @@
 #include "core/libraries/error_codes.h"
 #include "core/libraries/libs.h"
 #include "core/libraries/np_party/np_party.h"
+#include "core/libraries/np_party/np_party_error.h"
 
 namespace Libraries::NpParty {
 
@@ -30,22 +31,22 @@ s32 PS4_SYSV_ABI sceNpPartyGetId() {
 
 s32 PS4_SYSV_ABI sceNpPartyGetMemberInfo() {
     LOG_ERROR(Lib_NpParty, "(STUBBED) called");
-    return ORBIS_OK;
+    return ORBIS_NP_PARTY_ERROR_NOT_IN_PARTY;
 }
 
 s32 PS4_SYSV_ABI sceNpPartyGetMemberInfoA() {
     LOG_ERROR(Lib_NpParty, "(STUBBED) called");
-    return ORBIS_OK;
+    return ORBIS_NP_PARTY_ERROR_NOT_IN_PARTY;
 }
 
 s32 PS4_SYSV_ABI sceNpPartyGetMembers() {
     LOG_ERROR(Lib_NpParty, "(STUBBED) called");
-    return ORBIS_OK;
+    return ORBIS_NP_PARTY_ERROR_NOT_IN_PARTY;
 }
 
 s32 PS4_SYSV_ABI sceNpPartyGetMembersA() {
     LOG_ERROR(Lib_NpParty, "(STUBBED) called");
-    return ORBIS_OK;
+    return ORBIS_NP_PARTY_ERROR_NOT_IN_PARTY;
 }
 
 s32 PS4_SYSV_ABI sceNpPartyGetMemberSessionInfo() {
@@ -58,8 +59,9 @@ s32 PS4_SYSV_ABI sceNpPartyGetMemberVoiceInfo() {
     return ORBIS_OK;
 }
 
-s32 PS4_SYSV_ABI sceNpPartyGetState() {
+s32 PS4_SYSV_ABI sceNpPartyGetState(OrbisNpPartyState* state) {
     LOG_ERROR(Lib_NpParty, "(STUBBED) called");
+    *state = OrbisNpPartyState::NotInParty;
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/np_party/np_party.h
+++ b/src/core/libraries/np_party/np_party.h
@@ -11,6 +11,11 @@ class SymbolsResolver;
 
 namespace Libraries::NpParty {
 
+enum class OrbisNpPartyState : u16 {
+    NotInParty = 2,
+    InPrivateParty = 3,
+};
+
 s32 PS4_SYSV_ABI sceNpPartyCheckCallback();
 s32 PS4_SYSV_ABI sceNpPartyCreate();
 s32 PS4_SYSV_ABI sceNpPartyCreateA();
@@ -21,7 +26,7 @@ s32 PS4_SYSV_ABI sceNpPartyGetMembers();
 s32 PS4_SYSV_ABI sceNpPartyGetMembersA();
 s32 PS4_SYSV_ABI sceNpPartyGetMemberSessionInfo();
 s32 PS4_SYSV_ABI sceNpPartyGetMemberVoiceInfo();
-s32 PS4_SYSV_ABI sceNpPartyGetState();
+s32 PS4_SYSV_ABI sceNpPartyGetState(OrbisNpPartyState* state);
 s32 PS4_SYSV_ABI sceNpPartyGetStateAsUser();
 s32 PS4_SYSV_ABI sceNpPartyGetStateAsUserA();
 s32 PS4_SYSV_ABI sceNpPartyGetVoiceChatPriority();

--- a/src/core/libraries/np_party/np_party_error.h
+++ b/src/core/libraries/np_party/np_party_error.h
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "core/libraries/error_codes.h"
+
+constexpr int ORBIS_NP_PARTY_ERROR_NOT_IN_PARTY = 0x80552506;


### PR DESCRIPTION
From what I can tell, this is valid behavior since a user could choose not to enter a party. 
This fixes a potential crash on boot in Grand Theft Auto V (CUSA00419).