### PR TITLE
Increase the size of the description text box

### DIFF
--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -2364,7 +2364,7 @@
      <property name="maximumSize">
       <size>
        <width>16777215</width>
-       <height>120</height>
+       <height>170</height>
       </size>
      </property>
      <property name="readOnly">


### PR DESCRIPTION
Increases the size from 120 to 170. Reference images below:
<img width="972" height="782" alt="image" src="https://github.com/user-attachments/assets/c170b55c-5a41-4d07-b7eb-86282354feb1" />
<img width="972" height="782" alt="image" src="https://github.com/user-attachments/assets/2f76389d-da12-451b-b6a7-6eeb7dad6496" />
