### PR TITLE
filesystem: fix crashes caused by returning a pointer from an std::vector

### DIFF
--- a/src/core/file_sys/fs.cpp
+++ b/src/core/file_sys/fs.cpp
@@ -55,7 +55,7 @@ std::filesystem::path MntPoints::GetHostPath(std::string_view path, bool* is_rea
     if (path.length() > 255)
         return "";
 
-    const MntPair* mount = GetMount(corrected_path);
+    const std::optional<MntPair> mount = GetMount(corrected_path);
     if (!mount) {
         return "";
     }

--- a/src/core/file_sys/fs.h
+++ b/src/core/file_sys/fs.h
@@ -5,6 +5,7 @@
 
 #include <atomic>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <vector>
 #include <tsl/robin_map.h>
@@ -58,14 +59,17 @@ public:
         return it == m_mnt_pairs.end() ? nullptr : &*it;
     }
 
-    const MntPair* GetMount(const std::string& guest_path) {
+    const std::optional<MntPair> GetMount(const std::string& guest_path) {
         std::scoped_lock lock{m_mutex};
         const auto it = std::ranges::find_if(m_mnt_pairs, [&](const auto& mount) {
             // When doing starts-with check, add a trailing slash to make sure we don't match
             // against only part of the mount path.
             return guest_path == mount.mount || guest_path.starts_with(mount.mount + "/");
         });
-        return it == m_mnt_pairs.end() ? nullptr : &*it;
+        if (it == m_mnt_pairs.end()) {
+            return std::nullopt;
+        }
+        return *it;
     }
 
 private:

--- a/src/core/libraries/save_data/save_instance.cpp
+++ b/src/core/libraries/save_data/save_instance.cpp
@@ -105,7 +105,7 @@ SaveInstance::SaveInstance(int slot_num, Libraries::UserService::OrbisUserServic
     mount_point = "/savedata" + std::to_string(slot_num);
 
     this->exists = fs::exists(param_sfo_path);
-    this->mounted = g_mnt->GetMount(mount_point) != nullptr;
+    this->mounted = g_mnt->GetMount(mount_point) != std::nullopt;
 }
 
 SaveInstance::~SaveInstance() {


### PR DESCRIPTION
This fixes an issue where games can mount a save, add a new mountpoint to m_mnt_pairs, which triggers a realloc, while at the same time using a pointer from the current allocation in GetHostPath, which gets invalidated by the reallocation causing nullptr reads.
I'm pretty sure the only reason this wasn't an issue before is that the vector only reached its capacity and started resizing itself after the two new font mounts were added.