### PR TITLE
input: reduce multi-controller pad latency by trimming stale states

### DIFF
--- a/src/input/controller.h
+++ b/src/input/controller.h
@@ -71,6 +71,10 @@ class RingBufferQueue {
 public:
     RingBufferQueue(size_t size) : m_storage(size) {}
 
+    size_t Size() const {
+        return m_size;
+    }
+
     void Push(T item) {
         const size_t index = (m_begin + m_size) % m_storage.size();
         m_storage[index] = std::move(item);
@@ -79,6 +83,19 @@ public:
         } else {
             m_begin = (m_begin + 1) % m_storage.size();
         }
+    }
+
+    void DropOldest(size_t count) {
+        if (count == 0 || m_size == 0) {
+            return;
+        }
+        if (count >= m_size) {
+            m_begin = 0;
+            m_size = 0;
+            return;
+        }
+        m_begin = (m_begin + count) % m_storage.size();
+        m_size -= count;
     }
 
     std::optional<T> Pop() {

--- a/src/sdl_window.cpp
+++ b/src/sdl_window.cpp
@@ -271,6 +271,11 @@ using namespace Libraries::Pad;
 
 std::mutex motion_control_mutex;
 float gyro_buf[3] = {0.0f, 0.0f, 0.0f}, accel_buf[3] = {0.0f, 9.81f, 0.0f};
+static Uint32 SDLCALL PollController(void* userdata, SDL_TimerID timer_id, Uint32 interval) {
+    auto* controller = reinterpret_cast<Input::GameController*>(userdata);
+    return controller->Poll();
+}
+
 static Uint32 SDLCALL PollGyroAndAccel(void* userdata, SDL_TimerID timer_id, Uint32 interval) {
     auto* controller = reinterpret_cast<Input::GameController*>(userdata);
     std::scoped_lock l{motion_control_mutex};
@@ -480,7 +485,10 @@ void WindowSDL::WaitEvent() {
 }
 
 void WindowSDL::InitTimers() {
-    SDL_AddTimer(4, &PollGyroAndAccel, controller);
+    SDL_AddTimer(33, &PollController, controller);
+    if (Config::getIsMotionControlsEnabled()) {
+        SDL_AddTimer(4, &PollGyroAndAccel, controller);
+    }
     SDL_AddTimer(33, Input::MousePolling, (void*)controller);
 }
 


### PR DESCRIPTION
## Problem

In UFC 4, simultaneous use of two controllers causes noticeable input delay, while each controller used alone does not.  
This points to input age/backlog under higher event pressure rather than a single-controller mapping issue.

## Root Cause

Pad state delivery used FIFO consumption without trimming stale backlog in `GameController::ReadStates()`.  
When event production outpaced reads (especially with 2 active controllers), old states accumulated and were still delivered to the game, resulting in delayed input samples.

Additionally, a 4 ms gyro/accel timer was always active, adding extra state pushes even when motion controls were not needed, increasing queue pressure.

## Changes

- `src/input/controller.h`
  - Added `RingBufferQueue::Size()`.
  - Added `RingBufferQueue::DropOldest(size_t count)` to explicitly trim stale backlog.

- `src/input/controller.cpp`
  - Reduced queue depth from 64 to 32 to lower maximum stale window.
  - Added mutex protection in `ReadState()` for a consistent snapshot.
  - Updated `ReadStates()` to:
    - trim oldest excess states when queue size exceeds requested batch,
    - return freshest relevant states,
    - fallback to current state if queue is empty.

- `src/sdl_window.cpp`
  - Reintroduced regular controller polling at 33 ms (`PollController`).
  - Enabled 4 ms gyro/accel polling only when motion controls are enabled.

## Why This Fix Works

Under dual-controller load, stale queue entries are now dropped before consumption, so the game receives fresh state data instead of delayed historical samples.  
Input path pressure is also reduced by avoiding unnecessary high-frequency motion pushes when motion controls are off.

## Scope / Risk

- Localized to input/pad pipeline.
- No API surface changes.
- Single-controller behavior remains consistent while reducing worst-case latency under high input throughput.