### PR TITLE
semaphore: Invert priority order.

### DIFF
--- a/src/core/libraries/kernel/threads/semaphore.cpp
+++ b/src/core/libraries/kernel/threads/semaphore.cpp
@@ -172,9 +172,9 @@ public:
             wait_list.push_back(waiter);
             return --wait_list.end();
         }
-        // Find the first with priority less then us and insert right before it.
+        // Find the first with lower priority (greater number) than us and insert right before it.
         auto it = wait_list.begin();
-        while (it != wait_list.end() && (*it)->priority > waiter->priority) {
+        while (it != wait_list.end() && (*it)->priority <= waiter->priority) {
             ++it;
         }
         return wait_list.insert(it, waiter);

--- a/src/core/libraries/playgo/playgo.cpp
+++ b/src/core/libraries/playgo/playgo.cpp
@@ -39,7 +39,7 @@ s32 PS4_SYSV_ABI scePlayGoClose(OrbisPlayGoHandle handle) {
 
 s32 PS4_SYSV_ABI scePlayGoGetChunkId(OrbisPlayGoHandle handle, OrbisPlayGoChunkId* outChunkIdList,
                                      u32 numberOfEntries, u32* outEntries) {
-    LOG_INFO(Lib_PlayGo, "called");
+    LOG_DEBUG(Lib_PlayGo, "called");
 
     if (handle != PlaygoHandle) {
         return ORBIS_PLAYGO_ERROR_BAD_HANDLE;
@@ -74,7 +74,7 @@ s32 PS4_SYSV_ABI scePlayGoGetChunkId(OrbisPlayGoHandle handle, OrbisPlayGoChunkI
 
 s32 PS4_SYSV_ABI scePlayGoGetEta(OrbisPlayGoHandle handle, const OrbisPlayGoChunkId* chunkIds,
                                  u32 numberOfEntries, OrbisPlayGoEta* outEta) {
-    LOG_INFO(Lib_PlayGo, "called");
+    LOG_DEBUG(Lib_PlayGo, "called");
     if (handle != PlaygoHandle) {
         return ORBIS_PLAYGO_ERROR_BAD_HANDLE;
     }
@@ -170,8 +170,8 @@ s32 PS4_SYSV_ABI scePlayGoGetLocus(OrbisPlayGoHandle handle, const OrbisPlayGoCh
 
 s32 PS4_SYSV_ABI scePlayGoGetProgress(OrbisPlayGoHandle handle, const OrbisPlayGoChunkId* chunkIds,
                                       uint32_t numberOfEntries, OrbisPlayGoProgress* outProgress) {
-    LOG_INFO(Lib_PlayGo, "called handle = {}, chunkIds = {}, numberOfEntries = {}", handle,
-             *chunkIds, numberOfEntries);
+    LOG_DEBUG(Lib_PlayGo, "called handle = {}, chunkIds = {}, numberOfEntries = {}", handle,
+              *chunkIds, numberOfEntries);
 
     if (handle != PlaygoHandle) {
         return ORBIS_PLAYGO_ERROR_BAD_HANDLE;


### PR DESCRIPTION
Currently, priority-based `OrbisSem` treats a greater number as a greater priority. However, thread priorities should be ordered smallest-first. Fix the ordering by inverting the condition, such that:
* Smaller priority number wins.
* In ties, the new waiter is added to the end.

Additionally, lowered a few PlayGo logs to Debug as some games spam these functions infinitely to monitor status in the background.

Fixes hang on load in Valkyria Revolution (CUSA06810).