### PR TITLE
usbd: calloc libusb_interface instead of pointer

### DIFF
--- a/src/core/libraries/usbd/usb_backend.h
+++ b/src/core/libraries/usbd/usb_backend.h
@@ -312,7 +312,7 @@ public:
         const auto endpoint_descs = FillEndpointDescriptorPair();
         const auto interface_desc = FillInterfaceDescriptor(endpoint_descs);
 
-        const auto interface = static_cast<libusb_interface*>(calloc(1, sizeof(libusb_interface*)));
+        const auto interface = static_cast<libusb_interface*>(calloc(1, sizeof(libusb_interface)));
         interface->altsetting = interface_desc;
         interface->num_altsetting = 1;
 


### PR DESCRIPTION
The broken calloc will leave `interface->num_altsetting` out of bounds, which will cause crashing on Windows.