### PR TITLE
Fix deadlock from missed unlock call after #3946

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2025-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "common/alignment.h"


### PR DESCRIPTION
This fixes a regression in Shadow of the Colossus.
It also changes a heuristic that makes said game significantly more stable.