### PR TITLE
Fix address space wrapping in `Rasterizer::IsMapped` causing incorrect return

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -1015,6 +1015,10 @@ bool Rasterizer::IsMapped(VAddr addr, u64 size) {
         // There is no memory, so not mapped.
         return false;
     }
+    if (static_cast<u64>(addr) > std::numeric_limits<u64>::max() - size) {
+        // Memory range wrapped the address space, cannot be mapped.
+        return false;
+    }
     const auto range = decltype(mapped_ranges)::interval_type::right_open(addr, addr + size);
 
     Common::RecursiveSharedLock lock{mapped_ranges_mutex};


### PR DESCRIPTION
This PR adds a simple overflow check.

Explanation:
If `addr + size` overflow (and wrap), `boost::icl::contains` won't return an expected result for an interval where the left side is greater than the right side. This can cause an address size pair like `0xffffffffffffffff⁩⁩, 8` to be reported as mapped and causing an OOB access down the line when the page table is indexed with the address high bits. This would normally lead to a crash anyway, but with the wrapping bug present it will instead crash the shadPS4 liverpool thread, which is annoying for debugging.

How could this happen?
When a non-[canonical](https://stackoverflow.com/a/25852609) memory address is accessed, an access violation is raised. However, instead of the address itself, `ExceptionInformation[1]` may be set to `0xffffffffffffffff` instead in the exception handler. I can't really find a source where this is documented (so trust me ™).