### PR TITLE
shader_recompiler: Handle ExecLo source in S_FF1_I32_B64

### DIFF
--- a/src/shader_recompiler/frontend/translate/scalar_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_alu.cpp
@@ -687,6 +687,8 @@ void Translator::S_FF1_I32_B64(const GcnInst& inst) {
             return ir.GetThreadBitScalarReg(IR::ScalarReg(inst.src[0].code));
         case OperandField::VccLo:
             return ir.GetVcc();
+        case OperandField::ExecLo:
+            return ir.GetExec();
         default:
             UNREACHABLE_MSG("unhandled operand type {}", magic_enum::enum_name(inst.src[0].field));
         }


### PR DESCRIPTION
Fixes an unreachable in My First Gran Turismo® (CUSA49696)
```
[Debug] <Critical> scalar_alu.cpp:691 operator(): Unreachable code!
unhandled operand type ExecLo
```

With this and the other PR I just opened, My First Gran Turismo® (CUSA49696) reaches the title screen (then immediately crashes).
<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/2d611707-ea2e-4be8-a1d2-256b456c8fcf" />

Thanks to @raphaelthegreat for helping.