### PR TITLE
Libraries: libSceHmdSetupDialog stubs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -607,6 +607,8 @@ set(VR_LIBS  src/core/libraries/hmd/hmd.cpp
              src/core/libraries/hmd/hmd_reprojection.cpp
              src/core/libraries/hmd/hmd_distortion.cpp
              src/core/libraries/hmd/hmd.h
+             src/core/libraries/hmd/hmd_setup_dialog.cpp
+             src/core/libraries/hmd/hmd_setup_dialog.h
 )
 
 set(MISC_LIBS  src/core/libraries/screenshot/screenshot.cpp

--- a/src/common/logging/filter.cpp
+++ b/src/common/logging/filter.cpp
@@ -139,6 +139,7 @@ bool ParseFilterRule(Filter& instance, Iterator begin, Iterator end) {
     SUB(Lib, NpParty)                                                                              \
     SUB(Lib, Zlib)                                                                                 \
     SUB(Lib, Hmd)                                                                                  \
+    SUB(Lib, HmdSetupDialog)                                                                       \
     SUB(Lib, SigninDialog)                                                                         \
     SUB(Lib, Camera)                                                                               \
     SUB(Lib, CompanionHttpd)                                                                       \

--- a/src/common/logging/types.h
+++ b/src/common/logging/types.h
@@ -107,6 +107,7 @@ enum class Class : u8 {
     Lib_NpParty,           ///< The LibSceNpParty implementation
     Lib_Zlib,              ///< The LibSceZlib implementation.
     Lib_Hmd,               ///< The LibSceHmd implementation.
+    Lib_HmdSetupDialog,    ///< The LibSceHmdSetupDialog implementation.
     Lib_SigninDialog,      ///< The LibSigninDialog implementation.
     Lib_Camera,            ///< The LibCamera implementation.
     Lib_CompanionHttpd,    ///< The LibCompanionHttpd implementation.

--- a/src/core/libraries/hmd/hmd_setup_dialog.cpp
+++ b/src/core/libraries/hmd/hmd_setup_dialog.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "common/assert.h"
+#include "common/logging/log.h"
+#include "core/libraries/error_codes.h"
+#include "core/libraries/hmd/hmd_setup_dialog.h"
+#include "core/libraries/libs.h"
+
+namespace Libraries::HmdSetupDialog {
+
+s32 PS4_SYSV_ABI sceHmdSetupDialogInitialize() {
+    LOG_ERROR(Lib_HmdSetupDialog, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceHmdSetupDialogClose() {
+    LOG_ERROR(Lib_HmdSetupDialog, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceHmdSetupDialogOpen(const OrbisHmdSetupDialogParam* param) {
+    LOG_ERROR(Lib_HmdSetupDialog, "(STUBBED) called");
+    // On real hardware, a dialog would show up telling the user to connect a PSVR headset.
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceHmdSetupDialogGetResult(OrbisHmdSetupDialogResult* result) {
+    LOG_ERROR(Lib_HmdSetupDialog, "(STUBBED) called");
+    // Simulates behavior of user pressing circle to cancel the dialog.
+    // Result::OK would mean a headset was connected.
+    result->result = Libraries::CommonDialog::Result::USER_CANCELED;
+    return ORBIS_OK;
+}
+
+Libraries::CommonDialog::Status PS4_SYSV_ABI sceHmdSetupDialogUpdateStatus() {
+    LOG_ERROR(Lib_HmdSetupDialog, "(STUBBED) called");
+    return Libraries::CommonDialog::Status::FINISHED;
+}
+
+Libraries::CommonDialog::Status PS4_SYSV_ABI sceHmdSetupDialogGetStatus() {
+    LOG_ERROR(Lib_HmdSetupDialog, "(STUBBED) called");
+    return Libraries::CommonDialog::Status::FINISHED;
+}
+
+s32 PS4_SYSV_ABI sceHmdSetupDialogTerminate() {
+    LOG_ERROR(Lib_HmdSetupDialog, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
+void RegisterLib(Core::Loader::SymbolsResolver* sym) {
+    LIB_FUNCTION("nmHzU4Gh0xs", "libSceHmdSetupDialog", 1, "libSceHmdSetupDialog", 1, 1,
+                 sceHmdSetupDialogClose);
+    LIB_FUNCTION("6lVRHMV5LY0", "libSceHmdSetupDialog", 1, "libSceHmdSetupDialog", 1, 1,
+                 sceHmdSetupDialogGetResult);
+    LIB_FUNCTION("J9eBpW1udl4", "libSceHmdSetupDialog", 1, "libSceHmdSetupDialog", 1, 1,
+                 sceHmdSetupDialogGetStatus);
+    LIB_FUNCTION("NB1Y2kA2jCY", "libSceHmdSetupDialog", 1, "libSceHmdSetupDialog", 1, 1,
+                 sceHmdSetupDialogInitialize);
+    LIB_FUNCTION("NNgiV4T+akU", "libSceHmdSetupDialog", 1, "libSceHmdSetupDialog", 1, 1,
+                 sceHmdSetupDialogOpen);
+    LIB_FUNCTION("+z4OJmFreZc", "libSceHmdSetupDialog", 1, "libSceHmdSetupDialog", 1, 1,
+                 sceHmdSetupDialogTerminate);
+    LIB_FUNCTION("Ud7j3+RDIBg", "libSceHmdSetupDialog", 1, "libSceHmdSetupDialog", 1, 1,
+                 sceHmdSetupDialogUpdateStatus);
+};
+
+} // namespace Libraries::HmdSetupDialog

--- a/src/core/libraries/hmd/hmd_setup_dialog.h
+++ b/src/core/libraries/hmd/hmd_setup_dialog.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "common/types.h"
+#include "core/libraries/system/commondialog.h"
+#include "core/libraries/system/userservice.h"
+
+namespace Core::Loader {
+class SymbolsResolver;
+}
+
+namespace Libraries::HmdSetupDialog {
+
+struct OrbisHmdSetupDialogParam {
+    Libraries::CommonDialog::BaseParam base_param;
+    u64 size;
+    Libraries::UserService::OrbisUserServiceUserId user_id;
+    bool disable_handover_screen;
+    u8 reserved[40];
+};
+
+struct OrbisHmdSetupDialogResult {
+    Libraries::CommonDialog::Result result;
+    u8 reserved[32];
+};
+
+s32 PS4_SYSV_ABI sceHmdSetupDialogClose();
+s32 PS4_SYSV_ABI sceHmdSetupDialogGetResult(OrbisHmdSetupDialogResult* result);
+Libraries::CommonDialog::Status PS4_SYSV_ABI sceHmdSetupDialogGetStatus();
+s32 PS4_SYSV_ABI sceHmdSetupDialogInitialize();
+s32 PS4_SYSV_ABI sceHmdSetupDialogOpen(const OrbisHmdSetupDialogParam* param);
+s32 PS4_SYSV_ABI sceHmdSetupDialogTerminate();
+Libraries::CommonDialog::Status PS4_SYSV_ABI sceHmdSetupDialogUpdateStatus();
+
+void RegisterLib(Core::Loader::SymbolsResolver* sym);
+} // namespace Libraries::HmdSetupDialog

--- a/src/core/libraries/libs.cpp
+++ b/src/core/libraries/libs.cpp
@@ -15,6 +15,7 @@
 #include "core/libraries/game_live_streaming/gamelivestreaming.h"
 #include "core/libraries/gnmdriver/gnmdriver.h"
 #include "core/libraries/hmd/hmd.h"
+#include "core/libraries/hmd/hmd_setup_dialog.h"
 #include "core/libraries/ime/error_dialog.h"
 #include "core/libraries/ime/ime.h"
 #include "core/libraries/ime/ime_dialog.h"
@@ -127,6 +128,7 @@ void InitHLELibs(Core::Loader::SymbolsResolver* sym) {
     Libraries::NpParty::RegisterLib(sym);
     Libraries::Zlib::RegisterLib(sym);
     Libraries::Hmd::RegisterLib(sym);
+    Libraries::HmdSetupDialog::RegisterLib(sym);
     Libraries::DiscMap::RegisterLib(sym);
     Libraries::Ulobjmgr::RegisterLib(sym);
     Libraries::SigninDialog::RegisterLib(sym);


### PR DESCRIPTION
These are some basic stubs designed to get some VR-optional titles further by simulating a user canceling the dialog.

VR-required titles are expected to endlessly spam these calls, at least based on Sony's "When you see this screen repeatedly even after canceling, press the PS button to go to the home screen" message on the actual HmdSetupDialog.