### PR TITLE
Core: Fix NoOverwrite flag behavior in MapMemory

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -439,7 +439,7 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
 
         // If flag NoOverwrite is provided, don't overwrite mapped VMAs.
         // When it isn't provided, VMAs can be overwritten regardless of if they're mapped.
-        while ((False(flags & MemoryMapFlags::NoOverwrite) || !vma.IsMapped()) &&
+        while ((False(flags & MemoryMapFlags::NoOverwrite) || vma.IsFree()) &&
                unmap_addr < mapped_addr + size) {
             auto unmapped = UnmapBytesFromEntry(unmap_addr, vma, unmap_size);
             unmap_addr += unmapped;
@@ -449,7 +449,7 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
 
         vma = FindVMA(mapped_addr)->second;
         auto remaining_size = vma.base + vma.size - mapped_addr;
-        if (vma.IsMapped() || remaining_size < size) {
+        if (!vma.IsFree() || remaining_size < size) {
             LOG_ERROR(Kernel_Vmm, "Unable to map {:#x} bytes at address {:#x}", size, mapped_addr);
             return ORBIS_KERNEL_ERROR_ENOMEM;
         }

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -44,7 +44,7 @@ enum class MemoryMapFlags : u32 {
     Shared = 1,
     Private = 2,
     Fixed = 0x10,
-    NoOverwrite = 0x0080,
+    NoOverwrite = 0x80,
     NoSync = 0x800,
     NoCore = 0x20000,
     NoCoalesce = 0x400000,


### PR DESCRIPTION
NoOverwrite should be enforced with reserved VMAs too, so this code should be using IsFree instead of !IsMapped.

As far as I can tell, this should be the last of this type of oversight in our memory code?