### PR TITLE
vulkan: fix resetDescriptorPool and free ImGui descriptor sets

### DIFF
--- a/src/imgui/renderer/imgui_impl_vulkan.cpp
+++ b/src/imgui/renderer/imgui_impl_vulkan.cpp
@@ -10,6 +10,10 @@
 
 #include "imgui_impl_vulkan.h"
 
+#include <vulkan/vulkan.hpp>
+#include <fmt/core.h>
+#include <fmt/chrono.h>
+
 #ifndef IM_MAX
 #define IM_MAX(A, B) (((A) >= (B)) ? (A) : (B))
 #endif
@@ -471,7 +475,7 @@ void RemoveTexture(ImTextureID texture) {
     IM_ASSERT(texture != nullptr);
     VkData* bd = GetBackendData();
     const InitInfo& v = bd->init_info;
-    CheckVkErr(v.device.freeDescriptorSets(bd->descriptor_pool, {texture->descriptor_set}));
+    v.device.freeDescriptorSets(bd->descriptor_pool, {texture->descriptor_set});
     delete texture;
 }
 

--- a/src/video_core/renderer_vulkan/vk_resource_pool.cpp
+++ b/src/video_core/renderer_vulkan/vk_resource_pool.cpp
@@ -8,6 +8,8 @@
 #include "video_core/renderer_vulkan/vk_instance.h"
 #include "video_core/renderer_vulkan/vk_master_semaphore.h"
 #include "video_core/renderer_vulkan/vk_resource_pool.h"
+#include <type_traits>
+#include <utility>
 
 namespace Vulkan {
 
@@ -152,14 +154,15 @@ vk::DescriptorSet DescriptorHeap::Commit(vk::DescriptorSetLayout set_layout) {
     ASSERT_MSG(result == vk::Result::eErrorOutOfPoolMemory ||
                    result == vk::Result::eErrorFragmentedPool,
                "Unexpected error during descriptor set allocation: {}", vk::to_string(result));
+
     pending_pools.emplace_back(curr_pool, master_semaphore->CurrentTick());
     if (const auto [pool, tick] = pending_pools.front(); master_semaphore->IsFree(tick)) {
         curr_pool = pool;
         pending_pools.pop_front();
 
-        const auto reset_result = device.resetDescriptorPool(curr_pool);
-        ASSERT_MSG(reset_result == vk::Result::eSuccess,
-                   "Unexpected error resetting descriptor pool: {}", vk::to_string(reset_result));
+        // Just call resetDescriptorPool. Some Vulkan-Hpp variants return vk::Result,
+        // others return void. Discarding the return value is portable.
+        device.resetDescriptorPool(curr_pool);
     } else {
         CreateDescriptorPool();
     }


### PR DESCRIPTION
This change fixes two build/runtime issues related to Vulkan usage:

Build & test:
- Built successfully on macOS (Apple M2, MoltenVK) after these changes.
