### PR TITLE
constant_propagation_pass: Handle a few more bitwise instructions.

### DIFF
--- a/src/shader_recompiler/ir/passes/constant_propagation_pass.cpp
+++ b/src/shader_recompiler/ir/passes/constant_propagation_pass.cpp
@@ -456,6 +456,24 @@ void ConstantPropagation(IR::Block& block, IR::Inst& inst) {
     case IR::Opcode::BitwiseXor32:
         FoldWhenAllImmediates(inst, [](u32 a, u32 b) { return a ^ b; });
         return;
+    case IR::Opcode::BitwiseNot32:
+        FoldWhenAllImmediates(inst, [](u32 a) { return ~a; });
+        return;
+    case IR::Opcode::BitReverse32:
+        FoldWhenAllImmediates(inst, [](u32 a) {
+            u32 res{};
+            for (s32 i = 0; i < 32; i++, a >>= 1) {
+                res = (res << 1) | (a & 1);
+            }
+            return res;
+        });
+        return;
+    case IR::Opcode::BitCount32:
+        FoldWhenAllImmediates(inst, [](u32 a) { return static_cast<u32>(std::popcount(a)); });
+        return;
+    case IR::Opcode::BitCount64:
+        FoldWhenAllImmediates(inst, [](u64 a) { return static_cast<u32>(std::popcount(a)); });
+        return;
     case IR::Opcode::BitFieldUExtract:
         FoldWhenAllImmediates(inst, [](u32 base, u32 shift, u32 count) {
             if (static_cast<size_t>(shift) + static_cast<size_t>(count) > 32) {


### PR DESCRIPTION
Fold the following bitwise instructions when operands are immediates:
* `BitwiseNot32`
* `BitReverse32`
* `BitCount32`
* `BitCount64`

Fixes assertion in My First Gran Turismo® (CUSA49696) due to sharp being constructed using bit reverse with a constant. With constant propagation turning it into an immediate beforehand, this is handled properly.