### PR TITLE
Fix most of vscode problems and switch to Arch for more stability

### DIFF
--- a/documents/Docker Builder/.devcontainer/devcontainer.json
+++ b/documents/Docker Builder/.devcontainer/devcontainer.json
@@ -17,29 +17,32 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                "llvm-vs-code-extensions.vscode-clangd"
+			    "llvm-vs-code-extensions.vscode-clangd",
+                "ms-vscode.cmake-tools"
             ],
             "settings": {
-                "C_Cpp.intelliSenseEngine": "disabled",
                 "clangd.arguments": [
                     "--background-index",
                     "--clang-tidy",
                     "--completion-style=detailed",
-                    "--header-insertion=never"
-                ]
+                    "--header-insertion=never",
+					"--compile-commands-dir=/workspaces/shadPS4/Build/x64-Clang-Release"
+                ],
+				"C_Cpp.intelliSenseEngine": "Disabled"
             }
         }
     },
     "settings": {
-        "cmake.configureOnOpen": false,
+		"cmake.configureOnOpen": false,
         "cmake.generator": "Unix Makefiles",
         "cmake.environment": {
             "CC": "clang",
             "CXX": "clang++"
         },
-        "cmake.configureSettings": {
-            "CMAKE_CXX_STANDARD": "23",
-            "CMAKE_CXX_STANDARD_REQUIRED": "ON"
-        }
+        "cmake.configureEnvironment": {
+			"CMAKE_CXX_STANDARD": "23",
+			"CMAKE_CXX_STANDARD_REQUIRED": "ON",
+			"CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+		}
     }
 }

--- a/documents/Docker Builder/.docker/Dockerfile
+++ b/documents/Docker Builder/.docker/Dockerfile
@@ -1,38 +1,42 @@
 # SPDX-FileCopyrightText: 2026 shadPS4 Emulator Project
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-FROM ubuntu:24.04
+FROM archlinux:latest
 
-ENV DEBIAN_FRONTEND=noninteractive
+RUN pacman-key --init && \
+    pacman-key --populate archlinux && \
+    pacman -Syu --noconfirm
 
-RUN apt-get update && apt-get install -y \
-    build-essential \
+RUN pacman -S --noconfirm \
+    base-devel \
     clang \
+    ninja \
     git \
     ca-certificates \
     wget \
-    libasound2-dev \
-    libpulse-dev \
-    libopenal-dev \
-    libssl-dev \
-    zlib1g-dev \
-    libedit-dev \
-    libudev-dev \
-    libevdev-dev \
-    libsdl2-dev \
-    libjack-dev \
-    libsndio-dev \
-    libxtst-dev \
-    libvulkan-dev \
-    vulkan-validationlayers \
-    libpng-dev \
-    clang-tidy \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN wget -qO - https://apt.kitware.com/keys/kitware-archive-latest.asc | gpg --dearmor -o /usr/share/keyrings/kitware-archive-keyring.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ noble main" > /etc/apt/sources.list.d/kitware.list \
-    && apt-get update \
-    && apt-get install -y cmake \
-    && rm -rf /var/lib/apt/lists/*/*
+    alsa-lib \
+    libpulse \
+    openal \
+    openssl \
+    zlib \
+    libedit \
+    systemd-libs \
+    libevdev \
+    sdl2 \
+    jack \
+    sndio \
+    libxtst \
+    vulkan-headers \
+    vulkan-validation-layers \
+    libpng \
+    clang-tools-extra \
+    cmake \
+    libx11 \
+    libxrandr \
+    libxcursor \
+    libxi \
+    libxinerama \
+    libxss \
+    && pacman -Scc --noconfirm
 
 WORKDIR /workspaces/shadPS4

--- a/documents/building-docker.md
+++ b/documents/building-docker.md
@@ -54,7 +54,16 @@ or your fork link.
 git submodule update --init --recursive
 ```
 
-## Step 3: Build with CMake
+## Step 3: Build with CMake Tools (GUI)
+
+Generate build with CMake Tools.
+
+1. Go `CMake Tools > Configure > '>'`
+2. And `Build > '>'`
+
+Compiled executable in `Build` folder.
+
+## Alternative Step 3: Build with CMake
 
 Generate the build directory and configure the project using Clang:
 


### PR DESCRIPTION
The previous version had a few issues:

- The Ubuntu-based Docker setup was causing problems, so it has been switched to Arch Linux.
- compile_commands.json was not being generated; this has been fixed.
- CMake Tools is now included as a built-in VSCode extension, so the container will install it automatically.