### PR TITLE
Log SIGBUS signals

### DIFF
--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -76,8 +76,10 @@ static void SignalHandler(int sig, siginfo_t* info, void* raw_context) {
     auto* code_address = Common::GetRip(raw_context);
 
     switch (sig) {
-    case SIGSEGV:
-    case SIGBUS: {
+    case SIGBUS:
+        LOG_ERROR(Debug, "SIGBUS in thread '{}' at code address {}", GetThreadName(),
+                  fmt::ptr(code_address));
+    case SIGSEGV: {
         const bool is_write = Common::IsWriteError(raw_context);
         if (!signals->DispatchAccessViolation(raw_context, info->si_addr)) {
             UNREACHABLE_MSG(


### PR DESCRIPTION
Currently, if SIGBUS is hit, it'll just get silently skipped, which is not desirable if for example a game enters into an infinite loop of raising SIGBUS on a single instruction. I wasn't sure if I should make this an unreachable though, but given that so far no one complained about randomly hitting this while using a debugger, it might be the better choice, especially given that all three cases I've this this being hit the games either crashed anyway immediately after or hung. It should be mentioned that out of the three cases, two was messing around with things that changed memory allocations such as isNeo, and the third time was on PS4 Linux