### PR TITLE
Core: Add libSceRtc, libSceJpegDec, libSceJpegEnc, and libScePngEnc LLEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,9 @@ The following firmware modules are supported and must be placed in shadPS4's `sy
 | Modules                 | Modules                 | Modules                 | Modules                 |  
 |-------------------------|-------------------------|-------------------------|-------------------------|  
 | libSceCesCs.sprx        | libSceFont.sprx         | libSceFontFt.sprx       | libSceFreeTypeOt.sprx   |
-| libSceJpegDec.sprx      | libSceJson.sprx         | libSceJson2.sprx        | libSceLibcInternal.sprx |  
-| libSceNgs2.sprx         | libScePngEnc.sprx       | libSceRtc.sprx          | libSceUlt.sprx          |
-
+| libSceJpegDec.sprx      | libSceJpegEnc.sprx      | libSceJson.sprx         | libSceJson2.sprx        |  
+| libSceLibcInternal.sprx | libSceNgs2.sprx         | libScePngEnc.sprx       | libSceRtc.sprx          |
+| libSceUlt.sprx          |                         |                         |                         |
 </div>
 
 > [!Caution]

--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ The following firmware modules are supported and must be placed in shadPS4's `sy
 | Modules                 | Modules                 | Modules                 | Modules                 |  
 |-------------------------|-------------------------|-------------------------|-------------------------|  
 | libSceCesCs.sprx        | libSceFont.sprx         | libSceFontFt.sprx       | libSceFreeTypeOt.sprx   |
-| libSceJson.sprx         | libSceJson2.sprx        | libSceLibcInternal.sprx | libSceNgs2.sprx         |  
-| libSceUlt.sprx          |                         |                         |                         |
+| libSceJpegDec.sprx      | libSceJson.sprx         | libSceJson2.sprx        | libSceLibcInternal.sprx |  
+| libSceNgs2.sprx         | libScePngEnc.sprx       | libSceRtc.sprx          | libSceUlt.sprx          |
 
 </div>
 

--- a/src/core/libraries/libs.cpp
+++ b/src/core/libraries/libs.cpp
@@ -48,7 +48,6 @@
 #include "core/libraries/random/random.h"
 #include "core/libraries/razor_cpu/razor_cpu.h"
 #include "core/libraries/remote_play/remoteplay.h"
-#include "core/libraries/rtc/rtc.h"
 #include "core/libraries/rudp/rudp.h"
 #include "core/libraries/save_data/dialog/savedatadialog.h"
 #include "core/libraries/save_data/savedata.h"
@@ -143,7 +142,6 @@ void InitHLELibs(Core::Loader::SymbolsResolver* sym) {
     Libraries::CompanionHttpd::RegisterLib(sym);
     Libraries::CompanionUtil::RegisterLib(sym);
     Libraries::Voice::RegisterLib(sym);
-    Libraries::Rtc::RegisterLib(sym);
     Libraries::Rudp::RegisterLib(sym);
     Libraries::VrTracker::RegisterLib(sym);
 

--- a/src/core/libraries/libs.cpp
+++ b/src/core/libraries/libs.cpp
@@ -71,7 +71,6 @@
 #include "core/libraries/web_browser_dialog/webbrowserdialog.h"
 #include "core/libraries/zlib/zlib_sce.h"
 #include "fiber/fiber.h"
-#include "jpeg/jpegenc.h"
 
 namespace Libraries {
 
@@ -129,7 +128,6 @@ void InitHLELibs(Core::Loader::SymbolsResolver* sym) {
     Libraries::RazorCpu::RegisterLib(sym);
     Libraries::Move::RegisterLib(sym);
     Libraries::Fiber::RegisterLib(sym);
-    Libraries::JpegEnc::RegisterLib(sym);
     Libraries::Mouse::RegisterLib(sym);
     Libraries::WebBrowserDialog::RegisterLib(sym);
     Libraries::Zlib::RegisterLib(sym);

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -524,6 +524,7 @@ void Emulator::LoadSystemModules(const std::string& game_serial) {
         {{"libSceNgs2.sprx", &Libraries::Ngs2::RegisterLib},
          {"libSceUlt.sprx", nullptr},
          {"libSceRtc.sprx", &Libraries::Rtc::RegisterLib},
+         {"libSceJpegDec.sprx", nullptr},
          {"libSceJson.sprx", nullptr},
          {"libSceJson2.sprx", nullptr},
          {"libSceLibcInternal.sprx", &Libraries::LibcInternal::RegisterLib},

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -525,6 +525,7 @@ void Emulator::LoadSystemModules(const std::string& game_serial) {
          {"libSceUlt.sprx", nullptr},
          {"libSceRtc.sprx", &Libraries::Rtc::RegisterLib},
          {"libSceJpegDec.sprx", nullptr},
+         {"libScePngEnc.sprx", nullptr},
          {"libSceJson.sprx", nullptr},
          {"libSceJson2.sprx", nullptr},
          {"libSceLibcInternal.sprx", &Libraries::LibcInternal::RegisterLib},

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -523,6 +523,7 @@ void Emulator::LoadSystemModules(const std::string& game_serial) {
     constexpr auto ModulesToLoad = std::to_array<SysModules>(
         {{"libSceNgs2.sprx", &Libraries::Ngs2::RegisterLib},
          {"libSceUlt.sprx", nullptr},
+         {"libSceRtc.sprx", &Libraries::Rtc::RegisterLib},
          {"libSceJson.sprx", nullptr},
          {"libSceJson2.sprx", nullptr},
          {"libSceLibcInternal.sprx", &Libraries::LibcInternal::RegisterLib},

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -34,6 +34,7 @@
 #include "core/libraries/disc_map/disc_map.h"
 #include "core/libraries/font/font.h"
 #include "core/libraries/font/fontft.h"
+#include "core/libraries/jpeg/jpegenc.h"
 #include "core/libraries/libc_internal/libc_internal.h"
 #include "core/libraries/libs.h"
 #include "core/libraries/ngs2/ngs2.h"
@@ -525,6 +526,7 @@ void Emulator::LoadSystemModules(const std::string& game_serial) {
          {"libSceUlt.sprx", nullptr},
          {"libSceRtc.sprx", &Libraries::Rtc::RegisterLib},
          {"libSceJpegDec.sprx", nullptr},
+         {"libSceJpegEnc.sprx", &Libraries::JpegEnc::RegisterLib},
          {"libScePngEnc.sprx", nullptr},
          {"libSceJson.sprx", nullptr},
          {"libSceJson2.sprx", nullptr},


### PR DESCRIPTION
This PR adds three modules to our list of LLEs.

libSceRtc LLE isn't needed for anything specific right now, but works around several bugs with the HLE while we look at rewriting it.

libSceJpegDec LLE brings Trackmania (CUSA25218) ingame with broken rendering. Due to GPU emulation issues, some Linux devices don't reach ingame.

<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/bb982e78-413c-4f83-9f3b-86e05bafc7fb" />
<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/6c641a7c-4c8f-4dea-a068-222212a5db71" />

libScePngEnc LLE fixes the saving issues newer editions of Minecraft have.

<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/bb2d0dc4-3134-46f0-be82-468153c706b7" />