### PR TITLE
vk_rasterizer: Optimize full image compute clears

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -889,7 +889,7 @@ bool BufferCache::SynchronizeBuffer(Buffer& buffer, VAddr device_addr, u32 size,
         });
         TouchBuffer(buffer);
     }
-    if (is_texel_buffer) {
+    if (is_texel_buffer && !is_written) {
         return SynchronizeBufferFromImage(buffer, device_addr, size);
     }
     return false;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -112,6 +112,7 @@ private:
 
     bool IsComputeMetaClear(const Pipeline* pipeline);
     bool IsComputeImageCopy(const Pipeline* pipeline);
+    bool IsComputeImageClear(const Pipeline* pipeline);
 
 private:
     friend class VideoCore::BufferCache;


### PR DESCRIPTION
Image clears using compute can be achieved in two ways; either by clearing cmask with compute and later doing a fast clear on the image bound as render target, or by clearing the image itself. The latter option also has different variants, one could bind the memory as a storage image and clear it, or alias as a storage buffer and write it using BUFFER_STORE_FORMAT instructions.

This PR attempts to optimize that last method of clears by detecting compute shaders that are likely to be performing that operation and replacing it with a vkCmdClearColorImage call. On main this operation is done by a large chain of expensive operations (image copy to buffer -> tile dispatch -> clear dispatch -> detile dispatch -> buffer copy to image) which involves decompressing image data into a buffer and executing multiple dispatches to bring data into the format the guest expects for the sake of accuracy