### PR TITLE
Qt: prevent saving/canceling for remapping/hotkeys dialogs while waiting for inputs

### DIFF
--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -759,6 +759,7 @@ void ControlSettings::DisableMappingButtons() {
 
     ui->buttonBox->button(QDialogButtonBox::Save)->setEnabled(false);
     ui->buttonBox->button(QDialogButtonBox::Apply)->setEnabled(false);
+    ui->buttonBox->button(QDialogButtonBox::RestoreDefaults)->setEnabled(false);
 }
 
 void ControlSettings::EnableMappingButtons() {
@@ -772,6 +773,7 @@ void ControlSettings::EnableMappingButtons() {
 
     ui->buttonBox->button(QDialogButtonBox::Save)->setEnabled(true);
     ui->buttonBox->button(QDialogButtonBox::Apply)->setEnabled(true);
+    ui->buttonBox->button(QDialogButtonBox::RestoreDefaults)->setEnabled(true);
 }
 
 void ControlSettings::ConnectAxisInputs(QPushButton*& button) {

--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -756,6 +756,8 @@ void ControlSettings::DisableMappingButtons() {
     for (const auto& i : AxisList) {
         i->setEnabled(false);
     }
+
+    ui->buttonBox->setEnabled(false);
 }
 
 void ControlSettings::EnableMappingButtons() {
@@ -766,6 +768,8 @@ void ControlSettings::EnableMappingButtons() {
     for (const auto& i : AxisList) {
         i->setEnabled(true);
     }
+
+    ui->buttonBox->setEnabled(true);
 }
 
 void ControlSettings::ConnectAxisInputs(QPushButton*& button) {

--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -757,7 +757,8 @@ void ControlSettings::DisableMappingButtons() {
         i->setEnabled(false);
     }
 
-    ui->buttonBox->setEnabled(false);
+    ui->buttonBox->button(QDialogButtonBox::Save)->setEnabled(false);
+    ui->buttonBox->button(QDialogButtonBox::Apply)->setEnabled(false);
 }
 
 void ControlSettings::EnableMappingButtons() {
@@ -769,7 +770,8 @@ void ControlSettings::EnableMappingButtons() {
         i->setEnabled(true);
     }
 
-    ui->buttonBox->setEnabled(true);
+    ui->buttonBox->button(QDialogButtonBox::Save)->setEnabled(true);
+    ui->buttonBox->button(QDialogButtonBox::Apply)->setEnabled(true);
 }
 
 void ControlSettings::ConnectAxisInputs(QPushButton*& button) {

--- a/src/qt_gui/hotkeys.cpp
+++ b/src/qt_gui/hotkeys.cpp
@@ -71,7 +71,8 @@ void hotkeys::DisableMappingButtons() {
         i->setEnabled(false);
     }
 
-    ui->buttonBox->setEnabled(false);
+    ui->buttonBox->button(QDialogButtonBox::Save)->setEnabled(false);
+    ui->buttonBox->button(QDialogButtonBox::Apply)->setEnabled(false);
 }
 
 void hotkeys::EnableMappingButtons() {
@@ -79,7 +80,8 @@ void hotkeys::EnableMappingButtons() {
         i->setEnabled(true);
     }
 
-    ui->buttonBox->setEnabled(true);
+    ui->buttonBox->button(QDialogButtonBox::Save)->setEnabled(true);
+    ui->buttonBox->button(QDialogButtonBox::Apply)->setEnabled(true);
 }
 
 void hotkeys::SaveHotkeys(bool CloseOnSave) {

--- a/src/qt_gui/hotkeys.cpp
+++ b/src/qt_gui/hotkeys.cpp
@@ -70,12 +70,16 @@ void hotkeys::DisableMappingButtons() {
     for (const auto& i : ButtonsList) {
         i->setEnabled(false);
     }
+
+    ui->buttonBox->setEnabled(false);
 }
 
 void hotkeys::EnableMappingButtons() {
     for (const auto& i : ButtonsList) {
         i->setEnabled(true);
     }
+
+    ui->buttonBox->setEnabled(true);
 }
 
 void hotkeys::SaveHotkeys(bool CloseOnSave) {

--- a/src/qt_gui/kbm_gui.cpp
+++ b/src/qt_gui/kbm_gui.cpp
@@ -165,6 +165,7 @@ void KBMSettings::DisableMappingButtons() {
 
     ui->buttonBox->button(QDialogButtonBox::Save)->setEnabled(false);
     ui->buttonBox->button(QDialogButtonBox::Apply)->setEnabled(false);
+    ui->buttonBox->button(QDialogButtonBox::RestoreDefaults)->setEnabled(false);
 }
 
 void KBMSettings::EnableMappingButtons() {
@@ -174,6 +175,7 @@ void KBMSettings::EnableMappingButtons() {
 
     ui->buttonBox->button(QDialogButtonBox::Save)->setEnabled(true);
     ui->buttonBox->button(QDialogButtonBox::Apply)->setEnabled(true);
+    ui->buttonBox->button(QDialogButtonBox::RestoreDefaults)->setEnabled(true);
 }
 
 void KBMSettings::SaveKBMConfig(bool close_on_save) {

--- a/src/qt_gui/kbm_gui.cpp
+++ b/src/qt_gui/kbm_gui.cpp
@@ -162,12 +162,16 @@ void KBMSettings::DisableMappingButtons() {
     for (const auto& i : ButtonsList) {
         i->setEnabled(false);
     }
+
+    ui->buttonBox->setEnabled(false);
 }
 
 void KBMSettings::EnableMappingButtons() {
     for (const auto& i : ButtonsList) {
         i->setEnabled(true);
     }
+
+    ui->buttonBox->setEnabled(true);
 }
 
 void KBMSettings::SaveKBMConfig(bool close_on_save) {

--- a/src/qt_gui/kbm_gui.cpp
+++ b/src/qt_gui/kbm_gui.cpp
@@ -163,7 +163,8 @@ void KBMSettings::DisableMappingButtons() {
         i->setEnabled(false);
     }
 
-    ui->buttonBox->setEnabled(false);
+    ui->buttonBox->button(QDialogButtonBox::Save)->setEnabled(false);
+    ui->buttonBox->button(QDialogButtonBox::Apply)->setEnabled(false);
 }
 
 void KBMSettings::EnableMappingButtons() {
@@ -171,7 +172,8 @@ void KBMSettings::EnableMappingButtons() {
         i->setEnabled(true);
     }
 
-    ui->buttonBox->setEnabled(true);
+    ui->buttonBox->button(QDialogButtonBox::Save)->setEnabled(true);
+    ui->buttonBox->button(QDialogButtonBox::Apply)->setEnabled(true);
 }
 
 void KBMSettings::SaveKBMConfig(bool close_on_save) {


### PR DESCRIPTION
this prevents the GUI saving the string "press a button - [3]" that could be done when the save or apply buttons are pressed while the dialog is waiting for inputs