### PR TITLE
Implement guest signal handlers

### DIFF
--- a/src/core/debug_state.cpp
+++ b/src/core/debug_state.cpp
@@ -6,6 +6,7 @@
 #include "common/assert.h"
 #include "common/native_clock.h"
 #include "common/singleton.h"
+#include "core/signals.h"
 #include "debug_state.h"
 #include "devtools/widget/common.h"
 #include "libraries/kernel/time.h"
@@ -33,7 +34,7 @@ static void PauseThread(ThreadID id) {
     SuspendThread(handle);
     CloseHandle(handle);
 #else
-    pthread_kill(id, SIGUSR1);
+    pthread_kill(id, SIGSLEEP);
 #endif
 }
 
@@ -43,7 +44,7 @@ static void ResumeThread(ThreadID id) {
     ResumeThread(handle);
     CloseHandle(handle);
 #else
-    pthread_kill(id, SIGUSR1);
+    pthread_kill(id, SIGSLEEP);
 #endif
 }
 

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -16,7 +16,20 @@
 
 namespace Libraries::Kernel {
 
-s32 NativeToOrbisSignal(s32 s) {
+#ifdef _WIN32
+
+// Windows doesn't have native versions of these, and we don't need to use them either.
+static s32 NativeToOrbisSignal(s32 s) {
+    return s;
+}
+
+static s32 OrbisToNativeSignal(s32 s) {
+    return s;
+}
+
+#else
+
+static s32 NativeToOrbisSignal(s32 s) {
     switch (s) {
     case SIGHUP:
         return POSIX_SIGHUP;
@@ -81,7 +94,7 @@ s32 NativeToOrbisSignal(s32 s) {
     }
 }
 
-s32 OrbisToNativeSignal(s32 s) {
+static s32 OrbisToNativeSignal(s32 s) {
     switch (s) {
     case POSIX_SIGHUP:
         return SIGHUP;
@@ -145,6 +158,8 @@ s32 OrbisToNativeSignal(s32 s) {
         UNREACHABLE_MSG("Unknown signal {}", s);
     }
 }
+
+#endif
 
 static std::array<SceKernelExceptionHandler, 32> Handlers{};
 

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2024-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "common/assert.h"

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -248,6 +248,9 @@ int PS4_SYSV_ABI sceKernelInstallExceptionHandler(s32 signum, SceKernelException
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
     int const native_signum = OrbisToNativeSignal(signum);
+#ifdef __APPLE__
+    ASSERT_MSG(native_signum != SIGVTALRM, "SIGVTALRM is HLE-reserved on macOS!");
+#endif
     ASSERT_MSG(!Handlers[native_signum], "Invalid parameters");
     Handlers[native_signum] = handler;
 #ifndef _WIN64

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -16,11 +16,141 @@
 
 namespace Libraries::Kernel {
 
+s32 NativeToOrbisSignal(s32 s) {
+    switch (s) {
+    case SIGHUP:
+        return POSIX_SIGHUP;
+    case SIGINT:
+        return POSIX_SIGINT;
+    case SIGQUIT:
+        return POSIX_SIGQUIT;
+    case SIGILL:
+        return POSIX_SIGILL;
+    case SIGTRAP:
+        return POSIX_SIGTRAP;
+    case SIGABRT:
+        return POSIX_SIGABRT;
+    case SIGFPE:
+        return POSIX_SIGFPE;
+    case SIGKILL:
+        return POSIX_SIGKILL;
+    case SIGBUS:
+        return POSIX_SIGBUS;
+    case SIGSEGV:
+        return POSIX_SIGSEGV;
+    case SIGSYS:
+        return POSIX_SIGSYS;
+    case SIGPIPE:
+        return POSIX_SIGPIPE;
+    case SIGALRM:
+        return POSIX_SIGALRM;
+    case SIGTERM:
+        return POSIX_SIGTERM;
+    case SIGURG:
+        return POSIX_SIGURG;
+    case SIGSTOP:
+        return POSIX_SIGSTOP;
+    case SIGTSTP:
+        return POSIX_SIGTSTP;
+    case SIGCONT:
+        return POSIX_SIGCONT;
+    case SIGCHLD:
+        return POSIX_SIGCHLD;
+    case SIGTTIN:
+        return POSIX_SIGTTIN;
+    case SIGTTOU:
+        return POSIX_SIGTTOU;
+    case SIGIO:
+        return POSIX_SIGIO;
+    case SIGXCPU:
+        return POSIX_SIGXCPU;
+    case SIGXFSZ:
+        return POSIX_SIGXFSZ;
+    case SIGVTALRM:
+        return POSIX_SIGVTALRM;
+    case SIGPROF:
+        return POSIX_SIGPROF;
+    case SIGWINCH:
+        return POSIX_SIGWINCH;
+    case SIGUSR1:
+        return POSIX_SIGUSR1;
+    case SIGUSR2:
+        return POSIX_SIGUSR2;
+    default:
+        UNREACHABLE_MSG("Unknown signal {}", s);
+    }
+}
+
+s32 OrbisToNativeSignal(s32 s) {
+    switch (s) {
+    case POSIX_SIGHUP:
+        return SIGHUP;
+    case POSIX_SIGINT:
+        return SIGINT;
+    case POSIX_SIGQUIT:
+        return SIGQUIT;
+    case POSIX_SIGILL:
+        return SIGILL;
+    case POSIX_SIGTRAP:
+        return SIGTRAP;
+    case POSIX_SIGABRT:
+        return SIGABRT;
+    case POSIX_SIGFPE:
+        return SIGFPE;
+    case POSIX_SIGKILL:
+        return SIGKILL;
+    case POSIX_SIGBUS:
+        return SIGBUS;
+    case POSIX_SIGSEGV:
+        return SIGSEGV;
+    case POSIX_SIGSYS:
+        return SIGSYS;
+    case POSIX_SIGPIPE:
+        return SIGPIPE;
+    case POSIX_SIGALRM:
+        return SIGALRM;
+    case POSIX_SIGTERM:
+        return SIGTERM;
+    case POSIX_SIGURG:
+        return SIGURG;
+    case POSIX_SIGSTOP:
+        return SIGSTOP;
+    case POSIX_SIGTSTP:
+        return SIGTSTP;
+    case POSIX_SIGCONT:
+        return SIGCONT;
+    case POSIX_SIGCHLD:
+        return SIGCHLD;
+    case POSIX_SIGTTIN:
+        return SIGTTIN;
+    case POSIX_SIGTTOU:
+        return SIGTTOU;
+    case POSIX_SIGIO:
+        return SIGIO;
+    case POSIX_SIGXCPU:
+        return SIGXCPU;
+    case POSIX_SIGXFSZ:
+        return SIGXFSZ;
+    case POSIX_SIGVTALRM:
+        return SIGVTALRM;
+    case POSIX_SIGPROF:
+        return SIGPROF;
+    case POSIX_SIGWINCH:
+        return SIGWINCH;
+    case POSIX_SIGUSR1:
+        return SIGUSR1;
+    case POSIX_SIGUSR2:
+        return SIGUSR2;
+    default:
+        UNREACHABLE_MSG("Unknown signal {}", s);
+    }
+}
+
 static std::array<SceKernelExceptionHandler, 32> Handlers{};
 
 #ifndef _WIN64
-void SigactionHandler(int signum, siginfo_t* inf, ucontext_t* raw_context) {
-    const auto handler = Handlers[signum];
+void SigactionHandler(int native_signum, siginfo_t* inf, ucontext_t* raw_context) {
+    const auto handler = Handlers[native_signum];
     if (handler) {
         auto ctx = Ucontext{};
 #ifdef __APPLE__
@@ -64,15 +194,15 @@ void SigactionHandler(int signum, siginfo_t* inf, ucontext_t* raw_context) {
         ctx.uc_mcontext.mc_fs = (regs[REG_CSGSFS] >> 32) & 0xFFFF;
         ctx.uc_mcontext.mc_gs = (regs[REG_CSGSFS] >> 16) & 0xFFFF;
 #endif
-        handler(signum, &ctx);
+        handler(NativeToOrbisSignal(native_signum), &ctx);
     }
 }
 #else
 void ExceptionHandler(void* arg1, void* arg2, void* arg3, PCONTEXT context) {
     const char* thrName = (char*)arg1;
-    int signum = reinterpret_cast<uintptr_t>(arg2);
+    int native_signum = reinterpret_cast<uintptr_t>(arg2);
     LOG_INFO(Lib_Kernel, "Exception raised successfully on thread '{}'", thrName);
-    const auto handler = Handlers[signum];
+    const auto handler = Handlers[native_signum];
     if (handler) {
         auto ctx = Ucontext{};
         ctx.uc_mcontext.mc_r8 = context->R8;
@@ -93,49 +223,64 @@ void ExceptionHandler(void* arg1, void* arg2, void* arg3, PCONTEXT context) {
         ctx.uc_mcontext.mc_rsp = context->Rsp;
         ctx.uc_mcontext.mc_fs = context->SegFs;
         ctx.uc_mcontext.mc_gs = context->SegGs;
-        handler(POSIX_SIGUSR1, &ctx);
+        handler(NativeToOrbisSignal(native_signum), &ctx);
     }
 }
 #endif
 
 int PS4_SYSV_ABI sceKernelInstallExceptionHandler(s32 signum, SceKernelExceptionHandler handler) {
-    if (signum == SIGSLEEP) {
-        LOG_ERROR(Lib_Kernel, "Installing non-supported exception handler for signal {}", signum);
-        return 0;
+    if (signum > POSIX_SIGUSR2) {
+        return ORBIS_KERNEL_ERROR_EINVAL;
     }
-    ASSERT_MSG(!Handlers[signum], "Invalid parameters");
-    Handlers[signum] = handler;
+    int const native_signum = OrbisToNativeSignal(signum);
+    ASSERT_MSG(!Handlers[native_signum], "Invalid parameters");
+    Handlers[native_signum] = handler;
 #ifndef _WIN64
     struct sigaction act = {};
     act.sa_flags = SA_SIGINFO | SA_RESTART;
     act.sa_sigaction = reinterpret_cast<decltype(act.sa_sigaction)>(SigactionHandler);
-    sigaction(signum, &act, nullptr);
+    sigemptyset(&act.sa_mask);
+    sigaction(native_signum, &act, nullptr);
 #endif
     return 0;
 }
 
 int PS4_SYSV_ABI sceKernelRemoveExceptionHandler(s32 signum) {
-    if (signum == SIGSLEEP) {
-        LOG_ERROR(Lib_Kernel, "Removing non-supported exception handler for signal {}", signum);
-        return 0;
+    if (signum > POSIX_SIGUSR2) {
+        return ORBIS_KERNEL_ERROR_EINVAL;
     }
-    ASSERT_MSG(Handlers[signum], "Invalid parameters");
-    Handlers[signum] = nullptr;
+    int const native_signum = OrbisToNativeSignal(signum);
+    ASSERT_MSG(Handlers[native_signum], "Invalid parameters");
+    Handlers[native_signum] = nullptr;
 #ifndef _WIN64
-    struct sigaction act = {};
-    act.sa_flags = SA_SIGINFO | SA_RESTART;
-    act.sa_sigaction = nullptr;
-    sigaction(signum, &act, nullptr);
+    if (native_signum == SIGSEGV || native_signum == SIGBUS || native_signum == SIGILL) {
+        struct sigaction action{};
+        action.sa_sigaction = Core::SignalHandler;
+        action.sa_flags = SA_SIGINFO | SA_ONSTACK;
+        sigemptyset(&action.sa_mask);
+
+        ASSERT_MSG(sigaction(native_signum, &action, nullptr) == 0,
+                   "Failed to reinstate original signal handler for signal {}", native_signum);
+    } else {
+        struct sigaction act = {};
+        act.sa_flags = SA_SIGINFO | SA_RESTART;
+        act.sa_sigaction = nullptr;
+        sigemptyset(&act.sa_mask);
+        sigaction(native_signum, &act, nullptr);
+    }
 #endif
     return 0;
 }
 
 int PS4_SYSV_ABI sceKernelRaiseException(PthreadT thread, int signum) {
+    if (signum != POSIX_SIGUSR1) {
+        return ORBIS_KERNEL_ERROR_EINVAL;
+    }
     LOG_WARNING(Lib_Kernel, "Raising exception on thread '{}'", thread->name);
-    ASSERT_MSG(signum == SIGSLEEP, "Attempting to raise unsupported signal!");
+    int const native_signum = OrbisToNativeSignal(signum);
 #ifndef _WIN64
     const auto pthr = reinterpret_cast<pthread_t>(thread->native_thr.GetHandle());
-    const auto ret = pthread_kill(pthr, signum);
+    const auto ret = pthread_kill(pthr, native_signum);
     if (ret != 0) {
         LOG_ERROR(Kernel, "Failed to send exception signal to thread '{}': {}", thread->name,
                   strerror(ret));
@@ -145,7 +290,8 @@ int PS4_SYSV_ABI sceKernelRaiseException(PthreadT thread, int signum) {
     option.UserApcFlags = QueueUserApcFlagsSpecialUserApc;
 
     u64 res = NtQueueApcThreadEx(reinterpret_cast<HANDLE>(thread->native_thr.GetHandle()), option,
-                                 ExceptionHandler, (void*)thread->name.c_str(), reinterpret_cast<uintptr_t>(signum), nullptr);
+                                 ExceptionHandler, (void*)thread->name.c_str(),
+                                 (void*)native_signum, nullptr);
     ASSERT(res == 0);
 #endif
     return 0;

--- a/src/core/libraries/kernel/threads/exception.h
+++ b/src/core/libraries/kernel/threads/exception.h
@@ -13,8 +13,42 @@ namespace Libraries::Kernel {
 
 using SceKernelExceptionHandler = PS4_SYSV_ABI void (*)(int, void*);
 
-constexpr int POSIX_SIGSEGV = 11;
-constexpr int POSIX_SIGUSR1 = 30;
+constexpr s32 POSIX_SIGHUP = 1;
+constexpr s32 POSIX_SIGINT = 2;
+constexpr s32 POSIX_SIGQUIT = 3;
+constexpr s32 POSIX_SIGILL = 4;
+constexpr s32 POSIX_SIGTRAP = 5;
+constexpr s32 POSIX_SIGABRT = 6;
+constexpr s32 POSIX_SIGEMT = 7;
+constexpr s32 POSIX_SIGFPE = 8;
+constexpr s32 POSIX_SIGKILL = 9;
+constexpr s32 POSIX_SIGBUS = 10;
+constexpr s32 POSIX_SIGSEGV = 11;
+constexpr s32 POSIX_SIGSYS = 12;
+constexpr s32 POSIX_SIGPIPE = 13;
+constexpr s32 POSIX_SIGALRM = 14;
+constexpr s32 POSIX_SIGTERM = 15;
+constexpr s32 POSIX_SIGURG = 16;
+constexpr s32 POSIX_SIGSTOP = 17;
+constexpr s32 POSIX_SIGTSTP = 18;
+constexpr s32 POSIX_SIGCONT = 19;
+constexpr s32 POSIX_SIGCHLD = 20;
+constexpr s32 POSIX_SIGTTIN = 21;
+constexpr s32 POSIX_SIGTTOU = 22;
+constexpr s32 POSIX_SIGIO = 23;
+constexpr s32 POSIX_SIGXCPU = 24;
+constexpr s32 POSIX_SIGXFSZ = 25;
+constexpr s32 POSIX_SIGVTALRM = 26;
+constexpr s32 POSIX_SIGPROF = 27;
+constexpr s32 POSIX_SIGWINCH = 28;
+constexpr s32 POSIX_SIGINFO = 29;
+constexpr s32 POSIX_SIGUSR1 = 30;
+constexpr s32 POSIX_SIGUSR2 = 31;
+constexpr s32 POSIX_SIGTHR = 32;
+constexpr s32 POSIX_SIGLIBRT = 33;
+
+s32 NativeToOrbisSignal(s32 s);
+s32 OrbisToNativeSignal(s32 s);
 
 struct Mcontext {
     u64 mc_onstack;

--- a/src/core/libraries/kernel/threads/exception.h
+++ b/src/core/libraries/kernel/threads/exception.h
@@ -47,9 +47,6 @@ constexpr s32 POSIX_SIGUSR2 = 31;
 constexpr s32 POSIX_SIGTHR = 32;
 constexpr s32 POSIX_SIGLIBRT = 33;
 
-s32 NativeToOrbisSignal(s32 s);
-s32 OrbisToNativeSignal(s32 s);
-
 struct Mcontext {
     u64 mc_onstack;
     u64 mc_rdi;

--- a/src/core/libraries/kernel/threads/exception.h
+++ b/src/core/libraries/kernel/threads/exception.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2024-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -66,7 +66,7 @@ static std::string DisassembleInstruction(void* code_address) {
     return buffer;
 }
 
-static void SignalHandler(int sig, siginfo_t* info, void* raw_context) {
+void SignalHandler(int sig, siginfo_t* info, void* raw_context) {
     const auto* signals = Signals::Instance();
 
     auto* code_address = Common::GetRip(raw_context);

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -88,13 +88,14 @@ static void SignalHandler(int sig, siginfo_t* info, void* raw_context) {
                             fmt::ptr(code_address), DisassembleInstruction(code_address));
         }
         break;
-    case SIGUSR1: { // Sleep thread until signal is received
-        sigset_t sigset;
-        sigemptyset(&sigset);
-        sigaddset(&sigset, SIGUSR1);
-        sigwait(&sigset, &sig);
-    } break;
     default:
+        if (sig == SIGSLEEP) {
+            // Sleep thread until signal is received again
+            sigset_t sigset;
+            sigemptyset(&sigset);
+            sigaddset(&sigset, SIGSLEEP);
+            sigwait(&sigset, &sig);
+        }
         break;
     }
 }
@@ -116,7 +117,7 @@ SignalDispatch::SignalDispatch() {
                "Failed to register access violation signal handler.");
     ASSERT_MSG(sigaction(SIGILL, &action, nullptr) == 0,
                "Failed to register illegal instruction signal handler.");
-    ASSERT_MSG(sigaction(SIGUSR1, &action, nullptr) == 0,
+    ASSERT_MSG(sigaction(SIGSLEEP, &action, nullptr) == 0,
                "Failed to register sleep signal handler.");
 #endif
 }

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -18,12 +18,12 @@
 #endif
 #endif
 
+#ifndef _WIN32
 namespace Libraries::Kernel {
-
 void SigactionHandler(int native_signum, siginfo_t* inf, ucontext_t* raw_context);
 extern std::array<SceKernelExceptionHandler, 32> Handlers;
-
 } // namespace Libraries::Kernel
+#endif
 
 namespace Core {
 

--- a/src/core/signals.h
+++ b/src/core/signals.h
@@ -8,12 +8,19 @@
 #include "common/singleton.h"
 #include "common/types.h"
 
-#define SIGSLEEP (SIGRTMIN + 0)
-
+#ifdef _WIN32
+#define SIGSLEEP -1
+#else
+#define SIGSLEEP (SIGRTMAX)
+#endif
 namespace Core {
 
 using AccessViolationHandler = bool (*)(void* context, void* fault_address);
 using IllegalInstructionHandler = bool (*)(void* context);
+
+#ifndef _WIN32
+void SignalHandler(int sig, siginfo_t* info, void* raw_context);
+#endif
 
 /// Receives OS signals and dispatches to the appropriate handlers.
 class SignalDispatch {

--- a/src/core/signals.h
+++ b/src/core/signals.h
@@ -10,8 +10,10 @@
 
 #ifdef _WIN32
 #define SIGSLEEP -1
+#elif defined(__APPLE__)
+#define SIGSLEEP SIGVTALRM
 #else
-#define SIGSLEEP (SIGRTMAX)
+#define SIGSLEEP SIGRTMAX
 #endif
 namespace Core {
 

--- a/src/core/signals.h
+++ b/src/core/signals.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2024-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once

--- a/src/core/signals.h
+++ b/src/core/signals.h
@@ -4,8 +4,11 @@
 #pragma once
 
 #include <set>
+#include <signal.h>
 #include "common/singleton.h"
 #include "common/types.h"
+
+#define SIGSLEEP (SIGRTMIN + 0)
 
 namespace Core {
 


### PR DESCRIPTION
This PR adds the ability for games to set and use custom signal handlers for all 32 signals possible (except for the uncatchable ones, and SIGVTALRM on macOS) on UNIX systems. For Windows, nothing actually changed, as  while there's some scaffolding in place for that OS as well, it's currently doing a whole lot of nothing, as the fact that there's no equivalent feature for sigaction there is still true.
I've tested the PR with Eden's WIP PS4 port, and I got it to crash on a stub unrelated to this PR, so I'd say it is working well enough to make basic readonly usage of it function roughly as intended.