### PR TITLE
Fix thread names being set to garbage on Linux

### DIFF
--- a/src/common/thread.cpp
+++ b/src/common/thread.cpp
@@ -175,7 +175,7 @@ bool AccurateSleep(const std::chrono::nanoseconds duration, std::chrono::nanosec
 // Sets the debugger-visible name of the current thread.
 void SetCurrentThreadName(const char* name) {
     if (Libraries::Kernel::g_curthread) {
-        Libraries::Kernel::g_curthread->name = std::string{name};
+        Libraries::Kernel::g_curthread->name = name;
     }
     SetThreadDescription(GetCurrentThread(), UTF8ToUTF16W(name).data());
 }
@@ -190,7 +190,7 @@ void SetThreadName(void* thread, const char* name) {
 #if !defined(_WIN32) || defined(_MSC_VER)
 void SetCurrentThreadName(const char* name) {
     if (Libraries::Kernel::g_curthread) {
-        Libraries::Kernel::g_curthread->name = std::string{name};
+        Libraries::Kernel::g_curthread->name = name;
     }
 #ifdef __APPLE__
     pthread_setname_np(name);
@@ -219,7 +219,7 @@ void SetThreadName(void* thread, const char* name) {
 #if defined(_WIN32)
 void SetCurrentThreadName(const char*) {
     if (Libraries::Kernel::g_curthread) {
-        Libraries::Kernel::g_curthread->name = std::string{name};
+        Libraries::Kernel::g_curthread->name = name;
     }
     // Do Nothing on MinGW
 }


### PR DESCRIPTION
SetCurrentThreadName gets passed an std::string's c_str whose pointer gets invalidated by the assignment of g_curthread->name with a new std::string, resulting in broken thread names further down the line