### PR TITLE
Kernel.Equeue: Only reset trigger state on events that clear.

### DIFF
--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -165,10 +165,6 @@ int EqueueInternal::GetTriggeredEvents(SceKernelEvent* ev, int num) {
     for (auto it = m_events.begin(); it != m_events.end();) {
         if (it->IsTriggered()) {
             ev[count++] = it->event;
-
-            // Event should not trigger again
-            it->ResetTriggerState();
-
             if (it->event.flags & SceKernelEvent::Flags::Clear) {
                 it->Clear();
             }

--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -32,6 +32,14 @@ bool EqueueInternal::AddEvent(EqueueEvent& event) {
         event.timer_interval = std::chrono::microseconds(event.event.data - offset);
     }
 
+    // Remove add flag from event
+    event.event.flags &= ~SceKernelEvent::Flags::Add;
+
+    // Clear flag is appended to most event types internally.
+    if (event.event.filter != SceKernelEvent::Filter::User) {
+        event.event.flags |= SceKernelEvent::Flags::Clear;
+    }
+
     const auto& it = std::ranges::find(m_events, event);
     if (it != m_events.cend()) {
         *it = std::move(event);

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -84,11 +84,8 @@ struct EqueueEvent {
     std::chrono::microseconds timer_interval;
     std::unique_ptr<boost::asio::steady_timer> timer;
 
-    void ResetTriggerState() {
-        is_triggered = false;
-    }
-
     void Clear() {
+        is_triggered = false;
         event.fflags = 0;
         event.data = 0;
     }


### PR DESCRIPTION
Unless the event has the clear flag, it will be returned multiple times after triggering.

Not sure what all this helps, but it came up while running some tests.