### PR TITLE
Memory: Implement sceKernelMemoryPoolGetBlockStats

### DIFF
--- a/src/core/libraries/kernel/memory.h
+++ b/src/core/libraries/kernel/memory.h
@@ -126,6 +126,13 @@ struct OrbisKernelMemoryPoolBatchEntry {
     };
 };
 
+struct OrbisKernelMemoryPoolBlockStats {
+    s32 available_flushed_blocks;
+    s32 available_cached_blocks;
+    s32 allocated_flushed_blocks;
+    s32 allocated_cached_blocks;
+};
+
 u64 PS4_SYSV_ABI sceKernelGetDirectMemorySize();
 s32 PS4_SYSV_ABI sceKernelAllocateDirectMemory(s64 searchStart, s64 searchEnd, u64 len,
                                                u64 alignment, s32 memoryType, s64* physAddrOut);
@@ -176,6 +183,7 @@ s32 PS4_SYSV_ABI sceKernelMemoryPoolCommit(void* addr, u64 len, s32 type, s32 pr
 s32 PS4_SYSV_ABI sceKernelMemoryPoolDecommit(void* addr, u64 len, s32 flags);
 s32 PS4_SYSV_ABI sceKernelMemoryPoolBatch(const OrbisKernelMemoryPoolBatchEntry* entries, s32 count,
                                           s32* num_processed, s32 flags);
+s32 PS4_SYSV_ABI sceKernelMemoryPoolGetBlockStats(OrbisKernelMemoryPoolBlockStats* stats, u64 size);
 
 s32 PS4_SYSV_ABI sceKernelMunmap(void* addr, u64 len);
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -980,7 +980,7 @@ s32 MemoryManager::IsStack(VAddr addr, void** start, void** end) {
 }
 
 s32 MemoryManager::GetMemoryPoolStats(::Libraries::Kernel::OrbisKernelMemoryPoolBlockStats* stats) {
-    // Run through dma_map, determine how much physical memory is currently committed
+    // Run through dmem_map, determine how much physical memory is currently committed
     constexpr u64 block_size = 64_KB;
     u64 committed_size = 0;
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -979,6 +979,27 @@ s32 MemoryManager::IsStack(VAddr addr, void** start, void** end) {
     return ORBIS_OK;
 }
 
+s32 MemoryManager::GetMemoryPoolStats(::Libraries::Kernel::OrbisKernelMemoryPoolBlockStats* stats) {
+    // Run through dma_map, determine how much physical memory is currently committed
+    constexpr u64 block_size = 64_KB;
+    u64 committed_size = 0;
+
+    auto dma_handle = dmem_map.begin();
+    while (dma_handle != dmem_map.end()) {
+        if (dma_handle->second.dma_type == DMAType::Committed) {
+            committed_size += dma_handle->second.size;
+        }
+        dma_handle++;
+    }
+
+    stats->allocated_flushed_blocks = committed_size / block_size;
+    stats->available_flushed_blocks = committed_size / block_size;
+    // TODO: Determine how "cached blocks" work
+    stats->allocated_cached_blocks = 0;
+    stats->available_cached_blocks = 0;
+    return ORBIS_OK;
+}
+
 void MemoryManager::InvalidateMemory(const VAddr addr, const u64 size) const {
     if (rasterizer) {
         rasterizer->InvalidateMemory(addr, size);

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -258,6 +258,8 @@ public:
 
     void NameVirtualRange(VAddr virtual_addr, u64 size, std::string_view name);
 
+    s32 GetMemoryPoolStats(::Libraries::Kernel::OrbisKernelMemoryPoolBlockStats* stats);
+
     void InvalidateMemory(VAddr addr, u64 size) const;
 
 private:


### PR DESCRIPTION
This PR implements sceKernelMemoryPoolGetBlockStats, based on a mix of kernel decompilation and hardware testing. Some logic wasn't entirely clear to me, so I've left a warning log in case this function is seen in other titles and needs further work.

Implementing this function improves Fall Guys (CUSA29236), the game now hangs at a loading screen (though it probably gets further on Linux, this is a Unity game after all)
<img width="1922" height="1112" alt="image" src="https://github.com/user-attachments/assets/7bfe9d46-2f26-4b5f-b6a1-7bb32934f971" />