### PR TITLE
vk_graphics_pipeline: Prioritize depth clip when separate clip/clamp control is not supported.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -111,8 +111,8 @@ GraphicsPipeline::GraphicsPipeline(
 
     vk::StructureChain raster_chain = {
         vk::PipelineRasterizationStateCreateInfo{
-            .depthClampEnable = key.depth_clamp_enable ||
-                                (!key.depth_clip_enable && !instance.IsDepthClipEnableSupported()),
+            .depthClampEnable = key.depth_clamp_enable &&
+                                (!key.depth_clip_enable || instance.IsDepthClipEnableSupported()),
             .rasterizerDiscardEnable = false,
             .polygonMode = LiverpoolToVK::PolygonMode(key.polygon_mode),
             .lineWidth = 1.0f,


### PR DESCRIPTION
When separate depth clip control is not supported, the current logic prioritizes depth clamp over clip. However in the common case that both clamping and clipping are being performed with the same depth range, it makes more sense to prioritize clipping as it will effectively no-op the clamp. Adjust the logic to only use depth clamp if enabled and either clip is disabled or separate control is supported.

Fixes rendering issues in CUSA16404 on MoltenVK, which does not support separate clip control.