### PR TITLE
Core: Add entries for . and .. in MntPoints::IterateDirectory

### DIFF
--- a/src/core/file_sys/fs.cpp
+++ b/src/core/file_sys/fs.cpp
@@ -161,6 +161,10 @@ void MntPoints::IterateDirectory(std::string_view guest_directory,
     // Only need to consider patch path if it exists and does not resolve to the same as base.
     const auto apply_patch = base_path != patch_path && std::filesystem::exists(patch_path);
 
+    // Prepend entries for . and .., as both are treated as files on PS4.
+    callback(base_path / ".", false);
+    callback(base_path / "..", false);
+
     // Pass 1: Any files that existed in the base directory, using patch directory if needed.
     if (std::filesystem::exists(base_path)) {
         for (const auto& entry : std::filesystem::directory_iterator(base_path)) {


### PR DESCRIPTION
On a real PS4, all directories will start with an directory entry for "." and "..". Emulating this behavior is necessary for some games, since devs can safely assume there will always be at least one entry in a given directory, and try to read said entry regardless of what we return.

Emulating these two entries fixes an exception in Grand Theft Auto V (CUSA00419) that occurs if the game's /download0 mount is empty.

For context, here's the output on real hardware, from a homebrew I wrote for testing this:
<img width="452" height="266" alt="image" src="https://github.com/user-attachments/assets/f3780b43-89a3-4259-bf96-c0ea78440e1c" />

Here's what the current shadPS4 main build shows:
<img width="637" height="34" alt="image" src="https://github.com/user-attachments/assets/ed4b6511-b6d4-43f8-a6a3-3e1511845c18" />

And here's what my PR shows:
<img width="618" height="240" alt="image" src="https://github.com/user-attachments/assets/e24f39c7-feef-4fa1-a7f3-400720e0ef7e" />
