### PR TITLE
Linker: Lock linker mutex in RelocateAnyImports

### DIFF
--- a/src/core/linker.h
+++ b/src/core/linker.h
@@ -111,6 +111,8 @@ public:
     }
 
     void RelocateAnyImports(Module* m) {
+        std::scoped_lock lk{mutex};
+
         Relocate(m);
         const auto exports = m->GetExportModules();
         for (auto& export_mod : exports) {


### PR DESCRIPTION
Module relocation is not thread safe, games calling LoadAndStartModule on multiple threads can invalidate the m_modules iterators during the loops here.

This fixes crashes during sceKernelLoadStartModule in some apps.