### PR TITLE
shader_recompiler: Relax dual source blending assert to allow up to two targets.

### DIFF
--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -658,8 +658,10 @@ void EmitContext::DefineOutputs() {
             frag_outputs[i] = GetAttributeInfo(num_format, id, num_components, true);
             ++num_render_targets;
         }
-        ASSERT_MSG(!runtime_info.fs_info.dual_source_blending || num_render_targets == 2,
-                   "Dual source blending enabled, there must be exactly two MRT exports");
+        // Dual source blending allows at most 2 render targets, one for each source.
+        // Fewer targets are allowed but the missing blending source values will be undefined.
+        ASSERT_MSG(!runtime_info.fs_info.dual_source_blending || num_render_targets <= 2,
+                   "Dual source blending enabled, there must be at most two MRT exports");
         break;
     }
     case LogicalStage::Geometry: {


### PR DESCRIPTION
Dual source blending only supports 1 output render target, and thus only allows exports to 2 different target indices, 1 for each source. It is technically allowed, however, to have 0 or 1 export target(s) while dual source blending is enabled.

In the 0 targets case, both sources are undefined. In this case the game may just be rendering a pass writing depth and not color.

I am not sure if any games will hit the 1 target case, however this is technically allowed. In this case the second source is an undefined value for blending.