### PR TITLE
Simple implementation of sceGnmUnmapComputeQueue in gnmdriver

### DIFF
--- a/src/core/libraries/gnmdriver/gnmdriver.cpp
+++ b/src/core/libraries/gnmdriver/gnmdriver.cpp
@@ -2281,8 +2281,6 @@ int PS4_SYSV_ABI sceGnmSubmitDone() {
 
 int PS4_SYSV_ABI sceGnmUnmapComputeQueue(u32 vqid) {
     liverpool->asc_queues.erase(Common::SlotId{vqid - 1});
-    // a simple q&d implementation, called in Uncharted 4 v1.00 and my test renderer homebrew, possibly others?
-    // side effects unknown, if any 
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/gnmdriver/gnmdriver.cpp
+++ b/src/core/libraries/gnmdriver/gnmdriver.cpp
@@ -2279,8 +2279,10 @@ int PS4_SYSV_ABI sceGnmSubmitDone() {
     return ORBIS_OK;
 }
 
-int PS4_SYSV_ABI sceGnmUnmapComputeQueue() {
-    LOG_ERROR(Lib_GnmDriver, "(STUBBED) called");
+int PS4_SYSV_ABI sceGnmUnmapComputeQueue(u32 vqid) {
+    liverpool->asc_queues.erase(Common::SlotId{vqid - 1});
+    // a simple q&d implementation, called in Uncharted 4 v1.00 and my test renderer homebrew, possibly others?
+    // side effects unknown, if any 
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/gnmdriver/gnmdriver.h
+++ b/src/core/libraries/gnmdriver/gnmdriver.h
@@ -224,7 +224,7 @@ int PS4_SYSV_ABI sceGnmSubmitCommandBuffersForWorkload(u32 workload, u32 count,
                                                        const u32* ccb_gpu_addrs[],
                                                        u32* ccb_sizes_in_bytes);
 int PS4_SYSV_ABI sceGnmSubmitDone();
-int PS4_SYSV_ABI sceGnmUnmapComputeQueue();
+int PS4_SYSV_ABI sceGnmUnmapComputeQueue(u32 vqid);
 int PS4_SYSV_ABI sceGnmUnregisterAllResourcesForOwner();
 int PS4_SYSV_ABI sceGnmUnregisterOwnerAndResources();
 int PS4_SYSV_ABI sceGnmUnregisterResource();


### PR DESCRIPTION
just as the tile says, this is just a simple implementation of sceGnmUnmapComputeQueue
only known games to call this function is Uncharted 4 v1.00 according to Stephen on the discord, and a test renderer homebrew I was using to test iDTech2 3D rendering for later work on uHexenII porting