### PR TITLE
Fix resetting patches when the isEnabled field is not present

### DIFF
--- a/src/common/memory_patcher.cpp
+++ b/src/common/memory_patcher.cpp
@@ -287,6 +287,7 @@ void OnGameLoaded() {
                     QString appVer = xmlReader.attributes().value("AppVer").toString();
 
                     // Check and update the isEnabled attribute
+                    isEnabled = false;
                     for (const QXmlStreamAttribute& attr : xmlReader.attributes()) {
                         if (attr.name() == QStringLiteral("isEnabled")) {
                             isEnabled = (attr.value().toString() == "true");


### PR DESCRIPTION
Fixes the issue when you have two patches like so:
```xml
<Metadata Title="game" Name="patch1" Note="" Author="kalaposfos" PatchVer="1.0" AppVer="01.00" AppElf="eboot.bin" isEnabled="true">
    <PatchList>
        <Line Type="bytes" Address="0x0068bf60" Value="31c0c3"/>
    </PatchList>
</Metadata>
<Metadata Title="game" Name="patch2" Note="" Author="kalaposfos" PatchVer="1.0" AppVer="01.00" AppElf="eboot.bin">
    <PatchList>
        <Line Type="bytes" Address="0x0068bf60" Value="31c0c3"/>
    </PatchList>
</Metadata>
```
The first has the isEnabled field, but the second does not. The expected behaviour would be that the first is turned on, but the second isn't, but what happens is that both get turned on, because the internal isEnabled flag doesn't get reset, so the first "true" gets carried over.