### PR TITLE
Calculate flex memory size

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -1426,7 +1426,10 @@ u64 MemoryManager::GetFlexibleMappedBytesInRangeLocked(VAddr virtual_addr, u64 s
     }
 
     u64 mapped_bytes = 0;
-    auto it = std::prev(vma_map.upper_bound(range_start));
+    auto it = vma_map.upper_bound(range_start);
+    if (it != vma_map.begin()) {
+        it = std::prev(it);
+    }
     while (it != vma_map.end() && it->second.base < range_end) {
         const auto& vma = it->second;
         const VAddr vma_end = vma.base + vma.size;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -1394,7 +1394,8 @@ bool MemoryManager::IsFlexibleCommittedVma(const VirtualMemoryArea& vma) const {
     const bool has_physical_tracking =
         vma.type == VMAType::Direct || vma.type == VMAType::Flexible || vma.type == VMAType::Pooled;
     if (has_physical_tracking) {
-        // Direct/flexible/pooled mappings should expose at least one physical sub-area when committed.
+        // Direct/flexible/pooled mappings should expose at least one physical sub-area when
+        // committed.
         return !vma.phys_areas.empty();
     }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -1394,8 +1394,7 @@ bool MemoryManager::IsFlexibleCommittedVma(const VirtualMemoryArea& vma) const {
     const bool has_physical_tracking =
         vma.type == VMAType::Direct || vma.type == VMAType::Flexible || vma.type == VMAType::Pooled;
     if (has_physical_tracking) {
-        // Direct/flexible/pooled mappings should expose at least one physical sub-area when
-        // committed.
+        // Direct/flexible/pooled mappings should expose at least one physical sub-area when committed.
         return !vma.phys_areas.empty();
     }
 

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -157,9 +157,11 @@ struct VirtualMemoryArea {
 class MemoryManager {
     using PhysMap = std::map<PAddr, PhysicalMemoryArea>;
     using PhysHandle = PhysMap::iterator;
+    using PhysConstHandle = PhysMap::const_iterator;
 
     using VMAMap = std::map<VAddr, VirtualMemoryArea>;
     using VMAHandle = VMAMap::iterator;
+    using VMAConstHandle = VMAMap::const_iterator;
 
 public:
     explicit MemoryManager();
@@ -181,8 +183,17 @@ public:
         return total_flexible_size;
     }
 
+    u64 GetUsedFlexibleSize() const {
+        return flexible_mapped_usage;
+    }
+
     u64 GetAvailableFlexibleSize() const {
-        return total_flexible_size - flexible_usage;
+        const u64 used = GetUsedFlexibleSize();
+        return used < total_flexible_size ? total_flexible_size - used : 0;
+    }
+
+    bool IsFlexibleRegionConfigured() const {
+        return flexible_virtual_end > flexible_virtual_base;
     }
 
     VAddr SystemReservedVirtualBase() noexcept {
@@ -288,20 +299,31 @@ public:
 
     void InvalidateMemory(VAddr addr, u64 size) const;
 
+    void RecalculateFlexibleUsageForDebug();
+
 private:
     VMAHandle FindVMA(VAddr target) {
+        return std::prev(vma_map.upper_bound(target));
+    }
+    VMAConstHandle FindVMA(VAddr target) const {
         return std::prev(vma_map.upper_bound(target));
     }
 
     PhysHandle FindDmemArea(PAddr target) {
         return std::prev(dmem_map.upper_bound(target));
     }
+    PhysConstHandle FindDmemArea(PAddr target) const {
+        return std::prev(dmem_map.upper_bound(target));
+    }
 
     PhysHandle FindFmemArea(PAddr target) {
         return std::prev(fmem_map.upper_bound(target));
     }
+    PhysConstHandle FindFmemArea(PAddr target) const {
+        return std::prev(fmem_map.upper_bound(target));
+    }
 
-    bool HasPhysicalBacking(VirtualMemoryArea vma) {
+    bool HasPhysicalBacking(const VirtualMemoryArea& vma) const {
         return vma.type == VMAType::Direct || vma.type == VMAType::Flexible ||
                vma.type == VMAType::Pooled;
     }
@@ -327,6 +349,16 @@ private:
 
     s32 UnmapMemoryImpl(VAddr virtual_addr, u64 size);
 
+    bool IsFlexibleCountedVmaType(VMAType type) const;
+
+    bool IsFlexibleCommittedVma(const VirtualMemoryArea& vma) const;
+
+    u64 GetFlexibleMappedBytesInRangeLocked(VAddr virtual_addr, u64 size) const;
+
+    void AdjustFlexibleMappedUsageLocked(u64 mapped_before, u64 mapped_after);
+
+    void RecalculateFlexibleMappedUsageLocked();
+
 private:
     AddressSpace impl;
     PhysMap dmem_map;
@@ -337,6 +369,9 @@ private:
     u64 total_direct_size{};
     u64 total_flexible_size{};
     u64 flexible_usage{};
+    VAddr flexible_virtual_base{};
+    VAddr flexible_virtual_end{};
+    u64 flexible_mapped_usage{};
     u64 pool_budget{};
     s32 sdk_version{};
     Vulkan::Rasterizer* rasterizer{};

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -111,6 +111,7 @@ struct VirtualMemoryArea {
     std::string name = "";
     s32 fd = 0;
     bool disallow_merge = false;
+    bool is_system_module = false;
 
     bool Contains(VAddr addr, u64 size) const {
         return addr >= base && (addr + size) <= (base + this->size);
@@ -147,6 +148,9 @@ struct VirtualMemoryArea {
             return false;
         }
         if (name.compare(next.name) != 0) {
+            return false;
+        }
+        if (is_system_module != next.is_system_module) {
             return false;
         }
 
@@ -263,7 +267,8 @@ public:
 
     s32 MapMemory(void** out_addr, VAddr virtual_addr, u64 size, MemoryProt prot,
                   MemoryMapFlags flags, VMAType type, std::string_view name = "anon",
-                  bool validate_dmem = false, PAddr phys_addr = -1, u64 alignment = 0);
+                  bool validate_dmem = false, PAddr phys_addr = -1, u64 alignment = 0,
+                  bool is_system_module = false);
 
     s32 MapFile(void** out_addr, VAddr virtual_addr, u64 size, MemoryProt prot,
                 MemoryMapFlags flags, s32 fd, s64 phys_addr);
@@ -329,7 +334,7 @@ private:
     }
 
     VMAHandle CreateArea(VAddr virtual_addr, u64 size, MemoryProt prot, MemoryMapFlags flags,
-                         VMAType type, std::string_view name, u64 alignment);
+                         VMAType type, std::string_view name, u64 alignment, bool is_system_module);
 
     VAddr SearchFree(VAddr virtual_addr, u64 size, u32 alignment);
 

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -358,7 +358,11 @@ private:
 
     bool IsFlexibleCommittedVma(const VirtualMemoryArea& vma) const;
 
+    u64 GetFlexibleRangeOverlapBytesLocked(VAddr virtual_addr, u64 size) const;
+
     u64 GetFlexibleMappedBytesInRangeLocked(VAddr virtual_addr, u64 size) const;
+
+    void InvalidateFlexibleMappedRangeCacheLocked();
 
     void AdjustFlexibleMappedUsageLocked(u64 mapped_before, u64 mapped_after);
 
@@ -377,6 +381,15 @@ private:
     VAddr flexible_virtual_base{};
     VAddr flexible_virtual_end{};
     u64 flexible_mapped_usage{};
+    struct FlexibleMappedRangeCache {
+        VAddr range_start{};
+        VAddr range_end{};
+        u64 mapped_bytes{};
+        u64 revision{};
+        bool valid{};
+    };
+    mutable FlexibleMappedRangeCache flexible_mapped_range_cache{};
+    u64 vma_revision{};
     u64 pool_budget{};
     s32 sdk_version{};
     Vulkan::Rasterizer* rasterizer{};

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2025-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2024-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "common/alignment.h"

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -113,9 +113,10 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
 
     // Map module segments (and possible TLS trampolines)
     void** out_addr = reinterpret_cast<void**>(&base_virtual_addr);
+    const bool is_system_module = IsSystemLib();
     memory->MapMemory(out_addr, ModuleLoadBase, aligned_base_size,
                       MemoryProt::CpuReadWrite | MemoryProt::CpuExec, MemoryMapFlags::NoFlags,
-                      VMAType::Code, name);
+                      VMAType::Code, name, false, -1, 0, is_system_module);
     LOG_INFO(Core_Linker, "Loading module {} to {}", name, fmt::ptr(*out_addr));
 
 #ifdef ARCH_X86_64

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -121,13 +121,9 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
 #ifdef ARCH_X86_64
     void* trampoline_region = std::bit_cast<void*>(base_virtual_addr + aligned_base_size);
     const int tramp_ret = memory->MapMemory(
-        &trampoline_region,
-        base_virtual_addr + aligned_base_size,
-        TrampolineSize,
+        &trampoline_region, base_virtual_addr + aligned_base_size, TrampolineSize,
         MemoryProt::CpuReadWrite | MemoryProt::CpuExec,
-        MemoryMapFlags::Fixed | MemoryMapFlags::NoOverwrite,
-        VMAType::File,
-        "Trampoline");
+        MemoryMapFlags::Fixed | MemoryMapFlags::NoOverwrite, VMAType::File, "Trampoline");
     ASSERT_MSG(tramp_ret == 0, "Unable to map trampoline memory");
 
     // Initialize trampoline generator.

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -113,7 +113,7 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
 
     // Map module segments (and possible TLS trampolines)
     void** out_addr = reinterpret_cast<void**>(&base_virtual_addr);
-    memory->MapMemory(out_addr, ModuleLoadBase, aligned_base_size + TrampolineSize,
+    memory->MapMemory(out_addr, ModuleLoadBase, aligned_base_size,
                       MemoryProt::CpuReadWrite | MemoryProt::CpuExec, MemoryMapFlags::NoFlags,
                       VMAType::Code, name);
     LOG_INFO(Core_Linker, "Loading module {} to {}", name, fmt::ptr(*out_addr));

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -119,6 +119,17 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
     LOG_INFO(Core_Linker, "Loading module {} to {}", name, fmt::ptr(*out_addr));
 
 #ifdef ARCH_X86_64
+    void* trampoline_region = std::bit_cast<void*>(base_virtual_addr + aligned_base_size);
+    const int tramp_ret = memory->MapMemory(
+        &trampoline_region,
+        base_virtual_addr + aligned_base_size,
+        TrampolineSize,
+        MemoryProt::CpuReadWrite | MemoryProt::CpuExec,
+        MemoryMapFlags::Fixed | MemoryMapFlags::NoOverwrite,
+        VMAType::File,
+        "Trampoline");
+    ASSERT_MSG(tramp_ret == 0, "Unable to map trampoline memory");
+
     // Initialize trampoline generator.
     void* trampoline_addr = std::bit_cast<void*>(base_virtual_addr + aligned_base_size);
     RegisterPatchModule(*out_addr, aligned_base_size, trampoline_addr, TrampolineSize);


### PR DESCRIPTION
Based on: https://github.com/shadps4-emu/shadPS4/pull/4055#issuecomment-3930957339

I'm calculating flexible memory accounting based on VMM; module code is counted towards the flexible quota; host-side trampoline region is not counted.

This can solve some startup problems in games like Uncharted 4 and TLOU2.

I'm still learning process, ttrampoline will probably cause problems in other games.