### PR TITLE
Core: Improved workaround for legacy Windows versions.

### DIFF
--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -125,9 +125,10 @@ struct AddressSpace::Impl {
             // To prevent regressions, increase our minimum address.
             // This will give some space for mappings outside our control to use.
             supported_system_min = 0x10000000ULL;
-            LOG_WARNING(
-                Core, "Windows 10 detected, increasing minimum address to {:#x} to avoid problems",
-                supported_system_min);
+            LOG_WARNING(Core,
+                        "Outdated Windows build {} detected, increasing minimum address to {:#x} "
+                        "to avoid problems",
+                        os_version_info.dwBuildNumber, supported_system_min);
         }
 
         // Determine the free address ranges we can access.


### PR DESCRIPTION
Upon further investigation, the part of these OS memory mappings that "hung" were associated with searching for an address (so in our case, VirtualAlloc2 calls with nullptr address). We can "fix" hanging in our code by specifying an address to our allocation for the backing file's virtual memory.

Unfortunately, C and C++ functions seem to perform these types of mappings internally too, so to completely prevent hangs, we also need to increase `SYSTEM_MANAGED_MIN` to leave some lower addresses for mappings outside our control.

Based on my tests in a VM, these changes allow me to run basic homebrew on a Windows 10 VM (with our HLE for VideoOut and GnmDriver disabled).

For now, I've hardcoded the minimum based on the current lowest address we've observed in fixed mappings from games (see https://github.com/shadps4-compatibility/shadps4-game-compatibility/issues/1413).

This PR needs extensive testing from Windows 10 and old Windows 11 builds (22H2 and before). While my tests suggest there's plenty of address space this leaves open, it might be ideal to hardcode a start offset to apply for the workaround instead. Ideally, people should test with more complex AAA titles, since those are likely to create many threads or otherwise hit code that would allocate host memory.