### PR TITLE
vk_pipeline_cache: Cleanup graphics key refresh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -918,6 +918,7 @@ set(SHADER_RECOMPILER src/shader_recompiler/exception.h
                       src/shader_recompiler/ir/opcodes.inc
                       src/shader_recompiler/ir/patch.cpp
                       src/shader_recompiler/ir/patch.h
+                      src/shader_recompiler/ir/position.h
                       src/shader_recompiler/ir/post_order.cpp
                       src/shader_recompiler/ir/post_order.h
                       src/shader_recompiler/ir/program.cpp

--- a/src/shader_recompiler/ir/position.h
+++ b/src/shader_recompiler/ir/position.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "common/logging/log.h"
 #include "shader_recompiler/ir/ir_emitter.h"
 #include "shader_recompiler/runtime_info.h"
 
@@ -45,8 +46,12 @@ inline void ExportPosition(IREmitter& ir, const auto& stage, Attribute attribute
     case Output::GsMrtIndex:
         ir.SetAttribute(IR::Attribute::RenderTargetId, value);
         break;
+    case Output::None:
+        LOG_WARNING(Render_Recompiler, "The {} component of {} isn't mapped, skipping",
+                    "xyzw"[comp], NameOf(attribute));
+        break;
     default:
-        UNREACHABLE_MSG("Unhandled output {} on attribute {}", u32(output), u32(attribute));
+        UNREACHABLE_MSG("Unhandled output {} on attribute {}", u32(output), NameOf(attribute));
     }
 }
 

--- a/src/shader_recompiler/profile.h
+++ b/src/shader_recompiler/profile.h
@@ -35,6 +35,7 @@ struct Profile {
     bool needs_manual_interpolation{};
     bool needs_lds_barriers{};
     bool needs_buffer_offsets{};
+    bool needs_unorm_fixup{};
     u64 max_ubo_size{};
     u32 max_viewport_width{};
     u32 max_viewport_height{};

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -93,7 +93,8 @@ struct VertexRuntimeInfo {
     u32 hs_output_cp_stride{};
 
     bool operator==(const VertexRuntimeInfo& other) const noexcept {
-        return emulate_depth_negative_one_to_one == other.emulate_depth_negative_one_to_one &&
+        return num_outputs == other.num_outputs && outputs == other.outputs &&
+               emulate_depth_negative_one_to_one == other.emulate_depth_negative_one_to_one &&
                clip_disable == other.clip_disable && tess_type == other.tess_type &&
                tess_topology == other.tess_topology &&
                tess_partitioning == other.tess_partitioning &&
@@ -158,8 +159,9 @@ struct GeometryRuntimeInfo {
     u64 vs_copy_hash;
 
     bool operator==(const GeometryRuntimeInfo& other) const noexcept {
-        return num_invocations && other.num_invocations &&
-               output_vertices == other.output_vertices && in_primitive == other.in_primitive &&
+        return num_outputs == other.num_outputs && outputs == other.outputs && num_invocations &&
+               other.num_invocations && output_vertices == other.output_vertices &&
+               in_primitive == other.in_primitive &&
                std::ranges::equal(out_primitive, other.out_primitive);
     }
 };

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -177,8 +177,6 @@ struct PsColorBuffer {
     AmdGpu::NumberFormat num_format : 4;
     AmdGpu::NumberConversion num_conversion : 3;
     AmdGpu::Liverpool::ShaderExportFormat export_format : 4;
-    u32 needs_unorm_fixup : 1;
-    u32 pad : 20;
     AmdGpu::CompMapping swizzle;
 
     bool operator==(const PsColorBuffer& other) const noexcept = default;

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -794,6 +794,7 @@ struct Liverpool {
             ReverseSubtract = 4,
         };
 
+        u32 raw;
         BitField<0, 5, BlendFactor> color_src_factor;
         BitField<5, 3, BlendFunc> color_func;
         BitField<8, 5, BlendFactor> color_dst_factor;
@@ -803,6 +804,10 @@ struct Liverpool {
         BitField<29, 1, u32> separate_alpha_blend;
         BitField<30, 1, u32> enable;
         BitField<31, 1, u32> disable_rop3;
+
+        bool operator==(const BlendControl& other) const {
+            return raw == other.raw;
+        }
     };
 
     union ColorControl {
@@ -919,7 +924,7 @@ struct Liverpool {
         INSERT_PADDING_WORDS(2);
 
         operator bool() const {
-            return info.format != DataFormat::FormatInvalid;
+            return base_address && info.format != DataFormat::FormatInvalid;
         }
 
         u32 Pitch() const {

--- a/src/video_core/amdgpu/pixel_format.h
+++ b/src/video_core/amdgpu/pixel_format.h
@@ -85,7 +85,7 @@ enum class NumberClass {
     Uint,
 };
 
-enum class CompSwizzle : u32 {
+enum class CompSwizzle : u8 {
     Zero = 0,
     One = 1,
     Red = 4,
@@ -134,6 +134,12 @@ union CompMapping {
         InverseSingle(result.b, CompSwizzle::Blue);
         InverseSingle(result.a, CompSwizzle::Alpha);
         return result;
+    }
+
+    [[nodiscard]] u32 Map(u32 comp) const {
+        const u32 swizzled_comp = u32(array[comp]);
+        constexpr u32 min_comp = u32(AmdGpu::CompSwizzle::Red);
+        return swizzled_comp >= min_comp ? swizzled_comp - min_comp : comp;
     }
 
 private:

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -168,9 +168,6 @@ GraphicsPipeline::GraphicsPipeline(
         dynamic_states.push_back(vk::DynamicState::eDepthBoundsTestEnable);
         dynamic_states.push_back(vk::DynamicState::eDepthBounds);
     }
-    if (instance.IsDynamicColorWriteMaskSupported()) {
-        dynamic_states.push_back(vk::DynamicState::eColorWriteMaskEXT);
-    }
     if (instance.IsVertexInputDynamicState()) {
         dynamic_states.push_back(vk::DynamicState::eVertexInputEXT);
     } else if (!vertex_bindings.empty()) {
@@ -291,11 +288,7 @@ GraphicsPipeline::GraphicsPipeline(
             .alphaBlendOp = control.separate_alpha_blend
                                 ? LiverpoolToVK::BlendOp(control.alpha_func)
                                 : color_blend,
-            .colorWriteMask =
-                instance.IsDynamicColorWriteMaskSupported()
-                    ? vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG |
-                          vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA
-                    : key.write_masks[i],
+            .colorWriteMask = vk::ColorComponentFlags{key.write_masks[i]},
         };
 
         // On GCN GPU there is an additional mask which allows to control color components exported

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -38,7 +38,7 @@ struct GraphicsPipelineKey {
     u32 num_color_attachments;
     std::array<Shader::PsColorBuffer, Liverpool::NumColorBuffers> color_buffers;
     std::array<Liverpool::BlendControl, Liverpool::NumColorBuffers> blend_controls;
-    std::array<vk::ColorComponentFlags, Liverpool::NumColorBuffers> write_masks;
+    std::array<u32, Liverpool::NumColorBuffers> write_masks;
     Liverpool::ColorBufferMask cb_shader_mask;
     Liverpool::ColorControl::LogicOp logic_op;
     u32 num_samples;
@@ -76,11 +76,7 @@ public:
         return fetch_shader;
     }
 
-    auto GetWriteMasks() const {
-        return key.write_masks;
-    }
-
-    auto GetMrtMask() const {
+    u32 GetMrtMask() const {
         return key.mrt_mask;
     }
 

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -255,13 +255,6 @@ bool Instance::CreateDevice() {
     // Optional
     maintenance_8 = add_extension(VK_KHR_MAINTENANCE_8_EXTENSION_NAME);
     depth_range_unrestricted = add_extension(VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME);
-    dynamic_state_3 = add_extension(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
-    if (dynamic_state_3) {
-        dynamic_state_3_features =
-            feature_chain.get<vk::PhysicalDeviceExtendedDynamicState3FeaturesEXT>();
-        LOG_INFO(Render_Vulkan, "- extendedDynamicState3ColorWriteMask: {}",
-                 dynamic_state_3_features.extendedDynamicState3ColorWriteMask);
-    }
     robustness2 = add_extension(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
     if (robustness2) {
         robustness2_features = feature_chain.get<vk::PhysicalDeviceRobustness2FeaturesEXT>();
@@ -426,10 +419,6 @@ bool Instance::CreateDevice() {
             .customBorderColors = true,
             .customBorderColorWithoutFormat = true,
         },
-        vk::PhysicalDeviceExtendedDynamicState3FeaturesEXT{
-            .extendedDynamicState3ColorWriteMask =
-                dynamic_state_3_features.extendedDynamicState3ColorWriteMask,
-        },
         vk::PhysicalDeviceDepthClipControlFeaturesEXT{
             .depthClipControl = true,
         },
@@ -504,9 +493,6 @@ bool Instance::CreateDevice() {
 
     if (!custom_border_color) {
         device_chain.unlink<vk::PhysicalDeviceCustomBorderColorFeaturesEXT>();
-    }
-    if (!dynamic_state_3) {
-        device_chain.unlink<vk::PhysicalDeviceExtendedDynamicState3FeaturesEXT>();
     }
     if (!depth_clip_control) {
         device_chain.unlink<vk::PhysicalDeviceDepthClipControlFeaturesEXT>();

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -139,12 +139,6 @@ public:
         return depth_range_unrestricted;
     }
 
-    /// Returns true when the extendedDynamicState3ColorWriteMask feature of
-    /// VK_EXT_extended_dynamic_state3 is supported.
-    bool IsDynamicColorWriteMaskSupported() const {
-        return dynamic_state_3 && dynamic_state_3_features.extendedDynamicState3ColorWriteMask;
-    }
-
     /// Returns true when VK_EXT_vertex_input_dynamic_state is supported.
     bool IsVertexInputDynamicState() const {
         return vertex_input_dynamic_state;
@@ -439,7 +433,6 @@ private:
     vk::PhysicalDeviceFeatures features;
     vk::PhysicalDeviceVulkan12Features vk12_features;
     vk::PhysicalDevicePortabilitySubsetFeaturesKHR portability_features;
-    vk::PhysicalDeviceExtendedDynamicState3FeaturesEXT dynamic_state_3_features;
     vk::PhysicalDeviceRobustness2FeaturesEXT robustness2_features;
     vk::PhysicalDeviceShaderAtomicFloat2FeaturesEXT shader_atomic_float2_features;
     vk::PhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR
@@ -461,7 +454,6 @@ private:
     bool depth_clip_control{};
     bool depth_clip_enable{};
     bool depth_range_unrestricted{};
-    bool dynamic_state_3{};
     bool vertex_input_dynamic_state{};
     bool robustness2{};
     bool list_restart{};

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.h
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.h
@@ -74,6 +74,7 @@ public:
 
 private:
     bool RefreshGraphicsKey();
+    bool RefreshGraphicsStages();
     bool RefreshComputeKey();
 
     void DumpShader(std::span<const u32> code, u64 hash, Shader::Stage stage, size_t perm_idx,

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -113,6 +113,7 @@ RenderState Rasterizer::PrepareRenderState(u32 mrt_mask) {
     state.width = instance.GetMaxFramebufferWidth();
     state.height = instance.GetMaxFramebufferHeight();
     state.num_layers = std::numeric_limits<u32>::max();
+    state.num_color_attachments = std::bit_width(mrt_mask);
 
     cb_descs.clear();
     db_desc.reset();
@@ -125,29 +126,31 @@ RenderState Rasterizer::PrepareRenderState(u32 mrt_mask) {
 
     const bool skip_cb_binding =
         regs.color_control.mode == AmdGpu::Liverpool::ColorControl::OperationMode::Disable;
-    for (auto col_buf_id = 0u; col_buf_id < Liverpool::NumColorBuffers; ++col_buf_id) {
-        const auto& col_buf = regs.color_buffers[col_buf_id];
-        if (skip_cb_binding || !col_buf) {
+
+    for (s32 cb = 0; cb < state.num_color_attachments && !skip_cb_binding; ++cb) {
+        const auto& col_buf = regs.color_buffers[cb];
+        if (!col_buf) {
+            state.color_attachments[cb].imageView = VK_NULL_HANDLE;
             continue;
         }
 
         // Skip stale color buffers if shader doesn't output to them. Otherwise it will perform
         // an unnecessary transition and may result in state conflict if the resource is already
         // bound for reading.
-        if ((mrt_mask & (1 << col_buf_id)) == 0) {
-            state.color_attachments[state.num_color_attachments++].imageView = VK_NULL_HANDLE;
+        if ((mrt_mask & (1 << cb)) == 0) {
+            state.color_attachments[cb].imageView = VK_NULL_HANDLE;
             continue;
         }
 
         // If the color buffer is still bound but rendering to it is disabled by the target
         // mask, we need to prevent the render area from being affected by unbound render target
         // extents.
-        if (!regs.color_target_mask.GetMask(col_buf_id)) {
-            state.color_attachments[state.num_color_attachments++].imageView = VK_NULL_HANDLE;
+        if (!regs.color_target_mask.GetMask(cb)) {
+            state.color_attachments[cb].imageView = VK_NULL_HANDLE;
             continue;
         }
 
-        const auto& hint = liverpool->last_cb_extent[col_buf_id];
+        const auto& hint = liverpool->last_cb_extent[cb];
         auto& [image_id, desc] = cb_descs.emplace_back(std::piecewise_construct, std::tuple{},
                                                        std::tuple{col_buf, hint});
         const auto& image_view = texture_cache.FindRenderTarget(desc);
@@ -163,7 +166,7 @@ RenderState Rasterizer::PrepareRenderState(u32 mrt_mask) {
         state.width = std::min<u32>(state.width, std::max(image.info.size.width >> mip, 1u));
         state.height = std::min<u32>(state.height, std::max(image.info.size.height >> mip, 1u));
         state.num_layers = std::min<u32>(state.num_layers, image_view.info.range.extent.layers);
-        state.color_attachments[state.num_color_attachments++] = {
+        state.color_attachments[cb] = {
             .imageView = *image_view.image_view,
             .imageLayout = vk::ImageLayout::eUndefined,
             .loadOp = is_clear ? vk::AttachmentLoadOp::eClear : vk::AttachmentLoadOp::eLoad,
@@ -1094,7 +1097,6 @@ void Rasterizer::UpdateDynamicState(const GraphicsPipeline& pipeline) const {
 
     auto& dynamic_state = scheduler.GetDynamicState();
     dynamic_state.SetBlendConstants(liverpool->regs.blend_constants);
-    dynamic_state.SetColorWriteMasks(pipeline.GetWriteMasks());
 
     // Commit new dynamic state to the command buffer.
     dynamic_state.Commit(instance, scheduler.CommandBuffer());

--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -1,10 +1,8 @@
 // SPDX-FileCopyrightText: Copyright 2019 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include <mutex>
 #include "common/assert.h"
 #include "common/debug.h"
-#include "common/logging/log.h"
 #include "imgui/renderer/texture_manager.h"
 #include "video_core/renderer_vulkan/vk_instance.h"
 #include "video_core/renderer_vulkan/vk_scheduler.h"
@@ -324,12 +322,6 @@ void DynamicState::Commit(const Instance& instance, const vk::CommandBuffer& cmd
     if (dirty_state.blend_constants) {
         dirty_state.blend_constants = false;
         cmdbuf.setBlendConstants(blend_constants.data());
-    }
-    if (dirty_state.color_write_masks) {
-        dirty_state.color_write_masks = false;
-        if (instance.IsDynamicColorWriteMaskSupported()) {
-            cmdbuf.setColorWriteMaskEXT(0, color_write_masks);
-        }
     }
     if (dirty_state.line_width) {
         dirty_state.line_width = false;

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -5,6 +5,7 @@
 
 #include <condition_variable>
 #include <boost/container/static_vector.hpp>
+
 #include "common/types.h"
 #include "common/unique_function.h"
 #include "video_core/amdgpu/liverpool.h"
@@ -102,7 +103,6 @@ struct DynamicState {
         bool front_face : 1;
 
         bool blend_constants : 1;
-        bool color_write_masks : 1;
         bool line_width : 1;
     } dirty_state{};
 
@@ -138,7 +138,6 @@ struct DynamicState {
     vk::FrontFace front_face{};
 
     std::array<float, 4> blend_constants{};
-    ColorWriteMasks color_write_masks{};
     float line_width{};
 
     /// Commits the dynamic state to the provided command buffer.
@@ -299,13 +298,6 @@ struct DynamicState {
         if (rasterizer_discard_enable != enabled) {
             rasterizer_discard_enable = enabled;
             dirty_state.rasterizer_discard_enable = true;
-        }
-    }
-
-    void SetColorWriteMasks(const ColorWriteMasks& color_write_masks_) {
-        if (!std::ranges::equal(color_write_masks, color_write_masks_)) {
-            color_write_masks = color_write_masks_;
-            dirty_state.color_write_masks = true;
         }
     }
 


### PR DESCRIPTION
- Remove color write mask dynamic state. This needs a whole extension and checks just for it, and it doesn't even benefit compilation times because the pipeline key still hashes write masks, so triggers recompilations. It would be better to readd this when the entire color blending state can properly be made dynamic, since write masks are not a "hot" pipeline state that triggers often recompilations

- Moved MoltenVK unorm fixup into shader recompiler. The color buffer struct has contained both data and number formats for a while, so little reason to have pipeline cache do the check for it, instead of the intended user

- Split out shader stage binding from graphics pipeline key refresh, to make the whole function easier to parse

- Remove the concept of color buffer compaction. This never made much sense to me, maybe this change is wrong and this will break stuff but I believe hardware has 8 fixed MRT slots, shaders can export to those slots so the mapping between those is 1-1. I feel any compacting will break this if there are gaps between render targets.

The binding code has been rewritten, so first pass iterates all the slots and binds whatever is valid, then mrt_mask is used to fetch the number of render targets bound, which feels more correct then just counting the number of valid targets, as it will include gaps properly, and masks out render targets that don't appear in the mask (the gaps essentially)