### PR TITLE
shader_recompiler: VS clip distance emulation for NVIDIA GPUs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -916,6 +916,7 @@ set(SHADER_RECOMPILER src/shader_recompiler/profile.h
                       src/shader_recompiler/ir/passes/flatten_extended_userdata_pass.cpp
                       src/shader_recompiler/ir/passes/hull_shader_transform.cpp
                       src/shader_recompiler/ir/passes/identity_removal_pass.cpp
+                      src/shader_recompiler/ir/passes/inject_clip_distance_attributes.cpp
                       src/shader_recompiler/ir/passes/ir_passes.h
                       src/shader_recompiler/ir/passes/lower_buffer_format_to_raw.cpp
                       src/shader_recompiler/ir/passes/lower_fp64_to_fp32.cpp

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -204,6 +204,7 @@ add_subdirectory(tracy)
 
 # pugixml
 if (NOT TARGET pugixml::pugixml)
+    option(PUGIXML_NO_EXCEPTIONS "" ON)
     add_subdirectory(pugixml)
 endif()
 

--- a/src/shader_recompiler/ir/attribute.cpp
+++ b/src/shader_recompiler/ir/attribute.cpp
@@ -101,7 +101,7 @@ std::string NameOf(Attribute attribute) {
     case Attribute::Param31:
         return "Param31";
     case Attribute::ClipDistance:
-        return "ClipDistanace";
+        return "ClipDistance";
     case Attribute::CullDistance:
         return "CullDistance";
     case Attribute::RenderTargetIndex:

--- a/src/shader_recompiler/ir/passes/inject_clip_distance_attributes.cpp
+++ b/src/shader_recompiler/ir/passes/inject_clip_distance_attributes.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "shader_recompiler/info.h"
+#include "shader_recompiler/ir/basic_block.h"
+#include "shader_recompiler/ir/ir_emitter.h"
+#include "shader_recompiler/ir/program.h"
+
+namespace Shader {
+
+void InjectClipDistanceAttributes(IR::Program& program, RuntimeInfo& runtime_info) {
+    auto& info = runtime_info.fs_info;
+
+    if (!info.clip_distance_emulation || program.info.l_stage != LogicalStage::Fragment) {
+        return;
+    }
+
+    auto* first_block = *program.blocks.begin();
+    auto it = std::ranges::find_if(first_block->Instructions(), [](const IR::Inst& inst) {
+        return inst.GetOpcode() == IR::Opcode::Prologue;
+    });
+    ASSERT(it != first_block->end());
+    ++it;
+    ASSERT(it != first_block->end());
+    ++it;
+
+    IR::IREmitter ir{*first_block, it};
+
+    // We don't know how many clip distances are exported by VS as it is not processed at this point
+    // yet. Here is an assumption that we will have not more than 4 of them (while max is 8) to save
+    // one attributes export slot.
+    const auto attrib = IR::Attribute::Param0 + info.num_inputs;
+    for (u32 comp = 0; comp < MaxEmulatedClipDistances; ++comp) {
+        const auto attr_read = ir.GetAttribute(attrib, comp);
+        const auto cond_id = ir.FPLessThan(attr_read, ir.Imm32(0.0f));
+        ir.Discard(cond_id);
+    }
+    ++info.num_inputs;
+}
+
+} // namespace Shader

--- a/src/shader_recompiler/ir/passes/ir_passes.h
+++ b/src/shader_recompiler/ir/passes/ir_passes.h
@@ -8,7 +8,8 @@
 
 namespace Shader {
 struct Profile;
-}
+void InjectClipDistanceAttributes(IR::Program& program, RuntimeInfo& runtime_info);
+} // namespace Shader
 
 namespace Shader::Optimization {
 

--- a/src/shader_recompiler/profile.h
+++ b/src/shader_recompiler/profile.h
@@ -41,7 +41,7 @@ struct Profile {
     bool needs_lds_barriers{};
     bool needs_buffer_offsets{};
     bool needs_unorm_fixup{};
-    bool _pad0{};
+    bool needs_clip_distance_emulation{};
 };
 
 } // namespace Shader

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -34,6 +34,7 @@ enum class LogicalStage : u32 {
 };
 
 constexpr u32 MaxStageTypes = static_cast<u32>(LogicalStage::NumLogicalStages);
+constexpr auto MaxEmulatedClipDistances = 4u;
 
 constexpr Stage StageFromIndex(size_t index) noexcept {
     return static_cast<Stage>(index);
@@ -201,14 +202,16 @@ struct FragmentRuntimeInfo {
     std::array<PsInput, 32> inputs;
     std::array<PsColorBuffer, MaxColorBuffers> color_buffers;
     AmdGpu::ShaderExportFormat z_export_format;
-    u8 mrtz_mask;
-    bool dual_source_blending;
+    u8 mrtz_mask{};
+    bool dual_source_blending{false};
+    bool clip_distance_emulation{false};
 
     bool operator==(const FragmentRuntimeInfo& other) const noexcept {
         return std::ranges::equal(color_buffers, other.color_buffers) &&
                en_flags == other.en_flags && addr_flags == other.addr_flags &&
                num_inputs == other.num_inputs && z_export_format == other.z_export_format &&
                mrtz_mask == other.mrtz_mask && dual_source_blending == other.dual_source_blending &&
+               clip_distance_emulation == other.clip_distance_emulation &&
                std::ranges::equal(inputs.begin(), inputs.begin() + num_inputs, other.inputs.begin(),
                                   other.inputs.begin() + num_inputs);
     }


### PR DESCRIPTION
It looks like NVIDIA GPUs have precision issues with clip distances interpolation. At least the result slightly differs from what we see on AMD (and there is evidence even on Intel) GPUs, which usually results in artifacts like black stripes on tilted polygons. This PR adds emulation of VS outputted clip distances via discards on FS stage for NVIDIA cards.