### PR TITLE
IPC: commands for volume adjustment, input parsing, fsr, gamepad select

### DIFF
--- a/src/core/ipc/ipc.cpp
+++ b/src/core/ipc/ipc.cpp
@@ -170,6 +170,13 @@ void IPC::InputLoop() {
         } else if (cmd == "RELOAD_INPUTS") {
             std::string config = next_str();
             Input::ParseInputConfig(config);
+        } else if (cmd == "SET_ACTIVE_CONTROLLER") {
+            std::string active_controller = next_str();
+            GamepadSelect::SetSelectedGamepad(active_controller);
+            SDL_Event checkGamepad;
+            SDL_memset(&checkGamepad, 0, sizeof(checkGamepad));
+            checkGamepad.type = SDL_EVENT_CHANGE_CONTROLLER;
+            SDL_PushEvent(&checkGamepad);
         } else {
             std::cerr << ";UNKNOWN CMD: " << cmd << std::endl;
         }

--- a/src/core/ipc/ipc.cpp
+++ b/src/core/ipc/ipc.cpp
@@ -152,18 +152,18 @@ void IPC::InputLoop() {
             Config::setVolumeSlider(value, is_game_specific);
             Libraries::AudioOut::AdjustVol();
         } else if (cmd == "SET_FSR") {
+            bool use_fsr = next_u64() != 0;
             if (presenter) {
-                bool use_fsr = next_u64() != 0;
                 presenter->GetFsrSettingsRef().enable = use_fsr;
             }
         } else if (cmd == "SET_RCAS") {
+            bool use_rcas = next_u64() != 0;
             if (presenter) {
-                bool use_rcas = next_u64() != 0;
                 presenter->GetFsrSettingsRef().use_rcas = use_rcas;
             }
         } else if (cmd == "SET_RCAS_ATTENUATION") {
+            int value = static_cast<int>(next_u64());
             if (presenter) {
-                int value = static_cast<int>(next_u64());
                 presenter->GetFsrSettingsRef().rcas_attenuation =
                     static_cast<float>(value / 1000.0f);
             }

--- a/src/core/ipc/ipc.cpp
+++ b/src/core/ipc/ipc.cpp
@@ -8,13 +8,18 @@
 
 #include <SDL3/SDL.h>
 
+#include "common/config.h"
 #include "common/memory_patcher.h"
 #include "common/thread.h"
 #include "common/types.h"
 #include "core/debug_state.h"
 #include "core/debugger.h"
+#include "core/libraries/audio/audioout.h"
 #include "input/input_handler.h"
 #include "sdl_window.h"
+#include "video_core/renderer_vulkan/vk_presenter.h"
+
+extern std::unique_ptr<Vulkan::Presenter> presenter;
 
 /**
  * Protocol summary:
@@ -141,6 +146,30 @@ void IPC::InputLoop() {
             SDL_memset(&event, 0, sizeof(event));
             event.type = SDL_EVENT_TOGGLE_FULLSCREEN;
             SDL_PushEvent(&event);
+        } else if (cmd == "ADJUST_VOLUME") {
+            int value = static_cast<int>(next_u64());
+            bool is_game_specific = next_u64() != 0;
+            Config::setVolumeSlider(value, is_game_specific);
+            Libraries::AudioOut::AdjustVol();
+        } else if (cmd == "SET_FSR") {
+            if (presenter) {
+                bool use_fsr = next_u64() != 0;
+                presenter->GetFsrSettingsRef().enable = use_fsr;
+            }
+        } else if (cmd == "SET_RCAS") {
+            if (presenter) {
+                bool use_rcas = next_u64() != 0;
+                presenter->GetFsrSettingsRef().use_rcas = use_rcas;
+            }
+        } else if (cmd == "SET_RCAS_ATTENUATION") {
+            if (presenter) {
+                int value = static_cast<int>(next_u64());
+                presenter->GetFsrSettingsRef().rcas_attenuation =
+                    static_cast<float>(value / 1000.0f);
+            }
+        } else if (cmd == "RELOAD_INPUTS") {
+            std::string config = next_str();
+            Input::ParseInputConfig(config);
         } else {
             std::cerr << ";UNKNOWN CMD: " << cmd << std::endl;
         }


### PR DESCRIPTION
This adds IPC commands to re-enable the following functions which were in the Qt GUI prior to the separation:

1) Realtime in-game volume adjustment
2) Automatically reload bindings when remapping/hotkey dialogs are saved
3) Realtime in-game fsr adjustment
4) Support changing active controller in the GUI

Can be tested with this qtlauncher build: https://github.com/rainmakerv3/shadps4-qtlauncher/commits/realtime-widgets/