### PR TITLE
shader_recompiler: Support PointSize and ViewportIndex attributes.

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv.cpp
@@ -272,9 +272,6 @@ void SetupCapabilities(const Info& info, const Profile& profile, const RuntimeIn
     if (info.has_image_query) {
         ctx.AddCapability(spv::Capability::ImageQuery);
     }
-    if (info.has_layer_output) {
-        ctx.AddCapability(spv::Capability::ShaderLayer);
-    }
     if ((info.uses_image_atomic_float_min_max && profile.supports_image_fp32_atomic_min_max) ||
         (info.uses_buffer_atomic_float_min_max && profile.supports_buffer_fp32_atomic_min_max)) {
         ctx.AddExtension("SPV_EXT_shader_atomic_float_min_max");
@@ -311,6 +308,17 @@ void SetupCapabilities(const Info& info, const Profile& profile, const RuntimeIn
     }
     if (stage == LogicalStage::TessellationControl || stage == LogicalStage::TessellationEval) {
         ctx.AddCapability(spv::Capability::Tessellation);
+    }
+    if (stage == LogicalStage::Vertex || stage == LogicalStage::TessellationControl ||
+        stage == LogicalStage::TessellationEval) {
+        if (info.has_layer_output) {
+            ctx.AddCapability(spv::Capability::ShaderLayer);
+        }
+        if (info.has_viewport_index_output) {
+            ctx.AddCapability(spv::Capability::ShaderViewportIndex);
+        }
+    } else if (stage == LogicalStage::Geometry && info.has_viewport_index_output) {
+        ctx.AddCapability(spv::Capability::MultiViewport);
     }
     if (info.uses_dma) {
         ctx.AddCapability(spv::Capability::PhysicalStorageBufferAddresses);

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -49,8 +49,12 @@ Id OutputAttrPointer(EmitContext& ctx, IR::Attribute attr, u32 element) {
         return ctx.OpAccessChain(ctx.output_f32, ctx.clip_distances, ctx.ConstU32(element));
     case IR::Attribute::CullDistance:
         return ctx.OpAccessChain(ctx.output_f32, ctx.cull_distances, ctx.ConstU32(element));
-    case IR::Attribute::RenderTargetId:
+    case IR::Attribute::PointSize:
+        return ctx.output_point_size;
+    case IR::Attribute::RenderTargetIndex:
         return ctx.output_layer;
+    case IR::Attribute::ViewportIndex:
+        return ctx.output_viewport_index;
     case IR::Attribute::Depth:
         return ctx.frag_depth;
     default:
@@ -74,9 +78,10 @@ std::pair<Id, bool> OutputAttrComponentType(EmitContext& ctx, IR::Attribute attr
     case IR::Attribute::ClipDistance:
     case IR::Attribute::CullDistance:
     case IR::Attribute::Depth:
+    case IR::Attribute::PointSize:
         return {ctx.F32[1], false};
-    case IR::Attribute::RenderTargetId:
-    case IR::Attribute::ViewportId:
+    case IR::Attribute::RenderTargetIndex:
+    case IR::Attribute::ViewportIndex:
         return {ctx.S32[1], true};
     default:
         UNREACHABLE_MSG("Write attribute {}", attr);

--- a/src/shader_recompiler/backend/spirv/emit_spirv_special.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_special.cpp
@@ -28,6 +28,9 @@ void ConvertDepthMode(EmitContext& ctx) {
 }
 
 void ConvertPositionToClipSpace(EmitContext& ctx) {
+    ASSERT_MSG(!ctx.info.has_viewport_index_output,
+               "Multi-viewport with shader clip space conversion not yet implemented.");
+
     const Id type{ctx.F32[1]};
     Id position{ctx.OpLoad(ctx.F32[4], ctx.output_position)};
     const Id x{ctx.OpCompositeExtract(type, position, 0u)};

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -555,8 +555,16 @@ void EmitContext::DefineVertexBlock() {
         cull_distances = DefineVariable(type, spv::BuiltIn::CullDistance, spv::StorageClass::Output,
                                         initializer);
     }
-    if (info.stores.GetAny(IR::Attribute::RenderTargetId)) {
+    if (info.stores.GetAny(IR::Attribute::PointSize)) {
+        output_point_size =
+            DefineVariable(F32[1], spv::BuiltIn::PointSize, spv::StorageClass::Output);
+    }
+    if (info.stores.GetAny(IR::Attribute::RenderTargetIndex)) {
         output_layer = DefineVariable(S32[1], spv::BuiltIn::Layer, spv::StorageClass::Output);
+    }
+    if (info.stores.GetAny(IR::Attribute::ViewportIndex)) {
+        output_viewport_index =
+            DefineVariable(S32[1], spv::BuiltIn::ViewportIndex, spv::StorageClass::Output);
     }
 }
 

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -245,7 +245,9 @@ public:
     boost::container::small_vector<Id, 16> interfaces;
 
     Id output_position{};
+    Id output_point_size{};
     Id output_layer{};
+    Id output_viewport_index{};
     Id primitive_id{};
     Id vertex_index{};
     Id instance_id{};

--- a/src/shader_recompiler/info.h
+++ b/src/shader_recompiler/info.h
@@ -211,6 +211,7 @@ struct Info {
     bool has_image_gather{};
     bool has_image_query{};
     bool has_layer_output{};
+    bool has_viewport_index_output{};
     bool uses_buffer_atomic_float_min_max{};
     bool uses_image_atomic_float_min_max{};
     bool uses_lane_id{};

--- a/src/shader_recompiler/ir/attribute.cpp
+++ b/src/shader_recompiler/ir/attribute.cpp
@@ -104,10 +104,10 @@ std::string NameOf(Attribute attribute) {
         return "ClipDistanace";
     case Attribute::CullDistance:
         return "CullDistance";
-    case Attribute::RenderTargetId:
-        return "RenderTargetId";
-    case Attribute::ViewportId:
-        return "ViewportId";
+    case Attribute::RenderTargetIndex:
+        return "RenderTargetIndex";
+    case Attribute::ViewportIndex:
+        return "ViewportIndex";
     case Attribute::VertexId:
         return "VertexId";
     case Attribute::PrimitiveId:
@@ -158,6 +158,8 @@ std::string NameOf(Attribute attribute) {
         return "PackedHullInvocationInfo";
     case Attribute::TessFactorsBufferBase:
         return "TessFactorsBufferBase";
+    case Attribute::PointSize:
+        return "PointSize";
     default:
         break;
     }

--- a/src/shader_recompiler/ir/attribute.h
+++ b/src/shader_recompiler/ir/attribute.h
@@ -60,8 +60,8 @@ enum class Attribute : u64 {
     // System values
     ClipDistance = 64,
     CullDistance = 65,
-    RenderTargetId = 66,
-    ViewportId = 67,
+    RenderTargetIndex = 66,
+    ViewportIndex = 67,
     VertexId = 68,
     PrimitiveId = 69,
     InstanceId = 70,
@@ -87,6 +87,7 @@ enum class Attribute : u64 {
     PackedHullInvocationInfo = 90, // contains patch id within the VGT and invocation ID
     OffChipLdsBase = 91,
     TessFactorsBufferBase = 92,
+    PointSize = 93,
     Max,
 };
 

--- a/src/shader_recompiler/ir/passes/shader_info_collection_pass.cpp
+++ b/src/shader_recompiler/ir/passes/shader_info_collection_pass.cpp
@@ -160,8 +160,11 @@ void CollectShaderInfoPass(IR::Program& program, const Profile& profile) {
         }
     }
 
-    if (info.stores.GetAny(IR::Attribute::RenderTargetId)) {
+    if (info.stores.GetAny(IR::Attribute::RenderTargetIndex)) {
         info.has_layer_output = true;
+    }
+    if (info.stores.GetAny(IR::Attribute::ViewportIndex)) {
+        info.has_viewport_index_output = true;
     }
 
     // In case Flatbuf has not already been bound by IR and is needed

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -54,12 +54,12 @@ struct ExportRuntimeInfo {
 
 enum class Output : u8 {
     None,
-    PointSprite,
+    PointSize,
     EdgeFlag,
     KillFlag,
     GsCutFlag,
-    GsMrtIndex,
-    GsVpIndex,
+    RenderTargetIndex,
+    ViewportIndex,
     CullDist0,
     CullDist1,
     CullDist2,

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -42,14 +42,15 @@ static u32 MapOutputs(std::span<Shader::OutputMap, 3> outputs,
 
     if (ctl.vs_out_misc_enable) {
         auto& misc_vec = outputs[num_outputs++];
-        misc_vec[0] = ctl.use_vtx_point_size ? Output::PointSprite : Output::None;
+        misc_vec[0] = ctl.use_vtx_point_size ? Output::PointSize : Output::None;
         misc_vec[1] = ctl.use_vtx_edge_flag
                           ? Output::EdgeFlag
                           : (ctl.use_vtx_gs_cut_flag ? Output::GsCutFlag : Output::None);
-        misc_vec[2] = ctl.use_vtx_kill_flag
-                          ? Output::KillFlag
-                          : (ctl.use_vtx_render_target_idx ? Output::GsMrtIndex : Output::None);
-        misc_vec[3] = ctl.use_vtx_viewport_idx ? Output::GsVpIndex : Output::None;
+        misc_vec[2] =
+            ctl.use_vtx_kill_flag
+                ? Output::KillFlag
+                : (ctl.use_vtx_render_target_idx ? Output::RenderTargetIndex : Output::None);
+        misc_vec[3] = ctl.use_vtx_viewport_idx ? Output::ViewportIndex : Output::None;
     }
 
     if (ctl.vs_out_ccdist0_enable) {


### PR DESCRIPTION
Adds support for the `PointSize` and `ViewportIndex` pre-rasterization attribute exports, with the appropriate capabilities set for each pre-rasterization stage.

Note that it asserts for `ViewportIndex` if clip space conversion in-shader is needed, as the push constants only fit the first viewport currently. Hopefully a rare case if hit at all.

Fixes `Unhandled output 1 on attribute Position1` and `Unhandled output 6 on attribute Position1` asserts.