### PR TITLE
Adjust 'image view type' error log

### DIFF
--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -9,6 +9,8 @@
 #include "video_core/texture_cache/image.h"
 #include "video_core/texture_cache/image_view.h"
 
+#include <magic_enum/magic_enum.hpp>
+
 namespace VideoCore {
 
 vk::ImageViewType ConvertImageViewType(AmdGpu::ImageType type) {
@@ -125,8 +127,7 @@ ImageView::ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info
     };
     if (!IsViewTypeCompatible(info.type, image.info.type)) {
         LOG_ERROR(Render_Vulkan, "image view type {} is incompatible with image type {}",
-                  vk::to_string(image_view_ci.viewType),
-                  vk::to_string(ConvertImageViewType(image.info.type)));
+                  magic_enum::enum_name(info.type), magic_enum::enum_name(image.info.type));
     }
 
     auto [view_result, view] = instance.GetDevice().createImageViewUnique(image_view_ci);

--- a/src/video_core/texture_cache/image_view.cpp
+++ b/src/video_core/texture_cache/image_view.cpp
@@ -125,7 +125,8 @@ ImageView::ImageView(const Vulkan::Instance& instance, const ImageViewInfo& info
     };
     if (!IsViewTypeCompatible(info.type, image.info.type)) {
         LOG_ERROR(Render_Vulkan, "image view type {} is incompatible with image type {}",
-                  vk::to_string(image_view_ci.viewType), vk::to_string(image_view_ci.viewType));
+                  vk::to_string(image_view_ci.viewType),
+                  vk::to_string(ConvertImageViewType(image.info.type)));
     }
 
     auto [view_result, view] = instance.GetDevice().createImageViewUnique(image_view_ci);


### PR DESCRIPTION
Adjusted the Vulkan error log to correctly display the image type instead of repeating the view type.

I was previously receiving this log
`[Render.Vulkan] <Error> image_view.cpp:128 ImageView: image view type 1D is incompatible with image type 1D`

With this modification, it now looks like this:
`[Render.Vulkan] <Error> image_view.cpp:130 ImageView: image view type Color1D is incompatible with image type Color2D`