### PR TITLE
Render.Recompiler: Implement V_FLOOR_F64

### DIFF
--- a/src/shader_recompiler/frontend/format.cpp
+++ b/src/shader_recompiler/frontend/format.cpp
@@ -1837,11 +1837,17 @@ constexpr std::array<InstFormat, 71> InstructionFormatVOP1 = {{
     // 22 = V_CVT_F64_U32
     {InstClass::VectorConv, InstCategory::VectorALU, 1, 1, ScalarType::Uint32, ScalarType::Float64},
     // 23 = V_TRUNC_F64
-    {InstClass::VectorConv, InstCategory::VectorALU, 1, 1, ScalarType::Float64,
+    {InstClass::VectorFpRound64, InstCategory::VectorALU, 1, 1, ScalarType::Float64,
      ScalarType::Float64},
-    {},
-    {},
-    {},
+    // 24 = V_CEIL_F64
+    {InstClass::VectorFpRound64, InstCategory::VectorALU, 1, 1, ScalarType::Float64,
+     ScalarType::Float64},
+    // 25 = V_RNDNE_F64
+    {InstClass::VectorFpRound64, InstCategory::VectorALU, 1, 1, ScalarType::Float64,
+     ScalarType::Float64},
+    // 26 = V_FLOOR_F64
+    {InstClass::VectorFpRound64, InstCategory::VectorALU, 1, 1, ScalarType::Float64,
+     ScalarType::Float64},
     {},
     {},
     {},

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -201,6 +201,7 @@ public:
     void V_CVT_F32_F64(const GcnInst& inst);
     void V_CVT_F64_F32(const GcnInst& inst);
     void V_CVT_F32_UBYTE(u32 index, const GcnInst& inst);
+    void V_FLOOR_F64(const GcnInst& inst);
     void V_FRACT_F32(const GcnInst& inst);
     void V_TRUNC_F32(const GcnInst& inst);
     void V_CEIL_F32(const GcnInst& inst);

--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -810,7 +810,7 @@ void Translator::V_CVT_F32_UBYTE(u32 index, const GcnInst& inst) {
 
 void Translator::V_FLOOR_F64(const GcnInst& inst) {
     const IR::F64 src0{GetSrc64<IR::F64>(inst.src[0])};
-    SetDst(inst.dst[0], ir.FPFloor(src0));
+    SetDst64(inst.dst[0], ir.FPFloor(src0));
 }
 
 void Translator::V_FRACT_F32(const GcnInst& inst) {

--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -142,6 +142,8 @@ void Translator::EmitVectorAlu(const GcnInst& inst) {
         return V_CVT_F32_UBYTE(2, inst);
     case Opcode::V_CVT_F32_UBYTE3:
         return V_CVT_F32_UBYTE(3, inst);
+    case Opcode::V_FLOOR_F64:
+        return V_FLOOR_F64(inst);
     case Opcode::V_FRACT_F32:
         return V_FRACT_F32(inst);
     case Opcode::V_TRUNC_F32:
@@ -804,6 +806,11 @@ void Translator::V_CVT_F32_UBYTE(u32 index, const GcnInst& inst) {
     const IR::U32 src0{GetSrc(inst.src[0])};
     const IR::U32 byte = ir.BitFieldExtract(src0, ir.Imm32(8 * index), ir.Imm32(8));
     SetDst(inst.dst[0], ir.ConvertUToF(32, 32, byte));
+}
+
+void Translator::V_FLOOR_F64(const GcnInst& inst) {
+    const IR::F64 src0{GetSrc64<IR::F64>(inst.src[0])};
+    SetDst(inst.dst[0], ir.FPFloor(src0));
 }
 
 void Translator::V_FRACT_F32(const GcnInst& inst) {


### PR DESCRIPTION
Used by Just Cause 4, though that title is a little rough to test at the moment.
I also added format table definitions for the other F64 rounding ops, though they didn't come up in this title, so I didn't implement them.

This PR doesn't affect the title in any way currently, but my testing shows this implementation is at least enough to pass an error I happened to get after torturing my GPU drivers enough.
```
[Debug] <Critical> decode.cpp:264 operator(): Assertion Failed!
Instruction format table incomplete for opcode  (489, encoding = 0x7e000000)
```
[CUSA09254.zip](https://github.com/user-attachments/files/23738625/CUSA09254.zip)

