### PR TITLE
config: Add present mode option. 

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -79,6 +79,7 @@ static bool shouldPatchShaders = false;
 static u32 vblankDivider = 1;
 static bool isFullscreen = false;
 static std::string fullscreenMode = "Windowed";
+static std::string presentMode = "Mailbox";
 static bool isHDRAllowed = false;
 
 // Vulkan
@@ -192,6 +193,10 @@ bool getIsFullscreen() {
 
 std::string getFullscreenMode() {
     return fullscreenMode;
+}
+
+std::string getPresentMode() {
+    return presentMode;
 }
 
 bool getisTrophyPopupDisabled() {
@@ -466,6 +471,10 @@ void setFullscreenMode(std::string mode) {
     fullscreenMode = mode;
 }
 
+void setPresentMode(std::string mode) {
+    presentMode = mode;
+}
+
 void setisTrophyPopupDisabled(bool disable) {
     isTrophyPopupDisabled = disable;
 }
@@ -726,6 +735,7 @@ void load(const std::filesystem::path& path) {
         vblankDivider = toml::find_or<int>(gpu, "vblankDivider", vblankDivider);
         isFullscreen = toml::find_or<bool>(gpu, "Fullscreen", isFullscreen);
         fullscreenMode = toml::find_or<std::string>(gpu, "FullscreenMode", fullscreenMode);
+        presentMode = toml::find_or<std::string>(gpu, "presentMode", presentMode);
         isHDRAllowed = toml::find_or<bool>(gpu, "allowHDR", isHDRAllowed);
     }
 
@@ -894,6 +904,7 @@ void save(const std::filesystem::path& path) {
     data["GPU"]["vblankDivider"] = vblankDivider;
     data["GPU"]["Fullscreen"] = isFullscreen;
     data["GPU"]["FullscreenMode"] = fullscreenMode;
+    data["GPU"]["presentMode"] = presentMode;
     data["GPU"]["allowHDR"] = isHDRAllowed;
     data["Vulkan"]["gpuId"] = gpuId;
     data["Vulkan"]["validation"] = vkValidation;
@@ -1003,6 +1014,7 @@ void setDefaultValues() {
     vblankDivider = 1;
     isFullscreen = false;
     fullscreenMode = "Windowed";
+    presentMode = "Mailbox";
     isHDRAllowed = false;
 
     // Vulkan

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -27,6 +27,8 @@ bool getIsFullscreen();
 void setIsFullscreen(bool enable);
 std::string getFullscreenMode();
 void setFullscreenMode(std::string mode);
+std::string getPresentMode();
+void setPresentMode(std::string mode);
 u32 getWindowWidth();
 u32 getWindowHeight();
 void setWindowWidth(u32 width);

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -418,6 +418,7 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
         // Graphics
         ui->graphicsAdapterGroupBox->installEventFilter(this);
         ui->windowSizeGroupBox->installEventFilter(this);
+        ui->presentModeGroupBox->installEventFilter(this);
         ui->heightDivider->installEventFilter(this);
         ui->dumpShadersCheckBox->installEventFilter(this);
         ui->nullGpuCheckBox->installEventFilter(this);
@@ -753,6 +754,11 @@ void SettingsDialog::updateNoteTextEdit(const QString& elementName) {
     // Graphics
     if (elementName == "graphicsAdapterGroupBox") {
         text = tr("Graphics Device:\\nOn multiple GPU systems, select the GPU the emulator will use from the drop down list,\\nor select \"Auto Select\" to automatically determine it.");
+    } else if (elementName == "presentModeGroupBox") {
+        text = tr("Present Mode:\\nConfigures how video output will be presented to your screen.\\n\\n"
+                  "Mailbox: Frames synchronize with your screen's refresh rate. New frames will replace any pending frames. Reduces latency but may skip frames if running behind.\\n"
+                  "Fifo: Frames synchronize with your screen's refresh rate. New frames will be queued behind pending frames. Ensures all frames are presented but may increase latency.\\n"
+                  "Immediate: Frames immediately present to your screen when ready. May result in tearing.");
     } else if (elementName == "windowSizeGroupBox") {
         text = tr("Width/Height:\\nSets the size of the emulator window at launch, which can be resized during gameplay.\\nThis is different from the in-game resolution.");
     } else if (elementName == "heightDivider") {

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -67,6 +67,7 @@ const QVector<int> languageIndexes = {21, 23, 14, 6, 18, 1, 12, 22, 2, 4,  25, 2
 QMap<QString, QString> channelMap;
 QMap<QString, QString> logTypeMap;
 QMap<QString, QString> screenModeMap;
+QMap<QString, QString> presentModeMap;
 QMap<QString, QString> chooseHomeTabMap;
 QMap<QString, QString> micMap;
 
@@ -93,6 +94,9 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
     screenModeMap = {{tr("Fullscreen (Borderless)"), "Fullscreen (Borderless)"},
                      {tr("Windowed"), "Windowed"},
                      {tr("Fullscreen"), "Fullscreen"}};
+    presentModeMap = {{tr("Mailbox (Vsync)"), "Mailbox"},
+                      {tr("Fifo (Vsync)"), "Fifo"},
+                      {tr("Immediate (No Vsync)"), "Immediate"}};
     chooseHomeTabMap = {{tr("General"), "General"},   {tr("GUI"), "GUI"},
                         {tr("Graphics"), "Graphics"}, {tr("User"), "User"},
                         {tr("Input"), "Input"},       {tr("Paths"), "Paths"},
@@ -540,6 +544,9 @@ void SettingsDialog::LoadValuesFromConfig() {
     QString translatedText_FullscreenMode =
         screenModeMap.key(QString::fromStdString(Config::getFullscreenMode()));
     ui->displayModeComboBox->setCurrentText(translatedText_FullscreenMode);
+    QString translatedText_PresentMode =
+        presentModeMap.key(QString::fromStdString(Config::getPresentMode()));
+    ui->presentModeComboBox->setCurrentText(translatedText_PresentMode);
     ui->gameSizeCheckBox->setChecked(toml::find_or<bool>(data, "GUI", "loadGameSizeEnabled", true));
     ui->showSplashCheckBox->setChecked(toml::find_or<bool>(data, "General", "showSplash", false));
     QString translatedText_logType = logTypeMap.key(QString::fromStdString(Config::getLogType()));
@@ -834,6 +841,8 @@ void SettingsDialog::UpdateSettings() {
                             "Windowed");
     Config::setFullscreenMode(
         screenModeMap.value(ui->displayModeComboBox->currentText()).toStdString());
+    Config::setPresentMode(
+        presentModeMap.value(ui->presentModeComboBox->currentText()).toStdString());
     Config::setIsMotionControlsEnabled(ui->motionControlsCheckBox->isChecked());
     Config::setBackgroundControllerInput(ui->backgroundControllerCheckBox->isChecked());
     Config::setisTrophyPopupDisabled(ui->disableTrophycheckBox->isChecked());

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -1097,6 +1097,40 @@
                 </widget>
                </item>
                <item>
+                <widget class="QGroupBox" name="presentModeGroupBox">
+                 <property name="title">
+                  <string>Present Mode</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="presentModeLayout">
+                  <item>
+                   <widget class="QComboBox" name="presentModeComboBox">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <item>
+                     <property name="text">
+                      <string>Mailbox (Vsync)</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Fifo (Vsync)</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Immediate (No Vsync)</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
                 <layout class="QHBoxLayout" name="windowSizeLayout">
                  <item>
                   <widget class="QGroupBox" name="windowSizeGroupBox">

--- a/src/video_core/renderer_vulkan/vk_swapchain.h
+++ b/src/video_core/renderer_vulkan/vk_swapchain.h
@@ -96,6 +96,9 @@ private:
     /// Selects the best available swapchain image format
     void FindPresentFormat();
 
+    /// Selects the best available present mode
+    void FindPresentMode();
+
     /// Sets the surface properties according to device capabilities
     void SetSurfaceProperties();
 
@@ -115,6 +118,7 @@ private:
     vk::SurfaceKHR surface{};
     vk::SurfaceFormatKHR surface_format;
     vk::Format view_format;
+    vk::PresentModeKHR present_mode;
     vk::Extent2D extent;
     vk::SurfaceTransformFlagBitsKHR transform;
     vk::CompositeAlphaFlagBitsKHR composite_alpha;


### PR DESCRIPTION
Adds a config option to control the present mode. Available options are Mailbox (default), Fifo, and Immediate. If the selected mode is not supported, we fall back to FIFO as the Vulkan spec guarantees it is supported.

<img width="645" height="284" alt="screenshot" src="https://github.com/user-attachments/assets/e3d148a0-62b9-437c-aee7-4c4e627dd6c3" />

