### PR TITLE
Add informative update message for Qt build deprecation

### DIFF
--- a/src/qt_gui/check_update.cpp
+++ b/src/qt_gui/check_update.cpp
@@ -153,8 +153,12 @@ tr("The Auto Updater allows up to 60 update checks per hour.\\nYou have reached 
         }
 
         if (!found) {
-            QMessageBox::warning(this, tr("Error"),
-                                 tr("No download URL found for the specified asset."));
+            QMessageBox::warning(
+                this, tr("Auto Updater"),
+                // clang-format off
+tr("<b>Notice:</b><br><br> Starting from version <b>0.12.0</b>, the Qt version of the emulator will no longer receive direct updates.<br><br>However, the Qt interface remains available through the new official launcher:<br><br><a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'>Qt Launcher</a> - based on the original shadPS4 source code.<br><br>We recommend switching to this launcher to continue receiving updates."));
+            // clang-format on
+
             reply->deleteLater();
             return;
         }

--- a/src/qt_gui/translations/ar_SA.ts
+++ b/src/qt_gui/translations/ar_SA.ts
@@ -276,8 +276,8 @@
       <translation>بيانات الإصدار غير صالحة.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>لم يتم العثور على عنوان URL للتنزيل للأصل المحدد.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;تنويه:&lt;/b&gt;&lt;br&gt;&lt;br&gt; ابتداءً من الإصدار &lt;b&gt;0.12.0&lt;/b&gt;، لن تتلقى نسخة Qt من المحاكي تحديثات مباشرة.&lt;br&gt;&lt;br&gt; مع ذلك، تظل واجهة Qt متاحة من خلال المُشغّل الرسمي الجديد:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – مبنية على شفرة المصدر الأصلية لـ shadPS4.&lt;br&gt;&lt;br&gt;نوصي بالتحول إلى هذا المُشغّل لمواصلة تلقي التحديثات.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/ca_ES.ts
+++ b/src/qt_gui/translations/ca_ES.ts
@@ -276,8 +276,8 @@
       <translation>Dades de la versió no vàlides.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>No s'ha trobat la direcció web de descàrrega.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Avís:&lt;/b&gt;&lt;br&gt;&lt;br&gt; A partir de la versió &lt;b&gt;0.12.0&lt;/b&gt;, la versió Qt de l’emulador ja no rebrà actualitzacions directes.&lt;br&gt;&lt;br&gt; Tanmateix, la interfície Qt continua disponible mitjançant el nou llançador oficial:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – basat en el codi font original de shadPS4.&lt;br&gt;&lt;br&gt;Recomanem passar a aquest llançador per continuar rebent actualitzacions.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/da_DK.ts
+++ b/src/qt_gui/translations/da_DK.ts
@@ -276,8 +276,8 @@
       <translation>Ugyldige udgivelsesdata.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>Ingen download-URL fundet for den specificerede aktiver.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Bemærk:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Fra og med version &lt;b&gt;0.12.0&lt;/b&gt; vil Qt‑versionen af emulatoren ikke længere modtage direkte opdateringer.&lt;br&gt;&lt;br&gt; Qt‑grænsefladen forbliver dog tilgængelig via den nye officielle launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – baseret på den oprindelige shadPS4‑kildekode.&lt;br&gt;&lt;br&gt;Vi anbefaler at skifte til denne launcher for at fortsætte med at modtage opdateringer.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/de_DE.ts
+++ b/src/qt_gui/translations/de_DE.ts
@@ -276,8 +276,8 @@
       <translation>Ungültige Versionsdaten.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>Keine Download-URL für das angegebene Asset gefunden.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Hinweis:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Ab Version &lt;b&gt;0.12.0&lt;/b&gt; erhält die Qt‑Version des Emulators keine direkten Updates mehr.&lt;br&gt;&lt;br&gt; Die Qt‑Oberfläche bleibt jedoch über den neuen offiziellen Launcher verfügbar:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – basierend auf dem ursprünglichen shadPS4‑Quellcode.&lt;br&gt;&lt;br&gt;Wir empfehlen, auf diesen Launcher zu wechseln, um weiterhin Updates zu erhalten.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/el_GR.ts
+++ b/src/qt_gui/translations/el_GR.ts
@@ -276,8 +276,8 @@
       <translation>Μη έγκυρα δεδομένα έκδοσης.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>Δεν βρέθηκε URL λήψης για το συγκεκριμένο στοιχείο.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Σημείωση:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Από την έκδοση &lt;b&gt;0.12.0&lt;/b&gt;, η έκδοση Qt του emulator δεν θα λαμβάνει πλέον άμεσες ενημερώσεις.&lt;br&gt;&lt;br&gt; Η διεπαφή Qt παραμένει διαθέσιμη μέσω του νέου επίσημου εκτοξευτή (launcher):&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – βασισμένο στον αρχικό πηγαίο κώδικα του shadPS4.&lt;br&gt;&lt;br&gt;Συνιστούμε να μεταβείτε σε αυτόν τον launcher για να συνεχίσετε να λαμβάνετε ενημερώσεις.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/en_US.ts
+++ b/src/qt_gui/translations/en_US.ts
@@ -275,10 +275,10 @@
         <source>Invalid release data.</source>
         <translation>Invalid release data.</translation>
     </message>
-    <message>
-        <source>No download URL found for the specified asset.</source>
-        <translation>No download URL found for the specified asset.</translation>
-    </message>
+	<message>
+		<source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+		<translation>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</translation>
+	</message>
     <message>
         <source>Your version is already up to date!</source>
         <translation>Your version is already up to date!</translation>

--- a/src/qt_gui/translations/es_ES.ts
+++ b/src/qt_gui/translations/es_ES.ts
@@ -276,8 +276,8 @@
       <translation>Datos de versión no válidos.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>No se encontró URL de descarga para el activo especificado.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Aviso:&lt;/b&gt;&lt;br&gt;&lt;br&gt; A partir de la versión &lt;b&gt;0.12.0&lt;/b&gt;, la versión Qt del emulador ya no recibirá actualizaciones directas.&lt;br&gt;&lt;br&gt; Sin embargo, la interfaz Qt sigue disponible mediante el nuevo lanzador oficial:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – basado en el código fuente original de shadPS4.&lt;br&gt;&lt;br&gt;Recomendamos cambiar a este lanzador para seguir recibiendo actualizaciones.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/fa_IR.ts
+++ b/src/qt_gui/translations/fa_IR.ts
@@ -276,8 +276,8 @@
       <translation>داده های نسخه نامعتبر است.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>هیچ URL دانلودی برای دارایی مشخص شده پیدا نشد.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;توجه:&lt;/b&gt;&lt;br&gt;&lt;br&gt; از نسخه &lt;b&gt;0.12.0&lt;/b&gt; به بعد، نسخه Qt امولاتور دیگر به‌روزرسانی مستقیم دریافت نخواهد کرد.&lt;br&gt;&lt;br&gt; با این حال، رابط Qt همچنان از طریق لانچر رسمی جدید در دسترس است:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – مبتنی بر کد منبع اصلی shadPS4.&lt;br&gt;&lt;br&gt; توصیه می‌کنیم برای ادامه دریافت به‌روزرسانی‌ها به این لانچر مهاجرت کنید.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/fi_FI.ts
+++ b/src/qt_gui/translations/fi_FI.ts
@@ -276,8 +276,8 @@
       <translation>Virheelliset julkaisutiedot.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>Lataus-URL:ia ei löytynyt määritetylle omaisuudelle.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Huomio:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Versiosta &lt;b&gt;0.12.0&lt;/b&gt; lähtien emulaattorin Qt‑versio ei saa suoria päivityksiä enää.&lt;br&gt;&lt;br&gt; Qt‑käyttöliittymä on kuitenkin edelleen käytettävissä uuden virallisen käynnistäjän kautta:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – perustuen alkuperäiseen shadPS4‑lähdekoodiin.&lt;br&gt;&lt;br&gt;Suosittelemme siirtymistä tähän käynnistäjään, jotta voit jatkaa päivitysten saamista.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/fr_FR.ts
+++ b/src/qt_gui/translations/fr_FR.ts
@@ -276,8 +276,8 @@
       <translation>Données de version invalides.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>Aucune URL de téléchargement trouvée pour l&apos;élément spécifié.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Remarque :&lt;/b&gt;&lt;br&gt;&lt;br&gt; À partir de la version &lt;b&gt;0.12.0&lt;/b&gt;, la version Qt de l’émulateur ne recevra plus de mises à jour directes.&lt;br&gt;&lt;br&gt; Toutefois, l’interface Qt reste disponible via le nouveau lanceur officiel :&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – basé sur le code source original de shadPS4.&lt;br&gt;&lt;br&gt;Nous vous recommandons de passer à ce lanceur pour continuer à recevoir des mises à jour.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/hu_HU.ts
+++ b/src/qt_gui/translations/hu_HU.ts
@@ -276,8 +276,8 @@
       <translation>Érvénytelen kiadási adatok.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>Nincs letöltési URL a megadott eszközhöz.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Értesítés:&lt;/b&gt;&lt;br&gt;&lt;br&gt; A 0.12.0‑ás verziótól kezdve az emulátor Qt‑verziója már nem kap közvetlen frissítéseket.&lt;br&gt;&lt;br&gt; Ugyanakkor a Qt felület továbbra is elérhető az új hivatalos indítóprogrammal:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – az eredeti shadPS4 forráskód alapján.&lt;br&gt;&lt;br&gt;Ajánljuk, hogy erre az indítóra válts át, hogy folytathasd a frissítések fogadását.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/id_ID.ts
+++ b/src/qt_gui/translations/id_ID.ts
@@ -276,8 +276,8 @@
       <translation>Data rilis tidak valid.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>Tidak ada URL unduhan ditemukan untuk aset yang ditentukan.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Peringatan:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Mulai versi &lt;b&gt;0.12.0&lt;/b&gt;, versi Qt dari emulator tidak akan lagi menerima pembaruan langsung.&lt;br&gt;&lt;br&gt; Namun, antarmuka Qt tetap tersedia melalui peluncur resmi baru:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – berdasarkan kode sumber asli shadPS4.&lt;br&gt;&lt;br&gt;Kami menyarankan untuk beralih ke peluncur ini agar terus menerima pembaruan.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/it_IT.ts
+++ b/src/qt_gui/translations/it_IT.ts
@@ -276,8 +276,8 @@
       <translation>Dati della release non validi.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>Nessun URL di download trovato per l&apos;asset specificato.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Avviso:&lt;/b&gt;&lt;br&gt;&lt;br&gt; A partire dalla versione &lt;b&gt;0.12.0&lt;/b&gt;, la versione Qt dell’emulatore non riceverà più aggiornamenti diretti.&lt;br&gt;&lt;br&gt; Tuttavia, l’interfaccia Qt rimane disponibile tramite il nuovo launcher ufficiale:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – basato sul codice sorgente originale di shadPS4.&lt;br&gt;&lt;br&gt;Consigliamo di passare a questo launcher per continuare a ricevere aggiornamenti.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/ja_JP.ts
+++ b/src/qt_gui/translations/ja_JP.ts
@@ -276,8 +276,8 @@
       <translation>リリースデータが無効です。</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>指定されたアセットのダウンロードURLが見つかりませんでした。</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;通知:&lt;/b&gt;&lt;br&gt;&lt;br&gt; バージョン &lt;b&gt;0.12.0&lt;/b&gt; 以降、エミュレータの Qt バージョンは直接のアップデートを受け取らなくなります。&lt;br&gt;&lt;br&gt; ただし、Qt インターフェースは新しい公式ランチャーを通じて引き続き利用可能です：&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – オリジナルの shadPS4 ソースコードを基にしています。&lt;br&gt;&lt;br&gt; このランチャーに切り替えて、更新の受信を継続することをお勧めします。</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/ko_KR.ts
+++ b/src/qt_gui/translations/ko_KR.ts
@@ -276,8 +276,8 @@
       <translation>잘못된 릴리스 데이터입니다.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>지정된 자산에 대한 다운로드 URL을 찾을 수 없습니다.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;알림:&lt;/b&gt;&lt;br&gt;&lt;br&gt; 버전 &lt;b&gt;0.12.0&lt;/b&gt;부터 에뮬레이터의 Qt 버전은 더 이상 직접 업데이트를 받지 않습니다.&lt;br&gt;&lt;br&gt; 그러나 Qt 인터페이스는 새로운 공식 런처를 통해 계속 사용할 수 있습니다:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – 원래의 shadPS4 소스 코드를 기반으로 제작되었습니다.&lt;br&gt;&lt;br&gt;이 런처로 전환하여 업데이트를 계속 받으시기 바랍니다.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/lt_LT.ts
+++ b/src/qt_gui/translations/lt_LT.ts
@@ -276,8 +276,8 @@
       <translation>Neteisingi leidimo duomenys.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>Nerasta atsisiuntimo URL nurodytam turtui.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Pranešimas:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Nuo versijos &lt;b&gt;0.12.0&lt;/b&gt; emuliatoriaus Qt versija nebekvies tiesioginių atnaujinimų.&lt;br&gt;&lt;br&gt; Tačiau Qt sąsaja vis tiek prieinama per oficialų naują paleidimo programą:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – paremta pradiniu shadPS4 šaltinio kodu.&lt;br&gt;&lt;br&gt;Rekomenduojame pereiti prie šio paleidimo programos, kad ir toliau gautumėte atnaujinimus.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/nb_NO.ts
+++ b/src/qt_gui/translations/nb_NO.ts
@@ -276,8 +276,8 @@
       <translation>Ugyldige utgivelsesdata.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>Ingen nedlastings-URL funnet for den spesifiserte ressursen.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Merk:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Fra og med versjon &lt;b&gt;0.12.0&lt;/b&gt; vil Qt‑versjonen av emulatoren ikke lenger motta direkte oppdateringer.&lt;br&gt;&lt;br&gt; Qt‑grensesnittet er imidlertid fortsatt tilgjengelig via den nye offisielle lansereren:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – basert på original koden til shadPS4.&lt;br&gt;&lt;br&gt;Vi anbefaler å bytte til denne lansereren for å fortsette å motta oppdateringer.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/nl_NL.ts
+++ b/src/qt_gui/translations/nl_NL.ts
@@ -276,8 +276,8 @@
       <translation>Ongeldige releasegegevens.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>Geen download-URL gevonden voor het opgegeven bestand.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Opmerking:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Vanaf versie &lt;b&gt;0.12.0&lt;/b&gt; ontvangt de Qt‑versie van de emulator geen directe updates meer.&lt;br&gt;&lt;br&gt; De Qt‑interface blijft echter beschikbaar via de nieuwe officiële launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – gebaseerd op de oorspronkelijke shadPS4-broncode.&lt;br&gt;&lt;br&gt; We raden aan over te stappen op deze launcher om updates te blijven ontvangen.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/pl_PL.ts
+++ b/src/qt_gui/translations/pl_PL.ts
@@ -276,8 +276,8 @@
       <translation>Nieprawidłowe dane wydania.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>Nie znaleziono adresu URL do pobrania dla określonego zasobu.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Uwaga:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Począwszy od wersji &lt;b&gt;0.12.0&lt;/b&gt; wersja Qt emulatora nie będzie już otrzymywać bezpośrednich aktualizacji.&lt;br&gt;&lt;br&gt; Interfejs Qt pozostaje jednak dostępny poprzez nowy oficjalny launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – oparty na oryginalnym kodzie źródłowym shadPS4.&lt;br&gt;&lt;br&gt; Zalecamy przejście na ten launcher, aby nadal otrzymywać aktualizacje.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/pt_BR.ts
+++ b/src/qt_gui/translations/pt_BR.ts
@@ -276,8 +276,8 @@
       <translation>Dados do release inválidos.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>Nenhuma URL de download encontrada para o recurso especificado.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Aviso:&lt;/b&gt;&lt;br&gt;&lt;br&gt; A partir da versão &lt;b&gt;0.12.0&lt;/b&gt;, a versão Qt do emulador não receberá mais atualizações diretas.&lt;br&gt;&lt;br&gt;No entanto, a interface Qt continua disponível por meio do novo launcher oficial:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – baseado no código original do shadPS4.&lt;br&gt;&lt;br&gt;Recomendamos migrar para esse launcher para continuar recebendo atualizações.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/pt_PT.ts
+++ b/src/qt_gui/translations/pt_PT.ts
@@ -276,8 +276,8 @@
       <translation>Dados de lançamento inválidos.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>Nenhum URL de transferência encontrado para o recurso especificado.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Aviso:&lt;/b&gt;&lt;br&gt;&lt;br&gt; A partir da versão &lt;b&gt;0.12.0&lt;/b&gt;, a versão Qt do emulador não irá mais receber atualizações diretas.&lt;br&gt;&lt;br&gt; No entanto, a interface Qt continua disponível através do novo launcher oficial:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – baseado no código original do shadPS4.&lt;br&gt;&lt;br&gt;Recomendamos migrar para este launcher para continuar a receber atualizações.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/ro_RO.ts
+++ b/src/qt_gui/translations/ro_RO.ts
@@ -276,8 +276,8 @@
       <translation>Datele versiunii sunt invalide.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>Nu s-a găsit URL de descărcare pentru resursa specificată.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Notificare:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Începând cu versiunea &lt;b&gt;0.12.0&lt;/b&gt;, versiunea Qt a emulatorului nu va mai primi actualizări directe.&lt;br&gt;&lt;br&gt; Cu toate acestea, interfața Qt rămâne disponibilă prin noul launcher oficial:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – bazat pe codul sursă original shadPS4.&lt;br&gt;&lt;br&gt;Vă recomandăm să treceți la acest launcher pentru a continua să primiți actualizări.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/ru_RU.ts
+++ b/src/qt_gui/translations/ru_RU.ts
@@ -276,8 +276,8 @@
       <translation>Недопустимые данные релиза.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>Не найден URL для загрузки указанного ресурса.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Внимание:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Начиная с версии &lt;b&gt;0.12.0&lt;/b&gt; версия Qt эмулятора больше не будет получать прямые обновления.&lt;br&gt;&lt;br&gt; Тем не менее, интерфейс Qt остаётся доступным через новый официальный лаунчер:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – основан на исходном коде shadPS4.&lt;br&gt;&lt;br&gt;Рекомендуем перейти на этот лаунчер, чтобы продолжать получать обновления.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/ru_RU.ts
+++ b/src/qt_gui/translations/ru_RU.ts
@@ -277,7 +277,7 @@
     </message>
     <message>
       <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
-      <translation>&lt;b&gt;Внимание:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Начиная с версии &lt;b&gt;0.12.0&lt;/b&gt; версия Qt эмулятора больше не будет получать прямые обновления.&lt;br&gt;&lt;br&gt; Тем не менее, интерфейс Qt остаётся доступным через новый официальный лаунчер:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – основан на исходном коде shadPS4.&lt;br&gt;&lt;br&gt;Рекомендуем перейти на этот лаунчер, чтобы продолжать получать обновления.</translation>
+      <translation>&lt;b&gt;Внимание:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Начиная с версии &lt;b&gt;0.12.0&lt;/b&gt; версия Qt эмулятора больше не будет получать прямые обновления.&lt;br&gt;&lt;br&gt; Тем не менее, интерфейс Qt остаётся доступным через новый официальный лаунчер:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – основан на исходном коде shadPS4.&lt;br&gt;&lt;br&gt;Рекомендуем перейти на этот лаунчер, чтобы продолжать получать обновления.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/sl_SI.ts
+++ b/src/qt_gui/translations/sl_SI.ts
@@ -276,8 +276,8 @@
       <translation type="unfinished">Invalid release data.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation type="unfinished">No download URL found for the specified asset.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Obvestilo:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Od različice &lt;b&gt;0.12.0&lt;/b&gt; Qt različica emulatorja ne bo več prejemala neposrednih posodobitev.&lt;br&gt;&lt;br&gt; Vmesnik Qt je še vedno na voljo preko novega uradnega zaganjalnika:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – temelji na izvorni kodi shadPS4.&lt;br&gt;&lt;br&gt; Priporočamo preklop na ta zaganjalnik, da boste lahko še naprej prejemali posodobitve.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/sq_AL.ts
+++ b/src/qt_gui/translations/sq_AL.ts
@@ -276,8 +276,8 @@
       <translation>Të dhënat e lëshimit janë të pavlefshme.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>Nuk u gjet URL-ja e shkarkimit për burimin e specifikuar.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Njoftim:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Duke filluar nga versioni &lt;b&gt;0.12.0&lt;/b&gt;, versioni Qt i emulatorit nuk do të marrë më përditësime direkte.&lt;br&gt;&lt;br&gt; Megjithatë, ndërfaqja Qt vazhdon të jetë e disponueshme përmes launcher‑it të ri zyrtar:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – bazuar në kodin burimor origjinal të shadPS4.&lt;br&gt;&lt;br&gt; Ju rekomandojmë të kaloni te ky launcher për të vazhduar të merrni përditësime.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/sr_CS.ts
+++ b/src/qt_gui/translations/sr_CS.ts
@@ -276,8 +276,8 @@
       <translation type="unfinished">Invalid release data.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation type="unfinished">No download URL found for the specified asset.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Обавештење:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Почевши од верзије &lt;b&gt;0.12.0&lt;/b&gt;, Qt верзија емулатора више неће добијати директна ажурирања.&lt;br&gt;&lt;br&gt; Међутим, Qt интерфејс остаје доступан преко новог званичног ланчера:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – заснован на оригиналном izvor­nom kodu shadPS4.&lt;br&gt;&lt;br&gt; Препоручујемо прелазак на овај ланчер ради наставka примања ажурирања.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/sv_SE.ts
+++ b/src/qt_gui/translations/sv_SE.ts
@@ -276,8 +276,8 @@
       <translation>Ogiltig release-data.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>Ingen hämtnings-URL hittades för angiven tillgång.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Meddelande:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Från och med version &lt;b&gt;0.12.0&lt;/b&gt; kommer inte Qt‑versionen av emulatorn längre att ta emot direkta uppdateringar.&lt;br&gt;&lt;br&gt; Qt‑gränssnittet fortsätter dock att vara tillgängligt via den nya officiella launcher:n:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – baserat på originalkoden för shadPS4.&lt;br&gt;&lt;br&gt; Vi rekommenderar att byta till denna launcher för att fortsätta ta emot uppdateringar.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/tr_TR.ts
+++ b/src/qt_gui/translations/tr_TR.ts
@@ -276,8 +276,8 @@
       <translation>Geçersiz sürüm verisi.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>Belirtilen varlık için hiçbir indirme URL&apos;si bulunamadı.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Dikkat:&lt;/b&gt;&lt;br&gt;&lt;br&gt; 0.12.0 sürümünden itibaren emulatorün Qt sürümü doğrudan güncelleme almayacak.&lt;br&gt;&lt;br&gt; Ancak Qt arayüzü, yeni resmi başlatıcı (launcher) aracılığıyla kullanılabilir durumda kalacak:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – shadPS4’ün orijinal kaynak koduna dayanarak.&lt;br&gt;&lt;br&gt; Güncellemeleri almaya devam etmek için bu launcher’a geçiş yapmanızı öneririz.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/uk_UA.ts
+++ b/src/qt_gui/translations/uk_UA.ts
@@ -276,8 +276,8 @@
       <translation>Некоректні дані про випуск.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>Не знайдено URL для завантаження зазначеного ресурсу.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Увага:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Починаючи з версії &lt;b&gt;0.12.0&lt;/b&gt; QT‑версія емулятора більше не отримуватиме прямих оновлень.&lt;br&gt;&lt;br&gt; Однак інтерфейс Qt залишається доступним через новий офіційний лаунчер:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – заснований на оригінальному вихідному коді shadPS4.&lt;br&gt;&lt;br&gt; Рекомендуємо перейти на цей лаунчер, щоб продовжувати отримувати оновлення.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/ur_PK.ts
+++ b/src/qt_gui/translations/ur_PK.ts
@@ -278,8 +278,8 @@
       <translation>ریلیز کا ڈیٹا درست نہیں ہے۔</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>مخصوص کردہ اثاثے کے لیے کوئی ڈاؤن لوڈ URL نہیں ملا۔</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;نوٹ:&lt;/b&gt;&lt;br&gt;&lt;br&gt; ورژن &lt;b&gt;0.12.0&lt;/b&gt; سے، ایمولیٹر کا Qt ورژن براہِ راست اپ ڈیٹس حاصل نہیں کرے گا۔&lt;br&gt;&lt;br&gt; تاہم، Qt انٹرفیس نیا سرکاری لانچر کے ذریعے دستیاب رہے گا:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – جو اصل shadPS4 سورس کوڈ پر مبنی ہے۔&lt;br&gt;&lt;br&gt; ہم تجویز کرتے ہیں کہ اپ ڈیٹس وصول کرنا جاری رکھنے کے لیے اس لانچر پر منتقل ہوجائیں۔</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/vi_VN.ts
+++ b/src/qt_gui/translations/vi_VN.ts
@@ -276,8 +276,8 @@
       <translation>Dữ liệu bản phát hành không hợp lệ.</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>Không tìm thấy URL tải xuống cho tài sản đã chỉ định.</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;Thông báo:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Bắt đầu từ phiên bản &lt;b&gt;0.12.0&lt;/b&gt;, phiên bản Qt của trình giả lập sẽ không còn nhận cập nhật trực tiếp nữa.&lt;br&gt;&lt;br&gt; Tuy nhiên, giao diện Qt vẫn có sẵn qua trình khởi chạy chính thức mới:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – dựa trên mã nguồn gốc của shadPS4.&lt;br&gt;&lt;br&gt; Chúng tôi khuyến nghị bạn chuyển sang trình khởi chạy này để tiếp tục nhận cập nhật.</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/zh_CN.ts
+++ b/src/qt_gui/translations/zh_CN.ts
@@ -276,8 +276,8 @@
       <translation>无效的发布数据。</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>未找到指定资源的下载地址。</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;注意：&lt;/b&gt;&lt;br&gt;&lt;br&gt; 从版本 &lt;b&gt;0.12.0&lt;/b&gt; 起，模拟器的 Qt 版本将不再接收直接更新。&lt;br&gt;&lt;br&gt; 但是，Qt 接口仍可通过新的官方启动器使用：&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – 基于原始 shadPS4 源代码。&lt;br&gt;&lt;br&gt; 我们建议切换到此启动器，以继续接收更新。</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>

--- a/src/qt_gui/translations/zh_TW.ts
+++ b/src/qt_gui/translations/zh_TW.ts
@@ -276,8 +276,8 @@
       <translation>無效的發佈資料。</translation>
     </message>
     <message>
-      <source>No download URL found for the specified asset.</source>
-      <translation>未找到指定資源的下載 URL。</translation>
+      <source>&lt;b&gt;Notice:&lt;/b&gt;&lt;br&gt;&lt;br&gt; Starting from version &lt;b&gt;0.12.0&lt;/b&gt;, the Qt version of the emulator will no longer receive direct updates.&lt;br&gt;&lt;br&gt;However, the Qt interface remains available through the new official launcher:&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; - based on the original shadPS4 source code.&lt;br&gt;&lt;br&gt;We recommend switching to this launcher to continue receiving updates.</source>
+      <translation>&lt;b&gt;注意：&lt;/b&gt;&lt;br&gt;&lt;br&gt; 從版本 &lt;b&gt;0.12.0&lt;/b&gt; 起，模擬器的 Qt 版本將不再接收直接更新。&lt;br&gt;&lt;br&gt; 不過，Qt 介面仍可透過新的官方啟動程式使用：&lt;br&gt;&lt;br&gt;&lt;a href='https://github.com/shadps4-emu/shadps4-qtlauncher/releases/'&gt;Qt Launcher&lt;/a&gt; – 基於原始 shadPS4 原始碼。&lt;br&gt;&lt;br&gt; 我們建議切換到此啟動程式，以繼續接收更新。</translation>
     </message>
     <message>
       <source>Your version is already up to date!</source>


### PR DESCRIPTION
Starting from version 0.12.0, the Qt version of the emulator will no longer receive direct updates.

However, the Qt interface remains available through the new official launcher:
[shadps4-qtlauncher](https://github.com/shadps4-emu/shadps4-qtlauncher/releases/)
 – based on the original shadPS4 source code.

We recommend migrating to this launcher to continue receiving updates.

Previously, when no update was available, users would see the generic message:
"No download URL found for the specified asset."

Now, they will instead see the custom message from the screenshot, which makes the situation clearer and includes a clickable button to open the appropriate GitHub release page.

Note: This message only appears when the emulator fails to find a Qt version release on GitHub.

<img width="502" height="250" alt="image" src="https://github.com/user-attachments/assets/cd878a53-cb85-400c-abf8-7c7ba2aca2b0" />

*This message was also translated into all languages.