### PR TITLE
Min max deadzone

### DIFF
--- a/src/qt_gui/control_settings.cpp
+++ b/src/qt_gui/control_settings.cpp
@@ -88,10 +88,14 @@ ControlSettings::ControlSettings(std::shared_ptr<GameInfoClass> game_info_get, b
         SetUIValuestoMappings();
     });
 
-    connect(ui->LeftDeadzoneSlider, &QSlider::valueChanged, this,
-            [this](int value) { ui->LeftDeadzoneValue->setText(QString::number(value)); });
-    connect(ui->RightDeadzoneSlider, &QSlider::valueChanged, this,
-            [this](int value) { ui->RightDeadzoneValue->setText(QString::number(value)); });
+    connect(ui->LeftDeadzoneMinSlider, &QSlider::valueChanged, this,
+            [this](int value) { ui->LeftDeadzoneMinValue->setText(QString::number(value)); });
+    connect(ui->LeftDeadzoneMaxSlider, &QSlider::valueChanged, this,
+            [this](int value) { ui->LeftDeadzoneMaxValue->setText(QString::number(value)); });
+    connect(ui->RightDeadzoneMinSlider, &QSlider::valueChanged, this,
+            [this](int value) { ui->RightDeadzoneMinValue->setText(QString::number(value)); });
+    connect(ui->RightDeadzoneMaxSlider, &QSlider::valueChanged, this,
+            [this](int value) { ui->RightDeadzoneMaxValue->setText(QString::number(value)); });
 
     connect(ui->RSlider, &QSlider::valueChanged, this, [this](int value) {
         QString RedValue = QString("%1").arg(value, 3, 10, QChar('0'));
@@ -287,11 +291,15 @@ void ControlSettings::SaveControllerConfig(bool CloseOnSave) {
     lines.push_back("");
     lines.push_back("# Range of deadzones: 1 (almost none) to 127 (max)");
 
-    std::string deadzonevalue = std::to_string(ui->LeftDeadzoneSlider->value());
-    lines.push_back("analog_deadzone = leftjoystick, " + deadzonevalue + ", 127");
+    std::string deadzone_min_value = std::to_string(ui->LeftDeadzoneMinSlider->value());
+    std::string deadzone_max_value = std::to_string(ui->LeftDeadzoneMaxSlider->value());
+    lines.push_back("analog_deadzone = leftjoystick, " + deadzone_min_value + ", " +
+                    deadzone_max_value);
 
-    deadzonevalue = std::to_string(ui->RightDeadzoneSlider->value());
-    lines.push_back("analog_deadzone = rightjoystick, " + deadzonevalue + ", 127");
+    deadzone_min_value = std::to_string(ui->RightDeadzoneMinSlider->value());
+    deadzone_max_value = std::to_string(ui->RightDeadzoneMaxSlider->value());
+    lines.push_back("analog_deadzone = rightjoystick, " + deadzone_min_value + ", " +
+                    deadzone_max_value);
 
     lines.push_back("");
     std::string OverrideLB = ui->LightbarCheckBox->isChecked() ? "true" : "false";
@@ -387,8 +395,10 @@ void ControlSettings::SetDefault() {
     ui->RStickLeftButton->setText("axis_right_x");
     ui->RStickRightButton->setText("axis_right_x");
 
-    ui->LeftDeadzoneSlider->setValue(2);
-    ui->RightDeadzoneSlider->setValue(2);
+    ui->LeftDeadzoneMinSlider->setValue(2);
+    ui->LeftDeadzoneMaxSlider->setValue(127);
+    ui->RightDeadzoneMinSlider->setValue(2);
+    ui->RightDeadzoneMaxSlider->setValue(127);
 
     ui->RSlider->setValue(0);
     ui->GSlider->setValue(0);
@@ -527,24 +537,42 @@ void ControlSettings::SetUIValuestoMappings() {
         if (input_string.contains("leftjoystick")) {
             std::size_t comma_pos = line.find(',');
             if (comma_pos != std::string::npos) {
-                int deadzonevalue = std::stoi(line.substr(comma_pos + 1));
-                ui->LeftDeadzoneSlider->setValue(deadzonevalue);
-                ui->LeftDeadzoneValue->setText(QString::number(deadzonevalue));
+                std::string deadzone_values = line.substr(comma_pos + 1);
+                std::size_t comma_pos2 = deadzone_values.find(',');
+                if (comma_pos2 != std::string::npos) {
+                    int deadzone_min_value = std::stoi(deadzone_values.substr(0, comma_pos2));
+                    int deadzone_max_value = std::stoi(deadzone_values.substr(comma_pos2 + 1));
+                    ui->LeftDeadzoneMinSlider->setValue(deadzone_min_value);
+                    ui->LeftDeadzoneMaxSlider->setValue(deadzone_max_value);
+                    ui->LeftDeadzoneMinValue->setText(QString::number(deadzone_min_value));
+                    ui->LeftDeadzoneMaxValue->setText(QString::number(deadzone_max_value));
+                }
             } else {
-                ui->LeftDeadzoneSlider->setValue(2);
-                ui->LeftDeadzoneValue->setText("2");
+                ui->LeftDeadzoneMinSlider->setValue(2);
+                ui->LeftDeadzoneMaxSlider->setValue(127);
+                ui->LeftDeadzoneMinValue->setText("2");
+                ui->LeftDeadzoneMaxValue->setText("127");
             }
         }
 
         if (input_string.contains("rightjoystick")) {
             std::size_t comma_pos = line.find(',');
             if (comma_pos != std::string::npos) {
-                int deadzonevalue = std::stoi(line.substr(comma_pos + 1));
-                ui->RightDeadzoneSlider->setValue(deadzonevalue);
-                ui->RightDeadzoneValue->setText(QString::number(deadzonevalue));
+                std::string deadzone_values = line.substr(comma_pos + 1);
+                std::size_t comma_pos2 = deadzone_values.find(',');
+                if (comma_pos2 != std::string::npos) {
+                    int deadzone_min_value = std::stoi(deadzone_values.substr(0, comma_pos2));
+                    int deadzone_max_value = std::stoi(deadzone_values.substr(comma_pos2 + 1));
+                    ui->RightDeadzoneMinSlider->setValue(deadzone_min_value);
+                    ui->RightDeadzoneMaxSlider->setValue(deadzone_max_value);
+                    ui->RightDeadzoneMinValue->setText(QString::number(deadzone_min_value));
+                    ui->RightDeadzoneMaxValue->setText(QString::number(deadzone_max_value));
+                }
             } else {
-                ui->RightDeadzoneSlider->setValue(2);
-                ui->RightDeadzoneValue->setText("2");
+                ui->RightDeadzoneMinSlider->setValue(2);
+                ui->RightDeadzoneMaxSlider->setValue(127);
+                ui->RightDeadzoneMinValue->setText("2");
+                ui->RightDeadzoneMaxValue->setText("127");
             }
         }
 

--- a/src/qt_gui/control_settings.ui
+++ b/src/qt_gui/control_settings.ui
@@ -2,1938 +2,1815 @@
 <!-- SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
      SPDX-License-Identifier: GPL-2.0-or-later -->
 <ui version="4.0">
-  <class>ControlSettings</class>
-  <widget class="QDialog" name="ControlSettings">
-    <property name="windowModality">
-      <enum>Qt::WindowModality::WindowModal</enum>
-    </property>
-    <property name="geometry">
-      <rect>
+ <class>ControlSettings</class>
+ <widget class="QDialog" name="ControlSettings">
+  <property name="windowModality">
+   <enum>Qt::WindowModality::WindowModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1124</width>
+    <height>847</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Configure Controls</string>
+  </property>
+  <property name="windowIcon">
+   <iconset>
+    <normaloff>:/rpcs3.ico</normaloff>:/rpcs3.ico</iconset>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
         <x>0</x>
         <y>0</y>
-        <width>1124</width>
-        <height>847</height>
-      </rect>
-    </property>
-    <property name="windowTitle">
-      <string>Configure Controls</string>
-    </property>
-    <property name="windowIcon">
-      <iconset>
-        <normaloff>:/rpcs3.ico</normaloff>:/rpcs3.ico
-      </iconset>
-    </property>
-    <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-        <widget class="QScrollArea" name="scrollArea">
-          <property name="widgetResizable">
-            <bool>true</bool>
+        <width>1104</width>
+        <height>797</height>
+       </rect>
+      </property>
+      <widget class="QWidget" name="layoutWidget">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>1101</width>
+         <height>791</height>
+        </rect>
+       </property>
+       <layout class="QHBoxLayout" name="RemapLayout">
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_left">
+          <property name="spacing">
+           <number>5</number>
           </property>
-          <widget class="QWidget" name="scrollAreaWidgetContents">
-            <property name="geometry">
-              <rect>
-                <x>0</x>
-                <y>0</y>
-                <width>1104</width>
-                <height>797</height>
-              </rect>
+          <item>
+           <widget class="QGroupBox" name="gb_dpad">
+            <property name="enabled">
+             <bool>true</bool>
             </property>
-            <widget class="QWidget" name="layoutWidget">
-              <property name="geometry">
-                <rect>
-                  <x>0</x>
-                  <y>0</y>
-                  <width>1101</width>
-                  <height>791</height>
-                </rect>
-              </property>
-              <layout class="QHBoxLayout" name="RemapLayout">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="title">
+             <string>D-Pad</string>
+            </property>
+            <layout class="QVBoxLayout" name="gb_dpad_layout">
+             <property name="spacing">
+              <number>6</number>
+             </property>
+             <property name="leftMargin">
+              <number>5</number>
+             </property>
+             <property name="topMargin">
+              <number>5</number>
+             </property>
+             <property name="rightMargin">
+              <number>5</number>
+             </property>
+             <property name="bottomMargin">
+              <number>5</number>
+             </property>
+             <item>
+              <widget class="QWidget" name="dpad_up" native="true">
+               <layout class="QHBoxLayout" name="dpad_up_layout">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
                 <item>
-                  <layout class="QVBoxLayout" name="verticalLayout_left">
-                    <property name="spacing">
-                      <number>5</number>
-                    </property>
-                    <item>
-                      <widget class="QGroupBox" name="gb_dpad">
-                        <property name="enabled">
-                          <bool>true</bool>
-                        </property>
-                        <property name="sizePolicy">
-                          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                          </sizepolicy>
-                        </property>
-                        <property name="maximumSize">
-                          <size>
-                            <width>16777215</width>
-                            <height>16777215</height>
-                          </size>
-                        </property>
-                        <property name="title">
-                          <string>D-Pad</string>
-                        </property>
-                        <layout class="QVBoxLayout" name="gb_dpad_layout">
-                          <property name="spacing">
-                            <number>6</number>
-                          </property>
-                          <property name="leftMargin">
-                            <number>5</number>
-                          </property>
-                          <property name="topMargin">
-                            <number>5</number>
-                          </property>
-                          <property name="rightMargin">
-                            <number>5</number>
-                          </property>
-                          <property name="bottomMargin">
-                            <number>5</number>
-                          </property>
-                          <item>
-                            <widget class="QWidget" name="dpad_up" native="true">
-                              <layout class="QHBoxLayout" name="dpad_up_layout">
-                                <property name="spacing">
-                                  <number>0</number>
-                                </property>
-                                <property name="leftMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="topMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="rightMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="bottomMargin">
-                                  <number>0</number>
-                                </property>
-                                <item>
-                                  <widget class="QGroupBox" name="gb_dpad_up">
-                                    <property name="minimumSize">
-                                      <size>
-                                        <width>152</width>
-                                        <height>0</height>
-                                      </size>
-                                    </property>
-                                    <property name="maximumSize">
-                                      <size>
-                                        <width>0</width>
-                                        <height>16777215</height>
-                                      </size>
-                                    </property>
-                                    <property name="title">
-                                      <string>Up</string>
-                                    </property>
-                                    <property name="alignment">
-                                      <set>Qt::AlignmentFlag::AlignCenter</set>
-                                    </property>
-                                    <layout class="QHBoxLayout" name="horizontalLayout_4">
-                                      <item>
-                                        <widget class="QPushButton" name="DpadUpButton">
-                                          <property name="text">
-                                            <string>unmapped</string>
-                                          </property>
-                                        </widget>
-                                      </item>
-                                    </layout>
-                                  </widget>
-                                </item>
-                              </layout>
-                            </widget>
-                          </item>
-                          <item>
-                            <layout class="QHBoxLayout" name="layout_dpad_left_right">
-                              <item>
-                                <widget class="QGroupBox" name="gb_dpad_left">
-                                  <property name="title">
-                                    <string>Left</string>
-                                  </property>
-                                  <property name="alignment">
-                                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                                  </property>
-                                  <layout class="QVBoxLayout" name="gb_dpad_left_layout">
-                                    <property name="leftMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="topMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="rightMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="bottomMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <item>
-                                      <widget class="QPushButton" name="DpadLeftButton">
-                                        <property name="text">
-                                          <string>unmapped</string>
-                                        </property>
-                                      </widget>
-                                    </item>
-                                  </layout>
-                                </widget>
-                              </item>
-                              <item>
-                                <widget class="QGroupBox" name="gb_dpad_right">
-                                  <property name="title">
-                                    <string>Right</string>
-                                  </property>
-                                  <property name="alignment">
-                                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                                  </property>
-                                  <layout class="QVBoxLayout" name="gb_dpad_right_layout">
-                                    <property name="leftMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="topMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="rightMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="bottomMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <item>
-                                      <widget class="QPushButton" name="DpadRightButton">
-                                        <property name="text">
-                                          <string>unmapped</string>
-                                        </property>
-                                      </widget>
-                                    </item>
-                                  </layout>
-                                </widget>
-                              </item>
-                            </layout>
-                          </item>
-                          <item>
-                            <widget class="QWidget" name="dpad_down" native="true">
-                              <layout class="QHBoxLayout" name="dpad_down_layout">
-                                <property name="leftMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="topMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="rightMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="bottomMargin">
-                                  <number>0</number>
-                                </property>
-                                <item>
-                                  <widget class="QGroupBox" name="gb_dpad_down">
-                                    <property name="minimumSize">
-                                      <size>
-                                        <width>152</width>
-                                        <height>0</height>
-                                      </size>
-                                    </property>
-                                    <property name="maximumSize">
-                                      <size>
-                                        <width>124</width>
-                                        <height>16777215</height>
-                                      </size>
-                                    </property>
-                                    <property name="title">
-                                      <string>Down</string>
-                                    </property>
-                                    <property name="alignment">
-                                      <set>Qt::AlignmentFlag::AlignCenter</set>
-                                    </property>
-                                    <layout class="QHBoxLayout" name="horizontalLayout_3">
-                                      <item>
-                                        <widget class="QPushButton" name="DpadDownButton">
-                                          <property name="text">
-                                            <string>unmapped</string>
-                                          </property>
-                                        </widget>
-                                      </item>
-                                    </layout>
-                                  </widget>
-                                </item>
-                              </layout>
-                            </widget>
-                          </item>
-                        </layout>
-                      </widget>
-                    </item>
-                    <item>
-                      <widget class="QGroupBox" name="groupBox_5">
-                        <property name="title">
-                          <string>L1 and L2</string>
-                        </property>
-                        <layout class="QHBoxLayout" name="horizontalLayout_13">
-                          <item>
-                            <widget class="QGroupBox" name="gb_l1">
-                              <property name="sizePolicy">
-                                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                                  <horstretch>0</horstretch>
-                                  <verstretch>0</verstretch>
-                                </sizepolicy>
-                              </property>
-                              <property name="title">
-                                <string notr="true">L1</string>
-                              </property>
-                              <property name="alignment">
-                                <set>Qt::AlignmentFlag::AlignCenter</set>
-                              </property>
-                              <layout class="QVBoxLayout" name="gb_l1_layout">
-                                <property name="leftMargin">
-                                  <number>5</number>
-                                </property>
-                                <property name="topMargin">
-                                  <number>5</number>
-                                </property>
-                                <property name="rightMargin">
-                                  <number>5</number>
-                                </property>
-                                <property name="bottomMargin">
-                                  <number>5</number>
-                                </property>
-                                <item>
-                                  <widget class="QPushButton" name="L1Button">
-                                    <property name="text">
-                                      <string>unmapped</string>
-                                    </property>
-                                  </widget>
-                                </item>
-                              </layout>
-                            </widget>
-                          </item>
-                          <item>
-                            <widget class="QGroupBox" name="gb_l2">
-                              <property name="title">
-                                <string notr="true">L2</string>
-                              </property>
-                              <property name="alignment">
-                                <set>Qt::AlignmentFlag::AlignCenter</set>
-                              </property>
-                              <layout class="QVBoxLayout" name="gb_l2_layout">
-                                <property name="leftMargin">
-                                  <number>5</number>
-                                </property>
-                                <property name="topMargin">
-                                  <number>5</number>
-                                </property>
-                                <property name="rightMargin">
-                                  <number>5</number>
-                                </property>
-                                <property name="bottomMargin">
-                                  <number>5</number>
-                                </property>
-                                <item>
-                                  <widget class="QPushButton" name="L2Button">
-                                    <property name="text">
-                                      <string>unmapped</string>
-                                    </property>
-                                  </widget>
-                                </item>
-                              </layout>
-                            </widget>
-                          </item>
-                        </layout>
-                      </widget>
-                    </item>
-                    <item>
-                      <spacer name="verticalSpacer">
-                        <property name="orientation">
-                          <enum>Qt::Orientation::Vertical</enum>
-                        </property>
-                        <property name="sizeHint" stdset="0">
-                          <size>
-                            <width>20</width>
-                            <height>40</height>
-                          </size>
-                        </property>
-                      </spacer>
-                    </item>
-                    <item>
-                      <widget class="QGroupBox" name="LeftStickDeadZoneGB">
-                        <property name="sizePolicy">
-                          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                          </sizepolicy>
-                        </property>
-                        <property name="title">
-                          <string>Left Stick Deadzone</string>
-                        </property>
-                        <layout class="QVBoxLayout" name="verticalLayout_15">
-                          <item>
-                            <widget class="QLabel" name="LeftDeadzoneMinLabel">
-                              <property name="text">
-                                <string>Min Deadzone (def:2 max:127)</string>
-                              </property>
-                              <property name="alignment">
-                                <set>Qt::AlignmentFlag::AlignLeft</set>
-                              </property>
-                            </widget>
-                          </item>
-                          <item>
-                            <widget class="QLabel" name="LeftDeadzoneMinValue">
-                              <property name="sizePolicy">
-                                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                                  <horstretch>0</horstretch>
-                                  <verstretch>0</verstretch>
-                                </sizepolicy>
-                              </property>
-                              <property name="text">
-                                <string>2</string>
-                              </property>
-                              <property name="alignment">
-                                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                              </property>
-                            </widget>
-                          </item>
-                          <item>
-                            <widget class="QSlider" name="LeftDeadzoneMinSlider">
-                              <property name="sizePolicy">
-                                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                                  <horstretch>0</horstretch>
-                                  <verstretch>0</verstretch>
-                                </sizepolicy>
-                              </property>
-                              <property name="minimum">
-                                <number>1</number>
-                              </property>
-                              <property name="maximum">
-                                <number>127</number>
-                              </property>
-                              <property name="value">
-                                <number>2</number>
-                              </property>
-                              <property name="orientation">
-                                <enum>Qt::Orientation::Horizontal</enum>
-                              </property>
-                            </widget>
-                          </item>
-                          <item>
-                            <widget class="QLabel" name="LeftDeadzoneMaxLabel">
-                              <property name="text">
-                                <string>Max Deadzone (def:127 max:127)</string>
-                              </property>
-                              <property name="alignment">
-                                <set>Qt::AlignmentFlag::AlignLeft</set>
-                              </property>
-                            </widget>
-                          </item>
-                          <item>
-                            <widget class="QLabel" name="LeftDeadzoneMaxValue">
-                              <property name="sizePolicy">
-                                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                                  <horstretch>0</horstretch>
-                                  <verstretch>0</verstretch>
-                                </sizepolicy>
-                              </property>
-                              <property name="text">
-                                <string>127</string>
-                              </property>
-                              <property name="alignment">
-                                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                              </property>
-                            </widget>
-                          </item>
-                          <item>
-                            <widget class="QSlider" name="LeftDeadzoneMaxSlider">
-                              <property name="sizePolicy">
-                                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                                  <horstretch>0</horstretch>
-                                  <verstretch>0</verstretch>
-                                </sizepolicy>
-                              </property>
-                              <property name="minimum">
-                                <number>1</number>
-                              </property>
-                              <property name="maximum">
-                                <number>127</number>
-                              </property>
-                              <property name="value">
-                                <number>127</number>
-                              </property>
-                              <property name="orientation">
-                                <enum>Qt::Orientation::Horizontal</enum>
-                              </property>
-                            </widget>
-                          </item>
-                        </layout>
-                      </widget>
-                    </item>
-                    <item>
-                      <widget class="QGroupBox" name="gb_left_stick">
-                        <property name="sizePolicy">
-                          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                          </sizepolicy>
-                        </property>
-                        <property name="minimumSize">
-                          <size>
-                            <width>0</width>
-                            <height>0</height>
-                          </size>
-                        </property>
-                        <property name="title">
-                          <string>Left Stick</string>
-                        </property>
-                        <layout class="QVBoxLayout" name="gb_left_stick_layout">
-                          <property name="leftMargin">
-                            <number>5</number>
-                          </property>
-                          <property name="topMargin">
-                            <number>5</number>
-                          </property>
-                          <property name="rightMargin">
-                            <number>5</number>
-                          </property>
-                          <property name="bottomMargin">
-                            <number>5</number>
-                          </property>
-                          <item>
-                            <widget class="QWidget" name="left_stick_up" native="true">
-                              <property name="maximumSize">
-                                <size>
-                                  <width>16777215</width>
-                                  <height>2121</height>
-                                </size>
-                              </property>
-                              <layout class="QHBoxLayout" name="left_stick_up_layout">
-                                <property name="leftMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="topMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="rightMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="bottomMargin">
-                                  <number>0</number>
-                                </property>
-                                <item>
-                                  <widget class="QGroupBox" name="gb_left_stick_up">
-                                    <property name="minimumSize">
-                                      <size>
-                                        <width>0</width>
-                                        <height>0</height>
-                                      </size>
-                                    </property>
-                                    <property name="maximumSize">
-                                      <size>
-                                        <width>152</width>
-                                        <height>16777215</height>
-                                      </size>
-                                    </property>
-                                    <property name="title">
-                                      <string>Up</string>
-                                    </property>
-                                    <property name="alignment">
-                                      <set>Qt::AlignmentFlag::AlignCenter</set>
-                                    </property>
-                                    <layout class="QVBoxLayout" name="verticalLayout_10">
-                                      <item>
-                                        <widget class="QPushButton" name="LStickUpButton">
-                                          <property name="text">
-                                            <string>unmapped</string>
-                                          </property>
-                                        </widget>
-                                      </item>
-                                    </layout>
-                                  </widget>
-                                </item>
-                              </layout>
-                            </widget>
-                          </item>
-                          <item>
-                            <layout class="QHBoxLayout" name="layout_left_stick_left_right">
-                              <item>
-                                <widget class="QGroupBox" name="gb_left_stick_left">
-                                  <property name="title">
-                                    <string>Left</string>
-                                  </property>
-                                  <property name="alignment">
-                                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                                  </property>
-                                  <layout class="QVBoxLayout" name="gb_left_stick_left_layout">
-                                    <property name="leftMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="topMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="rightMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="bottomMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <item>
-                                      <widget class="QPushButton" name="LStickLeftButton">
-                                        <property name="text">
-                                          <string>unmapped</string>
-                                        </property>
-                                      </widget>
-                                    </item>
-                                  </layout>
-                                </widget>
-                              </item>
-                              <item>
-                                <widget class="QGroupBox" name="gb_left_stick_right">
-                                  <property name="maximumSize">
-                                    <size>
-                                      <width>179</width>
-                                      <height>16777215</height>
-                                    </size>
-                                  </property>
-                                  <property name="title">
-                                    <string>Right</string>
-                                  </property>
-                                  <property name="alignment">
-                                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                                  </property>
-                                  <layout class="QVBoxLayout" name="gb_left_stick_right_layout">
-                                    <property name="leftMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="topMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="rightMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="bottomMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <item>
-                                      <widget class="QPushButton" name="LStickRightButton">
-                                        <property name="text">
-                                          <string>unmapped</string>
-                                        </property>
-                                      </widget>
-                                    </item>
-                                  </layout>
-                                </widget>
-                              </item>
-                            </layout>
-                          </item>
-                          <item>
-                            <widget class="QWidget" name="left_stick_down" native="true">
-                              <layout class="QHBoxLayout" name="left_stick_down_layout">
-                                <property name="leftMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="topMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="rightMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="bottomMargin">
-                                  <number>0</number>
-                                </property>
-                                <item>
-                                  <widget class="QGroupBox" name="gb_left_stick_down">
-                                    <property name="minimumSize">
-                                      <size>
-                                        <width>152</width>
-                                        <height>0</height>
-                                      </size>
-                                    </property>
-                                    <property name="maximumSize">
-                                      <size>
-                                        <width>124</width>
-                                        <height>21212</height>
-                                      </size>
-                                    </property>
-                                    <property name="title">
-                                      <string>Down</string>
-                                    </property>
-                                    <property name="alignment">
-                                      <set>Qt::AlignmentFlag::AlignCenter</set>
-                                    </property>
-                                    <layout class="QVBoxLayout" name="verticalLayout_8">
-                                      <item>
-                                        <widget class="QPushButton" name="LStickDownButton">
-                                          <property name="text">
-                                            <string>unmapped</string>
-                                          </property>
-                                        </widget>
-                                      </item>
-                                    </layout>
-                                  </widget>
-                                </item>
-                              </layout>
-                            </widget>
-                          </item>
-                        </layout>
-                      </widget>
-                    </item>
+                 <widget class="QGroupBox" name="gb_dpad_up">
+                  <property name="minimumSize">
+                   <size>
+                    <width>152</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>0</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="title">
+                   <string>Up</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                  <layout class="QHBoxLayout" name="horizontalLayout_4">
+                   <item>
+                    <widget class="QPushButton" name="DpadUpButton">
+                     <property name="text">
+                      <string>unmapped</string>
+                     </property>
+                    </widget>
+                   </item>
                   </layout>
+                 </widget>
                 </item>
-                <item>
-                  <layout class="QVBoxLayout" name="verticalLayout_middle" stretch="0,0,0,0">
-                    <property name="spacing">
-                      <number>0</number>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="layout_dpad_left_right">
+               <item>
+                <widget class="QGroupBox" name="gb_dpad_left">
+                 <property name="title">
+                  <string>Left</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_dpad_left_layout">
+                  <property name="leftMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>5</number>
+                  </property>
+                  <item>
+                   <widget class="QPushButton" name="DpadLeftButton">
+                    <property name="text">
+                     <string>unmapped</string>
                     </property>
-                    <item>
-                      <widget class="QGroupBox" name="ProfileGroupBox">
-                        <property name="sizePolicy">
-                          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                          </sizepolicy>
-                        </property>
-                        <property name="font">
-                          <font>
-                            <pointsize>12</pointsize>
-                            <bold>true</bold>
-                          </font>
-                        </property>
-                        <property name="title">
-                          <string>Config Selection</string>
-                        </property>
-                        <property name="alignment">
-                          <set>Qt::AlignmentFlag::AlignCenter</set>
-                        </property>
-                        <layout class="QVBoxLayout" name="verticalLayout_16">
-                          <item>
-                            <layout class="QHBoxLayout" name="horizontalLayout_6">
-                              <item>
-                                <widget class="QComboBox" name="ProfileComboBox">
-                                  <property name="font">
-                                    <font>
-                                      <pointsize>9</pointsize>
-                                      <bold>false</bold>
-                                    </font>
-                                  </property>
-                                  <property name="currentText">
-                                    <string/>
-                                  </property>
-                                  <property name="currentIndex">
-                                    <number>-1</number>
-                                  </property>
-                                  <property name="placeholderText">
-                                    <string>Common Config</string>
-                                  </property>
-                                </widget>
-                              </item>
-                              <item>
-                                <widget class="QLabel" name="TitleLabel">
-                                  <property name="font">
-                                    <font>
-                                      <pointsize>10</pointsize>
-                                      <bold>true</bold>
-                                    </font>
-                                  </property>
-                                  <property name="text">
-                                    <string>Common Config</string>
-                                  </property>
-                                  <property name="alignment">
-                                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                                  </property>
-                                  <property name="wordWrap">
-                                    <bool>true</bool>
-                                  </property>
-                                </widget>
-                              </item>
-                            </layout>
-                          </item>
-                          <item>
-                            <widget class="QCheckBox" name="PerGameCheckBox">
-                              <property name="sizePolicy">
-                                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                                  <horstretch>0</horstretch>
-                                  <verstretch>0</verstretch>
-                                </sizepolicy>
-                              </property>
-                              <property name="font">
-                                <font>
-                                  <pointsize>9</pointsize>
-                                  <bold>false</bold>
-                                </font>
-                              </property>
-                              <property name="text">
-                                <string>Use per-game configs</string>
-                              </property>
-                            </widget>
-                          </item>
-                          <item>
-                            <widget class="QGroupBox" name="groupBox_2">
-                              <property name="font">
-                                <font>
-                                  <pointsize>9</pointsize>
-                                  <bold>true</bold>
-                                </font>
-                              </property>
-                              <property name="title">
-                                <string>Active Gamepad</string>
-                              </property>
-                              <layout class="QHBoxLayout" name="horizontalLayout_7">
-                                <item>
-                                  <widget class="QComboBox" name="ActiveGamepadBox">
-                                    <property name="font">
-                                      <font>
-                                        <pointsize>9</pointsize>
-                                        <bold>false</bold>
-                                      </font>
-                                    </property>
-                                  </widget>
-                                </item>
-                                <item>
-                                  <widget class="QLabel" name="ActiveGamepadLabel">
-                                    <property name="font">
-                                      <font>
-                                        <pointsize>9</pointsize>
-                                        <bold>false</bold>
-                                      </font>
-                                    </property>
-                                    <property name="text">
-                                      <string>Gamepad ID</string>
-                                    </property>
-                                    <property name="alignment">
-                                      <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                                    </property>
-                                  </widget>
-                                </item>
-                              </layout>
-                            </widget>
-                          </item>
-                          <item>
-                            <widget class="QGroupBox" name="groupBox_4">
-                              <property name="font">
-                                <font>
-                                  <pointsize>9</pointsize>
-                                  <bold>true</bold>
-                                </font>
-                              </property>
-                              <property name="title">
-                                <string>Default Gamepad</string>
-                              </property>
-                              <layout class="QHBoxLayout" name="horizontalLayout_12">
-                                <item>
-                                  <widget class="QLabel" name="DefaultGamepadName">
-                                    <property name="text">
-                                      <string>No default selected</string>
-                                    </property>
-                                  </widget>
-                                </item>
-                                <item>
-                                  <widget class="QLabel" name="DefaultGamepadLabel">
-                                    <property name="font">
-                                      <font>
-                                        <pointsize>9</pointsize>
-                                        <bold>false</bold>
-                                      </font>
-                                    </property>
-                                    <property name="text">
-                                      <string>n/a</string>
-                                    </property>
-                                    <property name="alignment">
-                                      <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                                    </property>
-                                  </widget>
-                                </item>
-                              </layout>
-                            </widget>
-                          </item>
-                          <item>
-                            <layout class="QHBoxLayout" name="horizontalLayout_19">
-                              <item>
-                                <widget class="QPushButton" name="DefaultGamepadButton">
-                                  <property name="font">
-                                    <font>
-                                      <pointsize>9</pointsize>
-                                      <bold>true</bold>
-                                    </font>
-                                  </property>
-                                  <property name="text">
-                                    <string>Set Active Gamepad as Default</string>
-                                  </property>
-                                </widget>
-                              </item>
-                              <item>
-                                <widget class="QPushButton" name="RemoveDefaultGamepadButton">
-                                  <property name="font">
-                                    <font>
-                                      <pointsize>9</pointsize>
-                                      <bold>true</bold>
-                                    </font>
-                                  </property>
-                                  <property name="text">
-                                    <string>Remove Default Gamepad</string>
-                                  </property>
-                                </widget>
-                              </item>
-                            </layout>
-                          </item>
-                        </layout>
-                      </widget>
-                    </item>
-                    <item>
-                      <widget class="QWidget" name="widget_controller" native="true">
-                        <property name="minimumSize">
-                          <size>
-                            <width>0</width>
-                            <height>200</height>
-                          </size>
-                        </property>
-                        <layout class="QHBoxLayout" name="widget_controller_layout">
-                          <property name="leftMargin">
-                            <number>0</number>
-                          </property>
-                          <property name="topMargin">
-                            <number>0</number>
-                          </property>
-                          <property name="rightMargin">
-                            <number>0</number>
-                          </property>
-                          <property name="bottomMargin">
-                            <number>0</number>
-                          </property>
-                          <item>
-                            <widget class="QLabel" name="l_controller">
-                              <property name="maximumSize">
-                                <size>
-                                  <width>415</width>
-                                  <height>256</height>
-                                </size>
-                              </property>
-                              <property name="pixmap">
-                                <pixmap resource="../shadps4.qrc">:/images/ps4_controller.png</pixmap>
-                              </property>
-                              <property name="scaledContents">
-                                <bool>true</bool>
-                              </property>
-                              <property name="alignment">
-                                <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignHCenter</set>
-                              </property>
-                            </widget>
-                          </item>
-                        </layout>
-                      </widget>
-                    </item>
-                    <item>
-                      <layout class="QVBoxLayout" name="verticalLayout_9">
-                        <property name="spacing">
-                          <number>10</number>
-                        </property>
-                        <property name="sizeConstraint">
-                          <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
-                        </property>
-                        <item>
-                          <layout class="QHBoxLayout" name="horizontalLayout">
-                            <item>
-                              <widget class="QGroupBox" name="gb_l3">
-                                <property name="sizePolicy">
-                                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                                    <horstretch>0</horstretch>
-                                    <verstretch>0</verstretch>
-                                  </sizepolicy>
-                                </property>
-                                <property name="title">
-                                  <string notr="true">L3</string>
-                                </property>
-                                <property name="alignment">
-                                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                                </property>
-                                <layout class="QVBoxLayout" name="gb_l3_layout">
-                                  <property name="leftMargin">
-                                    <number>5</number>
-                                  </property>
-                                  <property name="topMargin">
-                                    <number>5</number>
-                                  </property>
-                                  <property name="rightMargin">
-                                    <number>5</number>
-                                  </property>
-                                  <property name="bottomMargin">
-                                    <number>5</number>
-                                  </property>
-                                  <item>
-                                    <widget class="QPushButton" name="L3Button">
-                                      <property name="text">
-                                        <string>unmapped</string>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                </layout>
-                              </widget>
-                            </item>
-                            <item>
-                              <widget class="QGroupBox" name="gb_start">
-                                <property name="title">
-                                  <string>Options</string>
-                                </property>
-                                <property name="alignment">
-                                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                                </property>
-                                <layout class="QVBoxLayout" name="gb_start_layout">
-                                  <property name="leftMargin">
-                                    <number>5</number>
-                                  </property>
-                                  <property name="topMargin">
-                                    <number>5</number>
-                                  </property>
-                                  <property name="rightMargin">
-                                    <number>5</number>
-                                  </property>
-                                  <property name="bottomMargin">
-                                    <number>5</number>
-                                  </property>
-                                  <item>
-                                    <widget class="QPushButton" name="OptionsButton">
-                                      <property name="text">
-                                        <string>unmapped</string>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                </layout>
-                              </widget>
-                            </item>
-                            <item>
-                              <widget class="QGroupBox" name="gb_r3">
-                                <property name="sizePolicy">
-                                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                                    <horstretch>0</horstretch>
-                                    <verstretch>0</verstretch>
-                                  </sizepolicy>
-                                </property>
-                                <property name="title">
-                                  <string notr="true">R3</string>
-                                </property>
-                                <property name="alignment">
-                                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                                </property>
-                                <layout class="QVBoxLayout" name="gb_r3_layout">
-                                  <property name="leftMargin">
-                                    <number>5</number>
-                                  </property>
-                                  <property name="topMargin">
-                                    <number>5</number>
-                                  </property>
-                                  <property name="rightMargin">
-                                    <number>5</number>
-                                  </property>
-                                  <property name="bottomMargin">
-                                    <number>5</number>
-                                  </property>
-                                  <item>
-                                    <widget class="QPushButton" name="R3Button">
-                                      <property name="text">
-                                        <string>unmapped</string>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                </layout>
-                              </widget>
-                            </item>
-                          </layout>
-                        </item>
-                        <item>
-                          <layout class="QHBoxLayout" name="horizontalLayout_2">
-                            <item>
-                              <widget class="QGroupBox" name="gb_touchleft">
-                                <property name="title">
-                                  <string>Touchpad Left</string>
-                                </property>
-                                <property name="alignment">
-                                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                                </property>
-                                <layout class="QHBoxLayout" name="horizontalLayout_5">
-                                  <item>
-                                    <widget class="QPushButton" name="TouchpadLeftButton">
-                                      <property name="text">
-                                        <string>unmapped</string>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                </layout>
-                              </widget>
-                            </item>
-                            <item>
-                              <widget class="QGroupBox" name="gb_touchcenter">
-                                <property name="title">
-                                  <string>Touchpad Center</string>
-                                </property>
-                                <property name="alignment">
-                                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                                </property>
-                                <layout class="QVBoxLayout" name="verticalLayout_11">
-                                  <item>
-                                    <widget class="QPushButton" name="TouchpadCenterButton">
-                                      <property name="text">
-                                        <string>unmapped</string>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                </layout>
-                              </widget>
-                            </item>
-                            <item>
-                              <widget class="QGroupBox" name="gb_touchright">
-                                <property name="title">
-                                  <string>Touchpad Right</string>
-                                </property>
-                                <property name="alignment">
-                                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                                </property>
-                                <layout class="QVBoxLayout" name="verticalLayout_12">
-                                  <item>
-                                    <widget class="QPushButton" name="TouchpadRightButton">
-                                      <property name="text">
-                                        <string>unmapped</string>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                </layout>
-                              </widget>
-                            </item>
-                          </layout>
-                        </item>
-                      </layout>
-                    </item>
-                    <item>
-                      <layout class="QHBoxLayout" name="horizontalLayout_8">
-                        <item>
-                          <layout class="QVBoxLayout" name="verticalLayout_14">
-                            <item>
-                              <widget class="QGroupBox" name="groupBox">
-                                <property name="font">
-                                  <font>
-                                    <bold>false</bold>
-                                  </font>
-                                </property>
-                                <property name="title">
-                                  <string>Color Adjustment</string>
-                                </property>
-                                <layout class="QVBoxLayout" name="verticalLayout_18">
-                                  <property name="leftMargin">
-                                    <number>6</number>
-                                  </property>
-                                  <property name="rightMargin">
-                                    <number>6</number>
-                                  </property>
-                                  <item>
-                                    <layout class="QHBoxLayout" name="horizontalLayout_9">
-                                      <property name="spacing">
-                                        <number>6</number>
-                                      </property>
-                                      <item>
-                                        <widget class="QLabel" name="RLabel_text">
-                                          <property name="font">
-                                            <font>
-                                              <bold>false</bold>
-                                            </font>
-                                          </property>
-                                          <property name="text">
-                                            <string>RED</string>
-                                          </property>
-                                        </widget>
-                                      </item>
-                                      <item>
-                                        <widget class="QSlider" name="RSlider">
-                                          <property name="sizePolicy">
-                                            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                                              <horstretch>0</horstretch>
-                                              <verstretch>0</verstretch>
-                                            </sizepolicy>
-                                          </property>
-                                          <property name="maximum">
-                                            <number>255</number>
-                                          </property>
-                                          <property name="orientation">
-                                            <enum>Qt::Orientation::Horizontal</enum>
-                                          </property>
-                                        </widget>
-                                      </item>
-                                      <item>
-                                        <widget class="QLabel" name="RLabel">
-                                          <property name="maximumSize">
-                                            <size>
-                                              <width>20</width>
-                                              <height>16777215</height>
-                                            </size>
-                                          </property>
-                                          <property name="text">
-                                            <string notr="true">000</string>
-                                          </property>
-                                        </widget>
-                                      </item>
-                                    </layout>
-                                  </item>
-                                  <item>
-                                    <layout class="QHBoxLayout" name="horizontalLayout_10">
-                                      <item>
-                                        <widget class="QLabel" name="GLabel_text">
-                                          <property name="font">
-                                            <font>
-                                              <bold>false</bold>
-                                            </font>
-                                          </property>
-                                          <property name="text">
-                                            <string>GREEN</string>
-                                          </property>
-                                        </widget>
-                                      </item>
-                                      <item>
-                                        <widget class="QSlider" name="GSlider">
-                                          <property name="sizePolicy">
-                                            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                                              <horstretch>0</horstretch>
-                                              <verstretch>0</verstretch>
-                                            </sizepolicy>
-                                          </property>
-                                          <property name="maximum">
-                                            <number>255</number>
-                                          </property>
-                                          <property name="orientation">
-                                            <enum>Qt::Orientation::Horizontal</enum>
-                                          </property>
-                                        </widget>
-                                      </item>
-                                      <item>
-                                        <widget class="QLabel" name="GLabel">
-                                          <property name="maximumSize">
-                                            <size>
-                                              <width>20</width>
-                                              <height>16777215</height>
-                                            </size>
-                                          </property>
-                                          <property name="text">
-                                            <string notr="true">000</string>
-                                          </property>
-                                        </widget>
-                                      </item>
-                                    </layout>
-                                  </item>
-                                  <item>
-                                    <layout class="QHBoxLayout" name="horizontalLayout_11">
-                                      <item>
-                                        <widget class="QLabel" name="BLabel_text">
-                                          <property name="font">
-                                            <font>
-                                              <bold>false</bold>
-                                            </font>
-                                          </property>
-                                          <property name="text">
-                                            <string>BLUE</string>
-                                          </property>
-                                        </widget>
-                                      </item>
-                                      <item>
-                                        <widget class="QSlider" name="BSlider">
-                                          <property name="sizePolicy">
-                                            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                                              <horstretch>0</horstretch>
-                                              <verstretch>0</verstretch>
-                                            </sizepolicy>
-                                          </property>
-                                          <property name="maximum">
-                                            <number>255</number>
-                                          </property>
-                                          <property name="value">
-                                            <number>255</number>
-                                          </property>
-                                          <property name="orientation">
-                                            <enum>Qt::Orientation::Horizontal</enum>
-                                          </property>
-                                        </widget>
-                                      </item>
-                                      <item>
-                                        <widget class="QLabel" name="BLabel">
-                                          <property name="maximumSize">
-                                            <size>
-                                              <width>20</width>
-                                              <height>16777215</height>
-                                            </size>
-                                          </property>
-                                          <property name="text">
-                                            <string notr="true">255</string>
-                                          </property>
-                                        </widget>
-                                      </item>
-                                    </layout>
-                                  </item>
-                                </layout>
-                              </widget>
-                            </item>
-                          </layout>
-                        </item>
-                        <item>
-                          <layout class="QVBoxLayout" name="verticalLayout_17">
-                            <item>
-                              <widget class="QGroupBox" name="groupBox_3">
-                                <property name="font">
-                                  <font>
-                                    <bold>false</bold>
-                                  </font>
-                                </property>
-                                <property name="title">
-                                  <string>Override Lightbar Color</string>
-                                </property>
-                                <layout class="QVBoxLayout" name="verticalLayout_19">
-                                  <item>
-                                    <widget class="QCheckBox" name="LightbarCheckBox">
-                                      <property name="font">
-                                        <font>
-                                          <bold>false</bold>
-                                        </font>
-                                      </property>
-                                      <property name="text">
-                                        <string>Override Color</string>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                  <item>
-                                    <widget class="QFrame" name="LightbarColorFrame">
-                                      <property name="frameShape">
-                                        <enum>QFrame::Shape::StyledPanel</enum>
-                                      </property>
-                                      <property name="frameShadow">
-                                        <enum>QFrame::Shadow::Raised</enum>
-                                      </property>
-                                    </widget>
-                                  </item>
-                                </layout>
-                              </widget>
-                            </item>
-                          </layout>
-                        </item>
-                      </layout>
-                    </item>
-                  </layout>
-                </item>
-                <item>
-                  <layout class="QVBoxLayout" name="verticalLayout_right">
-                    <property name="spacing">
-                      <number>5</number>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_dpad_right">
+                 <property name="title">
+                  <string>Right</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_dpad_right_layout">
+                  <property name="leftMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>5</number>
+                  </property>
+                  <item>
+                   <widget class="QPushButton" name="DpadRightButton">
+                    <property name="text">
+                     <string>unmapped</string>
                     </property>
-                    <item>
-                      <widget class="QGroupBox" name="gb_face_buttons">
-                        <property name="sizePolicy">
-                          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                          </sizepolicy>
-                        </property>
-                        <property name="title">
-                          <string>Face Buttons</string>
-                        </property>
-                        <layout class="QVBoxLayout" name="gb_face_buttons_layout">
-                          <property name="leftMargin">
-                            <number>5</number>
-                          </property>
-                          <property name="topMargin">
-                            <number>5</number>
-                          </property>
-                          <property name="rightMargin">
-                            <number>5</number>
-                          </property>
-                          <property name="bottomMargin">
-                            <number>5</number>
-                          </property>
-                          <item>
-                            <widget class="QWidget" name="widget_triangle" native="true">
-                              <layout class="QHBoxLayout" name="widget_triangle_layout">
-                                <property name="leftMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="topMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="rightMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="bottomMargin">
-                                  <number>0</number>
-                                </property>
-                                <item>
-                                  <widget class="QGroupBox" name="gb_triangle">
-                                    <property name="sizePolicy">
-                                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                                        <horstretch>0</horstretch>
-                                        <verstretch>0</verstretch>
-                                      </sizepolicy>
-                                    </property>
-                                    <property name="minimumSize">
-                                      <size>
-                                        <width>152</width>
-                                        <height>0</height>
-                                      </size>
-                                    </property>
-                                    <property name="maximumSize">
-                                      <size>
-                                        <width>0</width>
-                                        <height>16777215</height>
-                                      </size>
-                                    </property>
-                                    <property name="title">
-                                      <string>Triangle</string>
-                                    </property>
-                                    <property name="alignment">
-                                      <set>Qt::AlignmentFlag::AlignCenter</set>
-                                    </property>
-                                    <layout class="QVBoxLayout" name="verticalLayout_3">
-                                      <item>
-                                        <widget class="QPushButton" name="TriangleButton">
-                                          <property name="text">
-                                            <string>unmapped</string>
-                                          </property>
-                                        </widget>
-                                      </item>
-                                    </layout>
-                                  </widget>
-                                </item>
-                              </layout>
-                            </widget>
-                          </item>
-                          <item>
-                            <layout class="QHBoxLayout" name="layout_square_circle">
-                              <item>
-                                <widget class="QGroupBox" name="gb_square">
-                                  <property name="title">
-                                    <string>Square</string>
-                                  </property>
-                                  <property name="alignment">
-                                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                                  </property>
-                                  <layout class="QVBoxLayout" name="gb_square_layout">
-                                    <property name="leftMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="topMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="rightMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="bottomMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <item>
-                                      <widget class="QPushButton" name="SquareButton">
-                                        <property name="text">
-                                          <string>unmapped</string>
-                                        </property>
-                                      </widget>
-                                    </item>
-                                  </layout>
-                                </widget>
-                              </item>
-                              <item>
-                                <widget class="QGroupBox" name="gb_circle">
-                                  <property name="title">
-                                    <string>Circle</string>
-                                  </property>
-                                  <property name="alignment">
-                                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                                  </property>
-                                  <layout class="QVBoxLayout" name="gb_circle_layout">
-                                    <property name="leftMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="topMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="rightMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="bottomMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <item>
-                                      <widget class="QPushButton" name="CircleButton">
-                                        <property name="text">
-                                          <string>unmapped</string>
-                                        </property>
-                                      </widget>
-                                    </item>
-                                  </layout>
-                                </widget>
-                              </item>
-                            </layout>
-                          </item>
-                          <item>
-                            <widget class="QWidget" name="widget_cross" native="true">
-                              <layout class="QHBoxLayout" name="widget_cross_layout">
-                                <property name="leftMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="topMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="rightMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="bottomMargin">
-                                  <number>0</number>
-                                </property>
-                                <item>
-                                  <widget class="QGroupBox" name="gb_cross">
-                                    <property name="minimumSize">
-                                      <size>
-                                        <width>152</width>
-                                        <height>0</height>
-                                      </size>
-                                    </property>
-                                    <property name="maximumSize">
-                                      <size>
-                                        <width>124</width>
-                                        <height>16777215</height>
-                                      </size>
-                                    </property>
-                                    <property name="title">
-                                      <string>Cross</string>
-                                    </property>
-                                    <property name="alignment">
-                                      <set>Qt::AlignmentFlag::AlignCenter</set>
-                                    </property>
-                                    <layout class="QVBoxLayout" name="verticalLayout_5">
-                                      <item>
-                                        <widget class="QPushButton" name="CrossButton">
-                                          <property name="text">
-                                            <string>unmapped</string>
-                                          </property>
-                                        </widget>
-                                      </item>
-                                    </layout>
-                                  </widget>
-                                </item>
-                              </layout>
-                            </widget>
-                          </item>
-                        </layout>
-                      </widget>
-                    </item>
-                    <item>
-                      <widget class="QGroupBox" name="groupBox_6">
-                        <property name="title">
-                          <string>R1 and R2</string>
-                        </property>
-                        <layout class="QHBoxLayout" name="horizontalLayout_14">
-                          <item>
-                            <widget class="QGroupBox" name="gb_r1">
-                              <property name="sizePolicy">
-                                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                                  <horstretch>0</horstretch>
-                                  <verstretch>0</verstretch>
-                                </sizepolicy>
-                              </property>
-                              <property name="title">
-                                <string notr="true">R1</string>
-                              </property>
-                              <property name="alignment">
-                                <set>Qt::AlignmentFlag::AlignCenter</set>
-                              </property>
-                              <layout class="QVBoxLayout" name="gb_r1_layout">
-                                <property name="leftMargin">
-                                  <number>5</number>
-                                </property>
-                                <property name="topMargin">
-                                  <number>5</number>
-                                </property>
-                                <property name="rightMargin">
-                                  <number>5</number>
-                                </property>
-                                <property name="bottomMargin">
-                                  <number>5</number>
-                                </property>
-                                <item>
-                                  <widget class="QPushButton" name="R1Button">
-                                    <property name="text">
-                                      <string>unmapped</string>
-                                    </property>
-                                  </widget>
-                                </item>
-                              </layout>
-                            </widget>
-                          </item>
-                          <item>
-                            <widget class="QGroupBox" name="gb_r2">
-                              <property name="title">
-                                <string notr="true">R2</string>
-                              </property>
-                              <property name="alignment">
-                                <set>Qt::AlignmentFlag::AlignCenter</set>
-                              </property>
-                              <layout class="QVBoxLayout" name="gb_r2_layout">
-                                <property name="leftMargin">
-                                  <number>5</number>
-                                </property>
-                                <property name="topMargin">
-                                  <number>5</number>
-                                </property>
-                                <property name="rightMargin">
-                                  <number>5</number>
-                                </property>
-                                <property name="bottomMargin">
-                                  <number>5</number>
-                                </property>
-                                <item>
-                                  <widget class="QPushButton" name="R2Button">
-                                    <property name="text">
-                                      <string>unmapped</string>
-                                    </property>
-                                  </widget>
-                                </item>
-                              </layout>
-                            </widget>
-                          </item>
-                        </layout>
-                      </widget>
-                    </item>
-                    <item>
-                      <spacer name="verticalSpacer_2">
-                        <property name="orientation">
-                          <enum>Qt::Orientation::Vertical</enum>
-                        </property>
-                        <property name="sizeType">
-                          <enum>QSizePolicy::Policy::Expanding</enum>
-                        </property>
-                        <property name="sizeHint" stdset="0">
-                          <size>
-                            <width>20</width>
-                            <height>40</height>
-                          </size>
-                        </property>
-                      </spacer>
-                    </item>
-                    <item>
-                      <widget class="QGroupBox" name="RightStickDeadZoneGB">
-                        <property name="sizePolicy">
-                          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                          </sizepolicy>
-                        </property>
-                        <property name="title">
-                          <string>Right Stick Deadzone</string>
-                        </property>
-                        <layout class="QVBoxLayout" name="verticalLayout_13">
-                          <item>
-                            <widget class="QLabel" name="RightDeadzoneMinLabel">
-                              <property name="text">
-                                <string>Min Deadzone (def:2 max:127)</string>
-                              </property>
-                              <property name="alignment">
-                                <set>Qt::AlignmentFlag::AlignLeft</set>
-                              </property>
-                            </widget>
-                          </item>
-                          <item>
-                            <widget class="QLabel" name="RightDeadzoneMinValue">
-                              <property name="sizePolicy">
-                                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                                  <horstretch>0</horstretch>
-                                  <verstretch>0</verstretch>
-                                </sizepolicy>
-                              </property>
-                              <property name="text">
-                                <string>2</string>
-                              </property>
-                              <property name="alignment">
-                                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                              </property>
-                            </widget>
-                          </item>
-                          <item>
-                            <widget class="QSlider" name="RightDeadzoneMinSlider">
-                              <property name="sizePolicy">
-                                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                                  <horstretch>0</horstretch>
-                                  <verstretch>0</verstretch>
-                                </sizepolicy>
-                              </property>
-                              <property name="minimum">
-                                <number>1</number>
-                              </property>
-                              <property name="maximum">
-                                <number>127</number>
-                              </property>
-                              <property name="value">
-                                <number>2</number>
-                              </property>
-                              <property name="orientation">
-                                <enum>Qt::Orientation::Horizontal</enum>
-                              </property>
-                            </widget>
-                          </item>
-                          <item>
-                            <widget class="QLabel" name="RightDeadzoneMaxLabel">
-                              <property name="text">
-                                <string>Max Deadzone (def:127 max:127)</string>
-                              </property>
-                              <property name="alignment">
-                                <set>Qt::AlignmentFlag::AlignLeft</set>
-                              </property>
-                            </widget>
-                          </item>
-                          <item>
-                            <widget class="QLabel" name="RightDeadzoneMaxValue">
-                              <property name="sizePolicy">
-                                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                                  <horstretch>0</horstretch>
-                                  <verstretch>0</verstretch>
-                                </sizepolicy>
-                              </property>
-                              <property name="text">
-                                <string>127</string>
-                              </property>
-                              <property name="alignment">
-                                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                              </property>
-                            </widget>
-                          </item>
-                          <item>
-                            <widget class="QSlider" name="RightDeadzoneMaxSlider">
-                              <property name="sizePolicy">
-                                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                                  <horstretch>0</horstretch>
-                                  <verstretch>0</verstretch>
-                                </sizepolicy>
-                              </property>
-                              <property name="minimum">
-                                <number>1</number>
-                              </property>
-                              <property name="maximum">
-                                <number>127</number>
-                              </property>
-                              <property name="value">
-                                <number>127</number>
-                              </property>
-                              <property name="orientation">
-                                <enum>Qt::Orientation::Horizontal</enum>
-                              </property>
-                            </widget>
-                          </item>
-                        </layout>
-                      </widget>
-                    </item>
-                    <item>
-                      <widget class="QGroupBox" name="gb_right_stick">
-                        <property name="sizePolicy">
-                          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                          </sizepolicy>
-                        </property>
-                        <property name="minimumSize">
-                          <size>
-                            <width>0</width>
-                            <height>0</height>
-                          </size>
-                        </property>
-                        <property name="title">
-                          <string>Right Stick</string>
-                        </property>
-                        <layout class="QVBoxLayout" name="verticalLayout_2">
-                          <property name="leftMargin">
-                            <number>5</number>
-                          </property>
-                          <property name="topMargin">
-                            <number>5</number>
-                          </property>
-                          <property name="rightMargin">
-                            <number>5</number>
-                          </property>
-                          <property name="bottomMargin">
-                            <number>5</number>
-                          </property>
-                          <item>
-                            <widget class="QWidget" name="widget_right_stick_up" native="true">
-                              <layout class="QHBoxLayout" name="widget_right_stick_up_layout">
-                                <property name="leftMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="topMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="rightMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="bottomMargin">
-                                  <number>0</number>
-                                </property>
-                                <item>
-                                  <widget class="QGroupBox" name="gb_right_stick_up">
-                                    <property name="sizePolicy">
-                                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                                        <horstretch>0</horstretch>
-                                        <verstretch>0</verstretch>
-                                      </sizepolicy>
-                                    </property>
-                                    <property name="minimumSize">
-                                      <size>
-                                        <width>0</width>
-                                        <height>0</height>
-                                      </size>
-                                    </property>
-                                    <property name="maximumSize">
-                                      <size>
-                                        <width>152</width>
-                                        <height>1231321</height>
-                                      </size>
-                                    </property>
-                                    <property name="title">
-                                      <string>Up</string>
-                                    </property>
-                                    <property name="alignment">
-                                      <set>Qt::AlignmentFlag::AlignCenter</set>
-                                    </property>
-                                    <layout class="QVBoxLayout" name="verticalLayout_7">
-                                      <item>
-                                        <widget class="QPushButton" name="RStickUpButton">
-                                          <property name="text">
-                                            <string>unmapped</string>
-                                          </property>
-                                        </widget>
-                                      </item>
-                                    </layout>
-                                  </widget>
-                                </item>
-                              </layout>
-                            </widget>
-                          </item>
-                          <item>
-                            <layout class="QHBoxLayout" name="layout_right_stick_left_right">
-                              <item>
-                                <widget class="QGroupBox" name="gb_right_stick_left">
-                                  <property name="title">
-                                    <string>Left</string>
-                                  </property>
-                                  <property name="alignment">
-                                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                                  </property>
-                                  <layout class="QVBoxLayout" name="gb_right_stick_left_layout">
-                                    <property name="leftMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="topMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="rightMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="bottomMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <item>
-                                      <widget class="QPushButton" name="RStickLeftButton">
-                                        <property name="text">
-                                          <string>unmapped</string>
-                                        </property>
-                                      </widget>
-                                    </item>
-                                  </layout>
-                                </widget>
-                              </item>
-                              <item>
-                                <widget class="QGroupBox" name="gb_right_stick_right">
-                                  <property name="title">
-                                    <string>Right</string>
-                                  </property>
-                                  <property name="alignment">
-                                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                                  </property>
-                                  <layout class="QVBoxLayout" name="gb_right_stick_right_layout">
-                                    <property name="leftMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="topMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="rightMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <property name="bottomMargin">
-                                      <number>5</number>
-                                    </property>
-                                    <item>
-                                      <widget class="QPushButton" name="RStickRightButton">
-                                        <property name="text">
-                                          <string>unmapped</string>
-                                        </property>
-                                      </widget>
-                                    </item>
-                                  </layout>
-                                </widget>
-                              </item>
-                            </layout>
-                          </item>
-                          <item>
-                            <widget class="QWidget" name="widget_right_stick_down" native="true">
-                              <layout class="QHBoxLayout" name="widget_right_stick_down_layout">
-                                <property name="leftMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="topMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="rightMargin">
-                                  <number>0</number>
-                                </property>
-                                <property name="bottomMargin">
-                                  <number>0</number>
-                                </property>
-                                <item>
-                                  <widget class="QGroupBox" name="gb_right_stick_down">
-                                    <property name="minimumSize">
-                                      <size>
-                                        <width>152</width>
-                                        <height>0</height>
-                                      </size>
-                                    </property>
-                                    <property name="maximumSize">
-                                      <size>
-                                        <width>124</width>
-                                        <height>2121</height>
-                                      </size>
-                                    </property>
-                                    <property name="title">
-                                      <string>Down</string>
-                                    </property>
-                                    <property name="alignment">
-                                      <set>Qt::AlignmentFlag::AlignCenter</set>
-                                    </property>
-                                    <layout class="QVBoxLayout" name="verticalLayout_6">
-                                      <item>
-                                        <widget class="QPushButton" name="RStickDownButton">
-                                          <property name="text">
-                                            <string>unmapped</string>
-                                          </property>
-                                        </widget>
-                                      </item>
-                                    </layout>
-                                  </widget>
-                                </item>
-                              </layout>
-                            </widget>
-                          </item>
-                        </layout>
-                      </widget>
-                    </item>
-                  </layout>
-                </item>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
               </layout>
-            </widget>
-          </widget>
-        </widget>
-      </item>
-      <item>
-        <widget class="QDialogButtonBox" name="buttonBox">
-          <property name="standardButtons">
-            <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::RestoreDefaults|QDialogButtonBox::StandardButton::Save</set>
+             </item>
+             <item>
+              <widget class="QWidget" name="dpad_down" native="true">
+               <layout class="QHBoxLayout" name="dpad_down_layout">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QGroupBox" name="gb_dpad_down">
+                  <property name="minimumSize">
+                   <size>
+                    <width>152</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>124</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="title">
+                   <string>Down</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                  <layout class="QHBoxLayout" name="horizontalLayout_3">
+                   <item>
+                    <widget class="QPushButton" name="DpadDownButton">
+                     <property name="text">
+                      <string>unmapped</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="groupBox_5">
+            <property name="title">
+             <string>L1 and L2</string>
+            </property>
+            <layout class="QHBoxLayout" name="horizontalLayout_13">
+             <item>
+              <widget class="QGroupBox" name="gb_l1">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="title">
+                <string notr="true">L1</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+               <layout class="QVBoxLayout" name="gb_l1_layout">
+                <property name="leftMargin">
+                 <number>5</number>
+                </property>
+                <property name="topMargin">
+                 <number>5</number>
+                </property>
+                <property name="rightMargin">
+                 <number>5</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>5</number>
+                </property>
+                <item>
+                 <widget class="QPushButton" name="L1Button">
+                  <property name="text">
+                   <string>unmapped</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QGroupBox" name="gb_l2">
+               <property name="title">
+                <string notr="true">L2</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+               <layout class="QVBoxLayout" name="gb_l2_layout">
+                <property name="leftMargin">
+                 <number>5</number>
+                </property>
+                <property name="topMargin">
+                 <number>5</number>
+                </property>
+                <property name="rightMargin">
+                 <number>5</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>5</number>
+                </property>
+                <item>
+                 <widget class="QPushButton" name="L2Button">
+                  <property name="text">
+                   <string>unmapped</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Orientation::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="LeftStickDeadZoneGB">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="title">
+             <string>Left Stick Deadzone (def:2 max:127)</string>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_15">
+             <item>
+              <widget class="QLabel" name="LeftDeadzoneValue">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Left Deadzone</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSlider" name="LeftDeadzoneSlider">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimum">
+                <number>1</number>
+               </property>
+               <property name="maximum">
+                <number>127</number>
+               </property>
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="gb_left_stick">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="title">
+             <string>Left Stick</string>
+            </property>
+            <layout class="QVBoxLayout" name="gb_left_stick_layout">
+             <property name="leftMargin">
+              <number>5</number>
+             </property>
+             <property name="topMargin">
+              <number>5</number>
+             </property>
+             <property name="rightMargin">
+              <number>5</number>
+             </property>
+             <property name="bottomMargin">
+              <number>5</number>
+             </property>
+             <item>
+              <widget class="QWidget" name="left_stick_up" native="true">
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>2121</height>
+                </size>
+               </property>
+               <layout class="QHBoxLayout" name="left_stick_up_layout">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QGroupBox" name="gb_left_stick_up">
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>152</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="title">
+                   <string>Up</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_10">
+                   <item>
+                    <widget class="QPushButton" name="LStickUpButton">
+                     <property name="text">
+                      <string>unmapped</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="layout_left_stick_left_right">
+               <item>
+                <widget class="QGroupBox" name="gb_left_stick_left">
+                 <property name="title">
+                  <string>Left</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_left_stick_left_layout">
+                  <property name="leftMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>5</number>
+                  </property>
+                  <item>
+                   <widget class="QPushButton" name="LStickLeftButton">
+                    <property name="text">
+                     <string>unmapped</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_left_stick_right">
+                 <property name="maximumSize">
+                  <size>
+                   <width>179</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="title">
+                  <string>Right</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_left_stick_right_layout">
+                  <property name="leftMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>5</number>
+                  </property>
+                  <item>
+                   <widget class="QPushButton" name="LStickRightButton">
+                    <property name="text">
+                     <string>unmapped</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <widget class="QWidget" name="left_stick_down" native="true">
+               <layout class="QHBoxLayout" name="left_stick_down_layout">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QGroupBox" name="gb_left_stick_down">
+                  <property name="minimumSize">
+                   <size>
+                    <width>152</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>124</width>
+                    <height>21212</height>
+                   </size>
+                  </property>
+                  <property name="title">
+                   <string>Down</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_8">
+                   <item>
+                    <widget class="QPushButton" name="LStickDownButton">
+                     <property name="text">
+                      <string>unmapped</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_middle" stretch="0,0,0,0">
+          <property name="spacing">
+           <number>0</number>
           </property>
-          <property name="centerButtons">
-            <bool>false</bool>
+          <item>
+           <widget class="QGroupBox" name="ProfileGroupBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>12</pointsize>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="title">
+             <string>Config Selection</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignCenter</set>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_16">
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_6">
+               <item>
+                <widget class="QComboBox" name="ProfileComboBox">
+                 <property name="font">
+                  <font>
+                   <pointsize>9</pointsize>
+                   <bold>false</bold>
+                  </font>
+                 </property>
+                 <property name="currentText">
+                  <string/>
+                 </property>
+                 <property name="currentIndex">
+                  <number>-1</number>
+                 </property>
+                 <property name="placeholderText">
+                  <string>Common Config</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="TitleLabel">
+                 <property name="font">
+                  <font>
+                   <pointsize>10</pointsize>
+                   <bold>true</bold>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string>Common Config</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="PerGameCheckBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="font">
+                <font>
+                 <pointsize>9</pointsize>
+                 <bold>false</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string>Use per-game configs</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QGroupBox" name="groupBox_2">
+               <property name="font">
+                <font>
+                 <pointsize>9</pointsize>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="title">
+                <string>Active Gamepad</string>
+               </property>
+               <layout class="QHBoxLayout" name="horizontalLayout_7">
+                <item>
+                 <widget class="QComboBox" name="ActiveGamepadBox">
+                  <property name="font">
+                   <font>
+                    <pointsize>9</pointsize>
+                    <bold>false</bold>
+                   </font>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="ActiveGamepadLabel">
+                  <property name="font">
+                   <font>
+                    <pointsize>9</pointsize>
+                    <bold>false</bold>
+                   </font>
+                  </property>
+                  <property name="text">
+                   <string>Gamepad ID</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QGroupBox" name="groupBox_4">
+               <property name="font">
+                <font>
+                 <pointsize>9</pointsize>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="title">
+                <string>Default Gamepad</string>
+               </property>
+               <layout class="QHBoxLayout" name="horizontalLayout_12">
+                <item>
+                 <widget class="QLabel" name="DefaultGamepadName">
+                  <property name="text">
+                   <string>No default selected</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="DefaultGamepadLabel">
+                  <property name="font">
+                   <font>
+                    <pointsize>9</pointsize>
+                    <bold>false</bold>
+                   </font>
+                  </property>
+                  <property name="text">
+                   <string>n/a</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_19">
+               <item>
+                <widget class="QPushButton" name="DefaultGamepadButton">
+                 <property name="font">
+                  <font>
+                   <pointsize>9</pointsize>
+                   <bold>true</bold>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string>Set Active Gamepad as Default</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="RemoveDefaultGamepadButton">
+                 <property name="font">
+                  <font>
+                   <pointsize>9</pointsize>
+                   <bold>true</bold>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string>Remove Default Gamepad</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QWidget" name="widget_controller" native="true">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>200</height>
+             </size>
+            </property>
+            <layout class="QHBoxLayout" name="widget_controller_layout">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="l_controller">
+               <property name="maximumSize">
+                <size>
+                 <width>415</width>
+                 <height>256</height>
+                </size>
+               </property>
+               <property name="pixmap">
+                <pixmap resource="../shadps4.qrc">:/images/ps4_controller.png</pixmap>
+               </property>
+               <property name="scaledContents">
+                <bool>true</bool>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignHCenter</set>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_9">
+            <property name="spacing">
+             <number>10</number>
+            </property>
+            <property name="sizeConstraint">
+             <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+            </property>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout">
+              <item>
+               <widget class="QGroupBox" name="gb_l3">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="title">
+                 <string notr="true">L3</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
+                </property>
+                <layout class="QVBoxLayout" name="gb_l3_layout">
+                 <property name="leftMargin">
+                  <number>5</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>5</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>5</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>5</number>
+                 </property>
+                 <item>
+                  <widget class="QPushButton" name="L3Button">
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QGroupBox" name="gb_start">
+                <property name="title">
+                 <string>Options</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
+                </property>
+                <layout class="QVBoxLayout" name="gb_start_layout">
+                 <property name="leftMargin">
+                  <number>5</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>5</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>5</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>5</number>
+                 </property>
+                 <item>
+                  <widget class="QPushButton" name="OptionsButton">
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QGroupBox" name="gb_r3">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="title">
+                 <string notr="true">R3</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
+                </property>
+                <layout class="QVBoxLayout" name="gb_r3_layout">
+                 <property name="leftMargin">
+                  <number>5</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>5</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>5</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>5</number>
+                 </property>
+                 <item>
+                  <widget class="QPushButton" name="R3Button">
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_2">
+              <item>
+               <widget class="QGroupBox" name="gb_touchleft">
+                <property name="title">
+                 <string>Touchpad Left</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_5">
+                 <item>
+                  <widget class="QPushButton" name="TouchpadLeftButton">
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QGroupBox" name="gb_touchcenter">
+                <property name="title">
+                 <string>Touchpad Center</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
+                </property>
+                <layout class="QVBoxLayout" name="verticalLayout_11">
+                 <item>
+                  <widget class="QPushButton" name="TouchpadCenterButton">
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item>
+               <widget class="QGroupBox" name="gb_touchright">
+                <property name="title">
+                 <string>Touchpad Right</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
+                </property>
+                <layout class="QVBoxLayout" name="verticalLayout_12">
+                 <item>
+                  <widget class="QPushButton" name="TouchpadRightButton">
+                   <property name="text">
+                    <string>unmapped</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_8">
+            <item>
+             <layout class="QVBoxLayout" name="verticalLayout_14">
+              <item>
+               <widget class="QGroupBox" name="groupBox">
+                <property name="font">
+                 <font>
+                  <bold>false</bold>
+                 </font>
+                </property>
+                <property name="title">
+                 <string>Color Adjustment</string>
+                </property>
+                <layout class="QVBoxLayout" name="verticalLayout_18">
+                 <property name="leftMargin">
+                  <number>6</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>6</number>
+                 </property>
+                 <item>
+                  <layout class="QHBoxLayout" name="horizontalLayout_9">
+                   <property name="spacing">
+                    <number>6</number>
+                   </property>
+                   <item>
+                    <widget class="QLabel" name="RLabel_text">
+                     <property name="font">
+                      <font>
+                       <bold>false</bold>
+                      </font>
+                     </property>
+                     <property name="text">
+                      <string>RED</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QSlider" name="RSlider">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="maximum">
+                      <number>255</number>
+                     </property>
+                     <property name="orientation">
+                      <enum>Qt::Orientation::Horizontal</enum>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="RLabel">
+                     <property name="maximumSize">
+                      <size>
+                       <width>20</width>
+                       <height>16777215</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string notr="true">000</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
+                  <layout class="QHBoxLayout" name="horizontalLayout_10">
+                   <item>
+                    <widget class="QLabel" name="GLabel_text">
+                     <property name="font">
+                      <font>
+                       <bold>false</bold>
+                      </font>
+                     </property>
+                     <property name="text">
+                      <string>GREEN</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QSlider" name="GSlider">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="maximum">
+                      <number>255</number>
+                     </property>
+                     <property name="orientation">
+                      <enum>Qt::Orientation::Horizontal</enum>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="GLabel">
+                     <property name="maximumSize">
+                      <size>
+                       <width>20</width>
+                       <height>16777215</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string notr="true">000</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
+                  <layout class="QHBoxLayout" name="horizontalLayout_11">
+                   <item>
+                    <widget class="QLabel" name="BLabel_text">
+                     <property name="font">
+                      <font>
+                       <bold>false</bold>
+                      </font>
+                     </property>
+                     <property name="text">
+                      <string>BLUE</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QSlider" name="BSlider">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="maximum">
+                      <number>255</number>
+                     </property>
+                     <property name="value">
+                      <number>255</number>
+                     </property>
+                     <property name="orientation">
+                      <enum>Qt::Orientation::Horizontal</enum>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="BLabel">
+                     <property name="maximumSize">
+                      <size>
+                       <width>20</width>
+                       <height>16777215</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string notr="true">255</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QVBoxLayout" name="verticalLayout_17">
+              <item>
+               <widget class="QGroupBox" name="groupBox_3">
+                <property name="font">
+                 <font>
+                  <bold>false</bold>
+                 </font>
+                </property>
+                <property name="title">
+                 <string>Override Lightbar Color</string>
+                </property>
+                <layout class="QVBoxLayout" name="verticalLayout_19">
+                 <item>
+                  <widget class="QCheckBox" name="LightbarCheckBox">
+                   <property name="font">
+                    <font>
+                     <bold>false</bold>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>Override Color</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QFrame" name="LightbarColorFrame">
+                   <property name="frameShape">
+                    <enum>QFrame::Shape::StyledPanel</enum>
+                   </property>
+                   <property name="frameShadow">
+                    <enum>QFrame::Shadow::Raised</enum>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_right">
+          <property name="spacing">
+           <number>5</number>
           </property>
-        </widget>
-      </item>
-    </layout>
-  </widget>
-  <resources>
-    <include location="../shadps4.qrc"/>
-  </resources>
-  <connections/>
+          <item>
+           <widget class="QGroupBox" name="gb_face_buttons">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="title">
+             <string>Face Buttons</string>
+            </property>
+            <layout class="QVBoxLayout" name="gb_face_buttons_layout">
+             <property name="leftMargin">
+              <number>5</number>
+             </property>
+             <property name="topMargin">
+              <number>5</number>
+             </property>
+             <property name="rightMargin">
+              <number>5</number>
+             </property>
+             <property name="bottomMargin">
+              <number>5</number>
+             </property>
+             <item>
+              <widget class="QWidget" name="widget_triangle" native="true">
+               <layout class="QHBoxLayout" name="widget_triangle_layout">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QGroupBox" name="gb_triangle">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>152</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>0</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="title">
+                   <string>Triangle</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_3">
+                   <item>
+                    <widget class="QPushButton" name="TriangleButton">
+                     <property name="text">
+                      <string>unmapped</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="layout_square_circle">
+               <item>
+                <widget class="QGroupBox" name="gb_square">
+                 <property name="title">
+                  <string>Square</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_square_layout">
+                  <property name="leftMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>5</number>
+                  </property>
+                  <item>
+                   <widget class="QPushButton" name="SquareButton">
+                    <property name="text">
+                     <string>unmapped</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_circle">
+                 <property name="title">
+                  <string>Circle</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_circle_layout">
+                  <property name="leftMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>5</number>
+                  </property>
+                  <item>
+                   <widget class="QPushButton" name="CircleButton">
+                    <property name="text">
+                     <string>unmapped</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <widget class="QWidget" name="widget_cross" native="true">
+               <layout class="QHBoxLayout" name="widget_cross_layout">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QGroupBox" name="gb_cross">
+                  <property name="minimumSize">
+                   <size>
+                    <width>152</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>124</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="title">
+                   <string>Cross</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_5">
+                   <item>
+                    <widget class="QPushButton" name="CrossButton">
+                     <property name="text">
+                      <string>unmapped</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="groupBox_6">
+            <property name="title">
+             <string>R1 and R2</string>
+            </property>
+            <layout class="QHBoxLayout" name="horizontalLayout_14">
+             <item>
+              <widget class="QGroupBox" name="gb_r1">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="title">
+                <string notr="true">R1</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+               <layout class="QVBoxLayout" name="gb_r1_layout">
+                <property name="leftMargin">
+                 <number>5</number>
+                </property>
+                <property name="topMargin">
+                 <number>5</number>
+                </property>
+                <property name="rightMargin">
+                 <number>5</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>5</number>
+                </property>
+                <item>
+                 <widget class="QPushButton" name="R1Button">
+                  <property name="text">
+                   <string>unmapped</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QGroupBox" name="gb_r2">
+               <property name="title">
+                <string notr="true">R2</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+               <layout class="QVBoxLayout" name="gb_r2_layout">
+                <property name="leftMargin">
+                 <number>5</number>
+                </property>
+                <property name="topMargin">
+                 <number>5</number>
+                </property>
+                <property name="rightMargin">
+                 <number>5</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>5</number>
+                </property>
+                <item>
+                 <widget class="QPushButton" name="R2Button">
+                  <property name="text">
+                   <string>unmapped</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Orientation::Vertical</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Policy::Expanding</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="RightStickDeadZoneGB">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="title">
+             <string>Right Stick Deadzone (def:2, max:127)</string>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_13">
+             <item>
+              <widget class="QLabel" name="RightDeadzoneValue">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Right Deadzone</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSlider" name="RightDeadzoneSlider">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimum">
+                <number>1</number>
+               </property>
+               <property name="maximum">
+                <number>127</number>
+               </property>
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="gb_right_stick">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="title">
+             <string>Right Stick</string>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_2">
+             <property name="leftMargin">
+              <number>5</number>
+             </property>
+             <property name="topMargin">
+              <number>5</number>
+             </property>
+             <property name="rightMargin">
+              <number>5</number>
+             </property>
+             <property name="bottomMargin">
+              <number>5</number>
+             </property>
+             <item>
+              <widget class="QWidget" name="widget_right_stick_up" native="true">
+               <layout class="QHBoxLayout" name="widget_right_stick_up_layout">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QGroupBox" name="gb_right_stick_up">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>152</width>
+                    <height>1231321</height>
+                   </size>
+                  </property>
+                  <property name="title">
+                   <string>Up</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_7">
+                   <item>
+                    <widget class="QPushButton" name="RStickUpButton">
+                     <property name="text">
+                      <string>unmapped</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="layout_right_stick_left_right">
+               <item>
+                <widget class="QGroupBox" name="gb_right_stick_left">
+                 <property name="title">
+                  <string>Left</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_right_stick_left_layout">
+                  <property name="leftMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>5</number>
+                  </property>
+                  <item>
+                   <widget class="QPushButton" name="RStickLeftButton">
+                    <property name="text">
+                     <string>unmapped</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_right_stick_right">
+                 <property name="title">
+                  <string>Right</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_right_stick_right_layout">
+                  <property name="leftMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>5</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>5</number>
+                  </property>
+                  <item>
+                   <widget class="QPushButton" name="RStickRightButton">
+                    <property name="text">
+                     <string>unmapped</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <widget class="QWidget" name="widget_right_stick_down" native="true">
+               <layout class="QHBoxLayout" name="widget_right_stick_down_layout">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QGroupBox" name="gb_right_stick_down">
+                  <property name="minimumSize">
+                   <size>
+                    <width>152</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>124</width>
+                    <height>2121</height>
+                   </size>
+                  </property>
+                  <property name="title">
+                   <string>Down</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignmentFlag::AlignCenter</set>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_6">
+                   <item>
+                    <widget class="QPushButton" name="RStickDownButton">
+                     <property name="text">
+                      <string>unmapped</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::RestoreDefaults|QDialogButtonBox::StandardButton::Save</set>
+     </property>
+     <property name="centerButtons">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../shadps4.qrc"/>
+ </resources>
+ <connections/>
 </ui>

--- a/src/qt_gui/control_settings.ui
+++ b/src/qt_gui/control_settings.ui
@@ -357,11 +357,21 @@
              </sizepolicy>
             </property>
             <property name="title">
-             <string>Left Stick Deadzone (def:2 max:127)</string>
+             <string>Left Stick Deadzone</string>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_15">
              <item>
-              <widget class="QLabel" name="LeftDeadzoneValue">
+              <widget class="QLabel" name="LeftDeadzoneMinLabel">
+               <property name="text">
+                <string>Min Deadzone (def:2 max:127)</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignLeft</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="LeftDeadzoneMinValue">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
                  <horstretch>0</horstretch>
@@ -369,7 +379,7 @@
                 </sizepolicy>
                </property>
                <property name="text">
-                <string>Left Deadzone</string>
+                <string>2</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
@@ -377,7 +387,7 @@
               </widget>
              </item>
              <item>
-              <widget class="QSlider" name="LeftDeadzoneSlider">
+              <widget class="QSlider" name="LeftDeadzoneMinSlider">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
                  <horstretch>0</horstretch>
@@ -388,6 +398,57 @@
                 <number>1</number>
                </property>
                <property name="maximum">
+                <number>127</number>
+               </property>
+               <property name="value">
+                <number>2</number>
+               </property>
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="LeftDeadzoneMaxLabel">
+               <property name="text">
+                <string>Max Deadzone (def:127 max:127)</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignLeft</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="LeftDeadzoneMaxValue">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>127</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSlider" name="LeftDeadzoneMaxSlider">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimum">
+                <number>1</number>
+               </property>
+               <property name="maximum">
+                <number>127</number>
+               </property>
+               <property name="value">
                 <number>127</number>
                </property>
                <property name="orientation">
@@ -1546,11 +1607,21 @@
              </sizepolicy>
             </property>
             <property name="title">
-             <string>Right Stick Deadzone (def:2, max:127)</string>
+             <string>Right Stick Deadzone</string>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_13">
              <item>
-              <widget class="QLabel" name="RightDeadzoneValue">
+              <widget class="QLabel" name="RightDeadzoneMinLabel">
+               <property name="text">
+                <string>Min Deadzone (def:2 max:127)</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignLeft</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="RightDeadzoneMinValue">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
                  <horstretch>0</horstretch>
@@ -1558,7 +1629,7 @@
                 </sizepolicy>
                </property>
                <property name="text">
-                <string>Right Deadzone</string>
+                <string>2</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
@@ -1566,7 +1637,7 @@
               </widget>
              </item>
              <item>
-              <widget class="QSlider" name="RightDeadzoneSlider">
+              <widget class="QSlider" name="RightDeadzoneMinSlider">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
                  <horstretch>0</horstretch>
@@ -1577,6 +1648,57 @@
                 <number>1</number>
                </property>
                <property name="maximum">
+                <number>127</number>
+               </property>
+               <property name="value">
+                <number>2</number>
+               </property>
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="RightDeadzoneMaxLabel">
+               <property name="text">
+                <string>Max Deadzone (def:127 max:127)</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignLeft</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="RightDeadzoneMaxValue">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>127</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSlider" name="RightDeadzoneMaxSlider">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimum">
+                <number>1</number>
+               </property>
+               <property name="maximum">
+                <number>127</number>
+               </property>
+               <property name="value">
                 <number>127</number>
                </property>
                <property name="orientation">

--- a/src/qt_gui/control_settings.ui
+++ b/src/qt_gui/control_settings.ui
@@ -2,1815 +2,1938 @@
 <!-- SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
      SPDX-License-Identifier: GPL-2.0-or-later -->
 <ui version="4.0">
- <class>ControlSettings</class>
- <widget class="QDialog" name="ControlSettings">
-  <property name="windowModality">
-   <enum>Qt::WindowModality::WindowModal</enum>
-  </property>
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>1124</width>
-    <height>847</height>
-   </rect>
-  </property>
-  <property name="windowTitle">
-   <string>Configure Controls</string>
-  </property>
-  <property name="windowIcon">
-   <iconset>
-    <normaloff>:/rpcs3.ico</normaloff>:/rpcs3.ico</iconset>
-  </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QScrollArea" name="scrollArea">
-     <property name="widgetResizable">
-      <bool>true</bool>
-     </property>
-     <widget class="QWidget" name="scrollAreaWidgetContents">
-      <property name="geometry">
-       <rect>
+  <class>ControlSettings</class>
+  <widget class="QDialog" name="ControlSettings">
+    <property name="windowModality">
+      <enum>Qt::WindowModality::WindowModal</enum>
+    </property>
+    <property name="geometry">
+      <rect>
         <x>0</x>
         <y>0</y>
-        <width>1104</width>
-        <height>797</height>
-       </rect>
-      </property>
-      <widget class="QWidget" name="layoutWidget">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>1101</width>
-         <height>791</height>
-        </rect>
-       </property>
-       <layout class="QHBoxLayout" name="RemapLayout">
-        <item>
-         <layout class="QVBoxLayout" name="verticalLayout_left">
-          <property name="spacing">
-           <number>5</number>
+        <width>1124</width>
+        <height>847</height>
+      </rect>
+    </property>
+    <property name="windowTitle">
+      <string>Configure Controls</string>
+    </property>
+    <property name="windowIcon">
+      <iconset>
+        <normaloff>:/rpcs3.ico</normaloff>:/rpcs3.ico
+      </iconset>
+    </property>
+    <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+        <widget class="QScrollArea" name="scrollArea">
+          <property name="widgetResizable">
+            <bool>true</bool>
           </property>
-          <item>
-           <widget class="QGroupBox" name="gb_dpad">
-            <property name="enabled">
-             <bool>true</bool>
+          <widget class="QWidget" name="scrollAreaWidgetContents">
+            <property name="geometry">
+              <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>1104</width>
+                <height>797</height>
+              </rect>
             </property>
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="title">
-             <string>D-Pad</string>
-            </property>
-            <layout class="QVBoxLayout" name="gb_dpad_layout">
-             <property name="spacing">
-              <number>6</number>
-             </property>
-             <property name="leftMargin">
-              <number>5</number>
-             </property>
-             <property name="topMargin">
-              <number>5</number>
-             </property>
-             <property name="rightMargin">
-              <number>5</number>
-             </property>
-             <property name="bottomMargin">
-              <number>5</number>
-             </property>
-             <item>
-              <widget class="QWidget" name="dpad_up" native="true">
-               <layout class="QHBoxLayout" name="dpad_up_layout">
-                <property name="spacing">
-                 <number>0</number>
-                </property>
-                <property name="leftMargin">
-                 <number>0</number>
-                </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
+            <widget class="QWidget" name="layoutWidget">
+              <property name="geometry">
+                <rect>
+                  <x>0</x>
+                  <y>0</y>
+                  <width>1101</width>
+                  <height>791</height>
+                </rect>
+              </property>
+              <layout class="QHBoxLayout" name="RemapLayout">
                 <item>
-                 <widget class="QGroupBox" name="gb_dpad_up">
-                  <property name="minimumSize">
-                   <size>
-                    <width>152</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="maximumSize">
-                   <size>
-                    <width>0</width>
-                    <height>16777215</height>
-                   </size>
-                  </property>
-                  <property name="title">
-                   <string>Up</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignCenter</set>
-                  </property>
-                  <layout class="QHBoxLayout" name="horizontalLayout_4">
-                   <item>
-                    <widget class="QPushButton" name="DpadUpButton">
-                     <property name="text">
-                      <string>unmapped</string>
-                     </property>
-                    </widget>
-                   </item>
+                  <layout class="QVBoxLayout" name="verticalLayout_left">
+                    <property name="spacing">
+                      <number>5</number>
+                    </property>
+                    <item>
+                      <widget class="QGroupBox" name="gb_dpad">
+                        <property name="enabled">
+                          <bool>true</bool>
+                        </property>
+                        <property name="sizePolicy">
+                          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                          </sizepolicy>
+                        </property>
+                        <property name="maximumSize">
+                          <size>
+                            <width>16777215</width>
+                            <height>16777215</height>
+                          </size>
+                        </property>
+                        <property name="title">
+                          <string>D-Pad</string>
+                        </property>
+                        <layout class="QVBoxLayout" name="gb_dpad_layout">
+                          <property name="spacing">
+                            <number>6</number>
+                          </property>
+                          <property name="leftMargin">
+                            <number>5</number>
+                          </property>
+                          <property name="topMargin">
+                            <number>5</number>
+                          </property>
+                          <property name="rightMargin">
+                            <number>5</number>
+                          </property>
+                          <property name="bottomMargin">
+                            <number>5</number>
+                          </property>
+                          <item>
+                            <widget class="QWidget" name="dpad_up" native="true">
+                              <layout class="QHBoxLayout" name="dpad_up_layout">
+                                <property name="spacing">
+                                  <number>0</number>
+                                </property>
+                                <property name="leftMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="topMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="rightMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="bottomMargin">
+                                  <number>0</number>
+                                </property>
+                                <item>
+                                  <widget class="QGroupBox" name="gb_dpad_up">
+                                    <property name="minimumSize">
+                                      <size>
+                                        <width>152</width>
+                                        <height>0</height>
+                                      </size>
+                                    </property>
+                                    <property name="maximumSize">
+                                      <size>
+                                        <width>0</width>
+                                        <height>16777215</height>
+                                      </size>
+                                    </property>
+                                    <property name="title">
+                                      <string>Up</string>
+                                    </property>
+                                    <property name="alignment">
+                                      <set>Qt::AlignmentFlag::AlignCenter</set>
+                                    </property>
+                                    <layout class="QHBoxLayout" name="horizontalLayout_4">
+                                      <item>
+                                        <widget class="QPushButton" name="DpadUpButton">
+                                          <property name="text">
+                                            <string>unmapped</string>
+                                          </property>
+                                        </widget>
+                                      </item>
+                                    </layout>
+                                  </widget>
+                                </item>
+                              </layout>
+                            </widget>
+                          </item>
+                          <item>
+                            <layout class="QHBoxLayout" name="layout_dpad_left_right">
+                              <item>
+                                <widget class="QGroupBox" name="gb_dpad_left">
+                                  <property name="title">
+                                    <string>Left</string>
+                                  </property>
+                                  <property name="alignment">
+                                    <set>Qt::AlignmentFlag::AlignCenter</set>
+                                  </property>
+                                  <layout class="QVBoxLayout" name="gb_dpad_left_layout">
+                                    <property name="leftMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="topMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="rightMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="bottomMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <item>
+                                      <widget class="QPushButton" name="DpadLeftButton">
+                                        <property name="text">
+                                          <string>unmapped</string>
+                                        </property>
+                                      </widget>
+                                    </item>
+                                  </layout>
+                                </widget>
+                              </item>
+                              <item>
+                                <widget class="QGroupBox" name="gb_dpad_right">
+                                  <property name="title">
+                                    <string>Right</string>
+                                  </property>
+                                  <property name="alignment">
+                                    <set>Qt::AlignmentFlag::AlignCenter</set>
+                                  </property>
+                                  <layout class="QVBoxLayout" name="gb_dpad_right_layout">
+                                    <property name="leftMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="topMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="rightMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="bottomMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <item>
+                                      <widget class="QPushButton" name="DpadRightButton">
+                                        <property name="text">
+                                          <string>unmapped</string>
+                                        </property>
+                                      </widget>
+                                    </item>
+                                  </layout>
+                                </widget>
+                              </item>
+                            </layout>
+                          </item>
+                          <item>
+                            <widget class="QWidget" name="dpad_down" native="true">
+                              <layout class="QHBoxLayout" name="dpad_down_layout">
+                                <property name="leftMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="topMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="rightMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="bottomMargin">
+                                  <number>0</number>
+                                </property>
+                                <item>
+                                  <widget class="QGroupBox" name="gb_dpad_down">
+                                    <property name="minimumSize">
+                                      <size>
+                                        <width>152</width>
+                                        <height>0</height>
+                                      </size>
+                                    </property>
+                                    <property name="maximumSize">
+                                      <size>
+                                        <width>124</width>
+                                        <height>16777215</height>
+                                      </size>
+                                    </property>
+                                    <property name="title">
+                                      <string>Down</string>
+                                    </property>
+                                    <property name="alignment">
+                                      <set>Qt::AlignmentFlag::AlignCenter</set>
+                                    </property>
+                                    <layout class="QHBoxLayout" name="horizontalLayout_3">
+                                      <item>
+                                        <widget class="QPushButton" name="DpadDownButton">
+                                          <property name="text">
+                                            <string>unmapped</string>
+                                          </property>
+                                        </widget>
+                                      </item>
+                                    </layout>
+                                  </widget>
+                                </item>
+                              </layout>
+                            </widget>
+                          </item>
+                        </layout>
+                      </widget>
+                    </item>
+                    <item>
+                      <widget class="QGroupBox" name="groupBox_5">
+                        <property name="title">
+                          <string>L1 and L2</string>
+                        </property>
+                        <layout class="QHBoxLayout" name="horizontalLayout_13">
+                          <item>
+                            <widget class="QGroupBox" name="gb_l1">
+                              <property name="sizePolicy">
+                                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                </sizepolicy>
+                              </property>
+                              <property name="title">
+                                <string notr="true">L1</string>
+                              </property>
+                              <property name="alignment">
+                                <set>Qt::AlignmentFlag::AlignCenter</set>
+                              </property>
+                              <layout class="QVBoxLayout" name="gb_l1_layout">
+                                <property name="leftMargin">
+                                  <number>5</number>
+                                </property>
+                                <property name="topMargin">
+                                  <number>5</number>
+                                </property>
+                                <property name="rightMargin">
+                                  <number>5</number>
+                                </property>
+                                <property name="bottomMargin">
+                                  <number>5</number>
+                                </property>
+                                <item>
+                                  <widget class="QPushButton" name="L1Button">
+                                    <property name="text">
+                                      <string>unmapped</string>
+                                    </property>
+                                  </widget>
+                                </item>
+                              </layout>
+                            </widget>
+                          </item>
+                          <item>
+                            <widget class="QGroupBox" name="gb_l2">
+                              <property name="title">
+                                <string notr="true">L2</string>
+                              </property>
+                              <property name="alignment">
+                                <set>Qt::AlignmentFlag::AlignCenter</set>
+                              </property>
+                              <layout class="QVBoxLayout" name="gb_l2_layout">
+                                <property name="leftMargin">
+                                  <number>5</number>
+                                </property>
+                                <property name="topMargin">
+                                  <number>5</number>
+                                </property>
+                                <property name="rightMargin">
+                                  <number>5</number>
+                                </property>
+                                <property name="bottomMargin">
+                                  <number>5</number>
+                                </property>
+                                <item>
+                                  <widget class="QPushButton" name="L2Button">
+                                    <property name="text">
+                                      <string>unmapped</string>
+                                    </property>
+                                  </widget>
+                                </item>
+                              </layout>
+                            </widget>
+                          </item>
+                        </layout>
+                      </widget>
+                    </item>
+                    <item>
+                      <spacer name="verticalSpacer">
+                        <property name="orientation">
+                          <enum>Qt::Orientation::Vertical</enum>
+                        </property>
+                        <property name="sizeHint" stdset="0">
+                          <size>
+                            <width>20</width>
+                            <height>40</height>
+                          </size>
+                        </property>
+                      </spacer>
+                    </item>
+                    <item>
+                      <widget class="QGroupBox" name="LeftStickDeadZoneGB">
+                        <property name="sizePolicy">
+                          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                          </sizepolicy>
+                        </property>
+                        <property name="title">
+                          <string>Left Stick Deadzone</string>
+                        </property>
+                        <layout class="QVBoxLayout" name="verticalLayout_15">
+                          <item>
+                            <widget class="QLabel" name="LeftDeadzoneMinLabel">
+                              <property name="text">
+                                <string>Min Deadzone (def:2 max:127)</string>
+                              </property>
+                              <property name="alignment">
+                                <set>Qt::AlignmentFlag::AlignLeft</set>
+                              </property>
+                            </widget>
+                          </item>
+                          <item>
+                            <widget class="QLabel" name="LeftDeadzoneMinValue">
+                              <property name="sizePolicy">
+                                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                </sizepolicy>
+                              </property>
+                              <property name="text">
+                                <string>2</string>
+                              </property>
+                              <property name="alignment">
+                                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                              </property>
+                            </widget>
+                          </item>
+                          <item>
+                            <widget class="QSlider" name="LeftDeadzoneMinSlider">
+                              <property name="sizePolicy">
+                                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                </sizepolicy>
+                              </property>
+                              <property name="minimum">
+                                <number>1</number>
+                              </property>
+                              <property name="maximum">
+                                <number>127</number>
+                              </property>
+                              <property name="value">
+                                <number>2</number>
+                              </property>
+                              <property name="orientation">
+                                <enum>Qt::Orientation::Horizontal</enum>
+                              </property>
+                            </widget>
+                          </item>
+                          <item>
+                            <widget class="QLabel" name="LeftDeadzoneMaxLabel">
+                              <property name="text">
+                                <string>Max Deadzone (def:127 max:127)</string>
+                              </property>
+                              <property name="alignment">
+                                <set>Qt::AlignmentFlag::AlignLeft</set>
+                              </property>
+                            </widget>
+                          </item>
+                          <item>
+                            <widget class="QLabel" name="LeftDeadzoneMaxValue">
+                              <property name="sizePolicy">
+                                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                </sizepolicy>
+                              </property>
+                              <property name="text">
+                                <string>127</string>
+                              </property>
+                              <property name="alignment">
+                                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                              </property>
+                            </widget>
+                          </item>
+                          <item>
+                            <widget class="QSlider" name="LeftDeadzoneMaxSlider">
+                              <property name="sizePolicy">
+                                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                </sizepolicy>
+                              </property>
+                              <property name="minimum">
+                                <number>1</number>
+                              </property>
+                              <property name="maximum">
+                                <number>127</number>
+                              </property>
+                              <property name="value">
+                                <number>127</number>
+                              </property>
+                              <property name="orientation">
+                                <enum>Qt::Orientation::Horizontal</enum>
+                              </property>
+                            </widget>
+                          </item>
+                        </layout>
+                      </widget>
+                    </item>
+                    <item>
+                      <widget class="QGroupBox" name="gb_left_stick">
+                        <property name="sizePolicy">
+                          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                          </sizepolicy>
+                        </property>
+                        <property name="minimumSize">
+                          <size>
+                            <width>0</width>
+                            <height>0</height>
+                          </size>
+                        </property>
+                        <property name="title">
+                          <string>Left Stick</string>
+                        </property>
+                        <layout class="QVBoxLayout" name="gb_left_stick_layout">
+                          <property name="leftMargin">
+                            <number>5</number>
+                          </property>
+                          <property name="topMargin">
+                            <number>5</number>
+                          </property>
+                          <property name="rightMargin">
+                            <number>5</number>
+                          </property>
+                          <property name="bottomMargin">
+                            <number>5</number>
+                          </property>
+                          <item>
+                            <widget class="QWidget" name="left_stick_up" native="true">
+                              <property name="maximumSize">
+                                <size>
+                                  <width>16777215</width>
+                                  <height>2121</height>
+                                </size>
+                              </property>
+                              <layout class="QHBoxLayout" name="left_stick_up_layout">
+                                <property name="leftMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="topMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="rightMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="bottomMargin">
+                                  <number>0</number>
+                                </property>
+                                <item>
+                                  <widget class="QGroupBox" name="gb_left_stick_up">
+                                    <property name="minimumSize">
+                                      <size>
+                                        <width>0</width>
+                                        <height>0</height>
+                                      </size>
+                                    </property>
+                                    <property name="maximumSize">
+                                      <size>
+                                        <width>152</width>
+                                        <height>16777215</height>
+                                      </size>
+                                    </property>
+                                    <property name="title">
+                                      <string>Up</string>
+                                    </property>
+                                    <property name="alignment">
+                                      <set>Qt::AlignmentFlag::AlignCenter</set>
+                                    </property>
+                                    <layout class="QVBoxLayout" name="verticalLayout_10">
+                                      <item>
+                                        <widget class="QPushButton" name="LStickUpButton">
+                                          <property name="text">
+                                            <string>unmapped</string>
+                                          </property>
+                                        </widget>
+                                      </item>
+                                    </layout>
+                                  </widget>
+                                </item>
+                              </layout>
+                            </widget>
+                          </item>
+                          <item>
+                            <layout class="QHBoxLayout" name="layout_left_stick_left_right">
+                              <item>
+                                <widget class="QGroupBox" name="gb_left_stick_left">
+                                  <property name="title">
+                                    <string>Left</string>
+                                  </property>
+                                  <property name="alignment">
+                                    <set>Qt::AlignmentFlag::AlignCenter</set>
+                                  </property>
+                                  <layout class="QVBoxLayout" name="gb_left_stick_left_layout">
+                                    <property name="leftMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="topMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="rightMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="bottomMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <item>
+                                      <widget class="QPushButton" name="LStickLeftButton">
+                                        <property name="text">
+                                          <string>unmapped</string>
+                                        </property>
+                                      </widget>
+                                    </item>
+                                  </layout>
+                                </widget>
+                              </item>
+                              <item>
+                                <widget class="QGroupBox" name="gb_left_stick_right">
+                                  <property name="maximumSize">
+                                    <size>
+                                      <width>179</width>
+                                      <height>16777215</height>
+                                    </size>
+                                  </property>
+                                  <property name="title">
+                                    <string>Right</string>
+                                  </property>
+                                  <property name="alignment">
+                                    <set>Qt::AlignmentFlag::AlignCenter</set>
+                                  </property>
+                                  <layout class="QVBoxLayout" name="gb_left_stick_right_layout">
+                                    <property name="leftMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="topMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="rightMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="bottomMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <item>
+                                      <widget class="QPushButton" name="LStickRightButton">
+                                        <property name="text">
+                                          <string>unmapped</string>
+                                        </property>
+                                      </widget>
+                                    </item>
+                                  </layout>
+                                </widget>
+                              </item>
+                            </layout>
+                          </item>
+                          <item>
+                            <widget class="QWidget" name="left_stick_down" native="true">
+                              <layout class="QHBoxLayout" name="left_stick_down_layout">
+                                <property name="leftMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="topMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="rightMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="bottomMargin">
+                                  <number>0</number>
+                                </property>
+                                <item>
+                                  <widget class="QGroupBox" name="gb_left_stick_down">
+                                    <property name="minimumSize">
+                                      <size>
+                                        <width>152</width>
+                                        <height>0</height>
+                                      </size>
+                                    </property>
+                                    <property name="maximumSize">
+                                      <size>
+                                        <width>124</width>
+                                        <height>21212</height>
+                                      </size>
+                                    </property>
+                                    <property name="title">
+                                      <string>Down</string>
+                                    </property>
+                                    <property name="alignment">
+                                      <set>Qt::AlignmentFlag::AlignCenter</set>
+                                    </property>
+                                    <layout class="QVBoxLayout" name="verticalLayout_8">
+                                      <item>
+                                        <widget class="QPushButton" name="LStickDownButton">
+                                          <property name="text">
+                                            <string>unmapped</string>
+                                          </property>
+                                        </widget>
+                                      </item>
+                                    </layout>
+                                  </widget>
+                                </item>
+                              </layout>
+                            </widget>
+                          </item>
+                        </layout>
+                      </widget>
+                    </item>
                   </layout>
-                 </widget>
                 </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="layout_dpad_left_right">
-               <item>
-                <widget class="QGroupBox" name="gb_dpad_left">
-                 <property name="title">
-                  <string>Left</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                 </property>
-                 <layout class="QVBoxLayout" name="gb_dpad_left_layout">
-                  <property name="leftMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>5</number>
-                  </property>
-                  <item>
-                   <widget class="QPushButton" name="DpadLeftButton">
-                    <property name="text">
-                     <string>unmapped</string>
+                <item>
+                  <layout class="QVBoxLayout" name="verticalLayout_middle" stretch="0,0,0,0">
+                    <property name="spacing">
+                      <number>0</number>
                     </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="gb_dpad_right">
-                 <property name="title">
-                  <string>Right</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                 </property>
-                 <layout class="QVBoxLayout" name="gb_dpad_right_layout">
-                  <property name="leftMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>5</number>
-                  </property>
-                  <item>
-                   <widget class="QPushButton" name="DpadRightButton">
-                    <property name="text">
-                     <string>unmapped</string>
+                    <item>
+                      <widget class="QGroupBox" name="ProfileGroupBox">
+                        <property name="sizePolicy">
+                          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                          </sizepolicy>
+                        </property>
+                        <property name="font">
+                          <font>
+                            <pointsize>12</pointsize>
+                            <bold>true</bold>
+                          </font>
+                        </property>
+                        <property name="title">
+                          <string>Config Selection</string>
+                        </property>
+                        <property name="alignment">
+                          <set>Qt::AlignmentFlag::AlignCenter</set>
+                        </property>
+                        <layout class="QVBoxLayout" name="verticalLayout_16">
+                          <item>
+                            <layout class="QHBoxLayout" name="horizontalLayout_6">
+                              <item>
+                                <widget class="QComboBox" name="ProfileComboBox">
+                                  <property name="font">
+                                    <font>
+                                      <pointsize>9</pointsize>
+                                      <bold>false</bold>
+                                    </font>
+                                  </property>
+                                  <property name="currentText">
+                                    <string/>
+                                  </property>
+                                  <property name="currentIndex">
+                                    <number>-1</number>
+                                  </property>
+                                  <property name="placeholderText">
+                                    <string>Common Config</string>
+                                  </property>
+                                </widget>
+                              </item>
+                              <item>
+                                <widget class="QLabel" name="TitleLabel">
+                                  <property name="font">
+                                    <font>
+                                      <pointsize>10</pointsize>
+                                      <bold>true</bold>
+                                    </font>
+                                  </property>
+                                  <property name="text">
+                                    <string>Common Config</string>
+                                  </property>
+                                  <property name="alignment">
+                                    <set>Qt::AlignmentFlag::AlignCenter</set>
+                                  </property>
+                                  <property name="wordWrap">
+                                    <bool>true</bool>
+                                  </property>
+                                </widget>
+                              </item>
+                            </layout>
+                          </item>
+                          <item>
+                            <widget class="QCheckBox" name="PerGameCheckBox">
+                              <property name="sizePolicy">
+                                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                </sizepolicy>
+                              </property>
+                              <property name="font">
+                                <font>
+                                  <pointsize>9</pointsize>
+                                  <bold>false</bold>
+                                </font>
+                              </property>
+                              <property name="text">
+                                <string>Use per-game configs</string>
+                              </property>
+                            </widget>
+                          </item>
+                          <item>
+                            <widget class="QGroupBox" name="groupBox_2">
+                              <property name="font">
+                                <font>
+                                  <pointsize>9</pointsize>
+                                  <bold>true</bold>
+                                </font>
+                              </property>
+                              <property name="title">
+                                <string>Active Gamepad</string>
+                              </property>
+                              <layout class="QHBoxLayout" name="horizontalLayout_7">
+                                <item>
+                                  <widget class="QComboBox" name="ActiveGamepadBox">
+                                    <property name="font">
+                                      <font>
+                                        <pointsize>9</pointsize>
+                                        <bold>false</bold>
+                                      </font>
+                                    </property>
+                                  </widget>
+                                </item>
+                                <item>
+                                  <widget class="QLabel" name="ActiveGamepadLabel">
+                                    <property name="font">
+                                      <font>
+                                        <pointsize>9</pointsize>
+                                        <bold>false</bold>
+                                      </font>
+                                    </property>
+                                    <property name="text">
+                                      <string>Gamepad ID</string>
+                                    </property>
+                                    <property name="alignment">
+                                      <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                                    </property>
+                                  </widget>
+                                </item>
+                              </layout>
+                            </widget>
+                          </item>
+                          <item>
+                            <widget class="QGroupBox" name="groupBox_4">
+                              <property name="font">
+                                <font>
+                                  <pointsize>9</pointsize>
+                                  <bold>true</bold>
+                                </font>
+                              </property>
+                              <property name="title">
+                                <string>Default Gamepad</string>
+                              </property>
+                              <layout class="QHBoxLayout" name="horizontalLayout_12">
+                                <item>
+                                  <widget class="QLabel" name="DefaultGamepadName">
+                                    <property name="text">
+                                      <string>No default selected</string>
+                                    </property>
+                                  </widget>
+                                </item>
+                                <item>
+                                  <widget class="QLabel" name="DefaultGamepadLabel">
+                                    <property name="font">
+                                      <font>
+                                        <pointsize>9</pointsize>
+                                        <bold>false</bold>
+                                      </font>
+                                    </property>
+                                    <property name="text">
+                                      <string>n/a</string>
+                                    </property>
+                                    <property name="alignment">
+                                      <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                                    </property>
+                                  </widget>
+                                </item>
+                              </layout>
+                            </widget>
+                          </item>
+                          <item>
+                            <layout class="QHBoxLayout" name="horizontalLayout_19">
+                              <item>
+                                <widget class="QPushButton" name="DefaultGamepadButton">
+                                  <property name="font">
+                                    <font>
+                                      <pointsize>9</pointsize>
+                                      <bold>true</bold>
+                                    </font>
+                                  </property>
+                                  <property name="text">
+                                    <string>Set Active Gamepad as Default</string>
+                                  </property>
+                                </widget>
+                              </item>
+                              <item>
+                                <widget class="QPushButton" name="RemoveDefaultGamepadButton">
+                                  <property name="font">
+                                    <font>
+                                      <pointsize>9</pointsize>
+                                      <bold>true</bold>
+                                    </font>
+                                  </property>
+                                  <property name="text">
+                                    <string>Remove Default Gamepad</string>
+                                  </property>
+                                </widget>
+                              </item>
+                            </layout>
+                          </item>
+                        </layout>
+                      </widget>
+                    </item>
+                    <item>
+                      <widget class="QWidget" name="widget_controller" native="true">
+                        <property name="minimumSize">
+                          <size>
+                            <width>0</width>
+                            <height>200</height>
+                          </size>
+                        </property>
+                        <layout class="QHBoxLayout" name="widget_controller_layout">
+                          <property name="leftMargin">
+                            <number>0</number>
+                          </property>
+                          <property name="topMargin">
+                            <number>0</number>
+                          </property>
+                          <property name="rightMargin">
+                            <number>0</number>
+                          </property>
+                          <property name="bottomMargin">
+                            <number>0</number>
+                          </property>
+                          <item>
+                            <widget class="QLabel" name="l_controller">
+                              <property name="maximumSize">
+                                <size>
+                                  <width>415</width>
+                                  <height>256</height>
+                                </size>
+                              </property>
+                              <property name="pixmap">
+                                <pixmap resource="../shadps4.qrc">:/images/ps4_controller.png</pixmap>
+                              </property>
+                              <property name="scaledContents">
+                                <bool>true</bool>
+                              </property>
+                              <property name="alignment">
+                                <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignHCenter</set>
+                              </property>
+                            </widget>
+                          </item>
+                        </layout>
+                      </widget>
+                    </item>
+                    <item>
+                      <layout class="QVBoxLayout" name="verticalLayout_9">
+                        <property name="spacing">
+                          <number>10</number>
+                        </property>
+                        <property name="sizeConstraint">
+                          <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+                        </property>
+                        <item>
+                          <layout class="QHBoxLayout" name="horizontalLayout">
+                            <item>
+                              <widget class="QGroupBox" name="gb_l3">
+                                <property name="sizePolicy">
+                                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                                    <horstretch>0</horstretch>
+                                    <verstretch>0</verstretch>
+                                  </sizepolicy>
+                                </property>
+                                <property name="title">
+                                  <string notr="true">L3</string>
+                                </property>
+                                <property name="alignment">
+                                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                                </property>
+                                <layout class="QVBoxLayout" name="gb_l3_layout">
+                                  <property name="leftMargin">
+                                    <number>5</number>
+                                  </property>
+                                  <property name="topMargin">
+                                    <number>5</number>
+                                  </property>
+                                  <property name="rightMargin">
+                                    <number>5</number>
+                                  </property>
+                                  <property name="bottomMargin">
+                                    <number>5</number>
+                                  </property>
+                                  <item>
+                                    <widget class="QPushButton" name="L3Button">
+                                      <property name="text">
+                                        <string>unmapped</string>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                </layout>
+                              </widget>
+                            </item>
+                            <item>
+                              <widget class="QGroupBox" name="gb_start">
+                                <property name="title">
+                                  <string>Options</string>
+                                </property>
+                                <property name="alignment">
+                                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                                </property>
+                                <layout class="QVBoxLayout" name="gb_start_layout">
+                                  <property name="leftMargin">
+                                    <number>5</number>
+                                  </property>
+                                  <property name="topMargin">
+                                    <number>5</number>
+                                  </property>
+                                  <property name="rightMargin">
+                                    <number>5</number>
+                                  </property>
+                                  <property name="bottomMargin">
+                                    <number>5</number>
+                                  </property>
+                                  <item>
+                                    <widget class="QPushButton" name="OptionsButton">
+                                      <property name="text">
+                                        <string>unmapped</string>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                </layout>
+                              </widget>
+                            </item>
+                            <item>
+                              <widget class="QGroupBox" name="gb_r3">
+                                <property name="sizePolicy">
+                                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                                    <horstretch>0</horstretch>
+                                    <verstretch>0</verstretch>
+                                  </sizepolicy>
+                                </property>
+                                <property name="title">
+                                  <string notr="true">R3</string>
+                                </property>
+                                <property name="alignment">
+                                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                                </property>
+                                <layout class="QVBoxLayout" name="gb_r3_layout">
+                                  <property name="leftMargin">
+                                    <number>5</number>
+                                  </property>
+                                  <property name="topMargin">
+                                    <number>5</number>
+                                  </property>
+                                  <property name="rightMargin">
+                                    <number>5</number>
+                                  </property>
+                                  <property name="bottomMargin">
+                                    <number>5</number>
+                                  </property>
+                                  <item>
+                                    <widget class="QPushButton" name="R3Button">
+                                      <property name="text">
+                                        <string>unmapped</string>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                </layout>
+                              </widget>
+                            </item>
+                          </layout>
+                        </item>
+                        <item>
+                          <layout class="QHBoxLayout" name="horizontalLayout_2">
+                            <item>
+                              <widget class="QGroupBox" name="gb_touchleft">
+                                <property name="title">
+                                  <string>Touchpad Left</string>
+                                </property>
+                                <property name="alignment">
+                                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                                </property>
+                                <layout class="QHBoxLayout" name="horizontalLayout_5">
+                                  <item>
+                                    <widget class="QPushButton" name="TouchpadLeftButton">
+                                      <property name="text">
+                                        <string>unmapped</string>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                </layout>
+                              </widget>
+                            </item>
+                            <item>
+                              <widget class="QGroupBox" name="gb_touchcenter">
+                                <property name="title">
+                                  <string>Touchpad Center</string>
+                                </property>
+                                <property name="alignment">
+                                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                                </property>
+                                <layout class="QVBoxLayout" name="verticalLayout_11">
+                                  <item>
+                                    <widget class="QPushButton" name="TouchpadCenterButton">
+                                      <property name="text">
+                                        <string>unmapped</string>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                </layout>
+                              </widget>
+                            </item>
+                            <item>
+                              <widget class="QGroupBox" name="gb_touchright">
+                                <property name="title">
+                                  <string>Touchpad Right</string>
+                                </property>
+                                <property name="alignment">
+                                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                                </property>
+                                <layout class="QVBoxLayout" name="verticalLayout_12">
+                                  <item>
+                                    <widget class="QPushButton" name="TouchpadRightButton">
+                                      <property name="text">
+                                        <string>unmapped</string>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                </layout>
+                              </widget>
+                            </item>
+                          </layout>
+                        </item>
+                      </layout>
+                    </item>
+                    <item>
+                      <layout class="QHBoxLayout" name="horizontalLayout_8">
+                        <item>
+                          <layout class="QVBoxLayout" name="verticalLayout_14">
+                            <item>
+                              <widget class="QGroupBox" name="groupBox">
+                                <property name="font">
+                                  <font>
+                                    <bold>false</bold>
+                                  </font>
+                                </property>
+                                <property name="title">
+                                  <string>Color Adjustment</string>
+                                </property>
+                                <layout class="QVBoxLayout" name="verticalLayout_18">
+                                  <property name="leftMargin">
+                                    <number>6</number>
+                                  </property>
+                                  <property name="rightMargin">
+                                    <number>6</number>
+                                  </property>
+                                  <item>
+                                    <layout class="QHBoxLayout" name="horizontalLayout_9">
+                                      <property name="spacing">
+                                        <number>6</number>
+                                      </property>
+                                      <item>
+                                        <widget class="QLabel" name="RLabel_text">
+                                          <property name="font">
+                                            <font>
+                                              <bold>false</bold>
+                                            </font>
+                                          </property>
+                                          <property name="text">
+                                            <string>RED</string>
+                                          </property>
+                                        </widget>
+                                      </item>
+                                      <item>
+                                        <widget class="QSlider" name="RSlider">
+                                          <property name="sizePolicy">
+                                            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                                              <horstretch>0</horstretch>
+                                              <verstretch>0</verstretch>
+                                            </sizepolicy>
+                                          </property>
+                                          <property name="maximum">
+                                            <number>255</number>
+                                          </property>
+                                          <property name="orientation">
+                                            <enum>Qt::Orientation::Horizontal</enum>
+                                          </property>
+                                        </widget>
+                                      </item>
+                                      <item>
+                                        <widget class="QLabel" name="RLabel">
+                                          <property name="maximumSize">
+                                            <size>
+                                              <width>20</width>
+                                              <height>16777215</height>
+                                            </size>
+                                          </property>
+                                          <property name="text">
+                                            <string notr="true">000</string>
+                                          </property>
+                                        </widget>
+                                      </item>
+                                    </layout>
+                                  </item>
+                                  <item>
+                                    <layout class="QHBoxLayout" name="horizontalLayout_10">
+                                      <item>
+                                        <widget class="QLabel" name="GLabel_text">
+                                          <property name="font">
+                                            <font>
+                                              <bold>false</bold>
+                                            </font>
+                                          </property>
+                                          <property name="text">
+                                            <string>GREEN</string>
+                                          </property>
+                                        </widget>
+                                      </item>
+                                      <item>
+                                        <widget class="QSlider" name="GSlider">
+                                          <property name="sizePolicy">
+                                            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                                              <horstretch>0</horstretch>
+                                              <verstretch>0</verstretch>
+                                            </sizepolicy>
+                                          </property>
+                                          <property name="maximum">
+                                            <number>255</number>
+                                          </property>
+                                          <property name="orientation">
+                                            <enum>Qt::Orientation::Horizontal</enum>
+                                          </property>
+                                        </widget>
+                                      </item>
+                                      <item>
+                                        <widget class="QLabel" name="GLabel">
+                                          <property name="maximumSize">
+                                            <size>
+                                              <width>20</width>
+                                              <height>16777215</height>
+                                            </size>
+                                          </property>
+                                          <property name="text">
+                                            <string notr="true">000</string>
+                                          </property>
+                                        </widget>
+                                      </item>
+                                    </layout>
+                                  </item>
+                                  <item>
+                                    <layout class="QHBoxLayout" name="horizontalLayout_11">
+                                      <item>
+                                        <widget class="QLabel" name="BLabel_text">
+                                          <property name="font">
+                                            <font>
+                                              <bold>false</bold>
+                                            </font>
+                                          </property>
+                                          <property name="text">
+                                            <string>BLUE</string>
+                                          </property>
+                                        </widget>
+                                      </item>
+                                      <item>
+                                        <widget class="QSlider" name="BSlider">
+                                          <property name="sizePolicy">
+                                            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                                              <horstretch>0</horstretch>
+                                              <verstretch>0</verstretch>
+                                            </sizepolicy>
+                                          </property>
+                                          <property name="maximum">
+                                            <number>255</number>
+                                          </property>
+                                          <property name="value">
+                                            <number>255</number>
+                                          </property>
+                                          <property name="orientation">
+                                            <enum>Qt::Orientation::Horizontal</enum>
+                                          </property>
+                                        </widget>
+                                      </item>
+                                      <item>
+                                        <widget class="QLabel" name="BLabel">
+                                          <property name="maximumSize">
+                                            <size>
+                                              <width>20</width>
+                                              <height>16777215</height>
+                                            </size>
+                                          </property>
+                                          <property name="text">
+                                            <string notr="true">255</string>
+                                          </property>
+                                        </widget>
+                                      </item>
+                                    </layout>
+                                  </item>
+                                </layout>
+                              </widget>
+                            </item>
+                          </layout>
+                        </item>
+                        <item>
+                          <layout class="QVBoxLayout" name="verticalLayout_17">
+                            <item>
+                              <widget class="QGroupBox" name="groupBox_3">
+                                <property name="font">
+                                  <font>
+                                    <bold>false</bold>
+                                  </font>
+                                </property>
+                                <property name="title">
+                                  <string>Override Lightbar Color</string>
+                                </property>
+                                <layout class="QVBoxLayout" name="verticalLayout_19">
+                                  <item>
+                                    <widget class="QCheckBox" name="LightbarCheckBox">
+                                      <property name="font">
+                                        <font>
+                                          <bold>false</bold>
+                                        </font>
+                                      </property>
+                                      <property name="text">
+                                        <string>Override Color</string>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                  <item>
+                                    <widget class="QFrame" name="LightbarColorFrame">
+                                      <property name="frameShape">
+                                        <enum>QFrame::Shape::StyledPanel</enum>
+                                      </property>
+                                      <property name="frameShadow">
+                                        <enum>QFrame::Shadow::Raised</enum>
+                                      </property>
+                                    </widget>
+                                  </item>
+                                </layout>
+                              </widget>
+                            </item>
+                          </layout>
+                        </item>
+                      </layout>
+                    </item>
+                  </layout>
+                </item>
+                <item>
+                  <layout class="QVBoxLayout" name="verticalLayout_right">
+                    <property name="spacing">
+                      <number>5</number>
                     </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
+                    <item>
+                      <widget class="QGroupBox" name="gb_face_buttons">
+                        <property name="sizePolicy">
+                          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                          </sizepolicy>
+                        </property>
+                        <property name="title">
+                          <string>Face Buttons</string>
+                        </property>
+                        <layout class="QVBoxLayout" name="gb_face_buttons_layout">
+                          <property name="leftMargin">
+                            <number>5</number>
+                          </property>
+                          <property name="topMargin">
+                            <number>5</number>
+                          </property>
+                          <property name="rightMargin">
+                            <number>5</number>
+                          </property>
+                          <property name="bottomMargin">
+                            <number>5</number>
+                          </property>
+                          <item>
+                            <widget class="QWidget" name="widget_triangle" native="true">
+                              <layout class="QHBoxLayout" name="widget_triangle_layout">
+                                <property name="leftMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="topMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="rightMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="bottomMargin">
+                                  <number>0</number>
+                                </property>
+                                <item>
+                                  <widget class="QGroupBox" name="gb_triangle">
+                                    <property name="sizePolicy">
+                                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                      </sizepolicy>
+                                    </property>
+                                    <property name="minimumSize">
+                                      <size>
+                                        <width>152</width>
+                                        <height>0</height>
+                                      </size>
+                                    </property>
+                                    <property name="maximumSize">
+                                      <size>
+                                        <width>0</width>
+                                        <height>16777215</height>
+                                      </size>
+                                    </property>
+                                    <property name="title">
+                                      <string>Triangle</string>
+                                    </property>
+                                    <property name="alignment">
+                                      <set>Qt::AlignmentFlag::AlignCenter</set>
+                                    </property>
+                                    <layout class="QVBoxLayout" name="verticalLayout_3">
+                                      <item>
+                                        <widget class="QPushButton" name="TriangleButton">
+                                          <property name="text">
+                                            <string>unmapped</string>
+                                          </property>
+                                        </widget>
+                                      </item>
+                                    </layout>
+                                  </widget>
+                                </item>
+                              </layout>
+                            </widget>
+                          </item>
+                          <item>
+                            <layout class="QHBoxLayout" name="layout_square_circle">
+                              <item>
+                                <widget class="QGroupBox" name="gb_square">
+                                  <property name="title">
+                                    <string>Square</string>
+                                  </property>
+                                  <property name="alignment">
+                                    <set>Qt::AlignmentFlag::AlignCenter</set>
+                                  </property>
+                                  <layout class="QVBoxLayout" name="gb_square_layout">
+                                    <property name="leftMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="topMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="rightMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="bottomMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <item>
+                                      <widget class="QPushButton" name="SquareButton">
+                                        <property name="text">
+                                          <string>unmapped</string>
+                                        </property>
+                                      </widget>
+                                    </item>
+                                  </layout>
+                                </widget>
+                              </item>
+                              <item>
+                                <widget class="QGroupBox" name="gb_circle">
+                                  <property name="title">
+                                    <string>Circle</string>
+                                  </property>
+                                  <property name="alignment">
+                                    <set>Qt::AlignmentFlag::AlignCenter</set>
+                                  </property>
+                                  <layout class="QVBoxLayout" name="gb_circle_layout">
+                                    <property name="leftMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="topMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="rightMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="bottomMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <item>
+                                      <widget class="QPushButton" name="CircleButton">
+                                        <property name="text">
+                                          <string>unmapped</string>
+                                        </property>
+                                      </widget>
+                                    </item>
+                                  </layout>
+                                </widget>
+                              </item>
+                            </layout>
+                          </item>
+                          <item>
+                            <widget class="QWidget" name="widget_cross" native="true">
+                              <layout class="QHBoxLayout" name="widget_cross_layout">
+                                <property name="leftMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="topMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="rightMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="bottomMargin">
+                                  <number>0</number>
+                                </property>
+                                <item>
+                                  <widget class="QGroupBox" name="gb_cross">
+                                    <property name="minimumSize">
+                                      <size>
+                                        <width>152</width>
+                                        <height>0</height>
+                                      </size>
+                                    </property>
+                                    <property name="maximumSize">
+                                      <size>
+                                        <width>124</width>
+                                        <height>16777215</height>
+                                      </size>
+                                    </property>
+                                    <property name="title">
+                                      <string>Cross</string>
+                                    </property>
+                                    <property name="alignment">
+                                      <set>Qt::AlignmentFlag::AlignCenter</set>
+                                    </property>
+                                    <layout class="QVBoxLayout" name="verticalLayout_5">
+                                      <item>
+                                        <widget class="QPushButton" name="CrossButton">
+                                          <property name="text">
+                                            <string>unmapped</string>
+                                          </property>
+                                        </widget>
+                                      </item>
+                                    </layout>
+                                  </widget>
+                                </item>
+                              </layout>
+                            </widget>
+                          </item>
+                        </layout>
+                      </widget>
+                    </item>
+                    <item>
+                      <widget class="QGroupBox" name="groupBox_6">
+                        <property name="title">
+                          <string>R1 and R2</string>
+                        </property>
+                        <layout class="QHBoxLayout" name="horizontalLayout_14">
+                          <item>
+                            <widget class="QGroupBox" name="gb_r1">
+                              <property name="sizePolicy">
+                                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                </sizepolicy>
+                              </property>
+                              <property name="title">
+                                <string notr="true">R1</string>
+                              </property>
+                              <property name="alignment">
+                                <set>Qt::AlignmentFlag::AlignCenter</set>
+                              </property>
+                              <layout class="QVBoxLayout" name="gb_r1_layout">
+                                <property name="leftMargin">
+                                  <number>5</number>
+                                </property>
+                                <property name="topMargin">
+                                  <number>5</number>
+                                </property>
+                                <property name="rightMargin">
+                                  <number>5</number>
+                                </property>
+                                <property name="bottomMargin">
+                                  <number>5</number>
+                                </property>
+                                <item>
+                                  <widget class="QPushButton" name="R1Button">
+                                    <property name="text">
+                                      <string>unmapped</string>
+                                    </property>
+                                  </widget>
+                                </item>
+                              </layout>
+                            </widget>
+                          </item>
+                          <item>
+                            <widget class="QGroupBox" name="gb_r2">
+                              <property name="title">
+                                <string notr="true">R2</string>
+                              </property>
+                              <property name="alignment">
+                                <set>Qt::AlignmentFlag::AlignCenter</set>
+                              </property>
+                              <layout class="QVBoxLayout" name="gb_r2_layout">
+                                <property name="leftMargin">
+                                  <number>5</number>
+                                </property>
+                                <property name="topMargin">
+                                  <number>5</number>
+                                </property>
+                                <property name="rightMargin">
+                                  <number>5</number>
+                                </property>
+                                <property name="bottomMargin">
+                                  <number>5</number>
+                                </property>
+                                <item>
+                                  <widget class="QPushButton" name="R2Button">
+                                    <property name="text">
+                                      <string>unmapped</string>
+                                    </property>
+                                  </widget>
+                                </item>
+                              </layout>
+                            </widget>
+                          </item>
+                        </layout>
+                      </widget>
+                    </item>
+                    <item>
+                      <spacer name="verticalSpacer_2">
+                        <property name="orientation">
+                          <enum>Qt::Orientation::Vertical</enum>
+                        </property>
+                        <property name="sizeType">
+                          <enum>QSizePolicy::Policy::Expanding</enum>
+                        </property>
+                        <property name="sizeHint" stdset="0">
+                          <size>
+                            <width>20</width>
+                            <height>40</height>
+                          </size>
+                        </property>
+                      </spacer>
+                    </item>
+                    <item>
+                      <widget class="QGroupBox" name="RightStickDeadZoneGB">
+                        <property name="sizePolicy">
+                          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                          </sizepolicy>
+                        </property>
+                        <property name="title">
+                          <string>Right Stick Deadzone</string>
+                        </property>
+                        <layout class="QVBoxLayout" name="verticalLayout_13">
+                          <item>
+                            <widget class="QLabel" name="RightDeadzoneMinLabel">
+                              <property name="text">
+                                <string>Min Deadzone (def:2 max:127)</string>
+                              </property>
+                              <property name="alignment">
+                                <set>Qt::AlignmentFlag::AlignLeft</set>
+                              </property>
+                            </widget>
+                          </item>
+                          <item>
+                            <widget class="QLabel" name="RightDeadzoneMinValue">
+                              <property name="sizePolicy">
+                                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                </sizepolicy>
+                              </property>
+                              <property name="text">
+                                <string>2</string>
+                              </property>
+                              <property name="alignment">
+                                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                              </property>
+                            </widget>
+                          </item>
+                          <item>
+                            <widget class="QSlider" name="RightDeadzoneMinSlider">
+                              <property name="sizePolicy">
+                                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                </sizepolicy>
+                              </property>
+                              <property name="minimum">
+                                <number>1</number>
+                              </property>
+                              <property name="maximum">
+                                <number>127</number>
+                              </property>
+                              <property name="value">
+                                <number>2</number>
+                              </property>
+                              <property name="orientation">
+                                <enum>Qt::Orientation::Horizontal</enum>
+                              </property>
+                            </widget>
+                          </item>
+                          <item>
+                            <widget class="QLabel" name="RightDeadzoneMaxLabel">
+                              <property name="text">
+                                <string>Max Deadzone (def:127 max:127)</string>
+                              </property>
+                              <property name="alignment">
+                                <set>Qt::AlignmentFlag::AlignLeft</set>
+                              </property>
+                            </widget>
+                          </item>
+                          <item>
+                            <widget class="QLabel" name="RightDeadzoneMaxValue">
+                              <property name="sizePolicy">
+                                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                </sizepolicy>
+                              </property>
+                              <property name="text">
+                                <string>127</string>
+                              </property>
+                              <property name="alignment">
+                                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                              </property>
+                            </widget>
+                          </item>
+                          <item>
+                            <widget class="QSlider" name="RightDeadzoneMaxSlider">
+                              <property name="sizePolicy">
+                                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                </sizepolicy>
+                              </property>
+                              <property name="minimum">
+                                <number>1</number>
+                              </property>
+                              <property name="maximum">
+                                <number>127</number>
+                              </property>
+                              <property name="value">
+                                <number>127</number>
+                              </property>
+                              <property name="orientation">
+                                <enum>Qt::Orientation::Horizontal</enum>
+                              </property>
+                            </widget>
+                          </item>
+                        </layout>
+                      </widget>
+                    </item>
+                    <item>
+                      <widget class="QGroupBox" name="gb_right_stick">
+                        <property name="sizePolicy">
+                          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                          </sizepolicy>
+                        </property>
+                        <property name="minimumSize">
+                          <size>
+                            <width>0</width>
+                            <height>0</height>
+                          </size>
+                        </property>
+                        <property name="title">
+                          <string>Right Stick</string>
+                        </property>
+                        <layout class="QVBoxLayout" name="verticalLayout_2">
+                          <property name="leftMargin">
+                            <number>5</number>
+                          </property>
+                          <property name="topMargin">
+                            <number>5</number>
+                          </property>
+                          <property name="rightMargin">
+                            <number>5</number>
+                          </property>
+                          <property name="bottomMargin">
+                            <number>5</number>
+                          </property>
+                          <item>
+                            <widget class="QWidget" name="widget_right_stick_up" native="true">
+                              <layout class="QHBoxLayout" name="widget_right_stick_up_layout">
+                                <property name="leftMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="topMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="rightMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="bottomMargin">
+                                  <number>0</number>
+                                </property>
+                                <item>
+                                  <widget class="QGroupBox" name="gb_right_stick_up">
+                                    <property name="sizePolicy">
+                                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                      </sizepolicy>
+                                    </property>
+                                    <property name="minimumSize">
+                                      <size>
+                                        <width>0</width>
+                                        <height>0</height>
+                                      </size>
+                                    </property>
+                                    <property name="maximumSize">
+                                      <size>
+                                        <width>152</width>
+                                        <height>1231321</height>
+                                      </size>
+                                    </property>
+                                    <property name="title">
+                                      <string>Up</string>
+                                    </property>
+                                    <property name="alignment">
+                                      <set>Qt::AlignmentFlag::AlignCenter</set>
+                                    </property>
+                                    <layout class="QVBoxLayout" name="verticalLayout_7">
+                                      <item>
+                                        <widget class="QPushButton" name="RStickUpButton">
+                                          <property name="text">
+                                            <string>unmapped</string>
+                                          </property>
+                                        </widget>
+                                      </item>
+                                    </layout>
+                                  </widget>
+                                </item>
+                              </layout>
+                            </widget>
+                          </item>
+                          <item>
+                            <layout class="QHBoxLayout" name="layout_right_stick_left_right">
+                              <item>
+                                <widget class="QGroupBox" name="gb_right_stick_left">
+                                  <property name="title">
+                                    <string>Left</string>
+                                  </property>
+                                  <property name="alignment">
+                                    <set>Qt::AlignmentFlag::AlignCenter</set>
+                                  </property>
+                                  <layout class="QVBoxLayout" name="gb_right_stick_left_layout">
+                                    <property name="leftMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="topMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="rightMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="bottomMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <item>
+                                      <widget class="QPushButton" name="RStickLeftButton">
+                                        <property name="text">
+                                          <string>unmapped</string>
+                                        </property>
+                                      </widget>
+                                    </item>
+                                  </layout>
+                                </widget>
+                              </item>
+                              <item>
+                                <widget class="QGroupBox" name="gb_right_stick_right">
+                                  <property name="title">
+                                    <string>Right</string>
+                                  </property>
+                                  <property name="alignment">
+                                    <set>Qt::AlignmentFlag::AlignCenter</set>
+                                  </property>
+                                  <layout class="QVBoxLayout" name="gb_right_stick_right_layout">
+                                    <property name="leftMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="topMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="rightMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <property name="bottomMargin">
+                                      <number>5</number>
+                                    </property>
+                                    <item>
+                                      <widget class="QPushButton" name="RStickRightButton">
+                                        <property name="text">
+                                          <string>unmapped</string>
+                                        </property>
+                                      </widget>
+                                    </item>
+                                  </layout>
+                                </widget>
+                              </item>
+                            </layout>
+                          </item>
+                          <item>
+                            <widget class="QWidget" name="widget_right_stick_down" native="true">
+                              <layout class="QHBoxLayout" name="widget_right_stick_down_layout">
+                                <property name="leftMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="topMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="rightMargin">
+                                  <number>0</number>
+                                </property>
+                                <property name="bottomMargin">
+                                  <number>0</number>
+                                </property>
+                                <item>
+                                  <widget class="QGroupBox" name="gb_right_stick_down">
+                                    <property name="minimumSize">
+                                      <size>
+                                        <width>152</width>
+                                        <height>0</height>
+                                      </size>
+                                    </property>
+                                    <property name="maximumSize">
+                                      <size>
+                                        <width>124</width>
+                                        <height>2121</height>
+                                      </size>
+                                    </property>
+                                    <property name="title">
+                                      <string>Down</string>
+                                    </property>
+                                    <property name="alignment">
+                                      <set>Qt::AlignmentFlag::AlignCenter</set>
+                                    </property>
+                                    <layout class="QVBoxLayout" name="verticalLayout_6">
+                                      <item>
+                                        <widget class="QPushButton" name="RStickDownButton">
+                                          <property name="text">
+                                            <string>unmapped</string>
+                                          </property>
+                                        </widget>
+                                      </item>
+                                    </layout>
+                                  </widget>
+                                </item>
+                              </layout>
+                            </widget>
+                          </item>
+                        </layout>
+                      </widget>
+                    </item>
+                  </layout>
+                </item>
               </layout>
-             </item>
-             <item>
-              <widget class="QWidget" name="dpad_down" native="true">
-               <layout class="QHBoxLayout" name="dpad_down_layout">
-                <property name="leftMargin">
-                 <number>0</number>
-                </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QGroupBox" name="gb_dpad_down">
-                  <property name="minimumSize">
-                   <size>
-                    <width>152</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="maximumSize">
-                   <size>
-                    <width>124</width>
-                    <height>16777215</height>
-                   </size>
-                  </property>
-                  <property name="title">
-                   <string>Down</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignCenter</set>
-                  </property>
-                  <layout class="QHBoxLayout" name="horizontalLayout_3">
-                   <item>
-                    <widget class="QPushButton" name="DpadDownButton">
-                     <property name="text">
-                      <string>unmapped</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="groupBox_5">
-            <property name="title">
-             <string>L1 and L2</string>
-            </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_13">
-             <item>
-              <widget class="QGroupBox" name="gb_l1">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="title">
-                <string notr="true">L1</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignCenter</set>
-               </property>
-               <layout class="QVBoxLayout" name="gb_l1_layout">
-                <property name="leftMargin">
-                 <number>5</number>
-                </property>
-                <property name="topMargin">
-                 <number>5</number>
-                </property>
-                <property name="rightMargin">
-                 <number>5</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>5</number>
-                </property>
-                <item>
-                 <widget class="QPushButton" name="L1Button">
-                  <property name="text">
-                   <string>unmapped</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QGroupBox" name="gb_l2">
-               <property name="title">
-                <string notr="true">L2</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignCenter</set>
-               </property>
-               <layout class="QVBoxLayout" name="gb_l2_layout">
-                <property name="leftMargin">
-                 <number>5</number>
-                </property>
-                <property name="topMargin">
-                 <number>5</number>
-                </property>
-                <property name="rightMargin">
-                 <number>5</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>5</number>
-                </property>
-                <item>
-                 <widget class="QPushButton" name="L2Button">
-                  <property name="text">
-                   <string>unmapped</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer">
-            <property name="orientation">
-             <enum>Qt::Orientation::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="LeftStickDeadZoneGB">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="title">
-             <string>Left Stick Deadzone (def:2 max:127)</string>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_15">
-             <item>
-              <widget class="QLabel" name="LeftDeadzoneValue">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Left Deadzone</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QSlider" name="LeftDeadzoneSlider">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimum">
-                <number>1</number>
-               </property>
-               <property name="maximum">
-                <number>127</number>
-               </property>
-               <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="gb_left_stick">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="title">
-             <string>Left Stick</string>
-            </property>
-            <layout class="QVBoxLayout" name="gb_left_stick_layout">
-             <property name="leftMargin">
-              <number>5</number>
-             </property>
-             <property name="topMargin">
-              <number>5</number>
-             </property>
-             <property name="rightMargin">
-              <number>5</number>
-             </property>
-             <property name="bottomMargin">
-              <number>5</number>
-             </property>
-             <item>
-              <widget class="QWidget" name="left_stick_up" native="true">
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>2121</height>
-                </size>
-               </property>
-               <layout class="QHBoxLayout" name="left_stick_up_layout">
-                <property name="leftMargin">
-                 <number>0</number>
-                </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QGroupBox" name="gb_left_stick_up">
-                  <property name="minimumSize">
-                   <size>
-                    <width>0</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="maximumSize">
-                   <size>
-                    <width>152</width>
-                    <height>16777215</height>
-                   </size>
-                  </property>
-                  <property name="title">
-                   <string>Up</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignCenter</set>
-                  </property>
-                  <layout class="QVBoxLayout" name="verticalLayout_10">
-                   <item>
-                    <widget class="QPushButton" name="LStickUpButton">
-                     <property name="text">
-                      <string>unmapped</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="layout_left_stick_left_right">
-               <item>
-                <widget class="QGroupBox" name="gb_left_stick_left">
-                 <property name="title">
-                  <string>Left</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                 </property>
-                 <layout class="QVBoxLayout" name="gb_left_stick_left_layout">
-                  <property name="leftMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>5</number>
-                  </property>
-                  <item>
-                   <widget class="QPushButton" name="LStickLeftButton">
-                    <property name="text">
-                     <string>unmapped</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="gb_left_stick_right">
-                 <property name="maximumSize">
-                  <size>
-                   <width>179</width>
-                   <height>16777215</height>
-                  </size>
-                 </property>
-                 <property name="title">
-                  <string>Right</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                 </property>
-                 <layout class="QVBoxLayout" name="gb_left_stick_right_layout">
-                  <property name="leftMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>5</number>
-                  </property>
-                  <item>
-                   <widget class="QPushButton" name="LStickRightButton">
-                    <property name="text">
-                     <string>unmapped</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <widget class="QWidget" name="left_stick_down" native="true">
-               <layout class="QHBoxLayout" name="left_stick_down_layout">
-                <property name="leftMargin">
-                 <number>0</number>
-                </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QGroupBox" name="gb_left_stick_down">
-                  <property name="minimumSize">
-                   <size>
-                    <width>152</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="maximumSize">
-                   <size>
-                    <width>124</width>
-                    <height>21212</height>
-                   </size>
-                  </property>
-                  <property name="title">
-                   <string>Down</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignCenter</set>
-                  </property>
-                  <layout class="QVBoxLayout" name="verticalLayout_8">
-                   <item>
-                    <widget class="QPushButton" name="LStickDownButton">
-                     <property name="text">
-                      <string>unmapped</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QVBoxLayout" name="verticalLayout_middle" stretch="0,0,0,0">
-          <property name="spacing">
-           <number>0</number>
+            </widget>
+          </widget>
+        </widget>
+      </item>
+      <item>
+        <widget class="QDialogButtonBox" name="buttonBox">
+          <property name="standardButtons">
+            <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::RestoreDefaults|QDialogButtonBox::StandardButton::Save</set>
           </property>
-          <item>
-           <widget class="QGroupBox" name="ProfileGroupBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>12</pointsize>
-              <bold>true</bold>
-             </font>
-            </property>
-            <property name="title">
-             <string>Config Selection</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignmentFlag::AlignCenter</set>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_16">
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_6">
-               <item>
-                <widget class="QComboBox" name="ProfileComboBox">
-                 <property name="font">
-                  <font>
-                   <pointsize>9</pointsize>
-                   <bold>false</bold>
-                  </font>
-                 </property>
-                 <property name="currentText">
-                  <string/>
-                 </property>
-                 <property name="currentIndex">
-                  <number>-1</number>
-                 </property>
-                 <property name="placeholderText">
-                  <string>Common Config</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="TitleLabel">
-                 <property name="font">
-                  <font>
-                   <pointsize>10</pointsize>
-                   <bold>true</bold>
-                  </font>
-                 </property>
-                 <property name="text">
-                  <string>Common Config</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                 </property>
-                 <property name="wordWrap">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="PerGameCheckBox">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="font">
-                <font>
-                 <pointsize>9</pointsize>
-                 <bold>false</bold>
-                </font>
-               </property>
-               <property name="text">
-                <string>Use per-game configs</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QGroupBox" name="groupBox_2">
-               <property name="font">
-                <font>
-                 <pointsize>9</pointsize>
-                 <bold>true</bold>
-                </font>
-               </property>
-               <property name="title">
-                <string>Active Gamepad</string>
-               </property>
-               <layout class="QHBoxLayout" name="horizontalLayout_7">
-                <item>
-                 <widget class="QComboBox" name="ActiveGamepadBox">
-                  <property name="font">
-                   <font>
-                    <pointsize>9</pointsize>
-                    <bold>false</bold>
-                   </font>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="ActiveGamepadLabel">
-                  <property name="font">
-                   <font>
-                    <pointsize>9</pointsize>
-                    <bold>false</bold>
-                   </font>
-                  </property>
-                  <property name="text">
-                   <string>Gamepad ID</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QGroupBox" name="groupBox_4">
-               <property name="font">
-                <font>
-                 <pointsize>9</pointsize>
-                 <bold>true</bold>
-                </font>
-               </property>
-               <property name="title">
-                <string>Default Gamepad</string>
-               </property>
-               <layout class="QHBoxLayout" name="horizontalLayout_12">
-                <item>
-                 <widget class="QLabel" name="DefaultGamepadName">
-                  <property name="text">
-                   <string>No default selected</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="DefaultGamepadLabel">
-                  <property name="font">
-                   <font>
-                    <pointsize>9</pointsize>
-                    <bold>false</bold>
-                   </font>
-                  </property>
-                  <property name="text">
-                   <string>n/a</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_19">
-               <item>
-                <widget class="QPushButton" name="DefaultGamepadButton">
-                 <property name="font">
-                  <font>
-                   <pointsize>9</pointsize>
-                   <bold>true</bold>
-                  </font>
-                 </property>
-                 <property name="text">
-                  <string>Set Active Gamepad as Default</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QPushButton" name="RemoveDefaultGamepadButton">
-                 <property name="font">
-                  <font>
-                   <pointsize>9</pointsize>
-                   <bold>true</bold>
-                  </font>
-                 </property>
-                 <property name="text">
-                  <string>Remove Default Gamepad</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QWidget" name="widget_controller" native="true">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>200</height>
-             </size>
-            </property>
-            <layout class="QHBoxLayout" name="widget_controller_layout">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QLabel" name="l_controller">
-               <property name="maximumSize">
-                <size>
-                 <width>415</width>
-                 <height>256</height>
-                </size>
-               </property>
-               <property name="pixmap">
-                <pixmap resource="../shadps4.qrc">:/images/ps4_controller.png</pixmap>
-               </property>
-               <property name="scaledContents">
-                <bool>true</bool>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignHCenter</set>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="verticalLayout_9">
-            <property name="spacing">
-             <number>10</number>
-            </property>
-            <property name="sizeConstraint">
-             <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
-            </property>
-            <item>
-             <layout class="QHBoxLayout" name="horizontalLayout">
-              <item>
-               <widget class="QGroupBox" name="gb_l3">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="title">
-                 <string notr="true">L3</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignCenter</set>
-                </property>
-                <layout class="QVBoxLayout" name="gb_l3_layout">
-                 <property name="leftMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>5</number>
-                 </property>
-                 <item>
-                  <widget class="QPushButton" name="L3Button">
-                   <property name="text">
-                    <string>unmapped</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="gb_start">
-                <property name="title">
-                 <string>Options</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignCenter</set>
-                </property>
-                <layout class="QVBoxLayout" name="gb_start_layout">
-                 <property name="leftMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>5</number>
-                 </property>
-                 <item>
-                  <widget class="QPushButton" name="OptionsButton">
-                   <property name="text">
-                    <string>unmapped</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="gb_r3">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="title">
-                 <string notr="true">R3</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignCenter</set>
-                </property>
-                <layout class="QVBoxLayout" name="gb_r3_layout">
-                 <property name="leftMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>5</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>5</number>
-                 </property>
-                 <item>
-                  <widget class="QPushButton" name="R3Button">
-                   <property name="text">
-                    <string>unmapped</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_2">
-              <item>
-               <widget class="QGroupBox" name="gb_touchleft">
-                <property name="title">
-                 <string>Touchpad Left</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignCenter</set>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_5">
-                 <item>
-                  <widget class="QPushButton" name="TouchpadLeftButton">
-                   <property name="text">
-                    <string>unmapped</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="gb_touchcenter">
-                <property name="title">
-                 <string>Touchpad Center</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignCenter</set>
-                </property>
-                <layout class="QVBoxLayout" name="verticalLayout_11">
-                 <item>
-                  <widget class="QPushButton" name="TouchpadCenterButton">
-                   <property name="text">
-                    <string>unmapped</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="gb_touchright">
-                <property name="title">
-                 <string>Touchpad Right</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignCenter</set>
-                </property>
-                <layout class="QVBoxLayout" name="verticalLayout_12">
-                 <item>
-                  <widget class="QPushButton" name="TouchpadRightButton">
-                   <property name="text">
-                    <string>unmapped</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_8">
-            <item>
-             <layout class="QVBoxLayout" name="verticalLayout_14">
-              <item>
-               <widget class="QGroupBox" name="groupBox">
-                <property name="font">
-                 <font>
-                  <bold>false</bold>
-                 </font>
-                </property>
-                <property name="title">
-                 <string>Color Adjustment</string>
-                </property>
-                <layout class="QVBoxLayout" name="verticalLayout_18">
-                 <property name="leftMargin">
-                  <number>6</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>6</number>
-                 </property>
-                 <item>
-                  <layout class="QHBoxLayout" name="horizontalLayout_9">
-                   <property name="spacing">
-                    <number>6</number>
-                   </property>
-                   <item>
-                    <widget class="QLabel" name="RLabel_text">
-                     <property name="font">
-                      <font>
-                       <bold>false</bold>
-                      </font>
-                     </property>
-                     <property name="text">
-                      <string>RED</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QSlider" name="RSlider">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="maximum">
-                      <number>255</number>
-                     </property>
-                     <property name="orientation">
-                      <enum>Qt::Orientation::Horizontal</enum>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QLabel" name="RLabel">
-                     <property name="maximumSize">
-                      <size>
-                       <width>20</width>
-                       <height>16777215</height>
-                      </size>
-                     </property>
-                     <property name="text">
-                      <string notr="true">000</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </item>
-                 <item>
-                  <layout class="QHBoxLayout" name="horizontalLayout_10">
-                   <item>
-                    <widget class="QLabel" name="GLabel_text">
-                     <property name="font">
-                      <font>
-                       <bold>false</bold>
-                      </font>
-                     </property>
-                     <property name="text">
-                      <string>GREEN</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QSlider" name="GSlider">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="maximum">
-                      <number>255</number>
-                     </property>
-                     <property name="orientation">
-                      <enum>Qt::Orientation::Horizontal</enum>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QLabel" name="GLabel">
-                     <property name="maximumSize">
-                      <size>
-                       <width>20</width>
-                       <height>16777215</height>
-                      </size>
-                     </property>
-                     <property name="text">
-                      <string notr="true">000</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </item>
-                 <item>
-                  <layout class="QHBoxLayout" name="horizontalLayout_11">
-                   <item>
-                    <widget class="QLabel" name="BLabel_text">
-                     <property name="font">
-                      <font>
-                       <bold>false</bold>
-                      </font>
-                     </property>
-                     <property name="text">
-                      <string>BLUE</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QSlider" name="BSlider">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="maximum">
-                      <number>255</number>
-                     </property>
-                     <property name="value">
-                      <number>255</number>
-                     </property>
-                     <property name="orientation">
-                      <enum>Qt::Orientation::Horizontal</enum>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QLabel" name="BLabel">
-                     <property name="maximumSize">
-                      <size>
-                       <width>20</width>
-                       <height>16777215</height>
-                      </size>
-                     </property>
-                     <property name="text">
-                      <string notr="true">255</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item>
-             <layout class="QVBoxLayout" name="verticalLayout_17">
-              <item>
-               <widget class="QGroupBox" name="groupBox_3">
-                <property name="font">
-                 <font>
-                  <bold>false</bold>
-                 </font>
-                </property>
-                <property name="title">
-                 <string>Override Lightbar Color</string>
-                </property>
-                <layout class="QVBoxLayout" name="verticalLayout_19">
-                 <item>
-                  <widget class="QCheckBox" name="LightbarCheckBox">
-                   <property name="font">
-                    <font>
-                     <bold>false</bold>
-                    </font>
-                   </property>
-                   <property name="text">
-                    <string>Override Color</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QFrame" name="LightbarColorFrame">
-                   <property name="frameShape">
-                    <enum>QFrame::Shape::StyledPanel</enum>
-                   </property>
-                   <property name="frameShadow">
-                    <enum>QFrame::Shadow::Raised</enum>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QVBoxLayout" name="verticalLayout_right">
-          <property name="spacing">
-           <number>5</number>
+          <property name="centerButtons">
+            <bool>false</bool>
           </property>
-          <item>
-           <widget class="QGroupBox" name="gb_face_buttons">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="title">
-             <string>Face Buttons</string>
-            </property>
-            <layout class="QVBoxLayout" name="gb_face_buttons_layout">
-             <property name="leftMargin">
-              <number>5</number>
-             </property>
-             <property name="topMargin">
-              <number>5</number>
-             </property>
-             <property name="rightMargin">
-              <number>5</number>
-             </property>
-             <property name="bottomMargin">
-              <number>5</number>
-             </property>
-             <item>
-              <widget class="QWidget" name="widget_triangle" native="true">
-               <layout class="QHBoxLayout" name="widget_triangle_layout">
-                <property name="leftMargin">
-                 <number>0</number>
-                </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QGroupBox" name="gb_triangle">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>152</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="maximumSize">
-                   <size>
-                    <width>0</width>
-                    <height>16777215</height>
-                   </size>
-                  </property>
-                  <property name="title">
-                   <string>Triangle</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignCenter</set>
-                  </property>
-                  <layout class="QVBoxLayout" name="verticalLayout_3">
-                   <item>
-                    <widget class="QPushButton" name="TriangleButton">
-                     <property name="text">
-                      <string>unmapped</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="layout_square_circle">
-               <item>
-                <widget class="QGroupBox" name="gb_square">
-                 <property name="title">
-                  <string>Square</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                 </property>
-                 <layout class="QVBoxLayout" name="gb_square_layout">
-                  <property name="leftMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>5</number>
-                  </property>
-                  <item>
-                   <widget class="QPushButton" name="SquareButton">
-                    <property name="text">
-                     <string>unmapped</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="gb_circle">
-                 <property name="title">
-                  <string>Circle</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                 </property>
-                 <layout class="QVBoxLayout" name="gb_circle_layout">
-                  <property name="leftMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>5</number>
-                  </property>
-                  <item>
-                   <widget class="QPushButton" name="CircleButton">
-                    <property name="text">
-                     <string>unmapped</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <widget class="QWidget" name="widget_cross" native="true">
-               <layout class="QHBoxLayout" name="widget_cross_layout">
-                <property name="leftMargin">
-                 <number>0</number>
-                </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QGroupBox" name="gb_cross">
-                  <property name="minimumSize">
-                   <size>
-                    <width>152</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="maximumSize">
-                   <size>
-                    <width>124</width>
-                    <height>16777215</height>
-                   </size>
-                  </property>
-                  <property name="title">
-                   <string>Cross</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignCenter</set>
-                  </property>
-                  <layout class="QVBoxLayout" name="verticalLayout_5">
-                   <item>
-                    <widget class="QPushButton" name="CrossButton">
-                     <property name="text">
-                      <string>unmapped</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="groupBox_6">
-            <property name="title">
-             <string>R1 and R2</string>
-            </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_14">
-             <item>
-              <widget class="QGroupBox" name="gb_r1">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="title">
-                <string notr="true">R1</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignCenter</set>
-               </property>
-               <layout class="QVBoxLayout" name="gb_r1_layout">
-                <property name="leftMargin">
-                 <number>5</number>
-                </property>
-                <property name="topMargin">
-                 <number>5</number>
-                </property>
-                <property name="rightMargin">
-                 <number>5</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>5</number>
-                </property>
-                <item>
-                 <widget class="QPushButton" name="R1Button">
-                  <property name="text">
-                   <string>unmapped</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QGroupBox" name="gb_r2">
-               <property name="title">
-                <string notr="true">R2</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignCenter</set>
-               </property>
-               <layout class="QVBoxLayout" name="gb_r2_layout">
-                <property name="leftMargin">
-                 <number>5</number>
-                </property>
-                <property name="topMargin">
-                 <number>5</number>
-                </property>
-                <property name="rightMargin">
-                 <number>5</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>5</number>
-                </property>
-                <item>
-                 <widget class="QPushButton" name="R2Button">
-                  <property name="text">
-                   <string>unmapped</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Orientation::Vertical</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Policy::Expanding</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="RightStickDeadZoneGB">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="title">
-             <string>Right Stick Deadzone (def:2, max:127)</string>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_13">
-             <item>
-              <widget class="QLabel" name="RightDeadzoneValue">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Right Deadzone</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QSlider" name="RightDeadzoneSlider">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimum">
-                <number>1</number>
-               </property>
-               <property name="maximum">
-                <number>127</number>
-               </property>
-               <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="gb_right_stick">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="title">
-             <string>Right Stick</string>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_2">
-             <property name="leftMargin">
-              <number>5</number>
-             </property>
-             <property name="topMargin">
-              <number>5</number>
-             </property>
-             <property name="rightMargin">
-              <number>5</number>
-             </property>
-             <property name="bottomMargin">
-              <number>5</number>
-             </property>
-             <item>
-              <widget class="QWidget" name="widget_right_stick_up" native="true">
-               <layout class="QHBoxLayout" name="widget_right_stick_up_layout">
-                <property name="leftMargin">
-                 <number>0</number>
-                </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QGroupBox" name="gb_right_stick_up">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>0</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="maximumSize">
-                   <size>
-                    <width>152</width>
-                    <height>1231321</height>
-                   </size>
-                  </property>
-                  <property name="title">
-                   <string>Up</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignCenter</set>
-                  </property>
-                  <layout class="QVBoxLayout" name="verticalLayout_7">
-                   <item>
-                    <widget class="QPushButton" name="RStickUpButton">
-                     <property name="text">
-                      <string>unmapped</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="layout_right_stick_left_right">
-               <item>
-                <widget class="QGroupBox" name="gb_right_stick_left">
-                 <property name="title">
-                  <string>Left</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                 </property>
-                 <layout class="QVBoxLayout" name="gb_right_stick_left_layout">
-                  <property name="leftMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>5</number>
-                  </property>
-                  <item>
-                   <widget class="QPushButton" name="RStickLeftButton">
-                    <property name="text">
-                     <string>unmapped</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="gb_right_stick_right">
-                 <property name="title">
-                  <string>Right</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                 </property>
-                 <layout class="QVBoxLayout" name="gb_right_stick_right_layout">
-                  <property name="leftMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>5</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>5</number>
-                  </property>
-                  <item>
-                   <widget class="QPushButton" name="RStickRightButton">
-                    <property name="text">
-                     <string>unmapped</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <widget class="QWidget" name="widget_right_stick_down" native="true">
-               <layout class="QHBoxLayout" name="widget_right_stick_down_layout">
-                <property name="leftMargin">
-                 <number>0</number>
-                </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QGroupBox" name="gb_right_stick_down">
-                  <property name="minimumSize">
-                   <size>
-                    <width>152</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="maximumSize">
-                   <size>
-                    <width>124</width>
-                    <height>2121</height>
-                   </size>
-                  </property>
-                  <property name="title">
-                   <string>Down</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignCenter</set>
-                  </property>
-                  <layout class="QVBoxLayout" name="verticalLayout_6">
-                   <item>
-                    <widget class="QPushButton" name="RStickDownButton">
-                     <property name="text">
-                      <string>unmapped</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </widget>
-    </widget>
-   </item>
-   <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::RestoreDefaults|QDialogButtonBox::StandardButton::Save</set>
-     </property>
-     <property name="centerButtons">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-  </layout>
- </widget>
- <resources>
-  <include location="../shadps4.qrc"/>
- </resources>
- <connections/>
+        </widget>
+      </item>
+    </layout>
+  </widget>
+  <resources>
+    <include location="../shadps4.qrc"/>
+  </resources>
+  <connections/>
 </ui>


### PR DESCRIPTION
Noticed that deadzone settings only has minimum distance toggle in ui. This pr adds maximum distance option to ui

<img width="1112" height="865" alt="Untitled" src="https://github.com/user-attachments/assets/f907ee91-2aeb-4a58-8c9c-3486bff58e2e" />
.