### PR TITLE
Render.Vulkan: Avoid initializing instances of Shader::PsColorBuffer in RefreshGraphicsKey

### DIFF
--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -355,13 +355,12 @@ bool PipelineCache::RefreshGraphicsKey() {
         }
 
         // Fill color target information
-        key.color_buffers[cb] = Shader::PsColorBuffer{
-            .data_format = col_buf.GetDataFmt(),
-            .num_format = col_buf.GetNumberFmt(),
-            .num_conversion = col_buf.GetNumberConversion(),
-            .export_format = regs.color_export_format.GetFormat(cb),
-            .swizzle = col_buf.Swizzle(),
-        };
+        auto& color_buffer = key.color_buffers[cb];
+        color_buffer.data_format = col_buf.GetDataFmt();
+        color_buffer.num_format = col_buf.GetNumberFmt();
+        color_buffer.num_conversion = col_buf.GetNumberConversion();
+        color_buffer.export_format = regs.color_export_format.GetFormat(cb);
+        color_buffer.swizzle = col_buf.Swizzle();
     }
 
     // Compile and bind shader stages
@@ -379,7 +378,7 @@ bool PipelineCache::RefreshGraphicsKey() {
             continue;
         }
         if ((key.mrt_mask & (1u << cb)) == 0) {
-            key.color_buffers[cb] = {};
+            std::memset(&key.color_buffers[cb], 0, sizeof(Shader::PsColorBuffer));
             continue;
         }
 


### PR DESCRIPTION
The bitfield in the `Shader::PsColorBuffer` struct is padded by the compiler due to the misaligned size of it's components. The memory occupied by this padding is not initialized with the default constructor. 
To avoid modifying the `Shader::PsColorBuffer` struct while making our `GraphicsPipelineKey` struct properly hashable, set color_buffer values directly instead of re-initializing.

This fixes pipeline compile spam on certain setups.