### PR TITLE
Kernel.Pthread: Fix default pthread attributes

### DIFF
--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -14,12 +14,6 @@
 
 namespace Libraries::Kernel {
 
-constexpr int PthreadInheritSched = 4;
-
-constexpr int ORBIS_KERNEL_PRIO_FIFO_DEFAULT = 700;
-constexpr int ORBIS_KERNEL_PRIO_FIFO_HIGHEST = 256;
-constexpr int ORBIS_KERNEL_PRIO_FIFO_LOWEST = 767;
-
 extern PthreadAttr PthreadAttrDefault;
 
 void _thread_cleanupspecific();
@@ -231,7 +225,7 @@ int PS4_SYSV_ABI posix_pthread_create_name_np(PthreadT* thread, const PthreadAtt
         new_thread->attr = *(*attr);
         new_thread->attr.cpusetsize = 0;
     }
-    if (new_thread->attr.sched_inherit == PthreadInheritSched) {
+    if (curthread != nullptr && new_thread->attr.sched_inherit == PthreadInheritSched) {
         if (True(curthread->attr.flags & PthreadAttrFlags::ScopeSystem)) {
             new_thread->attr.flags |= PthreadAttrFlags::ScopeSystem;
         } else {

--- a/src/core/libraries/kernel/threads/pthread.h
+++ b/src/core/libraries/kernel/threads/pthread.h
@@ -24,6 +24,12 @@ class SymbolsResolver;
 
 namespace Libraries::Kernel {
 
+constexpr int PthreadInheritSched = 4;
+
+constexpr int ORBIS_KERNEL_PRIO_FIFO_DEFAULT = 700;
+constexpr int ORBIS_KERNEL_PRIO_FIFO_HIGHEST = 256;
+constexpr int ORBIS_KERNEL_PRIO_FIFO_LOWEST = 767;
+
 struct Pthread;
 
 enum class PthreadMutexFlags : u32 {

--- a/src/core/libraries/kernel/threads/pthread_attr.cpp
+++ b/src/core/libraries/kernel/threads/pthread_attr.cpp
@@ -24,9 +24,9 @@ static constexpr std::array<PthreadPrio, 3> ThrPriorities = {{
 }};
 
 PthreadAttr PthreadAttrDefault = {
-    .sched_policy = SchedPolicy::Fifo,
-    .sched_inherit = 0,
-    .prio = 0,
+    .sched_policy = SchedPolicy::Other,
+    .sched_inherit = PthreadInheritSched,
+    .prio = ORBIS_KERNEL_PRIO_FIFO_DEFAULT,
     .suspend = false,
     .flags = PthreadAttrFlags::ScopeSystem,
     .stackaddr_attr = nullptr,


### PR DESCRIPTION
Based on cross referencing libkernel decompilation with fpPS4's old code, our default pthread attributes were incorrect.

This fixes a variety of issues in Attack On Titan 2, mostly related to broken audio, as the game refuses to create an audio thread if the game's main thread priority is too low.