### PR TITLE
Documents: More verbose warning about using --depth 1 when cloning

### DIFF
--- a/documents/building-windows.md
+++ b/documents/building-windows.md
@@ -6,7 +6,9 @@ SPDX-License-Identifier: GPL-2.0-or-later
 # Build shadPS4 for Windows
 
 This tutorial reads as if you have none of the prerequisites already installed. If you do, just ignore the steps regarding installation.
-If you are building to contribute to the project, please omit `--depth 1` from the git invocations.
+> [!WARNING]
+> If you are trying to compile older builds for testing, do not provide the `--depth 1` flag in `git clone`.
+> This flag omits the commit history from your clone, saving storage space in exchange for preventing you from testing older commits.
 
 Note: **ARM64 is not supported!** As of writing, it will not build nor run. The instructions with respect to ARM64 are for developers only.
 

--- a/documents/building-windows.md
+++ b/documents/building-windows.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 shadPS4 Emulator Project
+SPDX-FileCopyrightText: 2025 shadPS4 Emulator Project
 SPDX-License-Identifier: GPL-2.0-or-later
 -->
 
@@ -8,7 +8,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 This tutorial reads as if you have none of the prerequisites already installed. If you do, just ignore the steps regarding installation.
 > [!WARNING]
 > If you are trying to compile older builds for testing, do not provide the `--depth 1` flag in `git clone`.
-> This flag omits the commit history from your clone, saving storage space in exchange for preventing you from testing older commits.
+> This flag omits the commit history from your clone, saving storage space while preventing you from testing older commits.
 
 Note: **ARM64 is not supported!** As of writing, it will not build nor run. The instructions with respect to ARM64 are for developers only.
 


### PR DESCRIPTION
I've made the warning more visible, and given a proper description of what the flag actually does. 

Hopefully this prevents other devs with similarly lacking Git knowledge from learning the hard way 😅 