### PR TITLE
rtc: Fix date parsing detection.

### DIFF
--- a/src/core/libraries/rtc/rtc.cpp
+++ b/src/core/libraries/rtc/rtc.cpp
@@ -748,10 +748,10 @@ int PS4_SYSV_ABI sceRtcParseDateTime(OrbisRtcTick* pTickUtc, const char* pszDate
 
     std::string dateTimeString = std::string(pszDateTime);
 
-    char formatKey = dateTimeString[22];
+    char formatKey = dateTimeString[19];
     OrbisRtcDateTime dateTime;
 
-    if (formatKey == 'Z' || formatKey == '-' || formatKey == '+') {
+    if (formatKey == 'Z' || formatKey == '-' || formatKey == '+' || formatKey == '.') {
         // RFC3339
         sceRtcParseRFC3339(pTickUtc, pszDateTime);
     } else if (formatKey == ':') {


### PR DESCRIPTION
Fix time format detection in `sceRtcParseDateTime` by changing the format key index to 19.

* For RFC3339, index of 22 for the timezone specifier assumed a milliseconds component, which may not be present. We can use 19 instead, where the timezone indicator is when there is no milliseconds component, and add the `.` to the keys list for when there are milliseconds.
* For RFC2822, there will also be a `:` at index 19 so there is no change needed with the new index.