### PR TITLE
kernel: More thread code clean-up.

### DIFF
--- a/src/core/libraries/kernel/threads/event_flag.cpp
+++ b/src/core/libraries/kernel/threads/event_flag.cpp
@@ -187,8 +187,7 @@ int PS4_SYSV_ABI sceKernelCreateEventFlag(OrbisKernelEventFlag* ef, const char* 
     if (ef == nullptr || pName == nullptr) {
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
-    if (pOptParam || !pName ||
-        attr > (ORBIS_KERNEL_EVF_ATTR_MULTI | ORBIS_KERNEL_EVF_ATTR_TH_PRIO)) {
+    if (pOptParam || attr > (ORBIS_KERNEL_EVF_ATTR_MULTI | ORBIS_KERNEL_EVF_ATTR_TH_PRIO)) {
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
 
@@ -364,8 +363,7 @@ int PS4_SYSV_ABI sceKernelWaitEventFlag(OrbisKernelEventFlag ef, u64 bitPattern,
         UNREACHABLE();
     }
 
-    u32 result = ef->Wait(bitPattern, wait, clear, pResultPat, pTimeout);
-
+    const int result = ef->Wait(bitPattern, wait, clear, pResultPat, pTimeout);
     if (result != ORBIS_OK && result != ORBIS_KERNEL_ERROR_ETIMEDOUT) {
         LOG_DEBUG(Kernel_Event, "returned {:#x}", result);
     }

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -10,7 +10,7 @@
 #ifdef _WIN64
 #include "common/ntapi.h"
 #else
-#include <signal.h>
+#include <csignal>
 #endif
 
 namespace Libraries::Kernel {

--- a/src/core/libraries/kernel/threads/mutex.cpp
+++ b/src/core/libraries/kernel/threads/mutex.cpp
@@ -41,7 +41,7 @@ using CallocFun = void* (*)(size_t, size_t);
 
 static int MutexInit(PthreadMutexT* mutex, const PthreadMutexAttr* mutex_attr, const char* name) {
     const PthreadMutexAttr* attr;
-    if (mutex_attr == NULL) {
+    if (mutex_attr == nullptr) {
         attr = &PthreadMutexattrDefault;
     } else {
         attr = mutex_attr;
@@ -52,7 +52,7 @@ static int MutexInit(PthreadMutexT* mutex, const PthreadMutexAttr* mutex_attr, c
             return POSIX_EINVAL;
         }
     }
-    auto* pmutex = new PthreadMutex{};
+    auto* pmutex = new (std::nothrow) PthreadMutex{};
     if (pmutex == nullptr) {
         return POSIX_ENOMEM;
     }
@@ -350,7 +350,7 @@ int PthreadMutex::IsOwned(Pthread* curthread) const {
 }
 
 int PS4_SYSV_ABI posix_pthread_mutexattr_init(PthreadMutexAttrT* attr) {
-    PthreadMutexAttrT pattr = new PthreadMutexAttr{};
+    auto pattr = new (std::nothrow) PthreadMutexAttr{};
     if (pattr == nullptr) {
         return POSIX_ENOMEM;
     }

--- a/src/core/libraries/kernel/threads/pthread.h
+++ b/src/core/libraries/kernel/threads/pthread.h
@@ -7,7 +7,6 @@
 #include <forward_list>
 #include <list>
 #include <mutex>
-#include <semaphore>
 #include <shared_mutex>
 
 #include "common/enum.h"
@@ -55,7 +54,7 @@ struct PthreadMutex {
     PthreadMutexProt m_protocol;
     std::string name;
 
-    PthreadMutexType Type() const noexcept {
+    [[nodiscard]] PthreadMutexType Type() const noexcept {
         return static_cast<PthreadMutexType>(m_flags & PthreadMutexFlags::TypeMask);
     }
 
@@ -115,8 +114,8 @@ enum class ClockId : u32 {
 };
 
 struct PthreadCond {
-    u32 has_user_waiters;
-    u32 has_kern_waiters;
+    bool has_user_waiters;
+    bool has_kern_waiters;
     u32 flags;
     ClockId clock_id;
     std::string name;
@@ -239,7 +238,7 @@ enum class ThreadListFlags : u32 {
 
 using PthreadEntryFunc = void* PS4_SYSV_ABI (*)(void*);
 
-constexpr u32 TidTerminated = 1;
+constexpr s32 TidTerminated = 1;
 
 struct SleepQueue;
 
@@ -253,7 +252,7 @@ struct Pthread {
     static constexpr u32 ThrMagic = 0xd09ba115U;
     static constexpr u32 MaxDeferWaiters = 50;
 
-    std::atomic<long> tid;
+    std::atomic<s32> tid;
     std::mutex lock;
     u32 cycle;
     int locklevel;

--- a/src/core/libraries/kernel/threads/pthread_attr.cpp
+++ b/src/core/libraries/kernel/threads/pthread_attr.cpp
@@ -29,7 +29,7 @@ PthreadAttr PthreadAttrDefault = {
     .prio = 0,
     .suspend = false,
     .flags = PthreadAttrFlags::ScopeSystem,
-    .stackaddr_attr = NULL,
+    .stackaddr_attr = nullptr,
     .stacksize_attr = ThrStackDefault,
     .guardsize_attr = 0,
     .cpusetsize = 0,
@@ -112,7 +112,7 @@ int PS4_SYSV_ABI posix_pthread_attr_getstacksize(const PthreadAttrT* attr, size_
 }
 
 int PS4_SYSV_ABI posix_pthread_attr_init(PthreadAttrT* attr) {
-    PthreadAttrT pattr = new PthreadAttr{};
+    auto pattr = new (std::nothrow) PthreadAttr{};
     if (pattr == nullptr) {
         return POSIX_ENOMEM;
     }
@@ -122,7 +122,7 @@ int PS4_SYSV_ABI posix_pthread_attr_init(PthreadAttrT* attr) {
 }
 
 int PS4_SYSV_ABI posix_pthread_attr_setschedpolicy(PthreadAttrT* attr, SchedPolicy policy) {
-    if (attr == NULL || *attr == NULL) {
+    if (attr == nullptr || *attr == nullptr) {
         return POSIX_EINVAL;
     } else if ((policy < SchedPolicy::Fifo) || (policy > SchedPolicy::RoundRobin)) {
         return POSIX_ENOTSUP;
@@ -216,7 +216,7 @@ int PS4_SYSV_ABI posix_pthread_attr_get_np(PthreadT pthread, PthreadAttrT* dstat
         return POSIX_EINVAL;
     }
     auto* thread_state = ThrState::Instance();
-    int ret = thread_state->FindThread(pthread, /*include dead*/ 0);
+    const int ret = thread_state->FindThread(pthread, /*include dead*/ false);
     if (ret != 0) {
         return ret;
     }
@@ -225,9 +225,7 @@ int PS4_SYSV_ABI posix_pthread_attr_get_np(PthreadT pthread, PthreadAttrT* dstat
         attr.flags |= PthreadAttrFlags::Detached;
     }
     pthread->lock.unlock();
-    if (ret == 0) {
-        memcpy(dst, &attr, sizeof(PthreadAttr));
-    }
+    memcpy(dst, &attr, sizeof(PthreadAttr));
     return ret;
 }
 

--- a/src/core/libraries/kernel/threads/pthread_clean.cpp
+++ b/src/core/libraries/kernel/threads/pthread_clean.cpp
@@ -16,7 +16,7 @@ void PS4_SYSV_ABI __pthread_cleanup_push_imp(PthreadCleanupFunc routine, void* a
 
 void PS4_SYSV_ABI posix_pthread_cleanup_push(PthreadCleanupFunc routine, void* arg) {
     Pthread* curthread = g_curthread;
-    PthreadCleanup* newbuf = new PthreadCleanup{};
+    auto* newbuf = new (std::nothrow) PthreadCleanup{};
     if (newbuf == nullptr) {
         return;
     }

--- a/src/core/libraries/kernel/threads/rwlock.cpp
+++ b/src/core/libraries/kernel/threads/rwlock.cpp
@@ -27,7 +27,7 @@ static std::mutex RwlockStaticLock;
     }
 
 static int RwlockInit(PthreadRwlockT* rwlock, const PthreadRwlockAttrT* attr) {
-    PthreadRwlock* prwlock = new PthreadRwlock{};
+    auto* prwlock = new (std::nothrow) PthreadRwlock{};
     if (prwlock == nullptr) {
         return POSIX_ENOMEM;
     }
@@ -213,7 +213,7 @@ int PS4_SYSV_ABI posix_pthread_rwlockattr_init(PthreadRwlockAttrT* rwlockattr) {
         return POSIX_EINVAL;
     }
 
-    PthreadRwlockAttrT prwlockattr = new PthreadRwlockAttr{};
+    auto prwlockattr = new (std::nothrow) PthreadRwlockAttr{};
     if (prwlockattr == nullptr) {
         return POSIX_ENOMEM;
     }

--- a/src/core/libraries/kernel/threads/semaphore.cpp
+++ b/src/core/libraries/kernel/threads/semaphore.cpp
@@ -127,7 +127,7 @@ public:
             thr_name = g_curthread->name;
         }
 
-        s32 GetResult() const {
+        [[nodiscard]] s32 GetResult() const {
             if (was_signaled) {
                 return ORBIS_OK;
             }

--- a/src/core/libraries/kernel/threads/sleepq.cpp
+++ b/src/core/libraries/kernel/threads/sleepq.cpp
@@ -58,18 +58,18 @@ void SleepqAdd(void* wchan, Pthread* td) {
     sq->sq_blocked.push_front(td);
 }
 
-int SleepqRemove(SleepQueue* sq, Pthread* td) {
+bool SleepqRemove(SleepQueue* sq, Pthread* td) {
     std::erase(sq->sq_blocked, td);
     if (sq->sq_blocked.empty()) {
         td->sleepqueue = sq;
         sq->unlink();
         td->wchan = nullptr;
-        return 0;
+        return false;
     } else {
         td->sleepqueue = std::addressof(sq->sq_freeq.front());
         sq->sq_freeq.pop_front();
         td->wchan = nullptr;
-        return 1;
+        return true;
     }
 }
 

--- a/src/core/libraries/kernel/threads/sleepq.h
+++ b/src/core/libraries/kernel/threads/sleepq.h
@@ -30,7 +30,7 @@ SleepQueue* SleepqLookup(void* wchan);
 
 void SleepqAdd(void* wchan, Pthread* td);
 
-int SleepqRemove(SleepQueue* sq, Pthread* td);
+bool SleepqRemove(SleepQueue* sq, Pthread* td);
 
 void SleepqDrop(SleepQueue* sq, void (*callback)(Pthread*, void*), void* arg);
 

--- a/src/core/libraries/kernel/threads/stack.cpp
+++ b/src/core/libraries/kernel/threads/stack.cpp
@@ -16,7 +16,7 @@ static constexpr size_t RoundUp(size_t size) {
 }
 
 int ThreadState::CreateStack(PthreadAttr* attr) {
-    if ((attr->stackaddr_attr) != NULL) {
+    if ((attr->stackaddr_attr) != nullptr) {
         attr->guardsize_attr = 0;
         attr->flags |= PthreadAttrFlags::StackUser;
         return 0;
@@ -32,7 +32,7 @@ int ThreadState::CreateStack(PthreadAttr* attr) {
     size_t stacksize = RoundUp(attr->stacksize_attr);
     size_t guardsize = RoundUp(attr->guardsize_attr);
 
-    attr->stackaddr_attr = NULL;
+    attr->stackaddr_attr = nullptr;
     attr->flags &= ~PthreadAttrFlags::StackUser;
 
     /*
@@ -69,7 +69,7 @@ int ThreadState::CreateStack(PthreadAttr* attr) {
     }
 
     /* A cached stack was found.  Release the lock. */
-    if (attr->stackaddr_attr != NULL) {
+    if (attr->stackaddr_attr != nullptr) {
         thread_list_lock.unlock();
         return 0;
     }
@@ -122,8 +122,8 @@ void ThreadState::FreeStack(PthreadAttr* attr) {
         return;
     }
 
-    char* stack_base = (char*)attr->stackaddr_attr;
-    Stack* spare_stack = (Stack*)(stack_base + attr->stacksize_attr - sizeof(Stack));
+    auto* stack_base = static_cast<char*>(attr->stackaddr_attr);
+    auto* spare_stack = reinterpret_cast<Stack*>(stack_base + attr->stacksize_attr - sizeof(Stack));
     spare_stack->stacksize = RoundUp(attr->stacksize_attr);
     spare_stack->guardsize = RoundUp(attr->guardsize_attr);
     spare_stack->stackaddr = attr->stackaddr_attr;

--- a/src/core/libraries/kernel/threads/thread_state.cpp
+++ b/src/core/libraries/kernel/threads/thread_state.cpp
@@ -37,7 +37,7 @@ void ThreadState::Collect(Pthread* curthread) {
         for (auto it = gc_list.begin(); it != gc_list.end();) {
             Pthread* td = *it;
             if (td->tid != TidTerminated) {
-                it++;
+                ++it;
                 continue;
             }
             FreeStack(&td->attr);
@@ -131,7 +131,7 @@ void ThreadState::Free(Pthread* curthread, Pthread* thread) {
     }
 }
 
-int ThreadState::FindThread(Pthread* thread, bool include_dead) {
+int ThreadState::FindThread(Pthread* thread, const bool include_dead) {
     if (thread == nullptr) {
         return POSIX_EINVAL;
     }


### PR DESCRIPTION
Mostly just style warnings like `nullptr` instead of `NULL`, use of C++-style casts, using const where possible, type consistency, etc. Added in some `std::nothrow` constructions as well to make the null checks actually useful.