### PR TITLE
 liverpool: Write valid queries on PixelPipeStatDump 

### DIFF
--- a/src/shader_recompiler/frontend/translate/export.cpp
+++ b/src/shader_recompiler/frontend/translate/export.cpp
@@ -129,11 +129,12 @@ void Translator::EmitExport(const GcnInst& inst) {
         return ExportRenderTarget(inst);
     }
 
-    ASSERT_MSG(!exp.compr, "Compressed exports only supported for render targets");
     if (attrib == IR::Attribute::Depth && exp.en != 0 && exp.en != 1) {
         LOG_WARNING(Render_Vulkan, "Unsupported depth export");
         return;
     }
+
+    ASSERT_MSG(!exp.compr, "Compressed exports only supported for render targets");
 
     u32 mask = exp.en;
     for (u32 i = 0; i < 4; i++, mask >>= 1) {

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -9,6 +9,7 @@
 #include "common/polyfill_thread.h"
 #include "common/thread.h"
 #include "core/debug_state.h"
+#include "core/libraries/kernel/process.h"
 #include "core/libraries/videoout/driver.h"
 #include "core/memory.h"
 #include "video_core/amdgpu/liverpool.h"
@@ -64,6 +65,7 @@ static std::span<const u32> NextPacket(std::span<const u32> span, size_t offset)
 }
 
 Liverpool::Liverpool() {
+    num_counter_pairs = Libraries::Kernel::sceKernelIsNeoMode() ? 16 : 8;
     process_thread = std::jthread{std::bind_front(&Liverpool::Process, this)};
 }
 
@@ -163,7 +165,7 @@ Liverpool::Task Liverpool::ProcessCeUpdate(std::span<const u32> ccb) {
         const auto* it_body = reinterpret_cast<const u32*>(header) + 1;
         switch (opcode) {
         case PM4ItOpcode::Nop: {
-            const auto* nop = reinterpret_cast<const PM4CmdNop*>(header);
+            // const auto* nop = reinterpret_cast<const PM4CmdNop*>(header);
             break;
         }
         case PM4ItOpcode::WriteConstRam: {
@@ -604,7 +606,13 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
                     // immediately
                     regs.cp_strmout_cntl.offset_update_done = 1;
                 } else if (event->event_index.Value() == EventIndex::ZpassDone) {
-                    LOG_WARNING(Render, "Unimplemented occlusion query");
+                    if (event->event_type.Value() == EventType::PixelPipeStatDump) {
+                        static constexpr u64 DummyOcclusionCounter = 0x8000000000000000ULL;
+                        u64* results = event->Address<u64*>();
+                        for (s32 i = 0; i < num_counter_pairs; ++i, results += 2) {
+                            *results = DummyOcclusionCounter;
+                        }
+                    }
                 }
                 break;
             }

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -607,11 +607,13 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
                     regs.cp_strmout_cntl.offset_update_done = 1;
                 } else if (event->event_index.Value() == EventIndex::ZpassDone) {
                     if (event->event_type.Value() == EventType::PixelPipeStatDump) {
-                        static constexpr u64 DummyOcclusionCounter = 0x8000000000000000ULL;
+                        static constexpr u64 OcclusionCounterValidMask = 0x8000000000000000ULL;
+                        static constexpr u64 OcclusionCounterStep = 0x2FFFFFFULL;
                         u64* results = event->Address<u64*>();
                         for (s32 i = 0; i < num_counter_pairs; ++i, results += 2) {
-                            *results = DummyOcclusionCounter;
+                            *results = pixel_counter | OcclusionCounterValidMask;
                         }
+                        pixel_counter += OcclusionCounterStep;
                     }
                 }
                 break;

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -1667,6 +1667,7 @@ private:
 
     VAddr indirect_args_addr{};
     u32 num_counter_pairs{};
+    u64 pixel_counter{};
 
     struct ConstantEngine {
         void Reset() {

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -1666,6 +1666,7 @@ private:
     u32 num_mapped_queues{1u}; // GFX is always available
 
     VAddr indirect_args_addr{};
+    u32 num_counter_pairs{};
 
     struct ConstantEngine {
         void Reset() {

--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -415,6 +415,13 @@ struct PM4CmdEventWrite {
         BitField<20, 1, u32> inv_l2; ///< Send WBINVL2 op to the TC L2 cache when EVENT_INDEX = 0111
     };
     u32 address[];
+
+    template <typename T>
+    T Address() const {
+        ASSERT(event_index.Value() >= EventIndex::ZpassDone &&
+               event_index.Value() <= EventIndex::SampleStreamoutStatSx);
+        return std::bit_cast<T>((u64(address[1]) << 32u) | u64(address[0]));
+    }
 };
 
 struct PM4CmdEventWriteEop {


### PR DESCRIPTION
Fixes softlocks when guest is checking for and waiting for [valid](https://github.com/GPUOpen-Drivers/pal/blob/c5e800072a32f68b6ccc4422936d96167c6e0728/src/core/hw/gfxip/gfx12/gfx12OcclusionQueryPool.h#L43-L53) queries