### PR TITLE
ImGui: keep drawing when there's a pending change_layer

### DIFF
--- a/src/imgui/renderer/imgui_core.cpp
+++ b/src/imgui/renderer/imgui_core.cpp
@@ -250,7 +250,7 @@ void Render(const vk::CommandBuffer& cmdbuf, const vk::ImageView& image_view,
 }
 
 bool MustKeepDrawing() {
-    return layers.size() > 1 || DebugState.IsShowingDebugMenuBar();
+    return layers.size() > 1 || change_layers.size() > 1 || DebugState.IsShowingDebugMenuBar();
 }
 
 } // namespace Core


### PR DESCRIPTION
Certain games don't submit any new frames until an error message is dismissed, meaning the old MustKeepDrawing check for if a layer is active doesn't apply since the ErrorMessageUi is held up in change_layers until the next frame.

Fixes Amplitude (CUSA02670) black-screening upon boot.