### PR TITLE
shader_recompiler: Handle offsets and format overrides in fetch shaders

### DIFF
--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -553,7 +553,7 @@ void Translator::EmitFetch(const GcnInst& inst) {
         IR::VectorReg dst_reg{attrib.dest_vgpr};
 
         // Read the V# of the attribute to figure out component number and type.
-        const auto buffer = info.ReadUdReg<AmdGpu::Buffer>(attrib.sgpr_base, attrib.dword_offset);
+        const auto buffer = attrib.GetSharp(info);
         const auto values =
             ir.CompositeConstruct(ir.GetAttribute(attr, 0), ir.GetAttribute(attr, 1),
                                   ir.GetAttribute(attr, 2), ir.GetAttribute(attr, 3));

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -385,7 +385,7 @@ void GraphicsPipeline::GetVertexInputs(
     const auto& vs_info = GetStage(Shader::LogicalStage::Vertex);
     for (const auto& attrib : fetch_shader->attributes) {
         const auto step_rate = attrib.GetStepRate();
-        const auto& buffer = attrib.GetSharp(vs_info);
+        const auto buffer = attrib.GetSharp(vs_info);
         attributes.push_back(Attribute{
             .location = attrib.semantic,
             .binding = attrib.semantic,


### PR DESCRIPTION
This PR fixes the broken rendering in Kingdom Come: Deliverance Royal Edition (CUSA15436).
| Before | After |
|--------|-------|
| <img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/cc2d6836-5aa8-4e58-be1f-2d24b2083b71" /> | <img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/86512cc8-d98d-4c67-9fe2-37d8983aaf30" /> |

Credits to @raphaelthegreat for fixing this issue.