### PR TITLE
renderer_vulkan: Ignore blend parameters when disabled.

### DIFF
--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -210,7 +210,7 @@ vk::BlendFactor BlendFactor(Liverpool::BlendControl::BlendFactor factor) {
     case BlendFactor::OneMinusConstantAlpha:
         return vk::BlendFactor::eOneMinusConstantAlpha;
     default:
-        UNREACHABLE();
+        UNREACHABLE_MSG("Unknown blend factor: {}", static_cast<u32>(factor));
     }
 }
 
@@ -241,7 +241,7 @@ vk::BlendOp BlendOp(Liverpool::BlendControl::BlendFunc func) {
     case BlendFunc::ReverseSubtract:
         return vk::BlendOp::eReverseSubtract;
     default:
-        UNREACHABLE();
+        UNREACHABLE_MSG("Unknown blend op: {}", static_cast<u32>(func));
     }
 }
 


### PR DESCRIPTION
* When blending is disabled, ignore the configuration values instead of attempting to translate them.
* Add warning for unsupported scaled min/max blending.

Should fix cases of invalid blend factor/op assert.