### PR TITLE
Core: Mount system fonts

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -147,6 +147,7 @@ static ConfigEntry<string> isSideTrophy("right");
 static ConfigEntry<bool> isConnectedToNetwork(false);
 static bool enableDiscordRPC = false;
 static std::filesystem::path sys_modules_path = {};
+static std::filesystem::path fonts_path = {};
 
 // Input
 static ConfigEntry<int> cursorState(HideCursorState::Idle);
@@ -235,6 +236,17 @@ std::filesystem::path getSysModulesPath() {
 
 void setSysModulesPath(const std::filesystem::path& path) {
     sys_modules_path = path;
+}
+
+std::filesystem::path getFontsPath() {
+    if (fonts_path.empty()) {
+        return Common::FS::GetUserPath(Common::FS::PathType::FontsDir);
+    }
+    return fonts_path;
+}
+
+void setFontsPath(const std::filesystem::path& path) {
+    fonts_path = path;
 }
 
 int getVolumeSlider() {
@@ -888,6 +900,7 @@ void load(const std::filesystem::path& path, bool is_game_specific) {
         isConnectedToNetwork.setFromToml(general, "isConnectedToNetwork", is_game_specific);
         defaultControllerID.setFromToml(general, "defaultControllerID", is_game_specific);
         sys_modules_path = toml::find_fs_path_or(general, "sysModulesPath", sys_modules_path);
+        fonts_path = toml::find_fs_path_or(general, "fontsPath", fonts_path);
     }
 
     if (data.contains("Input")) {
@@ -1161,6 +1174,7 @@ void save(const std::filesystem::path& path, bool is_game_specific) {
         // Non game-specific entries
         data["General"]["enableDiscordRPC"] = enableDiscordRPC;
         data["General"]["sysModulesPath"] = string{fmt::UTF(sys_modules_path.u8string()).data};
+        data["General"]["fontsPath"] = string{fmt::UTF(fonts_path.u8string()).data};
         data["GUI"]["installDirs"] = install_dirs;
         data["GUI"]["installDirsEnabled"] = install_dirs_enabled;
         data["GUI"]["saveDataPath"] = string{fmt::UTF(save_data_path.u8string()).data};

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -153,6 +153,8 @@ void setConnectedToNetwork(bool enable, bool is_game_specific = false);
 void setUserName(const std::string& name, bool is_game_specific = false);
 std::filesystem::path getSysModulesPath();
 void setSysModulesPath(const std::filesystem::path& path);
+std::filesystem::path getFontsPath();
+void setFontsPath(const std::filesystem::path& path);
 
 enum UsbBackendType : int { Real, SkylandersPortal, InfinityBase, DimensionsToypad };
 int getUsbDeviceBackend();

--- a/src/common/path_util.cpp
+++ b/src/common/path_util.cpp
@@ -128,6 +128,7 @@ static auto UserPaths = [] {
     create_path(PathType::CustomTrophy, user_dir / CUSTOM_TROPHY);
     create_path(PathType::CustomConfigs, user_dir / CUSTOM_CONFIGS);
     create_path(PathType::CacheDir, user_dir / CACHE_DIR);
+    create_path(PathType::FontsDir, user_dir / FONTS_DIR);
 
     std::ofstream notice_file(user_dir / CUSTOM_TROPHY / "Notice.txt");
     if (notice_file.is_open()) {

--- a/src/common/path_util.h
+++ b/src/common/path_util.h
@@ -25,6 +25,7 @@ enum class PathType {
     CustomTrophy,   // Where custom files for trophies are stored.
     CustomConfigs,  // Where custom files for different games are stored.
     CacheDir,       // Where pipeline and shader cache is stored.
+    FontsDir,       // Where dumped system fonts are stored.
 };
 
 constexpr auto PORTABLE_DIR = "user";
@@ -44,6 +45,7 @@ constexpr auto METADATA_DIR = "game_data";
 constexpr auto CUSTOM_TROPHY = "custom_trophy";
 constexpr auto CUSTOM_CONFIGS = "custom_configs";
 constexpr auto CACHE_DIR = "cache";
+constexpr auto FONTS_DIR = "fonts";
 
 // Filenames
 constexpr auto LOG_FILE = "shad_log.txt";

--- a/src/core/libraries/kernel/kernel.h
+++ b/src/core/libraries/kernel/kernel.h
@@ -17,6 +17,7 @@ void ErrSceToPosix(s32 result);
 s32 ErrnoToSceKernelError(s32 e);
 void SetPosixErrno(s32 e);
 s32* PS4_SYSV_ABI __Error();
+const char* PS4_SYSV_ABI sceKernelGetFsSandboxRandomWord();
 
 extern Core::EntryParams entry_params;
 

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -370,7 +370,7 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
     VideoCore::SetOutputDir(mount_captures_dir, id);
 
     // Mount system fonts
-    const auto& fonts_dir = Common::FS::GetUserPath(Common::FS::PathType::FontsDir);
+    const auto& fonts_dir = Config::getFontsPath();
     if (!std::filesystem::exists(fonts_dir)) {
         std::filesystem::create_directory(fonts_dir);
     }

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -36,6 +36,7 @@
 #include "core/libraries/font/font.h"
 #include "core/libraries/font/fontft.h"
 #include "core/libraries/jpeg/jpegenc.h"
+#include "core/libraries/kernel/kernel.h"
 #include "core/libraries/libc_internal/libc_internal.h"
 #include "core/libraries/libpng/pngenc.h"
 #include "core/libraries/libs.h"
@@ -367,6 +368,34 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
         std::filesystem::create_directory(mount_captures_dir);
     }
     VideoCore::SetOutputDir(mount_captures_dir, id);
+
+    // Mount system fonts
+    const auto& fonts_dir = Common::FS::GetUserPath(Common::FS::PathType::FontsDir);
+    if (!std::filesystem::exists(fonts_dir)) {
+        std::filesystem::create_directory(fonts_dir);
+    }
+
+    // Fonts are mounted into the sandboxed system directory, construct the appropriate path.
+    const char* sandbox_root = Libraries::Kernel::sceKernelGetFsSandboxRandomWord();
+    std::string guest_font_dir = "/";
+    guest_font_dir.append(sandbox_root).append("/common/font");
+    const auto& host_font_dir = fonts_dir / "font";
+    if (!std::filesystem::exists(host_font_dir)) {
+        std::filesystem::create_directory(host_font_dir);
+    }
+    mnt->Mount(host_font_dir, guest_font_dir);
+
+    // There is a second font directory, mount that too.
+    guest_font_dir.append("2");
+    const auto& host_font2_dir = fonts_dir / "font2";
+    if (!std::filesystem::exists(host_font2_dir)) {
+        std::filesystem::create_directory(host_font2_dir);
+    }
+    mnt->Mount(host_font2_dir, guest_font_dir);
+
+    if (std::filesystem::is_empty(host_font_dir) || std::filesystem::is_empty(host_font2_dir)) {
+        LOG_WARNING(Loader, "No dumped system fonts, expect missing text or instability");
+    }
 
     // Initialize kernel and library facilities.
     Libraries::InitHLELibs(&linker->GetHLESymbols());


### PR DESCRIPTION
Now that libSceFont LLE works, mounting these will help some titles progress further. This fixes anywhereVR.

<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/5dc72698-e5e9-4a1a-ba5b-0adaf7aa7b04" />
<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/e1ad1bcf-7ba2-4e6d-8397-7aa3383a1ce2" />

I will add a proper font dumping guide to the shadPS4 wiki when I have a chance after this is merged. 
To dump firmware fonts:
- Load up your PS4 with some jailbreak
- On your computer, open your preferred ftp client and connect to the PS4, following the process as dumping firmware libraries.
- Navigate to `/preinst/common/`, copy the `font` folder in there into your shadPS4's fonts directory (by default, `{user folder}/fonts`).
- Navigate to `/system/common/`, copy the `font2` folder in there into your shadPS4's fonts directory (by default, `{user folder}/fonts`).
- Once you've completed these dumps, your shadPS4's fonts directory should have a `font` and `font2` directory inside it.

This PR has some overlap with the fonts mounting done in #3772, but since libSceFont LLE now works, I think this change should be prioritized until that PR is ready to go.