### PR TITLE
Core: Handle various edge cases related to executable permissions.

### DIFF
--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -157,7 +157,7 @@ struct AddressSpace::Impl {
                 ptr = MapViewOfFile3(backing, process, reinterpret_cast<PVOID>(virtual_addr),
                                      phys_addr, size, MEM_REPLACE_PLACEHOLDER,
                                      PAGE_EXECUTE_READWRITE, nullptr, 0);
-                ASSERT_MSG(ptr, "{}", Common::GetLastErrorMsg());
+                ASSERT_MSG(ptr, "MapViewOfFile3 failed. {}", Common::GetLastErrorMsg());
                 DWORD resultvar;
                 bool ret = VirtualProtect(ptr, size, prot, &resultvar);
                 ASSERT_MSG(ret, "VirtualProtect failed. {}", Common::GetLastErrorMsg());

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -155,7 +155,12 @@ struct AddressSpace::Impl {
                 ASSERT_MSG(ret, "VirtualProtect failed. {}", Common::GetLastErrorMsg());
             } else {
                 ptr = MapViewOfFile3(backing, process, reinterpret_cast<PVOID>(virtual_addr),
-                                     phys_addr, size, MEM_REPLACE_PLACEHOLDER, prot, nullptr, 0);
+                                     phys_addr, size, MEM_REPLACE_PLACEHOLDER,
+                                     PAGE_EXECUTE_READWRITE, nullptr, 0);
+                ASSERT_MSG(ptr, "{}", Common::GetLastErrorMsg());
+                DWORD resultvar;
+                bool ret = VirtualProtect(ptr, size, prot, &resultvar);
+                ASSERT_MSG(ret, "VirtualProtect failed. {}", Common::GetLastErrorMsg());
             }
         } else {
             ptr =
@@ -316,7 +321,7 @@ struct AddressSpace::Impl {
                 new_flags = PAGE_NOACCESS;
             }
         }
-        
+
         // If no flags are assigned, then something's gone wrong.
         if (new_flags == 0) {
             LOG_CRITICAL(Common_Memory,

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -666,8 +666,8 @@ void* PS4_SYSV_ABI posix_mmap(void* addr, u64 len, s32 prot, s32 flags, s32 fd, 
         result = memory->MapMemory(&addr_out, aligned_addr, aligned_size, mem_prot, mem_flags,
                                    Core::VMAType::Flexible, "anon", false);
     } else {
-        result = memory->MapFile(&addr_out, aligned_addr, aligned_size, mem_prot, mem_flags,
-                                 fd, phys_addr);
+        result = memory->MapFile(&addr_out, aligned_addr, aligned_size, mem_prot, mem_flags, fd,
+                                 phys_addr);
     }
 
     if (result != ORBIS_OK) {

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -537,11 +537,16 @@ s32 PS4_SYSV_ABI sceKernelMemoryPoolCommit(void* addr, u64 len, s32 type, s32 pr
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
 
+    const auto mem_prot = static_cast<Core::MemoryProt>(prot);
+    if (True(mem_prot & Core::MemoryProt::CpuExec)) {
+        LOG_ERROR(Kernel_Vmm, "Executable permissions are not allowed.");
+        return ORBIS_KERNEL_ERROR_EINVAL;
+    }
+
     LOG_INFO(Kernel_Vmm, "addr = {}, len = {:#x}, type = {:#x}, prot = {:#x}, flags = {:#x}",
              fmt::ptr(addr), len, type, prot, flags);
 
     const VAddr in_addr = reinterpret_cast<VAddr>(addr);
-    const auto mem_prot = static_cast<Core::MemoryProt>(prot);
     auto* memory = Core::Memory::Instance();
     return memory->PoolCommit(in_addr, len, mem_prot, type);
 }

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -237,7 +237,7 @@ s32 PS4_SYSV_ABI sceKernelMapDirectMemory2(void** addr, u64 len, s32 type, s32 p
     const auto mem_prot = static_cast<Core::MemoryProt>(prot);
     if (True(mem_prot & Core::MemoryProt::CpuExec)) {
         LOG_ERROR(Kernel_Vmm, "Executable permissions are not allowed.");
-        return ORBIS_KERNEL_ERROR_EACCES;
+        return ORBIS_KERNEL_ERROR_EINVAL;
     }
 
     const auto map_flags = static_cast<Core::MemoryMapFlags>(flags);

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -656,12 +656,17 @@ void* PS4_SYSV_ABI posix_mmap(void* addr, u64 len, s32 prot, s32 flags, s32 fd, 
     const auto mem_prot = static_cast<Core::MemoryProt>(prot);
     const auto mem_flags = static_cast<Core::MemoryMapFlags>(flags);
 
+    // mmap is less restrictive than other functions in regards to alignment
+    // To avoid potential issues, align address and size here.
+    const VAddr aligned_addr = Common::AlignDown(std::bit_cast<VAddr>(addr), 16_KB);
+    const u64 aligned_size = Common::AlignUp(len, 16_KB);
+
     s32 result = ORBIS_OK;
     if (fd == -1) {
-        result = memory->MapMemory(&addr_out, std::bit_cast<VAddr>(addr), len, mem_prot, mem_flags,
+        result = memory->MapMemory(&addr_out, aligned_addr, aligned_size, mem_prot, mem_flags,
                                    Core::VMAType::Flexible, "anon", false);
     } else {
-        result = memory->MapFile(&addr_out, std::bit_cast<VAddr>(addr), len, mem_prot, mem_flags,
+        result = memory->MapFile(&addr_out, aligned_addr, aligned_size, mem_prot, mem_flags,
                                  fd, phys_addr);
     }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -768,7 +768,6 @@ s64 MemoryManager::ProtectBytes(VAddr addr, VirtualMemoryArea& vma_base, u64 siz
         prot |= MemoryProt::CpuRead;
     }
 
-    
     // Set permissions
     Core::MemoryPermission perms{};
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -762,7 +762,7 @@ s64 MemoryManager::ProtectBytes(VAddr addr, VirtualMemoryArea& vma_base, u64 siz
         return adjusted_size;
     }
 
-    if (vma_base.type == VMAType::Direct) {
+    if (vma_base.type == VMAType::Direct || vma_base.type == VMAType::Pooled) {
         // On PS4, execute permissions are ignored when protecting direct memory.
         prot &= ~MemoryProt::CpuExec;
     }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -738,7 +738,7 @@ s32 MemoryManager::QueryProtection(VAddr addr, void** start, void** end, u32* pr
     return ORBIS_OK;
 }
 
-s64 MemoryManager::ProtectBytes(VAddr addr, VirtualMemoryArea vma_base, u64 size, MemoryProt prot) {
+s64 MemoryManager::ProtectBytes(VAddr addr, VirtualMemoryArea& vma_base, u64 size, MemoryProt prot) {
     const auto start_in_vma = addr - vma_base.base;
     const auto adjusted_size =
         vma_base.size - start_in_vma < size ? vma_base.size - start_in_vma : size;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -752,7 +752,8 @@ s32 MemoryManager::QueryProtection(VAddr addr, void** start, void** end, u32* pr
     return ORBIS_OK;
 }
 
-s64 MemoryManager::ProtectBytes(VAddr addr, VirtualMemoryArea& vma_base, u64 size, MemoryProt prot) {
+s64 MemoryManager::ProtectBytes(VAddr addr, VirtualMemoryArea& vma_base, u64 size,
+                                MemoryProt prot) {
     const auto start_in_vma = addr - vma_base.base;
     const auto adjusted_size =
         vma_base.size - start_in_vma < size ? vma_base.size - start_in_vma : size;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -226,8 +226,6 @@ PAddr MemoryManager::Allocate(PAddr search_start, PAddr search_end, u64 size, u6
 void MemoryManager::Free(PAddr phys_addr, u64 size) {
     std::scoped_lock lk{mutex};
 
-    auto dmem_area = CarveDmemArea(phys_addr, size);
-
     // Release any dmem mappings that reference this physical block.
     std::vector<std::pair<VAddr, u64>> remove_list;
     for (const auto& [addr, mapping] : vma_map) {
@@ -235,22 +233,46 @@ void MemoryManager::Free(PAddr phys_addr, u64 size) {
             continue;
         }
         if (mapping.phys_base <= phys_addr && phys_addr < mapping.phys_base + mapping.size) {
-            auto vma_segment_start_addr = phys_addr - mapping.phys_base + addr;
-            LOG_INFO(Kernel_Vmm, "Unmaping direct mapping {:#x} with size {:#x}",
-                     vma_segment_start_addr, size);
+            const auto vma_start_offset = phys_addr - mapping.phys_base;
+            const auto addr_in_vma = mapping.base + vma_start_offset;
+            const auto size_in_vma =
+                mapping.size - vma_start_offset > size ? size : mapping.size - vma_start_offset;
+
+            LOG_INFO(Kernel_Vmm, "Unmaping direct mapping {:#x} with size {:#x}", addr_in_vma,
+                     size_in_vma);
             // Unmaping might erase from vma_map. We can't do it here.
-            remove_list.emplace_back(vma_segment_start_addr, size);
+            remove_list.emplace_back(addr_in_vma, size_in_vma);
         }
     }
     for (const auto& [addr, size] : remove_list) {
         UnmapMemoryImpl(addr, size);
     }
 
-    // Mark region as free and attempt to coalesce it with neighbours.
-    auto& area = dmem_area->second;
-    area.dma_type = DMAType::Free;
-    area.memory_type = 0;
-    MergeAdjacent(dmem_map, dmem_area);
+    // Unmap all dmem areas within this area.
+    auto phys_addr_to_search = phys_addr;
+    auto remaining_size = size;
+    auto dmem_area = FindDmemArea(phys_addr);
+    while (dmem_area != dmem_map.end() && remaining_size > 0) {
+        // Carve a free dmem area in place of this one.
+        const auto start_phys_addr =
+            phys_addr > dmem_area->second.base ? phys_addr : dmem_area->second.base;
+        const auto offset_in_dma = start_phys_addr - dmem_area->second.base;
+        const auto size_in_dma = dmem_area->second.size - offset_in_dma > remaining_size
+                                     ? remaining_size
+                                     : dmem_area->second.size - offset_in_dma;
+        const auto dmem_handle = CarveDmemArea(start_phys_addr, size_in_dma);
+        auto& new_dmem_area = dmem_handle->second;
+        new_dmem_area.dma_type = DMAType::Free;
+        new_dmem_area.memory_type = 0;
+
+        // Merge the new dmem_area with dmem_map
+        MergeAdjacent(dmem_map, dmem_handle);
+
+        // Get the next relevant dmem area.
+        phys_addr_to_search = phys_addr + size_in_dma;
+        remaining_size -= size_in_dma;
+        dmem_area = FindDmemArea(phys_addr_to_search);
+    }
 }
 
 s32 MemoryManager::PoolCommit(VAddr virtual_addr, u64 size, MemoryProt prot, s32 mtype) {
@@ -653,7 +675,7 @@ u64 MemoryManager::UnmapBytesFromEntry(VAddr virtual_addr, VirtualMemoryArea vma
         auto remaining_size = adjusted_size;
         DMemHandle dmem_handle = FindDmemArea(phys_addr);
         while (dmem_handle != dmem_map.end() && remaining_size > 0) {
-            const auto start_in_dma = phys_base - dmem_handle->second.base;
+            const auto start_in_dma = phys_addr - dmem_handle->second.base;
             const auto size_in_dma = dmem_handle->second.size - start_in_dma > remaining_size
                                          ? remaining_size
                                          : dmem_handle->second.size - start_in_dma;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -809,8 +809,8 @@ s32 MemoryManager::Protect(VAddr addr, u64 size, MemoryProt prot) {
 
     // Validate protection flags
     constexpr static MemoryProt valid_flags =
-        MemoryProt::NoAccess | MemoryProt::CpuRead | MemoryProt::CpuReadWrite |
-        MemoryProt::CpuExec | MemoryProt::GpuRead | MemoryProt::GpuWrite | MemoryProt::GpuReadWrite;
+        MemoryProt::NoAccess | MemoryProt::CpuRead | MemoryProt::CpuWrite | MemoryProt::CpuExec |
+        MemoryProt::GpuRead | MemoryProt::GpuWrite | MemoryProt::GpuReadWrite;
 
     MemoryProt invalid_flags = prot & ~valid_flags;
     if (invalid_flags != MemoryProt::NoAccess) {

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -30,7 +30,8 @@ namespace Core {
 enum class MemoryProt : u32 {
     NoAccess = 0,
     CpuRead = 1,
-    CpuReadWrite = 2,
+    CpuWrite = 2,
+    CpuReadWrite = 3,
     CpuExec = 4,
     GpuRead = 16,
     GpuWrite = 32,

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -239,7 +239,7 @@ public:
 
     s32 Protect(VAddr addr, u64 size, MemoryProt prot);
 
-    s64 ProtectBytes(VAddr addr, VirtualMemoryArea vma_base, u64 size, MemoryProt prot);
+    s64 ProtectBytes(VAddr addr, VirtualMemoryArea& vma_base, u64 size, MemoryProt prot);
 
     s32 VirtualQuery(VAddr addr, s32 flags, ::Libraries::Kernel::OrbisVirtualQueryInfo* info);
 


### PR DESCRIPTION
As I tested various forms of protections on memory, I found a handful of inaccuracies this PR will address.
- Execute permissions are hidden from direct memory mappings.
- Attempting to map backed memory with execute permssions could fail on Windows, due to an edge case related to `MapViewOfFile3`. Fixing this is necessary for `sceKernelMprotect` to work properly on flexible memory after #3639 
- Protecting memory with read | execute (and no write permissions) would behave strangely on Windows. This was due to an issue with the flags we applied in `AddressSpace::Impl::Protect`, so I cleaned up the logic there too.
- Internally, the PS4 kernel seems to treat read and write permissions separately, but applies read permissions whenever only write is specified. Handling this properly fixes the raw value of VMA protections occasionally being exactly one less than equivalent mappings on real hardware.
- `sceKernelMapDirectMemory2` returns EINVAL when requesting execute permissions, not EACCES.