### PR TITLE
ajm: fix init params initialization

### DIFF
--- a/src/core/libraries/ajm/ajm_batch.cpp
+++ b/src/core/libraries/ajm/ajm_batch.cpp
@@ -280,9 +280,7 @@ AjmJob AjmJobFromBatchBuffer(u32 instance_id, AjmBatchBuffer batch_buffer) {
             job.input.resample_parameters = input_batch.Consume<AjmSidebandResampleParameters>();
         }
         if (True(control_flags & AjmJobControlFlags::Initialize)) {
-            job.input.init_params = AjmDecAt9InitializeParameters{};
-            std::memcpy(&job.input.init_params.value(), input_batch.GetCurrent(),
-                        input_batch.BytesRemaining());
+            job.input.init_params = input_batch.Consume<AjmSidebandInitParameters>();
         }
     }
 

--- a/src/core/libraries/ajm/ajm_batch.h
+++ b/src/core/libraries/ajm/ajm_batch.h
@@ -21,7 +21,7 @@ namespace Libraries::Ajm {
 
 struct AjmJob {
     struct Input {
-        std::optional<AjmDecAt9InitializeParameters> init_params;
+        std::optional<AjmSidebandInitParameters> init_params;
         std::optional<AjmSidebandResampleParameters> resample_parameters;
         std::optional<AjmSidebandStatisticsEngineParameters> statistics_engine_parameters;
         std::optional<AjmSidebandFormat> format;


### PR DESCRIPTION
Fixes a case where a game passes larger control buffer than expected, resulting in writing out-of-bounds. Should fix ajm at9 errors with LLE sceLibAudiodec.