### PR TITLE
Add Docker build support and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ This project began for fun. Given our limited free time, it may take some time b
 
 ## Docker
 
-Check the build instructions for [**Windows**](https://github.com/shadps4-emu/shadPS4/blob/main/documents/building-docker.md).
+For building shadPS4 in a containerized environment using Docker and VSCode, check the instructions here:  
+[**Docker Build Instructions**](https://github.com/shadps4-emu/shadPS4/blob/main/documents/building-docker.md)
 
 ## Windows
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 shadPS4 Emulator Project
+SPDX-FileCopyrightText: 2026 shadPS4 Emulator Project
 SPDX-License-Identifier: GPL-2.0-or-later
 -->
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ This project began for fun. Given our limited free time, it may take some time b
 
 # Building
 
+## Docker
+
+Check the build instructions for [**Windows**](https://github.com/shadps4-emu/shadPS4/blob/main/documents/building-docker.md).
+
 ## Windows
 
 Check the build instructions for [**Windows**](https://github.com/shadps4-emu/shadPS4/blob/main/documents/building-windows.md).

--- a/documents/Docker Builder/.devcontainer/devcontainer.json
+++ b/documents/Docker Builder/.devcontainer/devcontainer.json
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 {
     "name": "shadPS4-dev",
     "dockerComposeFile": [

--- a/documents/Docker Builder/.devcontainer/devcontainer.json
+++ b/documents/Docker Builder/.devcontainer/devcontainer.json
@@ -1,0 +1,42 @@
+{
+    "name": "shadPS4-dev",
+    "dockerComposeFile": [
+        "../docker-compose.yml"
+    ],
+    "containerEnv": {
+        "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}",
+        "GITHUB_USER": "${localEnv:GITHUB_USER}"
+    },
+    "service": "shadps4",
+    "workspaceFolder": "/workspaces/shadPS4",
+    "remoteUser": "root",
+    "shutdownAction": "none",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "llvm-vs-code-extensions.vscode-clangd"
+            ],
+            "settings": {
+                "C_Cpp.intelliSenseEngine": "disabled",
+                "clangd.arguments": [
+                    "--background-index",
+                    "--clang-tidy",
+                    "--completion-style=detailed",
+                    "--header-insertion=never"
+                ]
+            }
+        }
+    },
+    "settings": {
+        "cmake.configureOnOpen": false,
+        "cmake.generator": "Unix Makefiles",
+        "cmake.environment": {
+            "CC": "clang",
+            "CXX": "clang++"
+        },
+        "cmake.configureSettings": {
+            "CMAKE_CXX_STANDARD": "23",
+            "CMAKE_CXX_STANDARD_REQUIRED": "ON"
+        }
+    }
+}

--- a/documents/Docker Builder/.docker/Dockerfile
+++ b/documents/Docker Builder/.docker/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    clang \
+    git \
+    ca-certificates \
+    wget \
+    libasound2-dev \
+    libpulse-dev \
+    libopenal-dev \
+    libssl-dev \
+    zlib1g-dev \
+    libedit-dev \
+    libudev-dev \
+    libevdev-dev \
+    libsdl2-dev \
+    libjack-dev \
+    libsndio-dev \
+    libxtst-dev \
+    libvulkan-dev \
+    vulkan-validationlayers \
+    libpng-dev \
+    clang-tidy \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget -qO - https://apt.kitware.com/keys/kitware-archive-latest.asc | gpg --dearmor -o /usr/share/keyrings/kitware-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ noble main" > /etc/apt/sources.list.d/kitware.list \
+    && apt-get update \
+    && apt-get install -y cmake \
+    && rm -rf /var/lib/apt/lists/*/*
+
+WORKDIR /workspaces/shadPS4

--- a/documents/Docker Builder/.docker/Dockerfile
+++ b/documents/Docker Builder/.docker/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 shadPS4 Emulator Project
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/documents/Docker Builder/docker-compose.yml
+++ b/documents/Docker Builder/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  shadps4:
+    build:
+      context: ./.docker
+    volumes:
+      - ./emu:/workspaces/shadPS4:cached
+    tty: true

--- a/documents/Docker Builder/docker-compose.yml
+++ b/documents/Docker Builder/docker-compose.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 shadPS4 Emulator Project
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 services:
   shadps4:
     build:

--- a/documents/building-docker.md
+++ b/documents/building-docker.md
@@ -1,0 +1,86 @@
+# Building shadPS4 with Docker and VSCode Support
+
+This guide explains how to build **shadPS4** using Docker while keeping full compatibility with **VSCode** development.
+
+---
+
+## Prerequisites
+
+Before starting, ensure you have:
+
+- **Docker Engine** or **Docker Desktop** installed  
+  [Installation Guide](https://docs.docker.com/engine/install/)
+
+- **Git** installed on your system.
+
+---
+
+## Step 1: Prepare the Docker Environment
+
+Inside the container (or on your host if mounting volumes):
+
+1. Navigate to the repository folder containing the Docker Builder folder:
+
+```bash
+cd <path-to-repo>
+```
+
+2. Start the Docker container:
+
+```bash
+docker compose up -d
+```
+
+This will spin up a container with all the necessary build dependencies, including Clang, CMake, SDL2, Vulkan, and more.
+
+## Step 2: Clone shadPS4 Source
+
+```bash
+mkdir emu
+cd emu
+git clone --recursive https://github.com/shadps4-emu/shadPS4.git .
+
+or your fork link.
+```
+
+3. Initialize submodules:
+
+```bash
+git submodule update --init --recursive
+```
+
+## Step 3: Build with CMake
+
+Generate the build directory and configure the project using Clang:
+
+```bash
+cmake -S . -B build/ -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+```
+
+Then build the project:
+
+```bash
+cmake --build ./build --parallel $(nproc)
+```
+
+* Tip: To enable debug builds, add -DCMAKE_BUILD_TYPE=Debug to the CMake command.
+
+---
+
+After a successful build, the executable is located at:
+
+```bash
+./build/shadps4
+```
+
+## Step 4: VSCode Integration
+
+1. Open the repository in VSCode.
+2. The CMake Tools extension should automatically detect the build directory inside the container or on your host.
+3. You can configure build options, build, and debug directly from the VSCode interface without extra manual setup.
+
+# Notes
+
+* The Docker environment contains all dependencies, so you don’t need to install anything manually.
+* Using Clang inside Docker ensures consistent builds across Linux and macOS runners.
+* GitHub Actions are recommended for cross-platform builds, including Windows .exe output, which is not trivial to produce locally without Visual Studio or clang-cl.

--- a/documents/building-docker.md
+++ b/documents/building-docker.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2026 shadPS4 Emulator Project
+SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
 # Building shadPS4 with Docker and VSCode Support
 
 This guide explains how to build **shadPS4** using Docker while keeping full compatibility with **VSCode** development.


### PR DESCRIPTION
* Added documents/Docker Builder/ with Dockerfile, docker-compose, and devcontainer setup for building shadPS4 in a container.
* Created building-docker.md with instructions for building with Docker and VSCode support.
* Added SPDX copyright/license headers to all new files to comply with REUSE specification.

This allows contributors and users to build shadPS4 in a consistent containerized environment, simplifying setup and avoiding dependency issues on host systems.