### PR TITLE
video_core: Fix some struct comparisons.

### DIFF
--- a/src/shader_recompiler/specialization.h
+++ b/src/shader_recompiler/specialization.h
@@ -17,7 +17,7 @@ struct VsAttribSpecialization {
     AmdGpu::NumberClass num_class{};
     AmdGpu::CompMapping dst_select{};
 
-    auto operator<=>(const VsAttribSpecialization&) const = default;
+    bool operator==(const VsAttribSpecialization&) const = default;
 };
 
 struct BufferSpecialization {
@@ -52,21 +52,21 @@ struct ImageSpecialization {
     AmdGpu::CompMapping dst_select{};
     AmdGpu::NumberConversion num_conversion{};
 
-    auto operator<=>(const ImageSpecialization&) const = default;
+    bool operator==(const ImageSpecialization&) const = default;
 };
 
 struct FMaskSpecialization {
     u32 width;
     u32 height;
 
-    auto operator<=>(const FMaskSpecialization&) const = default;
+    bool operator==(const FMaskSpecialization&) const = default;
 };
 
 struct SamplerSpecialization {
     u8 force_unnormalized : 1;
     u8 force_degamma : 1;
 
-    auto operator<=>(const SamplerSpecialization&) const = default;
+    bool operator==(const SamplerSpecialization&) const = default;
 };
 
 /**

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -56,6 +56,10 @@ struct GraphicsPipelineKey {
         u32 depth_clip_enable : 1;
     };
 
+    GraphicsPipelineKey() {
+        std::memset(this, 0, sizeof(*this));
+    }
+
     bool operator==(const GraphicsPipelineKey& key) const noexcept {
         return std::memcmp(this, &key, sizeof(key)) == 0;
     }

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -20,15 +20,20 @@ namespace Vulkan {
 class Instance;
 
 struct RenderState {
-    std::array<vk::RenderingAttachmentInfo, 8> color_attachments{};
-    vk::RenderingAttachmentInfo depth_attachment{};
-    vk::RenderingAttachmentInfo stencil_attachment{};
-    u32 num_color_attachments{};
-    u32 num_layers{1};
-    bool has_depth{};
-    bool has_stencil{};
-    u32 width{};
-    u32 height{};
+    std::array<vk::RenderingAttachmentInfo, 8> color_attachments;
+    vk::RenderingAttachmentInfo depth_attachment;
+    vk::RenderingAttachmentInfo stencil_attachment;
+    u32 num_color_attachments;
+    u32 num_layers;
+    bool has_depth;
+    bool has_stencil;
+    u32 width;
+    u32 height;
+
+    RenderState() {
+        std::memset(this, 0, sizeof(*this));
+        num_layers = 1;
+    }
 
     bool operator==(const RenderState& other) const noexcept {
         return std::memcmp(this, &other, sizeof(RenderState)) == 0;


### PR DESCRIPTION
* In `specialization`, replace some three-way comparison operator declarations with equality operators, as some of the contents are not three-way comparable.
* For state structs that are compared using `memcmp`, initialize full struct (including padding) to zero in constructor.

Fixes some lag due to state being constantly deemed to be dirty.