### PR TITLE
threads: initialize TLS on thread creation

### DIFF
--- a/src/core/libraries/avplayer/avplayer_impl.cpp
+++ b/src/core/libraries/avplayer/avplayer_impl.cpp
@@ -12,28 +12,28 @@ void* PS4_SYSV_ABI AvPlayer::Allocate(void* handle, u32 alignment, u32 size) {
     const auto* const self = reinterpret_cast<AvPlayer*>(handle);
     const auto allocate = self->m_init_data_original.memory_replacement.allocate;
     const auto ptr = self->m_init_data_original.memory_replacement.object_ptr;
-    return Core::ExecuteGuest(allocate, ptr, alignment, size);
+    return allocate(ptr, alignment, size);
 }
 
 void PS4_SYSV_ABI AvPlayer::Deallocate(void* handle, void* memory) {
     const auto* const self = reinterpret_cast<AvPlayer*>(handle);
     const auto deallocate = self->m_init_data_original.memory_replacement.deallocate;
     const auto ptr = self->m_init_data_original.memory_replacement.object_ptr;
-    return Core::ExecuteGuest(deallocate, ptr, memory);
+    return deallocate(ptr, memory);
 }
 
 void* PS4_SYSV_ABI AvPlayer::AllocateTexture(void* handle, u32 alignment, u32 size) {
     const auto* const self = reinterpret_cast<AvPlayer*>(handle);
     const auto allocate = self->m_init_data_original.memory_replacement.allocate_texture;
     const auto ptr = self->m_init_data_original.memory_replacement.object_ptr;
-    return Core::ExecuteGuest(allocate, ptr, alignment, size);
+    return allocate(ptr, alignment, size);
 }
 
 void PS4_SYSV_ABI AvPlayer::DeallocateTexture(void* handle, void* memory) {
     const auto* const self = reinterpret_cast<AvPlayer*>(handle);
     const auto deallocate = self->m_init_data_original.memory_replacement.deallocate_texture;
     const auto ptr = self->m_init_data_original.memory_replacement.object_ptr;
-    return Core::ExecuteGuest(deallocate, ptr, memory);
+    return deallocate(ptr, memory);
 }
 
 int PS4_SYSV_ABI AvPlayer::OpenFile(void* handle, const char* filename) {
@@ -42,7 +42,7 @@ int PS4_SYSV_ABI AvPlayer::OpenFile(void* handle, const char* filename) {
 
     const auto open = self->m_init_data_original.file_replacement.open;
     const auto ptr = self->m_init_data_original.file_replacement.object_ptr;
-    return Core::ExecuteGuest(open, ptr, filename);
+    return open(ptr, filename);
 }
 
 int PS4_SYSV_ABI AvPlayer::CloseFile(void* handle) {
@@ -51,7 +51,7 @@ int PS4_SYSV_ABI AvPlayer::CloseFile(void* handle) {
 
     const auto close = self->m_init_data_original.file_replacement.close;
     const auto ptr = self->m_init_data_original.file_replacement.object_ptr;
-    return Core::ExecuteGuest(close, ptr);
+    return close(ptr);
 }
 
 int PS4_SYSV_ABI AvPlayer::ReadOffsetFile(void* handle, u8* buffer, u64 position, u32 length) {
@@ -60,7 +60,7 @@ int PS4_SYSV_ABI AvPlayer::ReadOffsetFile(void* handle, u8* buffer, u64 position
 
     const auto read_offset = self->m_init_data_original.file_replacement.read_offset;
     const auto ptr = self->m_init_data_original.file_replacement.object_ptr;
-    return Core::ExecuteGuest(read_offset, ptr, buffer, position, length);
+    return read_offset(ptr, buffer, position, length);
 }
 
 u64 PS4_SYSV_ABI AvPlayer::SizeFile(void* handle) {
@@ -69,7 +69,7 @@ u64 PS4_SYSV_ABI AvPlayer::SizeFile(void* handle) {
 
     const auto size = self->m_init_data_original.file_replacement.size;
     const auto ptr = self->m_init_data_original.file_replacement.object_ptr;
-    return Core::ExecuteGuest(size, ptr);
+    return size(ptr);
 }
 
 AvPlayerInitData AvPlayer::StubInitData(const AvPlayerInitData& data) {

--- a/src/core/libraries/avplayer/avplayer_state.cpp
+++ b/src/core/libraries/avplayer/avplayer_state.cpp
@@ -92,7 +92,7 @@ void AvPlayerState::DefaultEventCallback(void* opaque, AvPlayerEvents event_id, 
     const auto callback = self->m_event_replacement.event_callback;
     const auto ptr = self->m_event_replacement.object_ptr;
     if (callback != nullptr) {
-        Core::ExecuteGuest(callback, ptr, event_id, 0, event_data);
+        callback(ptr, event_id, 0, event_data);
     }
 }
 

--- a/src/core/libraries/ime/ime.cpp
+++ b/src/core/libraries/ime/ime.cpp
@@ -99,16 +99,16 @@ public:
         if (m_ime_mode) {
             OrbisImeParam param = m_param.ime;
             if (use_param_handler) {
-                Core::ExecuteGuest(param.handler, param.arg, event);
+                param.handler(param.arg, event);
             } else {
-                Core::ExecuteGuest(handler, param.arg, event);
+                handler(param.arg, event);
             }
         } else {
             OrbisImeKeyboardParam param = m_param.key;
             if (use_param_handler) {
-                Core::ExecuteGuest(param.handler, param.arg, event);
+                param.handler(param.arg, event);
             } else {
-                Core::ExecuteGuest(handler, param.arg, event);
+                handler(param.arg, event);
             }
         }
     }

--- a/src/core/libraries/ime/ime_dialog_ui.cpp
+++ b/src/core/libraries/ime/ime_dialog_ui.cpp
@@ -131,8 +131,7 @@ bool ImeDialogState::CallTextFilter() {
         return false;
     }
 
-    int ret =
-        Core::ExecuteGuest(text_filter, out_text, &out_text_length, src_text, src_text_length);
+    int ret = text_filter(out_text, &out_text_length, src_text, src_text_length);
 
     if (ret != 0) {
         return false;
@@ -153,7 +152,7 @@ bool ImeDialogState::CallKeyboardFilter(const OrbisImeKeycode* src_keycode, u16*
         return true;
     }
 
-    int ret = Core::ExecuteGuest(keyboard_filter, src_keycode, out_keycode, out_status, nullptr);
+    int ret = keyboard_filter(src_keycode, out_keycode, out_status, nullptr);
     return ret == 0;
 }
 

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -194,6 +194,21 @@ int PS4_SYSV_ABI posix_pthread_detach(PthreadT pthread) {
     return 0;
 }
 
+#ifdef __clang__
+__attribute__((optnone))
+#else
+__attribute__((optimize("O0")))
+#endif
+void ClearStack(const PthreadAttr& attr) {
+    void* sp;
+    asm("mov %%rsp, %0" : "=rm"(sp));
+    // leave a safety net of 128 bytes for memset
+    const u64 size = (u64)sp - (u64)attr.stackaddr_attr - 128;
+    volatile void* buf = alloca(size);
+    memset(const_cast<void*>(buf), 0, size);
+    buf = nullptr;
+}
+
 static void RunThread(void* arg) {
     auto* curthread = static_cast<Pthread*>(arg);
     g_curthread = curthread;
@@ -203,6 +218,10 @@ static void RunThread(void* arg) {
     /* Run the current thread's start routine with argument: */
     curthread->native_thr.Initialize();
     Core::EnsureThreadInitialized();
+
+    // Clear the stack before running the guest thread
+    ClearStack(curthread->attr);
+
     void* ret = curthread->start_routine(curthread->arg);
 
     /* Remove thread from tracking */

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -202,7 +202,8 @@ static void RunThread(void* arg) {
 
     /* Run the current thread's start routine with argument: */
     curthread->native_thr.Initialize();
-    void* ret = Core::ExecuteGuest(curthread->start_routine, curthread->arg);
+    Core::EnsureThreadInitialized();
+    void* ret = curthread->start_routine(curthread->arg);
 
     /* Remove thread from tracking */
     DebugState.RemoveCurrentThreadFromGuestList();

--- a/src/core/libraries/kernel/threads/pthread_spec.cpp
+++ b/src/core/libraries/kernel/threads/pthread_spec.cpp
@@ -84,7 +84,7 @@ void _thread_cleanupspecific() {
                  * destructor:
                  */
                 lk.unlock();
-                Core::ExecuteGuest(destructor, data);
+                destructor(data);
                 lk.lock();
             }
         }

--- a/src/core/libraries/network/net_ctl_obj.cpp
+++ b/src/core/libraries/network/net_ctl_obj.cpp
@@ -50,7 +50,7 @@ void NetCtlInternal::CheckCallback() {
                                                          : ORBIS_NET_CTL_EVENT_TYPE_DISCONNECTED;
     for (const auto [func, arg] : callbacks) {
         if (func != nullptr) {
-            Core::ExecuteGuest(func, event, arg);
+            func(event, arg);
         }
     }
 }
@@ -61,7 +61,7 @@ void NetCtlInternal::CheckNpToolkitCallback() {
                                                          : ORBIS_NET_CTL_EVENT_TYPE_DISCONNECTED;
     for (const auto [func, arg] : nptool_callbacks) {
         if (func != nullptr) {
-            Core::ExecuteGuest(func, event, arg);
+            func(event, arg);
         }
     }
 }

--- a/src/core/libraries/ngs2/ngs2.cpp
+++ b/src/core/libraries/ngs2/ngs2.cpp
@@ -160,13 +160,13 @@ s32 PS4_SYSV_ABI sceNgs2SystemCreateWithAllocator(const OrbisNgs2SystemOption* o
             result = SystemSetup(option, &bufferInfo, 0, 0);
             if (result >= 0) {
                 uintptr_t sysUserData = allocator->userData;
-                result = Core::ExecuteGuest(hostAlloc, &bufferInfo);
+                result = hostAlloc(&bufferInfo);
                 if (result >= 0) {
                     OrbisNgs2Handle* handleCopy = outHandle;
                     result = SystemSetup(option, &bufferInfo, hostFree, handleCopy);
                     if (result < 0) {
                         if (hostFree) {
-                            Core::ExecuteGuest(hostFree, &bufferInfo);
+                            hostFree(&bufferInfo);
                         }
                     }
                 }

--- a/src/core/libraries/usbd/emulated/dimensions.cpp
+++ b/src/core/libraries/usbd/emulated/dimensions.cpp
@@ -3,6 +3,8 @@
 
 #include "dimensions.h"
 
+#include "core/tls.h"
+
 #include <mutex>
 #include <thread>
 
@@ -622,6 +624,8 @@ libusb_transfer_status DimensionsBackend::HandleAsyncTransfer(libusb_transfer* t
 s32 DimensionsBackend::SubmitTransfer(libusb_transfer* transfer) {
     if (transfer->endpoint == 0x01) {
         std::thread write_thread([this, transfer] {
+            Core::EnsureThreadInitialized();
+
             HandleAsyncTransfer(transfer);
 
             const u8 flags = transfer->flags;

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -97,7 +97,8 @@ Module::~Module() = default;
 s32 Module::Start(u64 args, const void* argp, void* param) {
     LOG_INFO(Core_Linker, "Module started : {}", name);
     const VAddr addr = dynamic_info.init_virtual_addr + GetBaseAddress();
-    return ExecuteGuest(reinterpret_cast<EntryFunc>(addr), args, argp, param);
+    Core::EnsureThreadInitialized();
+    return reinterpret_cast<EntryFunc>(addr)(args, argp, param);
 }
 
 void Module::LoadModuleToMemory(u32& max_tls_index) {

--- a/src/core/tls.cpp
+++ b/src/core/tls.cpp
@@ -200,7 +200,6 @@ thread_local std::once_flag init_tls_flag;
 
 void EnsureThreadInitialized() {
     std::call_once(init_tls_flag, [] { SetTcbBase(Libraries::Kernel::g_curthread->tcb); });
-    Core::ClearStack<12_KB>();
 }
 
 } // namespace Core

--- a/src/core/tls.cpp
+++ b/src/core/tls.cpp
@@ -200,6 +200,7 @@ thread_local std::once_flag init_tls_flag;
 
 void EnsureThreadInitialized() {
     std::call_once(init_tls_flag, [] { SetTcbBase(Libraries::Kernel::g_curthread->tcb); });
+    Core::ClearStack<12_KB>();
 }
 
 } // namespace Core

--- a/src/core/tls.h
+++ b/src/core/tls.h
@@ -45,29 +45,6 @@ Tcb* GetTcbBase();
 /// Makes sure TLS is initialized for the thread before entering guest.
 void EnsureThreadInitialized();
 
-template <size_t size>
-#ifdef __clang__
-__attribute__((optnone))
-#else
-__attribute__((optimize("O0")))
-#endif
-void ClearStack() {
-    volatile void* buf = alloca(size);
-    memset(const_cast<void*>(buf), 0, size);
-    buf = nullptr;
-}
-
-template <class ReturnType, class... FuncArgs, class... CallArgs>
-ReturnType ExecuteGuest(PS4_SYSV_ABI ReturnType (*func)(FuncArgs...), CallArgs&&... args) {
-    EnsureThreadInitialized();
-    // clear stack to avoid trash from EnsureThreadInitialized
-    auto* tcb = GetTcbBase();
-    if (tcb != nullptr && tcb->tcb_fiber == nullptr) {
-        ClearStack<12_KB>();
-    }
-    return func(std::forward<CallArgs>(args)...);
-}
-
 template <class F, F f>
 struct HostCallWrapperImpl;
 

--- a/src/core/tls.h
+++ b/src/core/tls.h
@@ -45,18 +45,6 @@ Tcb* GetTcbBase();
 /// Makes sure TLS is initialized for the thread before entering guest.
 void EnsureThreadInitialized();
 
-template <size_t size>
-#ifdef __clang__
-__attribute__((optnone))
-#else
-__attribute__((optimize("O0")))
-#endif
-void ClearStack() {
-    volatile void* buf = alloca(size);
-    memset(const_cast<void*>(buf), 0, size);
-    buf = nullptr;
-}
-
 template <class F, F f>
 struct HostCallWrapperImpl;
 

--- a/src/core/tls.h
+++ b/src/core/tls.h
@@ -45,6 +45,18 @@ Tcb* GetTcbBase();
 /// Makes sure TLS is initialized for the thread before entering guest.
 void EnsureThreadInitialized();
 
+template <size_t size>
+#ifdef __clang__
+__attribute__((optnone))
+#else
+__attribute__((optimize("O0")))
+#endif
+void ClearStack() {
+    volatile void* buf = alloca(size);
+    memset(const_cast<void*>(buf), 0, size);
+    buf = nullptr;
+}
+
 template <class F, F f>
 struct HostCallWrapperImpl;
 


### PR DESCRIPTION
I'm not sure why this was like this before, but I assume the code in `ExecuteGuest` just initialized the TLS once per thread. I think this can be done on thread start instead of delaying it to the first guest call. This removes the need for stack cleanup hack.

I've tested this with Catherine and GR2

Let me know if this breaks something or has a potential to.