### PR TITLE
Add assert on SFO file being empty

### DIFF
--- a/src/core/file_format/psf.cpp
+++ b/src/core/file_format/psf.cpp
@@ -36,6 +36,7 @@ bool PSF::Open(const std::filesystem::path& filepath) {
     }
 
     const u64 psfSize = file.GetSize();
+    ASSERT_MSG(psfSize != 0, "SFO file at {} is empty!", filepath.string());
     std::vector<u8> psf(psfSize);
     file.Seek(0);
     file.Read(psf);


### PR DESCRIPTION
This PR is related to #3397, and provides a better error message on hitting the titular issue, instead of crashing silently on Windows or crashing with an access violation error elsewhere.
```
[Lib.SaveData] <Debug> savedata.cpp:1260 sceSaveDataMount: called dirName: PROFILE, mode: 1010, blocks: 320
[Debug] <Critical> psf.cpp:39 operator(): Assertion Failed!
SFO file at /home/kalaposfos/.local/share/shadPS4/savedata/1/CUSA00003/PROFILE/sce_sys/param.sfo is empty!
```