### PR TITLE
Lib.Kernel: Report accurate CPU mode through sceKernelGetCpumode

### DIFF
--- a/src/core/libraries/kernel/process.cpp
+++ b/src/core/libraries/kernel/process.cpp
@@ -42,6 +42,16 @@ s32 PS4_SYSV_ABI sceKernelGetCompiledSdkVersion(s32* ver) {
 }
 
 s32 PS4_SYSV_ABI sceKernelGetCpumode() {
+    LOG_DEBUG(Lib_Kernel, "called");
+    auto& attrs = Common::ElfInfo::Instance().GetPSFAttributes();
+    u32 is_cpu6 = attrs.six_cpu_mode.Value();
+    u32 is_cpu7 = attrs.seven_cpu_mode.Value();
+    if (is_cpu6 == 1 && is_cpu7 == 1) {
+        return 2;
+    }
+    if (is_cpu7 == 1) {
+        return 5;
+    }
     return 0;
 }
 


### PR DESCRIPTION
Wrote this up yesterday to try fixing an error that showed up in the Discord's help channel.
I confirmed this matches real hardware behavior (at least compared to my PS4 Pro), but I haven't heard back about whatever this is supposed to fix.

This PR derives appropriate sceKernelGetCpumode return values from the param.sfo's cpumode attributes, based on some testing I did with homebrew.