### PR TITLE
Network: Fixed null string crash on sceNetResolverCreate

### DIFF
--- a/src/core/libraries/network/net.cpp
+++ b/src/core/libraries/network/net.cpp
@@ -1356,9 +1356,9 @@ int PS4_SYSV_ABI sceNetResolverConnectDestroy() {
     return ORBIS_OK;
 }
 
-int PS4_SYSV_ABI sceNetResolverCreate(const char* name, int poolid, int flags) {
-    const char* safe_name = name ? name : "(null)";
-    LOG_INFO(Lib_Net, "name = {}, poolid = {}, flags = {}", safe_name, poolid, flags);
+int PS4_SYSV_ABI sceNetResolverCreate(char* name, int poolid, int flags) {
+    name = name ? name : "";
+    LOG_INFO(Lib_Net, "name = {}, poolid = {}, flags = {}", name, poolid, flags);
 
     if (flags != 0) {
         *sceNetErrnoLoc() = ORBIS_NET_EINVAL;
@@ -1369,8 +1369,8 @@ int PS4_SYSV_ABI sceNetResolverCreate(const char* name, int poolid, int flags) {
     auto* resolver = FDTable::Instance()->GetFile(fd);
     resolver->is_opened = true;
     resolver->type = Core::FileSys::FileType::Resolver;
-    resolver->resolver = std::make_shared<Resolver>(safe_name, poolid, flags);
-    resolver->m_guest_name = safe_name;
+    resolver->resolver = std::make_shared<Resolver>(name, poolid, flags);
+    resolver->m_guest_name = name;
     return fd;
 }
 

--- a/src/core/libraries/network/net.cpp
+++ b/src/core/libraries/network/net.cpp
@@ -1356,9 +1356,9 @@ int PS4_SYSV_ABI sceNetResolverConnectDestroy() {
     return ORBIS_OK;
 }
 
-int PS4_SYSV_ABI sceNetResolverCreate(char* name, int poolid, int flags) {
-    name = name ? name : "";
-    LOG_INFO(Lib_Net, "name = {}, poolid = {}, flags = {}", name, poolid, flags);
+int PS4_SYSV_ABI sceNetResolverCreate(const char* name, int poolid, int flags) {
+    const char* safe_name = name ? name : "";
+    LOG_INFO(Lib_Net, "name = {}, poolid = {}, flags = {}", safe_name, poolid, flags);
 
     if (flags != 0) {
         *sceNetErrnoLoc() = ORBIS_NET_EINVAL;
@@ -1369,8 +1369,8 @@ int PS4_SYSV_ABI sceNetResolverCreate(char* name, int poolid, int flags) {
     auto* resolver = FDTable::Instance()->GetFile(fd);
     resolver->is_opened = true;
     resolver->type = Core::FileSys::FileType::Resolver;
-    resolver->resolver = std::make_shared<Resolver>(name, poolid, flags);
-    resolver->m_guest_name = name;
+    resolver->resolver = std::make_shared<Resolver>(safe_name, poolid, flags);
+    resolver->m_guest_name = safe_name;
     return fd;
 }
 

--- a/src/core/libraries/network/net.cpp
+++ b/src/core/libraries/network/net.cpp
@@ -1357,7 +1357,8 @@ int PS4_SYSV_ABI sceNetResolverConnectDestroy() {
 }
 
 int PS4_SYSV_ABI sceNetResolverCreate(const char* name, int poolid, int flags) {
-    LOG_INFO(Lib_Net, "name = {}, poolid = {}, flags = {}", name, poolid, flags);
+    const char* safe_name = name ? name : "(null)";
+    LOG_INFO(Lib_Net, "name = {}, poolid = {}, flags = {}", safe_name, poolid, flags);
 
     if (flags != 0) {
         *sceNetErrnoLoc() = ORBIS_NET_EINVAL;
@@ -1368,8 +1369,8 @@ int PS4_SYSV_ABI sceNetResolverCreate(const char* name, int poolid, int flags) {
     auto* resolver = FDTable::Instance()->GetFile(fd);
     resolver->is_opened = true;
     resolver->type = Core::FileSys::FileType::Resolver;
-    resolver->resolver = std::make_shared<Resolver>(name, poolid, flags);
-    resolver->m_guest_name = name;
+    resolver->resolver = std::make_shared<Resolver>(safe_name, poolid, flags);
+    resolver->m_guest_name = safe_name;
     return fd;
 }
 


### PR DESCRIPTION
### Problem

`sceNetResolverCreate` would crash on boot when a null `name` parameter was passed.

### Changes

- Added a null-safe pointer wrapper for the `name` parameter
- Uses a fallback string to avoid dereferencing a null pointer
- Updated `sceNetResolverCreate` to use the safe pointer instead of the raw input

### Game
CUSA24769
name: Gran Turismo 7
version: 1.0.0