### PR TITLE
cli: add `--show-fps` to the CLI launcher

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -199,6 +199,7 @@ static ConfigEntry<bool> isDebugDump(false);
 static ConfigEntry<bool> isShaderDebug(false);
 static ConfigEntry<bool> isSeparateLogFilesEnabled(false);
 static ConfigEntry<bool> isFpsColor(true);
+static ConfigEntry<bool> showFpsCounter(false);
 static ConfigEntry<bool> logEnabled(true);
 
 // GUI
@@ -464,6 +465,14 @@ bool isPipelineCacheArchived() {
 
 bool fpsColor() {
     return isFpsColor.get();
+}
+
+bool getShowFpsCounter() {
+    return showFpsCounter.get();
+}
+
+void setShowFpsCounter(bool enable, bool is_game_specific) {
+    showFpsCounter.set(enable, is_game_specific);
 }
 
 bool isLoggingEnabled() {
@@ -969,6 +978,7 @@ void load(const std::filesystem::path& path, bool is_game_specific) {
         isSeparateLogFilesEnabled.setFromToml(debug, "isSeparateLogFilesEnabled", is_game_specific);
         isShaderDebug.setFromToml(debug, "CollectShader", is_game_specific);
         isFpsColor.setFromToml(debug, "FPSColor", is_game_specific);
+        showFpsCounter.setFromToml(debug, "ShowFpsCounter", is_game_specific);
         logEnabled.setFromToml(debug, "logEnabled", is_game_specific);
         current_version = toml::find_or<std::string>(debug, "ConfigVersion", current_version);
     }
@@ -1188,6 +1198,7 @@ void save(const std::filesystem::path& path, bool is_game_specific) {
         data["GPU"]["internalScreenHeight"] = internalScreenHeight.base_value;
         data["GPU"]["patchShaders"] = shouldPatchShaders.base_value;
         data["Debug"]["FPSColor"] = isFpsColor.base_value;
+        data["Debug"]["ShowFpsCounter"] = showFpsCounter.base_value;
     }
 
     // Sorting of TOML sections
@@ -1296,6 +1307,7 @@ void setDefaultValues(bool is_game_specific) {
 
         // Debug
         isFpsColor.base_value = true;
+        showFpsCounter.base_value = false;
     }
 }
 

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -978,7 +978,7 @@ void load(const std::filesystem::path& path, bool is_game_specific) {
         isSeparateLogFilesEnabled.setFromToml(debug, "isSeparateLogFilesEnabled", is_game_specific);
         isShaderDebug.setFromToml(debug, "CollectShader", is_game_specific);
         isFpsColor.setFromToml(debug, "FPSColor", is_game_specific);
-        showFpsCounter.setFromToml(debug, "ShowFpsCounter", is_game_specific);
+        showFpsCounter.setFromToml(debug, "showFpsCounter", is_game_specific);
         logEnabled.setFromToml(debug, "logEnabled", is_game_specific);
         current_version = toml::find_or<std::string>(debug, "ConfigVersion", current_version);
     }
@@ -1198,7 +1198,7 @@ void save(const std::filesystem::path& path, bool is_game_specific) {
         data["GPU"]["internalScreenHeight"] = internalScreenHeight.base_value;
         data["GPU"]["patchShaders"] = shouldPatchShaders.base_value;
         data["Debug"]["FPSColor"] = isFpsColor.base_value;
-        data["Debug"]["ShowFpsCounter"] = showFpsCounter.base_value;
+        data["Debug"]["showFpsCounter"] = showFpsCounter.base_value;
     }
 
     // Sorting of TOML sections

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -126,6 +126,8 @@ bool getPSNSignedIn();
 void setPSNSignedIn(bool sign, bool is_game_specific = false);
 bool patchShaders(); // no set
 bool fpsColor();     // no set
+bool getShowFpsCounter();
+void setShowFpsCounter(bool enable, bool is_game_specific = false);
 bool isNeoModeConsole();
 void setNeoMode(bool enable, bool is_game_specific = false);
 bool isDevKitConsole();

--- a/src/core/devtools/layer.cpp
+++ b/src/core/devtools/layer.cpp
@@ -311,6 +311,7 @@ static void LoadSettings(const char* line) {
 
 void L::SetupSettings() {
     frame_graph.is_open = true;
+    show_simple_fps = Config::getShowFpsCounter();
 
     using SettingLoader = void (*)(const char*);
 
@@ -472,6 +473,11 @@ namespace Overlay {
 
 void ToggleSimpleFps() {
     show_simple_fps = !show_simple_fps;
+    visibility_toggled = true;
+}
+
+void SetSimpleFps(bool enabled) {
+    show_simple_fps = enabled;
     visibility_toggled = true;
 }
 

--- a/src/core/devtools/layer.h
+++ b/src/core/devtools/layer.h
@@ -30,6 +30,7 @@ private:
 namespace Overlay {
 
 void ToggleSimpleFps();
+void SetSimpleFps(bool enabled);
 void ToggleQuitWindow();
 
 } // namespace Overlay

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -175,13 +175,14 @@ int main(int argc, char* argv[]) {
              game_folder = folder;
          }},
         {"--wait-for-debugger", [&](int& i) { waitForDebugger = true; }},
-        {"--wait-for-pid", [&](int& i) {
-            if (++i >= argc) {
-                std::cerr << "Error: Missing argument for --wait-for-pid\n";
-                exit(1);
-            }
-            waitPid = std::stoi(argv[i]);
-        }},
+        {"--wait-for-pid",
+         [&](int& i) {
+             if (++i >= argc) {
+                 std::cerr << "Error: Missing argument for --wait-for-pid\n";
+                 exit(1);
+             }
+             waitPid = std::stoi(argv[i]);
+         }},
         {"--show-fps", [&](int& i) { Config::setShowFpsCounter(true); }}};
 
     if (argc == 1) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,6 +67,7 @@ int main(int argc, char* argv[]) {
                     "values, ignores the config file(s) entirely.\n"
                     "  --config-global               Run the emulator with the base config file "
                     "only, ignores game specific configs.\n"
+                    "  --show-fps                    Enable FPS counter display at startup\n"
                     "  -h, --help                    Display this help message\n";
              exit(0);
          }},
@@ -175,12 +176,13 @@ int main(int argc, char* argv[]) {
          }},
         {"--wait-for-debugger", [&](int& i) { waitForDebugger = true; }},
         {"--wait-for-pid", [&](int& i) {
-             if (++i >= argc) {
-                 std::cerr << "Error: Missing argument for --wait-for-pid\n";
-                 exit(1);
-             }
-             waitPid = std::stoi(argv[i]);
-         }}};
+            if (++i >= argc) {
+                std::cerr << "Error: Missing argument for --wait-for-pid\n";
+                exit(1);
+            }
+            waitPid = std::stoi(argv[i]);
+        }},
+        {"--show-fps", [&](int& i) { Config::setShowFpsCounter(true); }}};
 
     if (argc == 1) {
         if (!SDL_ShowSimpleMessageBox(


### PR DESCRIPTION
It's possible to toggle this via the config, but for quick tests, this is much more convenient. Launch the emulator with `--show-fps` to toggle the simple FPS counter.