### PR TITLE
Net: Better return stub for sceNetPoolCreate

### DIFF
--- a/src/core/libraries/network/net.cpp
+++ b/src/core/libraries/network/net.cpp
@@ -1285,7 +1285,8 @@ u16 PS4_SYSV_ABI sceNetNtohs(u16 net16) {
 
 int PS4_SYSV_ABI sceNetPoolCreate(const char* name, int size, int flags) {
     LOG_ERROR(Lib_Net, "(DUMMY) name = {} size = {} flags = {} ", std::string(name), size, flags);
-    return ORBIS_OK;
+    static s32 id = 1;
+    return id++;
 }
 
 int PS4_SYSV_ABI sceNetPoolDestroy() {


### PR DESCRIPTION
sceNetPoolCreate never returns 0 on success, it returns a positive value as an ID for the net pool. Some games check to make sure the return is positive, these games wouldn't work properly before.

This PR sets the return value of sceNetPoolCreate to a positive, increasing value.
This gets THE PLAYROOM (CUSA00001) further, though now it dies on 
```
[Debug] <Critical> fiber.cpp:42 _sceFiberCheckStackOverflow: Unreachable code!
Stack overflow detected in fiber with size = 0x400
```