### PR TITLE
Lower "Trophy key is not specified" message from critical to info

### DIFF
--- a/src/core/file_format/trp.cpp
+++ b/src/core/file_format/trp.cpp
@@ -65,7 +65,7 @@ bool TRP::Extract(const std::filesystem::path& trophyPath, const std::string tit
 
     const auto user_key_str = Config::getTrophyKey();
     if (user_key_str.size() != 32) {
-        LOG_CRITICAL(Common_Filesystem, "Trophy decryption key is not specified");
+        LOG_INFO(Common_Filesystem, "Trophy decryption key is not specified");
         return false;
     }
 


### PR DESCRIPTION
I think it's not needed to have this logged as critical, it takes an extra second to check if there's a proper critical message in a log when looking at it, and in my experience there's only a handful of games which have issues without the trophy key (only one I know of is "MONOPOLY FAMILY FUN PACK"). I think the following line is more than enough for the end user to realize they won't get any trophies: "[Loader] <Error> emulator.cpp:212 Run: Couldn't extract trophies", worse case scenario it can be changed to something like "Couldn't extract trophies because the trophy key is missing" imo.