### PR TITLE
Equeue: More hotfixes

### DIFF
--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -98,14 +98,13 @@ struct EqueueEvent {
 
     void TriggerUser(void* data) {
         is_triggered = true;
-        event.fflags++;
         event.udata = data;
     }
 
     void TriggerDisplay(void* data) {
         is_triggered = true;
         if (data != nullptr) {
-            auto event_data = static_cast<OrbisVideoOutEventData>(event.data);
+            auto event_data = std::bit_cast<OrbisVideoOutEventData>(event.data);
             auto event_hint_raw = reinterpret_cast<u64>(data);
             auto event_hint = static_cast<OrbisVideoOutEventHint>(event_hint_raw);
             if (event_hint.event_id == event.ident && event.ident != 0xfe) {


### PR DESCRIPTION
User events don't increment fflags, so don't increment it.
Also added a bugfix for dce events, as static_cast wasn't properly unpacking the old event.data, so returned counters were occasionally off.