### PR TITLE
Prevent posix_pthread_mutexattr_settype from setting invalid mutex types

### DIFF
--- a/src/core/libraries/kernel/threads/mutex.cpp
+++ b/src/core/libraries/kernel/threads/mutex.cpp
@@ -378,7 +378,8 @@ int PS4_SYSV_ABI posix_pthread_mutexattr_getkind_np(PthreadMutexAttrT attr) {
 }
 
 int PS4_SYSV_ABI posix_pthread_mutexattr_settype(PthreadMutexAttrT* attr, PthreadMutexType type) {
-    if (attr == nullptr || *attr == nullptr || type >= PthreadMutexType::Max) {
+    if (attr == nullptr || *attr == nullptr || type < PthreadMutexType::ErrorCheck ||
+        type >= PthreadMutexType::Max) {
         return POSIX_EINVAL;
     }
     (*attr)->m_type = type;


### PR DESCRIPTION
Some games like NHL17 (CUSA04326) pass `0` as the mutex type to `posix_pthread_mutexattr_settype`, which resets its recursive mutexes and causes them to behave incorrectly. The real ps4 kernel rejects this value.

I tested this on NHL17 and managed to get past the initial loading screen without any more race conditions caused by broken mutexes. It now crashes later in some video code...