### PR TITLE
Lib.SaveData: Fix out of bounds iterator access in match

### DIFF
--- a/src/core/libraries/save_data/savedata.cpp
+++ b/src/core/libraries/save_data/savedata.cpp
@@ -330,7 +330,7 @@ static bool match(std::string_view str, std::string_view pattern) {
     auto pat_it = pattern.begin();
     while (str_it != str.end() && pat_it != pattern.end()) {
         if (*pat_it == '%') { // 0 or more wildcard
-            for (auto str_wild_it = str_it; str_wild_it <= str.end(); ++str_wild_it) {
+            for (auto str_wild_it = str_it; str_wild_it < str.end(); ++str_wild_it) {
                 if (match({str_wild_it, str.end()}, {pat_it + 1, pattern.end()})) {
                     return true;
                 }


### PR DESCRIPTION
When `str_wild_it == str.end()`,  `match({str_wild_it, str.end()}, {pat_it + 1, pattern.end()})` would throw debug asserts due to out of bounds iterator accesses.

This fixes a crash that occurs when trying to run Cyberpunk 2077 under a debugger.