### PR TITLE
Core: Read-only file mmap fix

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -558,6 +558,12 @@ s32 MemoryManager::MapFile(void** out_addr, VAddr virtual_addr, u64 size, Memory
     auto* h = Common::Singleton<Core::FileSys::HandleTable>::Instance();
     auto file = h->GetFile(fd);
     if (file == nullptr) {
+        LOG_WARNING(Kernel_Vmm, "Invalid file for mmap, fd {}", fd);
+        return ORBIS_KERNEL_ERROR_EBADF;
+    }
+
+    if (file->type != Core::FileSys::FileType::Regular) {
+        LOG_WARNING(Kernel_Vmm, "Unsupported file type for mmap, fd {}", fd);
         return ORBIS_KERNEL_ERROR_EBADF;
     }
 
@@ -567,6 +573,13 @@ s32 MemoryManager::MapFile(void** out_addr, VAddr virtual_addr, u64 size, Memory
     }
 
     const auto handle = file->f.GetFileMapping();
+
+    if (False(file->f.GetAccessMode() & Common::FS::FileAccessMode::Write) ||
+        False(file->f.GetAccessMode() & Common::FS::FileAccessMode::Append)) {
+        // If the file does not have write access, ensure prot does not contain write permissions.
+        // On real hardware, these mappings succeed, but the memory cannot be written to.
+        prot &= ~MemoryProt::CpuWrite;
+    }
 
     impl.MapFile(mapped_addr, size, phys_addr, std::bit_cast<u32>(prot), handle);
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -584,6 +584,7 @@ s32 MemoryManager::MapFile(void** out_addr, VAddr virtual_addr, u64 size, Memory
     impl.MapFile(mapped_addr, size, phys_addr, std::bit_cast<u32>(prot), handle);
 
     if (prot >= MemoryProt::GpuRead) {
+        // On real hardware, GPU file mmaps cause a full system crash due to an internal error.
         ASSERT_MSG(false, "Files cannot be mapped to GPU memory");
     }
 


### PR DESCRIPTION
PS4s allow read-only file mmaps with read-write permissions, though attempting to write to that memory causes full system crashes and data corruption. On shadPS4, attempting to do this causes an address space assert, through either a failed mmap on Linux, or a failed MapViewOfFile3 call on Windows.

This PR fixes the address space errors by removing write permissions on mmap for read-only files.

This should fix a regression noted on Discord, and slightly improves the behavior of my [memory testing suite](https://github.com/ps4emulation/integration_tests/pull/4) on shadPS4.