### PR TITLE
Lib.Net: Proper resolver errors when isConnectedToNetwork is disabled

### DIFF
--- a/src/core/libraries/network/net_resolver.cpp
+++ b/src/core/libraries/network/net_resolver.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "common/assert.h"
+#include "common/config.h"
 #include "common/singleton.h"
 #include "common/types.h"
 #include "core/libraries/error_codes.h"
@@ -26,11 +27,16 @@ int Resolver::ResolveAsync(const char* hostname, OrbisNetInAddr* addr, int timeo
 }
 
 void Resolver::Resolve() {
+    if (!Config::getIsConnectedToNetwork()) {
+        resolution_error = ORBIS_NET_ERROR_RESOLVER_ENODNS;
+        return;
+    }
+
     if (async_resolution) {
         auto* netinfo = Common::Singleton<NetUtil::NetUtilInternal>::Instance();
         auto ret = netinfo->ResolveHostname(async_resolution->hostname, async_resolution->addr);
-
-        resolution_error = ret;
+        // Resolver errors are stored as ORBIS_NET_ERROR values.
+        resolution_error = -ret | ORBIS_NET_ERROR_BASE;
     } else {
         LOG_ERROR(Lib_Net, "async resolution has not been set-up");
     }

--- a/src/core/libraries/network/net_resolver.h
+++ b/src/core/libraries/network/net_resolver.h
@@ -19,6 +19,7 @@ public:
     void Resolve();
 
     int resolution_error = ORBIS_OK;
+
 private:
     struct AsyncResolution {
         const char* hostname;

--- a/src/core/libraries/network/net_resolver.h
+++ b/src/core/libraries/network/net_resolver.h
@@ -18,6 +18,7 @@ public:
     int ResolveAsync(const char* hostname, OrbisNetInAddr* addr, int timeout, int retry, int flags);
     void Resolve();
 
+    int resolution_error = ORBIS_OK;
 private:
     struct AsyncResolution {
         const char* hostname;
@@ -31,7 +32,6 @@ private:
     int poolid;
     int flags;
     std::optional<AsyncResolution> async_resolution{};
-    int resolution_error = ORBIS_OK;
     std::mutex m_mutex;
 };
 


### PR DESCRIPTION
Error values are based on real hardware testing.
sceNetResolverGetError is based on libSceNet decompilation.