### PR TITLE
externals: Update MoltenVK and re-enable private API use

### DIFF
--- a/externals/MoltenVK/CMakeLists.txt
+++ b/externals/MoltenVK/CMakeLists.txt
@@ -90,4 +90,4 @@ target_compile_options(MoltenVK PRIVATE -w)
 target_link_libraries(MoltenVK PRIVATE
         ${APPKIT_LIBRARY} ${FOUNDATION_LIBRARY} ${IOKIT_LIBRARY} ${IOSURFACE_LIBRARY} ${METAL_LIBRARY} ${QUARTZCORE_LIBRARY}
         Vulkan::Headers cereal::cereal spirv-cross-msl MoltenVKCommon MoltenVKShaderConverter)
-target_compile_definitions(MoltenVK PRIVATE MVK_FRAMEWORK_VERSION=${MVK_VERSION})
+target_compile_definitions(MoltenVK PRIVATE MVK_FRAMEWORK_VERSION=${MVK_VERSION} MVK_USE_METAL_PRIVATE_API=1)


### PR DESCRIPTION
Fix for the previous build failure landed upstream, so updating and re-enabling private API use.