### PR TITLE
Volume hotkeys: show volume value, set game_specific arg, clamp values

### DIFF
--- a/src/core/devtools/layer.cpp
+++ b/src/core/devtools/layer.cpp
@@ -32,6 +32,9 @@ static bool show_simple_fps = false;
 static bool visibility_toggled = false;
 static bool show_quit_window = false;
 
+static bool show_volume = false;
+static float volume_start_time;
+
 static float fps_scale = 1.0f;
 static int dump_frame_count = 1;
 
@@ -454,6 +457,27 @@ void L::Draw() {
         End();
     }
 
+    if (show_volume) {
+        float current_time = ImGui::GetTime();
+
+        // Show volume for 3 seconds
+        if (current_time - volume_start_time >= 3.0) {
+            show_volume = false;
+        } else {
+            SetNextWindowPos(ImVec2(ImGui::GetMainViewport()->WorkPos.x +
+                                        ImGui::GetMainViewport()->WorkSize.x - 10,
+                                    ImGui::GetMainViewport()->WorkPos.y + 10),
+                             ImGuiCond_Always, ImVec2(1.0f, 0.0f));
+
+            if (ImGui::Begin("Volume Window", &show_volume,
+                             ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoDecoration |
+                                 ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoDocking)) {
+                Text("Volume: %d", Config::getVolumeSlider());
+            }
+            End();
+        }
+    }
+
     PopID();
 }
 
@@ -480,6 +504,11 @@ void SetSimpleFps(bool enabled) {
 
 void ToggleQuitWindow() {
     show_quit_window = !show_quit_window;
+}
+
+void ShowVolume() {
+    volume_start_time = ImGui::GetTime();
+    show_volume = true;
 }
 
 } // namespace Overlay

--- a/src/core/devtools/layer.h
+++ b/src/core/devtools/layer.h
@@ -32,5 +32,6 @@ namespace Overlay {
 void ToggleSimpleFps();
 void SetSimpleFps(bool enabled);
 void ToggleQuitWindow();
+void ShowVolume();
 
 } // namespace Overlay

--- a/src/core/emulator_state.cpp
+++ b/src/core/emulator_state.cpp
@@ -35,3 +35,11 @@ bool EmulatorState::IsAutoPatchesLoadEnabled() const {
 void EmulatorState::SetAutoPatchesLoadEnabled(bool enable) {
     m_load_patches_auto = enable;
 }
+
+bool EmulatorState::IsGameSpecifigConfigUsed() const {
+    return m_game_specific_config_used;
+}
+
+void EmulatorState::SetGameSpecifigConfigUsed(bool used) {
+    m_game_specific_config_used = used;
+}

--- a/src/core/emulator_state.h
+++ b/src/core/emulator_state.h
@@ -18,6 +18,8 @@ public:
     void SetGameRunning(bool running);
     bool IsAutoPatchesLoadEnabled() const;
     void SetAutoPatchesLoadEnabled(bool enable);
+    bool IsGameSpecifigConfigUsed() const;
+    void SetGameSpecifigConfigUsed(bool used);
 
 private:
     static std::shared_ptr<EmulatorState> s_instance;
@@ -26,4 +28,5 @@ private:
     // state variables
     bool m_running = false;
     bool m_load_patches_auto = true;
+    bool m_game_specific_config_used = false;
 };

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -28,6 +28,7 @@
 #include "common/singleton.h"
 #include "core/debugger.h"
 #include "core/devtools/widget/module_list.h"
+#include "core/emulator_state.h"
 #include "core/file_format/psf.h"
 #include "core/file_format/trp.h"
 #include "core/file_sys/fs.h"
@@ -205,6 +206,13 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
 
     Config::load(Common::FS::GetUserPath(Common::FS::PathType::CustomConfigs) / (id + ".toml"),
                  true);
+
+    if (std::filesystem::exists(Common::FS::GetUserPath(Common::FS::PathType::CustomConfigs) /
+                                (id + ".toml"))) {
+        EmulatorState::GetInstance()->SetGameSpecifigConfigUsed(true);
+    } else {
+        EmulatorState::GetInstance()->SetGameSpecifigConfigUsed(false);
+    }
 
     // Initialize logging as soon as possible
     if (!id.empty() && Config::getSeparateLogFilesEnabled()) {

--- a/src/input/input_handler.cpp
+++ b/src/input/input_handler.cpp
@@ -22,6 +22,8 @@
 #include "common/elf_info.h"
 #include "common/io_file.h"
 #include "common/path_util.h"
+#include "core/devtools/layer.h"
+#include "core/emulator_state.h"
 #include "input/controller.h"
 #include "input/input_mouse.h"
 
@@ -550,6 +552,7 @@ void ControllerOutput::FinalizeUpdate() {
     }
     old_button_state = new_button_state;
     old_param = *new_param;
+    bool is_game_specific = EmulatorState::GetInstance()->IsGameSpecifigConfigUsed();
     if (button != SDL_GAMEPAD_BUTTON_INVALID) {
         switch (button) {
         case SDL_GAMEPAD_BUTTON_TOUCHPAD_LEFT:
@@ -595,10 +598,14 @@ void ControllerOutput::FinalizeUpdate() {
             PushSDLEvent(SDL_EVENT_RDOC_CAPTURE);
             break;
         case HOTKEY_VOLUME_UP:
-            Config::setVolumeSlider(Config::getVolumeSlider() + 10, true);
+            Config::setVolumeSlider(std::clamp(Config::getVolumeSlider() + 10, 0, 500),
+                                    is_game_specific);
+            Overlay::ShowVolume();
             break;
         case HOTKEY_VOLUME_DOWN:
-            Config::setVolumeSlider(Config::getVolumeSlider() - 10, true);
+            Config::setVolumeSlider(std::clamp(Config::getVolumeSlider() - 10, 0, 500),
+                                    is_game_specific);
+            Overlay::ShowVolume();
             break;
         case HOTKEY_QUIT:
             PushSDLEvent(SDL_EVENT_QUIT_DIALOG);


### PR DESCRIPTION
Some changes to volume hotkeys

1) Show volume value using Imgui overlay
2) Set the game-specific arg dynamically depending on whether a game-specific config was loaded
3) clamp volume values to a range of 0-500 (same as allowed range in qtlauncher)

<img width="1262" height="708" alt="image" src="https://github.com/user-attachments/assets/8b127b58-8e64-4989-84d8-060d24098fc7" />
