### PR TITLE
Core: Increase address space limits and rework Windows address space initialization.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1216,7 +1216,7 @@ if (APPLE)
 
     if (ARCHITECTURE STREQUAL "x86_64")
         # Reserve system-managed memory space.
-        target_link_options(shadps4 PRIVATE -Wl,-ld_classic,-no_pie,-no_fixup_chains,-no_huge,-pagezero_size,0x4000,-segaddr,TCB_SPACE,0x4000,-segaddr,SYSTEM_MANAGED,0x400000,-segaddr,SYSTEM_RESERVED,0x7FFFFC000,-image_base,0x20000000000)
+        target_link_options(shadps4 PRIVATE -Wl,-ld_classic,-no_pie,-no_fixup_chains,-no_huge,-pagezero_size,0x4000,-segaddr,TCB_SPACE,0x4000,-segaddr,SYSTEM_MANAGED,0x400000,-segaddr,SYSTEM_RESERVED,0x7FFFFC000,-segaddr,USER_AREA,0x7000000000,-image_base,0x700000000000)
     endif()
 
     # Replacement for std::chrono::time_zone

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1180,7 +1180,6 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     endif()
 
     target_link_libraries(shadps4 PRIVATE uuid)
-    target_link_options(shadps4 PRIVATE "-Wl,--section-start=.interp=0x700000000000")
 endif()
 
 if (APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1266,6 +1266,13 @@ if (WIN32)
     else()
         target_link_options(shadps4 PRIVATE -Wl,--stack,2097152)
     endif()
+
+    # Change base image address
+    if (MSVC)
+        target_link_options(shadps4 PRIVATE /BASE:0x700000000000)
+    else()
+        target_link_options(shadps4 PRIVATE -Wl,--image-base=0x700000000000)
+    endif()
 endif()
 
 if (WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1180,6 +1180,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     endif()
 
     target_link_libraries(shadps4 PRIVATE uuid)
+    target_link_options(shadps4 PRIVATE "-Wl,--section-start=.interp=0x700000000000")
 endif()
 
 if (APPLE)

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -41,7 +41,12 @@ constexpr VAddr USER_MIN = 0x7000000000ULL;
 constexpr VAddr SYSTEM_RESERVED_MAX = 0xFFFFFFFFFULL;
 constexpr VAddr USER_MIN = 0x1000000000ULL;
 #endif
+#if defined(__linux__)
+// Linux maps the shadPS4 executable around here, so limit the user maximum
+constexpr VAddr USER_MAX = 0x54FFFFFFFFFFULL;
+#else
 constexpr VAddr USER_MAX = 0x5FFFFFFFFFFFULL;
+#endif
 
 // Constants for the sizes of the ranges in address space.
 static constexpr u64 SystemManagedSize = SYSTEM_MANAGED_MAX - SYSTEM_MANAGED_MIN + 1;

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -100,7 +100,7 @@ struct AddressSpace::Impl {
 
         // Determine the host OS build number
         // Retrieve module handle for ntdll
-        auto ntdll_handle = GetModuleHandle("ntdll.dll");
+        auto ntdll_handle = GetModuleHandleW(L"ntdll.dll");
         ASSERT_MSG(ntdll_handle, "Failed to retrieve ntdll handle");
 
         // Get the RtlGetVersion function

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -80,6 +80,7 @@ struct AddressSpace::Impl {
         VAddr next_addr = SYSTEM_MANAGED_MIN;
         MEMORY_BASIC_INFORMATION info{};
         while (next_addr <= USER_MAX) {
+            LOG_INFO(Core, "Querying information for address {:#x}", next_addr);
             ASSERT_MSG(VirtualQuery(reinterpret_cast<PVOID>(next_addr), &info, sizeof(info)),
                        "Failed to query memory information for address {:#x}", next_addr);
 

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -113,10 +113,10 @@ struct AddressSpace::Impl {
 
         // Set these constants to ensure code relying on them works.
         // These do not fully encapsulate the state of the address space.
+        system_managed_base = reinterpret_cast<u8*>(regions.begin()->first);
+        system_managed_size = SystemManagedSize - (regions.begin()->first - SYSTEM_MANAGED_MIN);
         system_reserved_base = reinterpret_cast<u8*>(SYSTEM_RESERVED_MIN);
         system_reserved_size = SystemReservedSize;
-        system_managed_base = reinterpret_cast<u8*>(SYSTEM_MANAGED_MIN);
-        system_managed_size = SystemManagedSize;
         user_base = reinterpret_cast<u8*>(USER_MIN);
         user_size = UserSize;
 

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -674,9 +674,9 @@ boost::icl::interval_set<VAddr> AddressSpace::GetUsableRegions() {
 #else
     // On Linux and Mac, the memory space is fully represented by the three major regions
     boost::icl::interval_set<VAddr> reserved_regions;
-    reserved_regions.insert({system_managed_addr, system_managed_addr + system_managed_size});
-    reserved_regions.insert({system_reserved_addr, system_reserved_addr + system_reserved_size});
-    reserved_regions.insert({user_addr, user_addr + user_size});
+    reserved_regions.insert({system_managed_base, system_managed_base + system_managed_size});
+    reserved_regions.insert({system_reserved_base, system_reserved_base + system_reserved_size});
+    reserved_regions.insert({user_base, user_base + user_size});
     return reserved_regions;
 #endif
 }

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -674,9 +674,13 @@ boost::icl::interval_set<VAddr> AddressSpace::GetUsableRegions() {
 #else
     // On Linux and Mac, the memory space is fully represented by the three major regions
     boost::icl::interval_set<VAddr> reserved_regions;
-    reserved_regions.insert({system_managed_base, system_managed_base + system_managed_size});
-    reserved_regions.insert({system_reserved_base, system_reserved_base + system_reserved_size});
-    reserved_regions.insert({user_base, user_base + user_size});
+    VAddr system_managed_addr = reinterpret_cast<VAddr>(system_managed_base);
+    VAddr system_reserved_addr = reinterpret_cast<VAddr>(system_reserved_base);
+    VAddr user_addr = reinterpret_cast<VAddr>(user_base);
+
+    reserved_regions.insert({system_managed_addr, system_managed_addr + system_managed_size});
+    reserved_regions.insert({system_reserved_addr, system_reserved_addr + system_reserved_size});
+    reserved_regions.insert({user_addr, user_addr + user_size});
     return reserved_regions;
 #endif
 }

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -29,9 +29,9 @@ asm(".zerofill USER_AREA,USER_AREA,__USER_AREA,0x5F9000000000");
 namespace Core {
 
 // Constants used for mapping address space.
-constexpr VAddr SYSTEM_MANAGED_MIN = 0x00000400000ULL;
-constexpr VAddr SYSTEM_MANAGED_MAX = 0x07FFFFBFFFULL;
-constexpr VAddr SYSTEM_RESERVED_MIN = 0x07FFFFC000ULL;
+constexpr VAddr SYSTEM_MANAGED_MIN = 0x400000ULL;
+constexpr VAddr SYSTEM_MANAGED_MAX = 0x7FFFFBFFFULL;
+constexpr VAddr SYSTEM_RESERVED_MIN = 0x7FFFFC000ULL;
 #if defined(__APPLE__) && defined(ARCH_X86_64)
 // Commpage ranges from 0xFC0000000 - 0xFFFFFFFFF, so decrease the system reserved maximum.
 constexpr VAddr SYSTEM_RESERVED_MAX = 0xFBFFFFFFFULL;

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -80,7 +80,6 @@ struct AddressSpace::Impl {
         VAddr next_addr = SYSTEM_MANAGED_MIN;
         MEMORY_BASIC_INFORMATION info{};
         while (next_addr <= USER_MAX) {
-            LOG_INFO(Core, "Querying information for address {:#x}", next_addr);
             ASSERT_MSG(VirtualQuery(reinterpret_cast<PVOID>(next_addr), &info, sizeof(info)),
                        "Failed to query memory information for address {:#x}", next_addr);
 
@@ -105,7 +104,6 @@ struct AddressSpace::Impl {
 
         // Reserve all detected free regions.
         for (auto region : regions) {
-            LOG_INFO(Core, "Mapping region {:#x} - {:#x}", region.second.base, region.second.base + region.second.size);
             auto addr = static_cast<u8*>(VirtualAlloc2(
                 process, reinterpret_cast<PVOID>(region.second.base), region.second.size,
                 MEM_RESERVE | MEM_RESERVE_PLACEHOLDER, PAGE_NOACCESS, NULL, 0));
@@ -123,8 +121,6 @@ struct AddressSpace::Impl {
         user_base = reinterpret_cast<u8*>(USER_MIN);
         user_size = UserSize;
 
-        LOG_INFO(Core, "Virtual address space initialized");
-
         // Increase BackingSize to account for config options.
         BackingSize += Config::getExtraDmemInMbytes() * 1_MB;
 
@@ -132,20 +128,19 @@ struct AddressSpace::Impl {
         backing_handle = CreateFileMapping2(INVALID_HANDLE_VALUE, nullptr, FILE_MAP_ALL_ACCESS,
                                             PAGE_EXECUTE_READWRITE, SEC_COMMIT, BackingSize,
                                             nullptr, nullptr, 0);
-        LOG_INFO(Core, "Backing file mapped");
+
         ASSERT_MSG(backing_handle, "{}", Common::GetLastErrorMsg());
         // Allocate a virtual memory for the backing file map as placeholder
         backing_base = static_cast<u8*>(VirtualAlloc2(process, nullptr, BackingSize,
                                                       MEM_RESERVE | MEM_RESERVE_PLACEHOLDER,
                                                       PAGE_NOACCESS, nullptr, 0));
         ASSERT_MSG(backing_base, "{}", Common::GetLastErrorMsg());
-        LOG_INFO(Core, "Backing file virtual memory mapped");
+
         // Map backing placeholder. This will commit the pages
         void* const ret =
             MapViewOfFile3(backing_handle, process, backing_base, 0, BackingSize,
                            MEM_REPLACE_PLACEHOLDER, PAGE_EXECUTE_READWRITE, nullptr, 0);
         ASSERT_MSG(ret == backing_base, "{}", Common::GetLastErrorMsg());
-        LOG_INFO(Core, "Address space initialized");
     }
 
     ~Impl() {

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -80,7 +80,8 @@ struct AddressSpace::Impl {
         VAddr next_addr = SYSTEM_MANAGED_MIN;
         MEMORY_BASIC_INFORMATION info{};
         while (next_addr <= USER_MAX) {
-            u64 result = VirtualQuery(reinterpret_cast<PVOID>(next_addr), &info, sizeof(info));
+            ASSERT_MSG(VirtualQuery(reinterpret_cast<PVOID>(next_addr), &info, sizeof(info)),
+                       "Failed to query memory information for address {:#x}", next_addr);
 
             // Ensure logic uses values aligned to bage boundaries.
             next_addr = reinterpret_cast<VAddr>(info.BaseAddress) + info.RegionSize;

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -28,7 +28,28 @@ asm(".zerofill USER_AREA,USER_AREA,__USER_AREA,0x5F9000000000");
 
 namespace Core {
 
-static size_t BackingSize = ORBIS_KERNEL_TOTAL_MEM_DEV_PRO;
+// Constants used for mapping address space.
+constexpr VAddr SYSTEM_MANAGED_MIN = 0x00000400000ULL;
+constexpr VAddr SYSTEM_MANAGED_MAX = 0x07FFFFBFFFULL;
+constexpr VAddr SYSTEM_RESERVED_MIN = 0x07FFFFC000ULL;
+#if defined(__APPLE__) && defined(ARCH_X86_64)
+// Commpage ranges from 0xFC0000000 - 0xFFFFFFFFF, so decrease the system reserved maximum.
+constexpr VAddr SYSTEM_RESERVED_MAX = 0xFBFFFFFFFULL;
+// GPU-reserved memory ranges from 0x1000000000 - 0x6FFFFFFFFF, so increase the user minimum.
+constexpr VAddr USER_MIN = 0x7000000000ULL;
+#else
+constexpr VAddr SYSTEM_RESERVED_MAX = 0xFFFFFFFFFULL;
+constexpr VAddr USER_MIN = 0x1000000000ULL;
+#endif
+constexpr VAddr USER_MAX = 0x5FFFFFFFFFFFULL;
+
+// Constants for the sizes of the ranges in address space.
+static constexpr u64 SystemManagedSize = SYSTEM_MANAGED_MAX - SYSTEM_MANAGED_MIN + 1;
+static constexpr u64 SystemReservedSize = SYSTEM_RESERVED_MAX - SYSTEM_RESERVED_MIN + 1;
+static constexpr u64 UserSize = USER_MAX - USER_MIN + 1;
+
+// Required backing file size for mapping physical address space.
+static u64 BackingSize = ORBIS_KERNEL_TOTAL_MEM_DEV_PRO;
 
 #ifdef _WIN32
 

--- a/src/core/address_space.h
+++ b/src/core/address_space.h
@@ -30,11 +30,11 @@ constexpr VAddr SYSTEM_RESERVED_MAX = 0xFBFFFFFFFULL;
 constexpr VAddr SYSTEM_RESERVED_MAX = 0xFFFFFFFFFULL;
 #endif
 constexpr VAddr USER_MIN = 0x1000000000ULL;
-constexpr VAddr USER_MAX = 0xFBFFFFFFFFULL;
+constexpr VAddr USER_MAX = 0x4FFFFFFFFFFFULL;
 
-static constexpr size_t SystemManagedSize = SYSTEM_MANAGED_MAX - SYSTEM_MANAGED_MIN + 1;
-static constexpr size_t SystemReservedSize = SYSTEM_RESERVED_MAX - SYSTEM_RESERVED_MIN + 1;
-static constexpr size_t UserSize = 1ULL << 40;
+static constexpr u64 SystemManagedSize = SYSTEM_MANAGED_MAX - SYSTEM_MANAGED_MIN + 1;
+static constexpr u64 SystemReservedSize = SYSTEM_RESERVED_MAX - SYSTEM_RESERVED_MIN + 1;
+static constexpr u64 UserSize = USER_MAX - USER_MIN + 1;
 
 /**
  * Represents the user virtual address space backed by a dmem memory block

--- a/src/core/address_space.h
+++ b/src/core/address_space.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <boost/icl/separate_interval_set.hpp>
 #include <memory>
+#include <boost/icl/separate_interval_set.hpp>
 #include "common/arch.h"
 #include "common/enum.h"
 #include "common/types.h"

--- a/src/core/address_space.h
+++ b/src/core/address_space.h
@@ -31,7 +31,7 @@ constexpr VAddr SYSTEM_RESERVED_MAX = 0xFBFFFFFFFULL;
 constexpr VAddr SYSTEM_RESERVED_MAX = 0xFFFFFFFFFULL;
 #endif
 constexpr VAddr USER_MIN = 0x1000000000ULL;
-constexpr VAddr USER_MAX = 0x4FFFFFFFFFFFULL;
+constexpr VAddr USER_MAX = 0x5FFFFFFFFFFFULL;
 
 static constexpr u64 SystemManagedSize = SYSTEM_MANAGED_MAX - SYSTEM_MANAGED_MIN + 1;
 static constexpr u64 SystemReservedSize = SYSTEM_RESERVED_MAX - SYSTEM_RESERVED_MIN + 1;

--- a/src/core/address_space.h
+++ b/src/core/address_space.h
@@ -31,7 +31,7 @@ constexpr VAddr SYSTEM_RESERVED_MAX = 0xFBFFFFFFFULL;
 constexpr VAddr SYSTEM_RESERVED_MAX = 0xFFFFFFFFFULL;
 #endif
 constexpr VAddr USER_MIN = 0x1000000000ULL;
-constexpr VAddr USER_MAX = 0x7FFFFFFFFFFULL;
+constexpr VAddr USER_MAX = 0x10FFFFFFFFFULL;
 
 static constexpr u64 SystemManagedSize = SYSTEM_MANAGED_MAX - SYSTEM_MANAGED_MIN + 1;
 static constexpr u64 SystemReservedSize = SYSTEM_RESERVED_MAX - SYSTEM_RESERVED_MIN + 1;

--- a/src/core/address_space.h
+++ b/src/core/address_space.h
@@ -31,7 +31,7 @@ constexpr VAddr SYSTEM_RESERVED_MAX = 0xFBFFFFFFFULL;
 constexpr VAddr SYSTEM_RESERVED_MAX = 0xFFFFFFFFFULL;
 #endif
 constexpr VAddr USER_MIN = 0x1000000000ULL;
-constexpr VAddr USER_MAX = 0x50FFFFFFFFFFULL;
+constexpr VAddr USER_MAX = 0x7FFFFFFFFFFULL;
 
 static constexpr u64 SystemManagedSize = SYSTEM_MANAGED_MAX - SYSTEM_MANAGED_MIN + 1;
 static constexpr u64 SystemReservedSize = SYSTEM_RESERVED_MAX - SYSTEM_RESERVED_MIN + 1;

--- a/src/core/address_space.h
+++ b/src/core/address_space.h
@@ -25,13 +25,15 @@ constexpr VAddr SYSTEM_MANAGED_MIN = 0x00000400000ULL;
 constexpr VAddr SYSTEM_MANAGED_MAX = 0x07FFFFBFFFULL;
 constexpr VAddr SYSTEM_RESERVED_MIN = 0x07FFFFC000ULL;
 #if defined(__APPLE__) && defined(ARCH_X86_64)
-// Can only comfortably reserve the first 0x7C0000000 of system reserved space.
+// Commpage ranges from 0xFC0000000 - 0xFFFFFFFFF, so decrease the system reserved maximum.
 constexpr VAddr SYSTEM_RESERVED_MAX = 0xFBFFFFFFFULL;
+// GPU-reserved memory ranges from 0x1000000000 - 0x6FFFFFFFFF, so increase the user minimum.
+constexpr VAddr USER_MIN = 0x7000000000ULL;
 #else
 constexpr VAddr SYSTEM_RESERVED_MAX = 0xFFFFFFFFFULL;
-#endif
 constexpr VAddr USER_MIN = 0x1000000000ULL;
-constexpr VAddr USER_MAX = 0x10FFFFFFFFFULL;
+#endif
+constexpr VAddr USER_MAX = 0x5FFFFFFFFFFFULL;
 
 static constexpr u64 SystemManagedSize = SYSTEM_MANAGED_MAX - SYSTEM_MANAGED_MIN + 1;
 static constexpr u64 SystemReservedSize = SYSTEM_RESERVED_MAX - SYSTEM_RESERVED_MIN + 1;

--- a/src/core/address_space.h
+++ b/src/core/address_space.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <boost/icl/separate_interval_set.hpp>
 #include <memory>
 #include "common/arch.h"
 #include "common/enum.h"
@@ -99,6 +100,9 @@ public:
                PAddr phys_base, bool is_exec, bool has_backing, bool readonly_file);
 
     void Protect(VAddr virtual_addr, size_t size, MemoryPermission perms);
+
+    // Returns an interval set containing all usable regions.
+    boost::icl::interval_set<VAddr> GetUsableRegions();
 
 private:
     struct Impl;

--- a/src/core/address_space.h
+++ b/src/core/address_space.h
@@ -31,7 +31,7 @@ constexpr VAddr SYSTEM_RESERVED_MAX = 0xFBFFFFFFFULL;
 constexpr VAddr SYSTEM_RESERVED_MAX = 0xFFFFFFFFFULL;
 #endif
 constexpr VAddr USER_MIN = 0x1000000000ULL;
-constexpr VAddr USER_MAX = 0x5FFFFFFFFFFFULL;
+constexpr VAddr USER_MAX = 0x50FFFFFFFFFFULL;
 
 static constexpr u64 SystemManagedSize = SYSTEM_MANAGED_MAX - SYSTEM_MANAGED_MIN + 1;
 static constexpr u64 SystemReservedSize = SYSTEM_RESERVED_MAX - SYSTEM_RESERVED_MIN + 1;

--- a/src/core/address_space.h
+++ b/src/core/address_space.h
@@ -21,24 +21,6 @@ enum class MemoryPermission : u32 {
 };
 DECLARE_ENUM_FLAG_OPERATORS(MemoryPermission)
 
-constexpr VAddr SYSTEM_MANAGED_MIN = 0x00000400000ULL;
-constexpr VAddr SYSTEM_MANAGED_MAX = 0x07FFFFBFFFULL;
-constexpr VAddr SYSTEM_RESERVED_MIN = 0x07FFFFC000ULL;
-#if defined(__APPLE__) && defined(ARCH_X86_64)
-// Commpage ranges from 0xFC0000000 - 0xFFFFFFFFF, so decrease the system reserved maximum.
-constexpr VAddr SYSTEM_RESERVED_MAX = 0xFBFFFFFFFULL;
-// GPU-reserved memory ranges from 0x1000000000 - 0x6FFFFFFFFF, so increase the user minimum.
-constexpr VAddr USER_MIN = 0x7000000000ULL;
-#else
-constexpr VAddr SYSTEM_RESERVED_MAX = 0xFFFFFFFFFULL;
-constexpr VAddr USER_MIN = 0x1000000000ULL;
-#endif
-constexpr VAddr USER_MAX = 0x5FFFFFFFFFFFULL;
-
-static constexpr u64 SystemManagedSize = SYSTEM_MANAGED_MAX - SYSTEM_MANAGED_MIN + 1;
-static constexpr u64 SystemReservedSize = SYSTEM_RESERVED_MAX - SYSTEM_RESERVED_MIN + 1;
-static constexpr u64 UserSize = USER_MAX - USER_MIN + 1;
-
 /**
  * Represents the user virtual address space backed by a dmem memory block
  */

--- a/src/core/libraries/gnmdriver/gnmdriver.cpp
+++ b/src/core/libraries/gnmdriver/gnmdriver.cpp
@@ -72,11 +72,8 @@ static int sdk_version{0};
 
 static u32 asc_next_offs_dw[Liverpool::NumComputeRings];
 
-// We need to get an instance of our address space to derive a proper ring address here.
-auto* memory = Core::Memory::Instance();
-auto& address_space = memory->GetAddressSpace();
-static VAddr tessellation_factors_ring_addr = address_space.SystemReservedVirtualBase() +
-                                              address_space.SystemReservedVirtualSize() - 0xFFFFFFF;
+// This address is initialized in sceGnmGetTheTessellationFactorRingBufferBaseAddress
+static VAddr tessellation_factors_ring_addr = -1;
 static constexpr u32 tessellation_offchip_buffer_size = 0x800000u;
 
 static void ResetSubmissionLock(Platform::InterruptId irq) {
@@ -1002,7 +999,14 @@ int PS4_SYSV_ABI sceGnmGetShaderStatus() {
 }
 
 VAddr PS4_SYSV_ABI sceGnmGetTheTessellationFactorRingBufferBaseAddress() {
+    auto* memory = Core::Memory::Instance();
+    auto& address_space = memory->GetAddressSpace();
     LOG_TRACE(Lib_GnmDriver, "called");
+    if (tessellation_factors_ring_addr == -1) {
+        tessellation_factors_ring_addr = address_space.SystemReservedVirtualBase() +
+                                         address_space.SystemReservedVirtualSize() - 0xFFFFFFF;
+    }
+
     return tessellation_factors_ring_addr;
 }
 

--- a/src/core/libraries/gnmdriver/gnmdriver.cpp
+++ b/src/core/libraries/gnmdriver/gnmdriver.cpp
@@ -17,6 +17,7 @@
 #include "core/libraries/kernel/process.h"
 #include "core/libraries/libs.h"
 #include "core/libraries/videoout/video_out.h"
+#include "core/memory.h"
 #include "core/platform.h"
 #include "video_core/amdgpu/liverpool.h"
 #include "video_core/amdgpu/pm4_cmds.h"
@@ -70,7 +71,12 @@ static bool send_init_packet{true}; // initialize HW state before first game's s
 static int sdk_version{0};
 
 static u32 asc_next_offs_dw[Liverpool::NumComputeRings];
-static constexpr VAddr tessellation_factors_ring_addr = Core::SYSTEM_RESERVED_MAX - 0xFFFFFFF;
+
+// We need to get an instance of our address space to derive a proper ring address here.
+auto* memory = Core::Memory::Instance();
+auto& address_space = memory->GetAddressSpace();
+static VAddr tessellation_factors_ring_addr = address_space.SystemReservedVirtualBase() +
+                                              address_space.SystemReservedVirtualSize() - 0xFFFFFFF;
 static constexpr u32 tessellation_offchip_buffer_size = 0x800000u;
 
 static void ResetSubmissionLock(Platform::InterruptId irq) {

--- a/src/core/libraries/gnmdriver/gnmdriver.cpp
+++ b/src/core/libraries/gnmdriver/gnmdriver.cpp
@@ -999,10 +999,10 @@ int PS4_SYSV_ABI sceGnmGetShaderStatus() {
 }
 
 VAddr PS4_SYSV_ABI sceGnmGetTheTessellationFactorRingBufferBaseAddress() {
-    auto* memory = Core::Memory::Instance();
-    auto& address_space = memory->GetAddressSpace();
     LOG_TRACE(Lib_GnmDriver, "called");
     if (tessellation_factors_ring_addr == -1) {
+        auto* memory = Core::Memory::Instance();
+        auto& address_space = memory->GetAddressSpace();
         tessellation_factors_ring_addr = address_space.SystemReservedVirtualBase() +
                                          address_space.SystemReservedVirtualSize() - 0xFFFFFFF;
     }

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -267,7 +267,7 @@ int PS4_SYSV_ABI posix_pthread_create_name_np(PthreadT* thread, const PthreadAtt
     new_thread->cancel_async = false;
 
     auto* memory = Core::Memory::Instance();
-    if (name && memory->IsValidAddress(name)) {
+    if (name && memory->IsValidMapping(reinterpret_cast<VAddr>(name))) {
         new_thread->name = name;
     } else {
         new_thread->name = fmt::format("Thread{}", new_thread->tid.load());

--- a/src/core/libraries/kernel/threads/thread_state.cpp
+++ b/src/core/libraries/kernel/threads/thread_state.cpp
@@ -21,9 +21,10 @@ void TcbDtor(Core::Tcb* oldtls);
 ThreadState::ThreadState() {
     // Reserve memory for maximum amount of threads allowed.
     auto* memory = Core::Memory::Instance();
+    auto& impl = memory->GetAddressSpace();
     static constexpr u32 ThrHeapSize = Common::AlignUp(sizeof(Pthread) * MaxThreads, 16_KB);
     void* heap_addr{};
-    const int ret = memory->MapMemory(&heap_addr, Core::SYSTEM_RESERVED_MIN, ThrHeapSize,
+    const int ret = memory->MapMemory(&heap_addr, impl.SystemReservedVirtualBase(), ThrHeapSize,
                                       Core::MemoryProt::CpuReadWrite, Core::MemoryMapFlags::NoFlags,
                                       Core::VMAType::File, "ThrHeap");
     ASSERT_MSG(ret == 0, "Unable to allocate thread heap memory {}", ret);

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -133,8 +133,8 @@ void MemoryManager::CopySparseMemory(VAddr virtual_addr, u8* dest, u64 size) {
 
 bool MemoryManager::TryWriteBacking(void* address, const void* data, u32 num_bytes) {
     const VAddr virtual_addr = std::bit_cast<VAddr>(address);
-    ASSERT_MSG(IsValidMapping(virtual_addr, num_bytes), "Attempted to access invalid address {}",
-               virtual_addr);
+    ASSERT_MSG(IsValidMapping(virtual_addr, num_bytes),
+               "Attempted to access invalid address {:#x}", virtual_addr);
     const auto& vma = FindVMA(virtual_addr)->second;
     if (!HasPhysicalBacking(vma)) {
         return false;
@@ -1153,7 +1153,7 @@ VAddr MemoryManager::SearchFree(VAddr virtual_addr, u64 size, u32 alignment) {
     }
 
     // If the requested address is beyond the maximum our code can handle, throw an assert
-    ASSERT_MSG(IsValidMapping(virtual_addr, 0), "Input address {:#x} is out of bounds",
+    ASSERT_MSG(IsValidMapping(virtual_addr), "Input address {:#x} is out of bounds",
                virtual_addr);
 
     // Align up the virtual_addr first.

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -133,8 +133,8 @@ void MemoryManager::CopySparseMemory(VAddr virtual_addr, u8* dest, u64 size) {
 
 bool MemoryManager::TryWriteBacking(void* address, const void* data, u32 num_bytes) {
     const VAddr virtual_addr = std::bit_cast<VAddr>(address);
-    ASSERT_MSG(IsValidMapping(virtual_addr, num_bytes),
-               "Attempted to access invalid address {:#x}", virtual_addr);
+    ASSERT_MSG(IsValidMapping(virtual_addr, num_bytes), "Attempted to access invalid address {:#x}",
+               virtual_addr);
     const auto& vma = FindVMA(virtual_addr)->second;
     if (!HasPhysicalBacking(vma)) {
         return false;
@@ -1153,8 +1153,7 @@ VAddr MemoryManager::SearchFree(VAddr virtual_addr, u64 size, u32 alignment) {
     }
 
     // If the requested address is beyond the maximum our code can handle, throw an assert
-    ASSERT_MSG(IsValidMapping(virtual_addr), "Input address {:#x} is out of bounds",
-               virtual_addr);
+    ASSERT_MSG(IsValidMapping(virtual_addr), "Input address {:#x} is out of bounds", virtual_addr);
 
     // Align up the virtual_addr first.
     virtual_addr = Common::AlignUp(virtual_addr, alignment);

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -26,7 +26,8 @@ MemoryManager::MemoryManager() {
     // Log initialization.
     const auto last_valid_vma = --vma_map.end();
     LOG_INFO(Kernel_Vmm, "Virtual memory space initialized");
-    LOG_INFO(Kernel_Vmm, "Minimum address = {:#x}, maximum address = {:#x}", vma_map.begin()->first, last_valid_vma->second.base + last_valid_vma->second.size);
+    LOG_INFO(Kernel_Vmm, "Minimum address = {:#x}, maximum address = {:#x}", vma_map.begin()->first,
+             last_valid_vma->second.base + last_valid_vma->second.size);
 }
 
 MemoryManager::~MemoryManager() = default;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -1156,7 +1156,7 @@ VAddr MemoryManager::SearchFree(VAddr virtual_addr, u64 size, u32 alignment) {
     }
 
     // If the requested address is beyond the maximum our code can handle, throw an assert
-    ASSERT_MSG(IsValidMapping(virtual_addr, size), "Input address {:#x} is out of bounds",
+    ASSERT_MSG(IsValidMapping(virtual_addr, 0), "Input address {:#x} is out of bounds",
                virtual_addr);
 
     // Align up the virtual_addr first.

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -15,19 +15,16 @@
 namespace Core {
 
 MemoryManager::MemoryManager() {
+    LOG_INFO(Kernel_Vmm, "Virtual memory space initialized with regions:");
+
     // Construct vma_map using the regions reserved by the address space
     auto regions = impl.GetUsableRegions();
     u64 total_usable_space = 0;
     for (auto region : regions) {
         vma_map.emplace(region.lower(),
                         VirtualMemoryArea{region.lower(), region.upper() - region.lower()});
+        LOG_INFO(Kernel_Vmm, "{:#x} - {:#x}", region.lower(), region.upper());
     }
-
-    // Log initialization.
-    const auto last_valid_vma = --vma_map.end();
-    LOG_INFO(Kernel_Vmm, "Virtual memory space initialized");
-    LOG_INFO(Kernel_Vmm, "Minimum address = {:#x}, maximum address = {:#x}", vma_map.begin()->first,
-             last_valid_vma->second.base + last_valid_vma->second.size);
 }
 
 MemoryManager::~MemoryManager() = default;

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -301,7 +301,7 @@ private:
                vma.type == VMAType::Pooled;
     }
 
-    VAddr SearchFree(VAddr virtual_addr, u64 size, u32 alignment = 0);
+    VAddr SearchFree(VAddr virtual_addr, u64 size, u32 alignment);
 
     VMAHandle CarveVMA(VAddr virtual_addr, u64 size);
 

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -200,11 +200,40 @@ public:
         return virtual_addr + size < max_gpu_address;
     }
 
-    bool IsValidAddress(const void* addr) const noexcept {
-        const VAddr virtual_addr = reinterpret_cast<VAddr>(addr);
+    bool IsValidMapping(const VAddr virtual_addr, const u64 size = 0) {
         const auto end_it = std::prev(vma_map.end());
         const VAddr end_addr = end_it->first + end_it->second.size;
-        return virtual_addr >= vma_map.begin()->first && virtual_addr < end_addr;
+
+        // If the address fails boundary checks, return early.
+        if (virtual_addr < vma_map.begin()->first || virtual_addr >= end_addr) {
+            return false;
+        }
+
+        // If size is zero and boundary checks succeed, then skip more robust checking
+        if (size == 0) {
+            return true;
+        }
+
+        // Now make sure the full address range is contained in vma_map.
+        auto vma_handle = FindVMA(virtual_addr);
+        auto addr_to_check = virtual_addr;
+        s64 size_to_validate = size;
+        while (vma_handle != vma_map.end() && size_to_validate > 0) {
+            const auto offset_in_vma = addr_to_check - vma_handle->second.base;
+            const auto size_in_vma = vma_handle->second.size - offset_in_vma;
+            size_to_validate -= size_in_vma;
+            addr_to_check += size_in_vma;
+            vma_handle++;
+
+            // Make sure there isn't any gap here
+            if (size_to_validate > 0 && vma_handle != vma_map.end() &&
+                addr_to_check != vma_handle->second.base) {
+                return false;
+            }
+        }
+
+        // If we reach this point and size to validate is not positive, then this mapping is valid.
+        return size_to_validate <= 0;
     }
 
     u64 ClampRangeSize(VAddr virtual_addr, u64 size);


### PR DESCRIPTION
Current Windows builds of shadPS4 are prone to asserting in address_space on emulator initialization due to Windows' address space randomization. This also prevents expanding the address space to higher addresses (which is needed for a handful of EA titles).

This PR introduces logic to detect and map around system mappings on Windows devices, pass information about these gaps to our memory code, and more robust address validation logic to ensure gaps are accounted for when detecting if requested memory areas are within the vma map.

For Mac users: this PR should make asserts trigger more consistently when games try mapping to addresses that we can't reserve.

For Windows users: this PR should fix those random-ish cases of
```
[Debug] <Critical> address_space.cpp:105 operator(): Assertion Failed!
Unable to reserve virtual address space: Not enough memory resources are available to process this command.
```

For all users: this PR should address cases of the following assert triggering on addresses greater than 0x11000000000 (mainly seen in earlier titles published by EA).

```
[Debug] memory.cpp:902 operator(): Assertion Failed!
Input address .... is out of bounds
```
I'm opening this as a draft for now since I need to test edge cases further, and ideally make sure our own HLE mappings aren't going to hit asserts in the more extreme cases.

I would also appreciate some tests from the aforementioned EA games, the only thing I have hitting that out of bounds assert is an app, and it dies from a Windows-specific issue with code patches.