### PR TITLE
Windows: Limit address space maximum when higher addresses are not needed

### DIFF
--- a/src/common/elf_info.h
+++ b/src/common/elf_info.h
@@ -68,6 +68,7 @@ class ElfInfo {
     std::string app_ver{};
     u32 firmware_ver = 0;
     u32 raw_firmware_ver = 0;
+    u32 sdk_ver = 0;
     PSFAttributes psf_attributes{};
 
     std::filesystem::path splash_path{};
@@ -115,6 +116,11 @@ public:
     [[nodiscard]] u32 RawFirmwareVer() const {
         ASSERT(initialized);
         return raw_firmware_ver;
+    }
+
+    [[nodiscard]] u32 CompiledSdkVer() const {
+        ASSERT(initialized);
+        return sdk_ver;
     }
 
     [[nodiscard]] const PSFAttributes& GetPSFAttributes() const {

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -6,6 +6,7 @@
 #include "common/arch.h"
 #include "common/assert.h"
 #include "common/config.h"
+#include "common/elf_info.h"
 #include "common/error.h"
 #include "core/address_space.h"
 #include "core/libraries/kernel/memory.h"
@@ -120,12 +121,20 @@ struct AddressSpace::Impl {
         u64 supported_user_max = USER_MAX;
         // This is the build number for Windows 11 22H2
         static constexpr s32 AffectedBuildNumber = 22621;
-        if (os_version_info.dwBuildNumber <= AffectedBuildNumber) {
-            // Older Windows builds have an issue with VirtualAlloc2 on higher addresses.
-            // To prevent regressions, limit the maximum address we reserve for this platform.
-            supported_user_max = 0x11000000000ULL;
-            LOG_WARNING(Core, "Windows 10 detected, reducing user max to {:#x} to avoid problems",
-                        supported_user_max);
+
+        // Higher PS4 firmware versions prevent higher address mappings too.
+        s32 sdk_ver = Common::ElfInfo::Instance().CompiledSdkVer();
+        if (os_version_info.dwBuildNumber <= AffectedBuildNumber ||
+            sdk_ver >= Common::ElfInfo::FW_30) {
+            supported_user_max = 0x10000000000ULL;
+            // Only log the message if we're restricting the user max due to operating system.
+            // Since higher compiled SDK versions also get reduced max, we don't need to log there.
+            if (sdk_ver < Common::ElfInfo::FW_30) {
+                LOG_WARNING(
+                    Core,
+                    "Older Windows version detected, reducing user max to {:#x} to avoid problems",
+                    supported_user_max);
+            }
         }
 
         // Determine the free address ranges we can access.

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -104,8 +104,8 @@ struct AddressSpace::Impl {
         GetSystemInfo(&sys_info);
         u64 alignment = sys_info.dwAllocationGranularity;
 
-        // Determine the host OS build number
-        // Retrieve module handle for ntdll
+        // Older Windows builds have a severe performance issue with VirtualAlloc2.
+        // We need to get the host's Windows version, then determine if it needs a workaround.
         auto ntdll_handle = GetModuleHandleW(L"ntdll.dll");
         ASSERT_MSG(ntdll_handle, "Failed to retrieve ntdll handle");
 

--- a/src/core/libraries/kernel/process.cpp
+++ b/src/core/libraries/kernel/process.cpp
@@ -22,7 +22,7 @@ s32 PS4_SYSV_ABI sceKernelIsNeoMode() {
 }
 
 s32 PS4_SYSV_ABI sceKernelGetCompiledSdkVersion(s32* ver) {
-    s32 version = Common::ElfInfo::Instance().RawFirmwareVer();
+    s32 version = Common::ElfInfo::Instance().CompiledSdkVer();
     *ver = version;
     return (version >= 0) ? ORBIS_OK : ORBIS_KERNEL_ERROR_EINVAL;
 }

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -234,8 +234,8 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
     LOG_INFO(Config, "Operating System: {}", os.name());
 
     if (param_sfo_exists) {
-        LOG_INFO(Loader, "Game id: {} Title: {}", id, title);
-        LOG_INFO(Loader, "Fw: {:#x} App Version: {}", fw_version, app_version);
+        LOG_INFO(Loader, "Game id: {}, Title: {}, Version: {}", id, title, app_version);
+        LOG_INFO(Loader, "FW version: {:#x}, SDK version: {:#x}", fw_version, sdk_version);
         LOG_INFO(Loader, "PSVR Supported: {}", (bool)psf_attributes.support_ps_vr.Value());
         LOG_INFO(Loader, "PSVR Required: {}", (bool)psf_attributes.require_ps_vr.Value());
     }

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -235,8 +235,9 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
     LOG_INFO(Config, "Operating System: {}", os.name());
 
     if (param_sfo_exists) {
-        LOG_INFO(Loader, "Game id: {}, Title: {}, Version: {}", id, title, app_version);
-        LOG_INFO(Loader, "FW version: {:#x}, SDK version: {:#x}", fw_version, sdk_version);
+        LOG_INFO(Loader, "Game id: {} Title: {}", id, title);
+        LOG_INFO(Loader, "Fw: {:#x} App Version: {}", fw_version, app_version);
+        LOG_INFO(Loader, "Compiled SDK version: {:#x}", sdk_version);
         LOG_INFO(Loader, "PSVR Supported: {}", (bool)psf_attributes.support_ps_vr.Value());
         LOG_INFO(Loader, "PSVR Required: {}", (bool)psf_attributes.require_ps_vr.Value());
     }

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -135,9 +135,10 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
         }
 
         // Extract sdk version from pubtool info.
-        std::string_view pubtool_info = param_sfo->GetString("PUBTOOLINFO").value_or("Unknown value");
+        std::string_view pubtool_info =
+            param_sfo->GetString("PUBTOOLINFO").value_or("Unknown value");
         u64 sdk_ver_offset = pubtool_info.find("sdk_ver");
-        
+
         if (sdk_ver_offset == pubtool_info.npos) {
             // Default to using firmware version if SDK version is not found.
             sdk_version = fw_version;

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -164,6 +164,7 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
     game_info.app_ver = app_version;
     game_info.firmware_ver = fw_version & 0xFFF00000;
     game_info.raw_firmware_ver = fw_version;
+    game_info.sdk_ver = sdk_version;
     game_info.psf_attributes = psf_attributes;
 
     const auto pic1_path = mnt->GetHostPath("/app0/sce_sys/pic1.png");


### PR DESCRIPTION
While decompiling the PS4 kernel, I've found that every form of memory mapping restricts the maximum address to `0xfc00000000`, but only if the compiled SDK version is at or above firmware 3.00.

Since the expanded address space causes performance issues on Windows specifically, this PR restricts the address space maximum to `0x10000000000` when running newer games that would have this address restriction applied.

To enable this change, I've also addressed some issues with game loading logic. Specifically, I've added logic for getting the actual compiled SDK version from the param.sfo, as opposed to the game's required firmware version. I also shifted ElfInfo initialization earlier in our code, since we're already loading the param.sfo earlier to accomodate separated logs.

This PR is primarily to address the severe Windows-specific loading time regression in Cyberpunk 2077 (see report https://github.com/shadps4-compatibility/shadps4-game-compatibility/issues/33#issuecomment-3483378217 for details), and similar performance regressions visible in my homebrew tests. I plan to properly implement the kernel-side address checks in a future PR.

This PR needs regression tests, particularly from EA titles that abuse high address mappings.