### PR TITLE
Kernel.Fs: Skip stdin for select reads

### DIFF
--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -1262,7 +1262,8 @@ s32 PS4_SYSV_ABI posix_select(s32 nfds, fd_set_posix* readfds, fd_set_posix* wri
         if (file->type == Core::FileSys::FileType::Regular ||
             file->type == Core::FileSys::FileType::Device) {
             // Disk files always ready
-            if (want_read) {
+            // For devices, stdin (fd 0) is never read-ready.
+            if (want_read && i != 0) {
                 FD_SET_POSIX(i, &read_ready);
             }
             if (want_write) {


### PR DESCRIPTION
UE uses select on stdin to signal if it should read from stdin. You can't write to stdin, so select never marks stdin as readable. (and attempting to read from stdin hangs the calling thread).