### PR TITLE
Timer touchups

### DIFF
--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -268,9 +268,6 @@ s32 PS4_SYSV_ABI sceKernelAddHRTimerEvent(SceKernelEqueue eq, int id, timespec* 
         return ORBIS_KERNEL_ERROR_EBADF;
     }
 
-    if (ts->tv_sec > 100 || ts->tv_nsec < 100'000) {
-        return ORBIS_KERNEL_ERROR_EINVAL;
-    }
     const auto total_us = ts->tv_sec * 1000'000 + ts->tv_nsec / 1000;
 
     EqueueEvent event{};

--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -278,7 +278,6 @@ s32 PS4_SYSV_ABI sceKernelAddHRTimerEvent(SceKernelEqueue eq, int id, timespec* 
     if (ts->tv_sec > 100 || ts->tv_nsec < 100'000) {
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
-    ASSERT(ts->tv_nsec > 1000); // assume 1us resolution
     const auto total_us = ts->tv_sec * 1000'000 + ts->tv_nsec / 1000;
 
     EqueueEvent event{};

--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -27,13 +27,8 @@ bool EqueueInternal::AddEvent(EqueueEvent& event) {
 
     event.time_added = std::chrono::steady_clock::now();
     if (filter == SceKernelEvent::Filter::Timer || filter == SceKernelEvent::Filter::HrTimer) {
-        // HrTimer events are offset by the threshold of time at the end that we spinlock for
-        // greater accuracy.
-        const auto offset =
-            filter == SceKernelEvent::Filter::HrTimer ? HrTimerSpinlockThresholdUs : 0u;
-        event.timer_interval = std::chrono::microseconds(event.event.data - offset);
-
-        // Timer interval is hidden from event data.
+        // Store requested timer interval, then remove it from the actual event data.
+        event.timer_interval = std::chrono::microseconds(event.event.data);
         event.event.data = 0;
     }
 

--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -156,7 +156,8 @@ bool EqueueInternal::TriggerEvent(u64 ident, s16 filter, void* trigger_data) {
                     event.TriggerDisplay(trigger_data);
                 } else if (filter == SceKernelEvent::Filter::User) {
                     event.TriggerUser(trigger_data);
-                } else if (filter == SceKernelEvent::Filter::Timer || filter == SceKernelEvent::HrTimer) {
+                } else if (filter == SceKernelEvent::Filter::Timer ||
+                           filter == SceKernelEvent::HrTimer) {
                     event.TriggerTimer();
                 } else {
                     event.Trigger(trigger_data);

--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -15,10 +15,7 @@ namespace Libraries::Kernel {
 extern boost::asio::io_context io_context;
 extern void KernelSignalRequest();
 
-static constexpr auto HrTimerSpinlockThresholdUs = 1200u;
-
 // Events are uniquely identified by id and filter.
-
 bool EqueueInternal::AddEvent(EqueueEvent& event) {
     std::scoped_lock lock{m_mutex};
 

--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -30,6 +30,9 @@ bool EqueueInternal::AddEvent(EqueueEvent& event) {
         const auto offset =
             event.event.filter == SceKernelEvent::Filter::HrTimer ? HrTimerSpinlockThresholdUs : 0u;
         event.timer_interval = std::chrono::microseconds(event.event.data - offset);
+
+        // Timer interval is hidden from event data.
+        event.event.data = 0;
     }
 
     // Remove add flag from event
@@ -157,6 +160,8 @@ bool EqueueInternal::TriggerEvent(u64 ident, s16 filter, void* trigger_data) {
                     event.TriggerDisplay(trigger_data);
                 } else if (filter == SceKernelEvent::Filter::User) {
                     event.TriggerUser(trigger_data);
+                } else if (filter == SceKernelEvent::Filter::Timer) {
+                    event.TriggerTimer();
                 } else {
                     event.Trigger(trigger_data);
                 }

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -157,22 +157,6 @@ public:
     int WaitForEvents(SceKernelEvent* ev, int num, const SceKernelUseconds* timo);
     bool TriggerEvent(u64 ident, s16 filter, void* trigger_data);
     int GetTriggeredEvents(SceKernelEvent* ev, int num);
-
-    bool AddSmallTimer(EqueueEvent& event);
-    bool HasSmallTimer() {
-        std::scoped_lock lock{m_mutex};
-        return !m_small_timers.empty();
-    }
-    bool RemoveSmallTimer(u64 id) {
-        if (HasSmallTimer()) {
-            std::scoped_lock lock{m_mutex};
-            return m_small_timers.erase(id) > 0;
-        }
-        return false;
-    }
-
-    int WaitForSmallTimer(SceKernelEvent* ev, int num, u32 micros);
-
     bool EventExists(u64 id, s16 filter);
 
 private:

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -119,6 +119,11 @@ struct EqueueEvent {
         }
     }
 
+    void TriggerTimer() {
+        is_triggered = true;
+        event.data++;
+    }
+
     bool IsTriggered() const {
         return is_triggered;
     }

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -92,7 +92,6 @@ struct EqueueEvent {
 
     void Trigger(void* data) {
         is_triggered = true;
-        event.fflags++;
         event.data = reinterpret_cast<uintptr_t>(data);
     }
 

--- a/src/core/libraries/videoout/driver.cpp
+++ b/src/core/libraries/videoout/driver.cpp
@@ -312,20 +312,23 @@ void VideoOutDriver::PresentThread(std::stop_token token) {
         }
 
         {
+            // Trigger flip events for the port.
+            for (auto& event : main_port.vblank_events) {
+                if (event != nullptr) {
+                    event->TriggerEvent(static_cast<u64>(OrbisVideoOutInternalEventId::Vblank),
+                                        Kernel::SceKernelEvent::Filter::VideoOut,
+                                        reinterpret_cast<void*>(
+                                            static_cast<u64>(OrbisVideoOutInternalEventId::Vblank) |
+                                            (vblank_status.count << 16)));
+                }
+            }
+
             // Needs lock here as can be concurrently read by `sceVideoOutGetVblankStatus`
             std::scoped_lock lock{main_port.vo_mutex};
             vblank_status.count++;
             vblank_status.process_time = Libraries::Kernel::sceKernelGetProcessTime();
             vblank_status.tsc = Libraries::Kernel::sceKernelReadTsc();
             main_port.vblank_cv.notify_all();
-        }
-
-        // Trigger flip events for the port.
-        for (auto& event : main_port.vblank_events) {
-            if (event != nullptr) {
-                event->TriggerEvent(static_cast<u64>(OrbisVideoOutInternalEventId::Vblank),
-                                    Kernel::SceKernelEvent::Filter::VideoOut, nullptr);
-            }
         }
 
         timer.End();


### PR DESCRIPTION
This PR fixes several inaccuracies with our event queues implementation.
- Removed fflags incrementing
- Removed small timer logic
- Fixed event data for timer events
- Fixed event duplication
- Fixed data for VideoOut vblank events

These changes fix some random hanging and debugger crashes seen in titles abusing high-res timers.

Regarding my removal of small timer-specific logic: my hardware tests (posted at https://github.com/ps4emulation/integration_tests/pull/16) suggest that small timers are around the same accuracy as normal timers, somewhere between 10 and 20ms is as low as you can go before real hardware's timing inaccuracies become apparent. Even our timer event logic is fast enough to be more accurate than real hardware.

I'm opening this as a draft, I'd like to see some tests before this gets merged, primarily to make sure removing the special high accuracy small timer logic doesn't break titles using those.