### PR TITLE
Libs: Miscellaneous fixes

### DIFF
--- a/src/core/libraries/companion/companion_util.cpp
+++ b/src/core/libraries/companion/companion_util.cpp
@@ -29,10 +29,9 @@ u32 PS4_SYSV_ABI getEvent(sceCompanionUtilContext* ctx, sceCompanionUtilEvent* o
 }
 
 s32 PS4_SYSV_ABI sceCompanionUtilGetEvent(sceCompanionUtilEvent* outEvent) {
-    sceCompanionUtilContext* ctx = nullptr;
-    u32 ret = getEvent(ctx, outEvent, 1);
+    u32 ret = ORBIS_COMPANION_UTIL_NO_EVENT;
 
-    LOG_DEBUG(Lib_CompanionUtil, "(STUBBED) called ret: {}", ret);
+    LOG_DEBUG(Lib_CompanionUtil, "(STUBBED) called ret: {:#x}", ret);
     return ret;
 }
 

--- a/src/core/libraries/np/np_auth.cpp
+++ b/src/core/libraries/np/np_auth.cpp
@@ -123,7 +123,9 @@ s32 GetAuthorizationCode(s32 req_id, const OrbisNpAuthGetAuthorizationCodeParame
 
     // Not sure what values are expected here, so zeroing these for now.
     std::memset(auth_code, 0, sizeof(OrbisNpAuthorizationCode));
-    *issuer_id = 0;
+    if (issuer_id != nullptr) {
+        *issuer_id = 0;
+    }
     return ORBIS_OK;
 }
 


### PR DESCRIPTION
First change is a change to the return value of sceCompanionUtilGetEvent. Pretty sure I've rejected similar changes in the past, but with no incoming fixes, we might as well just make it a better stub for now.

Second change is a fix to libSceNpAuth's GetAuthorizationCode helper function. Mirror's Edge™ Catalyst throws a null issuer_id into the function if our PSN connectivity stub is enabled, and given the lack of null checks, I'm assuming this is considered valid for now.

Based on some debugging done by @brad0demx, these two changes should bring Mirror's Edge™ Catalyst to menus. I don't own the game, so someone else will need to showcase that working on here.