### PR TITLE
vk_platform: Remove workaround to use Vulkan loader on macOS.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_platform.cpp
+++ b/src/video_core/renderer_vulkan/vk_platform.cpp
@@ -226,8 +226,7 @@ vk::UniqueInstance CreateInstance(Frontend::WindowSystemType window_type, bool e
                                   bool enable_crash_diagnostic) {
     LOG_INFO(Render_Vulkan, "Creating vulkan instance");
 
-#ifdef __APPLE__
-#ifndef ENABLE_QT_GUI
+#if defined(__APPLE__) && !defined(ENABLE_QT_GUI)
     // Initialize the environment with the path to the MoltenVK ICD, so that the loader will
     // find it.
     static const auto icd_path = [] {
@@ -238,17 +237,8 @@ vk::UniqueInstance CreateInstance(Frontend::WindowSystemType window_type, bool e
     }();
     setenv("VK_DRIVER_FILES", icd_path.c_str(), true);
 #endif
-    // If the Vulkan loader exists in /usr/local/lib, give it priority. The Vulkan SDK
-    // installs it here by default, but it is not in the default library search path.
-    // The loader has a clause to check for it, but at a lower priority than the bundled
-    // libMoltenVK.dylib, so we need to handle it ourselves to give it priority.
-    static const std::string usr_local_path = "/usr/local/lib/libvulkan.dylib";
-    static vk::detail::DynamicLoader dl = std::filesystem::exists(usr_local_path)
-                                              ? vk::detail::DynamicLoader(usr_local_path)
-                                              : vk::detail::DynamicLoader();
-#else
+
     static vk::detail::DynamicLoader dl;
-#endif
     VULKAN_HPP_DEFAULT_DISPATCHER.init(
         dl.getProcAddress<PFN_vkGetInstanceProcAddr>("vkGetInstanceProcAddr"));
 


### PR DESCRIPTION
Previously the loader in `Vulkan-Headers` would prioritize a loading a bundled `libMoltenVK` over the Vulkan SDK `libvulkan` loader in `/usr/local/lib`, meaning in order to properly use the loader to enable layers we had to work around by checking for and manually supplying the right dylib path.

In newer commits of `Vulkan-Headers` (which we use already), `/usr/local/lib/libvulkan.dylib` is now properly prioritized over `libMoltenVK.dylib`, so we can remove this workaround.