### PR TITLE
Memory: Align size and address in posix_munmap

### DIFF
--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -571,7 +571,7 @@ s32 PS4_SYSV_ABI sceKernelMemoryPoolBatch(const OrbisKernelMemoryPoolBatchEntry*
 
 void* PS4_SYSV_ABI posix_mmap(void* addr, u64 len, s32 prot, s32 flags, s32 fd, s64 phys_addr) {
     LOG_INFO(Kernel_Vmm,
-             "called addr = {}, len = {}, prot = {}, flags = {}, fd = {}, phys_addr = {}",
+             "called addr = {}, len = {:#x}, prot = {}, flags = {}, fd = {}, phys_addr = {:#x}",
              fmt::ptr(addr), len, prot, flags, fd, phys_addr);
 
     void* addr_out;

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -570,9 +570,10 @@ s32 PS4_SYSV_ABI sceKernelMemoryPoolBatch(const OrbisKernelMemoryPoolBatchEntry*
 }
 
 void* PS4_SYSV_ABI posix_mmap(void* addr, u64 len, s32 prot, s32 flags, s32 fd, s64 phys_addr) {
-    LOG_INFO(Kernel_Vmm,
-             "called addr = {}, len = {:#x}, prot = {}, flags = {}, fd = {}, phys_addr = {:#x}",
-             fmt::ptr(addr), len, prot, flags, fd, phys_addr);
+    LOG_INFO(
+        Kernel_Vmm,
+        "called addr = {}, len = {:#x}, prot = {:#x}, flags = {:#x}, fd = {}, phys_addr = {:#x}",
+        fmt::ptr(addr), len, prot, flags, fd, phys_addr);
 
     void* addr_out;
     auto* memory = Core::Memory::Instance();

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -573,6 +573,8 @@ u64 MemoryManager::UnmapBytesFromEntry(VAddr virtual_addr, VirtualMemoryArea vma
 
 s32 MemoryManager::UnmapMemoryImpl(VAddr virtual_addr, u64 size) {
     u64 unmapped_bytes = 0;
+    virtual_addr = Common::AlignDown(virtual_addr, 16_KB);
+    size = Common::AlignUp(size, 16_KB);
     do {
         auto it = FindVMA(virtual_addr + unmapped_bytes);
         auto& vma_base = it->second;


### PR DESCRIPTION
From looking at the FreeBSD source code, munmap aligns down the address, and aligns up the size (like what's done for mprotect). 

Fixing this resolves the a case of the following unreachable, which was encountered by War Thunder (CUSA00224) because we aligned size during a file mmap, but didn't perform the same alignment for the unmap.
```
[Debug] <Critical> address_space.cpp:234 EnsureSplitRegionForMapping: Unreachable code!
Region splitting failed: The parameter is incorrect.
```

[CUSA00224 Main.log](https://github.com/user-attachments/files/21781880/CUSA00224.Main.log)
[CUSA00224 PR.log](https://github.com/user-attachments/files/21781881/CUSA00224.PR.log)

I've also added parameter formatting to `posix_mmap` logging, since it's the only memory function where we didn't have any formatting for length, phys_addr, flags, or prot values.