### PR TITLE
Config: toggle background controller inputs

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -58,6 +58,7 @@ static bool isMotionControlsEnabled = true;
 static bool useUnifiedInputConfig = true;
 static std::string micDevice = "Default Device";
 static std::string defaultControllerID = "";
+static bool backgroundControllerInput = false;
 
 // These two entries aren't stored in the config
 static bool overrideControllerColor = false;
@@ -621,6 +622,14 @@ void setDefaultControllerID(std::string id) {
     defaultControllerID = id;
 }
 
+bool getBackgroundControllerInput() {
+    return backgroundControllerInput;
+}
+
+void setBackgroundControllerInput(bool enable) {
+    backgroundControllerInput = enable;
+}
+
 void load(const std::filesystem::path& path) {
     // If the configuration file does not exist, create it and return
     std::error_code error;
@@ -680,6 +689,8 @@ void load(const std::filesystem::path& path) {
         useUnifiedInputConfig =
             toml::find_or<bool>(input, "useUnifiedInputConfig", useUnifiedInputConfig);
         micDevice = toml::find_or<std::string>(input, "micDevice", micDevice);
+        backgroundControllerInput =
+            toml::find_or<bool>(input, "backgroundControllerInput", backgroundControllerInput);
     }
 
     if (data.contains("GPU")) {
@@ -855,6 +866,7 @@ void save(const std::filesystem::path& path) {
     data["Input"]["isMotionControlsEnabled"] = isMotionControlsEnabled;
     data["Input"]["useUnifiedInputConfig"] = useUnifiedInputConfig;
     data["Input"]["micDevice"] = micDevice;
+    data["Input"]["backgroundControllerInput"] = backgroundControllerInput;
     data["GPU"]["screenWidth"] = windowWidth;
     data["GPU"]["screenHeight"] = windowHeight;
     data["GPU"]["internalScreenWidth"] = internalScreenWidth;
@@ -960,6 +972,7 @@ void setDefaultValues() {
     controllerCustomColorRGB[1] = 0;
     controllerCustomColorRGB[2] = 255;
     micDevice = "Default Device";
+    backgroundControllerInput = false;
 
     // GPU
     windowWidth = 1280;

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -109,6 +109,8 @@ bool getIsMotionControlsEnabled();
 void setIsMotionControlsEnabled(bool use);
 std::string getDefaultControllerID();
 void setDefaultControllerID(std::string id);
+bool getBackgroundControllerInput();
+void setBackgroundControllerInput(bool enable);
 
 // TODO
 bool GetLoadGameSizeEnabled();

--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -1020,7 +1020,9 @@ void ControlSettings::Cleanup() {
         SDL_QuitSubSystem(SDL_INIT_EVENTS);
         SDL_Quit();
     } else {
-        SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "0");
+        if (!Config::getBackgroundControllerInput()) {
+            SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "0");
+        }
         SDL_Event checkGamepad{};
         checkGamepad.type = SDL_EVENT_CHANGE_CONTROLLER;
         SDL_PushEvent(&checkGamepad);

--- a/src/qt_gui/hotkeys.cpp
+++ b/src/qt_gui/hotkeys.cpp
@@ -385,7 +385,9 @@ void hotkeys::Cleanup() {
         SDL_QuitSubSystem(SDL_INIT_EVENTS);
         SDL_Quit();
     } else {
-        SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "0");
+        if (!Config::getBackgroundControllerInput()) {
+            SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "0");
+        }
     }
 }
 

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -394,6 +394,7 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
         // Input
         ui->hideCursorGroupBox->installEventFilter(this);
         ui->idleTimeoutGroupBox->installEventFilter(this);
+        ui->backgroundControllerCheckBox->installEventFilter(this);
 
         // Graphics
         ui->graphicsAdapterGroupBox->installEventFilter(this);
@@ -581,6 +582,8 @@ void SettingsDialog::LoadValuesFromConfig() {
 
     ui->motionControlsCheckBox->setChecked(
         toml::find_or<bool>(data, "Input", "isMotionControlsEnabled", true));
+    ui->backgroundControllerCheckBox->setChecked(
+        toml::find_or<bool>(data, "Input", "backgroundControllerInput", false));
 
     ui->removeFolderButton->setEnabled(!ui->gameFoldersListWidget->selectedItems().isEmpty());
     SyncRealTimeWidgetstoConfig();
@@ -712,6 +715,8 @@ void SettingsDialog::updateNoteTextEdit(const QString& elementName) {
         text = tr("Hide Cursor:\\nChoose when the cursor will disappear:\\nNever: You will always see the mouse.\\nidle: Set a time for it to disappear after being idle.\\nAlways: you will never see the mouse.");
     } else if (elementName == "idleTimeoutGroupBox") {
         text = tr("Hide Idle Cursor Timeout:\\nThe duration (seconds) after which the cursor that has been idle hides itself.");
+    } else if (elementName == "backgroundControllerCheckBox") {
+        text = tr("Enable Controller Background Input:\\nAllow shadPS4 to detect controller inputs when the game window is not in focus.");
     }
 
     // Graphics
@@ -797,6 +802,7 @@ void SettingsDialog::UpdateSettings() {
     Config::setFullscreenMode(
         screenModeMap.value(ui->displayModeComboBox->currentText()).toStdString());
     Config::setIsMotionControlsEnabled(ui->motionControlsCheckBox->isChecked());
+    Config::setBackgroundControllerInput(ui->backgroundControllerCheckBox->isChecked());
     Config::setisTrophyPopupDisabled(ui->disableTrophycheckBox->isChecked());
     Config::setTrophyNotificationDuration(ui->popUpDurationSpinBox->value());
 

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -74,7 +74,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>540</height>
+         <height>536</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="generalTabVLayout" stretch="0">
@@ -369,7 +369,7 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>375</width>
+                  <width>400</width>
                   <height>68</height>
                  </rect>
                 </property>
@@ -539,7 +539,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>540</height>
+         <height>536</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="guiTabVLayout" stretch="0">
@@ -988,7 +988,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>540</height>
+         <height>536</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="graphicsTabVLayout" stretch="0,0">
@@ -1283,7 +1283,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>540</height>
+         <height>536</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="userTabVLayout" stretch="0,0,1">
@@ -1525,7 +1525,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>540</height>
+         <height>536</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="inputTabVLayout" stretch="0,0">
@@ -1726,6 +1726,13 @@
                  </property>
                 </widget>
                </item>
+               <item>
+                <widget class="QCheckBox" name="backgroundControllerCheckBox">
+                 <property name="text">
+                  <string>Enable Background Controller Input</string>
+                 </property>
+                </widget>
+               </item>
               </layout>
              </widget>
             </item>
@@ -1790,7 +1797,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>540</height>
+         <height>536</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="pathsTabLayout">
@@ -1932,7 +1939,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>540</height>
+         <height>536</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="debugTabVLayout" stretch="0,0">

--- a/src/sdl_window.cpp
+++ b/src/sdl_window.cpp
@@ -353,6 +353,10 @@ WindowSDL::WindowSDL(s32 width_, s32 height_, Input::GameController* controller_
     Input::ControllerOutput::LinkJoystickAxes();
     Input::ParseInputConfig(std::string(Common::ElfInfo::Instance().GameSerial()));
     Input::LoadHotkeyInputs();
+
+    if (Config::getBackgroundControllerInput()) {
+        SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
+    }
 }
 
 WindowSDL::~WindowSDL() = default;


### PR DESCRIPTION
closes https://github.com/shadps4-emu/shadPS4/issues/3390

Gives the option to allow the emulator to process controller inputs even when the game window is not in focus.

Can be good for multi-monitor set-ups and the like.