### PR TITLE
Fixes scePlayGoDialog status stub

### DIFF
--- a/src/core/libraries/playgo/playgo_dialog.cpp
+++ b/src/core/libraries/playgo/playgo_dialog.cpp
@@ -30,7 +30,7 @@ Error PS4_SYSV_ABI scePlayGoDialogGetResult(OrbisPlayGoDialogResult* result) {
 
 Status PS4_SYSV_ABI scePlayGoDialogGetStatus() {
     LOG_ERROR(Lib_PlayGoDialog, "(DUMMY) called");
-    return Status::FINISHED;
+    return Status::NONE;
 }
 
 Error PS4_SYSV_ABI scePlayGoDialogInitialize() {
@@ -55,7 +55,7 @@ Error PS4_SYSV_ABI scePlayGoDialogTerminate() {
 
 Status PS4_SYSV_ABI scePlayGoDialogUpdateStatus() {
     LOG_ERROR(Lib_PlayGoDialog, "(DUMMY) called");
-    return Status::FINISHED;
+    return Status::NONE;
 }
 
 void RegisterLib(Core::Loader::SymbolsResolver* sym) {


### PR DESCRIPTION
Allows the game CUSA18056 - Ys: Memories of Celceta to pass the main menu and go into a playable state.

Fixes analog stick stuttering in games that use `scePadRead()` for input polling. Games like CUSA18056 exhibited severe stuttering during continuous movement, direction changes, and circular motion (spinning the analog stick).

Still some areas seem too bright.

<img width="1268" height="734" alt="image" src="https://github.com/user-attachments/assets/4427ecde-f59d-42fc-818d-de74d633a2dd" />
<img width="1268" height="739" alt="image" src="https://github.com/user-attachments/assets/0e1e78fc-4e32-4f50-bcc9-98ede8206e3a" />
<img width="1269" height="740" alt="image" src="https://github.com/user-attachments/assets/b894fc83-0c40-4aa3-b704-b951a68aa2eb" />
<img width="1264" height="742" alt="image" src="https://github.com/user-attachments/assets/266bb324-5c38-4b90-8473-8ebb0fbbe503" />
<img width="1268" height="744" alt="image" src="https://github.com/user-attachments/assets/8b00dacd-29d7-491b-9b4b-1be0d8c336da" />
