### PR TITLE
VK settings activation based on layers

### DIFF
--- a/src/video_core/renderer_vulkan/vk_platform.cpp
+++ b/src/video_core/renderer_vulkan/vk_platform.cpp
@@ -131,8 +131,7 @@ static auto GetLayerExtensions(std::vector<const char*>&& extensions,
         const auto [layer_properties_result, layer_extensions] =
             vk::enumerateInstanceExtensionProperties(std::string(layer_name));
         if (layer_properties_result != vk::Result::eSuccess) {
-            LOG_ERROR(Render_Vulkan, "Failed to query extension properties of {}: {}",
-                      layer_name,
+            LOG_ERROR(Render_Vulkan, "Failed to query extension properties of {}: {}", layer_name,
                       vk::to_string(layer_properties_result));
         }
         auto found = false;


### PR DESCRIPTION
1. Fix nullptr log when accessing emulator GUI settings with extension missing causing signal handler to call stop (it would be better to setup logs before anything else, but here it is a quick fix).

2. Fix VK extension warning:
```
[Render.Vulkan] <Info> vk_platform.cpp:227 CreateInstance: Creating vulkan instance
[Render.Vulkan] <Info> vk_platform.cpp:183 operator(): Candidate instance extension VK_EXT_layer_settings is not available
[Render.Vulkan] <Info> vk_platform.cpp:270 CreateInstance: Enabled instance extensions: VK_KHR_wayland_surface, VK_KHR_surface, VK_EXT_debug_utils
```

Based on
- https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8760#issuecomment-2447462238
- https://github.com/KhronosGroup/Vulkan-Samples/pull/1366/files#diff-590ca11c17edcf2236215b1326e168d8b2d515f0d4469af2cd22caf6c89b1f13
- https://registry.khronos.org/vulkan/specs/latest/man/html/vkEnumerateInstanceExtensionProperties.html#_description

Normal start
```
[Render.Vulkan] <Info> vk_platform.cpp:256 CreateInstance: Creating vulkan instance
[Render.Vulkan] <Info> vk_platform.cpp:299 CreateInstance: Enabled instance extensions: VK_KHR_wayland_surface, VK_KHR_surface, VK_EXT_swapchain_colorspace, VK_EXT_debug_utils, VK_EXT_layer_settings
[Render.Vulkan] <Info> vk_platform.cpp:300 CreateInstance: Enabled instance layers: VK_LAYER_KHRONOS_validation, VK_LAYER_LUNARG_crash_diagnostic
[Render.Vulkan] <Info> vk_instance.cpp:105 Instance: Found 2 physical devices
[Render.Vulkan] <Info> vk_instance.cpp:651 CollectDeviceParameters: GPU_Vendor: NVIDIA
[Render.Vulkan] <Info> vk_instance.cpp:652 CollectDeviceParameters: GPU_Model: NVIDIA RTX PRO 6000 Blackwell Workstation Edition
[Render.Vulkan] <Info> vk_instance.cpp:653 CollectDeviceParameters: GPU_Integrated: No
[Render.Vulkan] <Info> vk_instance.cpp:654 CollectDeviceParameters: GPU_Vulkan_Driver: NVIDIA 580.82.9.0
[Render.Vulkan] <Info> vk_instance.cpp:655 CollectDeviceParameters: GPU_Vulkan_Version: 1.4.312
```

With RenderDoc
```
[Render.Vulkan] <Info> vk_platform.cpp:256 CreateInstance: Creating vulkan instance
[Render.Vulkan] <Error> vk_platform.cpp:210 GetInstanceExtensions: Settings for layer VK_LAYER_KHRONOS_validation not available.
[Render.Vulkan] <Error> vk_platform.cpp:210 GetInstanceExtensions: Settings for layer VK_LAYER_LUNARG_crash_diagnostic not available.
[Render.Vulkan] <Info> vk_platform.cpp:299 CreateInstance: Enabled instance extensions: VK_KHR_xlib_surface, VK_KHR_surface, VK_EXT_swapchain_colorspace, VK_EXT_debug_utils
[Render.Vulkan] <Info> vk_platform.cpp:300 CreateInstance: Enabled instance layers: VK_LAYER_KHRONOS_validation, VK_LAYER_LUNARG_crash_diagnostic
[Render.Vulkan] <Info> vk_instance.cpp:105 Instance: Found 3 physical devices
[Render.Vulkan] <Info> vk_instance.cpp:651 CollectDeviceParameters: GPU_Vendor: NVIDIA
[Render.Vulkan] <Info> vk_instance.cpp:652 CollectDeviceParameters: GPU_Model: NVIDIA RTX PRO 6000 Blackwell Workstation Edition
[Render.Vulkan] <Info> vk_instance.cpp:653 CollectDeviceParameters: GPU_Integrated: No
[Render.Vulkan] <Info> vk_instance.cpp:654 CollectDeviceParameters: GPU_Vulkan_Driver: NVIDIA 580.82.9.0
[Render.Vulkan] <Info> vk_instance.cpp:655 CollectDeviceParameters: GPU_Vulkan_Version: 1.4.0
```

I am guessing RenderDoc is messing with layer path to not have my VK settings available there

The next improvement would be to use vk_layer_settings.txt instead IMO
https://vulkan.lunarg.com/doc/sdk/1.4.321.1/windows/layer_configuration.html