### PR TITLE
Low readbacks mode

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -172,7 +172,7 @@ static ConfigEntry<u32> internalScreenWidth(1280);
 static ConfigEntry<u32> internalScreenHeight(720);
 static ConfigEntry<bool> isNullGpu(false);
 static ConfigEntry<bool> shouldCopyGPUBuffers(false);
-static ConfigEntry<bool> readbacksEnabled(false);
+static ConfigEntry<int> readbacksMode(GpuReadbacksMode::Disabled);
 static ConfigEntry<bool> readbackLinearImagesEnabled(false);
 static ConfigEntry<bool> directMemoryAccessEnabled(false);
 static ConfigEntry<bool> shouldDumpShaders(false);
@@ -440,8 +440,8 @@ bool copyGPUCmdBuffers() {
     return shouldCopyGPUBuffers.get();
 }
 
-bool readbacks() {
-    return readbacksEnabled.get();
+int getReadbacksMode() {
+    return readbacksMode.get();
 }
 
 bool readbackLinearImages() {
@@ -591,8 +591,8 @@ void setCopyGPUCmdBuffers(bool enable, bool is_game_specific) {
     shouldCopyGPUBuffers.set(enable, is_game_specific);
 }
 
-void setReadbacks(bool enable, bool is_game_specific) {
-    readbacksEnabled.set(enable, is_game_specific);
+void setReadbacksMode(int mode, bool is_game_specific) {
+    readbacksMode.set(mode, is_game_specific);
 }
 
 void setReadbackLinearImages(bool enable, bool is_game_specific) {
@@ -943,7 +943,7 @@ void load(const std::filesystem::path& path, bool is_game_specific) {
         internalScreenHeight.setFromToml(gpu, "internalScreenHeight", is_game_specific);
         isNullGpu.setFromToml(gpu, "nullGpu", is_game_specific);
         shouldCopyGPUBuffers.setFromToml(gpu, "copyGPUBuffers", is_game_specific);
-        readbacksEnabled.setFromToml(gpu, "readbacks", is_game_specific);
+        readbacksMode.setFromToml(gpu, "readbacksMode", is_game_specific);
         readbackLinearImagesEnabled.setFromToml(gpu, "readbackLinearImages", is_game_specific);
         directMemoryAccessEnabled.setFromToml(gpu, "directMemoryAccess", is_game_specific);
         shouldDumpShaders.setFromToml(gpu, "dumpShaders", is_game_specific);
@@ -1119,7 +1119,7 @@ void save(const std::filesystem::path& path, bool is_game_specific) {
     windowHeight.setTomlValue(data, "GPU", "screenHeight", is_game_specific);
     isNullGpu.setTomlValue(data, "GPU", "nullGpu", is_game_specific);
     shouldCopyGPUBuffers.setTomlValue(data, "GPU", "copyGPUBuffers", is_game_specific);
-    readbacksEnabled.setTomlValue(data, "GPU", "readbacks", is_game_specific);
+    readbacksMode.setTomlValue(data, "GPU", "readbacksMode", is_game_specific);
     readbackLinearImagesEnabled.setTomlValue(data, "GPU", "readbackLinearImages", is_game_specific);
     shouldDumpShaders.setTomlValue(data, "GPU", "dumpShaders", is_game_specific);
     vblankFrequency.setTomlValue(data, "GPU", "vblankFrequency", is_game_specific);
@@ -1218,7 +1218,7 @@ void setDefaultValues(bool is_game_specific) {
     // Entries with game-specific settings that are in the game-specific setings GUI but not in
     // the global settings GUI
     if (is_game_specific) {
-        readbacksEnabled.set(false, is_game_specific);
+        readbacksMode.set(GpuReadbacksMode::Disabled, is_game_specific);
         readbackLinearImagesEnabled.set(false, is_game_specific);
         isNeo.set(false, is_game_specific);
         isDevKit.set(false, is_game_specific);

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -23,6 +23,12 @@ struct GameInstallDir {
 
 enum HideCursorState : int { Never, Idle, Always };
 
+enum GpuReadbacksMode : int {
+    Disabled,
+    Low,
+    High,
+};
+
 void load(const std::filesystem::path& path, bool is_game_specific = false);
 void save(const std::filesystem::path& path, bool is_game_specific = false);
 void resetGameSpecificValue(std::string entry);
@@ -63,8 +69,8 @@ bool nullGpu();
 void setNullGpu(bool enable, bool is_game_specific = false);
 bool copyGPUCmdBuffers();
 void setCopyGPUCmdBuffers(bool enable, bool is_game_specific = false);
-bool readbacks();
-void setReadbacks(bool enable, bool is_game_specific = false);
+int getReadbacksMode();
+void setReadbacksMode(int mode, bool is_game_specific = false);
 bool readbackLinearImages();
 void setReadbackLinearImages(bool enable, bool is_game_specific = false);
 bool directMemoryAccess();

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -245,7 +245,7 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
     LOG_INFO(Config, "General isConnectedToNetwork: {}", Config::getIsConnectedToNetwork());
     LOG_INFO(Config, "General isPsnSignedIn: {}", Config::getPSNSignedIn());
     LOG_INFO(Config, "GPU isNullGpu: {}", Config::nullGpu());
-    LOG_INFO(Config, "GPU readbacks: {}", Config::readbacks());
+    LOG_INFO(Config, "GPU readbacksMode: {}", Config::getReadbacksMode());
     LOG_INFO(Config, "GPU readbackLinearImages: {}", Config::readbackLinearImages());
     LOG_INFO(Config, "GPU directMemoryAccess: {}", Config::directMemoryAccess());
     LOG_INFO(Config, "GPU shouldDumpShaders: {}", Config::dumpShaders());

--- a/src/video_core/buffer_cache/memory_tracker.h
+++ b/src/video_core/buffer_cache/memory_tracker.h
@@ -5,8 +5,10 @@
 
 #include <algorithm>
 #include <deque>
+#include <mutex>
 #include <type_traits>
 #include <vector>
+
 #include "common/debug.h"
 #include "common/types.h"
 #include "video_core/buffer_cache/region_manager.h"
@@ -71,7 +73,7 @@ public:
                     // modified. If we need to flush the flush function is going to perform CPU
                     // state change.
                     std::scoped_lock lk{manager->lock};
-                    if (Config::readbacks() &&
+                    if (Config::getReadbacksMode() != Config::GpuReadbacksMode::Disabled &&
                         manager->template IsRegionModified<Type::GPU>(offset, size)) {
                         return true;
                     }

--- a/src/video_core/buffer_cache/region_manager.h
+++ b/src/video_core/buffer_cache/region_manager.h
@@ -95,7 +95,7 @@ public:
         }
         if constexpr (type == Type::CPU) {
             UpdateProtection<!enable, false>();
-        } else if (Config::readbacks()) {
+        } else if (Config::getReadbacksMode() == Config::GpuReadbacksMode::High) {
             UpdateProtection<enable, true>();
         }
     }
@@ -126,7 +126,7 @@ public:
             bits.UnsetRange(start_page, end_page);
             if constexpr (type == Type::CPU) {
                 UpdateProtection<true, false>();
-            } else if (Config::readbacks()) {
+            } else if (Config::getReadbacksMode() != Config::GpuReadbacksMode::Disabled) {
                 UpdateProtection<false, true>();
             }
         }


### PR DESCRIPTION
Disclaimer: I don't really know how readbacks works, but I asked turtle about this and he said this was ok to PR

This takes only the part of the readback optimizations PR https://github.com/shadps4-emu/shadPS4/pull/3404 that implements a more relaxed readbacks mode, and excludes all other changes. Explanation from that PR:

"Low is the same as high [the level we have now] but fence detection is more relaxed and it only triggers on page writes, so no read protection. This is useful when guest doesn't want to access GPU data ever but readbacks are needed to fix data corruption (i.e vertex explosions). Performance is expected to be higher than "high" (possible, but haven't implemented it)"

Low readbacks mode seems to work to prevent vertex explosions with Bloodborne with far better performance, only additional issue is some significant additional stuttering during asset loading (presumably when the readbacks are being performed). Still, this seems much more usable then the current expensive readbacks we have. No other issues on my part from my Bloodborne test.

To test, add the current line under the GPU section in config.toml:

readbacksMode = 1