### PR TITLE
Use icons, music and background images of updates if available

### DIFF
--- a/src/qt_gui/game_info.h
+++ b/src/qt_gui/game_info.h
@@ -49,7 +49,7 @@ public:
             game_patch_path += "-patch";
             if (std::filesystem::exists(game_update_path / "sce_sys" / "icon0.png")) {
                 game.icon_path = game_update_path / "sce_sys" / "icon0.png";
-            } else if (std::filesystem::exists(game_patch_path / "sce_sys" / "icon0.png")){
+            } else if (std::filesystem::exists(game_patch_path / "sce_sys" / "icon0.png")) {
                 game.icon_path = game_patch_path / "sce_sys" / "icon0.png";
             } else {
                 game.icon_path = game.path / "sce_sys" / "icon0.png";
@@ -59,19 +59,19 @@ public:
             game.icon = QImage(iconpath);
             if (std::filesystem::exists(game_update_path / "sce_sys" / "pic1.png")) {
                 game.pic_path = game_update_path / "sce_sys" / "pic1.png";
-            } else if (std::filesystem::exists(game_patch_path / "sce_sys" / "pic1.png")){
+            } else if (std::filesystem::exists(game_patch_path / "sce_sys" / "pic1.png")) {
                 game.pic_path = game_patch_path / "sce_sys" / "pic1.png";
-            } else{
+            } else {
                 game.pic_path = game.path / "sce_sys" / "pic1.png";
             }
             if (std::filesystem::exists(game_update_path / "sce_sys" / "snd0.at9")) {
                 game.snd0_path = game_update_path / "sce_sys" / "snd0.at9";
-            } else if (std::filesystem::exists(game_patch_path / "sce_sys" / "snd0.at9")){
+            } else if (std::filesystem::exists(game_patch_path / "sce_sys" / "snd0.at9")) {
                 game.snd0_path = game_patch_path / "sce_sys" / "snd0.at9";
-            } else{
+            } else {
                 game.snd0_path = game.path / "sce_sys" / "snd0.at9";
             }
-            
+
             if (const auto title = psf.GetString("TITLE"); title.has_value()) {
                 game.name = *title;
             }

--- a/src/qt_gui/game_info.h
+++ b/src/qt_gui/game_info.h
@@ -47,8 +47,7 @@ public:
         game_update_path += "-UPDATE";
         std::filesystem::path game_patch_path = filePath;
         game_patch_path += "-patch";
-        SceUpdateChecker("param.sfo", param_sfo_path, game_update_path, game_patch_path,
-                         game.path);
+        SceUpdateChecker("param.sfo", param_sfo_path, game_update_path, game_patch_path, game.path);
 
         PSF psf;
         if (psf.Open(param_sfo_path)) {

--- a/src/qt_gui/game_info.h
+++ b/src/qt_gui/game_info.h
@@ -19,7 +19,7 @@ public:
     QVector<GameInfo> m_games;
     QVector<GameInfo> m_games_backup;
 
-    static void SceUpdateChecker(std::string sceItem, std::filesystem::path& gameItem, 
+    static void SceUpdateChecker(std::string sceItem, std::filesystem::path& gameItem,
                                  std::filesystem::path& update_folder,
                                  std::filesystem::path& patch_folder) {
         if (std::filesystem::exists(update_folder / "sce_sys" / sceItem)) {

--- a/src/qt_gui/game_info.h
+++ b/src/qt_gui/game_info.h
@@ -20,7 +20,7 @@ public:
     QVector<GameInfo> m_games_backup;
 
     static void SceUpdateChecker(std::string sceItem, std::filesystem::path& gameItem, 
-                                 std::filesystem::path& update_folder, 
+                                 std::filesystem::path& update_folder,
                                  std::filesystem::path& patch_folder) {
         if (std::filesystem::exists(update_folder / "sce_sys" / sceItem)) {
             gameItem = update_folder / "sce_sys" / sceItem;

--- a/src/qt_gui/game_info.h
+++ b/src/qt_gui/game_info.h
@@ -41,16 +41,37 @@ public:
                 sce_folder_path = game_update_path / "sce_sys" / "param.sfo";
             }
         }
-
         PSF psf;
         if (psf.Open(sce_folder_path)) {
-            game.icon_path = game.path / "sce_sys" / "icon0.png";
+            std::filesystem::path game_update_path = filePath;
+            game_update_path += "-UPDATE";
+            std::filesystem::path game_patch_path = filePath;
+            game_patch_path += "-patch";
+            if (std::filesystem::exists(game_update_path / "sce_sys" / "icon0.png")) {
+                game.icon_path = game_update_path / "sce_sys" / "icon0.png";
+            } else if (std::filesystem::exists(game_patch_path / "sce_sys" / "icon0.png")){
+                game.icon_path = game_patch_path / "sce_sys" / "icon0.png";
+            } else {
+                game.icon_path = game.path / "sce_sys" / "icon0.png";
+            }
             QString iconpath;
             Common::FS::PathToQString(iconpath, game.icon_path);
             game.icon = QImage(iconpath);
-            game.pic_path = game.path / "sce_sys" / "pic1.png";
-            game.snd0_path = game.path / "sce_sys" / "snd0.at9";
-
+            if (std::filesystem::exists(game_update_path / "sce_sys" / "pic1.png")) {
+                game.pic_path = game_update_path / "sce_sys" / "pic1.png";
+            } else if (std::filesystem::exists(game_patch_path / "sce_sys" / "pic1.png")){
+                game.pic_path = game_patch_path / "sce_sys" / "pic1.png";
+            } else{
+                game.pic_path = game.path / "sce_sys" / "pic1.png";
+            }
+            if (std::filesystem::exists(game_update_path / "sce_sys" / "snd0.at9")) {
+                game.snd0_path = game_update_path / "sce_sys" / "snd0.at9";
+            } else if (std::filesystem::exists(game_patch_path / "sce_sys" / "snd0.at9")){
+                game.snd0_path = game_patch_path / "sce_sys" / "snd0.at9";
+            } else{
+                game.snd0_path = game.path / "sce_sys" / "snd0.at9";
+            }
+            
             if (const auto title = psf.GetString("TITLE"); title.has_value()) {
                 game.name = *title;
             }

--- a/src/qt_gui/game_info.h
+++ b/src/qt_gui/game_info.h
@@ -19,7 +19,9 @@ public:
     QVector<GameInfo> m_games;
     QVector<GameInfo> m_games_backup;
 
-    static void SceUpdateChecker(std::string sceItem, std::filesystem::path& gameItem, std::filesystem::path& update_folder, std::filesystem::path& patch_folder) {
+    static void SceUpdateChecker(std::string sceItem, std::filesystem::path& gameItem, 
+                                 std::filesystem::path& update_folder, 
+                                 std::filesystem::path& patch_folder) {
         if (std::filesystem::exists(update_folder / "sce_sys" / sceItem)) {
             gameItem = update_folder / "sce_sys" / sceItem;
         } else if (std::filesystem::exists(patch_folder / "sce_sys" / sceItem)) {

--- a/src/qt_gui/game_info.h
+++ b/src/qt_gui/game_info.h
@@ -19,6 +19,14 @@ public:
     QVector<GameInfo> m_games;
     QVector<GameInfo> m_games_backup;
 
+    static void SceUpdateChecker(std::string sceItem, std::filesystem::path& gameItem, std::filesystem::path& update_folder, std::filesystem::path& patch_folder) {
+        if (std::filesystem::exists(update_folder / "sce_sys" / sceItem)) {
+            gameItem = update_folder / "sce_sys" / sceItem;
+        } else if (std::filesystem::exists(patch_folder / "sce_sys" / sceItem)) {
+            gameItem = patch_folder / "sce_sys" / sceItem;
+        }
+    }
+
     static bool CompareStrings(GameInfo& a, GameInfo& b) {
         std::string name_a = a.name, name_b = b.name;
         std::transform(name_a.begin(), name_a.end(), name_a.begin(), ::tolower);
@@ -32,45 +40,21 @@ public:
         std::filesystem::path sce_folder_path = filePath / "sce_sys" / "param.sfo";
         std::filesystem::path game_update_path = filePath;
         game_update_path += "-UPDATE";
-        if (std::filesystem::exists(game_update_path / "sce_sys" / "param.sfo")) {
-            sce_folder_path = game_update_path / "sce_sys" / "param.sfo";
-        } else {
-            game_update_path = filePath;
-            game_update_path += "-patch";
-            if (std::filesystem::exists(game_update_path / "sce_sys" / "param.sfo")) {
-                sce_folder_path = game_update_path / "sce_sys" / "param.sfo";
-            }
-        }
+        std::filesystem::path game_patch_path = filePath;
+        game_patch_path += "-patch";
+        SceUpdateChecker("param.sfo", sce_folder_path, game_update_path, game_patch_path);
+
         PSF psf;
         if (psf.Open(sce_folder_path)) {
-            std::filesystem::path game_update_path = filePath;
-            game_update_path += "-UPDATE";
-            std::filesystem::path game_patch_path = filePath;
-            game_patch_path += "-patch";
-            if (std::filesystem::exists(game_update_path / "sce_sys" / "icon0.png")) {
-                game.icon_path = game_update_path / "sce_sys" / "icon0.png";
-            } else if (std::filesystem::exists(game_patch_path / "sce_sys" / "icon0.png")) {
-                game.icon_path = game_patch_path / "sce_sys" / "icon0.png";
-            } else {
-                game.icon_path = game.path / "sce_sys" / "icon0.png";
-            }
+            game.icon_path = game.path / "sce_sys" / "icon0.png";
+            SceUpdateChecker("icon0.png", game.icon_path, game_update_path, game_patch_path);
             QString iconpath;
             Common::FS::PathToQString(iconpath, game.icon_path);
             game.icon = QImage(iconpath);
-            if (std::filesystem::exists(game_update_path / "sce_sys" / "pic1.png")) {
-                game.pic_path = game_update_path / "sce_sys" / "pic1.png";
-            } else if (std::filesystem::exists(game_patch_path / "sce_sys" / "pic1.png")) {
-                game.pic_path = game_patch_path / "sce_sys" / "pic1.png";
-            } else {
-                game.pic_path = game.path / "sce_sys" / "pic1.png";
-            }
-            if (std::filesystem::exists(game_update_path / "sce_sys" / "snd0.at9")) {
-                game.snd0_path = game_update_path / "sce_sys" / "snd0.at9";
-            } else if (std::filesystem::exists(game_patch_path / "sce_sys" / "snd0.at9")) {
-                game.snd0_path = game_patch_path / "sce_sys" / "snd0.at9";
-            } else {
-                game.snd0_path = game.path / "sce_sys" / "snd0.at9";
-            }
+            game.pic_path = game.path / "sce_sys" / "pic1.png";
+            SceUpdateChecker("pic1.png", game.pic_path, game_update_path, game_patch_path);
+            game.snd0_path = game.path / "sce_sys" / "snd0.at9";
+            SceUpdateChecker("snd0.at9", game.snd0_path, game_update_path, game_patch_path);
 
             if (const auto title = psf.GetString("TITLE"); title.has_value()) {
                 game.name = *title;


### PR DESCRIPTION
This addresses issue [#2553](https://github.com/shadps4-emu/shadPS4/issues/2553).
-UPDATE folders take priority, followed by -patch and then base game