### PR TITLE
Np: libSceNpPartner001 stubs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -599,6 +599,8 @@ set(NP_LIBS src/core/libraries/np/np_error.h
             src/core/libraries/np/np_profile_dialog.h
             src/core/libraries/np/np_sns_facebook_dialog.cpp
             src/core/libraries/np/np_sns_facebook_dialog.h
+            src/core/libraries/np/np_partner.cpp
+            src/core/libraries/np/np_partner.h
 )
 
 set(ZLIB_LIB src/core/libraries/zlib/zlib.cpp

--- a/src/common/logging/filter.cpp
+++ b/src/common/logging/filter.cpp
@@ -113,6 +113,7 @@ bool ParseFilterRule(Filter& instance, Iterator begin, Iterator end) {
     SUB(Lib, NpWebApi2)                                                                            \
     SUB(Lib, NpProfileDialog)                                                                      \
     SUB(Lib, NpSnsFacebookDialog)                                                                  \
+    SUB(Lib, NpPartner)                                                                            \
     SUB(Lib, Screenshot)                                                                           \
     SUB(Lib, LibCInternal)                                                                         \
     SUB(Lib, AppContent)                                                                           \

--- a/src/common/logging/types.h
+++ b/src/common/logging/types.h
@@ -110,6 +110,7 @@ enum class Class : u8 {
     Lib_Mouse,               ///< The LibSceMouse implementation
     Lib_WebBrowserDialog,    ///< The LibSceWebBrowserDialog implementation
     Lib_NpParty,             ///< The LibSceNpParty implementation
+    Lib_NpPartner,           ///< The LibSceNpPartner implementation
     Lib_Zlib,                ///< The LibSceZlib implementation.
     Lib_Hmd,                 ///< The LibSceHmd implementation.
     Lib_HmdSetupDialog,      ///< The LibSceHmdSetupDialog implementation.

--- a/src/core/libraries/libs.cpp
+++ b/src/core/libraries/libs.cpp
@@ -35,6 +35,7 @@
 #include "core/libraries/np/np_commerce.h"
 #include "core/libraries/np/np_common.h"
 #include "core/libraries/np/np_manager.h"
+#include "core/libraries/np/np_partner.h"
 #include "core/libraries/np/np_party.h"
 #include "core/libraries/np/np_profile_dialog.h"
 #include "core/libraries/np/np_score.h"
@@ -105,6 +106,7 @@ void InitHLELibs(Core::Loader::SymbolsResolver* sym) {
     Libraries::Np::NpSnsFacebookDialog::RegisterLib(sym);
     Libraries::Np::NpAuth::RegisterLib(sym);
     Libraries::Np::NpParty::RegisterLib(sym);
+    Libraries::Np::NpPartner::RegisterLib(sym);
     Libraries::ScreenShot::RegisterLib(sym);
     Libraries::AppContent::RegisterLib(sym);
     Libraries::PngDec::RegisterLib(sym);

--- a/src/core/libraries/np/np_partner.cpp
+++ b/src/core/libraries/np/np_partner.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <mutex>
+#include "common/logging/log.h"
+#include "core/libraries/error_codes.h"
+#include "core/libraries/libs.h"
+#include "core/libraries/np/np_partner.h"
+#include "core/libraries/np/np_partner_error.h"
+#include "core/libraries/system/userservice.h"
+
+namespace Libraries::Np::NpPartner {
+
+static bool g_library_init = false;
+std::mutex g_library_mutex{};
+
+/**
+ * Terminates the library
+ */
+s32 PS4_SYSV_ABI Func_A4CC5784DA33517F() {
+    LOG_ERROR(Lib_NpPartner, "(STUBBED) called");
+    if (!g_library_init) {
+        return ORBIS_NP_PARTNER_ERROR_NOT_INITIALIZED;
+    }
+    std::scoped_lock lk{g_library_mutex};
+    g_library_init = false;
+    return ORBIS_OK;
+}
+
+/**
+ * Aborts requests started by Func_F8E9DB52CD425743
+ */
+s32 PS4_SYSV_ABI Func_A507D84D91F39CC7() {
+    LOG_ERROR(Lib_NpPartner, "(STUBBED) called");
+    if (!g_library_init) {
+        return ORBIS_NP_PARTNER_ERROR_NOT_INITIALIZED;
+    }
+    // Request logic is unimplemented, so this does nothing.
+    return ORBIS_OK;
+}
+
+/**
+ * Initializes the library
+ */
+s32 PS4_SYSV_ABI Func_EC2C48E74FF19429() {
+    LOG_ERROR(Lib_NpPartner, "(STUBBED) called");
+    g_library_init = true;
+    // Also retrieves and sends compiled SDK version to server.
+    return ORBIS_OK;
+}
+
+/**
+ * Creates an NP request to determine if the user has a subscription to EA's services.
+ */
+s32 PS4_SYSV_ABI Func_F8E9DB52CD425743(UserService::OrbisUserServiceUserId user_id, bool* result) {
+    LOG_ERROR(Lib_NpPartner, "(STUBBED) called");
+    if (!g_library_init) {
+        return ORBIS_NP_PARTNER_ERROR_NOT_INITIALIZED;
+    }
+    if (result == nullptr) {
+        return ORBIS_NP_PARTNER_ERROR_INVALID_ARGUMENT;
+    }
+    std::scoped_lock lk{g_library_mutex};
+    // In the real library, this creates and sends a request that checks for EA subscription,
+    // then waits for the request to return a response, and returns that response.
+    // NP signed out likely returns an error, but I haven't figured out the error code yet.
+    // For now, stub having no subscription.
+    *result = false;
+    return ORBIS_OK;
+}
+
+void RegisterLib(Core::Loader::SymbolsResolver* sym) {
+    LIB_FUNCTION("pMxXhNozUX8", "libSceNpPartner001", 1, "libSceNpPartner001",
+                 Func_A4CC5784DA33517F);
+    LIB_FUNCTION("pQfYTZHznMc", "libSceNpPartner001", 1, "libSceNpPartner001",
+                 Func_A507D84D91F39CC7);
+    LIB_FUNCTION("7CxI50-xlCk", "libSceNpPartner001", 1, "libSceNpPartner001",
+                 Func_EC2C48E74FF19429);
+    LIB_FUNCTION("+OnbUs1CV0M", "libSceNpPartner001", 1, "libSceNpPartner001",
+                 Func_F8E9DB52CD425743);
+};
+
+} // namespace Libraries::Np::NpPartner

--- a/src/core/libraries/np/np_partner.h
+++ b/src/core/libraries/np/np_partner.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "common/types.h"
+
+namespace Core::Loader {
+class SymbolsResolver;
+}
+
+namespace Libraries::Np::NpPartner {
+
+void RegisterLib(Core::Loader::SymbolsResolver* sym);
+} // namespace Libraries::Np::NpPartner

--- a/src/core/libraries/np/np_partner_error.h
+++ b/src/core/libraries/np/np_partner_error.h
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "core/libraries/error_codes.h"
+
+constexpr int ORBIS_NP_PARTNER_ERROR_NOT_INITIALIZED = 0x819d0001;
+constexpr int ORBIS_NP_PARTNER_ERROR_INVALID_ARGUMENT = 0x819d0002;


### PR DESCRIPTION
This PR provides basics stubs for the functions exported by libSceNpPartner001.sprx.
This library, based on what I've decompiled of SceShellCore and the library itself, is used to determine if a player has a subscription to EA's services. Within SceShellCore, this library's functions are referred to as part of sceNpEAAccess.

Due to the lack of function names, I've provided some documentation on what each function appears to be used for.

I've cross referenced what I've done with decompiling STAR WARS Jedi: Fallen Order, to ensure uses and parameters make sense.