### PR TITLE
fix divide by zero

### DIFF
--- a/src/core/libraries/kernel/time.cpp
+++ b/src/core/libraries/kernel/time.cpp
@@ -163,7 +163,7 @@ s32 PS4_SYSV_ABI posix_clock_gettime(u32 clock_id, OrbisKernelTimespec* ts) {
     case ORBIS_CLOCK_MONOTONIC_FAST: {
         static LARGE_INTEGER pf = [] {
             LARGE_INTEGER res{};
-            QueryPerformanceFrequency(&pf);
+            QueryPerformanceFrequency(&res);
             return res;
         }();
 


### PR DESCRIPTION
```
shadps4.exe caused an Integer division by zero at location 00007000002417D0 in module shadps4.exe.

AddrPC           Params
00007000002417D0 00000008056A20E0 00000008056A2168 0000000000000190  shadps4.exe!posix_clock_gettime+0xe0  [C:/src/shadPS4/src/core/libraries/kernel/time.cpp @ 176]
   174:             return -1;
   175:         }
>  176:         ts->tv_sec = pc.QuadPart / pf.QuadPart;
   177:         ts->tv_nsec = ((pc.QuadPart % pf.QuadPart) * 1000'000'000) / pf.QuadPart;
   178:         return 0;
0000700000244A69 00000002073FFFE0 0000000200064760 00000008056A20F0  shadps4.exe!wrap+0x9  [C:/src/shadPS4/src/core/libraries/kernel/time.cpp @ 289]
   287: 
   288: s32 PS4_SYSV_ABI sceKernelClockGettime(const u32 clock_id, OrbisKernelTimespec* ts) {
>  289:     if (const auto ret = posix_clock_gettime(clock_id, ts); ret < 0) {
   290:         return ErrnoToSceKernelError(*__Error());
   291:     }
0000000800D1A81A 0000000200064760 00000008056A20F0 DEADBEEF54321ABC
00000002073FFFE0 00000008056A20F0 DEADBEEF54321ABC 0000000040000000
0000000200064760 DEADBEEF54321ABC 0000000040000000 0000000000000000
00000008056A20F0 0000000040000000 0000000000000000 00000007EFABEC80
DEADBEEF54321ABC 0000000000000000 00000007EFABEC80 0000000800D1DB17
0000000040000000 00000007EFABEC80 0000000800D1DB17 00000007EFABF9E8
```