### PR TITLE
filesystem: fill in timespec values for fstat

### DIFF
--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -34,6 +34,7 @@
 #include <winsock2.h>
 #else
 #include <sys/select.h>
+#include <sys/stat.h>
 #endif
 
 namespace D = Core::Devices;
@@ -751,6 +752,13 @@ s32 PS4_SYSV_ABI fstat(s32 fd, OrbisKernelStat* sb) {
         sb->st_size = file->f.GetSize();
         sb->st_blksize = 512;
         sb->st_blocks = (sb->st_size + 511) / 512;
+#ifndef _WIN32
+        struct stat filestat = {};
+        stat(file->f.GetPath().c_str(), &filestat);
+        sb->st_atim = *reinterpret_cast<OrbisKernelTimespec*>(&filestat.st_atim);
+        sb->st_mtim = *reinterpret_cast<OrbisKernelTimespec*>(&filestat.st_mtim);
+        sb->st_ctim = *reinterpret_cast<OrbisKernelTimespec*>(&filestat.st_ctim);
+#endif
         // TODO incomplete
         break;
     }

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -752,15 +752,21 @@ s32 PS4_SYSV_ABI fstat(s32 fd, OrbisKernelStat* sb) {
         sb->st_size = file->f.GetSize();
         sb->st_blksize = 512;
         sb->st_blocks = (sb->st_size + 511) / 512;
-#ifndef _WIN32
+#if defined(__linux__) || defined(__FreeBSD__)
         struct stat filestat = {};
         stat(file->f.GetPath().c_str(), &filestat);
         sb->st_atim = *reinterpret_cast<OrbisKernelTimespec*>(&filestat.st_atim);
         sb->st_mtim = *reinterpret_cast<OrbisKernelTimespec*>(&filestat.st_mtim);
         sb->st_ctim = *reinterpret_cast<OrbisKernelTimespec*>(&filestat.st_ctim);
-#elif
+#elif defined(__APPLE__)
+        struct stat filestat = {};
+        stat(file->f.GetPath().c_str(), &filestat);
+        sb->st_atim = *reinterpret_cast<OrbisKernelTimespec*>(&filestat.st_atimespec);
+        sb->st_mtim = *reinterpret_cast<OrbisKernelTimespec*>(&filestat.st_mtimespec);
+        sb->st_ctim = *reinterpret_cast<OrbisKernelTimespec*>(&filestat.st_ctimespec);
+#else
         const auto ft = std::filesystem::last_write_time(file->f.GetPath());
-        const auto sctp = std::chrono::time_point_cast<nanoseconds>(
+        const auto sctp = std::chrono::time_point_cast<std::chrono::nanoseconds>(
             ft - std::filesystem::file_time_type::clock::now() + std::chrono::system_clock::now());
         const auto secs = std::chrono::time_point_cast<std::chrono::seconds>(sctp);
         const auto nsecs = std::chrono::duration_cast<std::chrono::nanoseconds>(sctp - secs);


### PR DESCRIPTION
Tearaway Unfolded has a check for whether the save files' last modification fall into a specific timespan, and if they aren't, then the save gets flagged as corrupt. By leaving these fields as zero, that check fails. By providing the correct values, this save "corruption" issue is resolved, although this doesn't help much for the fact that the game is still hanging at the end of loading.
On the Windows side, all three values (creation, modification and access) are spoofed with the last modification date, because that's the only one that std::filesystem has a cross-platform implementation for.