### PR TITLE
Qt: update to 6.9.2 and remove Mac workaround

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
     - name: Setup Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.9.1
+        version: 6.9.2
         host: windows
         target: desktop
         arch: win64_msvc2022_64
@@ -218,15 +218,12 @@ jobs:
     - name: Setup Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: 6.9.1
+        version: 6.9.2
         host: mac
         target: desktop
         arch: clang_64
         archives: qtbase qttools
         modules: qtmultimedia
-
-    - name: Workaround Qt <=6.9.1 issue
-      run: sed -i '' '/target_link_libraries(WrapOpenGL::WrapOpenGL INTERFACE ${__opengl_agl_fw_path})/d' ${{env.QT_ROOT_DIR}}/lib/cmake/Qt6/FindWrapOpenGL.cmake
 
     - name: Cache CMake Configuration
       uses: actions/cache@v4 


### PR DESCRIPTION
Update QT to 6.9.2, this does seem to eliminate the need for the Mac build job "Workaround Qt <=6.9.1 issue". 

Test ran the github runners 3 times and the Mac builds never failed.