### PR TITLE
Replace direct usage of wrgsbase and rdgsbase with a more portable solution 

### DIFF
--- a/src/core/tls.cpp
+++ b/src/core/tls.cpp
@@ -19,8 +19,8 @@
 #include <pthread.h>
 #endif
 #if defined(__linux__) && defined(ARCH_X86_64)
-#include <sys/prctl.h>
 #include <asm/prctl.h>
+#include <sys/prctl.h>
 #endif
 
 namespace Core {

--- a/src/core/tls.cpp
+++ b/src/core/tls.cpp
@@ -18,6 +18,10 @@
 #elif !defined(ARCH_X86_64)
 #include <pthread.h>
 #endif
+#if defined(__linux__) && defined(ARCH_X86_64)
+#include <sys/prctl.h>
+#include <asm/prctl.h>
+#endif
 
 namespace Core {
 
@@ -156,13 +160,15 @@ Tcb* GetTcbBase() {
 // Other POSIX x86_64
 
 void SetTcbBase(void* image_address) {
-    asm volatile("wrgsbase %0" ::"r"(image_address) : "memory");
+    const int ret = syscall(SYS_arch_prctl, ARCH_SET_GS, (unsigned long)image_address);
+    ASSERT_MSG(ret == 0, "Failed to set GS base: errno {}", errno);
 }
 
 Tcb* GetTcbBase() {
-    Tcb* tcb;
-    asm volatile("rdgsbase %0" : "=r"(tcb)::"memory");
-    return tcb;
+    void* tcb = nullptr;
+    const int ret = syscall(SYS_arch_prctl, ARCH_GET_GS, &tcb);
+    ASSERT_MSG(ret == 0, "Failed to get GS base: errno {}", errno);
+    return static_cast<Tcb*>(tcb);
 }
 
 #else


### PR DESCRIPTION
From what I found online (https://www.kernel.org/doc/html/next/x86/x86_64/fsgs.html), using these syscalls are the intended way to access these instructions on Linux. However, the syscall also supports setups where this instruction is missing or is unsupported by the kernel, namely, PS4 Linux in my case (and with this, the only modification required for the emulator to run there is recompiling with an older march that's supported by the console). From testing by me and bread, this also doesn't come with any noticeable performance drop either. 