### PR TITLE
video_core: Upload buffer memory around unmapped pages

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -923,7 +923,7 @@ vk::Buffer BufferCache::UploadCopies(Buffer& buffer, std::span<vk::BufferCopy> c
         for (auto& copy : copies) {
             u8* const src_pointer = staging + copy.srcOffset;
             const VAddr device_addr = buffer.CpuAddr() + copy.dstOffset;
-            std::memcpy(src_pointer, std::bit_cast<const u8*>(device_addr), copy.size);
+            memory->CopySparseMemory(device_addr, src_pointer, copy.size);
             // Apply the staging offset
             copy.srcOffset += offset;
         }
@@ -939,7 +939,7 @@ vk::Buffer BufferCache::UploadCopies(Buffer& buffer, std::span<vk::BufferCopy> c
         for (const auto& copy : copies) {
             u8* const src_pointer = staging + copy.srcOffset;
             const VAddr device_addr = buffer.CpuAddr() + copy.dstOffset;
-            std::memcpy(src_pointer, std::bit_cast<const u8*>(device_addr), copy.size);
+            memory->CopySparseMemory(device_addr, src_pointer, copy.size);
         }
         scheduler.DeferOperation([buffer = std::move(temp_buffer)]() mutable { buffer.reset(); });
         return src_buffer;

--- a/src/video_core/page_manager.cpp
+++ b/src/video_core/page_manager.cpp
@@ -248,9 +248,11 @@ struct PageManager::Impl {
         // Iterate requested pages
         const u64 aligned_addr = page << PAGE_BITS;
         const u64 aligned_end = page_end << PAGE_BITS;
-        ASSERT_MSG(rasterizer->IsMapped(aligned_addr, aligned_end - aligned_addr),
-                   "Attempted to track non-GPU memory at address {:#x}, size {:#x}.", aligned_addr,
-                   aligned_end - aligned_addr);
+        if (!rasterizer->IsMapped(aligned_addr, aligned_end - aligned_addr)) {
+            LOG_WARNING(Render,
+                        "Tracking memory region {:#x} - {:#x} which is not fully GPU mapped.",
+                        aligned_addr, aligned_end);
+        }
 
         for (; page != page_end; ++page) {
             PageState& state = cached_pages[page];


### PR DESCRIPTION
* Use `CopySparseMemory` to copy memory for buffer upload, to copy around unmapped pages.
  * Remove `prt_areas` check optimization in `CopySparseMemory` to allow this use case.
* Bump `ClampRangeSize` threshold back up as this should handle more cases that would have applied to.
* Downgrade GPU memory assert to warning.

Should take care of GPU memory assert in Ratchet & Clank (2016).