### PR TITLE
externals: Update libusb to fix more ABI issues.

### DIFF
--- a/src/core/libraries/usbd/usbd.h
+++ b/src/core/libraries/usbd/usbd.h
@@ -27,7 +27,7 @@ using SceUsbdDeviceDescriptor = libusb_device_descriptor;
 using SceUsbdConfigDescriptor = libusb_config_descriptor;
 using SceUsbdTransfer = libusb_transfer;
 using SceUsbdControlSetup = libusb_control_setup;
-using SceUsbdTransferCallback = void (*)(SceUsbdTransfer* transfer);
+using SceUsbdTransferCallback = void PS4_SYSV_ABI (*)(SceUsbdTransfer* transfer);
 
 enum class SceUsbdSpeed : u32 {
     UNKNOWN = 0,


### PR DESCRIPTION
Moved the ABI declaration from a cast when calling the callback, to using the existing `LIBUSB_CALL` define to put it everywhere.

This should hopefully fix the issue that appeared with Tekken 7 by making sure that libusb's internal callback is declared with the right ABI. It also makes sure than any other potential users of libusb (e.g. SDL) will inherit the right ABI for callbacks.