### PR TITLE
texture_cache: Only queue image downloads if the image address is greater than zero.

### DIFF
--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -538,7 +538,8 @@ ImageView& TextureCache::FindTexture(ImageId image_id, const BaseDesc& desc) {
     Image& image = slot_images[image_id];
     if (desc.type == BindingType::Storage) {
         image.flags |= ImageFlagBits::GpuModified;
-        if (Config::readbackLinearImages() && !image.info.props.is_tiled) {
+        if (Config::readbackLinearImages() && !image.info.props.is_tiled &&
+            image.info.guest_address != 0) {
             download_images.emplace(image_id);
         }
     }


### PR DESCRIPTION
If the image address is zero, that means we're trying to download a null image, which causes other issues down the line.

This fixes an issue in Cyberpunk 2077 (CUSA16596) when readbackLinearImages is enabled.

Credits to @squidbus for helping.