### PR TITLE
Dropping "SDL audio queue backed up..." to INFO

### DIFF
--- a/src/core/libraries/audio/sdl_audio.cpp
+++ b/src/core/libraries/audio/sdl_audio.cpp
@@ -61,9 +61,8 @@ public:
         // audio queue stalling, which may happen during device changes, for example.
         // Otherwise, latency may grow over time unbounded.
         if (const auto queued = SDL_GetAudioStreamQueued(stream); queued >= queue_threshold) {
-            LOG_INFO(Lib_AudioOut,
-                     "SDL audio queue backed up ({} queued, {} threshold), clearing.", queued,
-                     queue_threshold);
+            LOG_INFO(Lib_AudioOut, "SDL audio queue backed up ({} queued, {} threshold), clearing.",
+                     queued, queue_threshold);
             SDL_ClearAudioStream(stream);
             // Recalculate the threshold in case this happened because of a device change.
             CalculateQueueThreshold();

--- a/src/core/libraries/audio/sdl_audio.cpp
+++ b/src/core/libraries/audio/sdl_audio.cpp
@@ -61,7 +61,7 @@ public:
         // audio queue stalling, which may happen during device changes, for example.
         // Otherwise, latency may grow over time unbounded.
         if (const auto queued = SDL_GetAudioStreamQueued(stream); queued >= queue_threshold) {
-            LOG_WARNING(Lib_AudioOut,
+            LOG_INFO(Lib_AudioOut,
                         "SDL audio queue backed up ({} queued, {} threshold), clearing.", queued,
                         queue_threshold);
             SDL_ClearAudioStream(stream);

--- a/src/core/libraries/audio/sdl_audio.cpp
+++ b/src/core/libraries/audio/sdl_audio.cpp
@@ -62,8 +62,8 @@ public:
         // Otherwise, latency may grow over time unbounded.
         if (const auto queued = SDL_GetAudioStreamQueued(stream); queued >= queue_threshold) {
             LOG_INFO(Lib_AudioOut,
-                        "SDL audio queue backed up ({} queued, {} threshold), clearing.", queued,
-                        queue_threshold);
+                     "SDL audio queue backed up ({} queued, {} threshold), clearing.", queued,
+                     queue_threshold);
             SDL_ClearAudioStream(stream);
             // Recalculate the threshold in case this happened because of a device change.
             CalculateQueueThreshold();


### PR DESCRIPTION
Dropping "SDL audio queue backed up..." to INFO instead of WARNING, a lot of people were confused about these in the logs, thinking either they were the cause of audio stutters or crashes when they're not, I don't think it's useful to keep it as warning for most people.