### PR TITLE
vk_scheduler: Properly initialize vulkan structures in RenderState. 

### DIFF
--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -33,6 +33,9 @@ struct RenderState {
 
     RenderState() {
         std::memset(this, 0, sizeof(*this));
+        color_attachments.fill({});
+        depth_attachment = {};
+        stencil_attachment = {};
         num_layers = 1;
     }
 

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -33,9 +33,9 @@ struct RenderState {
 
     RenderState() {
         std::memset(this, 0, sizeof(*this));
-        color_attachments.fill({});
-        depth_attachment = {};
-        stencil_attachment = {};
+        color_attachments.fill(vk::RenderingAttachmentInfo{});
+        depth_attachment = vk::RenderingAttachmentInfo{};
+        stencil_attachment = vk::RenderingAttachmentInfo{};
         num_layers = 1;
     }
 


### PR DESCRIPTION
Since `RenderState` is zero-initialized for equality check purposes, make sure to always initialize the attachment infos after to have the proper Vulkan struct `type`.

Fixes validation errors related to these not having the right `type`.