### PR TITLE
make sys_modules folder configurable

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -128,7 +128,7 @@ static ConfigEntry<bool> isConnectedToNetwork(false);
 static bool enableDiscordRPC = false;
 static bool checkCompatibilityOnStartup = false;
 static bool compatibilityData = false;
-std::filesystem::path sys_modules_path = {};
+static std::filesystem::path sys_modules_path = {};
 
 // Input
 static ConfigEntry<int> cursorState(HideCursorState::Idle);

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -128,6 +128,7 @@ static ConfigEntry<bool> isConnectedToNetwork(false);
 static bool enableDiscordRPC = false;
 static bool checkCompatibilityOnStartup = false;
 static bool compatibilityData = false;
+std::filesystem::path sys_modules_path = {};
 
 // Input
 static ConfigEntry<int> cursorState(HideCursorState::Idle);
@@ -201,6 +202,17 @@ static string config_version = Common::g_scm_rev;
 // These two entries aren't stored in the config
 static bool overrideControllerColor = false;
 static int controllerCustomColorRGB[3] = {0, 0, 255};
+
+std::filesystem::path getSysModulesPath() {
+    if (sys_modules_path.empty()) {
+        return Common::FS::GetUserPath(Common::FS::PathType::SysModuleDir);
+    }
+    return sys_modules_path;
+}
+
+void setSysModulesPath(const std::filesystem::path& path) {
+    sys_modules_path = path;
+}
 
 int getVolumeSlider() {
     return volumeSlider.get();
@@ -835,6 +847,7 @@ void load(const std::filesystem::path& path, bool is_game_specific) {
         isConnectedToNetwork.setFromToml(general, "isConnectedToNetwork", is_game_specific);
         chooseHomeTab.setFromToml(general, "chooseHomeTab", is_game_specific);
         defaultControllerID.setFromToml(general, "defaultControllerID", is_game_specific);
+        sys_modules_path = toml::find_fs_path_or(general, "sysModulesPath", sys_modules_path);
     }
 
     if (data.contains("Input")) {
@@ -1100,6 +1113,7 @@ void save(const std::filesystem::path& path, bool is_game_specific) {
         data["General"]["enableDiscordRPC"] = enableDiscordRPC;
         data["General"]["compatibilityEnabled"] = compatibilityData;
         data["General"]["checkCompatibilityOnStartup"] = checkCompatibilityOnStartup;
+        data["General"]["sysModulesPath"] = string{fmt::UTF(sys_modules_path.u8string()).data};
         data["GUI"]["installDirs"] = install_dirs;
         data["GUI"]["installDirsEnabled"] = install_dirs_enabled;
         data["GUI"]["saveDataPath"] = string{fmt::UTF(save_data_path.u8string()).data};

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -134,6 +134,8 @@ bool getIsConnectedToNetwork();
 void setConnectedToNetwork(bool enable, bool is_game_specific = false);
 void setUserName(const std::string& name, bool is_game_specific = false);
 void setChooseHomeTab(const std::string& type, bool is_game_specific = false);
+std::filesystem::path getSysModulesPath();
+void setSysModulesPath(const std::filesystem::path& path);
 
 // TODO
 bool GetLoadGameSizeEnabled();

--- a/src/core/devtools/widget/module_list.h
+++ b/src/core/devtools/widget/module_list.h
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <string>
 #include <vector>
+#include "common/config.h"
 #include "common/elf_info.h"
 #include "common/path_util.h"
 
@@ -22,7 +23,7 @@ public:
     bool open = false;
 
     static bool IsSystemModule(const std::filesystem::path& path) {
-        const auto sys_modules_path = Common::FS::GetUserPath(Common::FS::PathType::SysModuleDir);
+        const auto sys_modules_path = Config::getSysModulesPath();
 
         const auto abs_path = std::filesystem::absolute(path).lexically_normal();
         const auto abs_sys_path = std::filesystem::absolute(sys_modules_path).lexically_normal();

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -486,7 +486,7 @@ void Emulator::LoadSystemModules(const std::string& game_serial) {
          {"libSceFreeTypeOt.sprx", nullptr}});
 
     std::vector<std::filesystem::path> found_modules;
-    const auto& sys_module_path = Common::FS::GetUserPath(Common::FS::PathType::SysModuleDir);
+    const auto& sys_module_path = Config::getSysModulesPath();
     for (const auto& entry : std::filesystem::directory_iterator(sys_module_path)) {
         found_modules.push_back(entry.path());
     }


### PR DESCRIPTION
This will make sys_modules folder configurable so if you have multiple copies of the emu , not gonna need to have sys_modules in several places. If not set default place will be used