### PR TITLE
Make FSR off by default

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -178,7 +178,7 @@ static ConfigEntry<string> fullscreenMode("Windowed");
 static ConfigEntry<string> presentMode("Mailbox");
 static ConfigEntry<bool> isHDRAllowed(false);
 static ConfigEntry<bool> fsrEnabled(false);
-static ConfigEntry<bool> rcasEnabled(false);
+static ConfigEntry<bool> rcasEnabled(true);
 static ConfigEntry<int> rcasAttenuation(250);
 
 // Vulkan

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -177,8 +177,8 @@ static ConfigEntry<bool> isFullscreen(false);
 static ConfigEntry<string> fullscreenMode("Windowed");
 static ConfigEntry<string> presentMode("Mailbox");
 static ConfigEntry<bool> isHDRAllowed(false);
-static ConfigEntry<bool> fsrEnabled(true);
-static ConfigEntry<bool> rcasEnabled(true);
+static ConfigEntry<bool> fsrEnabled(false);
+static ConfigEntry<bool> rcasEnabled(false);
 static ConfigEntry<int> rcasAttenuation(250);
 
 // Vulkan


### PR DESCRIPTION
I personally think it always made more sense to keep FSR disabled by default, and I think it makes even more sense since there's a [regression](https://github.com/shadps4-emu/shadPS4/issues/3794) with FSR, this obviously won't affect anyone who already has shadPS4 installed but for the future I believe it makes more sense to have this off, it can reduce performance a bit and I don't think everyone wants FSR to modify the looks of games for them by default.