### PR TITLE
Add thread names to log lines

### DIFF
--- a/src/common/logging/text_formatter.cpp
+++ b/src/common/logging/text_formatter.cpp
@@ -24,8 +24,9 @@ std::string FormatLogMessage(const Entry& entry) {
     const char* class_name = GetLogClassName(entry.log_class);
     const char* level_name = GetLevelName(entry.log_level);
 
-    return fmt::format("[{}] ({}) <{}> {}:{} {}: {}", class_name, Common::GetCurrentThreadName(),
-                       level_name, entry.filename, entry.line_num, entry.function, entry.message);
+    return fmt::format("[{}] <{}> ({}) {}:{} {}: {}", class_name, level_name,
+                       Common::GetCurrentThreadName(), entry.filename, entry.line_num,
+                       entry.function, entry.message);
 }
 
 void PrintMessage(const Entry& entry) {

--- a/src/common/logging/text_formatter.cpp
+++ b/src/common/logging/text_formatter.cpp
@@ -24,8 +24,8 @@ std::string FormatLogMessage(const Entry& entry) {
     const char* class_name = GetLogClassName(entry.log_class);
     const char* level_name = GetLevelName(entry.log_level);
 
-    return fmt::format("[{}] ({}) <{}> {}:{} {}: {}", class_name, Common::GetCurrentThreadName(), level_name,
-                       entry.filename, entry.line_num, entry.function, entry.message);
+    return fmt::format("[{}] ({}) <{}> {}:{} {}: {}", class_name, Common::GetCurrentThreadName(),
+                       level_name, entry.filename, entry.line_num, entry.function, entry.message);
 }
 
 void PrintMessage(const Entry& entry) {

--- a/src/common/logging/text_formatter.cpp
+++ b/src/common/logging/text_formatter.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: Copyright 2014 Citra Emulator Project
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <array>

--- a/src/common/logging/text_formatter.cpp
+++ b/src/common/logging/text_formatter.cpp
@@ -13,6 +13,7 @@
 #include "common/logging/log.h"
 #include "common/logging/log_entry.h"
 #include "common/logging/text_formatter.h"
+#include "core/signals.h"
 
 namespace Common::Log {
 
@@ -23,8 +24,8 @@ std::string FormatLogMessage(const Entry& entry) {
     const char* class_name = GetLogClassName(entry.log_class);
     const char* level_name = GetLevelName(entry.log_level);
 
-    return fmt::format("[{}] <{}> {}:{} {}: {}", class_name, level_name, entry.filename,
-                       entry.line_num, entry.function, entry.message);
+    return fmt::format("[{}] ({}) <{}> {}:{} {}: {}", class_name, Core::GetThreadName(), level_name,
+                       entry.filename, entry.line_num, entry.function, entry.message);
 }
 
 void PrintMessage(const Entry& entry) {

--- a/src/common/logging/text_formatter.cpp
+++ b/src/common/logging/text_formatter.cpp
@@ -13,7 +13,7 @@
 #include "common/logging/log.h"
 #include "common/logging/log_entry.h"
 #include "common/logging/text_formatter.h"
-#include "core/signals.h"
+#include "common/thread.h"
 
 namespace Common::Log {
 
@@ -24,7 +24,7 @@ std::string FormatLogMessage(const Entry& entry) {
     const char* class_name = GetLogClassName(entry.log_class);
     const char* level_name = GetLevelName(entry.log_level);
 
-    return fmt::format("[{}] ({}) <{}> {}:{} {}: {}", class_name, Core::GetThreadName(), level_name,
+    return fmt::format("[{}] ({}) <{}> {}:{} {}: {}", class_name, Common::GetCurrentThreadName(), level_name,
                        entry.filename, entry.line_num, entry.function, entry.message);
 }
 

--- a/src/common/thread.cpp
+++ b/src/common/thread.cpp
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2013 Dolphin Emulator Project
 // SPDX-FileCopyrightText: 2014 Citra Emulator Project
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <ctime>
@@ -34,10 +35,6 @@
 #ifdef __FreeBSD__
 #define cpu_set_t cpuset_t
 #endif
-
-namespace Libraries::Kernel {
-extern thread_local Libraries::Kernel::Pthread* g_curthread;
-}
 
 namespace Common {
 

--- a/src/common/thread.h
+++ b/src/common/thread.h
@@ -46,4 +46,6 @@ public:
     }
 };
 
+std::string GetCurrentThreadName();
+
 } // namespace Common

--- a/src/common/thread.h
+++ b/src/common/thread.h
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2013 Dolphin Emulator Project
 // SPDX-FileCopyrightText: 2014 Citra Emulator Project
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -22,12 +22,6 @@ namespace Core {
 
 #if defined(_WIN32)
 
-std::string GetThreadName() {
-    PWSTR name;
-    GetThreadDescription(GetCurrentThread(), &name);
-    return Common::UTF16ToUTF8(name);
-}
-
 static LONG WINAPI SignalHandler(EXCEPTION_POINTERS* pExp) noexcept {
     const auto* signals = Signals::Instance();
 
@@ -48,14 +42,6 @@ static LONG WINAPI SignalHandler(EXCEPTION_POINTERS* pExp) noexcept {
 }
 
 #else
-
-std::string GetThreadName() {
-    char name[256];
-    if (pthread_getname_np(pthread_self(), name, sizeof(name)) != 0) {
-        return "<unknown name>";
-    }
-    return std::string{name};
-}
 
 static std::string DisassembleInstruction(void* code_address) {
     char buffer[256] = "<unable to decode>";

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -80,18 +80,16 @@ static void SignalHandler(int sig, siginfo_t* info, void* raw_context) {
     case SIGBUS: {
         const bool is_write = Common::IsWriteError(raw_context);
         if (!signals->DispatchAccessViolation(raw_context, info->si_addr)) {
-            UNREACHABLE_MSG(
-                "Unhandled access violation in thread '{}' at code address {}: {} address {}",
-                GetThreadName(), fmt::ptr(code_address), is_write ? "Write to" : "Read from",
-                fmt::ptr(info->si_addr));
+            UNREACHABLE_MSG("Unhandled access violation at code address {}: {} address {}",
+                            fmt::ptr(code_address), is_write ? "Write to" : "Read from",
+                            fmt::ptr(info->si_addr));
         }
         break;
     }
     case SIGILL:
         if (!signals->DispatchIllegalInstruction(raw_context)) {
-            UNREACHABLE_MSG("Unhandled illegal instruction in thread '{}' at code address {}: {}",
-                            GetThreadName(), fmt::ptr(code_address),
-                            DisassembleInstruction(code_address));
+            UNREACHABLE_MSG("Unhandled illegal instruction at code address {}: {}",
+                            fmt::ptr(code_address), DisassembleInstruction(code_address));
         }
         break;
     case SIGUSR1: { // Sleep thread until signal is received

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2024-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "common/arch.h"

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "common/arch.h"

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -9,7 +9,6 @@
 
 #ifdef _WIN32
 #include <windows.h>
-#include "common/string_util.h"
 #else
 #include <csignal>
 #include <pthread.h>

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -9,6 +9,7 @@
 
 #ifdef _WIN32
 #include <windows.h>
+#include "common/string_util.h"
 #else
 #include <csignal>
 #include <pthread.h>
@@ -20,6 +21,12 @@
 namespace Core {
 
 #if defined(_WIN32)
+
+std::string GetThreadName() {
+    PWSTR name;
+    GetThreadDescription(GetCurrentThread(), &name);
+    return Common::UTF16ToUTF8(name);
+}
 
 static LONG WINAPI SignalHandler(EXCEPTION_POINTERS* pExp) noexcept {
     const auto* signals = Signals::Instance();

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -42,7 +42,7 @@ static LONG WINAPI SignalHandler(EXCEPTION_POINTERS* pExp) noexcept {
 
 #else
 
-static std::string GetThreadName() {
+std::string GetThreadName() {
     char name[256];
     if (pthread_getname_np(pthread_self(), name, sizeof(name)) != 0) {
         return "<unknown name>";

--- a/src/core/signals.h
+++ b/src/core/signals.h
@@ -54,4 +54,6 @@ private:
 
 using Signals = Common::Singleton<SignalDispatch>;
 
+std::string GetThreadName();
+
 } // namespace Core

--- a/src/core/signals.h
+++ b/src/core/signals.h
@@ -54,6 +54,4 @@ private:
 
 using Signals = Common::Singleton<SignalDispatch>;
 
-std::string GetThreadName();
-
 } // namespace Core


### PR DESCRIPTION
This PR adds which thread each log line came from. This is useful for debugging race conditions and the like.
Example:
```
[Loader] <Info> (shadps4) emulator.cpp:196 Run: Starting shadps4 emulator v0.13.1 WIP 
```