### PR TITLE
logging: fix thread name logging for async logs

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: Copyright 2014 Citra Emulator Project
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <chrono>

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -219,6 +219,7 @@ public:
             .line_num = line_num,
             .function = function,
             .message = std::move(message),
+            .thread = Common::GetCurrentThreadName(),
         };
         if (Config::getLogType() == "async") {
             message_queue.EmplaceWait(entry);

--- a/src/common/logging/log_entry.h
+++ b/src/common/logging/log_entry.h
@@ -21,6 +21,7 @@ struct Entry {
     u32 line_num = 0;
     std::string function;
     std::string message;
+    std::string thread;
 };
 
 } // namespace Common::Log

--- a/src/common/logging/text_formatter.cpp
+++ b/src/common/logging/text_formatter.cpp
@@ -14,7 +14,6 @@
 #include "common/logging/log.h"
 #include "common/logging/log_entry.h"
 #include "common/logging/text_formatter.h"
-#include "common/thread.h"
 
 namespace Common::Log {
 
@@ -25,9 +24,8 @@ std::string FormatLogMessage(const Entry& entry) {
     const char* class_name = GetLogClassName(entry.log_class);
     const char* level_name = GetLevelName(entry.log_level);
 
-    return fmt::format("[{}] <{}> ({}) {}:{} {}: {}", class_name, level_name,
-                       Common::GetCurrentThreadName(), entry.filename, entry.line_num,
-                       entry.function, entry.message);
+    return fmt::format("[{}] <{}> ({}) {}:{} {}: {}", class_name, level_name, entry.thread,
+                       entry.filename, entry.line_num, entry.function, entry.message);
 }
 
 void PrintMessage(const Entry& entry) {


### PR DESCRIPTION
Pros: this fixes async logs showing (shadPS4:Log) as the caller thread for everything
Cons: async logging gets a bit more sync than before