### PR TITLE
audio3d: sceAudio3dPortGetAttributesSupported() - init num_capabilities variable to zero

### DIFF
--- a/src/core/libraries/audio3d/audio3d.cpp
+++ b/src/core/libraries/audio3d/audio3d.cpp
@@ -371,10 +371,13 @@ s32 PS4_SYSV_ABI sceAudio3dPortFreeState() {
 s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported(OrbisAudio3dPortId port_id,
                                                       OrbisAudio3dAttributeId* capabilities,
                                                       u32* num_capabilities) {
-    LOG_DEBUG(Lib_Audio3d, "(STUBBED) called caps = {}, num = {}", static_cast<void*>(capabilities),
+    LOG_ERROR(Lib_Audio3d, "(STUBBED) called caps = {}, num = {}", static_cast<void*>(capabilities),
               static_cast<void*>(num_capabilities));
     if (capabilities == nullptr) {
-        *num_capabilities = 0;
+        // we use ORBIS_AUDIO3D_ATTRIBUTE_PCM, so return only one capability
+        *num_capabilities = 1;
+    } else {
+        capabilities[0] = OrbisAudio3dAttributeId::ORBIS_AUDIO3D_ATTRIBUTE_PCM;
     }
     return ORBIS_OK;
 }

--- a/src/core/libraries/audio3d/audio3d.cpp
+++ b/src/core/libraries/audio3d/audio3d.cpp
@@ -371,8 +371,8 @@ s32 PS4_SYSV_ABI sceAudio3dPortFreeState() {
 s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported(OrbisAudio3dPortId port_id,
                                                       OrbisAudio3dAttributeId* capabilities,
                                                       u32* num_capabilities) {
-    LOG_ERROR(Lib_Audio3d, "(STUBBED) called caps = {}, num = {}", static_cast<void*>(capabilities),
-              static_cast<void*>(num_capabilities));
+    LOG_ERROR(Lib_Audio3d, "(STUBBED) called caps = {}, num = {}", fmt::ptr(capabilities),
+              fmt::ptr(num_capabilities));
     if (capabilities == nullptr) {
         // we use ORBIS_AUDIO3D_ATTRIBUTE_PCM, so return only one capability
         *num_capabilities = 1;

--- a/src/core/libraries/audio3d/audio3d.cpp
+++ b/src/core/libraries/audio3d/audio3d.cpp
@@ -368,8 +368,14 @@ s32 PS4_SYSV_ABI sceAudio3dPortFreeState() {
     return ORBIS_OK;
 }
 
-s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported() {
-    LOG_ERROR(Lib_Audio3d, "(STUBBED) called");
+s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported(OrbisAudio3dPortId port_id,
+                                                      OrbisAudio3dAttributeId* capabilities,
+                                                      unsigned int* num_capabilities) {
+    LOG_DEBUG(Lib_Audio3d, "(STUBBED) called caps = {}, num = {}", static_cast<void*>(capabilities),
+              static_cast<void*>(num_capabilities));
+    if (capabilities == nullptr) {
+        *num_capabilities = 0;
+    }
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/audio3d/audio3d.cpp
+++ b/src/core/libraries/audio3d/audio3d.cpp
@@ -370,7 +370,7 @@ s32 PS4_SYSV_ABI sceAudio3dPortFreeState() {
 
 s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported(OrbisAudio3dPortId port_id,
                                                       OrbisAudio3dAttributeId* capabilities,
-                                                      unsigned int* num_capabilities) {
+                                                      u32* num_capabilities) {
     LOG_DEBUG(Lib_Audio3d, "(STUBBED) called caps = {}, num = {}", static_cast<void*>(capabilities),
               static_cast<void*>(num_capabilities));
     if (capabilities == nullptr) {

--- a/src/core/libraries/audio3d/audio3d.h
+++ b/src/core/libraries/audio3d/audio3d.h
@@ -122,7 +122,7 @@ s32 PS4_SYSV_ABI sceAudio3dPortFlush();
 s32 PS4_SYSV_ABI sceAudio3dPortFreeState();
 s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported(OrbisAudio3dPortId port_id,
                                                       OrbisAudio3dAttributeId* capabilities,
-                                                      unsigned int* num_capabilities);
+                                                      u32* num_capabilities);
 s32 PS4_SYSV_ABI sceAudio3dPortGetList();
 s32 PS4_SYSV_ABI sceAudio3dPortGetParameters();
 s32 PS4_SYSV_ABI sceAudio3dPortGetQueueLevel(OrbisAudio3dPortId port_id, u32* queue_level,

--- a/src/core/libraries/audio3d/audio3d.h
+++ b/src/core/libraries/audio3d/audio3d.h
@@ -120,7 +120,9 @@ s32 PS4_SYSV_ABI sceAudio3dPortCreate();
 s32 PS4_SYSV_ABI sceAudio3dPortDestroy();
 s32 PS4_SYSV_ABI sceAudio3dPortFlush();
 s32 PS4_SYSV_ABI sceAudio3dPortFreeState();
-s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported();
+s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported(OrbisAudio3dPortId port_id,
+                                                      OrbisAudio3dAttributeId* capabilities,
+                                                      unsigned int* num_capabilities);
 s32 PS4_SYSV_ABI sceAudio3dPortGetList();
 s32 PS4_SYSV_ABI sceAudio3dPortGetParameters();
 s32 PS4_SYSV_ABI sceAudio3dPortGetQueueLevel(OrbisAudio3dPortId port_id, u32* queue_level,


### PR DESCRIPTION
when `capabilities` is `nullptr`, sceAudio3dPortGetAttributesSupported() should return count of available `capabilities`
this PR initialized `num_capabilities` variable to zero, to return empty `capabilities`

