### PR TITLE
Fix stop hotkey

### DIFF
--- a/src/input/input_handler.cpp
+++ b/src/input/input_handler.cpp
@@ -771,7 +771,7 @@ void LoadHotkeyInputs() {
 
         if (line.contains("controllerFullscreen")) {
             controllerFullscreenString = line.substr(equal_pos + 2);
-        } else if (line.contains("controllerQuit")) {
+        } else if (line.contains("controllerStop")) {
             controllerQuitString = line.substr(equal_pos + 2);
         } else if (line.contains("controllerFps")) {
             controllerFpsString = line.substr(equal_pos + 2);

--- a/src/qt_gui/hotkeys.cpp
+++ b/src/qt_gui/hotkeys.cpp
@@ -102,8 +102,8 @@ void hotkeys::SaveHotkeys(bool CloseOnSave) {
 
         if (line.contains("controllerFullscreen")) {
             line = "controllerFullscreen = " + ui->fullscreenButtonPad->text().toStdString();
-        } else if (line.contains("controllerQuit")) {
-            line = "controllerQuit = " + ui->quitButtonPad->text().toStdString();
+        } else if (line.contains("controllerStop")) {
+            line = "controllerStop = " + ui->quitButtonPad->text().toStdString();
         } else if (line.contains("controllerFps")) {
             line = "controllerFps = " + ui->fpsButtonPad->text().toStdString();
         } else if (line.contains("controllerPause")) {
@@ -148,7 +148,7 @@ void hotkeys::LoadHotkeys() {
 
         if (line.contains("controllerFullscreen")) {
             controllerFullscreenString = QString::fromStdString(line.substr(equal_pos + 2));
-        } else if (line.contains("controllerQuit")) {
+        } else if (line.contains("controllerStop")) {
             controllerQuitString = QString::fromStdString(line.substr(equal_pos + 2));
         } else if (line.contains("controllerFps")) {
             controllerFpsString = QString::fromStdString(line.substr(equal_pos + 2));


### PR DESCRIPTION
I forgot that I renamed the entry in the hotkey file to ControllerStop when the rest of the code expects it to be ControllerQuit.

This fixes the quit hotkey. I know these changes will be superseded by https://github.com/shadps4-emu/shadPS4/pull/3391 but at least this quickly fixes the issue until that one is merged.