### PR TITLE
sampler: Fix custom border color fallback condition.

### DIFF
--- a/src/video_core/texture_cache/sampler.cpp
+++ b/src/video_core/texture_cache/sampler.cpp
@@ -19,7 +19,8 @@ Sampler::Sampler(const Vulkan::Instance& instance, const AmdGpu::Sampler& sample
         anisotropy_enable ? std::clamp(sampler.MaxAniso(), 1.0f, instance.MaxSamplerAnisotropy())
                           : 1.0f;
     auto border_color = LiverpoolToVK::BorderColor(sampler.border_color_type);
-    if (!instance.IsCustomBorderColorSupported()) {
+    if (border_color == vk::BorderColor::eFloatCustomEXT &&
+        !instance.IsCustomBorderColorSupported()) {
         LOG_WARNING(Render_Vulkan, "Custom border color is not supported, falling back to black");
         border_color = vk::BorderColor::eFloatOpaqueBlack;
     }


### PR DESCRIPTION
Condition was always warning and forcing border color to black when custom border color is not supported, even if the border color was not custom.

One example of something this fixes is black borders around the moving graphics in the initial screens of LittleBigPlanet 3, when the Vulkan driver does not support custom border colors.