### PR TITLE
build: Fix a few warnings

### DIFF
--- a/src/core/devtools/widget/memory_map.cpp
+++ b/src/core/devtools/widget/memory_map.cpp
@@ -26,7 +26,7 @@ bool MemoryMapViewer::Iterator::DrawLine() {
         TableNextColumn();
         Text("%" PRIXPTR, m.base);
         TableNextColumn();
-        Text("%zX", m.size);
+        Text("%llX", m.size);
         TableNextColumn();
         Text("%s", magic_enum::enum_name(m.type).data());
         TableNextColumn();
@@ -51,7 +51,7 @@ bool MemoryMapViewer::Iterator::DrawLine() {
     TableNextColumn();
     Text("%" PRIXPTR, m.base);
     TableNextColumn();
-    Text("%zX", m.size);
+    Text("%llX", m.size);
     TableNextColumn();
     auto type = static_cast<::Libraries::Kernel::MemoryTypes>(m.memory_type);
     Text("%s", magic_enum::enum_name(type).data());

--- a/src/video_core/renderer_vulkan/vk_presenter.cpp
+++ b/src/video_core/renderer_vulkan/vk_presenter.cpp
@@ -461,7 +461,9 @@ void Presenter::Present(Frame* frame, bool is_reusing_frame) {
     // Reset fence for queue submission. Do it here instead of GetRenderFrame() because we may
     // skip frame because of slow swapchain recreation. If a frame skip occurs, we skip signal
     // the frame's present fence and future GetRenderFrame() call will hang waiting for this frame.
-    instance.GetDevice().resetFences(frame->present_done);
+    const auto reset_result = instance.GetDevice().resetFences(frame->present_done);
+    ASSERT_MSG(reset_result == vk::Result::eSuccess,
+               "Unexpected error resetting present done fence: {}", vk::to_string(reset_result));
 
     ImGuiID dockId = ImGui::Core::NewFrame(is_reusing_frame);
 

--- a/src/video_core/renderer_vulkan/vk_resource_pool.cpp
+++ b/src/video_core/renderer_vulkan/vk_resource_pool.cpp
@@ -151,12 +151,15 @@ vk::DescriptorSet DescriptorHeap::Commit(vk::DescriptorSetLayout set_layout) {
     // The pool has run out. Record current tick and place it in pending list.
     ASSERT_MSG(result == vk::Result::eErrorOutOfPoolMemory ||
                    result == vk::Result::eErrorFragmentedPool,
-               "Unexpected error during descriptor set allocation {}", vk::to_string(result));
+               "Unexpected error during descriptor set allocation: {}", vk::to_string(result));
     pending_pools.emplace_back(curr_pool, master_semaphore->CurrentTick());
     if (const auto [pool, tick] = pending_pools.front(); master_semaphore->IsFree(tick)) {
         curr_pool = pool;
         pending_pools.pop_front();
-        device.resetDescriptorPool(curr_pool);
+
+        const auto reset_result = device.resetDescriptorPool(curr_pool);
+        ASSERT_MSG(reset_result == vk::Result::eSuccess,
+                   "Unexpected error resetting descriptor pool: {}", vk::to_string(reset_result));
     } else {
         CreateDescriptorPool();
     }


### PR DESCRIPTION
* Use proper format string for `u64` values for some dev tools text.
* Check result values when resetting descriptor pools and present done fence.