### PR TITLE
Changing QT version in the Windows build instructions

### DIFF
--- a/documents/building-windows.md
+++ b/documents/building-windows.md
@@ -25,7 +25,7 @@ Once you are within the installer:
 
 Beware, this requires you to create a Qt account. If you do not want to do this, please follow the MSYS2/MinGW compilation method instead.
 
-1. Under the current, non beta version of Qt (at the time of writing 6.9.1), select the option `MSVC 2022 64-bit` or similar, as well as `QT Multimedia`.  
+1. Under the current, non beta version of Qt (at the time of writing 6.9.2), select the option `MSVC 2022 64-bit` or similar, as well as `QT Multimedia`.  
    If you are on Windows on ARM / Qualcomm Snapdragon Elite X, select `MSVC 2022 ARM64` instead.
 
    Go through the installation normally. If you know what you are doing, you may unselect individual components that eat up too much disk space.
@@ -35,7 +35,7 @@ Beware, this requires you to create a Qt account. If you do not want to do this,
 Once you are finished, you will have to configure Qt within Visual Studio:
 
 1. Tools -> Options -> Qt -> Versions
-2. Add a new Qt version and navigate it to the correct folder. Should look like so: `C:\Qt\6.9.1\msvc2022_64`
+2. Add a new Qt version and navigate it to the correct folder. Should look like so: `C:\Qt\6.9.2\msvc2022_64`
 3. Enable the default checkmark on the new version you just created.
 
 ### (Prerequisite) Download [**Git for Windows**](https://git-scm.com/download/win)
@@ -55,7 +55,7 @@ Go through the Git for Windows installation as normal
 3. If you want to build shadPS4 with the Qt Gui:
    1. Click x64-Clang-Release and select "Manage Configurations"
    2. Look for "CMake command arguments" and add to the text field  
-    `-DENABLE_QT_GUI=ON -DCMAKE_PREFIX_PATH=C:\Qt\6.9.1\msvc2022_64`  
+    `-DENABLE_QT_GUI=ON -DCMAKE_PREFIX_PATH=C:\Qt\6.9.2\msvc2022_64`  
     (Change Qt path if you've installed it to non-default path)
    3. Press CTRL+S to save and wait a moment for CMake generation
 4. Change the project to build to shadps4.exe
@@ -64,7 +64,7 @@ Go through the Git for Windows installation as normal
 Your shadps4.exe will be in `C:\path\to\source\Build\x64-Clang-Release\`
 
 To automatically populate the necessary files to run shadPS4.exe, run in a command prompt or terminal:  
-`C:\Qt\6.9.1\msvc2022_64\bin\windeployqt6.exe "C:\path\to\shadps4.exe"`  
+`C:\Qt\6.9.2\msvc2022_64\bin\windeployqt6.exe "C:\path\to\shadps4.exe"`  
 (Change Qt path if you've installed it to non-default path)
 
 ## Option 2: MSYS2/MinGW


### PR DESCRIPTION
Changing QT version from 6.9.1 to 6.9.2 in the Windows building instructions since it was updated the other day.