### PR TITLE
buffer_cache: Split DMA fault handling code from buffer cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -960,6 +960,8 @@ set(VIDEO_CORE src/video_core/amdgpu/cb_db_extent.h
                src/video_core/buffer_cache/buffer.h
                src/video_core/buffer_cache/buffer_cache.cpp
                src/video_core/buffer_cache/buffer_cache.h
+               src/video_core/buffer_cache/fault_manager.cpp
+               src/video_core/buffer_cache/fault_manager.h
                src/video_core/buffer_cache/memory_tracker.h
                src/video_core/buffer_cache/range_set.h
                src/video_core/buffer_cache/region_definitions.h

--- a/src/shader_recompiler/ir/passes/shader_info_collection_pass.cpp
+++ b/src/shader_recompiler/ir/passes/shader_info_collection_pass.cpp
@@ -190,7 +190,7 @@ void CollectShaderInfoPass(IR::Program& program, const Profile& profile) {
         });
         info.buffers.push_back({
             .used_types = IR::Type::U32,
-            .inline_cbuf = AmdGpu::Buffer::Placeholder(VideoCore::BufferCache::FAULT_BUFFER_SIZE),
+            .inline_cbuf = AmdGpu::Buffer::Placeholder(std::numeric_limits<u32>::max()),
             .buffer_type = BufferType::FaultBuffer,
             .is_written = true,
         });

--- a/src/video_core/buffer_cache/fault_manager.cpp
+++ b/src/video_core/buffer_cache/fault_manager.cpp
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "common/div_ceil.h"
+#include "video_core/buffer_cache/buffer_cache.h"
+#include "video_core/buffer_cache/fault_manager.h"
+#include "video_core/renderer_vulkan/vk_instance.h"
+#include "video_core/renderer_vulkan/vk_platform.h"
+#include "video_core/renderer_vulkan/vk_scheduler.h"
+#include "video_core/renderer_vulkan/vk_shader_util.h"
+
+#include "video_core/host_shaders/fault_buffer_process_comp.h"
+
+namespace VideoCore {
+
+static constexpr size_t MaxPageFaults = 1024;
+static constexpr size_t PageFaultAreaSize = MaxPageFaults * sizeof(u64);
+
+FaultManager::FaultManager(const Vulkan::Instance& instance, Vulkan::Scheduler& scheduler_,
+                           BufferCache& buffer_cache_, u32 caching_pagebits, u64 caching_num_pages_)
+    : scheduler{scheduler_}, buffer_cache{buffer_cache_},
+      caching_pagesize{1ULL << caching_pagebits}, caching_num_pages{caching_num_pages_},
+      fault_buffer_size{caching_num_pages_ / 8},
+      fault_buffer{instance, scheduler, MemoryUsage::DeviceLocal, 0, AllFlags, fault_buffer_size},
+      download_buffer{instance, scheduler, MemoryUsage::Download,
+                      0,        AllFlags,  MaxPendingFaults * PageFaultAreaSize} {
+    const auto device = instance.GetDevice();
+    Vulkan::SetObjectName(device, fault_buffer.Handle(), "Fault Buffer");
+
+    const std::array<vk::DescriptorSetLayoutBinding, 2> bindings = {{
+        {
+            .binding = 0,
+            .descriptorType = vk::DescriptorType::eStorageBuffer,
+            .descriptorCount = 1,
+            .stageFlags = vk::ShaderStageFlagBits::eCompute,
+        },
+        {
+            .binding = 1,
+            .descriptorType = vk::DescriptorType::eStorageBuffer,
+            .descriptorCount = 1,
+            .stageFlags = vk::ShaderStageFlagBits::eCompute,
+        },
+    }};
+    const vk::DescriptorSetLayoutCreateInfo desc_layout_ci = {
+        .flags = vk::DescriptorSetLayoutCreateFlagBits::ePushDescriptorKHR,
+        .bindingCount = 2,
+        .pBindings = bindings.data(),
+    };
+    fault_process_desc_layout =
+        Vulkan::Check(device.createDescriptorSetLayoutUnique(desc_layout_ci));
+
+    std::vector<std::string> defines{{fmt::format("CACHING_PAGEBITS={}", caching_pagebits),
+                                      fmt::format("MAX_PAGE_FAULTS={}", MaxPageFaults)}};
+    const auto module = Vulkan::Compile(HostShaders::FAULT_BUFFER_PROCESS_COMP,
+                                        vk::ShaderStageFlagBits::eCompute, device, defines);
+    Vulkan::SetObjectName(device, module, "Fault Buffer Parser");
+
+    const vk::PipelineShaderStageCreateInfo shader_ci = {
+        .stage = vk::ShaderStageFlagBits::eCompute,
+        .module = module,
+        .pName = "main",
+    };
+
+    const vk::PipelineLayoutCreateInfo layout_info = {
+        .setLayoutCount = 1U,
+        .pSetLayouts = &(*fault_process_desc_layout),
+    };
+    fault_process_pipeline_layout = Vulkan::Check(device.createPipelineLayoutUnique(layout_info));
+
+    const vk::ComputePipelineCreateInfo pipeline_info = {
+        .stage = shader_ci,
+        .layout = *fault_process_pipeline_layout,
+    };
+    fault_process_pipeline = Vulkan::Check(device.createComputePipelineUnique({}, pipeline_info));
+    Vulkan::SetObjectName(device, *fault_process_pipeline, "Fault Buffer Parser Pipeline");
+
+    device.destroyShaderModule(module);
+}
+
+void FaultManager::ProcessFaultBuffer() {
+    if (u64 wait_tick = fault_areas[current_area]) {
+        scheduler.Wait(wait_tick);
+        scheduler.PopPendingOperations();
+    }
+
+    const u32 offset = current_area * PageFaultAreaSize;
+    u8* mapped = download_buffer.mapped_data.data() + offset;
+    std::memset(mapped, 0, PageFaultAreaSize);
+
+    const vk::BufferMemoryBarrier2 pre_barrier = {
+        .srcStageMask = vk::PipelineStageFlagBits2::eAllCommands,
+        .srcAccessMask = vk::AccessFlagBits2::eShaderWrite,
+        .dstStageMask = vk::PipelineStageFlagBits2::eComputeShader,
+        .dstAccessMask = vk::AccessFlagBits2::eShaderRead,
+        .buffer = fault_buffer.Handle(),
+        .offset = 0,
+        .size = fault_buffer_size,
+    };
+    const vk::BufferMemoryBarrier2 post_barrier = {
+        .srcStageMask = vk::PipelineStageFlagBits2::eComputeShader,
+        .srcAccessMask = vk::AccessFlagBits2::eShaderWrite,
+        .dstStageMask = vk::PipelineStageFlagBits2::eAllCommands,
+        .dstAccessMask = vk::AccessFlagBits2::eShaderWrite,
+        .buffer = fault_buffer.Handle(),
+        .offset = 0,
+        .size = fault_buffer_size,
+    };
+    const vk::DescriptorBufferInfo fault_buffer_info = {
+        .buffer = fault_buffer.Handle(),
+        .offset = 0,
+        .range = fault_buffer_size,
+    };
+    const vk::DescriptorBufferInfo download_info = {
+        .buffer = download_buffer.Handle(),
+        .offset = offset,
+        .range = PageFaultAreaSize,
+    };
+    const std::array<vk::WriteDescriptorSet, 2> writes = {{
+        {
+            .dstSet = VK_NULL_HANDLE,
+            .dstBinding = 0,
+            .dstArrayElement = 0,
+            .descriptorCount = 1,
+            .descriptorType = vk::DescriptorType::eStorageBuffer,
+            .pBufferInfo = &fault_buffer_info,
+        },
+        {
+            .dstSet = VK_NULL_HANDLE,
+            .dstBinding = 1,
+            .dstArrayElement = 0,
+            .descriptorCount = 1,
+            .descriptorType = vk::DescriptorType::eStorageBuffer,
+            .pBufferInfo = &download_info,
+        },
+    }};
+    scheduler.EndRendering();
+    const auto cmdbuf = scheduler.CommandBuffer();
+    cmdbuf.pipelineBarrier2(vk::DependencyInfo{
+        .dependencyFlags = vk::DependencyFlagBits::eByRegion,
+        .bufferMemoryBarrierCount = 1,
+        .pBufferMemoryBarriers = &pre_barrier,
+    });
+    cmdbuf.bindPipeline(vk::PipelineBindPoint::eCompute, *fault_process_pipeline);
+    cmdbuf.pushDescriptorSetKHR(vk::PipelineBindPoint::eCompute, *fault_process_pipeline_layout, 0,
+                                writes);
+    // 1 bit per page, 32 pages per workgroup
+    const u32 num_threads = caching_num_pages / 32;
+    const u32 num_workgroups = Common::DivCeil(num_threads, 64u);
+    cmdbuf.dispatch(num_workgroups, 1, 1);
+
+    cmdbuf.pipelineBarrier2(vk::DependencyInfo{
+        .dependencyFlags = vk::DependencyFlagBits::eByRegion,
+        .bufferMemoryBarrierCount = 1,
+        .pBufferMemoryBarriers = &post_barrier,
+    });
+
+    scheduler.DeferOperation([this, mapped, area = current_area] {
+        fault_ranges.Clear();
+        const u64* fault_buf = std::bit_cast<const u64*>(mapped);
+        const u32 fault_count = fault_buf[0];
+        for (u32 i = 1; i <= fault_count; ++i) {
+            fault_ranges.Add(fault_buf[i], caching_pagesize);
+            LOG_INFO(Render_Vulkan, "Accessed non-GPU cached memory at {:#x}", fault_buf[i]);
+        }
+        fault_ranges.ForEach([&](VAddr start, VAddr end) {
+            ASSERT_MSG((end - start) <= std::numeric_limits<u32>::max(),
+                       "Buffer size is too large");
+            buffer_cache.FindBuffer(start, static_cast<u32>(end - start));
+        });
+        fault_areas[area] = 0;
+    });
+
+    fault_areas[current_area++] = scheduler.CurrentTick();
+    current_area %= MaxPendingFaults;
+}
+
+} // namespace VideoCore

--- a/src/video_core/buffer_cache/fault_manager.h
+++ b/src/video_core/buffer_cache/fault_manager.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "video_core/buffer_cache/buffer.h"
+#include "video_core/buffer_cache/range_set.h"
+
+namespace VideoCore {
+
+class BufferCache;
+
+class FaultManager {
+    static constexpr size_t MaxPendingFaults = 8;
+
+public:
+    explicit FaultManager(const Vulkan::Instance& instance, Vulkan::Scheduler& scheduler,
+                          BufferCache& buffer_cache, u32 caching_pagebits, u64 caching_num_pages);
+
+    [[nodiscard]] Buffer* GetFaultBuffer() noexcept {
+        return &fault_buffer;
+    }
+
+    void ProcessFaultBuffer();
+
+private:
+    Vulkan::Scheduler& scheduler;
+    BufferCache& buffer_cache;
+    RangeSet fault_ranges;
+    u64 caching_pagesize;
+    u64 caching_num_pages;
+    u64 fault_buffer_size;
+    Buffer fault_buffer;
+    Buffer download_buffer;
+    std::array<u64, MaxPendingFaults> fault_areas{};
+    u32 current_area{};
+    vk::UniqueDescriptorSetLayout fault_process_desc_layout;
+    vk::UniquePipeline fault_process_pipeline;
+    vk::UniquePipelineLayout fault_process_pipeline_layout;
+};
+
+} // namespace VideoCore

--- a/src/video_core/host_shaders/fault_buffer_process.comp
+++ b/src/video_core/host_shaders/fault_buffer_process.comp
@@ -13,30 +13,23 @@ layout(std430, binding = 0) buffer input_buf {
 layout(std430, binding = 1) buffer output_buf {
     uint64_t download_buffer[];
 };
-
-// Overlap for 32 bit atomics
 layout(std430, binding = 1) buffer output_buf32 {
     uint download_buffer32[];
 };
 
-layout(constant_id = 0) const uint CACHING_PAGEBITS = 0;
-
 void main() {
-    uint id = gl_GlobalInvocationID.x;
+    const uint id = gl_GlobalInvocationID.x;
     uint word = fault_buffer[id];
-    if (word == 0u) {
-        return;
-    }
-    // 1 page per bit
-    uint base_bit = id * 32u;
+    fault_buffer[id] = 0u;
+    const uint base_bit = id * 32u;
     while (word != 0u) {
-        uint bit = findLSB(word);
-        word &= word - 1;
-        uint page = base_bit + bit;
-        uint store_index = atomicAdd(download_buffer32[0], 1u) + 1u;
-        // It is very unlikely, but should we check for overflow?
-        if (store_index < 1024u) { // only support 1024 page faults
-            download_buffer[store_index] = uint64_t(page) << CACHING_PAGEBITS;
+        const uint store_index = atomicAdd(download_buffer32[0], 1u) + 1u;
+        if (store_index >= MAX_PAGE_FAULTS) {
+            return;
         }
+        const uint bit = findLSB(word);
+        word &= word - 1;
+        const uint page = base_bit + bit;
+        download_buffer[store_index] = uint64_t(page) << CACHING_PAGEBITS;
     }
 }

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -407,17 +407,12 @@ bool Rasterizer::BindResources(const Pipeline* pipeline) {
 
     if (uses_dma) {
         // We only use fault buffer for DMA right now.
-        {
-            Common::RecursiveSharedLock lock{mapped_ranges_mutex};
-            for (auto& range : mapped_ranges) {
-                buffer_cache.SynchronizeBuffersInRange(range.lower(),
-                                                       range.upper() - range.lower());
-            }
+        Common::RecursiveSharedLock lock{mapped_ranges_mutex};
+        for (auto& range : mapped_ranges) {
+            buffer_cache.SynchronizeBuffersInRange(range.lower(), range.upper() - range.lower());
         }
-        buffer_cache.MemoryBarrier();
+        fault_process_pending = true;
     }
-
-    fault_process_pending |= uses_dma;
 
     return true;
 }


### PR DESCRIPTION
Pulls out the raw vulkan code from the buffer cache into a separate class that is easier to reason with. Also comes with some small improvements:

* Faults are now processed on a separate buffer, removing the dependency on the buffer cache download buffer which necessitates the hack in Scheduler::Wait.
* Bunch of redundant vkCmdFillBuffer operations have been removed
* Use FindBuffer instead of CreateBuffer when processing fault ranges. Avoids potentially recreating buffer if next frame also faults on that range before its created.