### PR TITLE
Fix: Device loss caused by image overlap (Partial)

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -114,6 +114,10 @@ private:
     bool IsComputeImageCopy(const Pipeline* pipeline);
     bool IsComputeImageClear(const Pipeline* pipeline);
 
+    // --- 新增：为特定计算着色器生成 mip 链 ---
+    void GenerateMipChainForWrittenImages(const Shader::Info& cs_info);
+    void GenerateMipChainForImage(VideoCore::Image& image);
+
 private:
     friend class VideoCore::BufferCache;
 

--- a/src/video_core/texture_cache/image.h
+++ b/src/video_core/texture_cache/image.h
@@ -185,6 +185,9 @@ public:
         u32 needs_rebind : 1;
         u32 force_general : 1;
     } binding{};
+
+    // --- 新增：标记是否已为此图像生成过 mip 链（用于避免重复生成）---
+    bool generated_mip_chain = false;
 };
 
 } // namespace VideoCore


### PR DESCRIPTION
Root Cause:
- When an existing image in the texture cache overlaps with a new image request at the same address but with incompatible properties, ResolveOverlap detects block size mismatch and returns an empty ID indicating the need for a new image
- However, when attempting to copy data from the source image to the new image, CopyImage fails due to the source image being in an invalid state (pitch=0 or sample count=0), causing device loss

Changes:
1. Added detection for pitch mismatch and block size mismatch in ResolveOverlap, returning empty ID to indicate the need for a new image instead of reusing
2. Modified FindImage to recognize cases requiring a new image and create a fresh image instance
3. Temporarily disabled image copy logic to prevent device loss; CopyImage function needs further fixes

Status: Partial completion - images can be created normally, but content
        copying functionality is currently disabled

修复: 图像重叠导致的设备丢失问题 (部分完成)

问题原因：
- 当纹理缓存中已存在图像与新请求图像地址相同但属性不兼容时， ResolveOverlap 检测到块大小不匹配，返回空ID指示需要创建新图像
- 但在尝试从源图像复制数据到新图像时，由于源图像可能处于无效状态 （pitch=0 或采样数为0），导致 CopyImage 调用失败，引发设备丢失

本次修改：
1. 在 ResolveOverlap 中添加了对 pitch 不匹配、块大小不匹配等情况的检测， 返回空ID指示需要创建新图像而非直接复用
2. 在 FindImage 中识别需要新图像的情况，创建全新的图像实例
3. 暂时禁用图像复制逻辑以避免设备丢失，后续需要进一步修复 CopyImage 函数

状态：部分完成，图像已能正常创建，但内容复制功能暂未启用