### PR TITLE
Core: Include older Windows 11 builds in the address space workaround

### DIFF
--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -118,9 +118,10 @@ struct AddressSpace::Impl {
         RtlGetVersion(&os_version_info);
 
         u64 supported_user_max = USER_MAX;
-        static constexpr s32 Windows11BuildNumber = 22000;
-        if (os_version_info.dwBuildNumber < Windows11BuildNumber) {
-            // Windows 10 has an issue with VirtualAlloc2 on higher addresses.
+        // This is the build number for Windows 11 22H2
+        static constexpr s32 AffectedBuildNumber = 22621;
+        if (os_version_info.dwBuildNumber <= AffectedBuildNumber) {
+            // Older Windows builds have an issue with VirtualAlloc2 on higher addresses.
             // To prevent regressions, limit the maximum address we reserve for this platform.
             supported_user_max = 0x11000000000ULL;
             LOG_WARNING(Core, "Windows 10 detected, reducing user max to {:#x} to avoid problems",


### PR DESCRIPTION
I've received reports that older Windows 11 builds are affected by the same VirtualAlloc2 bug seen in Windows 10, so increase the build number we apply the reduced USER_MAX value to.

For now, I've hardcoded the build number used by Windows 11 22H2, to correspond with the fact that Windows 10 22H2 was affected. I've only seen issue reports for up to Windows 11 21H2 though.