### PR TITLE
usbd: calloc UsbDevice instead of pointer

### DIFF
--- a/src/core/libraries/usbd/usb_backend.h
+++ b/src/core/libraries/usbd/usb_backend.h
@@ -366,7 +366,7 @@ public:
         const auto desc = FillDeviceDescriptor();
         ASSERT(desc);
 
-        const auto fake = static_cast<UsbDevice*>(calloc(1, sizeof(UsbDevice*)));
+        const auto fake = static_cast<UsbDevice*>(calloc(1, sizeof(UsbDevice)));
         fake->bus_number = 0;
         fake->port_number = 0;
         fake->device_address = 0;


### PR DESCRIPTION
Issue was raised in the Discord server, where when using an emulated backend caused the Skylander games to crash on launch. Bisected this issue to the FreeDeviceList method (specifically line 296) where calling free on the emulated device pointer was causing the crash. I saw that when allocating the emulated device in GetDevice we were using calloc to initialize a pointer with a sizeof UsbDevice pointer rather than size of UsbDevice. Some testing would be appreciated here, as I still get some crashes on Windows with this change (however instead of 100% of the time it is only 33% of the time)