### PR TITLE
Qt: Group game-specific and non-game-specific items in the same tabs

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -100,8 +100,12 @@ public:
     void setTomlValue(toml::ordered_value& data, const std::string& header, const std::string& key,
                       bool is_game_specific = false) {
         if (is_game_specific) {
-            if (game_specific_value == std::nullopt)
+            if (game_specific_value == std::nullopt) {
+                fmt::print("Attempted to save std::nullopt value to {}-{}, matching config entry "
+                           "may not be correctly set-up\n",
+                           header, key);
                 return;
+            }
             data[header][key] = game_specific_value.value_or(base_value);
             game_specific_value = std::nullopt;
         } else {

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -100,6 +100,8 @@ public:
     void setTomlValue(toml::ordered_value& data, const std::string& header, const std::string& key,
                       bool is_game_specific = false) {
         if (is_game_specific) {
+            if (game_specific_value == std::nullopt)
+                return;
             data[header][key] = game_specific_value.value_or(base_value);
             game_specific_value = std::nullopt;
         } else {

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -1110,6 +1110,8 @@ void setDefaultValues(bool is_game_specific) {
     // Entries with game-specific settings that are in the game-specific setings GUI but not in
     // the global settings GUI
     if (is_game_specific) {
+        readbacksEnabled.set(false, is_game_specific);
+        readbackLinearImagesEnabled.set(false, is_game_specific);
         isNeo.set(false, is_game_specific);
         isDevKit.set(false, is_game_specific);
         isPSNSignedIn.set(false, is_game_specific);
@@ -1141,8 +1143,6 @@ void setDefaultValues(bool is_game_specific) {
     windowHeight.set(720, is_game_specific);
     isNullGpu.set(false, is_game_specific);
     shouldCopyGPUBuffers.set(false, is_game_specific);
-    readbacksEnabled.set(false, is_game_specific);
-    readbackLinearImagesEnabled.set(false, is_game_specific);
     shouldDumpShaders.set(false, is_game_specific);
     vblankFrequency.set(60, is_game_specific);
     isFullscreen.set(false, is_game_specific);

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -94,25 +94,18 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
     ui->logFilterLineEdit->setClearButtonEnabled(true);
 
     if (game_specific) {
+        // Paths tab
         ui->tabWidgetSettings->setTabVisible(5, false);
         ui->chooseHomeTabComboBox->removeItem(5);
 
-        ui->label_Trophy->setVisible(false);
-        ui->trophyKeyLineEdit->setVisible(false);
-        ui->CompatgroupBox->setVisible(false);
-        ui->gameSizeCheckBox->setVisible(false);
-        ui->GUIBackgroundImageGroupBox->setVisible(false);
-        ui->GUIMusicGroupBox->setVisible(false);
-        ui->gameSizeCheckBox->setVisible(false);
-        ui->updaterGroupBox->setVisible(false);
-        ui->discordRPCCheckbox->setVisible(false);
-        ui->emulatorLanguageGroupBox->setVisible(false);
+        // Frontend tab
+        ui->tabWidgetSettings->setTabVisible(1, false);
+        ui->chooseHomeTabComboBox->removeItem(1);
+
     } else {
-        ui->dmaCheckBox->setVisible(false);
-        ui->devkitCheckBox->setVisible(false);
-        ui->neoCheckBox->setVisible(false);
-        ui->networkConnectedCheckBox->setVisible(false);
-        ui->psnSignInCheckBox->setVisible(false);
+        // Experimental tab
+        ui->tabWidgetSettings->setTabVisible(8, false);
+        ui->chooseHomeTabComboBox->removeItem(8);
     }
 
     std::filesystem::path config_file =
@@ -130,10 +123,15 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
     presentModeMap = {{tr("Mailbox (Vsync)"), "Mailbox"},
                       {tr("Fifo (Vsync)"), "Fifo"},
                       {tr("Immediate (No Vsync)"), "Immediate"}};
-    chooseHomeTabMap = {{tr("General"), "General"},   {tr("GUI"), "GUI"},
-                        {tr("Graphics"), "Graphics"}, {tr("User"), "User"},
-                        {tr("Input"), "Input"},       {tr("Paths"), "Paths"},
-                        {tr("Log"), "Log"},           {tr("Debug"), "Debug"}};
+    chooseHomeTabMap = {{tr("General"), "General"},
+                        {tr("Frontend"), "Frontend"},
+                        {tr("Graphics"), "Graphics"},
+                        {tr("User"), "User"},
+                        {tr("Input"), "Input"},
+                        {tr("Paths"), "Paths"},
+                        {tr("Log"), "Log"},
+                        {tr("Debug"), "Debug"},
+                        {tr("Experimental"), "Experimental"}};
     micMap = {{tr("None"), "None"}, {tr("Default Device"), "Default Device"}};
 
     if (m_physical_devices.empty()) {
@@ -646,6 +644,9 @@ void SettingsDialog::LoadValuesFromConfig() {
         ui->micComboBox->setCurrentIndex(0);
     }
 
+    ui->readbacksCheckBox->setChecked(toml::find_or<bool>(data, "GPU", "readbacks", false));
+    ui->readbackLinearImagesCheckBox->setChecked(
+        toml::find_or<bool>(data, "GPU", "readbackLinearImages", false));
     ui->dmaCheckBox->setChecked(toml::find_or<bool>(data, "GPU", "directMemoryAccess", false));
     ui->neoCheckBox->setChecked(toml::find_or<bool>(data, "General", "isPS4Pro", false));
     ui->devkitCheckBox->setChecked(toml::find_or<bool>(data, "General", "isDevKit", false));
@@ -725,10 +726,7 @@ void SettingsDialog::LoadValuesFromConfig() {
         toml::find_or<bool>(data, "GPU", "copyGPUBuffers", false));
     ui->collectShaderCheckBox->setChecked(
         toml::find_or<bool>(data, "Debug", "CollectShader", false));
-    ui->readbacksCheckBox->setChecked(toml::find_or<bool>(data, "GPU", "readbacks", false));
     ui->enableLoggingCheckBox->setChecked(toml::find_or<bool>(data, "Debug", "logEnabled", true));
-    ui->readbackLinearImagesCheckBox->setChecked(
-        toml::find_or<bool>(data, "GPU", "readbackLinearImages", false));
 
     std::string chooseHomeTab =
         toml::find_or<std::string>(data, "General", "chooseHomeTab", "General");
@@ -981,17 +979,15 @@ bool SettingsDialog::eventFilter(QObject* obj, QEvent* event) {
 }
 
 void SettingsDialog::UpdateSettings(bool game_specific) {
-    // Entries that are only in the game-specific gui
-
-    if (game_specific) {
-        Config::setDirectMemoryAccess(ui->dmaCheckBox->isChecked(), true);
-        Config::setDevKitConsole(ui->devkitCheckBox->isChecked(), true);
-        Config::setNeoMode(ui->neoCheckBox->isChecked(), true);
-        Config::setConnectedToNetwork(ui->networkConnectedCheckBox->isChecked(), true);
-        Config::setPSNSignedIn(ui->psnSignInCheckBox->isChecked(), true);
-    }
-
     // Entries with game-specific settings, needs the game-specific arg
+    Config::setReadbacks(ui->readbacksCheckBox->isChecked(), game_specific);
+    Config::setReadbackLinearImages(ui->readbackLinearImagesCheckBox->isChecked(), game_specific);
+    Config::setDirectMemoryAccess(ui->dmaCheckBox->isChecked(), game_specific);
+    Config::setDevKitConsole(ui->devkitCheckBox->isChecked(), game_specific);
+    Config::setNeoMode(ui->neoCheckBox->isChecked(), game_specific);
+    Config::setConnectedToNetwork(ui->networkConnectedCheckBox->isChecked(), game_specific);
+    Config::setPSNSignedIn(ui->psnSignInCheckBox->isChecked(), game_specific);
+
     Config::setIsFullscreen(
         screenModeMap.value(ui->displayModeComboBox->currentText()) != "Windowed", game_specific);
     Config::setFullscreenMode(
@@ -1043,8 +1039,6 @@ void SettingsDialog::UpdateSettings(bool game_specific) {
     Config::setVkHostMarkersEnabled(ui->hostMarkersCheckBox->isChecked(), game_specific);
     Config::setVkGuestMarkersEnabled(ui->guestMarkersCheckBox->isChecked(), game_specific);
     Config::setVkCrashDiagnosticEnabled(ui->crashDiagnosticsCheckBox->isChecked(), game_specific);
-    Config::setReadbacks(ui->readbacksCheckBox->isChecked(), game_specific);
-    Config::setReadbackLinearImages(ui->readbackLinearImagesCheckBox->isChecked(), game_specific);
     Config::setCollectShaderForDebug(ui->collectShaderCheckBox->isChecked(), game_specific);
     Config::setCopyGPUCmdBuffers(ui->copyGPUBuffersCheckBox->isChecked(), game_specific);
     Config::setChooseHomeTab(

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -1021,7 +1021,8 @@ void SettingsDialog::UpdateSettings(bool game_specific) {
     Config::setCursorHideTimeout(ui->hideCursorComboBox->currentIndex(), game_specific);
     Config::setGpuId(ui->graphicsAdapterBox->currentIndex() - 1, game_specific);
     Config::setVolumeSlider(ui->horizontalVolumeSlider->value(), game_specific);
-    Config::setLanguage(languageIndexes[ui->consoleLanguageComboBox->currentIndex()]);
+    Config::setLanguage(languageIndexes[ui->consoleLanguageComboBox->currentIndex()],
+                        game_specific);
     Config::setWindowWidth(ui->widthSpinBox->value(), game_specific);
     Config::setWindowHeight(ui->heightSpinBox->value(), game_specific);
     Config::setVblankFreq(ui->vblankSpinBox->value(), game_specific);

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -59,7 +59,10 @@
       </size>
      </property>
      <property name="currentIndex">
-      <number>7</number>
+      <number>1</number>
+     </property>
+     <property name="usesScrollButtons">
+      <bool>true</bool>
      </property>
      <widget class="QScrollArea" name="generalTab">
       <property name="widgetResizable">
@@ -138,14 +141,7 @@
                  <item>
                   <widget class="QCheckBox" name="showSplashCheckBox">
                    <property name="text">
-                    <string>Show Splash</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QCheckBox" name="discordRPCCheckbox">
-                   <property name="text">
-                    <string>Enable Discord Rich Presence</string>
+                    <string>Show Splash Screen When Launching Game</string>
                    </property>
                   </widget>
                  </item>
@@ -224,13 +220,82 @@
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="emulatorLanguageGroupBox">
+                <widget class="QGroupBox" name="volumeSliderElement">
                  <property name="title">
-                  <string>Emulator Language</string>
+                  <string>Volume</string>
                  </property>
-                 <layout class="QVBoxLayout" name="langSettingsLayout">
+                 <layout class="QVBoxLayout" name="volumeLayout">
                   <item>
-                   <widget class="QComboBox" name="emulatorLanguageComboBox"/>
+                   <widget class="QScrollArea" name="scrollArea">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="toolTip">
+                     <string/>
+                    </property>
+                    <property name="widgetResizable">
+                     <bool>true</bool>
+                    </property>
+                    <widget class="QWidget" name="scrollAreaWidgetContents_2">
+                     <property name="geometry">
+                      <rect>
+                       <x>0</x>
+                       <y>0</y>
+                       <width>503</width>
+                       <height>68</height>
+                      </rect>
+                     </property>
+                     <layout class="QHBoxLayout" name="horizontalLayout_6">
+                      <item>
+                       <widget class="QLineEdit" name="volumeText">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Fixed" vsizetype="Maximum">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="maximumSize">
+                         <size>
+                          <width>60</width>
+                          <height>16777215</height>
+                         </size>
+                        </property>
+                        <property name="text">
+                         <string notr="true">100%</string>
+                        </property>
+                        <property name="alignment">
+                         <set>Qt::AlignmentFlag::AlignCenter</set>
+                        </property>
+                        <property name="readOnly">
+                         <bool>true</bool>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QSlider" name="horizontalVolumeSlider">
+                        <property name="focusPolicy">
+                         <enum>Qt::FocusPolicy::StrongFocus</enum>
+                        </property>
+                        <property name="maximum">
+                         <number>500</number>
+                        </property>
+                        <property name="value">
+                         <number>100</number>
+                        </property>
+                        <property name="sliderPosition">
+                         <number>100</number>
+                        </property>
+                        <property name="orientation">
+                         <enum>Qt::Orientation::Horizontal</enum>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
+                   </widget>
                   </item>
                  </layout>
                 </widget>
@@ -273,240 +338,7 @@
             <property name="bottomMargin">
              <number>0</number>
             </property>
-            <item>
-             <widget class="QGroupBox" name="updaterGroupBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="title">
-               <string>Update</string>
-              </property>
-              <layout class="QVBoxLayout" name="UpdateLayout" stretch="0,0,0,0">
-               <property name="spacing">
-                <number>6</number>
-               </property>
-               <property name="topMargin">
-                <number>9</number>
-               </property>
-               <property name="rightMargin">
-                <number>9</number>
-               </property>
-               <property name="bottomMargin">
-                <number>80</number>
-               </property>
-               <item>
-                <widget class="QCheckBox" name="updateCheckBox">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="font">
-                  <font>
-                   <pointsize>11</pointsize>
-                   <bold>false</bold>
-                  </font>
-                 </property>
-                 <property name="text">
-                  <string>Check for Updates at Startup</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="changelogCheckBox">
-                 <property name="text">
-                  <string>Always Show Changelog</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="updaterComboBox">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="minimumSize">
-                  <size>
-                   <width>0</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                 <property name="maximumSize">
-                  <size>
-                   <width>16777215</width>
-                   <height>16777215</height>
-                  </size>
-                 </property>
-                 <property name="title">
-                  <string>Update Channel</string>
-                 </property>
-                 <layout class="QVBoxLayout" name="UpdateChannelLayout">
-                  <property name="spacing">
-                   <number>7</number>
-                  </property>
-                  <property name="leftMargin">
-                   <number>11</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>11</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>11</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>11</number>
-                  </property>
-                  <item>
-                   <widget class="QComboBox" name="updateComboBox">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <item>
-                     <property name="text">
-                      <string>Release</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Nightly</string>
-                     </property>
-                    </item>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QPushButton" name="checkUpdateButton">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="minimumSize">
-                  <size>
-                   <width>0</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                 <property name="maximumSize">
-                  <size>
-                   <width>16777215</width>
-                   <height>16777215</height>
-                  </size>
-                 </property>
-                 <property name="text">
-                  <string>Check for Updates</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
            </layout>
-          </item>
-          <item row="1" column="0">
-           <widget class="QGroupBox" name="volumeSliderElement">
-            <property name="title">
-             <string>Volume</string>
-            </property>
-            <layout class="QVBoxLayout" name="volumeLayout">
-             <item>
-              <widget class="QScrollArea" name="scrollArea">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="toolTip">
-                <string/>
-               </property>
-               <property name="widgetResizable">
-                <bool>true</bool>
-               </property>
-               <widget class="QWidget" name="scrollAreaWidgetContents_2">
-                <property name="geometry">
-                 <rect>
-                  <x>0</x>
-                  <y>0</y>
-                  <width>400</width>
-                  <height>68</height>
-                 </rect>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_6">
-                 <item>
-                  <widget class="QLineEdit" name="volumeText">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Fixed" vsizetype="Maximum">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>60</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                   <property name="text">
-                    <string notr="true">100%</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                   </property>
-                   <property name="readOnly">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSlider" name="horizontalVolumeSlider">
-                   <property name="focusPolicy">
-                    <enum>Qt::FocusPolicy::StrongFocus</enum>
-                   </property>
-                   <property name="maximum">
-                    <number>500</number>
-                   </property>
-                   <property name="value">
-                    <number>100</number>
-                   </property>
-                   <property name="sliderPosition">
-                    <number>100</number>
-                   </property>
-                   <property name="orientation">
-                    <enum>Qt::Orientation::Horizontal</enum>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </widget>
-             </item>
-            </layout>
-           </widget>
           </item>
           <item row="2" column="3">
            <spacer name="verticalSpacer_5">
@@ -531,15 +363,15 @@
        <bool>true</bool>
       </property>
       <attribute name="title">
-       <string>GUI</string>
+       <string>Frontend</string>
       </attribute>
       <widget class="QWidget" name="guiTabContents">
        <property name="geometry">
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>946</width>
-         <height>501</height>
+         <width>932</width>
+         <height>504</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -577,7 +409,7 @@
                </size>
               </property>
               <property name="title">
-               <string>GUI Settings</string>
+               <string>General Frontend Settings</string>
               </property>
               <layout class="QVBoxLayout" name="GUILayout">
                <property name="topMargin">
@@ -587,62 +419,10 @@
                 <number>9</number>
                </property>
                <item>
-                <widget class="QGroupBox" name="chooseHomeTabGroupBox">
-                 <property name="title">
-                  <string>Default tab when opening settings</string>
+                <widget class="QCheckBox" name="discordRPCCheckbox">
+                 <property name="text">
+                  <string>Enable Discord Rich Presence</string>
                  </property>
-                 <layout class="QVBoxLayout" name="tabSettingsLayout">
-                  <item>
-                   <widget class="QComboBox" name="chooseHomeTabComboBox">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <item>
-                     <property name="text">
-                      <string>General</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>GUI</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Graphics</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>User</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Input</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Paths</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Log</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Debug</string>
-                     </property>
-                    </item>
-                   </widget>
-                  </item>
-                 </layout>
                 </widget>
                </item>
                <item>
@@ -650,6 +430,18 @@
                  <property name="text">
                   <string>Show Game Size In List</string>
                  </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="emulatorLanguageGroupBox">
+                 <property name="title">
+                  <string>Emulator Language</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="langSettingsLayout">
+                  <item>
+                   <widget class="QComboBox" name="emulatorLanguageComboBox"/>
+                  </item>
+                 </layout>
                 </widget>
                </item>
                <item>
@@ -865,6 +657,45 @@
                  </widget>
                 </widget>
                </item>
+               <item>
+                <widget class="QGroupBox" name="groupBox">
+                 <property name="title">
+                  <string>Trophy Key</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_6">
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_trophyKey">
+                    <property name="bottomMargin">
+                     <number>0</number>
+                    </property>
+                    <item>
+                     <widget class="QLabel" name="label_Trophy">
+                      <property name="text">
+                       <string>Trophy Key</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLineEdit" name="trophyKeyLineEdit">
+                      <property name="minimumSize">
+                       <size>
+                        <width>0</width>
+                        <height>0</height>
+                       </size>
+                      </property>
+                      <property name="font">
+                       <font>
+                        <pointsize>10</pointsize>
+                        <bold>false</bold>
+                       </font>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
               </layout>
              </widget>
             </item>
@@ -967,17 +798,156 @@
              </widget>
             </item>
             <item>
-             <spacer name="verticalSpacer_6">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
+             <widget class="QGroupBox" name="updaterGroupBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
               </property>
-              <property name="sizeHint" stdset="0">
+              <property name="minimumSize">
                <size>
-                <width>20</width>
-                <height>40</height>
+                <width>0</width>
+                <height>0</height>
                </size>
               </property>
-             </spacer>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="title">
+               <string>Update</string>
+              </property>
+              <layout class="QVBoxLayout" name="UpdateLayout" stretch="0,0,0,0">
+               <property name="spacing">
+                <number>6</number>
+               </property>
+               <property name="topMargin">
+                <number>9</number>
+               </property>
+               <property name="rightMargin">
+                <number>9</number>
+               </property>
+               <property name="bottomMargin">
+                <number>80</number>
+               </property>
+               <item>
+                <widget class="QCheckBox" name="updateCheckBox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="font">
+                  <font>
+                   <pointsize>11</pointsize>
+                   <bold>false</bold>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string>Check for Updates at Startup</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="changelogCheckBox">
+                 <property name="text">
+                  <string>Always Show Changelog</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="updaterComboBox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>16777215</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="title">
+                  <string>Update Channel</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="UpdateChannelLayout">
+                  <property name="spacing">
+                   <number>7</number>
+                  </property>
+                  <property name="leftMargin">
+                   <number>11</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>11</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>11</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>11</number>
+                  </property>
+                  <item>
+                   <widget class="QComboBox" name="updateComboBox">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <item>
+                     <property name="text">
+                      <string>Release</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Nightly</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="checkUpdateButton">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>16777215</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>Check for Updates</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
             </item>
            </layout>
           </item>
@@ -1560,36 +1530,6 @@
                 </layout>
                </item>
                <item>
-                <layout class="QHBoxLayout" name="horizontalLayout_trophyKey">
-                 <property name="bottomMargin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <widget class="QLabel" name="label_Trophy">
-                   <property name="text">
-                    <string>Trophy Key</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLineEdit" name="trophyKeyLineEdit">
-                   <property name="minimumSize">
-                    <size>
-                     <width>0</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="font">
-                    <font>
-                     <pointsize>10</pointsize>
-                     <bold>false</bold>
-                    </font>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item>
                 <widget class="QPushButton" name="OpenCustomTrophyLocationButton">
                  <property name="text">
                   <string>Open the custom trophy images/sounds folder</string>
@@ -1601,6 +1541,93 @@
             </item>
             <item>
              <spacer name="horizontalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_5">
+            <item>
+             <widget class="QGroupBox" name="chooseHomeTabGroupBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="title">
+               <string>Default tab when opening settings</string>
+              </property>
+              <layout class="QVBoxLayout" name="tabSettingsLayout">
+               <item>
+                <widget class="QComboBox" name="chooseHomeTabComboBox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <item>
+                  <property name="text">
+                   <string>General</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Frontend</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Graphics</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>User</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Input</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Paths</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Log</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Debug</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Experimental</string>
+                  </property>
+                 </item>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_7">
               <property name="orientation">
                <enum>Qt::Orientation::Horizontal</enum>
               </property>
@@ -1651,7 +1678,7 @@
          <height>501</height>
         </rect>
        </property>
-       <layout class="QVBoxLayout" name="inputTabVLayout" stretch="0,0">
+       <layout class="QVBoxLayout" name="inputTabVLayout" stretch="0,0,0">
         <item>
          <layout class="QHBoxLayout" name="inputTabHLayoutTop" stretch="1,1">
           <item>
@@ -1872,30 +1899,31 @@
            <layout class="QHBoxLayout" name="micTabLayoutLeft">
             <item>
              <widget class="QGroupBox" name="MicGroupBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="title">
                <string>Microphone</string>
               </property>
-              <widget class="QComboBox" name="micComboBox">
-               <property name="geometry">
-                <rect>
-                 <x>14</x>
-                 <y>33</y>
-                 <width>431</width>
-                 <height>31</height>
-                </rect>
-               </property>
-              </widget>
+              <layout class="QHBoxLayout" name="horizontalLayout_7">
+               <item>
+                <widget class="QComboBox" name="micComboBox"/>
+               </item>
+              </layout>
              </widget>
             </item>
             <item>
-             <spacer name="verticalSpacer_8">
+             <spacer name="horizontalSpacer_8">
               <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
-                <width>0</width>
-                <height>40</height>
+                <width>40</width>
+                <height>20</height>
                </size>
               </property>
              </spacer>
@@ -1903,6 +1931,19 @@
            </layout>
           </item>
          </layout>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_11">
+          <property name="orientation">
+           <enum>Qt::Orientation::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
         </item>
        </layout>
       </widget>
@@ -2234,8 +2275,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>932</width>
-         <height>507</height>
+         <width>946</width>
+         <height>229</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -2380,123 +2421,6 @@
            </layout>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="experimentalHLayout">
-            <item>
-             <widget class="QGroupBox" name="ExperimentalGroupBox">
-              <property name="title">
-               <string>Experimental Features</string>
-              </property>
-              <layout class="QVBoxLayout" name="verticalLayout_3">
-               <property name="spacing">
-                <number>6</number>
-               </property>
-               <property name="leftMargin">
-                <number>9</number>
-               </property>
-               <property name="topMargin">
-                <number>9</number>
-               </property>
-               <property name="rightMargin">
-                <number>9</number>
-               </property>
-               <property name="bottomMargin">
-                <number>9</number>
-               </property>
-               <item>
-                <widget class="QCheckBox" name="readbacksCheckBox">
-                 <property name="text">
-                  <string>Enable Readbacks</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="readbackLinearImagesCheckBox">
-                 <property name="text">
-                  <string>Enable Readback Linear Images</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="dmaCheckBox">
-                 <property name="text">
-                  <string>Enable Direct Memory Access</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="devkitCheckBox">
-                 <property name="text">
-                  <string>Enable Devkit Console Mode</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="neoCheckBox">
-                 <property name="text">
-                  <string>Enable PS4 Neo Mode</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="psnSignInCheckBox">
-                 <property name="text">
-                  <string>Set &quot;PSN signed-in&quot; to True</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="networkConnectedCheckBox">
-                 <property name="text">
-                  <string>Set &quot;Network Connected&quot; to True</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="ExperimentalLabel">
-              <property name="sizeIncrement">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="baseSize">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>11</pointsize>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string>WARNING: These features are experimental and should not be enabled unless you were told to, or a game requires it. Please ask in the shadPS4 Discord server if you have any questions.</string>
-              </property>
-              <property name="scaledContents">
-               <bool>false</bool>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-              <property name="margin">
-               <number>20</number>
-              </property>
-              <property name="indent">
-               <number>-1</number>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
            <spacer name="verticalSpacer_10">
             <property name="orientation">
              <enum>Qt::Orientation::Vertical</enum>
@@ -2513,6 +2437,149 @@
         </item>
        </layout>
       </widget>
+     </widget>
+     <widget class="QWidget" name="experimentalTab">
+      <attribute name="title">
+       <string>Experimental</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <widget class="QScrollArea" name="scrollArea_2">
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="scrollAreaWidgetContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>928</width>
+            <height>483</height>
+           </rect>
+          </property>
+          <layout class="QFormLayout" name="formLayout">
+           <item row="0" column="0" colspan="2">
+            <layout class="QHBoxLayout" name="experimentalHLayout">
+             <item>
+              <widget class="QGroupBox" name="ExperimentalGroupBox">
+               <property name="title">
+                <string>Experimental Features</string>
+               </property>
+               <layout class="QVBoxLayout" name="verticalLayout_3">
+                <property name="spacing">
+                 <number>6</number>
+                </property>
+                <property name="leftMargin">
+                 <number>9</number>
+                </property>
+                <property name="topMargin">
+                 <number>9</number>
+                </property>
+                <property name="rightMargin">
+                 <number>9</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>9</number>
+                </property>
+                <item>
+                 <widget class="QCheckBox" name="readbacksCheckBox">
+                  <property name="text">
+                   <string>Enable Readbacks</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="readbackLinearImagesCheckBox">
+                  <property name="text">
+                   <string>Enable Readback Linear Images</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="dmaCheckBox">
+                  <property name="text">
+                   <string>Enable Direct Memory Access</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="devkitCheckBox">
+                  <property name="text">
+                   <string>Enable Devkit Console Mode</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="neoCheckBox">
+                  <property name="text">
+                   <string>Enable PS4 Pro Mode</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="psnSignInCheckBox">
+                  <property name="text">
+                   <string>Set &quot;PSN signed-in&quot; to True</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="networkConnectedCheckBox">
+                  <property name="text">
+                   <string>Set &quot;Network Connected&quot; to True</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="ExperimentalLabel">
+               <property name="sizeIncrement">
+                <size>
+                 <width>0</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="baseSize">
+                <size>
+                 <width>0</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="font">
+                <font>
+                 <pointsize>11</pointsize>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string>WARNING: These features are experimental and should not be enabled unless you were told to, or a game requires it. Please ask in the shadPS4 Discord server if you have any questions.</string>
+               </property>
+               <property name="scaledContents">
+                <bool>false</bool>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
+               <property name="margin">
+                <number>20</number>
+               </property>
+               <property name="indent">
+                <number>-1</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
      </widget>
     </widget>
    </item>

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -59,7 +59,7 @@
       </size>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <property name="usesScrollButtons">
       <bool>true</bool>
@@ -109,7 +109,7 @@
                </sizepolicy>
               </property>
               <property name="title">
-               <string>Emulator</string>
+               <string>Miscellaneous</string>
               </property>
               <property name="flat">
                <bool>false</bool>
@@ -117,7 +117,7 @@
               <property name="checkable">
                <bool>false</bool>
               </property>
-              <layout class="QVBoxLayout" name="additionalSettingsVLayout" stretch="0">
+              <layout class="QVBoxLayout" name="additionalSettingsVLayout" stretch="0,0,0">
                <property name="spacing">
                 <number>6</number>
                </property>
@@ -134,36 +134,112 @@
                 <number>9</number>
                </property>
                <item>
-                <layout class="QVBoxLayout" name="emulatorverticalLayout">
-                 <property name="spacing">
-                  <number>10</number>
+                <widget class="QGroupBox" name="chooseHomeTabGroupBox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
                  </property>
-                 <item>
-                  <widget class="QCheckBox" name="showSplashCheckBox">
-                   <property name="text">
-                    <string>Show Splash Screen When Launching Game</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="verticalSpacer_9">
-                   <property name="orientation">
-                    <enum>Qt::Orientation::Vertical</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>20</width>
-                     <height>40</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
+                 <property name="title">
+                  <string>Default tab when opening settings</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="tabSettingsLayout">
+                  <item>
+                   <widget class="QComboBox" name="chooseHomeTabComboBox">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <item>
+                     <property name="text">
+                      <string>General</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Frontend</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Graphics</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>User</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Input</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Paths</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Log</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Debug</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Experimental</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="showSplashCheckBox">
+                 <property name="text">
+                  <string>Show Splash Screen When Launching Game</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacer_9">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>40</height>
+                  </size>
+                 </property>
+                </spacer>
                </item>
               </layout>
              </widget>
             </item>
            </layout>
+          </item>
+          <item row="2" column="0">
+           <spacer name="verticalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Orientation::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
           </item>
           <item row="2" column="2">
            <spacer name="verticalSpacer_4">
@@ -244,7 +320,7 @@
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>503</width>
+                       <width>408</width>
                        <height>68</height>
                       </rect>
                      </property>
@@ -305,54 +381,6 @@
             </item>
            </layout>
           </item>
-          <item row="2" column="0">
-           <spacer name="verticalSpacer_3">
-            <property name="orientation">
-             <enum>Qt::Orientation::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="0" column="3">
-           <layout class="QVBoxLayout" name="updaterTabLayoutLeft">
-            <property name="spacing">
-             <number>6</number>
-            </property>
-            <property name="sizeConstraint">
-             <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
-            </property>
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="rightMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>0</number>
-            </property>
-           </layout>
-          </item>
-          <item row="2" column="3">
-           <spacer name="verticalSpacer_5">
-            <property name="orientation">
-             <enum>Qt::Orientation::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
          </layout>
         </item>
        </layout>
@@ -371,7 +399,7 @@
          <x>0</x>
          <y>0</y>
          <width>932</width>
-         <height>504</height>
+         <height>507</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -1555,91 +1583,7 @@
            </layout>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_5">
-            <item>
-             <widget class="QGroupBox" name="chooseHomeTabGroupBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>Default tab when opening settings</string>
-              </property>
-              <layout class="QVBoxLayout" name="tabSettingsLayout">
-               <item>
-                <widget class="QComboBox" name="chooseHomeTabComboBox">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <item>
-                  <property name="text">
-                   <string>General</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Frontend</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Graphics</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>User</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Input</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Paths</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Log</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Debug</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Experimental</string>
-                  </property>
-                 </item>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_7">
-              <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
+           <layout class="QHBoxLayout" name="horizontalLayout_5"/>
           </item>
          </layout>
         </item>
@@ -2276,7 +2220,7 @@
          <x>0</x>
          <y>0</y>
          <width>946</width>
-         <height>229</height>
+         <height>234</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -2444,11 +2388,11 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
-        <widget class="QScrollArea" name="scrollArea_2">
+        <widget class="QScrollArea" name="experimtenalScrollArea">
          <property name="widgetResizable">
           <bool>true</bool>
          </property>
-         <widget class="QWidget" name="scrollAreaWidgetContents">
+         <widget class="QWidget" name="experimentalTabContents">
           <property name="geometry">
            <rect>
             <x>0</x>

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -2512,7 +2512,7 @@
                 <item>
                  <widget class="QCheckBox" name="neoCheckBox">
                   <property name="text">
-                   <string>Enable PS4 Pro Mode</string>
+                   <string>Enable PS4 Neo Mode</string>
                   </property>
                  </widget>
                 </item>

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -59,7 +59,7 @@
       </size>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <property name="usesScrollButtons">
       <bool>true</bool>
@@ -743,7 +743,7 @@
            </layout>
           </item>
           <item>
-           <layout class="QVBoxLayout" name="CompatTabLayoutRight" stretch="0,0">
+           <layout class="QVBoxLayout" name="CompatTabLayoutRight" stretch="0,0,0">
             <property name="spacing">
              <number>6</number>
             </property>
@@ -976,6 +976,19 @@
                </item>
               </layout>
              </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_5">
+              <property name="orientation">
+               <enum>Qt::Orientation::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
             </item>
            </layout>
           </item>
@@ -2382,148 +2395,158 @@
        </layout>
       </widget>
      </widget>
-     <widget class="QWidget" name="experimentalTab">
+     <widget class="QScrollArea" name="experimentalTab">
+      <property name="widgetResizable">
+       <bool>true</bool>
+      </property>
       <attribute name="title">
        <string>Experimental</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_4">
-       <item>
-        <widget class="QScrollArea" name="experimtenalScrollArea">
-         <property name="widgetResizable">
-          <bool>true</bool>
-         </property>
-         <widget class="QWidget" name="experimentalTabContents">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>928</width>
-            <height>483</height>
-           </rect>
-          </property>
-          <layout class="QFormLayout" name="formLayout">
-           <item row="0" column="0" colspan="2">
-            <layout class="QHBoxLayout" name="experimentalHLayout">
-             <item>
-              <widget class="QGroupBox" name="ExperimentalGroupBox">
-               <property name="title">
-                <string>Experimental Features</string>
+      <widget class="QWidget" name="experimentalTabContents">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>946</width>
+         <height>287</height>
+        </rect>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <layout class="QVBoxLayout" name="debugTabVLayout2" stretch="0">
+        <item>
+         <layout class="QVBoxLayout" name="experimentalVLayout">
+          <item>
+           <layout class="QHBoxLayout" name="experimentalHLayout">
+            <item>
+             <widget class="QGroupBox" name="experimentalGroupBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="title">
+               <string>Experimental Features</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_3">
+               <property name="spacing">
+                <number>6</number>
                </property>
-               <layout class="QVBoxLayout" name="verticalLayout_3">
-                <property name="spacing">
-                 <number>6</number>
-                </property>
-                <property name="leftMargin">
-                 <number>9</number>
-                </property>
-                <property name="topMargin">
-                 <number>9</number>
-                </property>
-                <property name="rightMargin">
-                 <number>9</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>9</number>
-                </property>
-                <item>
-                 <widget class="QCheckBox" name="readbacksCheckBox">
-                  <property name="text">
-                   <string>Enable Readbacks</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="readbackLinearImagesCheckBox">
-                  <property name="text">
-                   <string>Enable Readback Linear Images</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="dmaCheckBox">
-                  <property name="text">
-                   <string>Enable Direct Memory Access</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="devkitCheckBox">
-                  <property name="text">
-                   <string>Enable Devkit Console Mode</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="neoCheckBox">
-                  <property name="text">
-                   <string>Enable PS4 Neo Mode</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="psnSignInCheckBox">
-                  <property name="text">
-                   <string>Set &quot;PSN signed-in&quot; to True</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="networkConnectedCheckBox">
-                  <property name="text">
-                   <string>Set &quot;Network Connected&quot; to True</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="ExperimentalLabel">
-               <property name="sizeIncrement">
-                <size>
-                 <width>0</width>
-                 <height>0</height>
-                </size>
+               <property name="leftMargin">
+                <number>9</number>
                </property>
-               <property name="baseSize">
-                <size>
-                 <width>0</width>
-                 <height>0</height>
-                </size>
+               <property name="topMargin">
+                <number>9</number>
                </property>
-               <property name="font">
-                <font>
-                 <pointsize>11</pointsize>
-                 <bold>true</bold>
-                </font>
+               <property name="rightMargin">
+                <number>9</number>
                </property>
-               <property name="text">
-                <string>WARNING: These features are experimental and should not be enabled unless you were told to, or a game requires it. Please ask in the shadPS4 Discord server if you have any questions.</string>
+               <property name="bottomMargin">
+                <number>9</number>
                </property>
-               <property name="scaledContents">
-                <bool>false</bool>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-               </property>
-               <property name="wordWrap">
-                <bool>true</bool>
-               </property>
-               <property name="margin">
-                <number>20</number>
-               </property>
-               <property name="indent">
-                <number>-1</number>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-          </layout>
-         </widget>
-        </widget>
-       </item>
-      </layout>
+               <item>
+                <widget class="QCheckBox" name="readbacksCheckBox">
+                 <property name="text">
+                  <string>Enable Readbacks</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="readbackLinearImagesCheckBox">
+                 <property name="text">
+                  <string>Enable Readback Linear Images</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="dmaCheckBox">
+                 <property name="text">
+                  <string>Enable Direct Memory Access</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="devkitCheckBox">
+                 <property name="text">
+                  <string>Enable Devkit Console Mode</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="neoCheckBox">
+                 <property name="text">
+                  <string>Enable PS4 Neo Mode</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="psnSignInCheckBox">
+                 <property name="text">
+                  <string>Set &quot;PSN signed-in&quot; to True</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="networkConnectedCheckBox">
+                 <property name="text">
+                  <string>Set &quot;Network Connected&quot; to True</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="ExperimentalLabel">
+              <property name="sizeIncrement">
+               <size>
+                <width>0</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="baseSize">
+               <size>
+                <width>0</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>11</pointsize>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string>WARNING: These features are experimental and should not be enabled unless you were told to, or a game requires it. Please ask in the shadPS4 Discord server if you have any questions.</string>
+              </property>
+              <property name="scaledContents">
+               <bool>false</bool>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+              <property name="margin">
+               <number>20</number>
+              </property>
+              <property name="indent">
+               <number>-1</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
      </widget>
     </widget>
    </item>


### PR DESCRIPTION
Right now in the game-specific GUI, each individual item has to be manually hidden if it shares a tab with the non-game-specific item, and vice versa.

This simplifies adding items to the GUI (just add them to the appropriate tabs if game specific or non game-specific), and everything that needs to be hidden will already be hidden.

Hiding individual items within tabs also causes certain elements to stretch, so it's also kinda ugly that way.

This however means I kinda had to force certain entries in certain tabs. A couple of things that some might not like:
1) Trophy key put in the Frontend Tab (formerly the GUI tab)
2) Default settings tab put in the User Tab

Also, I moved the readbacks and readbacklinearimages to the experimental tab that is only accessible via custom configs. I think it makes sense since you want to enable those on a per-game basis anyway and it's not something probably that we want the casual users touching a lot since we acknowledge that it's experimental

Let me know if this seems iffy