### PR TITLE
vk_pipeline_cache: Log pipeline creation.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -273,6 +273,9 @@ const GraphicsPipeline* PipelineCache::GetGraphicsPipeline() {
     }
     const auto [it, is_new] = graphics_pipelines.try_emplace(graphics_key);
     if (is_new) {
+        const auto pipeline_hash = std::hash<GraphicsPipelineKey>{}(graphics_key);
+        LOG_INFO(Render, "Compiling graphics pipeline {:#x}", pipeline_hash);
+
         it.value() = std::make_unique<GraphicsPipeline>(instance, scheduler, desc_heap, profile,
                                                         graphics_key, *pipeline_cache, infos,
                                                         runtime_infos, fetch_shader, modules);
@@ -294,6 +297,9 @@ const ComputePipeline* PipelineCache::GetComputePipeline() {
     }
     const auto [it, is_new] = compute_pipelines.try_emplace(compute_key);
     if (is_new) {
+        const auto pipeline_hash = std::hash<ComputePipelineKey>{}(compute_key);
+        LOG_INFO(Render, "Compiling compute pipeline {:#x}", pipeline_hash);
+
         it.value() =
             std::make_unique<ComputePipeline>(instance, scheduler, desc_heap, profile,
                                               *pipeline_cache, compute_key, *infos[0], modules[0]);


### PR DESCRIPTION
Log created pipelines by hash. This can help to understand how many pipelines a game creates, how many variations there are compared to number of shader compiles, whether any stutter is from pipeline compiles, etc.