### PR TITLE
renderer_vulkan: Remove primitive restart disable support check.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -94,10 +94,6 @@ GraphicsPipeline::GraphicsPipeline(
     const auto topology = LiverpoolToVK::PrimitiveType(key.prim_type);
     const vk::PipelineInputAssemblyStateCreateInfo input_assembly = {
         .topology = topology,
-        // Avoid warning spam on all pipelines about unsupported restart disable, if not supported.
-        // However, must be false for list topologies to avoid validation errors.
-        .primitiveRestartEnable =
-            !instance.IsPrimitiveRestartDisableSupported() && !IsPrimitiveTopologyList(topology),
     };
 
     const bool is_rect_list = key.prim_type == AmdGpu::PrimitiveType::RectList;
@@ -156,12 +152,9 @@ GraphicsPipeline::GraphicsPipeline(
         vk::DynamicState::eStencilCompareMask, vk::DynamicState::eStencilWriteMask,
         vk::DynamicState::eStencilOp,          vk::DynamicState::eCullMode,
         vk::DynamicState::eFrontFace,          vk::DynamicState::eRasterizerDiscardEnable,
-        vk::DynamicState::eLineWidth,
+        vk::DynamicState::eLineWidth,          vk::DynamicState::ePrimitiveRestartEnable,
     };
 
-    if (instance.IsPrimitiveRestartDisableSupported()) {
-        dynamic_states.push_back(vk::DynamicState::ePrimitiveRestartEnable);
-    }
     if (instance.IsDepthBoundsSupported()) {
         dynamic_states.push_back(vk::DynamicState::eDepthBoundsTestEnable);
         dynamic_states.push_back(vk::DynamicState::eDepthBounds);

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -411,11 +411,6 @@ public:
                properties.limits.framebufferStencilSampleCounts;
     }
 
-    /// Returns whether disabling primitive restart is supported.
-    bool IsPrimitiveRestartDisableSupported() const {
-        return driver_id != vk::DriverId::eMoltenvk;
-    }
-
     /// Returns true if logic ops are supported by the device.
     bool IsLogicOpSupported() const {
         return features.logicOp;

--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -290,9 +290,7 @@ void DynamicState::Commit(const Instance& instance, const vk::CommandBuffer& cmd
     }
     if (dirty_state.primitive_restart_enable) {
         dirty_state.primitive_restart_enable = false;
-        if (instance.IsPrimitiveRestartDisableSupported()) {
-            cmdbuf.setPrimitiveRestartEnable(primitive_restart_enable);
-        }
+        cmdbuf.setPrimitiveRestartEnable(primitive_restart_enable);
     }
     if (dirty_state.rasterizer_discard_enable) {
         dirty_state.rasterizer_discard_enable = false;


### PR DESCRIPTION
This is supported in MoltenVK now via private API.