### PR TITLE
Core: Fix out of flexible memory error return in MapMemory

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -361,7 +361,7 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
                   "Out of flexible memory, available flexible memory = {:#x}"
                   " requested size = {:#x}",
                   total_flexible_size - flexible_usage, size);
-        return ORBIS_KERNEL_ERROR_ENOMEM;
+        return ORBIS_KERNEL_ERROR_EINVAL;
     }
 
     std::scoped_lock lk{mutex};


### PR DESCRIPTION
This case returns `ORBIS_KERNEL_ERROR_EINVAL` on real hardware, not `ORBIS_KERNEL_ERROR_ENOMEM`.