### PR TITLE
videoout: Move HDR swapchain configuration to present thread.

### DIFF
--- a/src/core/libraries/videoout/driver.cpp
+++ b/src/core/libraries/videoout/driver.cpp
@@ -165,6 +165,9 @@ int VideoOutDriver::UnregisterBuffers(VideoOutPort* port, s32 attributeIndex) {
 }
 
 void VideoOutDriver::Flip(const Request& req) {
+    // Update HDR status before presenting.
+    presenter->SetHDR(req.port->is_hdr);
+
     // Present the frame.
     presenter->Present(req.frame);
 

--- a/src/core/libraries/videoout/driver.h
+++ b/src/core/libraries/videoout/driver.h
@@ -34,7 +34,7 @@ struct VideoOutPort {
     int flip_rate = 0;
     int prev_index = -1;
     bool is_open = false;
-    bool is_mode_changing = false; // Used to prevent flip during mode change
+    bool is_hdr = false;
 
     s32 FindFreeGroup() const {
         s32 index = 0;

--- a/src/core/libraries/videoout/video_out.cpp
+++ b/src/core/libraries/videoout/video_out.cpp
@@ -429,16 +429,17 @@ s32 PS4_SYSV_ABI sceVideoOutConfigureOutputMode_(s32 handle, u32 reserved, const
         return ORBIS_VIDEO_OUT_ERROR_INVALID_VALUE;
     }
 
-    if (mode->colorimetry != OrbisVideoOutColorimetry::Any) {
-        auto& game_info = Common::ElfInfo::Instance();
-        if (mode->colorimetry == OrbisVideoOutColorimetry::Bt2020PQ &&
-            game_info.GetPSFAttributes().support_hdr) {
-            port->is_mode_changing = true;
-            presenter->SetHDR(true);
-            port->is_mode_changing = false;
-        } else {
-            return ORBIS_VIDEO_OUT_ERROR_INVALID_VALUE;
+    switch (mode->colorimetry) {
+    case OrbisVideoOutColorimetry::Any:
+        port->is_hdr = false;
+        break;
+    case OrbisVideoOutColorimetry::Bt2020PQ:
+        if (Common::ElfInfo::Instance().GetPSFAttributes().support_hdr) {
+            port->is_hdr = true;
         }
+        break;
+    default:
+        return ORBIS_VIDEO_OUT_ERROR_INVALID_VALUE;
     }
 
     return ORBIS_OK;


### PR DESCRIPTION
On current main I'm hitting a crash when HDR is set up due to threading issues with recreating the Vulkan swapchain during present. Possibly due to recent changes to presenter logic.

Fixing this by moving the HDR swapchain re-configuration into the present thread. Note that we can safely call `SetHDR` each time as it is a no-op if the current HDR state is the same as input.