### PR TITLE
Lib.Net: Misc fixes

### DIFF
--- a/src/core/libraries/network/net_resolver.cpp
+++ b/src/core/libraries/network/net_resolver.cpp
@@ -35,8 +35,11 @@ void Resolver::Resolve() {
     if (async_resolution) {
         auto* netinfo = Common::Singleton<NetUtil::NetUtilInternal>::Instance();
         auto ret = netinfo->ResolveHostname(async_resolution->hostname, async_resolution->addr);
-        // Resolver errors are stored as ORBIS_NET_ERROR values.
-        resolution_error = -ret | ORBIS_NET_ERROR_BASE;
+        resolution_error = ret;
+        if (ret != ORBIS_OK) {
+            // Resolver errors are stored as ORBIS_NET_ERROR values.
+            resolution_error = -ret | ORBIS_NET_ERROR_BASE;
+        }
     } else {
         LOG_ERROR(Lib_Net, "async resolution has not been set-up");
     }

--- a/src/core/libraries/network/sys_net.cpp
+++ b/src/core/libraries/network/sys_net.cpp
@@ -404,8 +404,11 @@ s64 PS4_SYSV_ABI sys_recvfrom(OrbisNetId s, void* buf, u64 len, int flags, Orbis
     if (returncode >= 0) {
         return returncode;
     }
-    LOG_ERROR(Lib_Net, "s = {} ({}) returned error code: {}", s, file->m_guest_name,
-              (u32)*Libraries::Kernel::__Error());
+    // Don't log EWOULDBLOCK, this is normal to see from non-blocking communication.
+    u32 error = *Libraries::Kernel::__Error();
+    if (error != ORBIS_NET_EWOULDBLOCK) {
+        LOG_ERROR(Lib_Net, "s = {} ({}) returned error code: {}", s, file->m_guest_name, error);
+    }
     return -1;
 }
 

--- a/src/core/libraries/network/sys_net.cpp
+++ b/src/core/libraries/network/sys_net.cpp
@@ -28,8 +28,11 @@ int PS4_SYSV_ABI sys_connect(OrbisNetId s, const OrbisNetSockaddr* addr, u32 add
     if (returncode >= 0) {
         return returncode;
     }
-    LOG_ERROR(Lib_Net, "s = {} ({}) returned error code: {}", s, file->m_guest_name,
-              (u32)*Libraries::Kernel::__Error());
+    u32 error = *Libraries::Kernel::__Error();
+    // Don't log EINPROGRESS or EISCONN, these are normal to see from non-blocking communication.
+    if (error != ORBIS_NET_EINPROGRESS && error != ORBIS_NET_EISCONN) {
+        LOG_ERROR(Lib_Net, "s = {} ({}) returned error code: {}", s, file->m_guest_name, error);
+    }
     return -1;
 }
 
@@ -59,8 +62,13 @@ int PS4_SYSV_ABI sys_accept(OrbisNetId s, OrbisNetSockaddr* addr, u32* paddrlen)
     LOG_DEBUG(Lib_Net, "s = {} ({})", s, file->m_guest_name);
     auto new_sock = file->socket->Accept(addr, paddrlen);
     if (!new_sock) {
-        LOG_ERROR(Lib_Net, "s = {} ({}) returned error code creating new socket for accepting: {}",
-                  s, file->m_guest_name, (u32)*Libraries::Kernel::__Error());
+        u32 error = *Libraries::Kernel::__Error();
+        // Don't log EWOULDBLOCK, this is normal to see from non-blocking communication.
+        if (error != ORBIS_NET_EWOULDBLOCK) {
+            LOG_ERROR(Lib_Net,
+                      "s = {} ({}) returned error code creating new socket for accepting: {}", s,
+                      file->m_guest_name, error);
+        }
         return -1;
     }
     auto fd = FDTable::Instance()->CreateHandle();


### PR DESCRIPTION
This PR has three main changes:
- Fix incorrect error behavior for non-blocking native connect calls on Windows
- Hide typical non-blocking socket communication errors from log
  - Typical non-blocking communication involves constantly retrying communications until they succeed.
- Fix a bug with resolvers introduced by #4081 