### PR TITLE
Fixed potential UAF in `EqueueInternal::ScheduleEvent`

### DIFF
--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -65,8 +65,16 @@ bool EqueueInternal::ScheduleEvent(u64 id, s16 filter,
         it->timer->expires_at(it->timer->expiry() + event.timer_interval);
     }
 
+    std::weak_ptr weak_token = m_life_token;
+
     it->timer->async_wait(
-        [this, event_data = event.event, callback](const boost::system::error_code& ec) {
+        [this, event_data = event.event, callback, weak_token](const boost::system::error_code& ec) {
+
+            // If the token already expires return to avoid calling to callback with an invalid pointer.
+            if (weak_token.expired()) {
+                return;
+            }
+
             if (ec) {
                 if (ec != boost::system::errc::operation_canceled) {
                     LOG_ERROR(Kernel_Event, "Timer callback error: {}", ec.message());

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -180,6 +180,7 @@ private:
     std::vector<EqueueEvent> m_events;
     std::condition_variable m_cond;
     std::unordered_map<u64, SmallTimer> m_small_timers;
+    std::shared_ptr<void> m_life_token = std::make_shared<int>(0);
 };
 
 u64 PS4_SYSV_ABI sceKernelGetEventData(const SceKernelEvent* ev);


### PR DESCRIPTION
### Problem
Asynchronous timer callbacks in `ScheduleEvent()` could access the this pointer after the destruction of `EqueueInternal` object.

### Changes
- Added a life token to `EqueueInternal`.
- When scheduling a timer, we capture a weak_ptr to this token in the async_wait callback.
- Before executing the callback, check if the weak token has expired (indicating the `EqueueInternal` object has been destroyed)