### PR TITLE
video_core: Small fixes regarding GDS

### DIFF
--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -1036,6 +1036,9 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
             const auto* release_mem = reinterpret_cast<const PM4CmdReleaseMem*>(header);
             release_mem->SignalFence([pipe_id = queue.pipe_id] {
                 Platform::IrqC::Instance()->Signal(static_cast<Platform::InterruptId>(pipe_id));
+            },
+            [this](VAddr dst, u16 gds_index, u16 num_dwords) {
+                rasterizer->CopyBuffer(dst, gds_index, num_dwords * sizeof(u32), false, true);
             });
             break;
         }

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -1034,12 +1034,13 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
         }
         case PM4ItOpcode::ReleaseMem: {
             const auto* release_mem = reinterpret_cast<const PM4CmdReleaseMem*>(header);
-            release_mem->SignalFence([pipe_id = queue.pipe_id] {
-                Platform::IrqC::Instance()->Signal(static_cast<Platform::InterruptId>(pipe_id));
-            },
-            [this](VAddr dst, u16 gds_index, u16 num_dwords) {
-                rasterizer->CopyBuffer(dst, gds_index, num_dwords * sizeof(u32), false, true);
-            });
+            release_mem->SignalFence(
+                [pipe_id = queue.pipe_id] {
+                    Platform::IrqC::Instance()->Signal(static_cast<Platform::InterruptId>(pipe_id));
+                },
+                [this](VAddr dst, u16 gds_index, u16 num_dwords) {
+                    rasterizer->CopyBuffer(dst, gds_index, num_dwords * sizeof(u32), false, true);
+                });
             break;
         }
         case PM4ItOpcode::EventWrite: {

--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -327,6 +327,7 @@ enum class DataSelect : u32 {
     Data64 = 2,
     GpuClock64 = 3,
     PerfCounter = 4,
+    GdsMemStore = 5,
 };
 
 enum class InterruptSelect : u32 {
@@ -920,8 +921,8 @@ struct PM4CmdReleaseMem {
     u32 data_hi;
 
     template <typename T>
-    T* Address() const {
-        return reinterpret_cast<T*>(address_lo | u64(address_hi) << 32);
+    T Address() const {
+        return reinterpret_cast<T>(address_lo | u64(address_hi) << 32);
     }
 
     u32 DataDWord() const {
@@ -932,22 +933,26 @@ struct PM4CmdReleaseMem {
         return data_lo | u64(data_hi) << 32;
     }
 
-    void SignalFence(auto&& signal_irq) const {
+    void SignalFence(auto&& signal_irq, auto&& gds_to_mem) const {
         switch (data_sel.Value()) {
         case DataSelect::Data32Low: {
-            *Address<u32>() = DataDWord();
+            *Address<u32*>() = DataDWord();
             break;
         }
         case DataSelect::Data64: {
-            *Address<u64>() = DataQWord();
+            *Address<u64*>() = DataQWord();
             break;
         }
         case DataSelect::GpuClock64: {
-            *Address<u64>() = GetGpuClock64();
+            *Address<u64*>() = GetGpuClock64();
             break;
         }
         case DataSelect::PerfCounter: {
-            *Address<u64>() = GetGpuPerfCounter();
+            *Address<u64*>() = GetGpuPerfCounter();
+            break;
+        }
+        case DataSelect::GdsMemStore: {
+            gds_to_mem(Address<VAddr>(), gds_index, num_dw);
             break;
         }
         default: {

--- a/src/video_core/amdgpu/pm4_cmds.h
+++ b/src/video_core/amdgpu/pm4_cmds.h
@@ -922,7 +922,8 @@ struct PM4CmdReleaseMem {
 
     template <typename T>
     T Address() const {
-        return reinterpret_cast<T>(address_lo | u64(address_hi) << 32);
+        u64 full_address = address_lo | (u64(address_hi) << 32);
+        return std::bit_cast<T>(full_address);
     }
 
     u32 DataDWord() const {


### PR DESCRIPTION
* First commit fixes an issue where the transformation of GDS atomics to buffer atomics would not set the buffer descriptor type, causing a silent crash in spirv backend due to missing buffer type alias
* Implements GDS to memory copy mode of ReleaseMem which affects https://github.com/shadps4-compatibility/shadps4-game-compatibility/issues/581 