### PR TITLE
kernel: Improvements to condvars.

### DIFF
--- a/src/core/libraries/kernel/threads/mutex.cpp
+++ b/src/core/libraries/kernel/threads/mutex.cpp
@@ -282,13 +282,13 @@ int PthreadMutex::Unlock() {
     if (Type() == PthreadMutexType::Recursive && m_count > 0) [[unlikely]] {
         m_count--;
     } else {
-        int defered = True(m_flags & PthreadMutexFlags::Defered);
-        m_flags &= ~PthreadMutexFlags::Defered;
+        const bool deferred = True(m_flags & PthreadMutexFlags::Deferred);
+        m_flags &= ~PthreadMutexFlags::Deferred;
 
         m_owner = nullptr;
         m_lock.unlock();
 
-        if (curthread->will_sleep == 0 && defered) {
+        if (curthread->will_sleep == 0 && deferred) {
             curthread->WakeAll();
         }
     }

--- a/src/core/libraries/kernel/threads/pthread.h
+++ b/src/core/libraries/kernel/threads/pthread.h
@@ -27,7 +27,7 @@ struct Pthread;
 
 enum class PthreadMutexFlags : u32 {
     TypeMask = 0xff,
-    Defered = 0x200,
+    Deferred = 0x200,
 };
 DECLARE_ENUM_FLAG_OPERATORS(PthreadMutexFlags)
 
@@ -319,8 +319,13 @@ struct Pthread {
         nwaiter_defer = 0;
     }
 
+    void ClearWake() {
+        // Try to acquire wake semaphore to reset it.
+        void(wake_sema.try_acquire());
+    }
+
     bool Sleep(const OrbisKernelTimespec* abstime, u64 usec) {
-        will_sleep = 0;
+        will_sleep = false;
         if (nwaiter_defer > 0) {
             WakeAll();
         }

--- a/src/core/libraries/kernel/threads/sleepq.cpp
+++ b/src/core/libraries/kernel/threads/sleepq.cpp
@@ -53,7 +53,7 @@ void SleepqAdd(void* wchan, Pthread* td) {
         sq->sq_wchan = wchan;
         /* sq->sq_type = type; */
     }
-    td->sleepqueue = NULL;
+    td->sleepqueue = nullptr;
     td->wchan = wchan;
     sq->sq_blocked.push_front(td);
 }
@@ -88,10 +88,10 @@ void SleepqDrop(SleepQueue* sq, void (*callback)(Pthread*, void*), void* arg) {
     td->wchan = nullptr;
 
     auto sq2 = sq->sq_freeq.begin();
-    for (Pthread* td : sq->sq_blocked) {
-        callback(td, arg);
-        td->sleepqueue = std::addressof(*sq2);
-        td->wchan = nullptr;
+    for (Pthread* td2 : sq->sq_blocked) {
+        callback(td2, arg);
+        td2->sleepqueue = std::addressof(*sq2);
+        td2->wchan = nullptr;
         ++sq2;
     }
     sq->sq_blocked.clear();

--- a/src/core/libraries/kernel/time.cpp
+++ b/src/core/libraries/kernel/time.cpp
@@ -16,7 +16,7 @@
 #include <windows.h>
 #include "common/ntapi.h"
 #else
-#if __APPLE__
+#ifdef __APPLE__
 #include <date/tz.h>
 #endif
 #include <ctime>


### PR DESCRIPTION
Some misc changes I made while investigating a condvar issue:
* Fix an oversight in Windows semaphore `try_acquire_for` where the time since the start of the acquire would be subtracted from the remaining time each iteration instead of the time since that iteration started.
* Simplify semaphore `try_acquire_until` to utilize other existing functions instead of requiring its own platform implementations.
* Few type and typo fixes in condvar and mutex code.
* Misc change in time code to check `__APPLE__` definition properly.