### PR TITLE
Core: Fix MXCSR and FPUCW registers on created threads

### DIFF
--- a/src/core/thread.cpp
+++ b/src/core/thread.cpp
@@ -11,6 +11,7 @@
 #include <csignal>
 #include <pthread.h>
 #include <unistd.h>
+#include <xmmintrin.h>
 #endif
 
 namespace Core {

--- a/src/core/thread.cpp
+++ b/src/core/thread.cpp
@@ -129,7 +129,7 @@ void NativeThread::Initialize() {
     _mm_setcsr(ORBIS_MXCSR);
 #if _WIN64
     // Windows needs the FPUCW register set manually.
-    asm volatile ("fldcw %0" : : "m"(ORBIS_FPUCW));
+    asm volatile("fldcw %0" : : "m"(ORBIS_FPUCW));
     tid = GetCurrentThreadId();
 #else
     tid = (u64)pthread_self();

--- a/src/core/thread.cpp
+++ b/src/core/thread.cpp
@@ -126,7 +126,7 @@ void NativeThread::Exit() {
 
 void NativeThread::Initialize() {
     // MXCSR register needs to be set on all platforms
-    asm volatile("ldmxcsr %0" : : "m"(ORBIS_MXCSR));
+    _mm_setcsr(ORBIS_MXCSR);
 #if _WIN64
     // Windows needs the FPUCW register set manually.
     asm volatile ("fldcw %0" : : "m"(ORBIS_FPUCW));


### PR DESCRIPTION
Orbis seems to set the flush-to-zero and denormals-are-zero flags of MXCSR, unlike all other platforms, and defaults to a higher floating point precision than Windows.
This PR sets these registers using constants dumped from real hardware.

This fixes the currently Linux-specific crash in base versions of Uncharted 4: A Thief’s End™, as described in https://github.com/shadps4-compatibility/shadps4-game-compatibility/issues/146

Let me know if there are any formatting changes I need to make here, I don't typically use inline assembly.