### PR TITLE
Kernel.Vmm: Fix bug with VMA physical area tracking

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -630,7 +630,7 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
             // Get the next relevant dmem area.
             current_phys_addr += size_in_dma;
             remaining_size -= size_in_dma;
-            dmem_area = FindDmemArea(phys_addr_to_search);
+            dmem_area = FindDmemArea(current_phys_addr);
         }
         ASSERT_MSG(remaining_size == 0, "Failed to map physical memory");
     }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -593,7 +593,10 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
             // Tracy memory tracking breaks from merging memory areas. Disabled for now.
             // TRACK_ALLOC(out_addr, size_to_map, "VMEM");
 
+            // Merge this handle with adjacent areas
             handle = MergeAdjacent(fmem_map, new_fmem_handle);
+
+            // Get the next flexible area.
             current_addr += size_to_map;
             remaining_size -= size_to_map;
             flexible_usage += size_to_map;
@@ -602,13 +605,13 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
         ASSERT_MSG(remaining_size == 0, "Failed to map physical memory");
     } else if (type == VMAType::Direct) {
         // Map the physical memory for this direct memory mapping.
-        auto phys_addr_to_search = phys_addr;
+        auto current_phys_addr = phys_addr;
         u64 remaining_size = size;
         auto dmem_area = FindDmemArea(phys_addr);
         while (dmem_area != dmem_map.end() && remaining_size > 0) {
             // Carve a new dmem area in place of this one with the appropriate type.
             // Ensure the carved area only covers the current dmem area.
-            const auto start_phys_addr = std::max<PAddr>(phys_addr, dmem_area->second.base);
+            const auto start_phys_addr = std::max<PAddr>(current_phys_addr, dmem_area->second.base);
             const auto offset_in_dma = start_phys_addr - dmem_area->second.base;
             const auto size_in_dma =
                 std::min<u64>(dmem_area->second.size - offset_in_dma, remaining_size);
@@ -617,15 +620,16 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
             new_dmem_area.dma_type = PhysicalMemoryType::Mapped;
 
             // Add the dmem area to this vma, merge it with any similar tracked areas.
-            new_vma.phys_areas[phys_addr_to_search - phys_addr] = dmem_handle->second;
+            const u64 offset_in_vma = current_phys_addr - phys_addr;
+            new_vma.phys_areas[offset_in_vma] = dmem_handle->second;
             MergeAdjacent(new_vma.phys_areas,
-                          new_vma.phys_areas.find(phys_addr_to_search - phys_addr));
+                          new_vma.phys_areas.find(offset_in_vma));
 
             // Merge the new dmem_area with dmem_map
             MergeAdjacent(dmem_map, dmem_handle);
 
             // Get the next relevant dmem area.
-            phys_addr_to_search = phys_addr + size_in_dma;
+            current_phys_addr += size_in_dma;
             remaining_size -= size_in_dma;
             dmem_area = FindDmemArea(phys_addr_to_search);
         }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -622,8 +622,7 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
             // Add the dmem area to this vma, merge it with any similar tracked areas.
             const u64 offset_in_vma = current_phys_addr - phys_addr;
             new_vma.phys_areas[offset_in_vma] = dmem_handle->second;
-            MergeAdjacent(new_vma.phys_areas,
-                          new_vma.phys_areas.find(offset_in_vma));
+            MergeAdjacent(new_vma.phys_areas, new_vma.phys_areas.find(offset_in_vma));
 
             // Merge the new dmem_area with dmem_map
             MergeAdjacent(dmem_map, dmem_handle);


### PR DESCRIPTION
This appears to fix memory asserts when loading ingame in Battlefield™ V (CUSA08724), which is only possible to test with nullGPU currently. This also fixes memory asserts when booting FIFA 18 (CUSA07994).
