### PR TITLE
[clang-format] Added correct version and vscode formatter

### DIFF
--- a/documents/Docker Builder/.devcontainer/devcontainer.json
+++ b/documents/Docker Builder/.devcontainer/devcontainer.json
@@ -17,8 +17,9 @@
     "customizations": {
         "vscode": {
             "extensions": [
-			    "llvm-vs-code-extensions.vscode-clangd",
-                "ms-vscode.cmake-tools"
+                "llvm-vs-code-extensions.vscode-clangd",
+                "ms-vscode.cmake-tools",
+                "xaver.clang-format"
             ],
             "settings": {
                 "clangd.arguments": [
@@ -26,23 +27,25 @@
                     "--clang-tidy",
                     "--completion-style=detailed",
                     "--header-insertion=never",
-					"--compile-commands-dir=/workspaces/shadPS4/Build/x64-Clang-Release"
+                    "--compile-commands-dir=/workspaces/shadPS4/Build/x64-Clang-Release"
                 ],
-				"C_Cpp.intelliSenseEngine": "Disabled"
+                "C_Cpp.intelliSenseEngine": "Disabled"
             }
         }
     },
     "settings": {
-		"cmake.configureOnOpen": false,
+        "cmake.configureOnOpen": false,
         "cmake.generator": "Unix Makefiles",
         "cmake.environment": {
             "CC": "clang",
             "CXX": "clang++"
         },
         "cmake.configureEnvironment": {
-			"CMAKE_CXX_STANDARD": "23",
-			"CMAKE_CXX_STANDARD_REQUIRED": "ON",
-			"CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
-		}
+            "CMAKE_CXX_STANDARD": "23",
+            "CMAKE_CXX_STANDARD_REQUIRED": "ON",
+            "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+        },
+        "editor.formatOnSave": true,
+        "clang-format.executable": "clang-format-19"
     }
 }

--- a/documents/Docker Builder/.docker/Dockerfile
+++ b/documents/Docker Builder/.docker/Dockerfile
@@ -10,6 +10,7 @@ RUN pacman-key --init && \
 RUN pacman -S --noconfirm \
     base-devel \
     clang \
+	clang19 \
     ninja \
     git \
     ca-certificates \
@@ -38,5 +39,7 @@ RUN pacman -S --noconfirm \
     libxinerama \
     libxss \
     && pacman -Scc --noconfirm
+	
+RUN ln -sf /usr/lib/llvm19/bin/clang-format /usr/bin/clang-format-19
 
 WORKDIR /workspaces/shadPS4


### PR DESCRIPTION
Follow up: https://github.com/shadps4-emu/shadPS4/pull/3964

* Added correct clang-format (19)
* And added vscode formatter