### PR TITLE
Core: Log error on MapMemory out of flexible memory case

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -314,8 +314,10 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
     // Certain games perform flexible mappings on loop to determine
     // the available flexible memory size. Questionable but we need to handle this.
     if (type == VMAType::Flexible && flexible_usage + size > total_flexible_size) {
-        LOG_ERROR(Kernel_Vmm, "Out of flexible memory, available flexible memory = {:#x}"
-                  " requested size = {:#x}", total_flexible_size - flexible_usage, size);
+        LOG_ERROR(Kernel_Vmm,
+                  "Out of flexible memory, available flexible memory = {:#x}"
+                  " requested size = {:#x}",
+                  total_flexible_size - flexible_usage, size);
         return ORBIS_KERNEL_ERROR_ENOMEM;
     }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -314,6 +314,8 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
     // Certain games perform flexible mappings on loop to determine
     // the available flexible memory size. Questionable but we need to handle this.
     if (type == VMAType::Flexible && flexible_usage + size > total_flexible_size) {
+        LOG_ERROR(Kernel_Vmm, "Out of flexible memory, available flexible memory = {:#x}"
+                  " requested size = {:#x}", total_flexible_size - flexible_usage, size);
         return ORBIS_KERNEL_ERROR_ENOMEM;
     }
 


### PR DESCRIPTION
This PR does exactly what the title says, adds a error log for hitting the out of flexible memory error case.
This should make some memory issues more visible, so ideally I'd like this to get merged before release.