### PR TITLE
Revert minimum CPU requirements to match the PS4's instruction set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,9 +53,9 @@ else()
 endif()
 
 if (ARCHITECTURE STREQUAL "x86_64")
-    # Target x86-64-v3 CPU architecture as this is a good balance between supporting performance critical
-    # instructions like AVX2 and maintaining support for older CPUs.
-    add_compile_options(-march=x86-64-v3)
+    # Target the same CPU architecture as the PS4, to maintain the same level of compatibility.
+    # Exclude SSE4a as it is only available on AMD CPUs.
+    add_compile_options(-march=btver2 -mtune=generic -mno-sse4a)
 endif()
 
 if (APPLE AND ARCHITECTURE STREQUAL "x86_64" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")


### PR DESCRIPTION
Originally the PR contained on optional CMake flag for using just the PS4's instruction set, and now it's changed to lowering the baseline to that level. This means that the AVX2 requirement is now dropped, and from some preliminary testing, this doesn't seem to affect performance in any way. The main target platform this PR aims to make compatible is PS4 Linux, as that is the only CPU that people using a PS4 emulator is reasonably expected to have that falls into the small list of processors that are at or above the PS4's requirements, but were under shadPS4's.