### PR TITLE
tiling: Pass correct tile split to shader

### DIFF
--- a/src/video_core/amdgpu/tiling.h
+++ b/src/video_core/amdgpu/tiling.h
@@ -120,7 +120,7 @@ PipeConfig GetAltPipeConfig(TileMode tile_mode);
 
 u32 GetSampleSplit(TileMode tile_mode);
 
-u32 GetTileSplit(TileMode tile_mode);
+u32 GetTileSplitHw(TileMode tile_mode);
 
 u32 GetBankWidth(MacroTileMode mode);
 
@@ -143,6 +143,9 @@ bool IsPrt(ArrayMode array_mode);
 u32 GetMicroTileThickness(ArrayMode array_mode);
 
 u32 GetPipeCount(PipeConfig pipe_cfg);
+
+u32 CalculateTileSplit(TileMode tile_mode, ArrayMode array_mode, MicroTileMode micro_tile_mode,
+                       u32 bpp);
 
 MacroTileMode CalculateMacrotileMode(TileMode tile_mode, u32 bpp, u32 num_samples);
 


### PR DESCRIPTION
The tile split value provided was not correct for non depth microtiled images, causing certain Display2DThin images to get detiled improperly. Fix this by extracting the proper tile split computation routine from the macro tile mode calculation function and use it for the input value in the shader. Verified this from addrlib too which [sets](https://github.com/GPUOpen-Drivers/pal/blob/2de164b431f8a27652e63513ae73338dc512e5bf/src/core/imported/addrlib/src/r800/ciaddrlib.cpp#L1857) this from the macro tile mode function and [uses](https://github.com/GPUOpen-Drivers/pal/blob/2de164b431f8a27652e63513ae73338dc512e5bf/src/core/imported/addrlib/src/r800/egbaddrlib.cpp#L1675) it during macro tile address computation