### PR TITLE
video_core: Scheduler priority pending operation queue

### DIFF
--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -180,7 +180,7 @@ void Scheduler::PriorityPendingOpsThread(std::stop_token stoken) {
         {
             std::unique_lock lk(priority_pending_ops_mutex);
             priority_pending_ops_cv.wait(lk, stoken,
-                                         [this] { !priority_pending_ops.empty(); });
+                                         [this] { return !priority_pending_ops.empty(); });
             if (stoken.stop_requested()) {
                 break;
             }

--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -20,7 +20,8 @@ Scheduler::Scheduler(const Instance& instance)
     profiler_scope = reinterpret_cast<tracy::VkCtxScope*>(std::malloc(sizeof(tracy::VkCtxScope)));
 #endif
     AllocateWorkerCommandBuffers();
-    priority_pending_ops_thread = std::jthread(std::bind_front(&Scheduler::PriorityPendingOpsThread, this));
+    priority_pending_ops_thread =
+        std::jthread(std::bind_front(&Scheduler::PriorityPendingOpsThread, this));
 }
 
 Scheduler::~Scheduler() {
@@ -174,7 +175,7 @@ void Scheduler::SubmitExecution(SubmitInfo& info) {
 void Scheduler::PriorityPendingOpsThread(std::stop_token stoken) {
     Common::SetCurrentThreadName("shadPS4:GpuSchedPriorityPendingOpsRunner");
     boost::container::small_vector<Common::UniqueFunction<void>, 16> callbacks;
-    
+
     while (!stoken.stop_requested()) {
         u64 tick;
         {

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -412,7 +412,7 @@ public:
     void DeferPriorityOperation(Common::UniqueFunction<void>&& func) {
         {
             std::unique_lock lk(priority_pending_ops_mutex);
-            pending_ops.emplace(std::move(func), CurrentTick());
+            priority_pending_ops.emplace(std::move(func), CurrentTick());
         }
         priority_pending_ops_cv.notify_one();
     }

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -5,6 +5,7 @@
 
 #include <condition_variable>
 #include <mutex>
+#include <thread>
 #include <queue>
 
 #include "common/unique_function.h"
@@ -401,8 +402,17 @@ public:
     }
 
     /// Defers an operation until the gpu has reached the current cpu tick.
+    /// Will be run when submitting or calling PopPendingOperations.
     void DeferOperation(Common::UniqueFunction<void>&& func) {
         pending_ops.emplace(std::move(func), CurrentTick());
+    }
+
+    /// Defers an operation until the gpu has reached the current cpu tick.
+    /// Runs as soon as possible in another thread.
+    void DeferPriorityOperation(Common::UniqueFunction<void>&& func) {
+        std::unique_lock lk(priority_pending_ops_mutex);
+        pending_ops.emplace(std::move(func), CurrentTick());
+        priority_pending_ops_cv.notify_one();
     }
 
     static std::mutex submit_mutex;
@@ -411,6 +421,8 @@ private:
     void AllocateWorkerCommandBuffers();
 
     void SubmitExecution(SubmitInfo& info);
+
+    void PriorityPendingOpsThread(std::stop_token stoken);
 
 private:
     const Instance& instance;
@@ -424,6 +436,10 @@ private:
         u64 gpu_tick;
     };
     std::queue<PendingOp> pending_ops;
+    std::queue<PendingOp> priority_pending_ops;
+    std::mutex priority_pending_ops_mutex;
+    std::condition_variable_any priority_pending_ops_cv;
+    std::jthread priority_pending_ops_thread;
     RenderState render_state;
     bool is_rendering = false;
     tracy::VkCtxScope* profiler_scope{};

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -410,8 +410,10 @@ public:
     /// Defers an operation until the gpu has reached the current cpu tick.
     /// Runs as soon as possible in another thread.
     void DeferPriorityOperation(Common::UniqueFunction<void>&& func) {
-        std::unique_lock lk(priority_pending_ops_mutex);
-        pending_ops.emplace(std::move(func), CurrentTick());
+        {
+            std::unique_lock lk(priority_pending_ops_mutex);
+            pending_ops.emplace(std::move(func), CurrentTick());
+        }
         priority_pending_ops_cv.notify_one();
     }
 

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -122,9 +122,11 @@ void TextureCache::DownloadImageMemory(ImageId image_id) {
     cmdbuf.copyImageToBuffer(image.GetImage(), vk::ImageLayout::eTransferSrcOptimal,
                              download_buffer.Handle(), image_download);
 
-    scheduler.DeferPriorityOperation([this, device_addr = image.info.guest_address, download, download_size] {
-        Core::Memory::Instance()->TryWriteBacking(std::bit_cast<u8*>(device_addr), download, download_size);
-    });
+    scheduler.DeferPriorityOperation(
+        [this, device_addr = image.info.guest_address, download, download_size] {
+            Core::Memory::Instance()->TryWriteBacking(std::bit_cast<u8*>(device_addr), download,
+                                                      download_size);
+        });
 }
 
 void TextureCache::MarkAsMaybeDirty(ImageId image_id, Image& image) {

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -52,9 +52,6 @@ TextureCache::TextureCache(const Vulkan::Instance& instance_, Vulkan::Scheduler&
         std::max<u64>(std::min(device_local_memory - min_vacancy_critical, min_spacing_critical),
                       DEFAULT_CRITICAL_GC_MEMORY));
     trigger_gc_memory = static_cast<u64>((device_local_memory - mem_threshold) / 2);
-
-    downloaded_images_thread =
-        std::jthread([&](const std::stop_token& token) { DownloadedImagesThread(token); });
 }
 
 TextureCache::~TextureCache() = default;
@@ -125,33 +122,9 @@ void TextureCache::DownloadImageMemory(ImageId image_id) {
     cmdbuf.copyImageToBuffer(image.GetImage(), vk::ImageLayout::eTransferSrcOptimal,
                              download_buffer.Handle(), image_download);
 
-    {
-        std::unique_lock lock(downloaded_images_mutex);
-        downloaded_images_queue.emplace(scheduler.CurrentTick(), image.info.guest_address, download,
-                                        download_size);
-        downloaded_images_cv.notify_one();
-    }
-}
-
-void TextureCache::DownloadedImagesThread(const std::stop_token& token) {
-    auto* memory = Core::Memory::Instance();
-    while (!token.stop_requested()) {
-        DownloadedImage image;
-        {
-            std::unique_lock lock{downloaded_images_mutex};
-            downloaded_images_cv.wait(lock, token,
-                                      [this] { return !downloaded_images_queue.empty(); });
-            if (token.stop_requested()) {
-                break;
-            }
-            image = downloaded_images_queue.front();
-            downloaded_images_queue.pop();
-        }
-
-        scheduler.GetMasterSemaphore()->Wait(image.tick);
-        memory->TryWriteBacking(std::bit_cast<u8*>(image.device_addr), image.download,
-                                image.download_size);
-    }
+    scheduler.DeferPriorityOperation([this, device_addr = image.info.guest_address, download, download_size] {
+        Core::Memory::Instance()->TryWriteBacking(std::bit_cast<u8*>(device_addr), download, download_size);
+    });
 }
 
 void TextureCache::MarkAsMaybeDirty(ImageId image_id, Image& image) {

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -314,16 +314,6 @@ private:
     Common::LeastRecentlyUsedCache<ImageId, u64> lru_cache;
     PageTable page_table;
     std::mutex mutex;
-    struct DownloadedImage {
-        u64 tick;
-        VAddr device_addr;
-        void* download;
-        size_t download_size;
-    };
-    std::queue<DownloadedImage> downloaded_images_queue;
-    std::mutex downloaded_images_mutex;
-    std::condition_variable_any downloaded_images_cv;
-    std::jthread downloaded_images_thread;
     struct MetaDataInfo {
         enum class Type {
             CMask,


### PR DESCRIPTION
This should make it more straightforward to execute operations as soon as possible insteeed of doing so whenever PopPendingOperations is called on the Gpu processing thread.

This replaces the dedicated thread for downloading image memory.