### PR TITLE
Avoid storing the Tcb pointer on the stack

### DIFF
--- a/src/core/libraries/fiber/fiber.cpp
+++ b/src/core/libraries/fiber/fiber.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "fiber.h"

--- a/src/core/libraries/fiber/fiber.cpp
+++ b/src/core/libraries/fiber/fiber.cpp
@@ -7,7 +7,7 @@
 #include "common/logging/log.h"
 #include "core/libraries/fiber/fiber_error.h"
 #include "core/libraries/libs.h"
-#include "core/tls.h"
+#include "core/libraries/kernel/threads/pthread.h"
 
 namespace Libraries::Fiber {
 
@@ -20,7 +20,7 @@ static constexpr u64 kFiberStackSizeCheck = 0xdeadbeefdeadbeef;
 static std::atomic<u32> context_size_check = false;
 
 OrbisFiberContext* GetFiberContext() {
-    return Core::GetTcbBase()->tcb_fiber;
+    return Libraries::Kernel::g_curthread->tcb->tcb_fiber;
 }
 
 extern "C" s32 PS4_SYSV_ABI _sceFiberSetJmp(OrbisFiberContext* ctx) asm("_sceFiberSetJmp");
@@ -269,7 +269,7 @@ s32 PS4_SYSV_ABI sceFiberRunImpl(OrbisFiber* fiber, void* addr_context, u64 size
         return ORBIS_FIBER_ERROR_INVALID;
     }
 
-    Core::Tcb* tcb = Core::GetTcbBase();
+    Core::Tcb* tcb = Libraries::Kernel::g_curthread->tcb;
     if (tcb->tcb_fiber) {
         return ORBIS_FIBER_ERROR_PERMISSION;
     }

--- a/src/core/libraries/fiber/fiber.cpp
+++ b/src/core/libraries/fiber/fiber.cpp
@@ -6,8 +6,8 @@
 #include "common/elf_info.h"
 #include "common/logging/log.h"
 #include "core/libraries/fiber/fiber_error.h"
-#include "core/libraries/libs.h"
 #include "core/libraries/kernel/threads/pthread.h"
+#include "core/libraries/libs.h"
 
 namespace Libraries::Fiber {
 

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -368,7 +368,7 @@ bool Linker::Resolve(const std::string& name, Loader::SymbolType sym_type, Modul
 void* Linker::TlsGetAddr(u64 module_index, u64 offset) {
     std::scoped_lock lk{mutex};
 
-    DtvEntry* dtv_table = GetTcbBase()->tcb_dtv;
+    DtvEntry* dtv_table = Libraries::Kernel::g_curthread->tcb->tcb_dtv;
     if (dtv_table[0].counter != dtv_generation_counter) {
         // Generation counter changed, a dynamic module was either loaded or unloaded.
         const u32 old_num_dtvs = dtv_table[1].counter;
@@ -381,7 +381,7 @@ void* Linker::TlsGetAddr(u64 module_index, u64 offset) {
         delete[] dtv_table;
 
         // Update TCB pointer.
-        GetTcbBase()->tcb_dtv = new_dtv_table;
+        Libraries::Kernel::g_curthread->tcb->tcb_dtv = new_dtv_table;
         dtv_table = new_dtv_table;
     }
 

--- a/src/core/tls.cpp
+++ b/src/core/tls.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <mutex>

--- a/src/core/tls.cpp
+++ b/src/core/tls.cpp
@@ -178,10 +178,6 @@ void SetTcbBase(void* image_address) {
 
 #endif
 
-Tcb* GetTcbBase() {
-    return Libraries::Kernel::g_curthread->tcb;
-}
-
 thread_local std::once_flag init_tls_flag;
 
 void EnsureThreadInitialized() {

--- a/src/core/tls.cpp
+++ b/src/core/tls.cpp
@@ -165,10 +165,10 @@ void SetTcbBase(void* image_address) {
 }
 
 Tcb* GetTcbBase() {
-    void* tcb = nullptr;
+    static thread_local Tcb* tcb = nullptr;
     const int ret = syscall(SYS_arch_prctl, ARCH_GET_GS, &tcb);
     ASSERT_MSG(ret == 0, "Failed to get GS base: errno {}", errno);
-    return static_cast<Tcb*>(tcb);
+    return tcb;
 }
 
 #else

--- a/src/core/tls.h
+++ b/src/core/tls.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once

--- a/src/core/tls.h
+++ b/src/core/tls.h
@@ -36,9 +36,6 @@ u32 GetTcbKey();
 /// Sets the data pointer to the TCB block.
 void SetTcbBase(void* image_address);
 
-/// Retrieves Tcb structure for the calling thread.
-Tcb* GetTcbBase();
-
 /// Makes sure TLS is initialized for the thread before entering guest.
 void EnsureThreadInitialized();
 


### PR DESCRIPTION
This PR fixes some of the random crashes in SotC on Linux.