### PR TITLE
Kernel.Vmm: Fix potential race condition involving concurrent Allocate and Free calls

### DIFF
--- a/src/core/file_sys/fs.cpp
+++ b/src/core/file_sys/fs.cpp
@@ -232,6 +232,9 @@ File* HandleTable::GetSocket(int d) {
         return nullptr;
     }
     auto file = m_files.at(d);
+    if (!file) {
+        return nullptr;
+    }
     if (file->type != Core::FileSys::FileType::Socket) {
         return nullptr;
     }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -177,7 +177,7 @@ bool MemoryManager::TryWriteBacking(void* address, const void* data, u64 size) {
 }
 
 PAddr MemoryManager::PoolExpand(PAddr search_start, PAddr search_end, u64 size, u64 alignment) {
-    std::scoped_lock lk{mutex};
+    std::scoped_lock lk{mutex, unmap_mutex};
     alignment = alignment > 0 ? alignment : 64_KB;
 
     auto dmem_area = FindDmemArea(search_start);
@@ -219,7 +219,7 @@ PAddr MemoryManager::PoolExpand(PAddr search_start, PAddr search_end, u64 size, 
 
 PAddr MemoryManager::Allocate(PAddr search_start, PAddr search_end, u64 size, u64 alignment,
                               s32 memory_type) {
-    std::scoped_lock lk{mutex};
+    std::scoped_lock lk{mutex, unmap_mutex};
     alignment = alignment > 0 ? alignment : 16_KB;
 
     auto dmem_area = FindDmemArea(search_start);


### PR DESCRIPTION
PAYDAY 2 occasionally crashes from a memory assert during dmem Free calls.
This PR makes PoolExpand and Allocate lock the extra "unmap" mutex I added in #3956, which will ensure they don't modify the dmem map after Free searches for areas to unmap.

Not fully sure this fixes the issue, as I can't consistently reproduce this issue, but this is something I should've fixed in that PR in the first place. I'm surprised Unity games didn't reveal this 😅 

Also snuck in a fix for sockets, HandleTable::GetSocket would crash if called with an invalid descriptor within the bounds of m_files. Came up while I was making my homebrew, but my socket PR got merged before I could push this fix there.