### PR TITLE
Lib.SaveData: Fix the fix

### DIFF
--- a/src/core/libraries/save_data/savedata.cpp
+++ b/src/core/libraries/save_data/savedata.cpp
@@ -330,9 +330,12 @@ static bool match(std::string_view str, std::string_view pattern) {
     auto pat_it = pattern.begin();
     while (str_it != str.end() && pat_it != pattern.end()) {
         if (*pat_it == '%') { // 0 or more wildcard
-            for (auto str_wild_it = str_it; str_wild_it < str.end(); ++str_wild_it) {
+            for (auto str_wild_it = str_it; str_wild_it <= str.end(); ++str_wild_it) {
                 if (match({str_wild_it, str.end()}, {pat_it + 1, pattern.end()})) {
                     return true;
+                } else if (str_wild_it == str.end()) {
+                    // Avoid incrementing str_wild_it past str.end().
+                    break;
                 }
             }
             return false;


### PR DESCRIPTION
Cyberpunk's issue seems to actually come from the incrementing in the loop. It wasn't clear while debugging, but the problem is that the pattern the game supplies causes match to fail when str_wild_it hits the end, and then tries iterating past end due to the loop condition.

Our pattern matching code seems broken for the case Cyberpunk triggers, but since I'm not aware of the intricacies of how real hardware behaves, best to just revert the loop condition change and instead break the loop before the broken iteration.

When I can, I'll supply the requested str and pattern so someone more familiar (probably @viniciuslrangel) can make this actually function properly.