### PR TITLE
Core: Better message for missing game trophies directory

### DIFF
--- a/src/core/file_format/trp.cpp
+++ b/src/core/file_format/trp.cpp
@@ -59,7 +59,7 @@ static void hexToBytes(const char* hex, unsigned char* dst) {
 bool TRP::Extract(const std::filesystem::path& trophyPath, const std::string titleId) {
     std::filesystem::path gameSysDir = trophyPath / "sce_sys/trophy/";
     if (!std::filesystem::exists(gameSysDir)) {
-        LOG_CRITICAL(Common_Filesystem, "Game sce_sys directory doesn't exist");
+        LOG_WARNING(Common_Filesystem, "Game trophy directory doesn't exist");
         return false;
     }
 


### PR DESCRIPTION
Also decreased the log level from critical to warning, as all this affects is the ability to earn trophies. If a missing trophy key is only worth an info log, I see no reason to keep a similarly problematic issue as a critical log.