### PR TITLE
macos/Linux timer optimizations, FSR bandwidth optimization

### DIFF
--- a/src/common/thread.cpp
+++ b/src/common/thread.cpp
@@ -30,8 +30,8 @@
 #include <time.h>
 #endif
 #ifndef _WIN32
-#include <unistd.h>
 #include <cerrno>
+#include <unistd.h>
 #endif
 
 #ifdef __FreeBSD__
@@ -308,8 +308,9 @@ void AccurateTimer::Start() {
     if (total_wait.count() > 0) {
         AccurateSleep(total_wait, nullptr, false);
     }
-    const auto start_time = std::chrono::high_resolution_clock::now();
-    total_wait -= std::chrono::duration_cast<std::chrono::nanoseconds>(start_time - begin_sleep);
+    start_time_win = std::chrono::high_resolution_clock::now();
+    total_wait -=
+        std::chrono::duration_cast<std::chrono::nanoseconds>(start_time_win - begin_sleep);
     start_time_ns = 0;
     next_deadline_ns = 0;
 #else
@@ -340,8 +341,8 @@ void AccurateTimer::Start() {
 void AccurateTimer::End() {
 #ifdef _WIN32
     auto now = std::chrono::high_resolution_clock::now();
-    total_wait +=
-        target_interval - std::chrono::duration_cast<std::chrono::nanoseconds>(now - start_time);
+    total_wait += target_interval -
+                  std::chrono::duration_cast<std::chrono::nanoseconds>(now - start_time_win);
 #else
     const u64 now_ns = MonotonicNowNs();
     const s64 remaining_ns = static_cast<s64>(next_deadline_ns) - static_cast<s64>(now_ns);

--- a/src/common/thread.h
+++ b/src/common/thread.h
@@ -33,7 +33,8 @@ class AccurateTimer {
     std::chrono::nanoseconds target_interval{};
     std::chrono::nanoseconds total_wait{};
 
-    std::chrono::high_resolution_clock::time_point start_time;
+    u64 start_time_ns{};
+    u64 next_deadline_ns{};
 
 public:
     explicit AccurateTimer(std::chrono::nanoseconds target_interval);

--- a/src/common/thread.h
+++ b/src/common/thread.h
@@ -36,6 +36,10 @@ class AccurateTimer {
     u64 start_time_ns{};
     u64 next_deadline_ns{};
 
+#ifdef _WIN32
+    std::chrono::high_resolution_clock::time_point start_time_win{};
+#endif
+
 public:
     explicit AccurateTimer(std::chrono::nanoseconds target_interval);
 

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -73,6 +73,8 @@ Emulator::Emulator() {
     WORD versionWanted = MAKEWORD(2, 2);
     WSADATA wsaData;
     WSAStartup(versionWanted, &wsaData);
+#elif defined(__APPLE__)
+    pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
 #endif
 }
 

--- a/src/video_core/renderer_vulkan/host_passes/fsr_pass.cpp
+++ b/src/video_core/renderer_vulkan/host_passes/fsr_pass.cpp
@@ -161,7 +161,7 @@ vk::ImageView FsrPass::Render(vk::CommandBuffer cmdbuf, vk::ImageView input,
     }
 
     if (img.dirty) {
-        CreateImages(img);
+        CreateImages(img, hdr);
     }
 
     if (Config::getVkHostMarkersEnabled()) {
@@ -404,12 +404,12 @@ void FsrPass::ResizeAndInvalidate(u32 width, u32 height) {
     }
 }
 
-void FsrPass::CreateImages(Img& img) const {
+void FsrPass::CreateImages(Img& img, bool hdr) const {
     img.dirty = false;
 
     vk::ImageCreateInfo image_create_info{
         .imageType = vk::ImageType::e2D,
-        .format = vk::Format::eR16G16B16A16Sfloat,
+        .format = hdr ? vk::Format::eR16G16B16A16Sfloat : vk::Format::eR8G8B8A8Unorm,
         .extent{
             .width = cur_size.width,
             .height = cur_size.height,
@@ -434,7 +434,7 @@ void FsrPass::CreateImages(Img& img) const {
     vk::ImageViewCreateInfo image_view_create_info{
         .image = img.intermediary_image,
         .viewType = vk::ImageViewType::e2D,
-        .format = vk::Format::eR16G16B16A16Sfloat,
+        .format = hdr ? vk::Format::eR16G16B16A16Sfloat : vk::Format::eR8G8B8A8Unorm,
         .subresourceRange{
             .aspectMask = vk::ImageAspectFlagBits::eColor,
             .levelCount = 1,

--- a/src/video_core/renderer_vulkan/host_passes/fsr_pass.h
+++ b/src/video_core/renderer_vulkan/host_passes/fsr_pass.h
@@ -35,7 +35,7 @@ private:
     };
 
     void ResizeAndInvalidate(u32 width, u32 height);
-    void CreateImages(Img& img) const;
+    void CreateImages(Img& img, bool hdr) const;
 
     vk::Device device{};
     u32 num_images{};

--- a/src/video_core/renderer_vulkan/vk_presenter.cpp
+++ b/src/video_core/renderer_vulkan/vk_presenter.cpp
@@ -437,7 +437,6 @@ void Presenter::Present(Frame* frame, bool is_reusing_frame) {
 
     // Recreate the swapchain if the window was resized.
     if (window.GetWidth() != swapchain.GetWidth() || window.GetHeight() != swapchain.GetHeight()) {
-        printf("recreating swapchain\n");
         swapchain.Recreate(window.GetWidth(), window.GetHeight());
     }
 


### PR DESCRIPTION
* fsr_pass only use eR16G16B16A16Sfloat if HDR is enabled otherwise fall back to eR8G8B8A8Unorm
* on macOS set thread priority to QOS_CLASS_USER_INTERACTIVE
* drift-free absolute timer pacing using monotonic clock and platform specific timing code for macOS and linux (only tested on macOS)
* improve sync by switching to vk::PipelineBarrier2
* optimize swapchain image acquisition to minimize blocking