### PR TITLE
Lib.Videodec2: Stub sceVideodec2AllocateComputeQueue to return a valid computeQueue pointer.

### DIFF
--- a/src/core/libraries/libs.cpp
+++ b/src/core/libraries/libs.cpp
@@ -120,13 +120,13 @@ void InitHLELibs(Core::Loader::SymbolsResolver* sym) {
     Libraries::ErrorDialog::RegisterLib(sym);
     Libraries::ImeDialog::RegisterLib(sym);
     Libraries::AvPlayer::RegisterLib(sym);
-    Libraries::Vdec2::RegisterLib(sym);
+    Libraries::Videodec::RegisterLib(sym);
+    Libraries::Videodec2::RegisterLib(sym);
     Libraries::Audio3d::RegisterLib(sym);
     Libraries::Ime::RegisterLib(sym);
     Libraries::GameLiveStreaming::RegisterLib(sym);
     Libraries::SharePlay::RegisterLib(sym);
     Libraries::Remoteplay::RegisterLib(sym);
-    Libraries::Videodec::RegisterLib(sym);
     Libraries::RazorCpu::RegisterLib(sym);
     Libraries::Move::RegisterLib(sym);
     Libraries::Fiber::RegisterLib(sym);

--- a/src/core/libraries/videodec/videodec2.cpp
+++ b/src/core/libraries/videodec/videodec2.cpp
@@ -34,7 +34,35 @@ s32 PS4_SYSV_ABI
 sceVideodec2AllocateComputeQueue(const OrbisVideodec2ComputeConfigInfo* computeCfgInfo,
                                  const OrbisVideodec2ComputeMemoryInfo* computeMemInfo,
                                  OrbisVideodec2ComputeQueue* computeQueue) {
-    LOG_INFO(Lib_Vdec2, "called");
+    LOG_WARNING(Lib_Vdec2, "called");
+    if (!computeCfgInfo || !computeMemInfo || !computeQueue) {
+        LOG_ERROR(Lib_Vdec2, "Invalid arguments");
+        return ORBIS_VIDEODEC2_ERROR_ARGUMENT_POINTER;
+    }
+    if (computeCfgInfo->thisSize != sizeof(OrbisVideodec2ComputeConfigInfo) ||
+        computeMemInfo->thisSize != sizeof(OrbisVideodec2ComputeMemoryInfo)) {
+        LOG_ERROR(Lib_Vdec2, "Invalid struct size");
+        return ORBIS_VIDEODEC2_ERROR_STRUCT_SIZE;
+    }
+    if (computeCfgInfo->reserved0 != 0 || computeCfgInfo->reserved1 != 0) {
+        LOG_ERROR(Lib_Vdec2, "Invalid compute config");
+        return ORBIS_VIDEODEC2_ERROR_CONFIG_INFO;
+    }
+    if (computeCfgInfo->computePipeId >= 4) {
+        LOG_ERROR(Lib_Vdec2, "Invalid compute pipe id");
+        return ORBIS_VIDEODEC2_ERROR_COMPUTE_PIPE_ID;
+    }
+    if (computeCfgInfo->computeQueueId >= 7) {
+        LOG_ERROR(Lib_Vdec2, "Invalid compute queue id");
+        return ORBIS_VIDEODEC2_ERROR_COMPUTE_QUEUE_ID;
+    }
+    if (!computeMemInfo->cpuGpuMemory) {
+        LOG_ERROR(Lib_Vdec2, "Invalid memory pointer");
+        return ORBIS_VIDEODEC2_ERROR_MEMORY_POINTER;
+    }
+
+    // The real library returns a pointer to memory inside cpuGpuMemory
+    *computeQueue = computeMemInfo->cpuGpuMemory;
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/videodec/videodec2.cpp
+++ b/src/core/libraries/videodec/videodec2.cpp
@@ -48,11 +48,11 @@ sceVideodec2AllocateComputeQueue(const OrbisVideodec2ComputeConfigInfo* computeC
         LOG_ERROR(Lib_Vdec2, "Invalid compute config");
         return ORBIS_VIDEODEC2_ERROR_CONFIG_INFO;
     }
-    if (computeCfgInfo->computePipeId >= 4) {
+    if (computeCfgInfo->computePipeId > 4) {
         LOG_ERROR(Lib_Vdec2, "Invalid compute pipe id");
         return ORBIS_VIDEODEC2_ERROR_COMPUTE_PIPE_ID;
     }
-    if (computeCfgInfo->computeQueueId >= 7) {
+    if (computeCfgInfo->computeQueueId > 7) {
         LOG_ERROR(Lib_Vdec2, "Invalid compute queue id");
         return ORBIS_VIDEODEC2_ERROR_COMPUTE_QUEUE_ID;
     }

--- a/src/core/libraries/videodec/videodec2.cpp
+++ b/src/core/libraries/videodec/videodec2.cpp
@@ -8,7 +8,7 @@
 #include "core/libraries/videodec/videodec2_impl.h"
 #include "core/libraries/videodec/videodec_error.h"
 
-namespace Libraries::Vdec2 {
+namespace Libraries::Videodec2 {
 
 static constexpr u64 kMinimumMemorySize = 16_MB; ///> Fake minimum memory size for querying
 
@@ -261,4 +261,4 @@ void RegisterLib(Core::Loader::SymbolsResolver* sym) {
                  sceVideodec2GetPictureInfo);
 }
 
-} // namespace Libraries::Vdec2
+} // namespace Libraries::Videodec2

--- a/src/core/libraries/videodec/videodec2.h
+++ b/src/core/libraries/videodec/videodec2.h
@@ -10,7 +10,7 @@
 namespace Core::Loader {
 class SymbolsResolver;
 }
-namespace Libraries::Vdec2 {
+namespace Libraries::Videodec2 {
 
 class VdecDecoder;
 
@@ -138,4 +138,4 @@ s32 PS4_SYSV_ABI sceVideodec2GetPictureInfo(const OrbisVideodec2OutputInfo* outp
                                             void* p1stPictureInfo, void* p2ndPictureInfo);
 
 void RegisterLib(Core::Loader::SymbolsResolver* sym);
-} // namespace Libraries::Vdec2
+} // namespace Libraries::Videodec2

--- a/src/core/libraries/videodec/videodec2_avc.h
+++ b/src/core/libraries/videodec/videodec2_avc.h
@@ -5,7 +5,7 @@
 
 #include "common/types.h"
 
-namespace Libraries::Vdec2 {
+namespace Libraries::Videodec2 {
 
 struct OrbisVideodec2AvcPictureInfo {
     u64 thisSize;
@@ -127,4 +127,4 @@ struct OrbisVideodec2LegacyAvcPictureInfo {
 };
 static_assert(sizeof(OrbisVideodec2LegacyAvcPictureInfo) == 0x68);
 
-} // namespace Libraries::Vdec2
+} // namespace Libraries::Videodec2

--- a/src/core/libraries/videodec/videodec2_impl.cpp
+++ b/src/core/libraries/videodec/videodec2_impl.cpp
@@ -9,7 +9,7 @@
 
 #include "common/support/avdec.h"
 
-namespace Libraries::Vdec2 {
+namespace Libraries::Videodec2 {
 
 std::vector<OrbisVideodec2AvcPictureInfo> gPictureInfos;
 std::vector<OrbisVideodec2LegacyAvcPictureInfo> gLegacyPictureInfos;
@@ -278,4 +278,4 @@ AVFrame* VdecDecoder::ConvertNV12Frame(AVFrame& frame) {
     return nv12_frame;
 }
 
-} // namespace Libraries::Vdec2
+} // namespace Libraries::Videodec2

--- a/src/core/libraries/videodec/videodec2_impl.h
+++ b/src/core/libraries/videodec/videodec2_impl.h
@@ -13,7 +13,7 @@ extern "C" {
 #include <libswscale/swscale.h>
 }
 
-namespace Libraries::Vdec2 {
+namespace Libraries::Videodec2 {
 
 extern std::vector<OrbisVideodec2AvcPictureInfo> gPictureInfos;
 extern std::vector<OrbisVideodec2LegacyAvcPictureInfo> gLegacyPictureInfos;
@@ -37,4 +37,4 @@ private:
     SwsContext* mSwsContext = nullptr;
 };
 
-} // namespace Libraries::Vdec2
+} // namespace Libraries::Videodec2


### PR DESCRIPTION
Some games check the computeQueue output of sceVideodec2AllocateComputeQueue before performing video decoding. These titles were hanging when they should play videos as a result.

Based on some decompilation and debugging of this library's code, it appears that the returned compute queue pointer is always part of the inputted cpuGpuMemory, so to make affected titles work, I just return the cpuGpuMemory pointer as the compute queue.

This fix brings NEO : The World Ends with You ingame, with no noticeable cutscene issues.

<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/56992092-1c21-4143-a2b2-82ac41938dce" />

<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/0aec421a-788a-45a0-9c54-99fcb7239c6f" />

<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/d5f0c385-cc8a-4c37-9815-a848b7bff02c" />

My own testing doesn't reveal any regressions, though I don't have many games using libSceVideodec2.