### PR TITLE
vk_rasterizer: Only assert on primitive restart if performing indexed draw.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -90,10 +90,10 @@ private:
     void DepthStencilCopy(bool is_depth, bool is_stencil);
     void EliminateFastClear();
 
-    void UpdateDynamicState(const GraphicsPipeline& pipeline) const;
+    void UpdateDynamicState(const GraphicsPipeline& pipeline, bool is_indexed) const;
     void UpdateViewportScissorState() const;
     void UpdateDepthStencilState() const;
-    void UpdatePrimitiveState() const;
+    void UpdatePrimitiveState(bool is_indexed) const;
     void UpdateRasterizationState() const;
 
     bool FilterDraw();


### PR DESCRIPTION
Primitive restart only matters if we are actually performing an indexed draw, so don't assert on unsupported restart index if the draw is not indexed.

Fixes instance of this assert in UFC.