### PR TITLE
Core: Memory code cleanup and further direct memory fixes

### DIFF
--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -103,17 +103,18 @@ struct AddressSpace::Impl {
                         MemoryRegion{system_managed_addr, virtual_size, false});
 
         // Allocate backing file that represents the total physical memory.
-        backing_handle =
-            CreateFileMapping2(INVALID_HANDLE_VALUE, nullptr, FILE_MAP_WRITE | FILE_MAP_READ,
-                               PAGE_READWRITE, SEC_COMMIT, BackingSize, nullptr, nullptr, 0);
+        backing_handle = CreateFileMapping2(INVALID_HANDLE_VALUE, nullptr, FILE_MAP_ALL_ACCESS,
+                                            PAGE_EXECUTE_READWRITE, SEC_COMMIT, BackingSize,
+                                            nullptr, nullptr, 0);
         ASSERT_MSG(backing_handle, "{}", Common::GetLastErrorMsg());
         // Allocate a virtual memory for the backing file map as placeholder
         backing_base = static_cast<u8*>(VirtualAlloc2(process, nullptr, BackingSize,
                                                       MEM_RESERVE | MEM_RESERVE_PLACEHOLDER,
                                                       PAGE_NOACCESS, nullptr, 0));
         // Map backing placeholder. This will commit the pages
-        void* const ret = MapViewOfFile3(backing_handle, process, backing_base, 0, BackingSize,
-                                         MEM_REPLACE_PLACEHOLDER, PAGE_READWRITE, nullptr, 0);
+        void* const ret =
+            MapViewOfFile3(backing_handle, process, backing_base, 0, BackingSize,
+                           MEM_REPLACE_PLACEHOLDER, PAGE_EXECUTE_READWRITE, nullptr, 0);
         ASSERT_MSG(ret == backing_base, "{}", Common::GetLastErrorMsg());
     }
 

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -509,7 +509,7 @@ s32 PS4_SYSV_ABI sceKernelMemoryPoolCommit(void* addr, u64 len, s32 type, s32 pr
     const VAddr in_addr = reinterpret_cast<VAddr>(addr);
     const auto mem_prot = static_cast<Core::MemoryProt>(prot);
     auto* memory = Core::Memory::Instance();
-    return memory->PoolCommit(in_addr, len, mem_prot);
+    return memory->PoolCommit(in_addr, len, mem_prot, type);
 }
 
 s32 PS4_SYSV_ABI sceKernelMemoryPoolDecommit(void* addr, u64 len, s32 flags) {

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <bit>

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -187,9 +187,14 @@ s32 PS4_SYSV_ABI sceKernelMapNamedDirectMemory(void** addr, u64 len, s32 prot, s
         return ORBIS_KERNEL_ERROR_ENAMETOOLONG;
     }
 
-    const VAddr in_addr = reinterpret_cast<VAddr>(*addr);
     const auto mem_prot = static_cast<Core::MemoryProt>(prot);
+    if (True(mem_prot & Core::MemoryProt::CpuExec)) {
+        LOG_ERROR(Kernel_Vmm, "Executable permissions are not allowed.");
+        return ORBIS_KERNEL_ERROR_EACCES;
+    }
+
     const auto map_flags = static_cast<Core::MemoryMapFlags>(flags);
+    const VAddr in_addr = reinterpret_cast<VAddr>(*addr);
 
     auto* memory = Core::Memory::Instance();
     const auto ret = memory->MapMemory(addr, in_addr, len, mem_prot, map_flags,
@@ -229,9 +234,14 @@ s32 PS4_SYSV_ABI sceKernelMapDirectMemory2(void** addr, u64 len, s32 type, s32 p
         }
     }
 
-    const VAddr in_addr = reinterpret_cast<VAddr>(*addr);
     const auto mem_prot = static_cast<Core::MemoryProt>(prot);
+    if (True(mem_prot & Core::MemoryProt::CpuExec)) {
+        LOG_ERROR(Kernel_Vmm, "Executable permissions are not allowed.");
+        return ORBIS_KERNEL_ERROR_EACCES;
+    }
+
     const auto map_flags = static_cast<Core::MemoryMapFlags>(flags);
+    const VAddr in_addr = reinterpret_cast<VAddr>(*addr);
 
     auto* memory = Core::Memory::Instance();
     const auto ret = memory->MapMemory(addr, in_addr, len, mem_prot, map_flags,

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -250,9 +250,9 @@ s32 PS4_SYSV_ABI sceKernelMapDirectMemory2(void** addr, u64 len, s32 type, s32 p
     if (ret == 0) {
         // If the map call succeeds, set the direct memory type using the output address.
         auto* memory = Core::Memory::Instance();
-        const auto in_addr = reinterpret_cast<VAddr>(*addr);
-        memory->SetDirectMemoryType(in_addr, len, type);
-        LOG_INFO(Kernel_Vmm, "out_addr = {:#x}", in_addr);
+        const auto out_addr = reinterpret_cast<VAddr>(*addr);
+        memory->SetDirectMemoryType(out_addr, len, type);
+        LOG_INFO(Kernel_Vmm, "out_addr = {:#x}", out_addr);
     }
     return ret;
 }

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -306,7 +306,7 @@ s32 PS4_SYSV_ABI sceKernelMtypeprotect(const void* addr, u64 size, s32 mtype, s3
     Core::MemoryProt protection_flags = static_cast<Core::MemoryProt>(prot);
 
     s32 result = memory_manager->Protect(aligned_addr, aligned_size, protection_flags);
-    if (result == 0) {
+    if (result == ORBIS_OK) {
         memory_manager->SetDirectMemoryType(aligned_addr, aligned_size, mtype);
     }
     return result;

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -237,9 +237,8 @@ s32 PS4_SYSV_ABI sceKernelMapDirectMemory2(void** addr, u64 len, s32 type, s32 p
     const auto map_flags = static_cast<Core::MemoryMapFlags>(flags);
 
     auto* memory = Core::Memory::Instance();
-    const auto ret =
-        memory->MapMemory(addr, in_addr, len, mem_prot, map_flags, Core::VMAType::Direct, "anon",
-                          true, phys_addr, alignment);
+    const auto ret = memory->MapMemory(addr, in_addr, len, mem_prot, map_flags,
+                                       Core::VMAType::Direct, "anon", true, phys_addr, alignment);
 
     if (ret == 0) {
         // If the map call succeeds, set the direct memory type using the output address.

--- a/src/core/libraries/kernel/memory.h
+++ b/src/core/libraries/kernel/memory.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once

--- a/src/core/libraries/kernel/memory.h
+++ b/src/core/libraries/kernel/memory.h
@@ -137,10 +137,9 @@ u64 PS4_SYSV_ABI sceKernelGetDirectMemorySize();
 s32 PS4_SYSV_ABI sceKernelAllocateDirectMemory(s64 searchStart, s64 searchEnd, u64 len,
                                                u64 alignment, s32 memoryType, s64* physAddrOut);
 s32 PS4_SYSV_ABI sceKernelMapNamedDirectMemory(void** addr, u64 len, s32 prot, s32 flags,
-                                               s64 directMemoryStart, u64 alignment,
-                                               const char* name);
-s32 PS4_SYSV_ABI sceKernelMapDirectMemory(void** addr, u64 len, s32 prot, s32 flags,
-                                          s64 directMemoryStart, u64 alignment);
+                                               s64 phys_addr, u64 alignment, const char* name);
+s32 PS4_SYSV_ABI sceKernelMapDirectMemory(void** addr, u64 len, s32 prot, s32 flags, s64 phys_addr,
+                                          u64 alignment);
 s32 PS4_SYSV_ABI sceKernelAllocateMainDirectMemory(u64 len, u64 alignment, s32 memoryType,
                                                    s64* physAddrOut);
 s32 PS4_SYSV_ABI sceKernelReleaseDirectMemory(u64 start, u64 len);

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -738,8 +738,7 @@ s32 MemoryManager::Protect(VAddr addr, u64 size, MemoryProt prot) {
                    "Attempted to access invalid address {:#x}", addr);
         auto it = FindVMA(addr + protected_bytes);
         auto& vma_base = it->second;
-        auto result = ProtectBytes(addr + protected_bytes, vma_base,
-                                   size - protected_bytes, prot);
+        auto result = ProtectBytes(addr + protected_bytes, vma_base, size - protected_bytes, prot);
         if (result < 0) {
             // ProtectBytes returned an error, return it
             return result;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -944,7 +944,7 @@ void MemoryManager::NameVirtualRange(VAddr virtual_addr, u64 size, std::string_v
 
 s32 MemoryManager::GetDirectMemoryType(PAddr addr, s32* directMemoryTypeOut,
                                        void** directMemoryStartOut, void** directMemoryEndOut) {
-    if (addr > total_direct_size) {
+    if (addr >= total_direct_size) {
         LOG_ERROR(Kernel_Vmm, "Unable to find allocated direct memory region to check type!");
         return ORBIS_KERNEL_ERROR_ENOENT;
     }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -253,7 +253,7 @@ void MemoryManager::Free(PAddr phys_addr, u64 size) {
     MergeAdjacent(dmem_map, dmem_area);
 }
 
-s32 MemoryManager::PoolCommit(VAddr virtual_addr, u64 size, MemoryProt prot) {
+s32 MemoryManager::PoolCommit(VAddr virtual_addr, u64 size, MemoryProt prot, s32 mtype) {
     ASSERT_MSG(IsValidAddress(reinterpret_cast<void*>(virtual_addr)),
                "Attempted to access invalid address {:#x}", virtual_addr);
     std::scoped_lock lk{mutex};
@@ -309,6 +309,7 @@ s32 MemoryManager::PoolCommit(VAddr virtual_addr, u64 size, MemoryProt prot) {
     const auto new_dmem_handle = CarveDmemArea(handle->second.base, size);
     auto& new_dmem_area = new_dmem_handle->second;
     new_dmem_area.dma_type = DMAType::Committed;
+    new_dmem_area.memory_type = mtype;
     new_vma.phys_base = new_dmem_area.base;
     MergeAdjacent(dmem_map, new_dmem_handle);
 

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -53,8 +53,8 @@ DECLARE_ENUM_FLAG_OPERATORS(MemoryMapFlags)
 enum class DMAType : u32 {
     Free = 0,
     Direct = 1,
-    Pooled = 3,
-    Committed = 4,
+    Pooled = 2,
+    Committed = 3,
 };
 
 enum class VMAType : u32 {

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -52,8 +52,7 @@ DECLARE_ENUM_FLAG_OPERATORS(MemoryMapFlags)
 
 enum class DMAType : u32 {
     Free = 0,
-    Allocated = 1,
-    Mapped = 2,
+    Direct = 1,
     Pooled = 3,
     Committed = 4,
 };

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -253,7 +253,7 @@ public:
 
     s32 IsStack(VAddr addr, void** start, void** end);
 
-    s32 SetDirectMemoryType(s64 phys_addr, s32 memory_type);
+    s32 SetDirectMemoryType(VAddr addr, u64 size, s32 memory_type);
 
     void NameVirtualRange(VAddr virtual_addr, u64 size, std::string_view name);
 

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -221,7 +221,7 @@ public:
 
     void Free(PAddr phys_addr, u64 size);
 
-    s32 PoolCommit(VAddr virtual_addr, u64 size, MemoryProt prot);
+    s32 PoolCommit(VAddr virtual_addr, u64 size, MemoryProt prot, s32 mtype);
 
     s32 MapMemory(void** out_addr, VAddr virtual_addr, u64 size, MemoryProt prot,
                   MemoryMapFlags flags, VMAType type, std::string_view name = "anon",

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -52,9 +52,10 @@ DECLARE_ENUM_FLAG_OPERATORS(MemoryMapFlags)
 
 enum class DMAType : u32 {
     Free = 0,
-    Direct = 1,
-    Pooled = 2,
-    Committed = 3,
+    Allocated = 1,
+    Mapped = 2,
+    Pooled = 3,
+    Committed = 4,
 };
 
 enum class VMAType : u32 {
@@ -225,7 +226,7 @@ public:
 
     s32 MapMemory(void** out_addr, VAddr virtual_addr, u64 size, MemoryProt prot,
                   MemoryMapFlags flags, VMAType type, std::string_view name = "anon",
-                  bool is_exec = false, PAddr phys_addr = -1, u64 alignment = 0);
+                  bool validate_dmem = false, PAddr phys_addr = -1, u64 alignment = 0);
 
     s32 MapFile(void** out_addr, VAddr virtual_addr, u64 size, MemoryProt prot,
                 MemoryMapFlags flags, s32 fd, s64 phys_addr);

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -113,7 +113,8 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
     // Map module segments (and possible TLS trampolines)
     void** out_addr = reinterpret_cast<void**>(&base_virtual_addr);
     memory->MapMemory(out_addr, ModuleLoadBase, aligned_base_size + TrampolineSize,
-                      MemoryProt::CpuReadWrite, MemoryMapFlags::NoFlags, VMAType::Code, name, true);
+                      MemoryProt::CpuReadWrite | MemoryProt::CpuExec, MemoryMapFlags::NoFlags,
+                      VMAType::Code, name);
     LOG_INFO(Core_Linker, "Loading module {} to {}", name, fmt::ptr(*out_addr));
 
 #ifdef ARCH_X86_64


### PR DESCRIPTION
This PR changes some more logic, primarily related to direct memory handling and the dmem map.

- Reimplemented `MemoryManager::SetDirectMemoryType` to search through VMAs to find the physical memory areas to update.
- Updated `sceKernelMtypeprotect` to apply mtype using `MemoryManager::SetDirectMemoryType`.
- Updated `sceKernelMemoryPoolCommit` to apply mtype during `MemoryManager::PoolCommit`.
- Restored overlapping direct memory check, but properly restricted it to `sceKernelMapDirectMemory2` calls.
- Fixed detection of executable memory mappings in libkernel memory functions.
- Fixed issues with backed executable mappings on Windows.
- Fixed a variety of smaller things I've noticed while looking at memory code.

Everything I've changed appears to work fine on my end, but it would be good to have some other tests before merging.