### PR TITLE
Kernel.Pthreads: Remove unreachable in posix_pthread_mutex_timedlock

### DIFF
--- a/src/core/libraries/kernel/threads/mutex.cpp
+++ b/src/core/libraries/kernel/threads/mutex.cpp
@@ -261,7 +261,6 @@ int PS4_SYSV_ABI posix_pthread_mutex_lock(PthreadMutexT* mutex) {
 int PS4_SYSV_ABI posix_pthread_mutex_timedlock(PthreadMutexT* mutex,
                                                const OrbisKernelTimespec* abstime) {
     CHECK_AND_INIT_MUTEX
-    UNREACHABLE();
     return (*mutex)->Lock(abstime);
 }
 

--- a/src/core/libraries/np/np_web_api_internal.cpp
+++ b/src/core/libraries/np/np_web_api_internal.cpp
@@ -457,7 +457,7 @@ s32 createRequest(s32 titleUserCtxId, const char* pApiGroup, const char* pPath,
         request_id--;
     }
     // Real library would hang if this assert fails.
-    ASSERT_MSG(request_id > user_ctx_id << 0x20, "Too many requests!");
+    ASSERT_MSG(request_id <= (user_ctx_id << 0x20), "Too many requests!");
     user_context->requests[request_id] = new OrbisNpWebApiRequest{};
 
     auto& request = user_context->requests[request_id];


### PR DESCRIPTION
From what I can see, the code paths for handling timedlock appears to be fully implemented, so I don't see what the unreachable is for here. Removing the unreachable reportedly fixes an issue in Overwatch: Origins Edition (tested by @PirkyP)