### PR TITLE
IPC: Fix LoadFigure and RemoveFigure inconsistency

### DIFF
--- a/src/core/ipc/ipc.cpp
+++ b/src/core/ipc/ipc.cpp
@@ -174,12 +174,18 @@ void IPC::InputLoop() {
         } else if (cmd == "USB_LOAD_FIGURE") {
             const auto ref = Libraries::Usbd::usb_backend->GetImplRef();
             if (ref) {
-                ref->LoadFigure(next_str(), next_u64(), next_u64());
+                std::string file_name = next_str();
+                const u8 pad = next_u64();
+                const u8 slot = next_u64();
+                ref->LoadFigure(file_name, pad, slot);
             }
         } else if (cmd == "USB_REMOVE_FIGURE") {
             const auto ref = Libraries::Usbd::usb_backend->GetImplRef();
             if (ref) {
-                ref->RemoveFigure(next_u64(), next_u64(), next_u64() != 0);
+                const u8 pad = next_u64();
+                const u8 slot = next_u64();
+                bool full_remove = next_u64() != 0;
+                ref->RemoveFigure(pad, slot, full_remove);
             }
         } else if (cmd == "USB_MOVE_FIGURE") {
             const auto ref = Libraries::Usbd::usb_backend->GetImplRef();


### PR DESCRIPTION
Thought I'd fix this while looking into a separate issue, these IPC commands don't store the read values like the others so this should fix any jank that was obscuring that issue.