### PR TITLE
shader_recompiler: some fixes for tess shaders

### DIFF
--- a/src/shader_recompiler/ir/attribute.cpp
+++ b/src/shader_recompiler/ir/attribute.cpp
@@ -153,9 +153,9 @@ std::string NameOf(Attribute attribute) {
     case Attribute::TessellationEvaluationPointV:
         return "TessellationEvaluationPointV";
     case Attribute::PackedHullInvocationInfo:
-        return "OffChipLdsBase";
-    case Attribute::OffChipLdsBase:
         return "PackedHullInvocationInfo";
+    case Attribute::OffChipLdsBase:
+        return "OffChipLdsBase";
     case Attribute::TessFactorsBufferBase:
         return "TessFactorsBufferBase";
     case Attribute::PointSize:


### PR DESCRIPTION
When walking the users of special constants which form LDS addresses:
-ignore when a user contributes to the wrong operand of an LDS inst, for example the data operand of WriteShared* instead of the address operand. This can mistakenly happen due to phi nodes.
-don't use flags to stash temp info about phis, since flags may already be in use. Use a separate map.