### PR TITLE
video_core: GPU watchdog thread

### DIFF
--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -99,8 +99,9 @@ void Liverpool::Process(std::stop_token stoken) {
     while (!stoken.stop_requested()) {
         {
             std::unique_lock lk{submit_mutex};
-            Common::CondvarWait(submit_cv, lk, stoken,
-                                [this] { return num_commands || num_submits || submit_done || pop_pending; });
+            Common::CondvarWait(submit_cv, lk, stoken, [this] {
+                return num_commands || num_submits || submit_done || pop_pending;
+            });
         }
         if (stoken.stop_requested()) {
             break;
@@ -165,7 +166,7 @@ void Liverpool::Watchdog(std::stop_token stoken) {
         {
             std::unique_lock lk(submit_mutex);
             Common::CondvarWait(submit_cv, lk, stoken,
-                                [this] {return !submit_done && !pop_pending; });
+                                [this] { return !submit_done && !pop_pending; });
         }
 
         if (stoken.stop_requested()) {

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -108,7 +108,7 @@ void Liverpool::Process(std::stop_token stoken) {
         }
 
         if (pop_pending) {
-            rasterizer->PopPendingOpèrations();
+            rasterizer->PopPendingOperations();
             pop_pending = false;
             continue;
         }

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -6,6 +6,7 @@
 #include <condition_variable>
 #include <coroutine>
 #include <exception>
+#include <functional>
 #include <mutex>
 #include <semaphore>
 #include <span>
@@ -92,7 +93,11 @@ public:
     }
 
     void BindRasterizer(Vulkan::Rasterizer* rasterizer_) {
+        const bool start_watchdog = !rasterizer;
         rasterizer = rasterizer_;
+        if (start_watchdog) {
+            watchdog_thread = std::jthread(std::bind_front(&Liverpool::Watchdog, this));
+        }
     }
 
     template <bool wait_done = false>

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -185,6 +185,7 @@ private:
 
     void ProcessCommands();
     void Process(std::stop_token stoken);
+    void Watchdog(std::stop_token stoken);
 
     struct GpuQueue {
         std::mutex m_access{};
@@ -223,9 +224,11 @@ private:
     Vulkan::Rasterizer* rasterizer{};
     Libraries::VideoOut::VideoOutPort* vo_port{};
     std::jthread process_thread{};
+    std::jthread watchdog_thread{};
     std::atomic<u32> num_submits{};
     std::atomic<u32> num_commands{};
     std::atomic<bool> submit_done{};
+    std::atomic<bool> pop_pending{};
     std::mutex submit_mutex;
     std::condition_variable_any submit_cv;
     std::queue<Common::UniqueFunction<void>> command_queue{};

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -379,6 +379,14 @@ void Rasterizer::OnSubmit() {
     buffer_cache.RunGarbageCollector();
 }
 
+void Rasterizer::WaitForPendingOperation() {
+    scheduler.WaitForPendingOperation();
+}
+
+void Rasterizer::PopPendingOpèrations() {
+    scheduler.PopPendingOperations();
+}
+
 bool Rasterizer::BindResources(const Pipeline* pipeline) {
     if (IsComputeImageCopy(pipeline) || IsComputeMetaClear(pipeline) ||
         IsComputeImageClear(pipeline)) {

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -383,7 +383,7 @@ void Rasterizer::WaitForPendingOperation() {
     scheduler.WaitForPendingOperation();
 }
 
-void Rasterizer::PopPendingOpèrations() {
+void Rasterizer::PopPendingOperations() {
     scheduler.PopPendingOperations();
 }
 

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -69,7 +69,7 @@ public:
     void Finish();
     void OnSubmit();
     void WaitForPendingOperation();
-    void PopPendingOpèrations();
+    void PopPendingOperations();
 
     PipelineCache& GetPipelineCache() {
         return pipeline_cache;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -68,6 +68,8 @@ public:
     u64 Flush();
     void Finish();
     void OnSubmit();
+    void WaitForPendingOperation();
+    void PopPendingOpèrations();
 
     PipelineCache& GetPipelineCache() {
         return pipeline_cache;

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -52,9 +52,6 @@ TextureCache::TextureCache(const Vulkan::Instance& instance_, Vulkan::Scheduler&
         std::max<u64>(std::min(device_local_memory - min_vacancy_critical, min_spacing_critical),
                       DEFAULT_CRITICAL_GC_MEMORY));
     trigger_gc_memory = static_cast<u64>((device_local_memory - mem_threshold) / 2);
-
-    downloaded_images_thread =
-        std::jthread([&](const std::stop_token& token) { DownloadedImagesThread(token); });
 }
 
 TextureCache::~TextureCache() = default;
@@ -125,33 +122,10 @@ void TextureCache::DownloadImageMemory(ImageId image_id) {
     cmdbuf.copyImageToBuffer(image.GetImage(), vk::ImageLayout::eTransferSrcOptimal,
                              download_buffer.Handle(), image_download);
 
-    {
-        std::unique_lock lock(downloaded_images_mutex);
-        downloaded_images_queue.emplace(scheduler.CurrentTick(), image.info.guest_address, download,
-                                        download_size);
-        downloaded_images_cv.notify_one();
-    }
-}
-
-void TextureCache::DownloadedImagesThread(const std::stop_token& token) {
-    auto* memory = Core::Memory::Instance();
-    while (!token.stop_requested()) {
-        DownloadedImage image;
-        {
-            std::unique_lock lock{downloaded_images_mutex};
-            downloaded_images_cv.wait(lock, token,
-                                      [this] { return !downloaded_images_queue.empty(); });
-            if (token.stop_requested()) {
-                break;
-            }
-            image = downloaded_images_queue.front();
-            downloaded_images_queue.pop();
-        }
-
-        scheduler.GetMasterSemaphore()->Wait(image.tick);
-        memory->TryWriteBacking(std::bit_cast<u8*>(image.device_addr), image.download,
-                                image.download_size);
-    }
+    scheduler.DeferOperation([this, addr = image.info.guest_address, download, download_size] {
+        Core::Memory::Instance()->TryWriteBacking(std::bit_cast<u8*>(addr), download,
+                                                  download_size);
+    });
 }
 
 void TextureCache::MarkAsMaybeDirty(ImageId image_id, Image& image) {

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -314,15 +314,6 @@ private:
     Common::LeastRecentlyUsedCache<ImageId, u64> lru_cache;
     PageTable page_table;
     std::mutex mutex;
-    struct DownloadedImage {
-        u64 tick;
-        VAddr device_addr;
-        void* download;
-        size_t download_size;
-    };
-    std::queue<DownloadedImage> downloaded_images_queue;
-    std::mutex downloaded_images_mutex;
-    std::condition_variable_any downloaded_images_cv;
     std::jthread downloaded_images_thread;
     struct MetaDataInfo {
         enum class Type {


### PR DESCRIPTION
This incorporates a thread that acts as a watchdog to prevent scheduler pending operations to not run when no submits have been done.

This should allow to use pending operations to download image memory insteeed of using a separate thread just for that. Using a thread just for downloading textures to memory prevents downloading textures in a syncrhonous way.

@squidbus You made the change to add the image download thread. What was the game giving issues that made you add it? I haven't tested this.