### PR TITLE
Kernel.Event: Implement kqueue and kevent

### DIFF
--- a/src/core/file_sys/fs.h
+++ b/src/core/file_sys/fs.h
@@ -85,7 +85,8 @@ enum class FileType {
     Device,
     Socket,
     Epoll,
-    Resolver
+    Resolver,
+    Equeue
 };
 
 struct File {

--- a/src/core/libraries/gnmdriver/gnmdriver.cpp
+++ b/src/core/libraries/gnmdriver/gnmdriver.cpp
@@ -123,7 +123,7 @@ static inline bool IsValidEventType(Platform::InterruptId id) {
            static_cast<u32>(id) == static_cast<u32>(Platform::InterruptId::GfxEop);
 }
 
-s32 PS4_SYSV_ABI sceGnmAddEqEvent(SceKernelEqueue eq, u64 id, void* udata) {
+s32 PS4_SYSV_ABI sceGnmAddEqEvent(OrbisKernelEqueue eq, u64 id, void* udata) {
     LOG_TRACE(Lib_GnmDriver, "called");
 
     if (!eq) {
@@ -132,8 +132,8 @@ s32 PS4_SYSV_ABI sceGnmAddEqEvent(SceKernelEqueue eq, u64 id, void* udata) {
 
     EqueueEvent kernel_event{};
     kernel_event.event.ident = id;
-    kernel_event.event.filter = SceKernelEvent::Filter::GraphicsCore;
-    kernel_event.event.flags = SceKernelEvent::Flags::Add;
+    kernel_event.event.filter = OrbisKernelEvent::Filter::GraphicsCore;
+    kernel_event.event.flags = OrbisKernelEvent::Flags::Add;
     kernel_event.event.fflags = 0;
     kernel_event.event.data = id;
     kernel_event.event.udata = udata;
@@ -149,7 +149,7 @@ s32 PS4_SYSV_ABI sceGnmAddEqEvent(SceKernelEqueue eq, u64 id, void* udata) {
                 return;
 
             // Event data is expected to be an event type as per sceGnmGetEqEventType.
-            eq->TriggerEvent(static_cast<GnmEventType>(id), SceKernelEvent::Filter::GraphicsCore,
+            eq->TriggerEvent(static_cast<GnmEventType>(id), OrbisKernelEvent::Filter::GraphicsCore,
                              reinterpret_cast<void*>(id));
         },
         eq);
@@ -267,14 +267,14 @@ int PS4_SYSV_ABI sceGnmDebugHardwareStatus() {
     return ORBIS_OK;
 }
 
-s32 PS4_SYSV_ABI sceGnmDeleteEqEvent(SceKernelEqueue eq, u64 id) {
+s32 PS4_SYSV_ABI sceGnmDeleteEqEvent(OrbisKernelEqueue eq, u64 id) {
     LOG_TRACE(Lib_GnmDriver, "called");
 
     if (!eq) {
         return ORBIS_KERNEL_ERROR_EBADF;
     }
 
-    eq->RemoveEvent(id, SceKernelEvent::Filter::GraphicsCore);
+    eq->RemoveEvent(id, OrbisKernelEvent::Filter::GraphicsCore);
 
     Platform::IrqC::Instance()->Unregister(static_cast<Platform::InterruptId>(id), eq);
     return ORBIS_OK;
@@ -895,7 +895,7 @@ int PS4_SYSV_ABI sceGnmGetDebugTimestamp() {
     return ORBIS_OK;
 }
 
-int PS4_SYSV_ABI sceGnmGetEqEventType(const SceKernelEvent* ev) {
+int PS4_SYSV_ABI sceGnmGetEqEventType(const OrbisKernelEvent* ev) {
     LOG_TRACE(Lib_GnmDriver, "called");
     return sceKernelGetEventData(ev);
 }

--- a/src/core/libraries/gnmdriver/gnmdriver.cpp
+++ b/src/core/libraries/gnmdriver/gnmdriver.cpp
@@ -151,8 +151,9 @@ s32 PS4_SYSV_ABI sceGnmAddEqEvent(OrbisKernelEqueue eq, u64 id, void* udata) {
                 return;
 
             // Event data is expected to be an event type as per sceGnmGetEqEventType.
-            equeue->TriggerEvent(static_cast<GnmEventType>(id), OrbisKernelEvent::Filter::GraphicsCore,
-                             reinterpret_cast<void*>(id));
+            equeue->TriggerEvent(static_cast<GnmEventType>(id),
+                                 OrbisKernelEvent::Filter::GraphicsCore,
+                                 reinterpret_cast<void*>(id));
         },
         equeue);
     return ORBIS_OK;

--- a/src/core/libraries/gnmdriver/gnmdriver.h
+++ b/src/core/libraries/gnmdriver/gnmdriver.h
@@ -14,7 +14,7 @@ namespace Libraries::GnmDriver {
 
 using namespace Kernel;
 
-s32 PS4_SYSV_ABI sceGnmAddEqEvent(SceKernelEqueue eq, u64 id, void* udata);
+s32 PS4_SYSV_ABI sceGnmAddEqEvent(OrbisKernelEqueue eq, u64 id, void* udata);
 int PS4_SYSV_ABI sceGnmAreSubmitsAllowed();
 int PS4_SYSV_ABI sceGnmBeginWorkload(u32 workload_stream, u64* workload);
 s32 PS4_SYSV_ABI sceGnmComputeWaitOnAddress(u32* cmdbuf, u32 size, uintptr_t addr, u32 mask,
@@ -31,7 +31,7 @@ int PS4_SYSV_ABI sceGnmDebuggerSetAddressWatch();
 int PS4_SYSV_ABI sceGnmDebuggerWriteGds();
 int PS4_SYSV_ABI sceGnmDebuggerWriteSqIndirectRegister();
 int PS4_SYSV_ABI sceGnmDebugHardwareStatus();
-s32 PS4_SYSV_ABI sceGnmDeleteEqEvent(SceKernelEqueue eq, u64 id);
+s32 PS4_SYSV_ABI sceGnmDeleteEqEvent(OrbisKernelEqueue eq, u64 id);
 int PS4_SYSV_ABI sceGnmDestroyWorkloadStream();
 void PS4_SYSV_ABI sceGnmDingDong(u32 gnm_vqid, u32 next_offs_dw);
 void PS4_SYSV_ABI sceGnmDingDongForWorkload(u32 gnm_vqid, u32 next_offs_dw, u64 workload_id);
@@ -87,7 +87,7 @@ int PS4_SYSV_ABI sceGnmGetCoredumpMode();
 int PS4_SYSV_ABI sceGnmGetCoredumpProtectionFaultTimestamp();
 int PS4_SYSV_ABI sceGnmGetDbgGcHandle();
 int PS4_SYSV_ABI sceGnmGetDebugTimestamp();
-int PS4_SYSV_ABI sceGnmGetEqEventType(const SceKernelEvent* ev);
+int PS4_SYSV_ABI sceGnmGetEqEventType(const OrbisKernelEvent* ev);
 int PS4_SYSV_ABI sceGnmGetEqTimeStamp();
 int PS4_SYSV_ABI sceGnmGetGpuBlockStatus();
 u32 PS4_SYSV_ABI sceGnmGetGpuCoreClockFrequency();

--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -152,15 +152,6 @@ int EqueueInternal::WaitForEvents(SceKernelEvent* ev, int num, const SceKernelUs
         m_cond.wait_for(lock, std::chrono::microseconds(micros), predicate);
     }
 
-    if (HasSmallTimer()) {
-        if (count > 0) {
-            const auto time_waited = std::chrono::duration_cast<std::chrono::microseconds>(
-                                         std::chrono::steady_clock::now() - m_events[0].time_added)
-                                         .count();
-            count = WaitForSmallTimer(ev, num, std::max(0l, long(micros - time_waited)));
-        }
-    }
-
     return count;
 }
 

--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -345,6 +345,9 @@ bool SupportedEqueueFilter(OrbisKernelEvent::Filter filter) {
 s32 PS4_SYSV_ABI posix_kevent(s32 handle, OrbisKernelEvent* changelist, u64 nchanges,
                               OrbisKernelEvent* eventlist, u64 nevents,
                               OrbisKernelTimespec* timeout) {
+    LOG_INFO(Kernel_Event, "called, eq = {}, nchanges = {}, nevents = {}", handle, nchanges,
+             nevents);
+
     // Get the equeue
     if (!kqueues.contains(handle)) {
         *__Error() = POSIX_EBADF;

--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -18,7 +18,7 @@ namespace Libraries::Kernel {
 extern boost::asio::io_context io_context;
 extern void KernelSignalRequest();
 
-static std::unordered_map<OrbisKernelEqueue, EqueueInternal*> kqueues;
+static std::unordered_map<s32, EqueueInternal*> kqueues;
 static constexpr auto HrTimerSpinlockThresholdNs = 1200000u;
 
 EqueueInternal* GetEqueue(OrbisKernelEqueue eq) {

--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -318,6 +318,8 @@ s32 PS4_SYSV_ABI posix_kqueue() {
     // Reserve a file handle for the kqueue
     auto* handles = Common::Singleton<Core::FileSys::HandleTable>::Instance();
     s32 kqueue_handle = handles->CreateHandle();
+    auto* kqueue_file = handles->GetFile(kqueue_handle);
+    kqueue_file->type = Core::FileSys::FileType::Equeue;
 
     // Plenty of equeue logic uses names to identify queues.
     // Create a unique name for the queue we create.
@@ -435,6 +437,10 @@ int PS4_SYSV_ABI sceKernelCreateEqueue(OrbisKernelEqueue* eq, const char* name) 
     // Reserve a file handle for the kqueue
     auto* handles = Common::Singleton<Core::FileSys::HandleTable>::Instance();
     OrbisKernelEqueue kqueue_handle = handles->CreateHandle();
+    auto* kqueue_file = handles->GetFile(kqueue_handle);
+    kqueue_file->type = Core::FileSys::FileType::Equeue;
+
+    // Create the equeue
     kqueues[kqueue_handle] = new EqueueInternal(kqueue_handle, name);
     *eq = kqueue_handle;
 

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -23,7 +23,7 @@ class EqueueInternal;
 struct EqueueEvent;
 
 using OrbisKernelUseconds = u32;
-using OrbisKernelEqueue = EqueueInternal*;
+using OrbisKernelEqueue = s32;
 
 struct OrbisKernelEvent {
     enum Filter : s16 {
@@ -143,7 +143,7 @@ class EqueueInternal {
     };
 
 public:
-    explicit EqueueInternal(std::string_view name) : m_name(name) {}
+    explicit EqueueInternal(OrbisKernelEqueue handle, std::string_view name) : m_handle(handle), m_name(name) {}
 
     std::string_view GetName() const {
         return m_name;
@@ -175,6 +175,7 @@ public:
     bool EventExists(u64 id, s16 filter);
 
 private:
+    OrbisKernelEqueue m_handle;
     std::string m_name;
     std::mutex m_mutex;
     std::vector<EqueueEvent> m_events;
@@ -182,6 +183,7 @@ private:
     std::unordered_map<u64, SmallTimer> m_small_timers;
 };
 
+EqueueInternal* GetEqueue(OrbisKernelEqueue eq);
 u64 PS4_SYSV_ABI sceKernelGetEventData(const OrbisKernelEvent* ev);
 
 void RegisterEventQueue(Core::Loader::SymbolsResolver* sym);

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -22,6 +22,11 @@ namespace Libraries::Kernel {
 class EqueueInternal;
 struct EqueueEvent;
 
+struct OrbisKernelBintime {
+    s64 sec;
+    s64 frac;
+};
+
 using OrbisKernelUseconds = u32;
 using OrbisKernelEqueue = s64;
 

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -23,7 +23,7 @@ class EqueueInternal;
 struct EqueueEvent;
 
 using OrbisKernelUseconds = u32;
-using OrbisKernelEqueue = s32;
+using OrbisKernelEqueue = s64;
 
 struct OrbisKernelEvent {
     enum Filter : s16 {

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -143,7 +143,8 @@ class EqueueInternal {
     };
 
 public:
-    explicit EqueueInternal(OrbisKernelEqueue handle, std::string_view name) : m_handle(handle), m_name(name) {}
+    explicit EqueueInternal(OrbisKernelEqueue handle, std::string_view name)
+        : m_handle(handle), m_name(name) {}
 
     std::string_view GetName() const {
         return m_name;

--- a/src/core/libraries/kernel/equeue.h
+++ b/src/core/libraries/kernel/equeue.h
@@ -22,10 +22,10 @@ namespace Libraries::Kernel {
 class EqueueInternal;
 struct EqueueEvent;
 
-using SceKernelUseconds = u32;
-using SceKernelEqueue = EqueueInternal*;
+using OrbisKernelUseconds = u32;
+using OrbisKernelEqueue = EqueueInternal*;
 
-struct SceKernelEvent {
+struct OrbisKernelEvent {
     enum Filter : s16 {
         None = 0,
         Read = -1,
@@ -78,7 +78,7 @@ struct OrbisVideoOutEventData {
 };
 
 struct EqueueEvent {
-    SceKernelEvent event;
+    OrbisKernelEvent event;
     void* data = nullptr;
     std::chrono::steady_clock::time_point time_added;
     std::chrono::nanoseconds timer_interval;
@@ -137,7 +137,7 @@ private:
 
 class EqueueInternal {
     struct SmallTimer {
-        SceKernelEvent event;
+        OrbisKernelEvent event;
         std::chrono::steady_clock::time_point added;
         std::chrono::nanoseconds interval;
     };
@@ -151,11 +151,11 @@ public:
 
     bool AddEvent(EqueueEvent& event);
     bool ScheduleEvent(u64 id, s16 filter,
-                       void (*callback)(SceKernelEqueue, const SceKernelEvent&));
+                       void (*callback)(OrbisKernelEqueue, const OrbisKernelEvent&));
     bool RemoveEvent(u64 id, s16 filter);
-    int WaitForEvents(SceKernelEvent* ev, int num, const SceKernelUseconds* timo);
+    int WaitForEvents(OrbisKernelEvent* ev, int num, const OrbisKernelUseconds* timo);
     bool TriggerEvent(u64 ident, s16 filter, void* trigger_data);
-    int GetTriggeredEvents(SceKernelEvent* ev, int num);
+    int GetTriggeredEvents(OrbisKernelEvent* ev, int num);
 
     bool AddSmallTimer(EqueueEvent& event);
     bool HasSmallTimer() {
@@ -170,7 +170,7 @@ public:
         return false;
     }
 
-    int WaitForSmallTimer(SceKernelEvent* ev, int num, u32 micros);
+    int WaitForSmallTimer(OrbisKernelEvent* ev, int num, u32 micros);
 
     bool EventExists(u64 id, s16 filter);
 
@@ -182,7 +182,7 @@ private:
     std::unordered_map<u64, SmallTimer> m_small_timers;
 };
 
-u64 PS4_SYSV_ABI sceKernelGetEventData(const SceKernelEvent* ev);
+u64 PS4_SYSV_ABI sceKernelGetEventData(const OrbisKernelEvent* ev);
 
 void RegisterEventQueue(Core::Loader::SymbolsResolver* sym);
 

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -792,7 +792,8 @@ s32 PS4_SYSV_ABI fstat(s32 fd, OrbisKernelStat* sb) {
         return file->socket->fstat(sb);
     }
     case Core::FileSys::FileType::Epoll:
-    case Core::FileSys::FileType::Resolver: {
+    case Core::FileSys::FileType::Resolver:
+    case Core::FileSys::FileType::Equeue: {
         LOG_ERROR(Kernel_Fs, "(STUBBED) file type {}", magic_enum::enum_name(file->type.load()));
         break;
     }

--- a/src/core/libraries/videoout/driver.cpp
+++ b/src/core/libraries/videoout/driver.cpp
@@ -193,7 +193,7 @@ void VideoOutDriver::Flip(const Request& req) {
         if (event != nullptr) {
             event->TriggerEvent(
                 static_cast<u64>(OrbisVideoOutInternalEventId::Flip),
-                Kernel::SceKernelEvent::Filter::VideoOut,
+                Kernel::OrbisKernelEvent::Filter::VideoOut,
                 reinterpret_cast<void*>(static_cast<u64>(OrbisVideoOutInternalEventId::Flip) |
                                         (req.flip_arg << 16)));
         }
@@ -320,7 +320,7 @@ void VideoOutDriver::PresentThread(std::stop_token token) {
             for (auto& event : main_port.vblank_events) {
                 if (event != nullptr) {
                     event->TriggerEvent(static_cast<u64>(OrbisVideoOutInternalEventId::Vblank),
-                                        Kernel::SceKernelEvent::Filter::VideoOut,
+                                        Kernel::OrbisKernelEvent::Filter::VideoOut,
                                         reinterpret_cast<void*>(
                                             static_cast<u64>(OrbisVideoOutInternalEventId::Vblank) |
                                             (vblank_status.count << 16)));

--- a/src/core/libraries/videoout/driver.h
+++ b/src/core/libraries/videoout/driver.h
@@ -25,8 +25,8 @@ struct VideoOutPort {
     std::array<BufferAttributeGroup, MaxDisplayBufferGroups> groups;
     FlipStatus flip_status;
     SceVideoOutVblankStatus vblank_status;
-    std::vector<Kernel::OrbisKernelEqueue> flip_events;
-    std::vector<Kernel::OrbisKernelEqueue> vblank_events;
+    std::vector<Kernel::EqueueInternal*> flip_events;
+    std::vector<Kernel::EqueueInternal*> vblank_events;
     std::mutex vo_mutex;
     std::mutex port_mutex;
     std::condition_variable vo_cv;

--- a/src/core/libraries/videoout/driver.h
+++ b/src/core/libraries/videoout/driver.h
@@ -25,8 +25,8 @@ struct VideoOutPort {
     std::array<BufferAttributeGroup, MaxDisplayBufferGroups> groups;
     FlipStatus flip_status;
     SceVideoOutVblankStatus vblank_status;
-    std::vector<Kernel::SceKernelEqueue> flip_events;
-    std::vector<Kernel::SceKernelEqueue> vblank_events;
+    std::vector<Kernel::OrbisKernelEqueue> flip_events;
+    std::vector<Kernel::OrbisKernelEqueue> vblank_events;
     std::mutex vo_mutex;
     std::mutex port_mutex;
     std::condition_variable vo_cv;

--- a/src/core/libraries/videoout/video_out.cpp
+++ b/src/core/libraries/videoout/video_out.cpp
@@ -38,7 +38,7 @@ void PS4_SYSV_ABI sceVideoOutSetBufferAttribute(BufferAttribute* attribute, Pixe
     attribute->option = SCE_VIDEO_OUT_BUFFER_ATTRIBUTE_OPTION_NONE;
 }
 
-s32 PS4_SYSV_ABI sceVideoOutAddFlipEvent(Kernel::SceKernelEqueue eq, s32 handle, void* udata) {
+s32 PS4_SYSV_ABI sceVideoOutAddFlipEvent(Kernel::OrbisKernelEqueue eq, s32 handle, void* udata) {
     LOG_INFO(Lib_VideoOut, "handle = {}", handle);
 
     auto* port = driver->GetPort(handle);
@@ -52,8 +52,8 @@ s32 PS4_SYSV_ABI sceVideoOutAddFlipEvent(Kernel::SceKernelEqueue eq, s32 handle,
 
     Kernel::EqueueEvent event{};
     event.event.ident = static_cast<u64>(OrbisVideoOutInternalEventId::Flip);
-    event.event.filter = Kernel::SceKernelEvent::Filter::VideoOut;
-    event.event.flags = Kernel::SceKernelEvent::Flags::Add;
+    event.event.filter = Kernel::OrbisKernelEvent::Filter::VideoOut;
+    event.event.flags = Kernel::OrbisKernelEvent::Flags::Add;
     event.event.udata = udata;
     event.event.fflags = 0;
     event.event.data = 0;
@@ -64,7 +64,7 @@ s32 PS4_SYSV_ABI sceVideoOutAddFlipEvent(Kernel::SceKernelEqueue eq, s32 handle,
     return ORBIS_OK;
 }
 
-s32 PS4_SYSV_ABI sceVideoOutDeleteFlipEvent(Kernel::SceKernelEqueue eq, s32 handle) {
+s32 PS4_SYSV_ABI sceVideoOutDeleteFlipEvent(Kernel::OrbisKernelEqueue eq, s32 handle) {
     auto* port = driver->GetPort(handle);
     if (port == nullptr) {
         return ORBIS_VIDEO_OUT_ERROR_INVALID_HANDLE;
@@ -73,12 +73,12 @@ s32 PS4_SYSV_ABI sceVideoOutDeleteFlipEvent(Kernel::SceKernelEqueue eq, s32 hand
     if (eq == nullptr) {
         return ORBIS_VIDEO_OUT_ERROR_INVALID_EVENT_QUEUE;
     }
-    eq->RemoveEvent(handle, Kernel::SceKernelEvent::Filter::VideoOut);
+    eq->RemoveEvent(handle, Kernel::OrbisKernelEvent::Filter::VideoOut);
     port->flip_events.erase(find(port->flip_events.begin(), port->flip_events.end(), eq));
     return ORBIS_OK;
 }
 
-s32 PS4_SYSV_ABI sceVideoOutAddVblankEvent(Kernel::SceKernelEqueue eq, s32 handle, void* udata) {
+s32 PS4_SYSV_ABI sceVideoOutAddVblankEvent(Kernel::OrbisKernelEqueue eq, s32 handle, void* udata) {
     LOG_INFO(Lib_VideoOut, "handle = {}", handle);
 
     auto* port = driver->GetPort(handle);
@@ -92,8 +92,8 @@ s32 PS4_SYSV_ABI sceVideoOutAddVblankEvent(Kernel::SceKernelEqueue eq, s32 handl
 
     Kernel::EqueueEvent event{};
     event.event.ident = static_cast<u64>(OrbisVideoOutInternalEventId::Vblank);
-    event.event.filter = Kernel::SceKernelEvent::Filter::VideoOut;
-    event.event.flags = Kernel::SceKernelEvent::Flags::Add;
+    event.event.filter = Kernel::OrbisKernelEvent::Filter::VideoOut;
+    event.event.flags = Kernel::OrbisKernelEvent::Flags::Add;
     event.event.udata = udata;
     event.event.fflags = 0;
     event.event.data = 0;
@@ -104,7 +104,7 @@ s32 PS4_SYSV_ABI sceVideoOutAddVblankEvent(Kernel::SceKernelEqueue eq, s32 handl
     return ORBIS_OK;
 }
 
-s32 PS4_SYSV_ABI sceVideoOutDeleteVblankEvent(Kernel::SceKernelEqueue eq, s32 handle) {
+s32 PS4_SYSV_ABI sceVideoOutDeleteVblankEvent(Kernel::OrbisKernelEqueue eq, s32 handle) {
     auto* port = driver->GetPort(handle);
     if (port == nullptr) {
         return ORBIS_VIDEO_OUT_ERROR_INVALID_HANDLE;
@@ -113,7 +113,7 @@ s32 PS4_SYSV_ABI sceVideoOutDeleteVblankEvent(Kernel::SceKernelEqueue eq, s32 ha
     if (eq == nullptr) {
         return ORBIS_VIDEO_OUT_ERROR_INVALID_EVENT_QUEUE;
     }
-    eq->RemoveEvent(handle, Kernel::SceKernelEvent::Filter::VideoOut);
+    eq->RemoveEvent(handle, Kernel::OrbisKernelEvent::Filter::VideoOut);
     port->vblank_events.erase(find(port->vblank_events.begin(), port->vblank_events.end(), eq));
     return ORBIS_OK;
 }
@@ -180,11 +180,11 @@ s32 PS4_SYSV_ABI sceVideoOutSubmitFlip(s32 handle, s32 bufferIndex, s32 flipMode
     return ORBIS_OK;
 }
 
-s32 PS4_SYSV_ABI sceVideoOutGetEventId(const Kernel::SceKernelEvent* ev) {
+s32 PS4_SYSV_ABI sceVideoOutGetEventId(const Kernel::OrbisKernelEvent* ev) {
     if (ev == nullptr) {
         return ORBIS_VIDEO_OUT_ERROR_INVALID_ADDRESS;
     }
-    if (ev->filter != Kernel::SceKernelEvent::Filter::VideoOut) {
+    if (ev->filter != Kernel::OrbisKernelEvent::Filter::VideoOut) {
         return ORBIS_VIDEO_OUT_ERROR_INVALID_EVENT;
     }
 
@@ -208,11 +208,11 @@ s32 PS4_SYSV_ABI sceVideoOutGetEventId(const Kernel::SceKernelEvent* ev) {
     }
 }
 
-s32 PS4_SYSV_ABI sceVideoOutGetEventData(const Kernel::SceKernelEvent* ev, s64* data) {
+s32 PS4_SYSV_ABI sceVideoOutGetEventData(const Kernel::OrbisKernelEvent* ev, s64* data) {
     if (ev == nullptr || data == nullptr) {
         return ORBIS_VIDEO_OUT_ERROR_INVALID_ADDRESS;
     }
-    if (ev->filter != Kernel::SceKernelEvent::Filter::VideoOut) {
+    if (ev->filter != Kernel::OrbisKernelEvent::Filter::VideoOut) {
         return ORBIS_VIDEO_OUT_ERROR_INVALID_EVENT;
     }
 
@@ -225,11 +225,11 @@ s32 PS4_SYSV_ABI sceVideoOutGetEventData(const Kernel::SceKernelEvent* ev, s64* 
     return ORBIS_OK;
 }
 
-s32 PS4_SYSV_ABI sceVideoOutGetEventCount(const Kernel::SceKernelEvent* ev) {
+s32 PS4_SYSV_ABI sceVideoOutGetEventCount(const Kernel::OrbisKernelEvent* ev) {
     if (ev == nullptr) {
         return ORBIS_VIDEO_OUT_ERROR_INVALID_ADDRESS;
     }
-    if (ev->filter != Kernel::SceKernelEvent::Filter::VideoOut) {
+    if (ev->filter != Kernel::OrbisKernelEvent::Filter::VideoOut) {
         return ORBIS_VIDEO_OUT_ERROR_INVALID_EVENT;
     }
 

--- a/src/core/libraries/videoout/video_out.cpp
+++ b/src/core/libraries/videoout/video_out.cpp
@@ -46,7 +46,8 @@ s32 PS4_SYSV_ABI sceVideoOutAddFlipEvent(Kernel::OrbisKernelEqueue eq, s32 handl
         return ORBIS_VIDEO_OUT_ERROR_INVALID_HANDLE;
     }
 
-    if (eq == nullptr) {
+    auto equeue = Kernel::GetEqueue(eq);
+    if (equeue == nullptr) {
         return ORBIS_VIDEO_OUT_ERROR_INVALID_EVENT_QUEUE;
     }
 
@@ -58,9 +59,9 @@ s32 PS4_SYSV_ABI sceVideoOutAddFlipEvent(Kernel::OrbisKernelEqueue eq, s32 handl
     event.event.fflags = 0;
     event.event.data = 0;
     event.data = port;
-    eq->AddEvent(event);
+    equeue->AddEvent(event);
 
-    port->flip_events.push_back(eq);
+    port->flip_events.push_back(equeue);
     return ORBIS_OK;
 }
 
@@ -70,11 +71,12 @@ s32 PS4_SYSV_ABI sceVideoOutDeleteFlipEvent(Kernel::OrbisKernelEqueue eq, s32 ha
         return ORBIS_VIDEO_OUT_ERROR_INVALID_HANDLE;
     }
 
-    if (eq == nullptr) {
+    auto equeue = Kernel::GetEqueue(eq);
+    if (equeue == nullptr) {
         return ORBIS_VIDEO_OUT_ERROR_INVALID_EVENT_QUEUE;
     }
-    eq->RemoveEvent(handle, Kernel::OrbisKernelEvent::Filter::VideoOut);
-    port->flip_events.erase(find(port->flip_events.begin(), port->flip_events.end(), eq));
+    equeue->RemoveEvent(handle, Kernel::OrbisKernelEvent::Filter::VideoOut);
+    port->flip_events.erase(find(port->flip_events.begin(), port->flip_events.end(), equeue));
     return ORBIS_OK;
 }
 
@@ -86,7 +88,8 @@ s32 PS4_SYSV_ABI sceVideoOutAddVblankEvent(Kernel::OrbisKernelEqueue eq, s32 han
         return ORBIS_VIDEO_OUT_ERROR_INVALID_HANDLE;
     }
 
-    if (eq == nullptr) {
+    auto equeue = Kernel::GetEqueue(eq);
+    if (equeue == nullptr) {
         return ORBIS_VIDEO_OUT_ERROR_INVALID_EVENT_QUEUE;
     }
 
@@ -98,9 +101,9 @@ s32 PS4_SYSV_ABI sceVideoOutAddVblankEvent(Kernel::OrbisKernelEqueue eq, s32 han
     event.event.fflags = 0;
     event.event.data = 0;
     event.data = port;
-    eq->AddEvent(event);
+    equeue->AddEvent(event);
 
-    port->vblank_events.push_back(eq);
+    port->vblank_events.push_back(equeue);
     return ORBIS_OK;
 }
 
@@ -110,11 +113,12 @@ s32 PS4_SYSV_ABI sceVideoOutDeleteVblankEvent(Kernel::OrbisKernelEqueue eq, s32 
         return ORBIS_VIDEO_OUT_ERROR_INVALID_HANDLE;
     }
 
-    if (eq == nullptr) {
+    auto equeue = Kernel::GetEqueue(eq);
+    if (equeue == nullptr) {
         return ORBIS_VIDEO_OUT_ERROR_INVALID_EVENT_QUEUE;
     }
-    eq->RemoveEvent(handle, Kernel::OrbisKernelEvent::Filter::VideoOut);
-    port->vblank_events.erase(find(port->vblank_events.begin(), port->vblank_events.end(), eq));
+    equeue->RemoveEvent(handle, Kernel::OrbisKernelEvent::Filter::VideoOut);
+    port->vblank_events.erase(find(port->vblank_events.begin(), port->vblank_events.end(), equeue));
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/videoout/video_out.h
+++ b/src/core/libraries/videoout/video_out.h
@@ -119,8 +119,8 @@ struct OrbisVideoOutEventData {
 void PS4_SYSV_ABI sceVideoOutSetBufferAttribute(BufferAttribute* attribute, PixelFormat pixelFormat,
                                                 u32 tilingMode, u32 aspectRatio, u32 width,
                                                 u32 height, u32 pitchInPixel);
-s32 PS4_SYSV_ABI sceVideoOutAddFlipEvent(Kernel::SceKernelEqueue eq, s32 handle, void* udata);
-s32 PS4_SYSV_ABI sceVideoOutAddVblankEvent(Kernel::SceKernelEqueue eq, s32 handle, void* udata);
+s32 PS4_SYSV_ABI sceVideoOutAddFlipEvent(Kernel::OrbisKernelEqueue eq, s32 handle, void* udata);
+s32 PS4_SYSV_ABI sceVideoOutAddVblankEvent(Kernel::OrbisKernelEqueue eq, s32 handle, void* udata);
 s32 PS4_SYSV_ABI sceVideoOutRegisterBuffers(s32 handle, s32 startIndex, void* const* addresses,
                                             s32 bufferNum, const BufferAttribute* attribute);
 s32 PS4_SYSV_ABI sceVideoOutGetBufferLabelAddress(s32 handle, uintptr_t* label_addr);
@@ -133,8 +133,8 @@ s32 PS4_SYSV_ABI sceVideoOutGetResolutionStatus(s32 handle, SceVideoOutResolutio
 s32 PS4_SYSV_ABI sceVideoOutOpen(Libraries::UserService::OrbisUserServiceUserId userId, s32 busType,
                                  s32 index, const void* param);
 s32 PS4_SYSV_ABI sceVideoOutClose(s32 handle);
-s32 PS4_SYSV_ABI sceVideoOutGetEventId(const Kernel::SceKernelEvent* ev);
-s32 PS4_SYSV_ABI sceVideoOutGetEventData(const Kernel::SceKernelEvent* ev, s64* data);
+s32 PS4_SYSV_ABI sceVideoOutGetEventId(const Kernel::OrbisKernelEvent* ev);
+s32 PS4_SYSV_ABI sceVideoOutGetEventData(const Kernel::OrbisKernelEvent* ev, s64* data);
 s32 PS4_SYSV_ABI sceVideoOutColorSettingsSetGamma(SceVideoOutColorSettings* settings, float gamma);
 s32 PS4_SYSV_ABI sceVideoOutAdjustColor(s32 handle, const SceVideoOutColorSettings* settings);
 


### PR DESCRIPTION
The bulk of this PR is a refactor, swapping our SceKernelEqueue to a 64-bit integer to match real hardware behavior, and implementing the necessary structure to store equeues instead of relying on games passing them around. I also renamed our structs to OrbisKernel prefixes to match our modern standards.
Additionally, to make this implementation reasonable, I moved timer scheduling to `EqueueInternal::AddEvent`, and changed logic for data storage in timer and small timer events to match libkernel behavior.

This needs testing, the only title I own that calls these is Assassin's Creed Unity, and that isn't really affected by this, since it's just using kevent to add a read event to their equeue.

As far as I've tested locally, I haven't broken anything involving normal equeue event usage.