### PR TITLE
Keybard/pad config common preset name is translated to target language

### DIFF
--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -178,7 +178,7 @@ void ControlSettings::SaveControllerConfig(bool CloseOnSave) {
     }
 
     std::string config_id;
-    config_id = (ui->ProfileComboBox->currentText() == "Common Config")
+    config_id = (ui->ProfileComboBox->currentText() == tr("Common Config"))
                     ? "default"
                     : ui->ProfileComboBox->currentText().toStdString();
     const auto config_file = Config::GetFoolproofKbmConfigFile(config_id);
@@ -397,17 +397,17 @@ void ControlSettings::SetDefault() {
 }
 
 void ControlSettings::AddBoxItems() {
-    ui->ProfileComboBox->addItem("Common Config");
+    ui->ProfileComboBox->addItem(tr("Common Config"));
     for (int i = 0; i < m_game_info->m_games.size(); i++) {
         ui->ProfileComboBox->addItem(QString::fromStdString(m_game_info->m_games[i].serial));
     }
-    ui->ProfileComboBox->setCurrentText("Common Config");
-    ui->TitleLabel->setText("Common Config");
+    ui->ProfileComboBox->setCurrentText(tr("Common Config"));
+    ui->TitleLabel->setText(tr("Common Config"));
 }
 
 void ControlSettings::SetUIValuestoMappings() {
     std::string config_id;
-    config_id = (ui->ProfileComboBox->currentText() == "Common Config")
+    config_id = (ui->ProfileComboBox->currentText() == tr("Common Config"))
                     ? "default"
                     : ui->ProfileComboBox->currentText().toStdString();
 
@@ -641,8 +641,8 @@ void ControlSettings::SetUIValuestoMappings() {
 }
 
 void ControlSettings::GetGameTitle() {
-    if (ui->ProfileComboBox->currentText() == "Common Config") {
-        ui->TitleLabel->setText("Common Config");
+    if (ui->ProfileComboBox->currentText() == tr("Common Config")) {
+        ui->TitleLabel->setText(tr("Common Config"));
     } else {
         for (int i = 0; i < m_game_info->m_games.size(); i++) {
             if (m_game_info->m_games[i].serial ==

--- a/src/qt_gui/kbm_gui.cpp
+++ b/src/qt_gui/kbm_gui.cpp
@@ -31,7 +31,7 @@ KBMSettings::KBMSettings(std::shared_ptr<GameInfoClass> game_info_get, bool isGa
     ui->MouseJoystickBox->addItem("right");
     ui->MouseJoystickBox->addItem("left");
 
-    ui->ProfileComboBox->addItem("Common Config");
+    ui->ProfileComboBox->addItem(tr("Common Config"));
     for (int i = 0; i < m_game_info->m_games.size(); i++) {
         ui->ProfileComboBox->addItem(QString::fromStdString(m_game_info->m_games[i].serial));
     }
@@ -69,8 +69,8 @@ KBMSettings::KBMSettings(std::shared_ptr<GameInfoClass> game_info_get, bool isGa
     SetUIValuestoMappings("default");
     installEventFilter(this);
 
-    ui->ProfileComboBox->setCurrentText("Common Config");
-    ui->TitleLabel->setText("Common Config");
+    ui->ProfileComboBox->setCurrentText(tr("Common Config"));
+    ui->TitleLabel->setText(tr("Common Config"));
     config_id = "default";
 
     connect(ui->buttonBox, &QDialogButtonBox::clicked, this, [this](QAbstractButton* button) {
@@ -113,7 +113,7 @@ KBMSettings::KBMSettings(std::shared_ptr<GameInfoClass> game_info_get, bool isGa
     });
 
     connect(ui->CopyCommonButton, &QPushButton::clicked, this, [this] {
-        if (ui->ProfileComboBox->currentText() == "Common Config") {
+        if (ui->ProfileComboBox->currentText() == tr("Common Config")) {
             QMessageBox::information(this, tr("Common Config Selected"),
                                      // clang-format off
 tr("This button copies mappings from the Common Config to the currently selected profile, and cannot be used when the currently selected profile is the Common Config."));
@@ -513,8 +513,8 @@ void KBMSettings::SetUIValuestoMappings(std::string config_id) {
 }
 
 void KBMSettings::GetGameTitle() {
-    if (ui->ProfileComboBox->currentText() == "Common Config") {
-        ui->TitleLabel->setText("Common Config");
+    if (ui->ProfileComboBox->currentText() == tr("Common Config")) {
+        ui->TitleLabel->setText(tr("Common Config"));
     } else {
         for (int i = 0; i < m_game_info->m_games.size(); i++) {
             if (m_game_info->m_games[i].serial ==
@@ -523,7 +523,7 @@ void KBMSettings::GetGameTitle() {
             }
         }
     }
-    config_id = (ui->ProfileComboBox->currentText() == "Common Config")
+    config_id = (ui->ProfileComboBox->currentText() == tr("Common Config"))
                     ? "default"
                     : ui->ProfileComboBox->currentText().toStdString();
 }


### PR DESCRIPTION
"Common Config" is translated to target language now  
<img width="554" height="138" alt="obraz" src="https://github.com/user-attachments/assets/05a72970-99e5-4f79-9a0b-27584557babb" />  
<img width="554" height="138" alt="obraz" src="https://github.com/user-attachments/assets/ce252168-c680-49b8-a9ac-8f841153a05b" />
