### PR TITLE
Net: Delete unused fds in sceNetEpollDestroy and sys_socketclose

### DIFF
--- a/src/core/libraries/network/net.cpp
+++ b/src/core/libraries/network/net.cpp
@@ -803,6 +803,7 @@ int PS4_SYSV_ABI sceNetEpollDestroy(OrbisNetId epollid) {
     LOG_DEBUG(Lib_Net, "called, epollid = {} ({})", epollid, file->epoll->name);
 
     file->epoll->Destroy();
+    FDTable::Instance()->DeleteHandle(epollid);
 
     return ORBIS_OK;
 }

--- a/src/core/libraries/network/sys_net.cpp
+++ b/src/core/libraries/network/sys_net.cpp
@@ -335,6 +335,7 @@ int PS4_SYSV_ABI sys_socketclose(OrbisNetId s) {
     LOG_DEBUG(Lib_Net, "s = {} ({})", s, file->m_guest_name);
     int returncode = file->socket->Close();
     if (returncode >= 0) {
+        FDTable::Instance()->DeleteHandle(s);
         return returncode;
     }
     LOG_ERROR(Lib_Net, "error code returned: {}", (u32)*Libraries::Kernel::__Error());


### PR DESCRIPTION
sceNetEpollDestroy and sys_socketclose should delete the descriptors associated with their file.
Not doing so led to some games (particularly from EA) blowing up the fd table with thousands of epolls and sockets.