### PR TITLE
minor adjustments to the interface and translation

### DIFF
--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -95,22 +95,19 @@ ControlSettings::ControlSettings(std::shared_ptr<GameInfoClass> game_info_get, b
 
     connect(ui->RSlider, &QSlider::valueChanged, this, [this](int value) {
         QString RedValue = QString("%1").arg(value, 3, 10, QChar('0'));
-        QString RValue = tr("R:") + " " + RedValue;
-        ui->RLabel->setText(RValue);
+        ui->RLabel->setText(RedValue);
         UpdateLightbarColor();
     });
 
     connect(ui->GSlider, &QSlider::valueChanged, this, [this](int value) {
         QString GreenValue = QString("%1").arg(value, 3, 10, QChar('0'));
-        QString GValue = tr("G:") + " " + GreenValue;
-        ui->GLabel->setText(GValue);
+        ui->GLabel->setText(GreenValue);
         UpdateLightbarColor();
     });
 
     connect(ui->BSlider, &QSlider::valueChanged, this, [this](int value) {
         QString BlueValue = QString("%1").arg(value, 3, 10, QChar('0'));
-        QString BValue = tr("B:") + " " + BlueValue;
-        ui->BLabel->setText(BValue);
+        ui->BLabel->setText(BlueValue);
         UpdateLightbarColor();
     });
 
@@ -564,8 +561,7 @@ void ControlSettings::SetUIValuestoMappings() {
                     std::string Rstring = lightbarstring.substr(0, comma_pos2);
                     ui->RSlider->setValue(std::stoi(Rstring));
                     QString RedValue = QString("%1").arg(std::stoi(Rstring), 3, 10, QChar('0'));
-                    QString RValue = tr("R:") + " " + RedValue;
-                    ui->RLabel->setText(RValue);
+                    ui->RLabel->setText(RedValue);
                 }
 
                 std::string GBstring = lightbarstring.substr(comma_pos2 + 1);
@@ -574,14 +570,12 @@ void ControlSettings::SetUIValuestoMappings() {
                     std::string Gstring = GBstring.substr(0, comma_pos3);
                     ui->GSlider->setValue(std::stoi(Gstring));
                     QString GreenValue = QString("%1").arg(std::stoi(Gstring), 3, 10, QChar('0'));
-                    QString GValue = tr("G:") + " " + GreenValue;
-                    ui->GLabel->setText(GValue);
+                    ui->GLabel->setText(GreenValue);
 
                     std::string Bstring = GBstring.substr(comma_pos3 + 1);
                     ui->BSlider->setValue(std::stoi(Bstring));
                     QString BlueValue = QString("%1").arg(std::stoi(Bstring), 3, 10, QChar('0'));
-                    QString BValue = tr("B:") + " " + BlueValue;
-                    ui->BLabel->setText(BValue);
+                    ui->BLabel->setText(BlueValue);
                 }
             }
         }

--- a/src/qt_gui/control_settings.ui
+++ b/src/qt_gui/control_settings.ui
@@ -123,6 +123,9 @@
                   <property name="title">
                    <string>Up</string>
                   </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
                   <layout class="QHBoxLayout" name="horizontalLayout_4">
                    <item>
                     <widget class="QPushButton" name="DpadUpButton">
@@ -143,6 +146,9 @@
                 <widget class="QGroupBox" name="gb_dpad_left">
                  <property name="title">
                   <string>Left</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
                  </property>
                  <layout class="QVBoxLayout" name="gb_dpad_left_layout">
                   <property name="leftMargin">
@@ -171,6 +177,9 @@
                 <widget class="QGroupBox" name="gb_dpad_right">
                  <property name="title">
                   <string>Right</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
                  </property>
                  <layout class="QVBoxLayout" name="gb_dpad_right_layout">
                   <property name="leftMargin">
@@ -229,6 +238,9 @@
                   <property name="title">
                    <string>Down</string>
                   </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
                   <layout class="QHBoxLayout" name="horizontalLayout_3">
                    <item>
                     <widget class="QPushButton" name="DpadDownButton">
@@ -261,7 +273,10 @@
                 </sizepolicy>
                </property>
                <property name="title">
-                <string>L1</string>
+                <string notr="true">L1</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
                </property>
                <layout class="QVBoxLayout" name="gb_l1_layout">
                 <property name="leftMargin">
@@ -289,7 +304,10 @@
              <item>
               <widget class="QGroupBox" name="gb_l2">
                <property name="title">
-                <string>L2</string>
+                <string notr="true">L2</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
                </property>
                <layout class="QVBoxLayout" name="gb_l2_layout">
                 <property name="leftMargin">
@@ -448,6 +466,9 @@
                   <property name="title">
                    <string>Up</string>
                   </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
                   <layout class="QVBoxLayout" name="verticalLayout_10">
                    <item>
                     <widget class="QPushButton" name="LStickUpButton">
@@ -468,6 +489,9 @@
                 <widget class="QGroupBox" name="gb_left_stick_left">
                  <property name="title">
                   <string>Left</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
                  </property>
                  <layout class="QVBoxLayout" name="gb_left_stick_left_layout">
                   <property name="leftMargin">
@@ -502,6 +526,9 @@
                  </property>
                  <property name="title">
                   <string>Right</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
                  </property>
                  <layout class="QVBoxLayout" name="gb_left_stick_right_layout">
                   <property name="leftMargin">
@@ -559,6 +586,9 @@
                   </property>
                   <property name="title">
                    <string>Down</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
                   </property>
                   <layout class="QVBoxLayout" name="verticalLayout_8">
                    <item>
@@ -840,7 +870,10 @@
                  </sizepolicy>
                 </property>
                 <property name="title">
-                 <string>L3</string>
+                 <string notr="true">L3</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
                 </property>
                 <layout class="QVBoxLayout" name="gb_l3_layout">
                  <property name="leftMargin">
@@ -869,6 +902,9 @@
                <widget class="QGroupBox" name="gb_start">
                 <property name="title">
                  <string>Options</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
                 </property>
                 <layout class="QVBoxLayout" name="gb_start_layout">
                  <property name="leftMargin">
@@ -902,7 +938,10 @@
                  </sizepolicy>
                 </property>
                 <property name="title">
-                 <string>R3</string>
+                 <string notr="true">R3</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
                 </property>
                 <layout class="QVBoxLayout" name="gb_r3_layout">
                  <property name="leftMargin">
@@ -936,6 +975,9 @@
                 <property name="title">
                  <string>Touchpad Left</string>
                 </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
+                </property>
                 <layout class="QHBoxLayout" name="horizontalLayout_5">
                  <item>
                   <widget class="QPushButton" name="TouchpadLeftButton">
@@ -952,6 +994,9 @@
                 <property name="title">
                  <string>Touchpad Center</string>
                 </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
+                </property>
                 <layout class="QVBoxLayout" name="verticalLayout_11">
                  <item>
                   <widget class="QPushButton" name="TouchpadCenterButton">
@@ -967,6 +1012,9 @@
                <widget class="QGroupBox" name="gb_touchright">
                 <property name="title">
                  <string>Touchpad Right</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_12">
                  <item>
@@ -1213,6 +1261,9 @@
                   <property name="title">
                    <string>Triangle</string>
                   </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
                   <layout class="QVBoxLayout" name="verticalLayout_3">
                    <item>
                     <widget class="QPushButton" name="TriangleButton">
@@ -1233,6 +1284,9 @@
                 <widget class="QGroupBox" name="gb_square">
                  <property name="title">
                   <string>Square</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
                  </property>
                  <layout class="QVBoxLayout" name="gb_square_layout">
                   <property name="leftMargin">
@@ -1261,6 +1315,9 @@
                 <widget class="QGroupBox" name="gb_circle">
                  <property name="title">
                   <string>Circle</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
                  </property>
                  <layout class="QVBoxLayout" name="gb_circle_layout">
                   <property name="leftMargin">
@@ -1319,6 +1376,9 @@
                   <property name="title">
                    <string>Cross</string>
                   </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
                   <layout class="QVBoxLayout" name="verticalLayout_5">
                    <item>
                     <widget class="QPushButton" name="CrossButton">
@@ -1351,7 +1411,10 @@
                 </sizepolicy>
                </property>
                <property name="title">
-                <string>R1</string>
+                <string notr="true">R1</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
                </property>
                <layout class="QVBoxLayout" name="gb_r1_layout">
                 <property name="leftMargin">
@@ -1379,7 +1442,10 @@
              <item>
               <widget class="QGroupBox" name="gb_r2">
                <property name="title">
-                <string>R2</string>
+                <string notr="true">R2</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
                </property>
                <layout class="QVBoxLayout" name="gb_r2_layout">
                 <property name="leftMargin">
@@ -1541,6 +1607,9 @@
                   <property name="title">
                    <string>Up</string>
                   </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
                   <layout class="QVBoxLayout" name="verticalLayout_7">
                    <item>
                     <widget class="QPushButton" name="RStickUpButton">
@@ -1561,6 +1630,9 @@
                 <widget class="QGroupBox" name="gb_right_stick_left">
                  <property name="title">
                   <string>Left</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
                  </property>
                  <layout class="QVBoxLayout" name="gb_right_stick_left_layout">
                   <property name="leftMargin">
@@ -1589,6 +1661,9 @@
                 <widget class="QGroupBox" name="gb_right_stick_right">
                  <property name="title">
                   <string>Right</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
                  </property>
                  <layout class="QVBoxLayout" name="gb_right_stick_right_layout">
                   <property name="leftMargin">
@@ -1646,6 +1721,9 @@
                   </property>
                   <property name="title">
                    <string>Down</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
                   </property>
                   <layout class="QVBoxLayout" name="verticalLayout_6">
                    <item>

--- a/src/qt_gui/control_settings.ui
+++ b/src/qt_gui/control_settings.ui
@@ -1046,17 +1046,26 @@
                  <string>Color Adjustment</string>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_18">
+                 <property name="leftMargin">
+                  <number>6</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>6</number>
+                 </property>
                  <item>
                   <layout class="QHBoxLayout" name="horizontalLayout_9">
+                   <property name="spacing">
+                    <number>6</number>
+                   </property>
                    <item>
-                    <widget class="QLabel" name="RLabel">
+                    <widget class="QLabel" name="RLabel_text">
                      <property name="font">
                       <font>
                        <bold>false</bold>
                       </font>
                      </property>
                      <property name="text">
-                      <string notr="true">R: 000</string>
+                      <string>RED</string>
                      </property>
                     </widget>
                    </item>
@@ -1076,19 +1085,32 @@
                      </property>
                     </widget>
                    </item>
+                   <item>
+                    <widget class="QLabel" name="RLabel">
+                     <property name="maximumSize">
+                      <size>
+                       <width>20</width>
+                       <height>16777215</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string notr="true">000</string>
+                     </property>
+                    </widget>
+                   </item>
                   </layout>
                  </item>
                  <item>
                   <layout class="QHBoxLayout" name="horizontalLayout_10">
                    <item>
-                    <widget class="QLabel" name="GLabel">
+                    <widget class="QLabel" name="GLabel_text">
                      <property name="font">
                       <font>
                        <bold>false</bold>
                       </font>
                      </property>
                      <property name="text">
-                      <string notr="true">G: 000</string>
+                      <string>GREEN</string>
                      </property>
                     </widget>
                    </item>
@@ -1108,19 +1130,32 @@
                      </property>
                     </widget>
                    </item>
+                   <item>
+                    <widget class="QLabel" name="GLabel">
+                     <property name="maximumSize">
+                      <size>
+                       <width>20</width>
+                       <height>16777215</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string notr="true">000</string>
+                     </property>
+                    </widget>
+                   </item>
                   </layout>
                  </item>
                  <item>
                   <layout class="QHBoxLayout" name="horizontalLayout_11">
                    <item>
-                    <widget class="QLabel" name="BLabel">
+                    <widget class="QLabel" name="BLabel_text">
                      <property name="font">
                       <font>
                        <bold>false</bold>
                       </font>
                      </property>
                      <property name="text">
-                      <string notr="true">B: 255</string>
+                      <string>BLUE</string>
                      </property>
                     </widget>
                    </item>
@@ -1140,6 +1175,19 @@
                      </property>
                      <property name="orientation">
                       <enum>Qt::Orientation::Horizontal</enum>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="BLabel">
+                     <property name="maximumSize">
+                      <size>
+                       <width>20</width>
+                       <height>16777215</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string notr="true">255</string>
                      </property>
                     </widget>
                    </item>

--- a/src/qt_gui/kbm_gui.cpp
+++ b/src/qt_gui/kbm_gui.cpp
@@ -133,20 +133,17 @@ tr("Do you want to overwrite existing mappings with the mappings from the Common
 
     connect(ui->DeadzoneOffsetSlider, &QSlider::valueChanged, this, [this](int value) {
         QString DOSValue = QString::number(value / 100.0, 'f', 2);
-        QString DOSString = tr("Deadzone Offset (def 0.50):") + " " + DOSValue;
-        ui->DeadzoneOffsetLabel->setText(DOSString);
+        ui->DeadzoneOffsetLabel->setText(DOSValue);
     });
 
     connect(ui->SpeedMultiplierSlider, &QSlider::valueChanged, this, [this](int value) {
         QString SMSValue = QString::number(value / 10.0, 'f', 1);
-        QString SMSString = tr("Speed Multiplier (def 1.0):") + " " + SMSValue;
-        ui->SpeedMultiplierLabel->setText(SMSString);
+        ui->SpeedMultiplierLabel->setText(SMSValue);
     });
 
     connect(ui->SpeedOffsetSlider, &QSlider::valueChanged, this, [this](int value) {
         QString SOSValue = QString::number(value / 1000.0, 'f', 3);
-        QString SOSString = tr("Speed Offset (def 0.125):") + " " + SOSValue;
-        ui->SpeedOffsetLabel->setText(SOSString);
+        ui->SpeedOffsetLabel->setText(SOSValue);
     });
 
     connect(this, &KBMSettings::PushKBMEvent, this, [this]() { CheckMapping(MappingButton); });
@@ -491,8 +488,7 @@ void KBMSettings::SetUIValuestoMappings(std::string config_id) {
                     int DOffsetInt = static_cast<int>(DOffsetValue);
                     ui->DeadzoneOffsetSlider->setValue(DOffsetInt);
                     QString LabelValue = QString::number(DOffsetInt / 100.0, 'f', 2);
-                    QString LabelString = tr("Deadzone Offset (def 0.50):") + " " + LabelValue;
-                    ui->DeadzoneOffsetLabel->setText(LabelString);
+                    ui->DeadzoneOffsetLabel->setText(LabelValue);
 
                     std::string SMSOstring = line.substr(comma_pos + 1);
                     std::size_t comma_pos2 = SMSOstring.find(',');
@@ -502,16 +498,14 @@ void KBMSettings::SetUIValuestoMappings(std::string config_id) {
                         int SpeedMultInt = static_cast<int>(SpeedMultValue);
                         ui->SpeedMultiplierSlider->setValue(SpeedMultInt);
                         LabelValue = QString::number(SpeedMultInt / 10.0, 'f', 1);
-                        LabelString = tr("Speed Multiplier (def 1.0):") + " " + LabelValue;
-                        ui->SpeedMultiplierLabel->setText(LabelString);
+                        ui->SpeedMultiplierLabel->setText(LabelValue);
 
                         std::string SOstring = SMSOstring.substr(comma_pos2 + 1);
                         float SOffsetValue = std::stof(SOstring) * 1000.0;
                         int SOffsetInt = static_cast<int>(SOffsetValue);
                         ui->SpeedOffsetSlider->setValue(SOffsetInt);
                         LabelValue = QString::number(SOffsetInt / 1000.0, 'f', 3);
-                        LabelString = tr("Speed Offset (def 0.125):") + " " + LabelValue;
-                        ui->SpeedOffsetLabel->setText(LabelString);
+                        ui->SpeedOffsetLabel->setText(LabelValue);
                     }
                 }
             }

--- a/src/qt_gui/kbm_gui.ui
+++ b/src/qt_gui/kbm_gui.ui
@@ -1375,14 +1375,14 @@
                  <item>
                   <layout class="QHBoxLayout" name="horizontalLayout_9">
                    <item>
-                    <widget class="QLabel" name="DeadzoneOffsetLabel">
+                    <widget class="QLabel" name="DeadzoneOffsetLabel_text">
                      <property name="font">
                       <font>
                        <bold>false</bold>
                       </font>
                      </property>
                      <property name="text">
-                      <string notr="true">Deadzone Offset (def 0.50): 0.50</string>
+                      <string>Deadzone Offset (def 0.50):</string>
                      </property>
                     </widget>
                    </item>
@@ -1408,19 +1408,38 @@
                      </property>
                     </widget>
                    </item>
+                   <item>
+                    <widget class="QLabel" name="DeadzoneOffsetLabel">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="maximumSize">
+                      <size>
+                       <width>30</width>
+                       <height>16777215</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string notr="true">0.50</string>
+                     </property>
+                    </widget>
+                   </item>
                   </layout>
                  </item>
                  <item>
                   <layout class="QHBoxLayout" name="horizontalLayout_10">
                    <item>
-                    <widget class="QLabel" name="SpeedMultiplierLabel">
+                    <widget class="QLabel" name="SpeedMultiplierLabel_text">
                      <property name="font">
                       <font>
                        <bold>false</bold>
                       </font>
                      </property>
                      <property name="text">
-                      <string notr="true">Speed Multiplier (def 1.0): 1.0</string>
+                      <string>Speed Multiplier (def 1.0):</string>
                      </property>
                     </widget>
                    </item>
@@ -1452,19 +1471,38 @@
                      </property>
                     </widget>
                    </item>
+                   <item>
+                    <widget class="QLabel" name="SpeedMultiplierLabel">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="maximumSize">
+                      <size>
+                       <width>30</width>
+                       <height>16777215</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string notr="true">1.0</string>
+                     </property>
+                    </widget>
+                   </item>
                   </layout>
                  </item>
                  <item>
                   <layout class="QHBoxLayout" name="horizontalLayout_11">
                    <item>
-                    <widget class="QLabel" name="SpeedOffsetLabel">
+                    <widget class="QLabel" name="SpeedOffsetLabel_text">
                      <property name="font">
                       <font>
                        <bold>false</bold>
                       </font>
                      </property>
                      <property name="text">
-                      <string notr="true">Speed Offset (def 0.125): 0.125</string>
+                      <string>Speed Offset (def 0.125):</string>
                      </property>
                     </widget>
                    </item>
@@ -1490,6 +1528,19 @@
                      </property>
                      <property name="orientation">
                       <enum>Qt::Orientation::Horizontal</enum>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="SpeedOffsetLabel">
+                     <property name="maximumSize">
+                      <size>
+                       <width>30</width>
+                       <height>16777215</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string notr="true">0.125</string>
                      </property>
                     </widget>
                    </item>

--- a/src/qt_gui/kbm_gui.ui
+++ b/src/qt_gui/kbm_gui.ui
@@ -54,7 +54,7 @@
          <x>0</x>
          <y>0</y>
          <width>1211</width>
-         <height>791</height>
+         <height>800</height>
         </rect>
        </property>
        <layout class="QHBoxLayout" name="RemapLayout">
@@ -134,6 +134,9 @@
                   <property name="title">
                    <string>Up</string>
                   </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
                   <layout class="QHBoxLayout" name="horizontalLayout_4">
                    <item>
                     <widget class="QPushButton" name="DpadUpButton">
@@ -163,6 +166,9 @@
                  </property>
                  <property name="title">
                   <string>Left</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
                  </property>
                  <layout class="QVBoxLayout" name="gb_dpad_left_layout">
                   <property name="leftMargin">
@@ -200,6 +206,9 @@
                  </property>
                  <property name="title">
                   <string>Right</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
                  </property>
                  <layout class="QVBoxLayout" name="gb_dpad_right_layout">
                   <property name="leftMargin">
@@ -260,6 +269,9 @@
                   </property>
                   <property name="title">
                    <string>Down</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
                   </property>
                   <layout class="QHBoxLayout" name="horizontalLayout_3">
                    <item>
@@ -408,6 +420,9 @@
                   <property name="title">
                    <string>Up</string>
                   </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
                   <layout class="QVBoxLayout" name="verticalLayout_10">
                    <item>
                     <widget class="QPushButton" name="LStickUpButton">
@@ -437,6 +452,9 @@
                  </property>
                  <property name="title">
                   <string>Left</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
                  </property>
                  <layout class="QVBoxLayout" name="gb_left_stick_left_layout">
                   <property name="leftMargin">
@@ -480,6 +498,9 @@
                  </property>
                  <property name="title">
                   <string>Right</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
                  </property>
                  <layout class="QVBoxLayout" name="gb_left_stick_right_layout">
                   <property name="leftMargin">
@@ -540,6 +561,9 @@
                   </property>
                   <property name="title">
                    <string>Down</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
                   </property>
                   <layout class="QVBoxLayout" name="verticalLayout_8">
                    <item>
@@ -707,7 +731,10 @@
                  </size>
                 </property>
                 <property name="title">
-                 <string>L1</string>
+                 <string notr="true">L1</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
                 </property>
                 <layout class="QVBoxLayout" name="gb_l1_layout">
                  <property name="leftMargin">
@@ -756,7 +783,10 @@
                  </size>
                 </property>
                 <property name="title">
-                 <string>L2</string>
+                 <string notr="true">L2</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
                 </property>
                 <layout class="QVBoxLayout" name="gb_l2_layout">
                  <property name="leftMargin">
@@ -881,6 +911,9 @@
                 <property name="title">
                  <string>Options</string>
                 </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
+                </property>
                 <layout class="QVBoxLayout" name="gb_start_layout">
                  <property name="leftMargin">
                   <number>5</number>
@@ -932,7 +965,10 @@
                  </size>
                 </property>
                 <property name="title">
-                 <string>R1</string>
+                 <string notr="true">R1</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
                 </property>
                 <layout class="QVBoxLayout" name="gb_r1_layout">
                  <property name="leftMargin">
@@ -981,7 +1017,10 @@
                  </size>
                 </property>
                 <property name="title">
-                 <string>R2</string>
+                 <string notr="true">R2</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
                 </property>
                 <layout class="QVBoxLayout" name="gb_r2_layout">
                  <property name="leftMargin">
@@ -1087,7 +1126,10 @@
                  </size>
                 </property>
                 <property name="title">
-                 <string>L3</string>
+                 <string notr="true">L3</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
                 </property>
                 <layout class="QVBoxLayout" name="gb_l3_layout">
                  <property name="leftMargin">
@@ -1126,6 +1168,9 @@
                 <property name="title">
                  <string>Touchpad Left</string>
                 </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
+                </property>
                 <layout class="QVBoxLayout" name="verticalLayout_17">
                  <item>
                   <widget class="QPushButton" name="TouchpadLeftButton">
@@ -1158,6 +1203,9 @@
                 <property name="title">
                  <string>Mouse to Joystick</string>
                 </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
+                </property>
                 <layout class="QVBoxLayout" name="verticalLayout_22">
                  <item>
                   <widget class="QComboBox" name="MouseJoystickBox">
@@ -1189,6 +1237,9 @@
                 <property name="title">
                  <string>Touchpad Center</string>
                 </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
+                </property>
                 <layout class="QVBoxLayout" name="verticalLayout_11">
                  <item>
                   <widget class="QPushButton" name="TouchpadCenterButton">
@@ -1219,7 +1270,10 @@
                  </size>
                 </property>
                 <property name="title">
-                 <string>R3</string>
+                 <string notr="true">R3</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
                 </property>
                 <layout class="QVBoxLayout" name="gb_r3_layout">
                  <property name="leftMargin">
@@ -1269,6 +1323,9 @@
                 </property>
                 <property name="title">
                  <string>Touchpad Right</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_9">
                  <item>
@@ -1533,6 +1590,9 @@
                   <property name="title">
                    <string>Triangle</string>
                   </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
                   <layout class="QVBoxLayout" name="verticalLayout_3">
                    <item>
                     <widget class="QPushButton" name="TriangleButton">
@@ -1562,6 +1622,9 @@
                  </property>
                  <property name="title">
                   <string>Square</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
                  </property>
                  <layout class="QVBoxLayout" name="gb_square_layout">
                   <property name="leftMargin">
@@ -1599,6 +1662,9 @@
                  </property>
                  <property name="title">
                   <string>Circle</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
                  </property>
                  <layout class="QVBoxLayout" name="gb_circle_layout">
                   <property name="leftMargin">
@@ -1659,6 +1725,9 @@
                   </property>
                   <property name="title">
                    <string>Cross</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
                   </property>
                   <layout class="QVBoxLayout" name="verticalLayout_5">
                    <item>
@@ -1807,6 +1876,9 @@
                   <property name="title">
                    <string>Up</string>
                   </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
                   <layout class="QVBoxLayout" name="verticalLayout_7">
                    <item>
                     <widget class="QPushButton" name="RStickUpButton">
@@ -1842,6 +1914,9 @@
                  </property>
                  <property name="title">
                   <string>Left</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
                  </property>
                  <layout class="QVBoxLayout" name="gb_right_stick_left_layout">
                   <property name="leftMargin">
@@ -1879,6 +1954,9 @@
                  </property>
                  <property name="title">
                   <string>Right</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
                  </property>
                  <layout class="QVBoxLayout" name="gb_right_stick_right_layout">
                   <property name="leftMargin">
@@ -1939,6 +2017,9 @@
                   </property>
                   <property name="title">
                    <string>Down</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
                   </property>
                   <layout class="QVBoxLayout" name="verticalLayout_6">
                    <item>

--- a/src/qt_gui/log_presets_dialog.cpp
+++ b/src/qt_gui/log_presets_dialog.cpp
@@ -142,8 +142,8 @@ LogPresetsDialog::LogPresetsDialog(std::shared_ptr<gui_settings> gui_settings, Q
     root->addWidget(m_table);
 
     auto* buttons_layout = new QHBoxLayout();
-    m_add_btn = new QPushButton(tr("+"), this);
-    m_remove_btn = new QPushButton(tr("-"), this);
+    m_add_btn = new QPushButton("+", this);
+    m_remove_btn = new QPushButton("-", this);
     m_load_btn = new QPushButton(tr("Load"), this);
     m_close_btn = new QPushButton(tr("Close"), this);
 

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -430,50 +430,60 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
         ui->emulatorLanguageGroupBox->installEventFilter(this);
         ui->showSplashCheckBox->installEventFilter(this);
         ui->discordRPCCheckbox->installEventFilter(this);
-        ui->userName->installEventFilter(this);
-        ui->label_Trophy->installEventFilter(this);
-        ui->trophyKeyLineEdit->installEventFilter(this);
-        ui->logTypeGroupBox->installEventFilter(this);
-        ui->logFilter->installEventFilter(this);
+        ui->volumeSliderElement->installEventFilter(this);
 #ifdef ENABLE_UPDATER
         ui->updaterGroupBox->installEventFilter(this);
 #endif
+
+        // GUI
         ui->GUIBackgroundImageGroupBox->installEventFilter(this);
         ui->GUIMusicGroupBox->installEventFilter(this);
-        ui->disableTrophycheckBox->installEventFilter(this);
         ui->enableCompatibilityCheckBox->installEventFilter(this);
         ui->checkCompatibilityOnStartupCheckBox->installEventFilter(this);
         ui->updateCompatibilityButton->installEventFilter(this);
 
         // User
+        ui->userName->installEventFilter(this);
+        ui->disableTrophycheckBox->installEventFilter(this);
         ui->OpenCustomTrophyLocationButton->installEventFilter(this);
+        ui->label_Trophy->installEventFilter(this);
+        ui->trophyKeyLineEdit->installEventFilter(this);
 
         // Input
         ui->hideCursorGroupBox->installEventFilter(this);
         ui->idleTimeoutGroupBox->installEventFilter(this);
         ui->backgroundControllerCheckBox->installEventFilter(this);
+        ui->motionControlsCheckBox->installEventFilter(this);
+        ui->micComboBox->installEventFilter(this);
 
         // Graphics
         ui->graphicsAdapterGroupBox->installEventFilter(this);
         ui->windowSizeGroupBox->installEventFilter(this);
         ui->presentModeGroupBox->installEventFilter(this);
         ui->heightDivider->installEventFilter(this);
-        ui->dumpShadersCheckBox->installEventFilter(this);
         ui->nullGpuCheckBox->installEventFilter(this);
         ui->enableHDRCheckBox->installEventFilter(this);
+        ui->chooseHomeTabGroupBox->installEventFilter(this);
+        ui->gameSizeCheckBox->installEventFilter(this);
 
         // Paths
         ui->gameFoldersGroupBox->installEventFilter(this);
         ui->gameFoldersListWidget->installEventFilter(this);
         ui->addFolderButton->installEventFilter(this);
         ui->removeFolderButton->installEventFilter(this);
-
         ui->saveDataGroupBox->installEventFilter(this);
         ui->currentSaveDataPath->installEventFilter(this);
         ui->currentDLCFolder->installEventFilter(this);
         ui->browseButton->installEventFilter(this);
         ui->folderButton->installEventFilter(this);
         ui->PortableUserFolderGroupBox->installEventFilter(this);
+
+        // Log
+        ui->logTypeGroupBox->installEventFilter(this);
+        ui->logFilter->installEventFilter(this);
+        ui->enableLoggingCheckBox->installEventFilter(this);
+        ui->separateLogFilesCheckbox->installEventFilter(this);
+        ui->OpenLogLocationButton->installEventFilter(this);
 
         // Debug
         ui->debugDump->installEventFilter(this);
@@ -487,8 +497,7 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
         ui->copyGPUBuffersCheckBox->installEventFilter(this);
         ui->readbacksCheckBox->installEventFilter(this);
         ui->readbackLinearImagesCheckBox->installEventFilter(this);
-        ui->separateLogFilesCheckbox->installEventFilter(this);
-        ui->enableLoggingCheckBox->installEventFilter(this);
+        ui->dumpShadersCheckBox->installEventFilter(this);
     }
 }
 
@@ -863,7 +872,19 @@ void SettingsDialog::updateNoteTextEdit(const QString& elementName) {
     } else if (elementName == "separateLogFilesCheckbox") {
         text = tr("Separate Log Files:\\nWrites a separate logfile for each game.");
     } else if (elementName == "enableLoggingCheckBox") {
-        text = tr("Enable Logging:\\nEnables logging.\\nDo not change this if you do not know what you're doing!\\nWhen asking for help, make sure this setting is ENABLED."); }
+        text = tr("Enable Logging:\\nEnables logging.\\nDo not change this if you do not know what you're doing!\\nWhen asking for help, make sure this setting is ENABLED.");
+    } else if (elementName == "OpenLogLocationButton") {
+        text = tr("Open Log Location:\\nOpen the folder where the log file is saved.");
+    } else if (elementName == "micComboBox") {
+        text = tr("Microphone:\\nNone: Does not use the microphone.\\nDefault Device: Will use the default device defined in the system.\\nOr manually choose the microphone to be used from the list.");
+    } else if (elementName == "volumeSliderElement") {
+        text = tr("Volume:\\nAdjust volume for games on a global level, range goes from 0-500% with the default being 100%.");
+    } else if (elementName == "chooseHomeTabGroupBox") {
+        text = tr("Default tab when opening settings:\\nChoose which tab will open, the default is General.");
+    } else if (elementName == "gameSizeCheckBox") {
+        text = tr("Show Game Size In List:\\nThere is the size of the game in the list.");
+    } else if (elementName == "motionControlsCheckBox") {
+        text = tr("Enable Motion Controls:\\nWhen enabled it will use the controller's motion control if supported."); }
     // clang-format on
     ui->descriptionText->setText(text.replace("\\n", "\n"));
 }

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -59,7 +59,7 @@
       </size>
      </property>
      <property name="currentIndex">
-      <number>7</number>
+      <number>6</number>
      </property>
      <widget class="QScrollArea" name="generalTab">
       <property name="widgetResizable">
@@ -2075,7 +2075,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>361</height>
+         <height>299</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -2102,65 +2102,61 @@
               </property>
               <layout class="QVBoxLayout" name="loggerLayout">
                <item>
-                <widget class="QCheckBox" name="enableLoggingCheckBox">
-                 <property name="text">
-                  <string>Enable Logging</string>
+                <layout class="QHBoxLayout" name="horizontalLayout_12">
+                 <property name="topMargin">
+                  <number>0</number>
                  </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="separateLogFilesCheckbox">
-                 <property name="text">
-                  <string>Separate Log Files</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QWidget" name="LogTypeWidget" native="true">
-                 <layout class="QVBoxLayout" name="LogTypeLayout">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QGroupBox" name="logTypeGroupBox">
-                    <property name="maximumSize">
-                     <size>
-                      <width>250</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="title">
-                     <string>Log Type</string>
-                    </property>
-                    <layout class="QVBoxLayout" name="logTypeBoxLayout">
-                     <item>
-                      <widget class="QComboBox" name="logTypeComboBox">
-                       <item>
-                        <property name="text">
-                         <string>async</string>
-                        </property>
-                       </item>
-                       <item>
-                        <property name="text">
-                         <string>sync</string>
-                        </property>
-                       </item>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
+                 <item>
+                  <layout class="QVBoxLayout" name="verticalLayout_7">
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <item>
+                    <widget class="QCheckBox" name="enableLoggingCheckBox">
+                     <property name="text">
+                      <string>Enable Logging</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QCheckBox" name="separateLogFilesCheckbox">
+                     <property name="text">
+                      <string>Separate Log Files</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
+                  <widget class="QGroupBox" name="logTypeGroupBox">
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
+                   <property name="title">
+                    <string>Log Type</string>
+                   </property>
+                   <layout class="QVBoxLayout" name="logTypeBoxLayout">
+                    <item>
+                     <widget class="QComboBox" name="logTypeComboBox">
+                      <item>
+                       <property name="text">
+                        <string>async</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string>sync</string>
+                       </property>
+                      </item>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                </layout>
                </item>
                <item>
                 <layout class="QVBoxLayout" name="vLayoutLogFilter">

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -59,7 +59,7 @@
       </size>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>7</number>
      </property>
      <widget class="QScrollArea" name="generalTab">
       <property name="widgetResizable">
@@ -74,7 +74,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>536</height>
+         <height>486</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="generalTabVLayout" stretch="0">
@@ -452,8 +452,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>402</width>
-                  <height>68</height>
+                  <width>400</width>
+                  <height>60</height>
                  </rect>
                 </property>
                 <layout class="QHBoxLayout" name="horizontalLayout_6">
@@ -472,7 +472,7 @@
                     </size>
                    </property>
                    <property name="text">
-                    <string>100%</string>
+                    <string notr="true">100%</string>
                    </property>
                    <property name="alignment">
                     <set>Qt::AlignmentFlag::AlignCenter</set>
@@ -539,8 +539,14 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>536</height>
+         <height>486</height>
         </rect>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
        <layout class="QVBoxLayout" name="guiTabVLayout" stretch="0">
         <item>
@@ -988,7 +994,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>536</height>
+         <height>486</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="graphicsTabVLayout" stretch="0,0">
@@ -1315,7 +1321,7 @@
                     </font>
                    </property>
                    <property name="text">
-                    <string>0.250</string>
+                    <string notr="true">0.250</string>
                    </property>
                    <property name="alignment">
                     <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
@@ -1386,7 +1392,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>536</height>
+         <height>486</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="userTabVLayout" stretch="0,0,1">
@@ -1628,7 +1634,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>536</height>
+         <height>486</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="inputTabVLayout" stretch="0,0">
@@ -1900,7 +1906,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>536</height>
+         <height>486</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="pathsTabLayout">
@@ -2056,85 +2062,37 @@
        </layout>
       </widget>
      </widget>
-     <widget class="QScrollArea" name="debugTab">
+     <widget class="QScrollArea" name="logTab">
       <property name="widgetResizable">
        <bool>true</bool>
       </property>
       <attribute name="title">
-       <string>Debug</string>
+       <string>Log</string>
       </attribute>
-      <widget class="QWidget" name="debugTabContents">
+      <widget class="QWidget" name="logTabContents">
        <property name="geometry">
         <rect>
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>536</height>
+         <height>361</height>
         </rect>
        </property>
-       <layout class="QVBoxLayout" name="debugTabVLayout" stretch="0,0">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <layout class="QVBoxLayout" name="logTabVLayout" stretch="0">
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_5">
+         <layout class="QHBoxLayout" name="horizontalLayout_log">
           <property name="leftMargin">
            <number>0</number>
           </property>
           <property name="topMargin">
            <number>0</number>
           </property>
-          <item>
-           <layout class="QHBoxLayout" name="debugTabHLayout" stretch="0">
-            <item>
-             <widget class="QGroupBox" name="debugTabGroupBox">
-              <property name="enabled">
-               <bool>true</bool>
-              </property>
-              <property name="title">
-               <string>General</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
-              </property>
-              <layout class="QVBoxLayout" name="debugTabLayout">
-               <item>
-                <widget class="QCheckBox" name="dumpShadersCheckBox">
-                 <property name="text">
-                  <string>Enable Shaders Dumping</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="debugDump">
-                 <property name="text">
-                  <string>Enable Debug Dumping</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="vkValidationCheckBox">
-                 <property name="text">
-                  <string>Enable Vulkan Validation Layers</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="vkSyncValidationCheckBox">
-                 <property name="text">
-                  <string>Enable Vulkan Synchronization Validation</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="rdocCheckBox">
-                 <property name="text">
-                  <string>Enable RenderDoc Debugging</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-           </layout>
-          </item>
           <item>
            <layout class="QVBoxLayout" name="loggerTabLayoutRight">
             <item>
@@ -2174,6 +2132,12 @@
                   </property>
                   <item>
                    <widget class="QGroupBox" name="logTypeGroupBox">
+                    <property name="maximumSize">
+                     <size>
+                      <width>250</width>
+                      <height>16777215</height>
+                     </size>
+                    </property>
                     <property name="title">
                      <string>Log Type</string>
                     </property>
@@ -2245,61 +2209,183 @@
           </item>
          </layout>
         </item>
+       </layout>
+      </widget>
+     </widget>
+     <widget class="QScrollArea" name="debugTab">
+      <property name="widgetResizable">
+       <bool>true</bool>
+      </property>
+      <attribute name="title">
+       <string>Debug</string>
+      </attribute>
+      <widget class="QWidget" name="debugTabContents">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>946</width>
+         <height>382</height>
+        </rect>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <layout class="QVBoxLayout" name="debugTabVLayout" stretch="0,0">
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_7">
+         <layout class="QHBoxLayout" name="horizontalLayout_5">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
           <item>
-           <widget class="QGroupBox" name="advancedGroupBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="title">
-             <string>Advanced</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
-            </property>
-            <layout class="QVBoxLayout" name="advancedLayout">
-             <item>
-              <widget class="QCheckBox" name="collectShaderCheckBox">
-               <property name="text">
-                <string>Collect Shaders</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="crashDiagnosticsCheckBox">
-               <property name="text">
-                <string>Enable Crash Diagnostics</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="copyGPUBuffersCheckBox">
-               <property name="text">
-                <string>Copy GPU Buffers</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="hostMarkersCheckBox">
-               <property name="text">
-                <string>Host Debug Markers</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="guestMarkersCheckBox">
-               <property name="text">
-                <string>Guest Debug Markers</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
+           <layout class="QHBoxLayout" name="debugTabHLayout" stretch="0">
+            <item>
+             <widget class="QGroupBox" name="debugTabGroupBox">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>11</pointsize>
+                <bold>false</bold>
+                <stylestrategy>PreferDefault</stylestrategy>
+               </font>
+              </property>
+              <property name="title">
+               <string>General</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+              </property>
+              <layout class="QVBoxLayout" name="debugTabLayout">
+               <item>
+                <widget class="QCheckBox" name="dumpShadersCheckBox">
+                 <property name="text">
+                  <string>Enable Shaders Dumping</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="debugDump">
+                 <property name="text">
+                  <string>Enable Debug Dumping</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="vkValidationCheckBox">
+                 <property name="text">
+                  <string>Enable Vulkan Validation Layers</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="vkSyncValidationCheckBox">
+                 <property name="text">
+                  <string>Enable Vulkan Synchronization Validation</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="rdocCheckBox">
+                 <property name="text">
+                  <string>Enable RenderDoc Debugging</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
           </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_7">
+            <item>
+             <widget class="QGroupBox" name="advancedGroupBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="layoutDirection">
+               <enum>Qt::LayoutDirection::LeftToRight</enum>
+              </property>
+              <property name="autoFillBackground">
+               <bool>false</bool>
+              </property>
+              <property name="title">
+               <string>Advanced</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+              </property>
+              <layout class="QVBoxLayout" name="advancedLayout">
+               <property name="spacing">
+                <number>6</number>
+               </property>
+               <property name="leftMargin">
+                <number>9</number>
+               </property>
+               <item>
+                <widget class="QCheckBox" name="collectShaderCheckBox">
+                 <property name="text">
+                  <string>Collect Shaders</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="crashDiagnosticsCheckBox">
+                 <property name="text">
+                  <string>Enable Crash Diagnostics</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="copyGPUBuffersCheckBox">
+                 <property name="text">
+                  <string>Copy GPU Buffers</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="hostMarkersCheckBox">
+                 <property name="text">
+                  <string>Host Debug Markers</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="guestMarkersCheckBox">
+                 <property name="text">
+                  <string>Guest Debug Markers</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_8">
+          <property name="topMargin">
+           <number>0</number>
+          </property>
           <item>
            <layout class="QVBoxLayout" name="verticalLayout_4">
             <item>
@@ -2309,39 +2395,74 @@
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_3">
                <item>
-                <widget class="QCheckBox" name="readbacksCheckBox">
-                 <property name="text">
-                  <string>Enable Readbacks</string>
+                <layout class="QHBoxLayout" name="horizontalLayout_11">
+                 <property name="topMargin">
+                  <number>0</number>
                  </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="readbackLinearImagesCheckBox">
-                 <property name="text">
-                  <string>Enable Readback Linear Images</string>
-                 </property>
-                </widget>
+                 <item>
+                  <layout class="QVBoxLayout" name="verticalLayout_6">
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <item>
+                    <widget class="QCheckBox" name="readbacksCheckBox">
+                     <property name="text">
+                      <string>Enable Readbacks</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QCheckBox" name="readbackLinearImagesCheckBox">
+                     <property name="text">
+                      <string>Enable Readback Linear Images</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="ExperimentalLabel">
+                   <property name="sizeIncrement">
+                    <size>
+                     <width>0</width>
+                     <height>0</height>
+                    </size>
+                   </property>
+                   <property name="baseSize">
+                    <size>
+                     <width>0</width>
+                     <height>0</height>
+                    </size>
+                   </property>
+                   <property name="font">
+                    <font>
+                     <pointsize>11</pointsize>
+                     <bold>true</bold>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>WARNING: These features are experimental and should not be enabled unless you were told to, or a game requires it. Please ask in the shadPS4 Discord server if you have any questions.</string>
+                   </property>
+                   <property name="scaledContents">
+                    <bool>false</bool>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+                   </property>
+                   <property name="wordWrap">
+                    <bool>true</bool>
+                   </property>
+                   <property name="margin">
+                    <number>0</number>
+                   </property>
+                   <property name="indent">
+                    <number>-1</number>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
                </item>
               </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="ExperimentalLabel">
-              <property name="font">
-               <font>
-                <pointsize>11</pointsize>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string>WARNING: These features are experimental and should not be enabled unless you were told to, or a game requires it. Please ask in the shadPS4 Discord server if you have any questions.</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
              </widget>
             </item>
            </layout>


### PR DESCRIPTION
*This is a draft so I can adjust the text if it isn't correct(or improvement), as it's not my native language.

These texts will no longer be translated:
```
L1,L2,L3,R1,R2,R3
0.250
100%
```
*Do not include 'Options' as there is disagreement about this, so each language must decide, so there will still be a translation...

These descriptions have been added:
```
Open Log Location:
Open the folder where the log file is saved.

Microphone:
None: Does not use the microphone.
Default Device: Will use the default device defined in the system.
Or manually choose the microphone to be used from the list.

Volume:
Adjust volume for games on a global level, range goes from 0-500% with the default being 100%.

Default tab when opening settings:
Choose which tab will open, the default is General.

Show Game Size In List:
There is the size of the game in the list.

Enable Motion Controls:
When enabled it will use the controller's motion control if supported.
```


The debug screen has been revamped, as the log options have been added to a new tab.
| Before | After |
|-------------|-------------|
![image](https://github.com/user-attachments/assets/5a47509a-37cc-4afa-9a11-55cbe890f553) | ![image](https://github.com/user-attachments/assets/99fe3cd1-a186-4745-a8a7-8f83a409400b)

<img width="972" height="782" alt="image" src="https://github.com/user-attachments/assets/80aab88a-b8b3-4bfc-93d2-dfdf9cc0379c" />



Some text on these screens has been centered
| Before | After |
|-------------|-------------|
![image](https://github.com/user-attachments/assets/775d81de-3115-4259-986f-1ab4e58c3f6a) | ![image](https://github.com/user-attachments/assets/dd17db51-d62c-41e8-bc55-e2242f4c6e00)

| Before | After |
|-------------|-------------|
![image](https://github.com/user-attachments/assets/dbd85bcb-e9ca-47d4-b843-d04485c18f9b) | ![image](https://github.com/user-attachments/assets/c3b85670-c35c-47b1-bf67-7018d05cefc3)



Values ​​have been separated from the text
<img width="1137" height="136" alt="image" src="https://github.com/user-attachments/assets/5259db65-bb50-45bc-af6a-716c0cce0678" />


RGB is now written in full and the values ​​are separated to the other side
<img width="980" height="150" alt="image" src="https://github.com/user-attachments/assets/4d81e310-8465-4b3b-bbeb-bef6e1b52887" />

