### PR TITLE
Fix game arguments not being passed under a certain condition

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -211,7 +211,6 @@ int main(int argc, char* argv[]) {
                 game_path = argv[i];
                 has_game_argument = true;
             }
-            break;
         } else {
             std::cerr << "Unknown argument: " << cur_arg << ", see --help for info.\n";
         }


### PR DESCRIPTION
If the game argument was specified as the last argument before -- with -g or --game, the arguments passed to the game would skip getting parsed, due to an incorrect break.