### PR TITLE
Core: Force logging of critical errors

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -70,7 +70,7 @@ public:
     ~FileBackend() = default;
 
     void Write(const Entry& entry) {
-        if (!enabled && !entry.log_level == Level::Critical) {
+        if (!enabled && entry.log_level != Level::Critical) {
             return;
         }
 

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -70,7 +70,7 @@ public:
     ~FileBackend() = default;
 
     void Write(const Entry& entry) {
-        if (!enabled) {
+        if (!enabled && !entry.log_level == Level::Critical) {
             return;
         }
 


### PR DESCRIPTION
This ensures critical errors (asserts and unreachables) are logged when the log file exceeds 100MB.