### PR TITLE
Fix: Extend strlcpy implementation to Linux builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1169,12 +1169,6 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
         target_compile_definitions(shadps4 PRIVATE ENABLE_USERFAULTFD)
     endif()
 
-    # Add libbsd support for strlcpy and other BSD functions
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(LIBBSD REQUIRED libbsd)
-    target_link_libraries(shadps4 PRIVATE ${LIBBSD_LIBRARIES})
-    target_include_directories(shadps4 PRIVATE ${LIBBSD_INCLUDE_DIRS})
-
     target_link_libraries(shadps4 PRIVATE uuid)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1169,6 +1169,12 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
         target_compile_definitions(shadps4 PRIVATE ENABLE_USERFAULTFD)
     endif()
 
+    # Add libbsd support for strlcpy and other BSD functions
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(LIBBSD REQUIRED libbsd)
+    target_link_libraries(shadps4 PRIVATE ${LIBBSD_LIBRARIES})
+    target_include_directories(shadps4 PRIVATE ${LIBBSD_INCLUDE_DIRS})
+
     target_link_libraries(shadps4 PRIVATE uuid)
 endif()
 

--- a/src/core/libraries/network/net.cpp
+++ b/src/core/libraries/network/net.cpp
@@ -10,10 +10,6 @@
 #include <arpa/inet.h>
 #endif
 
-#ifdef __linux__
-#include <bsd/string.h>
-#endif
-
 #include <core/libraries/kernel/kernel.h>
 #include "common/assert.h"
 #include "common/logging/log.h"
@@ -806,8 +802,8 @@ u16 PS4_SYSV_ABI sceNetHtons(u16 host16) {
     return htons(host16);
 }
 
-#ifdef WIN32
-// there isn't a strlcpy function in windows so implement one
+#if defined(WIN32) || defined(__linux__)
+// there isn't a strlcpy function in windows/glibc so implement one
 u64 strlcpy(char* dst, const char* src, u64 size) {
     u64 src_len = strlen(src);
 

--- a/src/core/libraries/network/net.cpp
+++ b/src/core/libraries/network/net.cpp
@@ -10,6 +10,10 @@
 #include <arpa/inet.h>
 #endif
 
+#ifdef __linux__
+#include <bsd/string.h>
+#endif
+
 #include <core/libraries/kernel/kernel.h>
 #include "common/assert.h"
 #include "common/logging/log.h"


### PR DESCRIPTION
- Extend existing Windows strlcpy implementation to cover Linux systems
- Resolves undefined reference to strlcpy on glibc systems

Uses the project's existing internal implementation instead of adding
external dependencies, maintaining consistency with current approach.

Fixes build error:
undefined reference to symbol 'strlcpy@@LIBBSD_0.0'