### PR TITLE
shader_recompiler: Do not emit Layer when emulating primitive type with tessellation.

### DIFF
--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -82,6 +82,7 @@ using OutputMap = std::array<Output, 4>;
 struct VertexRuntimeInfo {
     u32 num_outputs;
     std::array<OutputMap, 3> outputs;
+    bool tess_emulated_primitive{};
     bool emulate_depth_negative_one_to_one{};
     bool clip_disable{};
     u32 step_rate_0;
@@ -94,6 +95,7 @@ struct VertexRuntimeInfo {
 
     bool operator==(const VertexRuntimeInfo& other) const noexcept {
         return num_outputs == other.num_outputs && outputs == other.outputs &&
+               tess_emulated_primitive == other.tess_emulated_primitive &&
                emulate_depth_negative_one_to_one == other.emulate_depth_negative_one_to_one &&
                clip_disable == other.clip_disable && tess_type == other.tess_type &&
                tess_topology == other.tess_topology &&

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -128,6 +128,9 @@ const Shader::RuntimeInfo& PipelineCache::BuildRuntimeInfo(Stage stage, LogicalS
         info.vs_info.emulate_depth_negative_one_to_one =
             !instance.IsDepthClipControlSupported() &&
             regs.clipper_control.clip_space == Liverpool::ClipSpace::MinusWToW;
+        info.vs_info.tess_emulated_primitive =
+            regs.primitive_type == AmdGpu::PrimitiveType::RectList ||
+            regs.primitive_type == AmdGpu::PrimitiveType::QuadList;
         info.vs_info.clip_disable = regs.IsClipDisabled();
         if (l_stage == LogicalStage::TessellationEval) {
             info.vs_info.tess_type = regs.tess_config.type;


### PR DESCRIPTION
Layer must be output from the final pre-rasterization stage, so when tessellation is being used the vertex shader cannot set it. We could pass it through to the tessellation shaders in some way, but unless it becomes an issue that's more effort than it's worth.

Fixes rendering in Hatsune Miku: Project DIVA X on MoltenVK. MoltenVK has a particular bug currently where rather than just being ignored, setting the Layer in the wrong stage of a tessellation pipeline causes vertex data issues. The draws in question seem to just always end up with layer 0 anyway.