### PR TITLE
Sdl message box when no args provided

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -186,7 +186,7 @@ int main(int argc, char* argv[]) {
         if (!SDL_ShowSimpleMessageBox(
                 SDL_MESSAGEBOX_INFORMATION, "shadPS4",
                 "This is a CLI application. Please use the QTLauncher for a GUI.", nullptr))
-            std::cout << "Could not display SDL message box! Error: " << SDL_GetError() << "\n";
+            std::cerr << "Could not display SDL message box! Error: " << SDL_GetError() << "\n";
         int dummy = 0; // one does not simply pass 0 directly
         arg_map.at("-h")(dummy);
         return -1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -183,7 +183,9 @@ int main(int argc, char* argv[]) {
          }}};
 
     if (argc == 1) {
-        if (!SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_INFORMATION, "shadPS4", "This is a CLI application. Please use the QTLauncher for a GUI.", nullptr))
+        if (!SDL_ShowSimpleMessageBox(
+                SDL_MESSAGEBOX_INFORMATION, "shadPS4",
+                "This is a CLI application. Please use the QTLauncher for a GUI.", nullptr))
             std::cout << "Could not display SDL message box! Error: " << SDL_GetError() << "\n";
         int dummy = 0; // one does not simply pass 0 directly
         arg_map.at("-h")(dummy);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include "string"
 #include "system_error"
 #include "unordered_map"
+#include <SDL3/SDL_messagebox.h>
 
 #include <fmt/core.h>
 #include "common/config.h"
@@ -182,6 +183,8 @@ int main(int argc, char* argv[]) {
          }}};
 
     if (argc == 1) {
+        if (!SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_INFORMATION, "shadPS4", "This is a CLI application. Please use the QTLauncher for a GUI.", nullptr))
+            std::cout << "Could not display SDL message box! Error: " << SDL_GetError() << "\n";
         int dummy = 0; // one does not simply pass 0 directly
         arg_map.at("-h")(dummy);
         return -1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <SDL3/SDL_messagebox.h>
 #include "functional"
 #include "iostream"
 #include "string"
 #include "system_error"
 #include "unordered_map"
-#include <SDL3/SDL_messagebox.h>
 
 #include <fmt/core.h>
 #include "common/config.h"


### PR DESCRIPTION
With the recent split of the QT launcher and SDL CLI application. There has been  a small increase in users confused that double clicking the application is not launching properly, or that it only spawns a command window. 

This small patch attempts to address this by providing a small message box cross platform using SDL to inform the user that they should consider using QT Launcher if that was their intention.

This should only trigger when argc is 1 and therefore other SDL users provided the correct flags should not notice this popup. 