### PR TITLE
image_info: Fix guest size calculation for linear render targets

### DIFF
--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -575,6 +575,9 @@ ImageView& TextureCache::FindTexture(ImageId image_id, const BaseDesc& desc) {
 ImageView& TextureCache::FindRenderTarget(ImageId image_id, const BaseDesc& desc) {
     Image& image = slot_images[image_id];
     image.flags |= ImageFlagBits::GpuModified;
+    if (Config::readbackLinearImages() && !image.info.props.is_tiled) {
+        download_images.emplace(image_id);
+    }
     image.usage.render_target = 1u;
     UpdateImage(image_id);
 


### PR DESCRIPTION
The linear aligned tile mode doesn't require image height to be tile aligned only the pitch [per addrlib](https://github.com/chaotic-cx/mesa-mirror/blob/52c7b0d20c88620fd55d21a62468211674559978/src/amd/addrlib/src/r800/egbaddrlib.cpp#L666)

This is an issue with render targets because the registers that hold size information store it in units of tiles, so using these makes the guest size appear larger than it actually is. For example a 16128x1 RGBA32 render target should have a size of 258048 bytes (16128 * 16), but the color buffer registers will report 2064384 bytes (16128 * 8 * 16) which would be correct if the height were to be padded to tile dimension (8). The fix is manually computing the size if the render target is not tiled. Also removed handling of ArrayLinearGeneral because this doesn't align at all, so the current code is wrong for it anyway and seems entirely unused.

This should resolve some "Encountered unresolvable image overlap with equal memory address." asserts like [this](https://github.com/shadps4-compatibility/shadps4-game-compatibility/issues/1701) and might also fix random crashes when readback linear images is enabled, because with previous code it could overwrite additional memory, especially if the image size was 1x1 which isn't uncommon

This issue was reported to me by @Xcedf who also provided needed debugging information