### PR TITLE
Fixes for thread (re)naming

### DIFF
--- a/src/common/thread.cpp
+++ b/src/common/thread.cpp
@@ -174,6 +174,9 @@ bool AccurateSleep(const std::chrono::nanoseconds duration, std::chrono::nanosec
 
 // Sets the debugger-visible name of the current thread.
 void SetCurrentThreadName(const char* name) {
+    if (Libraries::Kernel::g_curthread) {
+        Libraries::Kernel::g_curthread->name = std::string{name};
+    }
     SetThreadDescription(GetCurrentThread(), UTF8ToUTF16W(name).data());
 }
 
@@ -186,6 +189,9 @@ void SetThreadName(void* thread, const char* name) {
 // MinGW with the POSIX threading model does not support pthread_setname_np
 #if !defined(_WIN32) || defined(_MSC_VER)
 void SetCurrentThreadName(const char* name) {
+    if (Libraries::Kernel::g_curthread) {
+        Libraries::Kernel::g_curthread->name = std::string{name};
+    }
 #ifdef __APPLE__
     pthread_setname_np(name);
 #elif defined(__Bitrig__) || defined(__DragonFly__) || defined(__FreeBSD__) || defined(__OpenBSD__)
@@ -212,6 +218,9 @@ void SetThreadName(void* thread, const char* name) {
 
 #if defined(_WIN32)
 void SetCurrentThreadName(const char*) {
+    if (Libraries::Kernel::g_curthread) {
+        Libraries::Kernel::g_curthread->name = std::string{name};
+    }
     // Do Nothing on MinGW
 }
 

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2025-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "common/assert.h"
@@ -325,6 +325,7 @@ PthreadT PS4_SYSV_ABI posix_pthread_self() {
 }
 
 void PS4_SYSV_ABI posix_pthread_set_name_np(PthreadT thread, const char* name) {
+    LOG_INFO(Kernel_Pthread, "called, new name: {}", name);
     Common::SetCurrentThreadName(name);
 }
 

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2025-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "common/alignment.h"
@@ -105,7 +105,7 @@ void Linker::Execute(const std::vector<std::string>& args) {
     memory->SetupMemoryRegions(fmem_size, use_extended_mem1, use_extended_mem2);
 
     main_thread.Run([this, module, &args](std::stop_token) {
-        Common::SetCurrentThreadName("GAME_MainThread");
+        Common::SetCurrentThreadName("Game:Main");
         if (auto& ipc = IPC::Instance()) {
             ipc.WaitForStart();
         }

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2025-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <filesystem>
@@ -96,7 +96,7 @@ s32 ReadCompiledSdkVersion(const std::filesystem::path& file) {
 
 void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
                    std::optional<std::filesystem::path> p_game_folder) {
-    Common::SetCurrentThreadName("Main Thread");
+    Common::SetCurrentThreadName("shadPS4:Main");
     if (waitForDebuggerBeforeRun) {
         Debugger::WaitForDebuggerAttach();
     }


### PR DESCRIPTION
Now that thread names show up in the log, the small (and overall inconsequential) bugs with it are more noticeable than before. This PR fixes thread names not being renamed correctly (at least from the logs' perspective), and renames `Main Thread` to `shadPS4:Main`, and what was supposed to be `GAME_MainThread` but was `Thread2` due to the aforementioned renaming issue to `Game:Main` in order to be more consistent with other preexisting HLE thread names (such as `shadPS4:GpuCommandProcessor`, `shadPS4:AjmWorker` and other, less frequently logged threads).