### PR TITLE
vk_rasterizer: Set image flag bits in resolve

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -963,6 +963,9 @@ void Rasterizer::Resolve() {
             vk::ImageLayout::eTransferDstOptimal, region);
     }
 
+    mrt1_image.flags |= VideoCore::ImageFlagBits::GpuModified;
+    mrt1_image.flags &= ~VideoCore::ImageFlagBits::Dirty;
+
     ScopeMarkerEnd();
 }
 


### PR DESCRIPTION
This change fixes the blank image issues in some v2.xx versions of Minecraft.

Thanks to @raphaelthegreat for walking me through this change.