### PR TITLE
Rewrote hotkeys in json format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1081,6 +1081,8 @@ set(INPUT src/input/controller.cpp
           src/input/input_handler.h
           src/input/input_mouse.cpp
           src/input/input_mouse.h
+          src/input/hotkeys_settings.cpp
+          src/input/hotkeys_settings.h
 )
 
 set(EMULATOR src/emulator.cpp

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -1286,25 +1286,6 @@ void setDefaultValues(bool is_game_specific) {
     }
 }
 
-constexpr std::string_view GetDefaultGlobalConfig() {
-    return R"(# Anything put here will be loaded for all games,
-# alongside the game's config or default.ini depending on your preference.
-
-hotkey_renderdoc_capture = f12
-hotkey_fullscreen = f11
-hotkey_show_fps = f10
-hotkey_pause = f9
-hotkey_reload_inputs = f8
-hotkey_toggle_mouse_to_joystick = f7
-hotkey_toggle_mouse_to_gyro = f6
-hotkey_toggle_mouse_to_touchpad = delete
-hotkey_quit = lctrl, lshift, end
-
-hotkey_volume_up = kpplus
-hotkey_volume_down = kpminus
-)";
-}
-
 constexpr std::string_view GetDefaultInputConfig() {
     return R"(#Feeling lost? Check out the Help section!
 
@@ -1406,17 +1387,6 @@ std::filesystem::path GetFoolproofInputConfigFile(const string& game_id) {
     // if empty, we only need to execute the function up until this point
     if (game_id.empty()) {
         return default_config_file;
-    }
-
-    // Create global config if it doesn't exist yet
-    if (game_id == "global" && !std::filesystem::exists(config_file)) {
-        if (!std::filesystem::exists(config_file)) {
-            const auto global_config = GetDefaultGlobalConfig();
-            std::ofstream global_config_stream(config_file);
-            if (global_config_stream) {
-                global_config_stream << global_config;
-            }
-        }
     }
 
     // If game-specific config doesn't exist, create it from the default config

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -182,7 +182,6 @@ std::filesystem::path getAddonInstallDir();
 
 void setDefaultValues(bool is_game_specific = false);
 
-constexpr std::string_view GetDefaultGlobalConfig();
 std::filesystem::path GetFoolproofInputConfigFile(const std::string& game_id = "");
 
 }; // namespace Config

--- a/src/input/hotkeys_settings.cpp
+++ b/src/input/hotkeys_settings.cpp
@@ -1,0 +1,207 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include "common/path_util.h"
+#include "hotkeys_settings.h"
+
+using json = nlohmann::json;
+
+std::shared_ptr<HotkeysSettingsManager> HotkeysSettingsManager::s_instance = nullptr;
+std::mutex HotkeysSettingsManager::s_mutex;
+
+// --------------------
+// ctor/dtor + singleton
+// --------------------
+HotkeysSettingsManager::HotkeysSettingsManager() {
+    // Load on construction
+    Load();
+}
+
+HotkeysSettingsManager::~HotkeysSettingsManager() {
+    Save();
+}
+
+std::shared_ptr<HotkeysSettingsManager> HotkeysSettingsManager::GetInstance() {
+    std::lock_guard<std::mutex> lock(s_mutex);
+    if (!s_instance) {
+        s_instance = std::make_shared<HotkeysSettingsManager>();
+    }
+    return s_instance;
+}
+
+void HotkeysSettingsManager::SetInstance(std::shared_ptr<HotkeysSettingsManager> instance) {
+    std::lock_guard<std::mutex> lock(s_mutex);
+    s_instance = instance;
+}
+
+// --------------------
+// Path helpers
+// --------------------
+std::filesystem::path HotkeysSettingsManager::GetDefaultConfigPath() const {
+    const std::filesystem::path userDir = Common::FS::GetUserPath(Common::FS::PathType::UserDir);
+    return userDir / "hotkeys.json";
+}
+
+std::filesystem::path HotkeysSettingsManager::GetConfigPath() const {
+    return GetDefaultConfigPath();
+}
+
+// --------------------
+// Merge with latest defaults
+// --------------------
+void HotkeysSettingsManager::MergeWithLatestDefaults() {
+    // Create a settings object with latest defaults
+    HotkeysSettings latestDefaults;
+    latestDefaults.SetDefaultValues();
+    latestDefaults.UpdateToLatestVersion();
+
+    bool needsSave = false;
+    int originalVersion = m_settings.version;
+
+    // Update to latest version structure
+    m_settings.UpdateToLatestVersion();
+
+    // Check for missing hotkeys from latest defaults
+    for (const auto& [key, defaultValue] : latestDefaults.bindings) {
+        if (m_settings.bindings.find(key) == m_settings.bindings.end()) {
+            // Add missing default hotkey
+            m_settings.bindings[key] = defaultValue;
+            needsSave = true;
+            std::cout << "[HotkeysSettings] Added missing default hotkey: " << key << " = "
+                      << defaultValue << std::endl;
+        }
+    }
+
+    // Save if we made any changes
+    if (needsSave || originalVersion < m_settings.version) {
+        std::cout << "[HotkeysSettings] Updated from version " << originalVersion << " to version "
+                  << m_settings.version << std::endl;
+        Save();
+    }
+}
+
+// --------------------
+// Load/Save helpers
+// --------------------
+bool HotkeysSettingsManager::LoadFromPath(const std::filesystem::path& path) {
+    try {
+        if (!std::filesystem::exists(path)) {
+            std::cout << "[HotkeysSettings] Config file not found: " << path << std::endl;
+            return false;
+        }
+
+        std::ifstream in(path);
+        if (!in.is_open()) {
+            std::cerr << "[HotkeysSettings] Failed to open config file: " << path << std::endl;
+            return false;
+        }
+
+        json j;
+        in >> j;
+
+        // Load settings from JSON
+        m_settings = j.get<HotkeysSettings>();
+
+        std::cout << "[HotkeysSettings] Loaded version " << m_settings.version << " with "
+                  << m_settings.bindings.size() << " hotkeys from: " << path << std::endl;
+
+        return true;
+    } catch (const std::exception& e) {
+        std::cerr << "[HotkeysSettings] Error loading from " << path << ": " << e.what()
+                  << std::endl;
+        return false;
+    }
+}
+
+bool HotkeysSettingsManager::SaveToPath(const std::filesystem::path& path) const {
+    try {
+        // Ensure directory exists
+        std::filesystem::create_directories(path.parent_path());
+
+        json j = m_settings;
+
+        std::ofstream out(path);
+        if (!out.is_open()) {
+            std::cerr << "[HotkeysSettings] Failed to open file for writing: " << path << std::endl;
+            return false;
+        }
+
+        out << std::setw(4) << j;
+        out.flush();
+
+        if (out.fail()) {
+            std::cerr << "[HotkeysSettings] Failed to write hotkeys to: " << path << std::endl;
+            return false;
+        }
+
+        std::cout << "[HotkeysSettings] Saved version " << m_settings.version << " with "
+                  << m_settings.bindings.size() << " hotkeys to: " << path << std::endl;
+        return true;
+    } catch (const std::exception& e) {
+        std::cerr << "[HotkeysSettings] Error saving to " << path << ": " << e.what() << std::endl;
+        return false;
+    }
+}
+
+// --------------------
+// Public Load/Save
+// --------------------
+bool HotkeysSettingsManager::Load() {
+    const std::filesystem::path configPath = GetDefaultConfigPath();
+
+    if (LoadFromPath(configPath)) {
+        // Successfully loaded, merge with latest defaults
+        MergeWithLatestDefaults();
+        return true;
+    } else {
+        // File doesn't exist or failed to load, use latest defaults
+        std::cout << "[HotkeysSettings] Creating new config with latest defaults" << std::endl;
+        m_settings.SetDefaultValues();
+        m_settings.UpdateToLatestVersion();
+        // Save new config
+        Save();
+        return true;
+    }
+}
+
+bool HotkeysSettingsManager::Save() const {
+    return SaveToPath(GetDefaultConfigPath());
+}
+
+bool HotkeysSettingsManager::Load(const std::filesystem::path& customPath) {
+    if (LoadFromPath(customPath)) {
+        MergeWithLatestDefaults();
+        return true;
+    }
+    return false;
+}
+
+bool HotkeysSettingsManager::Save(const std::filesystem::path& customPath) const {
+    return SaveToPath(customPath);
+}
+
+// --------------------
+// Hotkey accessors
+// --------------------
+std::string HotkeysSettingsManager::GetHotkey(const std::string& action) const {
+    auto it = m_settings.bindings.find(action);
+    if (it != m_settings.bindings.end()) {
+        return it->second;
+    }
+    return ""; // Return empty string if not found
+}
+
+void HotkeysSettingsManager::SetHotkey(const std::string& action, const std::string& keyCombo) {
+    m_settings.bindings[action] = keyCombo;
+}
+
+bool HotkeysSettingsManager::HasHotkey(const std::string& action) const {
+    return m_settings.bindings.find(action) != m_settings.bindings.end();
+}
+
+void HotkeysSettingsManager::RemoveHotkey(const std::string& action) {
+    m_settings.bindings.erase(action);
+}

--- a/src/input/hotkeys_settings.h
+++ b/src/input/hotkeys_settings.h
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <nlohmann/json.hpp>
+
+struct HotkeysSettings {
+    int version{1};
+    std::unordered_map<std::string, std::string> bindings;
+
+    HotkeysSettings() {
+        SetDefaultValues();
+    }
+
+    void SetDefaultValues() {
+        bindings.clear();
+        // Version 1 defaults
+        bindings["renderdoc_capture"] = "f12";
+        bindings["fullscreen"] = "f11";
+        bindings["show_fps"] = "f10";
+        bindings["pause"] = "f9";
+        bindings["reload_inputs"] = "f8";
+        bindings["toggle_mouse_to_joystick"] = "f7";
+        bindings["toggle_mouse_to_gyro"] = "f6";
+        bindings["toggle_mouse_to_touchpad"] = "delete";
+        bindings["quit"] = "lctrl, lshift, end";
+        bindings["volume_up"] = "kpplus";
+        bindings["volume_down"] = "kpminus";
+        version = 1;
+    }
+
+    // Add new defaults for version 2
+    void AddVersion2Defaults() {
+        if (version < 2) {
+            // add new hotkeys for version 2
+            // version = 2; and increase version
+        }
+    }
+
+    // Apply all version updates
+    void UpdateToLatestVersion() {
+        // AddVersion2Defaults();
+        //  Add more version updates here as needed
+    }
+};
+
+namespace nlohmann {
+template <>
+struct adl_serializer<HotkeysSettings> {
+    static void to_json(json& j, const HotkeysSettings& s) {
+        j = json::object();
+        j["version"] = s.version;
+        j["hotkeys"] = json::object();
+        for (const auto& [key, value] : s.bindings) {
+            j["hotkeys"][key] = value;
+        }
+    }
+
+    static void from_json(const json& j, HotkeysSettings& s) {
+        s.bindings.clear();
+        s.version = j["version"].get<int>();
+        // Load hotkeys
+        if (j.contains("hotkeys") && j["hotkeys"].is_object()) {
+            for (auto& [key, value] : j["hotkeys"].items()) {
+                if (value.is_string()) {
+                    s.bindings[key] = value.get<std::string>();
+                }
+            }
+        }
+    }
+};
+} // namespace nlohmann
+
+class HotkeysSettingsManager {
+public:
+    HotkeysSettingsManager();
+    ~HotkeysSettingsManager();
+
+    static std::shared_ptr<HotkeysSettingsManager> GetInstance();
+    static void SetInstance(std::shared_ptr<HotkeysSettingsManager> instance);
+
+    bool Save() const;
+    bool Load();
+    bool Save(const std::filesystem::path& customPath) const;
+    bool Load(const std::filesystem::path& customPath);
+
+    // Hotkey accessors
+    std::string GetHotkey(const std::string& action) const;
+    void SetHotkey(const std::string& action, const std::string& keyCombo);
+    bool HasHotkey(const std::string& action) const;
+    void RemoveHotkey(const std::string& action);
+
+    // Get all hotkeys
+    const std::unordered_map<std::string, std::string>& GetAllHotkeys() const {
+        return m_settings.bindings;
+    }
+
+    // Get current version
+    int GetVersion() const {
+        return m_settings.version;
+    }
+
+    // Reset to latest defaults
+    void ResetToDefaults() {
+        m_settings.SetDefaultValues();
+        m_settings.UpdateToLatestVersion();
+    }
+
+    // Add new hotkeys (preserves user customizations)
+    void AddNewHotkeys(const std::unordered_map<std::string, std::string>& newHotkeys) {
+        for (const auto& [action, combo] : newHotkeys) {
+            // Only add if not already present (preserve user changes)
+            if (m_settings.bindings.find(action) == m_settings.bindings.end()) {
+                m_settings.bindings[action] = combo;
+            }
+        }
+    }
+
+    // Update to latest version (adds missing defaults)
+    void UpdateToLatestVersion() {
+        m_settings.UpdateToLatestVersion();
+    }
+
+    // Get the config file path
+    std::filesystem::path GetConfigPath() const;
+
+private:
+    HotkeysSettings m_settings;
+
+    static std::shared_ptr<HotkeysSettingsManager> s_instance;
+    static std::mutex s_mutex;
+
+    std::filesystem::path GetDefaultConfigPath() const;
+    bool LoadFromPath(const std::filesystem::path& path);
+    bool SaveToPath(const std::filesystem::path& path) const;
+
+    // Merge loaded settings with latest defaults (adds missing, preserves user values)
+    void MergeWithLatestDefaults();
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #ifdef _WIN32
 #include <windows.h>
 #endif
+#include <input/hotkeys_settings.h>
 
 int main(int argc, char* argv[]) {
 #ifdef _WIN32
@@ -33,6 +34,8 @@ int main(int argc, char* argv[]) {
 
     auto emu_state = std::make_shared<EmulatorState>();
     EmulatorState::SetInstance(emu_state);
+
+    auto hotkeys_manager = std::make_shared<HotkeysSettingsManager>();
 
     const auto user_dir = Common::FS::GetUserPath(Common::FS::PathType::UserDir);
     Config::load(user_dir / "config.toml");


### PR DESCRIPTION
As title says hotkeys are now in json format , with support for versioning , so we can add new ones without the need to erase the old settings , also more clear solution than the existing

```
{
    "hotkeys": {
        "fullscreen": "f11",
        "pause": "f9",
        "quit": "lctrl, lshift, end",
        "reload_inputs": "f8",
        "renderdoc_capture": "f12",
        "show_fps": "f10",
        "toggle_mouse_to_gyro": "f6",
        "toggle_mouse_to_joystick": "f7",
        "toggle_mouse_to_touchpad": "delete",
        "volume_down": "kpminus",
        "volume_up": "kpplus"
    },
    "version": 1
}
```