### PR TITLE
libkernel: Return EINVAL if mmap is called with length = 0

### DIFF
--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -575,6 +575,12 @@ void* PS4_SYSV_ABI posix_mmap(void* addr, u64 len, s32 prot, s32 flags, s32 fd, 
         "called addr = {}, len = {:#x}, prot = {:#x}, flags = {:#x}, fd = {}, phys_addr = {:#x}",
         fmt::ptr(addr), len, prot, flags, fd, phys_addr);
 
+    if (len == 0) {
+        // If length is 0, mmap returns EINVAL.
+        ErrSceToPosix(ORBIS_KERNEL_ERROR_EINVAL);
+        return reinterpret_cast<void*>(-1);
+    }
+
     void* addr_out;
     auto* memory = Core::Memory::Instance();
     const auto mem_prot = static_cast<Core::MemoryProt>(prot);


### PR DESCRIPTION
Some multimedia apps will try mmap-ing files of size 0. Currently, shadPS4 will go to platform-level memory functions, and likely error there. On real hardware, this returns EINVAL like most other memory functions.

This PR fixes a memory error encountered by some multimedia apps that don't work on main yet.