### PR TITLE
Lib.Audio3d: sceAudio3dGetDefaultOpenParameters fix

### DIFF
--- a/src/core/libraries/audio3d/audio3d.cpp
+++ b/src/core/libraries/audio3d/audio3d.cpp
@@ -190,7 +190,7 @@ s32 PS4_SYSV_ABI sceAudio3dGetDefaultOpenParameters(OrbisAudio3dOpenParameters* 
     LOG_DEBUG(Lib_Audio3d, "called");
     if (params) {
         *params = OrbisAudio3dOpenParameters{
-            .size_this = 0x20,
+            .size_this = sizeof(OrbisAudio3dOpenParameters),
             .granularity = 0x100,
             .rate = OrbisAudio3dRate::ORBIS_AUDIO3D_RATE_48000,
             .max_objects = 512,

--- a/src/core/libraries/audio3d/audio3d.cpp
+++ b/src/core/libraries/audio3d/audio3d.cpp
@@ -189,14 +189,15 @@ s32 PS4_SYSV_ABI sceAudio3dDeleteSpeakerArray() {
 s32 PS4_SYSV_ABI sceAudio3dGetDefaultOpenParameters(OrbisAudio3dOpenParameters* params) {
     LOG_DEBUG(Lib_Audio3d, "called");
     if (params) {
-        *params = OrbisAudio3dOpenParameters{
-            .size_this = sizeof(OrbisAudio3dOpenParameters),
+        auto default_params = OrbisAudio3dOpenParameters{
+            .size_this = 0x20,
             .granularity = 0x100,
             .rate = OrbisAudio3dRate::ORBIS_AUDIO3D_RATE_48000,
             .max_objects = 512,
             .queue_depth = 2,
             .buffer_mode = OrbisAudio3dBufferMode::ORBIS_AUDIO3D_BUFFER_ADVANCE_AND_PUSH,
         };
+        memcpy(params, &default_params, 0x20);
     }
     return ORBIS_OK;
 }

--- a/src/core/libraries/audio3d/audio3d.cpp
+++ b/src/core/libraries/audio3d/audio3d.cpp
@@ -446,7 +446,7 @@ s32 PS4_SYSV_ABI sceAudio3dPortOpen(const OrbisUserServiceUserId user_id,
     }
 
     *port_id = id;
-    std::memcpy(&state->ports[id].parameters, parameters, sizeof(OrbisAudio3dOpenParameters));
+    std::memcpy(&state->ports[id].parameters, parameters, parameters->size_this);
 
     return ORBIS_OK;
 }

--- a/src/core/libraries/audio3d/audio3d.h
+++ b/src/core/libraries/audio3d/audio3d.h
@@ -34,6 +34,7 @@ struct OrbisAudio3dOpenParameters {
     u32 max_objects;
     u32 queue_depth;
     OrbisAudio3dBufferMode buffer_mode;
+    int : 32;
     u32 num_beds;
 };
 

--- a/src/core/libraries/audio3d/audio3d.h
+++ b/src/core/libraries/audio3d/audio3d.h
@@ -34,7 +34,6 @@ struct OrbisAudio3dOpenParameters {
     u32 max_objects;
     u32 queue_depth;
     OrbisAudio3dBufferMode buffer_mode;
-    int : 32;
     u32 num_beds;
 };
 


### PR DESCRIPTION
sceAudio3dGetDefaultOpenParameters should only copy 0x20 bytes to the parameter output.
We were originally writing 0x28 bytes, which could corrupt the stack in titles using the function.

This fixes some cases of `kernel.cpp:81 stack_chk_fail: Unreachable code!` in games using libSceAudio3d.