### PR TITLE
liverpool: Finish GPU work before signaling idle.

### DIFF
--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -139,7 +139,7 @@ void Liverpool::Process(std::stop_token stoken) {
             VideoCore::EndCapture();
             if (rasterizer) {
                 rasterizer->OnSubmit();
-                rasterizer->Flush();
+                rasterizer->Finish();
             }
             submit_done = false;
         }


### PR DESCRIPTION
Finish pending GPU work before signaling the `GpuIdle` interrupt, to make sure the guest sees the results in case of e.g. readbacks.

This also fixes Ratchet & Clank (2016) same as https://github.com/shadps4-emu/shadPS4/pull/3593, but with a simpler solution that allows continuing to use scheduler deferred operations.

Performance testing compared to main is appreciated to see if this significantly impacts performance or not.