### PR TITLE
Kernel.Vmm: Remove hack from #2726

### DIFF
--- a/src/core/cpu_patches.cpp
+++ b/src/core/cpu_patches.cpp
@@ -755,11 +755,12 @@ static bool PatchesIllegalInstructionHandler(void* context) {
                 Common::Decoder::Instance()->decodeInstruction(instruction, operands, code_address);
             if (ZYAN_SUCCESS(status) && instruction.mnemonic == ZydisMnemonic::ZYDIS_MNEMONIC_UD2)
                 [[unlikely]] {
-                UNREACHABLE_MSG("ud2 at code address {:#x}", (u64)code_address);
+                UNREACHABLE_MSG("ud2 at code address {:#x}", reinterpret_cast<u64>(code_address));
             }
-            LOG_ERROR(Core, "Failed to patch address {:x} -- mnemonic: {}", (u64)code_address,
-                      ZYAN_SUCCESS(status) ? ZydisMnemonicGetString(instruction.mnemonic)
-                                           : "Failed to decode");
+            UNREACHABLE_MSG("Failed to patch address {:x} -- mnemonic: {}",
+                            reinterpret_cast<u64>(code_address),
+                            ZYAN_SUCCESS(status) ? ZydisMnemonicGetString(instruction.mnemonic)
+                                                 : "Failed to decode");
         }
     }
 

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -107,14 +107,6 @@ void Linker::Execute(const std::vector<std::string>& args) {
     // Simulate sceKernelInternalMemory mapping, a mapping usually performed during libkernel init.
     // Due to the large size of this mapping, failing to emulate it causes issues in some titles.
     // This mapping belongs in the system reserved area, which starts at address 0x880000000.
-    static constexpr VAddr KernelAllocBase = 0x880000000ULL;
-    static constexpr s64 InternalMemorySize = 0x1000000;
-    void* addr_out{reinterpret_cast<void*>(KernelAllocBase)};
-
-    s32 ret = Libraries::Kernel::sceKernelMapNamedFlexibleMemory(&addr_out, InternalMemorySize, 3,
-                                                                 0, "SceKernelInternalMemory");
-    ASSERT_MSG(ret == 0, "Unable to perform sceKernelInternalMemory mapping");
-
     main_thread.Run([this, module, &args](std::stop_token) {
         Common::SetCurrentThreadName("GAME_MainThread");
         if (auto& ipc = IPC::Instance()) {

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -104,9 +104,6 @@ void Linker::Execute(const std::vector<std::string>& args) {
 
     memory->SetupMemoryRegions(fmem_size, use_extended_mem1, use_extended_mem2);
 
-    // Simulate sceKernelInternalMemory mapping, a mapping usually performed during libkernel init.
-    // Due to the large size of this mapping, failing to emulate it causes issues in some titles.
-    // This mapping belongs in the system reserved area, which starts at address 0x880000000.
     main_thread.Run([this, module, &args](std::stop_token) {
         Common::SetCurrentThreadName("GAME_MainThread");
         if (auto& ipc = IPC::Instance()) {


### PR DESCRIPTION
In #2726, I mistakenly interpreted the SceKernelInternalMemory memory mapping I was seeing in some tests as a flexible memory mapping. As I've learned more about the PS4, I've learned that this mapping is treated as a system mapping, which falls under a different budget (which we don't yet emulate).

Through local tests, I've found that keeping this inaccurate behavior around will cause significant regressions when we start making library HLEs more accurate (especially pieces of the network stack), so I'm reverting this for now.

If I remember correctly, this should fix the regression seen in https://github.com/shadps4-compatibility/shadps4-game-compatibility/issues/370, though since I don't own the game, I cannot verify this.

This will regress The Last of Us™ Part II. This is not a title I plan to fix, as the inaccuracies in reported flexible memory come from behaviors that require time consuming, hacky fixes to handle properly on an emulator planning to be as high level as we are.

I've also replaced a cpu patches error for failing to patch an address with an unreachable. The error being hit would trigger an infinite loop of log spam (see reports like https://github.com/shadps4-compatibility/shadps4-game-compatibility/issues/615)