### PR TITLE
CI wget linuxdeploy retries

### DIFF
--- a/.github/linux-appimage-sdl.sh
+++ b/.github/linux-appimage-sdl.sh
@@ -8,8 +8,8 @@ if [[ -z $GITHUB_WORKSPACE ]]; then
 fi
 
 # Prepare Tools for building the AppImage
-wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
-wget -q https://github.com/linuxdeploy/linuxdeploy-plugin-checkrt/releases/download/continuous/linuxdeploy-plugin-checkrt-x86_64.sh
+wget --waitretry=3 --read-timeout=20 --timeout=15 --tries=5 -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+wget --waitretry=3 --read-timeout=20 --timeout=15 --tries=5 -q https://github.com/linuxdeploy/linuxdeploy-plugin-checkrt/releases/download/continuous/linuxdeploy-plugin-checkrt-x86_64.sh
 
 chmod a+x linuxdeploy-x86_64.AppImage
 chmod a+x linuxdeploy-plugin-checkrt-x86_64.sh


### PR DESCRIPTION
```
Run ./.github/linux-appimage-sdl.sh
  ./.github/linux-appimage-sdl.sh
  shell: /usr/bin/bash -e {0}
  env:
    BUILD_TYPE: Release
chmod: cannot access 'linuxdeploy-x86_64.AppImage': No such file or directory
./.github/linux-appimage-sdl.sh: line 18: ./linuxdeploy-x86_64.AppImage: No such file or directory
No such directory: AppDir
./.github/linux-appimage-sdl.sh: line 20: ./linuxdeploy-x86_64.AppImage: No such file or directory
mv: cannot stat 'shadPS4-x86_64.AppImage': No such file or directory
Error: Process completed with exit code 1.
```