### PR TITLE
Log presets feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1097,6 +1097,8 @@ set(QT_GUI src/qt_gui/about_dialog.cpp
            src/qt_gui/kbm_help_dialog.h
            src/qt_gui/main_window_themes.cpp
            src/qt_gui/main_window_themes.h
+           src/qt_gui/log_presets_dialog.cpp
+           src/qt_gui/log_presets_dialog.h
            src/qt_gui/settings_dialog.cpp
            src/qt_gui/settings_dialog.h
            src/qt_gui/settings_dialog.ui

--- a/src/qt_gui/log_presets_dialog.cpp
+++ b/src/qt_gui/log_presets_dialog.cpp
@@ -4,6 +4,7 @@
 #include "log_presets_dialog.h"
 
 #include <algorithm>
+#include <QCheckBox>
 #include <QHBoxLayout>
 #include <QHeaderView>
 #include <QItemSelection>
@@ -11,10 +12,9 @@
 #include <QPushButton>
 #include <QSet>
 #include <QSignalBlocker>
-#include <QTableWidget>
 #include <QStyleOptionViewItem>
+#include <QTableWidget>
 #include <QVBoxLayout>
-#include <QCheckBox>
 
 namespace {
 constexpr const char* kPresetsGroup = "logger_presets";
@@ -35,7 +35,6 @@ inline void SplitEntry(const QString& entry, QString& comment, QString& filter) 
     }
 }
 } // namespace
-
 
 LogPresetsDialog::LogPresetsDialog(std::shared_ptr<gui_settings> gui_settings, QWidget* parent)
     : QDialog(parent), m_gui_settings(std::move(gui_settings)) {
@@ -391,21 +390,25 @@ void LogPresetsDialog::PositionHeaderCheckbox() {
         // Use a representative cell rect width (section width) and a typical row height
         const int cell_h = m_table->rowHeight(0) > 0 ? m_table->rowHeight(0) : sz.height();
         opt.rect = QRect(0, 0, w, cell_h);
-        const QRect ind = m_table->style()->subElementRect(QStyle::SE_ItemViewItemCheckIndicator, &opt, m_table);
+        const QRect ind =
+            m_table->style()->subElementRect(QStyle::SE_ItemViewItemCheckIndicator, &opt, m_table);
         left_in_section = ind.left();
         // Guard against styles that return empty rects
         if (ind.isEmpty()) {
-            left_in_section = m_table->style()->pixelMetric(QStyle::PM_FocusFrameHMargin, nullptr, m_table);
+            left_in_section =
+                m_table->style()->pixelMetric(QStyle::PM_FocusFrameHMargin, nullptr, m_table);
         }
     } else {
-        left_in_section = m_table->style()->pixelMetric(QStyle::PM_FocusFrameHMargin, nullptr, m_table);
+        left_in_section =
+            m_table->style()->pixelMetric(QStyle::PM_FocusFrameHMargin, nullptr, m_table);
     }
 
     int cx = x + left_in_section;
     // Center vertically in header
     const int cy = (h - sz.height()) / 2;
     // Ensure checkbox fully visible within the section bounds
-    if (cx + sz.width() > x + w) cx = x + std::max(0, w - sz.width());
+    if (cx + sz.width() > x + w)
+        cx = x + std::max(0, w - sz.width());
     m_header_checkbox->setGeometry(QRect(QPoint(cx, cy), sz));
     m_header_checkbox->show();
 }

--- a/src/qt_gui/log_presets_dialog.cpp
+++ b/src/qt_gui/log_presets_dialog.cpp
@@ -3,13 +3,13 @@
 
 #include "log_presets_dialog.h"
 
+#include <algorithm>
 #include <QDialogButtonBox>
-#include <QHeaderView>
 #include <QHBoxLayout>
+#include <QHeaderView>
 #include <QPushButton>
 #include <QTableWidget>
 #include <QVBoxLayout>
-#include <algorithm>
 
 namespace {
 constexpr const char* kPresetsGroup = "logger_presets";
@@ -101,7 +101,8 @@ void LogPresetsDialog::reject() {
 }
 
 void LogPresetsDialog::LoadFromSettings() {
-    if (!m_gui_settings) return;
+    if (!m_gui_settings)
+        return;
     const auto var = m_gui_settings->GetValue(kPresetsGroup, kPresetsKey, QVariant());
     QList<QString> list;
     if (var.isValid()) {
@@ -111,7 +112,8 @@ void LogPresetsDialog::LoadFromSettings() {
 }
 
 void LogPresetsDialog::SaveToSettings() {
-    if (!m_gui_settings) return;
+    if (!m_gui_settings)
+        return;
     const auto list = SerializeTable();
     m_gui_settings->SetValue(kPresetsGroup, kPresetsKey, m_gui_settings->List2Var(list));
 }
@@ -159,11 +161,11 @@ void LogPresetsDialog::AddAfterSelection() {
 
 void LogPresetsDialog::RemoveSelected() {
     auto selected = m_table->selectionModel()->selectedRows();
-    if (selected.isEmpty()) return;
+    if (selected.isEmpty())
+        return;
     // Remove from bottom to top to keep indices valid
-    std::sort(selected.begin(), selected.end(), [](const QModelIndex& a, const QModelIndex& b) {
-        return a.row() > b.row();
-    });
+    std::sort(selected.begin(), selected.end(),
+              [](const QModelIndex& a, const QModelIndex& b) { return a.row() > b.row(); });
     for (const auto& idx : selected) {
         m_table->removeRow(idx.row());
     }
@@ -171,7 +173,8 @@ void LogPresetsDialog::RemoveSelected() {
 
 void LogPresetsDialog::LoadSelected() {
     const auto selected = m_table->selectionModel()->selectedRows();
-    if (selected.isEmpty()) return;
+    if (selected.isEmpty())
+        return;
     const int row = selected.first().row();
     const auto* item = m_table->item(row, 1);
     if (item) {

--- a/src/qt_gui/log_presets_dialog.cpp
+++ b/src/qt_gui/log_presets_dialog.cpp
@@ -4,18 +4,23 @@
 #include "log_presets_dialog.h"
 
 #include <algorithm>
-#include <QDialogButtonBox>
 #include <QHBoxLayout>
 #include <QHeaderView>
 #include <QPushButton>
 #include <QTableWidget>
+#include <QSignalBlocker>
+#include <QItemSelection>
+#include <QItemSelectionModel>
+#include <QSet>
+#include <QPainter>
+#include <QStyle>
+#include <QStyleOptionButton>
 #include <QVBoxLayout>
 
 namespace {
 constexpr const char* kPresetsGroup = "logger_presets";
 constexpr const char* kPresetsKey = "entries";
 
-// Use a single line per preset encoded as: comment + '\t' + filter
 inline QString MakeEntry(const QString& comment, const QString& filter) {
     return comment + "\t" + filter;
 }
@@ -32,6 +37,42 @@ inline void SplitEntry(const QString& entry, QString& comment, QString& filter) 
 }
 } // namespace
 
+class CheckBoxHeader : public QHeaderView {
+public:
+    explicit CheckBoxHeader(Qt::Orientation orientation, QWidget* parent = nullptr)
+        : QHeaderView(orientation, parent) {
+        setSectionsClickable(true);
+    }
+
+    void setCheckState(Qt::CheckState state) {
+        if (m_state == state) return;
+        m_state = state;
+        updateSection(0);
+    }
+    Qt::CheckState checkState() const { return m_state; }
+
+protected:
+    void paintSection(QPainter* painter, const QRect& rect, int logicalIndex) const override {
+        QHeaderView::paintSection(painter, rect, logicalIndex);
+        if (logicalIndex != 0)
+            return;
+
+        QStyleOptionButton opt;
+        opt.state = QStyle::State_Enabled;
+        switch (m_state) {
+            case Qt::Checked: opt.state |= QStyle::State_On; break;
+            case Qt::PartiallyChecked: opt.state |= QStyle::State_NoChange; break;
+            case Qt::Unchecked: default: opt.state |= QStyle::State_Off; break;
+        }
+        const QRect indicator = style()->subElementRect(QStyle::SE_CheckBoxIndicator, &opt, this);
+        opt.rect = QStyle::alignedRect(layoutDirection(), Qt::AlignCenter, indicator.size(), rect);
+        style()->drawControl(QStyle::CE_CheckBox, &opt, painter, this);
+    }
+
+private:
+    Qt::CheckState m_state = Qt::Unchecked;
+};
+
 LogPresetsDialog::LogPresetsDialog(std::shared_ptr<gui_settings> gui_settings, QWidget* parent)
     : QDialog(parent), m_gui_settings(std::move(gui_settings)) {
     setWindowTitle(tr("Log Filter Presets"));
@@ -40,27 +81,80 @@ LogPresetsDialog::LogPresetsDialog(std::shared_ptr<gui_settings> gui_settings, Q
     auto* root = new QVBoxLayout(this);
 
     m_table = new QTableWidget(this);
-    m_table->setColumnCount(2);
+    m_table->setColumnCount(3);
+    auto* cbh = new CheckBoxHeader(Qt::Horizontal, m_table);
+    m_table->setHorizontalHeader(cbh);
     QStringList headers;
-    headers << tr("Comment") << tr("Filter");
+    headers << QString() << tr("Comment") << tr("Filter");
     m_table->setHorizontalHeaderLabels(headers);
     m_table->horizontalHeader()->setStretchLastSection(true);
-    m_table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeMode::Interactive);
-    m_table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeMode::Stretch);
+    m_table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeMode::ResizeToContents);
+    m_table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeMode::Interactive);
+    m_table->horizontalHeader()->setSectionResizeMode(2, QHeaderView::ResizeMode::Stretch);
     m_table->setSelectionBehavior(QAbstractItemView::SelectionBehavior::SelectRows);
     m_table->setSelectionMode(QAbstractItemView::SelectionMode::ExtendedSelection);
     m_table->setEditTriggers(QAbstractItemView::EditTrigger::DoubleClicked |
                              QAbstractItemView::EditTrigger::SelectedClicked |
                              QAbstractItemView::EditTrigger::EditKeyPressed);
 
-    connect(m_table, &QTableWidget::cellDoubleClicked, this, [this](int row, int /*col*/) {
-        if (row >= 0) {
-            const auto* item = m_table->item(row, 1);
-            if (item) {
-                emit PresetChosen(item->text());
-                accept();
-            }
+    
+
+    connect(m_table, &QTableWidget::cellDoubleClicked, this, [this](int /*row*/, int /*col*/) {
+        LoadSelected();
+    });
+
+    connect(m_table, &QTableWidget::itemChanged, this, [this](QTableWidgetItem* item) {
+        if (m_updating_checks)
+            return;
+        if (item && item->column() == 0) {
+            m_updating_checks = true;
+            const int row = item->row();
+            auto* sm = m_table->selectionModel();
+            const auto idx = m_table->model()->index(row, 0);
+            const bool check = (item->checkState() == Qt::Checked);
+            sm->select(idx, (check ? QItemSelectionModel::Select : QItemSelectionModel::Deselect) | QItemSelectionModel::Rows);
+            m_updating_checks = false;
+            UpdateHeaderCheckState();
+            UpdateLoadButtonEnabled();
         }
+    });
+
+    connect(m_table->selectionModel(), &QItemSelectionModel::selectionChanged, this,
+            [this](const QItemSelection& selected, const QItemSelection& deselected) {
+                if (m_updating_checks) return;
+                m_updating_checks = true;
+                QSet<int> selRows;
+                for (const auto& idx : selected.indexes()) selRows.insert(idx.row());
+                QSet<int> deselRows;
+                for (const auto& idx : deselected.indexes()) deselRows.insert(idx.row());
+                for (int r : selRows) {
+                    auto* it = m_table->item(r, 0);
+                    if (!it) {
+                        it = new QTableWidgetItem();
+                        it->setFlags((QTableWidgetItem().flags() | Qt::ItemIsUserCheckable) & ~Qt::ItemIsEditable);
+                        m_table->setItem(r, 0, it);
+                    }
+                    it->setCheckState(Qt::Checked);
+                }
+                for (int r : deselRows) {
+                    auto* it = m_table->item(r, 0);
+                    if (it) it->setCheckState(Qt::Unchecked);
+                }
+                m_updating_checks = false;
+                UpdateHeaderCheckState();
+                UpdateLoadButtonEnabled();
+            });
+
+    connect(m_table->horizontalHeader(), &QHeaderView::sectionClicked, this, [this](int section) {
+        auto* cbh2 = static_cast<CheckBoxHeader*>(m_table->horizontalHeader());
+        if (section != 0)
+            return;
+        const auto state = cbh2->checkState();
+        const auto next = (state == Qt::Checked) ? Qt::Unchecked : Qt::Checked;
+        cbh2->setCheckState(next);
+        SetAllCheckStates(next);
+        UpdateHeaderCheckState();
+        UpdateLoadButtonEnabled();
     });
 
     root->addWidget(m_table);
@@ -82,12 +176,27 @@ LogPresetsDialog::LogPresetsDialog(std::shared_ptr<gui_settings> gui_settings, Q
     buttons_layout->addWidget(m_close_btn);
     root->addLayout(buttons_layout);
 
+    m_add_btn->setAutoDefault(false);
+    m_remove_btn->setAutoDefault(false);
+    m_load_btn->setAutoDefault(false);
+    m_close_btn->setAutoDefault(false);
+    m_add_btn->setDefault(false);
+    m_remove_btn->setDefault(false);
+    m_load_btn->setDefault(false);
+    m_close_btn->setDefault(false);
+
     connect(m_add_btn, &QPushButton::clicked, this, [this]() { AddAfterSelection(); });
     connect(m_remove_btn, &QPushButton::clicked, this, [this]() { RemoveSelected(); });
     connect(m_load_btn, &QPushButton::clicked, this, [this]() { LoadSelected(); });
     connect(m_close_btn, &QPushButton::clicked, this, [this]() { reject(); });
 
     LoadFromSettings();
+    m_updating_checks = true;
+    m_table->clearSelection();
+    m_table->setCurrentItem(nullptr);
+    m_updating_checks = false;
+    m_table->setFocus(Qt::OtherFocusReason);
+    UpdateLoadButtonEnabled();
 }
 
 void LogPresetsDialog::accept() {
@@ -122,8 +231,8 @@ QList<QString> LogPresetsDialog::SerializeTable() const {
     QList<QString> list;
     const int rows = m_table->rowCount();
     for (int r = 0; r < rows; ++r) {
-        const auto* comment = m_table->item(r, 0);
-        const auto* filter = m_table->item(r, 1);
+        const auto* comment = m_table->item(r, 1);
+        const auto* filter = m_table->item(r, 2);
         const QString c = comment ? comment->text() : QString();
         const QString f = filter ? filter->text() : QString();
         if (!c.isEmpty() || !f.isEmpty()) {
@@ -140,9 +249,20 @@ void LogPresetsDialog::PopulateFromList(const QList<QString>& list) {
         SplitEntry(entry, c, f);
         const int row = m_table->rowCount();
         m_table->insertRow(row);
-        m_table->setItem(row, 0, new QTableWidgetItem(c));
-        m_table->setItem(row, 1, new QTableWidgetItem(f));
+        auto* chk = new QTableWidgetItem();
+        chk->setFlags((chk->flags() | Qt::ItemIsUserCheckable) & ~Qt::ItemIsEditable);
+        chk->setCheckState(Qt::Unchecked);
+        m_table->setItem(row, 0, chk);
+
+        m_table->setItem(row, 1, new QTableWidgetItem(c));
+        m_table->setItem(row, 2, new QTableWidgetItem(f));
     }
+    m_updating_checks = true;
+    m_table->clearSelection();
+    m_table->setCurrentItem(nullptr);
+    m_updating_checks = false;
+    UpdateHeaderCheckState();
+    UpdateLoadButtonEnabled();
 }
 
 void LogPresetsDialog::AddAfterSelection() {
@@ -153,32 +273,106 @@ void LogPresetsDialog::AddAfterSelection() {
         insert_row = selected.last().row() + 1;
     }
     m_table->insertRow(insert_row);
-    m_table->setItem(insert_row, 0, new QTableWidgetItem(""));
+    auto* chk = new QTableWidgetItem();
+    chk->setFlags((chk->flags() | Qt::ItemIsUserCheckable) & ~Qt::ItemIsEditable);
+    chk->setCheckState(Qt::Unchecked);
+    m_table->setItem(insert_row, 0, chk);
     m_table->setItem(insert_row, 1, new QTableWidgetItem(""));
-    m_table->setCurrentCell(insert_row, 0);
-    m_table->editItem(m_table->item(insert_row, 0));
+    m_table->setItem(insert_row, 2, new QTableWidgetItem(""));
+    UpdateHeaderCheckState();
+    m_table->setCurrentCell(insert_row, 1);
+    m_table->editItem(m_table->item(insert_row, 1));
+    UpdateLoadButtonEnabled();
 }
 
 void LogPresetsDialog::RemoveSelected() {
-    auto selected = m_table->selectionModel()->selectedRows();
-    if (selected.isEmpty())
-        return;
-    // Remove from bottom to top to keep indices valid
-    std::sort(selected.begin(), selected.end(),
-              [](const QModelIndex& a, const QModelIndex& b) { return a.row() > b.row(); });
-    for (const auto& idx : selected) {
-        m_table->removeRow(idx.row());
+    // Prefer checked rows; fall back to selected rows if none checked
+    QList<int> to_remove = GetCheckedRows();
+    if (to_remove.isEmpty()) {
+        const auto selected = m_table->selectionModel()->selectedRows();
+        for (const auto& idx : selected) to_remove.push_back(idx.row());
     }
+    if (to_remove.isEmpty()) return;
+    std::sort(to_remove.begin(), to_remove.end(), [](int a, int b) { return a > b; });
+    for (int row : to_remove) m_table->removeRow(row);
+    UpdateHeaderCheckState();
+    UpdateLoadButtonEnabled();
 }
 
 void LogPresetsDialog::LoadSelected() {
-    const auto selected = m_table->selectionModel()->selectedRows();
-    if (selected.isEmpty())
-        return;
-    const int row = selected.first().row();
-    const auto* item = m_table->item(row, 1);
+    QList<int> rows = GetCheckedRows();
+    if (rows.isEmpty()) {
+        const auto selected = m_table->selectionModel()->selectedRows();
+        if (selected.isEmpty()) return;
+        rows.push_back(selected.first().row());
+    }
+    const int row = rows.first();
+    const auto* item = m_table->item(row, 2);
     if (item) {
         emit PresetChosen(item->text());
         accept();
+    }
+}
+
+
+void LogPresetsDialog::UpdateHeaderCheckState() {
+    auto* cbh = static_cast<CheckBoxHeader*>(m_table->horizontalHeader());
+    const int rows = m_table->rowCount();
+    if (rows == 0) {
+        cbh->setCheckState(Qt::Unchecked);
+        return;
+    }
+    int checked = 0;
+    for (int r = 0; r < rows; ++r) {
+        auto* it = m_table->item(r, 0);
+        if (it && it->checkState() == Qt::Checked) ++checked;
+    }
+    const auto state = (checked == 0) ? Qt::Unchecked : (checked == rows) ? Qt::Checked : Qt::PartiallyChecked;
+    cbh->setCheckState(state);
+}
+
+void LogPresetsDialog::SetAllCheckStates(Qt::CheckState state) {
+    const QSignalBlocker blocker(m_table);
+    m_updating_checks = true;
+    const int rows = m_table->rowCount();
+    auto* sm = m_table->selectionModel();
+    for (int r = 0; r < rows; ++r) {
+        auto* it = m_table->item(r, 0);
+        if (!it) {
+            it = new QTableWidgetItem();
+            it->setFlags((QTableWidgetItem().flags() | Qt::ItemIsUserCheckable) & ~Qt::ItemIsEditable);
+            m_table->setItem(r, 0, it);
+        }
+        it->setCheckState(state);
+        const auto idx = m_table->model()->index(r, 0);
+        sm->select(idx, ((state == Qt::Checked) ? QItemSelectionModel::Select : QItemSelectionModel::Deselect) | QItemSelectionModel::Rows);
+    }
+    m_updating_checks = false;
+}
+
+QList<int> LogPresetsDialog::GetCheckedRows() const {
+    QList<int> rows;
+    const int count = m_table->rowCount();
+    for (int r = 0; r < count; ++r) {
+        const auto* it = m_table->item(r, 0);
+        if (it && it->checkState() == Qt::Checked) rows.push_back(r);
+    }
+    return rows;
+}
+
+void LogPresetsDialog::UpdateLoadButtonEnabled() {
+    if (!m_table || !m_table->selectionModel()) return;
+    const int count = m_table->selectionModel()->selectedRows().size();
+
+    if (m_load_btn) {
+        const bool showLoad = (count == 1);
+        m_load_btn->setVisible(showLoad);
+        m_load_btn->setEnabled(showLoad);
+    }
+
+    if (m_remove_btn) {
+        const bool showRemove = (count >= 1);
+        m_remove_btn->setVisible(showRemove);
+        m_remove_btn->setEnabled(showRemove);
     }
 }

--- a/src/qt_gui/log_presets_dialog.cpp
+++ b/src/qt_gui/log_presets_dialog.cpp
@@ -6,15 +6,15 @@
 #include <algorithm>
 #include <QHBoxLayout>
 #include <QHeaderView>
-#include <QPushButton>
-#include <QTableWidget>
-#include <QSignalBlocker>
 #include <QItemSelection>
 #include <QItemSelectionModel>
-#include <QSet>
 #include <QPainter>
+#include <QPushButton>
+#include <QSet>
+#include <QSignalBlocker>
 #include <QStyle>
 #include <QStyleOptionButton>
+#include <QTableWidget>
 #include <QVBoxLayout>
 
 namespace {
@@ -45,11 +45,14 @@ public:
     }
 
     void setCheckState(Qt::CheckState state) {
-        if (m_state == state) return;
+        if (m_state == state)
+            return;
         m_state = state;
         updateSection(0);
     }
-    Qt::CheckState checkState() const { return m_state; }
+    Qt::CheckState checkState() const {
+        return m_state;
+    }
 
 protected:
     void paintSection(QPainter* painter, const QRect& rect, int logicalIndex) const override {
@@ -60,9 +63,16 @@ protected:
         QStyleOptionButton opt;
         opt.state = QStyle::State_Enabled;
         switch (m_state) {
-            case Qt::Checked: opt.state |= QStyle::State_On; break;
-            case Qt::PartiallyChecked: opt.state |= QStyle::State_NoChange; break;
-            case Qt::Unchecked: default: opt.state |= QStyle::State_Off; break;
+        case Qt::Checked:
+            opt.state |= QStyle::State_On;
+            break;
+        case Qt::PartiallyChecked:
+            opt.state |= QStyle::State_NoChange;
+            break;
+        case Qt::Unchecked:
+        default:
+            opt.state |= QStyle::State_Off;
+            break;
         }
         const QRect indicator = style()->subElementRect(QStyle::SE_CheckBoxIndicator, &opt, this);
         opt.rect = QStyle::alignedRect(layoutDirection(), Qt::AlignCenter, indicator.size(), rect);
@@ -97,11 +107,8 @@ LogPresetsDialog::LogPresetsDialog(std::shared_ptr<gui_settings> gui_settings, Q
                              QAbstractItemView::EditTrigger::SelectedClicked |
                              QAbstractItemView::EditTrigger::EditKeyPressed);
 
-    
-
-    connect(m_table, &QTableWidget::cellDoubleClicked, this, [this](int /*row*/, int /*col*/) {
-        LoadSelected();
-    });
+    connect(m_table, &QTableWidget::cellDoubleClicked, this,
+            [this](int /*row*/, int /*col*/) { LoadSelected(); });
 
     connect(m_table, &QTableWidget::itemChanged, this, [this](QTableWidgetItem* item) {
         if (m_updating_checks)
@@ -112,7 +119,8 @@ LogPresetsDialog::LogPresetsDialog(std::shared_ptr<gui_settings> gui_settings, Q
             auto* sm = m_table->selectionModel();
             const auto idx = m_table->model()->index(row, 0);
             const bool check = (item->checkState() == Qt::Checked);
-            sm->select(idx, (check ? QItemSelectionModel::Select : QItemSelectionModel::Deselect) | QItemSelectionModel::Rows);
+            sm->select(idx, (check ? QItemSelectionModel::Select : QItemSelectionModel::Deselect) |
+                                QItemSelectionModel::Rows);
             m_updating_checks = false;
             UpdateHeaderCheckState();
             UpdateLoadButtonEnabled();
@@ -121,24 +129,29 @@ LogPresetsDialog::LogPresetsDialog(std::shared_ptr<gui_settings> gui_settings, Q
 
     connect(m_table->selectionModel(), &QItemSelectionModel::selectionChanged, this,
             [this](const QItemSelection& selected, const QItemSelection& deselected) {
-                if (m_updating_checks) return;
+                if (m_updating_checks)
+                    return;
                 m_updating_checks = true;
                 QSet<int> selRows;
-                for (const auto& idx : selected.indexes()) selRows.insert(idx.row());
+                for (const auto& idx : selected.indexes())
+                    selRows.insert(idx.row());
                 QSet<int> deselRows;
-                for (const auto& idx : deselected.indexes()) deselRows.insert(idx.row());
+                for (const auto& idx : deselected.indexes())
+                    deselRows.insert(idx.row());
                 for (int r : selRows) {
                     auto* it = m_table->item(r, 0);
                     if (!it) {
                         it = new QTableWidgetItem();
-                        it->setFlags((QTableWidgetItem().flags() | Qt::ItemIsUserCheckable) & ~Qt::ItemIsEditable);
+                        it->setFlags((QTableWidgetItem().flags() | Qt::ItemIsUserCheckable) &
+                                     ~Qt::ItemIsEditable);
                         m_table->setItem(r, 0, it);
                     }
                     it->setCheckState(Qt::Checked);
                 }
                 for (int r : deselRows) {
                     auto* it = m_table->item(r, 0);
-                    if (it) it->setCheckState(Qt::Unchecked);
+                    if (it)
+                        it->setCheckState(Qt::Unchecked);
                 }
                 m_updating_checks = false;
                 UpdateHeaderCheckState();
@@ -290,11 +303,14 @@ void LogPresetsDialog::RemoveSelected() {
     QList<int> to_remove = GetCheckedRows();
     if (to_remove.isEmpty()) {
         const auto selected = m_table->selectionModel()->selectedRows();
-        for (const auto& idx : selected) to_remove.push_back(idx.row());
+        for (const auto& idx : selected)
+            to_remove.push_back(idx.row());
     }
-    if (to_remove.isEmpty()) return;
+    if (to_remove.isEmpty())
+        return;
     std::sort(to_remove.begin(), to_remove.end(), [](int a, int b) { return a > b; });
-    for (int row : to_remove) m_table->removeRow(row);
+    for (int row : to_remove)
+        m_table->removeRow(row);
     UpdateHeaderCheckState();
     UpdateLoadButtonEnabled();
 }
@@ -303,7 +319,8 @@ void LogPresetsDialog::LoadSelected() {
     QList<int> rows = GetCheckedRows();
     if (rows.isEmpty()) {
         const auto selected = m_table->selectionModel()->selectedRows();
-        if (selected.isEmpty()) return;
+        if (selected.isEmpty())
+            return;
         rows.push_back(selected.first().row());
     }
     const int row = rows.first();
@@ -313,7 +330,6 @@ void LogPresetsDialog::LoadSelected() {
         accept();
     }
 }
-
 
 void LogPresetsDialog::UpdateHeaderCheckState() {
     auto* cbh = static_cast<CheckBoxHeader*>(m_table->horizontalHeader());
@@ -325,9 +341,12 @@ void LogPresetsDialog::UpdateHeaderCheckState() {
     int checked = 0;
     for (int r = 0; r < rows; ++r) {
         auto* it = m_table->item(r, 0);
-        if (it && it->checkState() == Qt::Checked) ++checked;
+        if (it && it->checkState() == Qt::Checked)
+            ++checked;
     }
-    const auto state = (checked == 0) ? Qt::Unchecked : (checked == rows) ? Qt::Checked : Qt::PartiallyChecked;
+    const auto state = (checked == 0)      ? Qt::Unchecked
+                       : (checked == rows) ? Qt::Checked
+                                           : Qt::PartiallyChecked;
     cbh->setCheckState(state);
 }
 
@@ -340,12 +359,15 @@ void LogPresetsDialog::SetAllCheckStates(Qt::CheckState state) {
         auto* it = m_table->item(r, 0);
         if (!it) {
             it = new QTableWidgetItem();
-            it->setFlags((QTableWidgetItem().flags() | Qt::ItemIsUserCheckable) & ~Qt::ItemIsEditable);
+            it->setFlags((QTableWidgetItem().flags() | Qt::ItemIsUserCheckable) &
+                         ~Qt::ItemIsEditable);
             m_table->setItem(r, 0, it);
         }
         it->setCheckState(state);
         const auto idx = m_table->model()->index(r, 0);
-        sm->select(idx, ((state == Qt::Checked) ? QItemSelectionModel::Select : QItemSelectionModel::Deselect) | QItemSelectionModel::Rows);
+        sm->select(idx, ((state == Qt::Checked) ? QItemSelectionModel::Select
+                                                : QItemSelectionModel::Deselect) |
+                            QItemSelectionModel::Rows);
     }
     m_updating_checks = false;
 }
@@ -355,13 +377,15 @@ QList<int> LogPresetsDialog::GetCheckedRows() const {
     const int count = m_table->rowCount();
     for (int r = 0; r < count; ++r) {
         const auto* it = m_table->item(r, 0);
-        if (it && it->checkState() == Qt::Checked) rows.push_back(r);
+        if (it && it->checkState() == Qt::Checked)
+            rows.push_back(r);
     }
     return rows;
 }
 
 void LogPresetsDialog::UpdateLoadButtonEnabled() {
-    if (!m_table || !m_table->selectionModel()) return;
+    if (!m_table || !m_table->selectionModel())
+        return;
     const int count = m_table->selectionModel()->selectedRows().size();
 
     if (m_load_btn) {

--- a/src/qt_gui/log_presets_dialog.cpp
+++ b/src/qt_gui/log_presets_dialog.cpp
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "log_presets_dialog.h"
+
+#include <QDialogButtonBox>
+#include <QHeaderView>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QTableWidget>
+#include <QVBoxLayout>
+#include <algorithm>
+
+namespace {
+constexpr const char* kPresetsGroup = "logger_presets";
+constexpr const char* kPresetsKey = "entries";
+
+// Use a single line per preset encoded as: comment + '\t' + filter
+inline QString MakeEntry(const QString& comment, const QString& filter) {
+    return comment + "\t" + filter;
+}
+
+inline void SplitEntry(const QString& entry, QString& comment, QString& filter) {
+    const int idx = entry.indexOf('\t');
+    if (idx < 0) {
+        comment = entry;
+        filter = QString();
+    } else {
+        comment = entry.left(idx);
+        filter = entry.mid(idx + 1);
+    }
+}
+} // namespace
+
+LogPresetsDialog::LogPresetsDialog(std::shared_ptr<gui_settings> gui_settings, QWidget* parent)
+    : QDialog(parent), m_gui_settings(std::move(gui_settings)) {
+    setWindowTitle(tr("Log Filter Presets"));
+    resize(640, 360);
+
+    auto* root = new QVBoxLayout(this);
+
+    m_table = new QTableWidget(this);
+    m_table->setColumnCount(2);
+    QStringList headers;
+    headers << tr("Comment") << tr("Filter");
+    m_table->setHorizontalHeaderLabels(headers);
+    m_table->horizontalHeader()->setStretchLastSection(true);
+    m_table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeMode::Interactive);
+    m_table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeMode::Stretch);
+    m_table->setSelectionBehavior(QAbstractItemView::SelectionBehavior::SelectRows);
+    m_table->setSelectionMode(QAbstractItemView::SelectionMode::ExtendedSelection);
+    m_table->setEditTriggers(QAbstractItemView::EditTrigger::DoubleClicked |
+                             QAbstractItemView::EditTrigger::SelectedClicked |
+                             QAbstractItemView::EditTrigger::EditKeyPressed);
+
+    connect(m_table, &QTableWidget::cellDoubleClicked, this, [this](int row, int /*col*/) {
+        if (row >= 0) {
+            const auto* item = m_table->item(row, 1);
+            if (item) {
+                emit PresetChosen(item->text());
+                accept();
+            }
+        }
+    });
+
+    root->addWidget(m_table);
+
+    auto* buttons_layout = new QHBoxLayout();
+    m_add_btn = new QPushButton(tr("+"), this);
+    m_remove_btn = new QPushButton(tr("-"), this);
+    m_load_btn = new QPushButton(tr("Load"), this);
+    m_close_btn = new QPushButton(tr("Close"), this);
+
+    m_add_btn->setToolTip(tr("Add a new preset after the selected row"));
+    m_remove_btn->setToolTip(tr("Remove selected presets"));
+    m_load_btn->setToolTip(tr("Load the selected preset"));
+
+    buttons_layout->addWidget(m_add_btn);
+    buttons_layout->addWidget(m_remove_btn);
+    buttons_layout->addStretch();
+    buttons_layout->addWidget(m_load_btn);
+    buttons_layout->addWidget(m_close_btn);
+    root->addLayout(buttons_layout);
+
+    connect(m_add_btn, &QPushButton::clicked, this, [this]() { AddAfterSelection(); });
+    connect(m_remove_btn, &QPushButton::clicked, this, [this]() { RemoveSelected(); });
+    connect(m_load_btn, &QPushButton::clicked, this, [this]() { LoadSelected(); });
+    connect(m_close_btn, &QPushButton::clicked, this, [this]() { reject(); });
+
+    LoadFromSettings();
+}
+
+void LogPresetsDialog::accept() {
+    SaveToSettings();
+    QDialog::accept();
+}
+
+void LogPresetsDialog::reject() {
+    SaveToSettings();
+    QDialog::reject();
+}
+
+void LogPresetsDialog::LoadFromSettings() {
+    if (!m_gui_settings) return;
+    const auto var = m_gui_settings->GetValue(kPresetsGroup, kPresetsKey, QVariant());
+    QList<QString> list;
+    if (var.isValid()) {
+        list = m_gui_settings->Var2List(var);
+    }
+    PopulateFromList(list);
+}
+
+void LogPresetsDialog::SaveToSettings() {
+    if (!m_gui_settings) return;
+    const auto list = SerializeTable();
+    m_gui_settings->SetValue(kPresetsGroup, kPresetsKey, m_gui_settings->List2Var(list));
+}
+
+QList<QString> LogPresetsDialog::SerializeTable() const {
+    QList<QString> list;
+    const int rows = m_table->rowCount();
+    for (int r = 0; r < rows; ++r) {
+        const auto* comment = m_table->item(r, 0);
+        const auto* filter = m_table->item(r, 1);
+        const QString c = comment ? comment->text() : QString();
+        const QString f = filter ? filter->text() : QString();
+        if (!c.isEmpty() || !f.isEmpty()) {
+            list.push_back(MakeEntry(c, f));
+        }
+    }
+    return list;
+}
+
+void LogPresetsDialog::PopulateFromList(const QList<QString>& list) {
+    m_table->setRowCount(0);
+    for (const auto& entry : list) {
+        QString c, f;
+        SplitEntry(entry, c, f);
+        const int row = m_table->rowCount();
+        m_table->insertRow(row);
+        m_table->setItem(row, 0, new QTableWidgetItem(c));
+        m_table->setItem(row, 1, new QTableWidgetItem(f));
+    }
+}
+
+void LogPresetsDialog::AddAfterSelection() {
+    int insert_row = m_table->rowCount();
+    const auto selected = m_table->selectionModel()->selectedRows();
+    if (!selected.isEmpty()) {
+        // place after the last selected row
+        insert_row = selected.last().row() + 1;
+    }
+    m_table->insertRow(insert_row);
+    m_table->setItem(insert_row, 0, new QTableWidgetItem(""));
+    m_table->setItem(insert_row, 1, new QTableWidgetItem(""));
+    m_table->setCurrentCell(insert_row, 0);
+    m_table->editItem(m_table->item(insert_row, 0));
+}
+
+void LogPresetsDialog::RemoveSelected() {
+    auto selected = m_table->selectionModel()->selectedRows();
+    if (selected.isEmpty()) return;
+    // Remove from bottom to top to keep indices valid
+    std::sort(selected.begin(), selected.end(), [](const QModelIndex& a, const QModelIndex& b) {
+        return a.row() > b.row();
+    });
+    for (const auto& idx : selected) {
+        m_table->removeRow(idx.row());
+    }
+}
+
+void LogPresetsDialog::LoadSelected() {
+    const auto selected = m_table->selectionModel()->selectedRows();
+    if (selected.isEmpty()) return;
+    const int row = selected.first().row();
+    const auto* item = m_table->item(row, 1);
+    if (item) {
+        emit PresetChosen(item->text());
+        accept();
+    }
+}

--- a/src/qt_gui/log_presets_dialog.h
+++ b/src/qt_gui/log_presets_dialog.h
@@ -7,6 +7,7 @@
 #include <QPointer>
 class QTableWidget;
 class QPushButton;
+class QTableWidgetItem;
 
 #include "gui_settings.h"
 
@@ -31,6 +32,10 @@ private:
     void AddAfterSelection();
     void RemoveSelected();
     void LoadSelected();
+    void UpdateHeaderCheckState();
+    void SetAllCheckStates(Qt::CheckState state);
+    QList<int> GetCheckedRows() const;
+    void UpdateLoadButtonEnabled();
 
     QList<QString> SerializeTable() const;
     void PopulateFromList(const QList<QString>& list);
@@ -42,4 +47,5 @@ private:
     QPushButton* m_remove_btn = nullptr;
     QPushButton* m_load_btn = nullptr;
     QPushButton* m_close_btn = nullptr;
+    bool m_updating_checks = false;
 };

--- a/src/qt_gui/log_presets_dialog.h
+++ b/src/qt_gui/log_presets_dialog.h
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <QDialog>
+#include <QPointer>
+class QTableWidget;
+class QPushButton;
+
+#include "gui_settings.h"
+
+class LogPresetsDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit LogPresetsDialog(std::shared_ptr<gui_settings> gui_settings, QWidget* parent = nullptr);
+    ~LogPresetsDialog() override = default;
+
+signals:
+    void PresetChosen(const QString& filter);
+
+protected:
+    void accept() override;
+    void reject() override;
+
+private:
+    void LoadFromSettings();
+    void SaveToSettings();
+    void AddAfterSelection();
+    void RemoveSelected();
+    void LoadSelected();
+
+    QList<QString> SerializeTable() const;
+    void PopulateFromList(const QList<QString>& list);
+
+private:
+    std::shared_ptr<gui_settings> m_gui_settings;
+    QTableWidget* m_table = nullptr;
+    QPushButton* m_add_btn = nullptr;
+    QPushButton* m_remove_btn = nullptr;
+    QPushButton* m_load_btn = nullptr;
+    QPushButton* m_close_btn = nullptr;
+};
+

--- a/src/qt_gui/log_presets_dialog.h
+++ b/src/qt_gui/log_presets_dialog.h
@@ -8,6 +8,7 @@
 class QTableWidget;
 class QPushButton;
 class QTableWidgetItem;
+class QCheckBox;
 
 #include "gui_settings.h"
 
@@ -36,6 +37,7 @@ private:
     void SetAllCheckStates(Qt::CheckState state);
     QList<int> GetCheckedRows() const;
     void UpdateLoadButtonEnabled();
+    void PositionHeaderCheckbox();
 
     QList<QString> SerializeTable() const;
     void PopulateFromList(const QList<QString>& list);
@@ -43,6 +45,7 @@ private:
 private:
     std::shared_ptr<gui_settings> m_gui_settings;
     QTableWidget* m_table = nullptr;
+    QCheckBox* m_header_checkbox = nullptr;
     QPushButton* m_add_btn = nullptr;
     QPushButton* m_remove_btn = nullptr;
     QPushButton* m_load_btn = nullptr;

--- a/src/qt_gui/log_presets_dialog.h
+++ b/src/qt_gui/log_presets_dialog.h
@@ -14,7 +14,8 @@ class LogPresetsDialog : public QDialog {
     Q_OBJECT
 
 public:
-    explicit LogPresetsDialog(std::shared_ptr<gui_settings> gui_settings, QWidget* parent = nullptr);
+    explicit LogPresetsDialog(std::shared_ptr<gui_settings> gui_settings,
+                              QWidget* parent = nullptr);
     ~LogPresetsDialog() override = default;
 
 signals:
@@ -42,4 +43,3 @@ private:
     QPushButton* m_load_btn = nullptr;
     QPushButton* m_close_btn = nullptr;
 };
-

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -26,11 +26,11 @@
 #include "background_music_player.h"
 #include "common/logging/backend.h"
 #include "common/logging/filter.h"
+#include "log_presets_dialog.h"
 #include "settings_dialog.h"
 #include "ui_settings_dialog.h"
 #include "video_core/renderer_vulkan/vk_instance.h"
 #include "video_core/renderer_vulkan/vk_presenter.h"
-#include "log_presets_dialog.h"
 
 extern std::unique_ptr<Vulkan::Presenter> presenter;
 
@@ -391,9 +391,8 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
         // Log presets popup button
         connect(ui->logPresetsButton, &QPushButton::clicked, this, [this]() {
             auto dlg = new LogPresetsDialog(m_gui_settings, this);
-            connect(dlg, &LogPresetsDialog::PresetChosen, this, [this](const QString& filter) {
-                ui->logFilterLineEdit->setText(filter);
-            });
+            connect(dlg, &LogPresetsDialog::PresetChosen, this,
+                    [this](const QString& filter) { ui->logFilterLineEdit->setText(filter); });
             dlg->exec();
         });
     }

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -29,6 +29,7 @@
 #include "settings_dialog.h"
 #include "ui_settings_dialog.h"
 #include "video_core/renderer_vulkan/vk_instance.h"
+#include "log_presets_dialog.h"
 
 QStringList languageNames = {"Arabic",
                              "Czech",
@@ -363,6 +364,15 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
             Common::FS::PathToQString(userPath,
                                       Common::FS::GetUserPath(Common::FS::PathType::LogDir));
             QDesktopServices::openUrl(QUrl::fromLocalFile(userPath));
+        });
+
+        // Log presets popup button
+        connect(ui->logPresetsButton, &QPushButton::clicked, this, [this]() {
+            auto dlg = new LogPresetsDialog(m_gui_settings, this);
+            connect(dlg, &LogPresetsDialog::PresetChosen, this, [this](const QString& filter) {
+                ui->logFilterLineEdit->setText(filter);
+            });
+            dlg->exec();
         });
     }
 

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -2087,6 +2087,13 @@
                       <item>
                        <widget class="QLineEdit" name="logFilterLineEdit"/>
                       </item>
+                      <item>
+                       <widget class="QPushButton" name="logPresetsButton">
+                        <property name="text">
+                         <string>Load Presets...</string>
+                        </property>
+                       </widget>
+                      </item>
                      </layout>
                     </widget>
                    </item>


### PR DESCRIPTION
- Add “Load Presets…” button in Logger → Log Filter (settings_dialog.ui)
- Implement LogPresetsDialog (table: Comment, Filter)
- Support add (+), multi-remove (−), load via button or double-click
- Persist presets via QSettings at logger_presets/entries (qt_ui.ini)
- Wire button to open dialog and set logFilterLineEdit
- Update CMakeLists.txt to include new dialog sources