### PR TITLE
Core: ClampRangeSize fixes

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -82,7 +82,7 @@ u64 MemoryManager::ClampRangeSize(VAddr virtual_addr, u64 size) {
     ++vma;
 
     // Keep adding to the size while there is contigious virtual address space.
-    while (!vma->second.IsFree() && clamped_size < size) {
+    while (vma->second.IsMapped() && clamped_size < size) {
         clamped_size += vma->second.size;
         ++vma;
     }

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -283,7 +283,8 @@ void BufferCache::BindVertexBuffers(const Vulkan::GraphicsPipeline& pipeline) {
 
     // Map buffers for merged ranges
     for (auto& range : ranges_merged) {
-        const auto [buffer, offset] = ObtainBuffer(range.base_address, range.GetSize(), false);
+        const u64 size = memory->ClampRangeSize(range.base_address, range.GetSize());
+        const auto [buffer, offset] = ObtainBuffer(range.base_address, size, false);
         range.vk_buffer = buffer->buffer;
         range.offset = offset;
     }


### PR DESCRIPTION
This PR applies ClampRangeSize to vertex buffers, and fixes ClampRangeSize so it doesn't include memory that is Reserved or PoolReserved.