### PR TITLE
avplayer: fix play request state handling

### DIFF
--- a/src/core/libraries/avplayer/avplayer_data_streamer.h
+++ b/src/core/libraries/avplayer/avplayer_data_streamer.h
@@ -17,6 +17,7 @@ class IDataStreamer {
 public:
     virtual ~IDataStreamer() = default;
     virtual bool Init(std::string_view path) = 0;
+    virtual void Reset() = 0;
     virtual AVIOContext* GetContext() = 0;
 };
 

--- a/src/core/libraries/avplayer/avplayer_file_streamer.cpp
+++ b/src/core/libraries/avplayer/avplayer_file_streamer.cpp
@@ -43,6 +43,10 @@ bool AvPlayerFileStreamer::Init(std::string_view path) {
     return true;
 }
 
+void AvPlayerFileStreamer::Reset() {
+    m_position = 0;
+}
+
 s32 AvPlayerFileStreamer::ReadPacket(void* opaque, u8* buffer, s32 size) {
     const auto self = reinterpret_cast<AvPlayerFileStreamer*>(opaque);
     if (self->m_position >= self->m_file_size) {

--- a/src/core/libraries/avplayer/avplayer_file_streamer.h
+++ b/src/core/libraries/avplayer/avplayer_file_streamer.h
@@ -17,6 +17,7 @@ public:
     ~AvPlayerFileStreamer();
 
     bool Init(std::string_view path) override;
+    void Reset() override;
 
     AVIOContext* GetContext() override {
         return m_avio_context;

--- a/src/core/libraries/avplayer/avplayer_state.cpp
+++ b/src/core/libraries/avplayer/avplayer_state.cpp
@@ -177,8 +177,10 @@ bool AvPlayerState::GetStreamInfo(u32 stream_index, AvPlayerStreamInfo& info) {
 bool AvPlayerState::Start() {
     std::shared_lock lock(m_source_mutex);
     if (m_current_state == AvState::Ready || m_current_state == AvState::Stop || Stop()) {
+        SetState(AvState::Starting);
         if (!m_up_source->Start()) {
             LOG_ERROR(Lib_AvPlayer, "Could not start playback.");
+            SetState(AvState::Error);
             return false;
         }
         SetState(AvState::Play);


### PR DESCRIPTION
`Katamari Damacy Reroll` videos now play properly. Also re-initialized codecs on the subsequent play requests.