### PR TITLE
Core: Miscellaneous memory fixes and slight optimizations

### DIFF
--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -255,8 +255,7 @@ struct AddressSpace::Impl {
                 ASSERT_MSG(ret, "VirtualProtect failed. {}", Common::GetLastErrorMsg());
             } else {
                 ptr = MapViewOfFile3(backing, process, reinterpret_cast<PVOID>(virtual_addr),
-                                     phys_addr, size, MEM_REPLACE_PLACEHOLDER,
-                                     prot, nullptr, 0);
+                                     phys_addr, size, MEM_REPLACE_PLACEHOLDER, prot, nullptr, 0);
                 ASSERT_MSG(ptr, "MapViewOfFile3 failed. {}", Common::GetLastErrorMsg());
             }
         } else {
@@ -371,8 +370,7 @@ struct AddressSpace::Impl {
         }
     }
 
-    void* Map(VAddr virtual_addr, PAddr phys_addr, u64 size, ULONG prot, s32 fd = -1,
-              bool is_shared = false) {
+    void* Map(VAddr virtual_addr, PAddr phys_addr, u64 size, ULONG prot, s32 fd = -1) {
         // Get a pointer to the region containing virtual_addr
         auto it = std::prev(regions.upper_bound(virtual_addr));
 

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -249,11 +249,8 @@ struct AddressSpace::Impl {
             } else {
                 ptr = MapViewOfFile3(backing, process, reinterpret_cast<PVOID>(virtual_addr),
                                      phys_addr, size, MEM_REPLACE_PLACEHOLDER,
-                                     PAGE_EXECUTE_READWRITE, nullptr, 0);
+                                     prot, nullptr, 0);
                 ASSERT_MSG(ptr, "MapViewOfFile3 failed. {}", Common::GetLastErrorMsg());
-                DWORD resultvar;
-                bool ret = VirtualProtect(ptr, size, prot, &resultvar);
-                ASSERT_MSG(ret, "VirtualProtect failed. {}", Common::GetLastErrorMsg());
             }
         } else {
             ptr =

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -248,7 +248,7 @@ struct AddressSpace::Impl {
                 OVERLAPPED param{};
                 // Offset is the least-significant 32 bits, OffsetHigh is the most-significant.
                 param.Offset = phys_addr & 0xffffffffull;
-                param.OffsetHigh = phys_addr & 0xffffffff00000000ull;
+                param.OffsetHigh = (phys_addr & 0xffffffff00000000ull) >> 32;
                 bool ret = ReadFile(backing, ptr, size, &resultvar, &param);
                 ASSERT_MSG(ret, "ReadFile failed. {}", Common::GetLastErrorMsg());
                 ret = VirtualProtect(ptr, size, prot, &resultvar);

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -234,6 +234,8 @@ struct AddressSpace::Impl {
         ULONG prot = region->prot;
         s32 fd = region->fd;
 
+        LOG_INFO(Core, "addr = {:#x}, size = {:#x}, offset = {:#x}", virtual_addr, size, phys_addr);
+
         void* ptr = nullptr;
         if (phys_addr != -1) {
             HANDLE backing = fd != -1 ? reinterpret_cast<HANDLE>(fd) : backing_handle;
@@ -271,6 +273,8 @@ struct AddressSpace::Impl {
         VAddr virtual_addr = region->base;
         PAddr phys_base = region->phys_base;
         u64 size = region->size;
+
+        LOG_INFO(Core, "addr = {:#x}, size = {:#x}, offset = {:#x}", virtual_addr, size, phys_base);
 
         bool ret = false;
         if (phys_base != -1) {
@@ -318,6 +322,8 @@ struct AddressSpace::Impl {
                                MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER)) {
                 UNREACHABLE_MSG("Region splitting failed: {}", Common::GetLastErrorMsg());
             }
+            LOG_INFO(Core, "Splitting placeholder: addr = {:#x}, size = {:#x}", region.base,
+                     region.size);
 
             // If the mapping was mapped, remap the region.
             if (region.is_mapped) {
@@ -357,6 +363,8 @@ struct AddressSpace::Impl {
                                MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER)) {
                 UNREACHABLE_MSG("Region splitting failed: {}", Common::GetLastErrorMsg());
             }
+            LOG_INFO(Core, "Splitting placeholder: addr = {:#x}, size = {:#x}", region.base,
+                     region.size);
 
             // If these regions were mapped, then map the unmapped area beyond the requested range.
             if (region.is_mapped) {
@@ -425,6 +433,8 @@ struct AddressSpace::Impl {
                                MEM_RELEASE | MEM_COALESCE_PLACEHOLDERS)) {
                 UNREACHABLE_MSG("Region coalescing failed: {}", Common::GetLastErrorMsg());
             }
+            LOG_INFO(Core, "Coalescing placeholders: addr = {:#x}, size = {:#x}", it->first,
+                     it->second.size);
         }
     }
 

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -237,7 +237,7 @@ struct AddressSpace::Impl {
         void* ptr = nullptr;
         if (phys_addr != -1) {
             HANDLE backing = fd != -1 ? reinterpret_cast<HANDLE>(fd) : backing_handle;
-            if (fd && prot == PAGE_READONLY) {
+            if (fd != -1 && prot == PAGE_READONLY) {
                 DWORD resultvar;
                 ptr = VirtualAlloc2(process, reinterpret_cast<PVOID>(virtual_addr), size,
                                     MEM_RESERVE | MEM_COMMIT | MEM_REPLACE_PLACEHOLDER,
@@ -271,9 +271,11 @@ struct AddressSpace::Impl {
         VAddr virtual_addr = region->base;
         PAddr phys_base = region->phys_base;
         u64 size = region->size;
+        ULONG prot = region->prot;
+        s32 fd = region->fd;
 
         bool ret = false;
-        if (phys_base != -1) {
+        if ((fd != -1 && prot != PAGE_READONLY) || (fd == -1 && phys_base != -1)) {
             ret = UnmapViewOfFile2(process, reinterpret_cast<PVOID>(virtual_addr),
                                    MEM_PRESERVE_PLACEHOLDER);
         } else {

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -509,6 +509,7 @@ struct AddressSpace::Impl {
 
         const VAddr virtual_end = virtual_addr + size;
         auto it = --regions.upper_bound(virtual_addr);
+        ASSERT_MSG(it != regions.end(), "addr {:#x} out of bounds", virtual_addr);
         for (; it->first < virtual_end; it++) {
             if (!it->second.is_mapped) {
                 continue;

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -407,7 +407,7 @@ struct AddressSpace::Impl {
             it_prev->second.size = it_prev->second.size + it->second.size;
             regions.erase(it);
             it = it_prev;
-        
+
             // Mark this region as coalesce-able.
             can_coalesce = true;
 
@@ -421,7 +421,7 @@ struct AddressSpace::Impl {
             // If there is a later region, increase our current region's size
             it->second.size = it->second.size + it_next->second.size;
             regions.erase(it_next);
-        
+
             // Mark this region as coalesce-able.
             can_coalesce = true;
 

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -234,8 +234,6 @@ struct AddressSpace::Impl {
         ULONG prot = region->prot;
         s32 fd = region->fd;
 
-        LOG_INFO(Core, "addr = {:#x}, size = {:#x}, offset = {:#x}", virtual_addr, size, phys_addr);
-
         void* ptr = nullptr;
         if (phys_addr != -1) {
             HANDLE backing = fd != -1 ? reinterpret_cast<HANDLE>(fd) : backing_handle;
@@ -273,8 +271,6 @@ struct AddressSpace::Impl {
         VAddr virtual_addr = region->base;
         PAddr phys_base = region->phys_base;
         u64 size = region->size;
-
-        LOG_INFO(Core, "addr = {:#x}, size = {:#x}, offset = {:#x}", virtual_addr, size, phys_base);
 
         bool ret = false;
         if (phys_base != -1) {
@@ -322,8 +318,6 @@ struct AddressSpace::Impl {
                                MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER)) {
                 UNREACHABLE_MSG("Region splitting failed: {}", Common::GetLastErrorMsg());
             }
-            LOG_INFO(Core, "Splitting placeholder: addr = {:#x}, size = {:#x}", region.base,
-                     region.size);
 
             // If the mapping was mapped, remap the region.
             if (region.is_mapped) {
@@ -363,8 +357,6 @@ struct AddressSpace::Impl {
                                MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER)) {
                 UNREACHABLE_MSG("Region splitting failed: {}", Common::GetLastErrorMsg());
             }
-            LOG_INFO(Core, "Splitting placeholder: addr = {:#x}, size = {:#x}", region.base,
-                     region.size);
 
             // If these regions were mapped, then map the unmapped area beyond the requested range.
             if (region.is_mapped) {
@@ -433,8 +425,6 @@ struct AddressSpace::Impl {
                                MEM_RELEASE | MEM_COALESCE_PLACEHOLDERS)) {
                 UNREACHABLE_MSG("Region coalescing failed: {}", Common::GetLastErrorMsg());
             }
-            LOG_INFO(Core, "Coalescing placeholders: addr = {:#x}, size = {:#x}", it->first,
-                     it->second.size);
         }
     }
 

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -89,22 +89,27 @@ s32 PS4_SYSV_ABI sceKernelAllocateMainDirectMemory(u64 len, u64 alignment, s32 m
 }
 
 s32 PS4_SYSV_ABI sceKernelCheckedReleaseDirectMemory(u64 start, u64 len) {
+    if (!Common::Is16KBAligned(start) || !Common::Is16KBAligned(len)) {
+        return ORBIS_KERNEL_ERROR_EINVAL;
+    }
     if (len == 0) {
         return ORBIS_OK;
     }
     LOG_INFO(Kernel_Vmm, "called start = {:#x}, len = {:#x}", start, len);
     auto* memory = Core::Memory::Instance();
-    memory->Free(start, len);
-    return ORBIS_OK;
+    return memory->Free(start, len, true);
 }
 
 s32 PS4_SYSV_ABI sceKernelReleaseDirectMemory(u64 start, u64 len) {
+    if (!Common::Is16KBAligned(start) || !Common::Is16KBAligned(len)) {
+        return ORBIS_KERNEL_ERROR_EINVAL;
+    }
     if (len == 0) {
         return ORBIS_OK;
     }
     LOG_INFO(Kernel_Vmm, "called start = {:#x}, len = {:#x}", start, len);
     auto* memory = Core::Memory::Instance();
-    memory->Free(start, len);
+    memory->Free(start, len, false);
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -89,25 +89,29 @@ s32 PS4_SYSV_ABI sceKernelAllocateMainDirectMemory(u64 len, u64 alignment, s32 m
 }
 
 s32 PS4_SYSV_ABI sceKernelCheckedReleaseDirectMemory(u64 start, u64 len) {
+    LOG_INFO(Kernel_Vmm, "called start = {:#x}, len = {:#x}", start, len);
     if (!Common::Is16KBAligned(start) || !Common::Is16KBAligned(len)) {
+        LOG_ERROR(Kernel_Vmm, "Misaligned start or length, start = {:#x}, length = {:#x}", start,
+                  len);
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
     if (len == 0) {
         return ORBIS_OK;
     }
-    LOG_INFO(Kernel_Vmm, "called start = {:#x}, len = {:#x}", start, len);
     auto* memory = Core::Memory::Instance();
     return memory->Free(start, len, true);
 }
 
 s32 PS4_SYSV_ABI sceKernelReleaseDirectMemory(u64 start, u64 len) {
+    LOG_INFO(Kernel_Vmm, "called start = {:#x}, len = {:#x}", start, len);
     if (!Common::Is16KBAligned(start) || !Common::Is16KBAligned(len)) {
+        LOG_ERROR(Kernel_Vmm, "Misaligned start or length, start = {:#x}, length = {:#x}", start,
+                  len);
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
     if (len == 0) {
         return ORBIS_OK;
     }
-    LOG_INFO(Kernel_Vmm, "called start = {:#x}, len = {:#x}", start, len);
     auto* memory = Core::Memory::Instance();
     memory->Free(start, len, false);
     return ORBIS_OK;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -117,7 +117,7 @@ void MemoryManager::SetPrtArea(u32 id, VAddr address, u64 size) {
 }
 
 void MemoryManager::CopySparseMemory(VAddr virtual_addr, u8* dest, u64 size) {
-    mutex.lock_shared();
+    // mutex.lock_shared();
     ASSERT_MSG(IsValidMapping(virtual_addr), "Attempted to access invalid address {:#x}",
                virtual_addr);
 
@@ -135,12 +135,12 @@ void MemoryManager::CopySparseMemory(VAddr virtual_addr, u8* dest, u64 size) {
         ++vma;
     }
 
-    mutex.unlock_shared();
+    // mutex.unlock_shared();
 }
 
 bool MemoryManager::TryWriteBacking(void* address, const void* data, u64 size) {
     const VAddr virtual_addr = std::bit_cast<VAddr>(address);
-    mutex.lock_shared();
+    // mutex.lock_shared();
     ASSERT_MSG(IsValidMapping(virtual_addr, size), "Attempted to access invalid address {:#x}",
                virtual_addr);
 
@@ -148,7 +148,7 @@ bool MemoryManager::TryWriteBacking(void* address, const void* data, u64 size) {
     auto current_vma = FindVMA(virtual_addr);
     while (virtual_addr + size < current_vma->second.base + current_vma->second.size) {
         if (!HasPhysicalBacking(current_vma->second)) {
-            mutex.unlock_shared();
+            // mutex.unlock_shared();
             return false;
         }
         vmas_to_write.emplace_back(current_vma->second);
@@ -168,7 +168,7 @@ bool MemoryManager::TryWriteBacking(void* address, const void* data, u64 size) {
         }
     }
 
-    mutex.unlock_shared();
+    // mutex.unlock_shared();
     return true;
 }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -259,6 +259,7 @@ PAddr MemoryManager::Allocate(PAddr search_start, PAddr search_end, u64 size, u6
 s32 MemoryManager::Free(PAddr phys_addr, u64 size, bool is_checked) {
     // Basic bounds checking
     if (phys_addr > total_direct_size || (is_checked && phys_addr + size > total_direct_size)) {
+        LOG_ERROR(Kernel_Vmm, "phys_addr {:#x}, size {:#x} goes outside dmem map", phys_addr, size);
         if (is_checked) {
             return ORBIS_KERNEL_ERROR_ENOENT;
         }
@@ -283,6 +284,7 @@ s32 MemoryManager::Free(PAddr phys_addr, u64 size, bool is_checked) {
                 // Checked frees will error if anything in the area isn't allocated.
                 // Unchecked frees will just ignore free areas.
                 mutex.unlock();
+                LOG_ERROR(Kernel_Vmm, "Attempting to release a free dmem area");
                 return ORBIS_KERNEL_ERROR_ENOENT;
             }
             continue;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -119,7 +119,6 @@ void MemoryManager::SetPrtArea(u32 id, VAddr address, u64 size) {
 void MemoryManager::CopySparseMemory(VAddr virtual_addr, u8* dest, u64 size) {
     ASSERT_MSG(IsValidMapping(virtual_addr), "Attempted to access invalid address {:#x}",
                virtual_addr);
-    mutex.lock_shared();
 
     auto vma = FindVMA(virtual_addr);
     while (size) {
@@ -134,15 +133,12 @@ void MemoryManager::CopySparseMemory(VAddr virtual_addr, u8* dest, u64 size) {
         dest += copy_size;
         ++vma;
     }
-
-    mutex.unlock_shared();
 }
 
 bool MemoryManager::TryWriteBacking(void* address, const void* data, u64 size) {
     const VAddr virtual_addr = std::bit_cast<VAddr>(address);
     ASSERT_MSG(IsValidMapping(virtual_addr, size), "Attempted to access invalid address {:#x}",
                virtual_addr);
-    mutex.lock_shared();
 
     std::vector<VirtualMemoryArea> vmas_to_write;
     auto current_vma = FindVMA(virtual_addr);
@@ -168,7 +164,6 @@ bool MemoryManager::TryWriteBacking(void* address, const void* data, u64 size) {
         }
     }
 
-    mutex.unlock_shared();
     return true;
 }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -117,7 +117,7 @@ void MemoryManager::SetPrtArea(u32 id, VAddr address, u64 size) {
 }
 
 void MemoryManager::CopySparseMemory(VAddr virtual_addr, u8* dest, u64 size) {
-    // mutex.lock_shared();
+    mutex.lock_shared();
     ASSERT_MSG(IsValidMapping(virtual_addr), "Attempted to access invalid address {:#x}",
                virtual_addr);
 
@@ -135,12 +135,12 @@ void MemoryManager::CopySparseMemory(VAddr virtual_addr, u8* dest, u64 size) {
         ++vma;
     }
 
-    // mutex.unlock_shared();
+    mutex.unlock_shared();
 }
 
 bool MemoryManager::TryWriteBacking(void* address, const void* data, u64 size) {
     const VAddr virtual_addr = std::bit_cast<VAddr>(address);
-    // mutex.lock_shared();
+    mutex.lock_shared();
     ASSERT_MSG(IsValidMapping(virtual_addr, size), "Attempted to access invalid address {:#x}",
                virtual_addr);
 
@@ -148,7 +148,7 @@ bool MemoryManager::TryWriteBacking(void* address, const void* data, u64 size) {
     auto current_vma = FindVMA(virtual_addr);
     while (virtual_addr + size < current_vma->second.base + current_vma->second.size) {
         if (!HasPhysicalBacking(current_vma->second)) {
-            // mutex.unlock_shared();
+            mutex.unlock_shared();
             return false;
         }
         vmas_to_write.emplace_back(current_vma->second);
@@ -168,7 +168,7 @@ bool MemoryManager::TryWriteBacking(void* address, const void* data, u64 size) {
         }
     }
 
-    // mutex.unlock_shared();
+    mutex.unlock_shared();
     return true;
 }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -1168,7 +1168,7 @@ s32 MemoryManager::SetDirectMemoryType(VAddr addr, u64 size, s32 memory_type) {
             const auto start_in_vma = current_addr - vma_handle->second.base;
             const auto size_in_vma = vma_handle->second.size - start_in_vma;
             auto size_to_modify = std::min<u64>(remaining_size, size_in_vma);
-            
+
             // Split area to modify into a new VMA.
             vma_handle = CarveVMA(current_addr, size_to_modify);
             const auto base_phys_addr = vma_handle->second.phys_areas.begin()->second.base;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -166,7 +166,7 @@ bool MemoryManager::TryWriteBacking(void* address, const void* data, u64 size) {
             const u64 start_in_dma =
                 std::max<u64>(start_in_vma, phys_handle->first) - phys_handle->first;
             u8* backing = impl.BackingBase() + phys_handle->second.base + start_in_dma;
-            u64 copy_size = std::min<u64>(size, phys_handle->second.size);
+            u64 copy_size = std::min<u64>(size, phys_handle->second.size - start_in_dma);
             memcpy(backing, data, copy_size);
             size -= copy_size;
         }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -119,6 +119,7 @@ void MemoryManager::SetPrtArea(u32 id, VAddr address, u64 size) {
 void MemoryManager::CopySparseMemory(VAddr virtual_addr, u8* dest, u64 size) {
     ASSERT_MSG(IsValidMapping(virtual_addr), "Attempted to access invalid address {:#x}",
                virtual_addr);
+    mutex.lock_shared();
 
     auto vma = FindVMA(virtual_addr);
     while (size) {
@@ -133,12 +134,15 @@ void MemoryManager::CopySparseMemory(VAddr virtual_addr, u8* dest, u64 size) {
         dest += copy_size;
         ++vma;
     }
+
+    mutex.unlock_shared();
 }
 
 bool MemoryManager::TryWriteBacking(void* address, const void* data, u64 size) {
     const VAddr virtual_addr = std::bit_cast<VAddr>(address);
     ASSERT_MSG(IsValidMapping(virtual_addr, size), "Attempted to access invalid address {:#x}",
                virtual_addr);
+    mutex.lock_shared();
 
     std::vector<VirtualMemoryArea> vmas_to_write;
     auto current_vma = FindVMA(virtual_addr);
@@ -164,6 +168,7 @@ bool MemoryManager::TryWriteBacking(void* address, const void* data, u64 size) {
         }
     }
 
+    mutex.unlock_shared();
     return true;
 }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -386,7 +386,8 @@ s32 MemoryManager::PoolCommit(VAddr virtual_addr, u64 size, MemoryProt prot, s32
 
         // Perform an address space mapping for each physical area
         void* out_addr = impl.Map(current_addr, size_to_map, new_dmem_area.base);
-        TRACK_ALLOC(out_addr, size_to_map, "VMEM");
+        // Tracy memory tracking breaks from merging memory areas. Disabled for now.
+        // TRACK_ALLOC(out_addr, size_to_map, "VMEM");
 
         handle = MergeAdjacent(dmem_map, new_dmem_handle);
         current_addr += size_to_map;
@@ -542,7 +543,8 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
 
             // Perform an address space mapping for each physical area
             void* out_addr = impl.Map(current_addr, size_to_map, new_fmem_area.base, is_exec);
-            TRACK_ALLOC(out_addr, size_to_map, "VMEM");
+            // Tracy memory tracking breaks from merging memory areas. Disabled for now.
+            // TRACK_ALLOC(out_addr, size_to_map, "VMEM");
 
             handle = MergeAdjacent(fmem_map, new_fmem_handle);
             current_addr += size_to_map;
@@ -594,8 +596,9 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
         // Flexible address space mappings were performed while finding direct memory areas.
         if (type != VMAType::Flexible) {
             impl.Map(mapped_addr, size, phys_addr, is_exec);
+            // Tracy memory tracking breaks from merging memory areas. Disabled for now.
+            // TRACK_ALLOC(mapped_addr, size, "VMEM");
         }
-        TRACK_ALLOC(*out_addr, size, "VMEM");
 
         mutex.unlock();
 
@@ -768,7 +771,8 @@ s32 MemoryManager::PoolDecommit(VAddr virtual_addr, u64 size) {
 
     // Unmap from address space
     impl.Unmap(virtual_addr, size, true);
-    TRACK_FREE(virtual_addr, "VMEM");
+    // Tracy memory tracking breaks from merging memory areas. Disabled for now.
+    // TRACK_FREE(virtual_addr, "VMEM");
 
     mutex.unlock();
     return ORBIS_OK;
@@ -857,7 +861,8 @@ u64 MemoryManager::UnmapBytesFromEntry(VAddr virtual_addr, VirtualMemoryArea vma
     if (vma_type != VMAType::Reserved && vma_type != VMAType::PoolReserved) {
         // Unmap the memory region.
         impl.Unmap(virtual_addr, size_in_vma, has_backing);
-        TRACK_FREE(virtual_addr, "VMEM");
+        // Tracy memory tracking breaks from merging memory areas. Disabled for now.
+        // TRACK_FREE(virtual_addr, "VMEM");
 
         // If this mapping has GPU access, unmap from GPU.
         if (IsValidGpuMapping(virtual_addr, size)) {

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -300,6 +300,11 @@ private:
                vma.type == VMAType::Pooled;
     }
 
+    std::pair<s32, MemoryManager::VMAHandle> CreateArea(VAddr virtual_addr, u64 size,
+                                                        MemoryProt prot, MemoryMapFlags flags,
+                                                        VMAType type, std::string_view name,
+                                                        u64 alignment);
+
     VAddr SearchFree(VAddr virtual_addr, u64 size, u32 alignment);
 
     VMAHandle MergeAdjacent(VMAMap& map, VMAHandle iter);

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -240,7 +240,7 @@ public:
 
     PAddr Allocate(PAddr search_start, PAddr search_end, u64 size, u64 alignment, s32 memory_type);
 
-    void Free(PAddr phys_addr, u64 size);
+    s32 Free(PAddr phys_addr, u64 size, bool is_checked);
 
     s32 PoolCommit(VAddr virtual_addr, u64 size, MemoryProt prot, s32 mtype);
 

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -140,6 +140,9 @@ struct VirtualMemoryArea {
         if (prot != next.prot || type != next.type) {
             return false;
         }
+        if (name.compare(next.name) != 0) {
+            return false;
+        }
 
         return true;
     }

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -114,6 +114,10 @@ struct VirtualMemoryArea {
         return addr >= base && (addr + size) <= (base + this->size);
     }
 
+    bool Overlaps(VAddr addr, u64 size) const {
+        return addr <= (base + this->size) && (addr + size) >= base;
+    }
+
     bool IsFree() const noexcept {
         return type == VMAType::Free;
     }


### PR DESCRIPTION
After #3932, I received many mentions of performance regressions. From my own testing, these (as per usual) came from performing extra Microsoft API calls. Specifically, in order to shape placeholders properly for mapping memory (instead of requiring vma_map to match AddressSpace regions), my PR added multiple VirtualFreeEx calls over our old code.

While looking over the current Windows address space code, I found some areas that could be made faster. Specifically, this PR removes a VirtualProtect call we performed during physically backed address space mappings, and an unnecessary VirtualFreeEx call performed while coalescing regions.

In games limited by memory performance (and as a result, regressed by #3932), this should improve performance and bring it closer to where v0.13.0 was while keeping all the improvements of my PR.

I've also made two other smaller changes here, first I've updated our read-only file mmap code to properly handle file offsets, and secondly I've disabled Tracy memory tracking since it broke with VMA merging.

Opening as a draft until people test, I'd like to see the impacts of this before letting it get merged.