### PR TITLE
Vulkan pipeline cache: finish preload state before profile-mismatch early return

### DIFF
--- a/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
@@ -316,6 +316,9 @@ void PipelineCache::WarmUp() {
     if (std::memcmp(profile_data.data(), &profile, sizeof(profile)) != 0) {
         LOG_WARNING(Render,
                     "Pipeline cache isn't compatible with current system. Ignoring the cache");
+        // Keep DB lifecycle consistent before early return: in archived mode, Save() later in the
+        // session may still be called and expects writable archive state.
+        Storage::DataBase::Instance().FinishPreload();
         return;
     }
 


### PR DESCRIPTION
This fixes a cache lifecycle edge case in `PipelineCache::WarmUp()`.

If the stored pipeline profile doesn't match the current system profile, we currently return early. In archive mode that leaves cache DB state in preload/read-only mode for the rest of the run, while runtime registration paths can still call `DataBase::Save(...)`.

The change is just:
- call `Storage::DataBase::Instance().FinishPreload()` in the mismatch branch
- keep the same behavior otherwise (still ignore incompatible warmup cache)

So this is not changing compatibility logic, only cleaning up DB state before continuing.

Validation on my side:
- walked the control flow from `WarmUp()` to `RegisterShader*`/`RegisterPipelineData` save paths
- local configure succeeds
- full local build currently fails in unrelated external code (`externals/openal-soft`) in this environment
