### PR TITLE
shader_recompiler: Handle `S_LSHL_B32` in ParseCopyShader

### DIFF
--- a/src/shader_recompiler/frontend/copy_shader.cpp
+++ b/src/shader_recompiler/frontend/copy_shader.cpp
@@ -25,6 +25,14 @@ CopyShaderData ParseCopyShader(std::span<const u32> code) {
     while (!code_slice.atEnd()) {
         auto inst = decoder.decodeInstruction(code_slice);
         switch (inst.opcode) {
+        case Gcn::Opcode::S_LSHL_B32: {
+            ASSERT(inst.src[0].field == Gcn::OperandField::SignedConstIntPos &&
+                   inst.src[1].field == Gcn::OperandField::SignedConstIntPos);
+            sources[inst.dst[0].code] =
+                (inst.src[0].code - Gcn::OperandFieldRange::SignedConstIntPosMin + 1)
+                << (inst.src[1].code - Gcn::OperandFieldRange::SignedConstIntPosMin + 1);
+            break;
+        }
         case Gcn::Opcode::S_MOVK_I32: {
             sources[inst.dst[0].code] = inst.control.sopk.simm;
             break;


### PR DESCRIPTION
Fixes cases of `[Debug] <Critical> copy_shader.cpp:60 operator(): Assertion Failed!` appearing in My First Gran Turismo® (CUSA49696).
<img width="1284" height="767" alt="image" src="https://github.com/user-attachments/assets/a0726743-a157-499b-857b-dbd392fc3a72" />

Thanks to @raphaelthegreat for helping with this.