### PR TITLE
QT: Add the Log tab to 'Default tab when opening settings'

### DIFF
--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -632,6 +632,11 @@
                     </item>
                     <item>
                      <property name="text">
+                      <string>Log</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
                       <string>Debug</string>
                      </property>
                     </item>


### PR DESCRIPTION
I ended up forgetting to add it here...
<img width="517" height="357" alt="image" src="https://github.com/user-attachments/assets/029793f3-1abe-4ca0-b757-93634cc030b1" />
