### PR TITLE
GnmDriver: Implement sceGnmDrawInitToDefaultContextStateInternalCommand, sceGnmDrawInitToDefaultContextStateInternalSize

### DIFF
--- a/src/core/libraries/gnmdriver/gnmdriver.h
+++ b/src/core/libraries/gnmdriver/gnmdriver.h
@@ -286,7 +286,7 @@ int PS4_SYSV_ABI Func_ECB4C6BA41FE3350();
 int PS4_SYSV_ABI sceGnmDebugModuleReset();
 int PS4_SYSV_ABI sceGnmDebugReset();
 int PS4_SYSV_ABI Func_C4C328B7CF3B4171();
-int PS4_SYSV_ABI sceGnmDrawInitToDefaultContextStateInternalCommand();
+int PS4_SYSV_ABI sceGnmDrawInitToDefaultContextStateInternalCommand(u32* cmdbuf, u32 size);
 int PS4_SYSV_ABI sceGnmDrawInitToDefaultContextStateInternalSize();
 int PS4_SYSV_ABI sceGnmFindResources();
 int PS4_SYSV_ABI sceGnmGetResourceRegistrationBuffers();


### PR DESCRIPTION
These are presumably used by libSceVideodec LLE, as they're called when trying to run libSceAvPlayer LLE in some titles.

From decompiling the two GnmDriver libraries, it seems like sceGnmDrawInitToDefaultContextStateInternalCommand inlines a call to sceGnmDrawInitToDefaultContextState, so I've replaced that with an actual call to the function for readability. 

sceGnmDrawInitToDefaultContextStateInternalSize is one to one with decompilation.

I've also swapped hardcoded firmware constants for our actually defined firmware constants for improved code readability.