### PR TITLE
Getting rid of "Outdated config" message

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -784,7 +784,6 @@ void load(const std::filesystem::path& path) {
 
     // Run save after loading to generate any missing fields with default values.
     if (config_version != current_version) {
-        fmt::print("Outdated config detected, updating config file.\n");
         save(path);
     }
 }


### PR DESCRIPTION
Getting rid of "Outdated config" message since it caused a few users a bit of confusion, even though the message is clear. Since the message always shows up when launching the emulator for most people they think that their config file is outdated, not printing that message would make people not think about it (I think at least).