### PR TITLE
externals/MoltenVK: Disable MVK_USE_METAL_PRIVATE_API

### DIFF
--- a/externals/MoltenVK/CMakeLists.txt
+++ b/externals/MoltenVK/CMakeLists.txt
@@ -90,4 +90,4 @@ target_compile_options(MoltenVK PRIVATE -w)
 target_link_libraries(MoltenVK PRIVATE
         ${APPKIT_LIBRARY} ${FOUNDATION_LIBRARY} ${IOKIT_LIBRARY} ${IOSURFACE_LIBRARY} ${METAL_LIBRARY} ${QUARTZCORE_LIBRARY}
         Vulkan::Headers cereal::cereal spirv-cross-msl MoltenVKCommon MoltenVKShaderConverter)
-target_compile_definitions(MoltenVK PRIVATE MVK_FRAMEWORK_VERSION=${MVK_VERSION} MVK_USE_METAL_PRIVATE_API=1)
+target_compile_definitions(MoltenVK PRIVATE MVK_FRAMEWORK_VERSION=${MVK_VERSION})


### PR DESCRIPTION
This is primarily used for sampler lod bias and logic op, but is currently causing macOS compilation to fail in CI as the latest Xcode/macOS made the private API for sampler lod bias public and the definitions are conflicting.

I have a PR to fix this in MoltenVK which I'll pull in when it's merged, then I can re-enable this.