### PR TITLE
GR2-win-crash-fix

### DIFF
--- a/src/core/tls.h
+++ b/src/core/tls.h
@@ -62,7 +62,7 @@ ReturnType ExecuteGuest(PS4_SYSV_ABI ReturnType (*func)(FuncArgs...), CallArgs&&
     EnsureThreadInitialized();
     // clear stack to avoid trash from EnsureThreadInitialized
     auto* tcb = GetTcbBase();
-    if (tcb == nullptr && tcb->tcb_fiber == nullptr) {
+    if (tcb != nullptr && tcb->tcb_fiber == nullptr) {
         ClearStack<12_KB>();
     }
     return func(std::forward<CallArgs>(args)...);

--- a/src/core/tls.h
+++ b/src/core/tls.h
@@ -59,6 +59,7 @@ void ClearStack() {
 
 template <class ReturnType, class... FuncArgs, class... CallArgs>
 ReturnType ExecuteGuest(PS4_SYSV_ABI ReturnType (*func)(FuncArgs...), CallArgs&&... args) {
+    EnsureThreadInitialized();
     // clear stack to avoid trash from EnsureThreadInitialized
     auto* tcb = GetTcbBase();
     if (tcb == nullptr) {

--- a/src/core/tls.h
+++ b/src/core/tls.h
@@ -59,9 +59,9 @@ void ClearStack() {
 
 template <class ReturnType, class... FuncArgs, class... CallArgs>
 ReturnType ExecuteGuest(PS4_SYSV_ABI ReturnType (*func)(FuncArgs...), CallArgs&&... args) {
-    // clear stack to avoid trash from EnsureThreadInitialized (skip on fiber stacks)
+    // clear stack to avoid trash from EnsureThreadInitialized
     auto* tcb = GetTcbBase();
-    if (tcb == nullptr || tcb->tcb_fiber == nullptr) {
+    if (tcb == nullptr) {
         ClearStack<12_KB>();
     }
     return func(std::forward<CallArgs>(args)...);

--- a/src/core/tls.h
+++ b/src/core/tls.h
@@ -59,9 +59,11 @@ void ClearStack() {
 
 template <class ReturnType, class... FuncArgs, class... CallArgs>
 ReturnType ExecuteGuest(PS4_SYSV_ABI ReturnType (*func)(FuncArgs...), CallArgs&&... args) {
-    EnsureThreadInitialized();
-    // clear stack to avoid trash from EnsureThreadInitialized
-    ClearStack<12_KB>();
+    // clear stack to avoid trash from EnsureThreadInitialized (skip on fiber stacks)
+    auto* tcb = GetTcbBase();
+    if (tcb == nullptr || tcb->tcb_fiber == nullptr) {
+        ClearStack<12_KB>();
+    }
     return func(std::forward<CallArgs>(args)...);
 }
 

--- a/src/core/tls.h
+++ b/src/core/tls.h
@@ -62,7 +62,7 @@ ReturnType ExecuteGuest(PS4_SYSV_ABI ReturnType (*func)(FuncArgs...), CallArgs&&
     EnsureThreadInitialized();
     // clear stack to avoid trash from EnsureThreadInitialized
     auto* tcb = GetTcbBase();
-    if (tcb == nullptr) {
+    if (tcb == nullptr && tcb->tcb_fiber == nullptr) {
         ClearStack<12_KB>();
     }
     return func(std::forward<CallArgs>(args)...);


### PR DESCRIPTION
Added a check for fiber stacks before clearing the stack in ExecuteGuest. That fixes Gravity Rush 2 crash on Windows.