### PR TITLE
Mount /data to <userdir>/data instead of <userdir>/data/gameid

### DIFF
--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -341,11 +341,8 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
 
     g_window = window.get();
 
-    const auto& mount_data_dir = Common::FS::GetUserPath(Common::FS::PathType::GameDataDir) / id;
-    if (!std::filesystem::exists(mount_data_dir)) {
-        std::filesystem::create_directory(mount_data_dir);
-    }
-    mnt->Mount(mount_data_dir, "/data"); // should just exist, manually create with game serial
+    const auto& mount_data_dir = Common::FS::GetUserPath(Common::FS::PathType::GameDataDir);
+    mnt->Mount(mount_data_dir, "/data");
 
     // Mounting temp folders
     const auto& mount_temp_dir = Common::FS::GetUserPath(Common::FS::PathType::TempDataDir) / id;


### PR DESCRIPTION
Following the behaviour of homebrew enablers, mount /data to the same location for every process, instead of making a separate folder for each. This makes working with homebrew apps easier, as it saves you one folder of indirection. People with preexisting stuff in these folders will have to manually update the contents of it to match the new mount, but given that retail apps don't (and can't on OWF) access this anyway, and are therefore unaffected, that is a sacrifice I'm willing to make.