### PR TITLE
shader_recompiler: Initialize all ClipDistance and CullDistance values

### DIFF
--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -540,10 +540,14 @@ void EmitContext::DefineInputs() {
 }
 
 void EmitContext::DefineVertexBlock() {
+    const std::array<Id, 8> zero{f32_zero_value, f32_zero_value, f32_zero_value,
+                                 f32_zero_value, f32_zero_value, f32_zero_value,
+                                 f32_zero_value, f32_zero_value};
     output_position = DefineVariable(F32[4], spv::BuiltIn::Position, spv::StorageClass::Output);
     if (info.stores.GetAny(IR::Attribute::ClipDistance)) {
-        clip_distances = DefineVariable(TypeArray(F32[1], ConstU32(8U)), spv::BuiltIn::ClipDistance,
-                                        spv::StorageClass::Output);
+        const Id type{TypeArray(F32[1], ConstU32(8U))};
+        const Id initializer{ConstantComposite(type, zero)};
+        clip_distances = DefineVariable(type, spv::BuiltIn::ClipDistance, spv::StorageClass::Output, initializer);
     }
     if (info.stores.GetAny(IR::Attribute::CullDistance)) {
         cull_distances = DefineVariable(TypeArray(F32[1], ConstU32(8U)), spv::BuiltIn::CullDistance,

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -550,8 +550,10 @@ void EmitContext::DefineVertexBlock() {
                                         initializer);
     }
     if (info.stores.GetAny(IR::Attribute::CullDistance)) {
-        cull_distances = DefineVariable(TypeArray(F32[1], ConstU32(8U)), spv::BuiltIn::CullDistance,
-                                        spv::StorageClass::Output);
+        const Id type{TypeArray(F32[1], ConstU32(8U))};
+        const Id initializer{ConstantComposite(type, zero)};
+        cull_distances = DefineVariable(type, spv::BuiltIn::CullDistance, spv::StorageClass::Output,
+                                        initializer);
     }
     if (info.stores.GetAny(IR::Attribute::RenderTargetId)) {
         output_layer = DefineVariable(S32[1], spv::BuiltIn::Layer, spv::StorageClass::Output);

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -540,14 +540,14 @@ void EmitContext::DefineInputs() {
 }
 
 void EmitContext::DefineVertexBlock() {
-    const std::array<Id, 8> zero{f32_zero_value, f32_zero_value, f32_zero_value,
-                                 f32_zero_value, f32_zero_value, f32_zero_value,
-                                 f32_zero_value, f32_zero_value};
+    const std::array<Id, 8> zero{f32_zero_value, f32_zero_value, f32_zero_value, f32_zero_value,
+                                 f32_zero_value, f32_zero_value, f32_zero_value, f32_zero_value};
     output_position = DefineVariable(F32[4], spv::BuiltIn::Position, spv::StorageClass::Output);
     if (info.stores.GetAny(IR::Attribute::ClipDistance)) {
         const Id type{TypeArray(F32[1], ConstU32(8U))};
         const Id initializer{ConstantComposite(type, zero)};
-        clip_distances = DefineVariable(type, spv::BuiltIn::ClipDistance, spv::StorageClass::Output, initializer);
+        clip_distances = DefineVariable(type, spv::BuiltIn::ClipDistance, spv::StorageClass::Output,
+                                        initializer);
     }
     if (info.stores.GetAny(IR::Attribute::CullDistance)) {
         cull_distances = DefineVariable(TypeArray(F32[1], ConstU32(8U)), spv::BuiltIn::CullDistance,


### PR DESCRIPTION
This PR fixes some graphical regressions on certain AMD and Intel GPUs after #3447 

| Before | After |
|--------|-------|
| <img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/cc604d1f-ca7d-4f7d-b63d-752b087a3234" /> | <img width="1284" height="767" alt="image" src="https://github.com/user-attachments/assets/39ada999-a197-43fb-aeb9-85b43e6d23b0" /> |


Thanks to @squidbus for helping with debugging this, and @raphaelthegreat for helping with the solution.