### PR TITLE
Make shadps4 default repo for patches

### DIFF
--- a/src/qt_gui/cheats_patches.cpp
+++ b/src/qt_gui/cheats_patches.cpp
@@ -643,6 +643,14 @@ void CheatsPatches::populateFileListPatches() {
         }
     }
     QStringListModel* model = new QStringListModel(matchingFiles, this);
+    if (!matchingFiles.isEmpty()) {
+        QModelIndexList matches = model->match(model->index(0, 0), Qt::DisplayRole, "shadPS4", 1,
+                                               Qt::MatchContains | Qt::MatchCaseSensitive);
+        if (!matches.empty()) {
+            QModelIndex shadPS4Index = matches.first();
+            model->moveRow(QModelIndex(), shadPS4Index.row(), QModelIndex(), 0);
+        }
+    }
     patchesListView->setModel(model);
 
     connect(

--- a/src/qt_gui/cheats_patches.cpp
+++ b/src/qt_gui/cheats_patches.cpp
@@ -614,6 +614,7 @@ void CheatsPatches::populateFileListPatches() {
 
     QStringList folders = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
     QStringList matchingFiles;
+    QString shadPS4entry = "";
 
     foreach (const QString& folder, folders) {
         QString folderPath = dir.filePath(folder);
@@ -636,6 +637,9 @@ void CheatsPatches::populateFileListPatches() {
                 if (serials.contains(QJsonValue(m_gameSerial))) {
                     QString fileEntry = fileName + " | " + folder;
                     if (!matchingFiles.contains(fileEntry)) {
+                        if (folder == "shadPS4") {
+                            shadPS4entry = fileEntry;
+                        }
                         matchingFiles << fileEntry;
                     }
                 }
@@ -643,13 +647,11 @@ void CheatsPatches::populateFileListPatches() {
         }
     }
     QStringListModel* model = new QStringListModel(matchingFiles, this);
-    if (!matchingFiles.isEmpty()) {
-        QModelIndexList matches = model->match(model->index(0, 0), Qt::DisplayRole, "shadPS4", 1,
-                                               Qt::MatchContains | Qt::MatchCaseSensitive);
-        if (!matches.empty()) {
-            QModelIndex shadPS4Index = matches.first();
-            model->moveRow(QModelIndex(), shadPS4Index.row(), QModelIndex(), 0);
-        }
+    if (shadPS4entry != "") {
+        QModelIndexList matches = model->match(model->index(0, 0), Qt::DisplayRole, shadPS4entry, 1,
+                                               Qt::MatchExactly | Qt::MatchCaseSensitive);
+        QModelIndex shadPS4Index = matches.first();
+        model->moveRow(QModelIndex(), shadPS4Index.row(), QModelIndex(), 0);
     }
     patchesListView->setModel(model);
 

--- a/src/qt_gui/cheats_patches.cpp
+++ b/src/qt_gui/cheats_patches.cpp
@@ -243,8 +243,8 @@ void CheatsPatches::setupUI() {
 
     // Add the combo box with options
     patchesComboBox = new QComboBox();
-    patchesComboBox->addItem("GoldHEN", "GoldHEN");
     patchesComboBox->addItem("shadPS4", "shadPS4");
+    patchesComboBox->addItem("GoldHEN", "GoldHEN");
     patchesControlLayout->addWidget(patchesComboBox);
 
     QPushButton* patchesButton = new QPushButton(tr("Download Patches"));
@@ -730,11 +730,11 @@ void CheatsPatches::populateFileListPatches() {
 
 void CheatsPatches::downloadPatches(const QString repository, const bool showMessageBox) {
     QString url;
-    if (repository == "GoldHEN") {
-        url = "https://api.github.com/repos/illusion0001/PS4-PS5-Game-Patch/contents/patches/xml";
-    }
     if (repository == "shadPS4") {
         url = "https://api.github.com/repos/shadps4-emu/ps4_cheats/contents/PATCHES";
+    }
+    if (repository == "GoldHEN") {
+        url = "https://api.github.com/repos/illusion0001/PS4-PS5-Game-Patch/contents/patches/xml";
     }
     QNetworkAccessManager* manager = new QNetworkAccessManager(this);
     QNetworkRequest request(url);


### PR DESCRIPTION
Title. One issue that's left is that once downloaded, the GoldHEN patches are still above in the patch list, not sure if there's a part in the code I missed or if it's just alphabetical order, if anyone knows how to change that I would appreciate it but I don't think it's a big deal personally.

<img width="1371" height="1293" alt="image" src="https://github.com/user-attachments/assets/62be4c52-8af7-4d83-ab35-e37987937cfb" />
