### PR TITLE
memory_patcher: Fix isEnabled not being reset between patches.

### DIFF
--- a/src/common/memory_patcher.cpp
+++ b/src/common/memory_patcher.cpp
@@ -287,6 +287,7 @@ void OnGameLoaded() {
                     QString appVer = xmlReader.attributes().value("AppVer").toString();
 
                     // Check and update the isEnabled attribute
+                    isEnabled = false;
                     for (const QXmlStreamAttribute& attr : xmlReader.attributes()) {
                         if (attr.name() == QStringLiteral("isEnabled")) {
                             isEnabled = (attr.value().toString() == "true");


### PR DESCRIPTION
If subsequent patch metadata does not define `isEnabled`, the previous patch's value was being used.