### PR TITLE
Add stubbed get_authinfo

### DIFF
--- a/src/core/libraries/kernel/kernel.cpp
+++ b/src/core/libraries/kernel/kernel.cpp
@@ -256,6 +256,12 @@ const char** PS4_SYSV_ABI getargv() {
     return entry_params.argv;
 }
 
+s32 PS4_SYSV_ABI get_authinfo(u64 pid, AuthInfoData p2) {
+    LOG_WARNING(Lib_Kernel, "(STUBBED) called, pid: {:#x}", pid);
+    *Kernel::__Error() = POSIX_ESRCH;
+    return -1;
+}
+
 void RegisterLib(Core::Loader::SymbolsResolver* sym) {
     service_thread = std::jthread{KernelServiceThread};
 
@@ -273,6 +279,7 @@ void RegisterLib(Core::Loader::SymbolsResolver* sym) {
     LIB_OBJ("f7uOxY9mM1U", "libkernel", 1, "libkernel", &g_stack_chk_guard);
     LIB_FUNCTION("D4yla3vx4tY", "libkernel", 1, "libkernel", sceKernelError);
     LIB_FUNCTION("Mv1zUObHvXI", "libkernel", 1, "libkernel", sceKernelGetSystemSwVersion);
+    LIB_FUNCTION("igMefp4SAv0", "libkernel", 1, "libkernel", get_authinfo);
     LIB_FUNCTION("PfccT7qURYE", "libkernel", 1, "libkernel", kernel_ioctl);
     LIB_FUNCTION("wW+k21cmbwQ", "libkernel", 1, "libkernel", kernel_ioctl);
     LIB_FUNCTION("JGfTMBOdUJo", "libkernel", 1, "libkernel", sceKernelGetFsSandboxRandomWord);

--- a/src/core/libraries/kernel/kernel.cpp
+++ b/src/core/libraries/kernel/kernel.cpp
@@ -256,10 +256,14 @@ const char** PS4_SYSV_ABI getargv() {
     return entry_params.argv;
 }
 
-s32 PS4_SYSV_ABI get_authinfo(u64 pid, AuthInfoData p2) {
-    LOG_WARNING(Lib_Kernel, "(STUBBED) called, pid: {:#x}", pid);
-    *Kernel::__Error() = POSIX_ESRCH;
-    return -1;
+s32 PS4_SYSV_ABI get_authinfo(u64 tid, AuthInfoData* p2) {
+    LOG_WARNING(Lib_Kernel, "(STUBBED) called, pid: {:#x}", tid);
+    if (g_curthread->tid != tid) {
+        *Kernel::__Error() = POSIX_ESRCH;
+        return -1;
+    }
+    p2->caps[0] = 0x2000000000000000;
+    return ORBIS_OK;
 }
 
 void RegisterLib(Core::Loader::SymbolsResolver* sym) {

--- a/src/core/libraries/kernel/kernel.h
+++ b/src/core/libraries/kernel/kernel.h
@@ -44,6 +44,13 @@ struct SwVersionStruct {
     u32 hex_representation;
 };
 
+struct AuthInfoData {
+    u64 unk0;
+    u64 caps[4];
+    u64 attrs[4];
+    u64 ucred[8];
+};
+
 void RegisterLib(Core::Loader::SymbolsResolver* sym);
 
 } // namespace Libraries::Kernel


### PR DESCRIPTION
The struct was taken from https://github.com/RPCSX/rpcsx/blob/master/orbis-kernel/include/orbis/AuthInfo.hpp.
The function is completely one-to-one with real hardware, as long as it is called from game code. If it gets called from an LLEd system library, then we shouldn't reject the call with EPERM, however, LLE HTTP works with Driveclub even like this, so I don't really care.