### PR TITLE
Improve signal emulation

### DIFF
--- a/src/core/cpu_patches.cpp
+++ b/src/core/cpu_patches.cpp
@@ -788,14 +788,11 @@ static bool PatchesIllegalInstructionHandler(void* context) {
             ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT];
             const auto status =
                 Common::Decoder::Instance()->decodeInstruction(instruction, operands, code_address);
-            if (ZYAN_SUCCESS(status) && instruction.mnemonic == ZydisMnemonic::ZYDIS_MNEMONIC_UD2)
-                [[unlikely]] {
-                UNREACHABLE_MSG("ud2 at code address {:#x}", reinterpret_cast<u64>(code_address));
-            }
-            UNREACHABLE_MSG("Failed to patch address {:x} -- mnemonic: {}",
-                            reinterpret_cast<u64>(code_address),
-                            ZYAN_SUCCESS(status) ? ZydisMnemonicGetString(instruction.mnemonic)
-                                                 : "Failed to decode");
+            LOG_ERROR(Core, "Failed to patch address {:x} -- mnemonic: {}",
+                      reinterpret_cast<u64>(code_address),
+                      ZYAN_SUCCESS(status) ? ZydisMnemonicGetString(instruction.mnemonic)
+                                           : "Failed to decode");
+            return false;
         }
     }
 

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -317,15 +317,6 @@ s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
             LOG_ERROR(Lib_Kernel, "Unhandled sa_mask: {:x}", act->sa_mask.bits[0]);
         }
     }
-    struct sigaction native_oact{};
-    if (act) {
-        native_oact.sa_flags = act->sa_flags;
-        native_oact.sa_sigaction = reinterpret_cast<decltype(native_oact.sa_sigaction)>(
-            act->__sigaction_handler.sigaction);
-        if (act->sa_mask.bits[0] != 0) {
-            LOG_ERROR(Lib_Kernel, "Unhandled sa_mask: {:x}", act->sa_mask.bits[0]);
-        }
-    }
     Handlers[sig] = reinterpret_cast<OrbisKernelExceptionHandler>(
         act ? act->__sigaction_handler.sigaction : nullptr);
 
@@ -336,7 +327,17 @@ s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
         LOG_WARNING(Lib_Kernel, "We can't install a handler for native signal {}!", native_sig);
         return ORBIS_OK;
     }
+    struct sigaction native_oact{};
     s32 ret = sigaction(native_sig, act ? &native_act : nullptr, oact ? &native_oact : nullptr);
+    if (oact) {
+        oact->sa_flags = native_oact.sa_flags;
+        oact->__sigaction_handler.sigaction =
+            reinterpret_cast<decltype(oact->__sigaction_handler.sigaction)>(
+                native_oact.sa_sigaction);
+        if (native_oact.sa_mask.__val[0] != 0) {
+            LOG_ERROR(Lib_Kernel, "Unhandled sa_mask: {:x}", native_oact.sa_mask.__val[0]);
+        }
+    }
     if (ret < 0) {
         LOG_ERROR(Lib_Kernel, "sigaction failed: {}", strerror(errno));
         *__Error() = ErrnoToSceKernelError(errno);

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -305,8 +305,6 @@ s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
                   "Guest is attempting to use SIGRT signals, which aren't available on this "
                   "platform (signal: {})!",
                   sig);
-        *__Error() = POSIX_EINVAL;
-        return ORBIS_FAIL;
     }
 #endif
     LOG_INFO(Lib_Kernel, "called, sig: {}, native sig: {}", sig, native_sig);

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -278,6 +278,10 @@ s32 PS4_SYSV_ABI posix_sigemptyset(Sigset* s) {
     return 0;
 }
 
+bool PS4_SYSV_ABI posix_sigisemptyset(Sigset* s) {
+    return s->bits[0] == 0 && s->bits[1] == 0;
+}
+
 s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
     if (sig < 1 || sig > 128 || sig == POSIX_SIGTHR || sig == POSIX_SIGKILL ||
         sig == POSIX_SIGSTOP) {
@@ -313,7 +317,7 @@ s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
         native_act.sa_flags = act->sa_flags; // todo check compatibility, on Linux it seems fine
         native_act.sa_sigaction =
             reinterpret_cast<decltype(native_act.sa_sigaction)>(SigactionHandler);
-        if (act->sa_mask.bits[0] != 0) {
+        if (posix_sigisemptyset(&act->sa_mask)) {
             LOG_ERROR(Lib_Kernel, "Unhandled sa_mask: {:x}", act->sa_mask.bits[0]);
         }
     }
@@ -334,8 +338,8 @@ s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
         oact->sa_flags = native_oact.sa_flags;
         oact->__sigaction_handler.sigaction =
             reinterpret_cast<decltype(oact->__sigaction_handler.sigaction)>(prev_handler);
-        if (native_oact.sa_mask.__val[0] != 0) {
-            LOG_ERROR(Lib_Kernel, "Unhandled sa_mask: {:x}", native_oact.sa_mask.__val[0]);
+        if (sigisemptyset(&native_oact.sa_mask)) {
+            LOG_ERROR(Lib_Kernel, "Unhandled sa_mask");
         }
     }
     if (ret < 0) {

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -96,6 +96,8 @@ s32 NativeToOrbisSignal(s32 s) {
         return POSIX_SIGEMT;
     case _SIGINFO:
         return POSIX_SIGINFO;
+    case 0:
+        return 128;
     default:
         if (s > 0 && s < 128) {
             return s;
@@ -168,6 +170,8 @@ s32 OrbisToNativeSignal(s32 s) {
         return SIGUSR1;
     case POSIX_SIGUSR2:
         return SIGUSR2;
+    case 128:
+        return 0;
     default:
         if (s > 0 && s < 128) {
             return s;
@@ -288,11 +292,11 @@ s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
     }
 #ifdef _WIN32
     LOG_ERROR(Lib_Kernel, "(STUBBED) called, sig: {}", sig);
-    return ORBIS_OK;
 #else
+    LOG_INFO(Lib_Kernel, "called, sig: {}", sig);
     struct sigaction native_act{};
     if (act) {
-        native_act.sa_flags = SA_SIGINFO | SA_RESTART;
+        native_act.sa_flags = act->sa_flags; // todo check compatibility, on Linux it seems fine
         native_act.sa_sigaction =
             reinterpret_cast<decltype(native_act.sa_sigaction)>(act->__sigaction_handler.sigaction);
         if (act->sa_mask.bits[0] != 0) {
@@ -301,7 +305,7 @@ s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
     }
     struct sigaction native_oact{};
     if (act) {
-        native_oact.sa_flags = SA_SIGINFO | SA_RESTART;
+        native_oact.sa_flags = act->sa_flags;
         native_oact.sa_sigaction = reinterpret_cast<decltype(native_oact.sa_sigaction)>(
             act->__sigaction_handler.sigaction);
         if (act->sa_mask.bits[0] != 0) {
@@ -314,22 +318,19 @@ s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
     if (native_sig == SIGSEGV || native_sig == SIGBUS || native_sig == SIGILL) {
         return ORBIS_OK; // These are handled in Core::SignalHandler
     }
-    sigaction(native_sig, &native_act, &native_oact);
-
-    return ORBIS_OK;
+    s32 ret = sigaction(native_sig, &native_act, &native_oact);
+    if (ret < 0) {
+        LOG_ERROR(Lib_Kernel, "sigaction failed: {}", strerror(errno));
+        *__Error() = ErrnoToSceKernelError(errno);
+        return ORBIS_FAIL;
+    }
 #endif
+    return ORBIS_OK;
 }
 
 s32 PS4_SYSV_ABI posix_pthread_kill(PthreadT thread, s32 sig) {
     if (sig < 1 || sig > 128) { // off-by-one error?
-        *__Error() = POSIX_EINVAL;
-        return ORBIS_FAIL;
-    }
-    if (sig == 128) {
-        LOG_WARNING(Lib_Kernel, "sig {} can be raised for some reason but we don't do that here",
-                    sig);
-        *__Error() = POSIX_EINVAL;
-        return ORBIS_FAIL;
+        return POSIX_EINVAL;
     }
     LOG_WARNING(Lib_Kernel, "Raising signal {} on thread '{}'", sig, thread->name);
     int const native_signum = OrbisToNativeSignal(sig);
@@ -369,23 +370,16 @@ int PS4_SYSV_ABI sceKernelInstallExceptionHandler(s32 signum, OrbisKernelExcepti
         return ORBIS_KERNEL_ERROR_EAGAIN;
     }
     LOG_INFO(Lib_Kernel, "Installing signal handler for {}", signum);
-    int const native_signum = OrbisToNativeSignal(signum);
-    Handlers[signum] = handler;
-#ifndef _WIN64
-    if (native_signum == SIGSEGV || native_signum == SIGBUS || native_signum == SIGILL) {
-        return ORBIS_OK; // These are handled in Core::SignalHandler
-    }
-    struct sigaction act = {};
+    Sigaction act = {};
     act.sa_flags = SA_SIGINFO | SA_RESTART;
-    act.sa_sigaction = reinterpret_cast<decltype(act.sa_sigaction)>(SigactionHandler);
-    sigemptyset(&act.sa_mask);
-    s32 ret = sigaction(native_signum, &act, nullptr);
+    act.__sigaction_handler.sigaction =
+        reinterpret_cast<decltype(act.__sigaction_handler.sigaction)>(SigactionHandler);
+    posix_sigemptyset(&act.sa_mask);
+    s32 ret = posix_sigaction(signum, &act, nullptr);
     if (ret < 0) {
-        LOG_ERROR(Lib_Kernel, "Failed to add handler for signal {}: {}", signum, strerror(errno));
-        SetPosixErrno(errno);
+        LOG_ERROR(Lib_Kernel, "Failed to add handler for signal {}: {}", signum, strerror(*__Error()));
         return ErrnoToSceKernelError(*__Error());
     }
-#endif
     return ORBIS_OK;
 }
 
@@ -395,29 +389,15 @@ int PS4_SYSV_ABI sceKernelRemoveExceptionHandler(s32 signum) {
     }
     int const native_signum = OrbisToNativeSignal(signum);
     Handlers[signum] = nullptr;
-#ifndef _WIN64
-    if (native_signum == SIGSEGV || native_signum == SIGBUS || native_signum == SIGILL) {
-        struct sigaction action{};
-        action.sa_sigaction = Core::SignalHandler;
-        action.sa_flags = SA_SIGINFO | SA_ONSTACK;
-        sigemptyset(&action.sa_mask);
-
-        ASSERT_MSG(sigaction(native_signum, &action, nullptr) == 0,
-                   "Failed to reinstate original signal handler for signal {}", native_signum);
-    } else {
-        struct sigaction act = {};
-        act.sa_flags = SA_SIGINFO | SA_RESTART;
-        act.sa_sigaction = nullptr;
-        sigemptyset(&act.sa_mask);
-        s32 ret = sigaction(native_signum, &act, nullptr);
-        if (ret < 0) {
-            LOG_ERROR(Lib_Kernel, "Failed to remove handler for signal {}: {}", signum,
-                      strerror(errno));
-            SetPosixErrno(errno);
-            return ErrnoToSceKernelError(*__Error());
-        }
+    Sigaction act = {};
+    act.sa_flags = SA_SIGINFO;
+    act.__sigaction_handler.sigaction = nullptr;
+    posix_sigemptyset(&act.sa_mask);
+    s32 ret = posix_sigaction(signum, &act, nullptr);
+    if (ret < 0) {
+        LOG_ERROR(Lib_Kernel, "Failed to remove handler for signal {}: {}", signum, strerror(*__Error()));
+        return ErrnoToSceKernelError(*__Error());
     }
-#endif
     return ORBIS_OK;
 }
 
@@ -425,25 +405,8 @@ int PS4_SYSV_ABI sceKernelRaiseException(PthreadT thread, int signum) {
     if (signum != POSIX_SIGUSR1) {
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
-    LOG_WARNING(Lib_Kernel, "Raising exception on thread '{}'", thread->name);
-    int const native_signum = OrbisToNativeSignal(signum);
-#ifndef _WIN64
-    const auto pthr = reinterpret_cast<pthread_t>(thread->native_thr.GetHandle());
-    const auto ret = pthread_kill(pthr, native_signum);
-    if (ret != 0) {
-        LOG_ERROR(Kernel, "Failed to send exception signal to thread '{}': {}", thread->name,
-                  strerror(ret));
-    }
-#else
-    USER_APC_OPTION option;
-    option.UserApcFlags = QueueUserApcFlagsSpecialUserApc;
-
-    u64 res = NtQueueApcThreadEx(reinterpret_cast<HANDLE>(thread->native_thr.GetHandle()), option,
-                                 ExceptionHandler, (void*)thread->name.c_str(),
-                                 (void*)(s64)native_signum, nullptr);
-    ASSERT(res == 0);
-#endif
-    return ORBIS_OK;
+    s32 ret = posix_pthread_kill(thread, signum);
+    return ErrnoToSceKernelError(ret);
 }
 
 s32 PS4_SYSV_ABI sceKernelDebugRaiseException(s32 error, s64 unk) {

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -288,10 +288,12 @@ s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
         *__Error() = POSIX_EINVAL;
         return ORBIS_FAIL;
     }
-    s32 native_sig = OrbisToNativeSignal(sig);
 #ifdef _WIN32
     LOG_ERROR(Lib_Kernel, "(STUBBED) called, sig: {}", sig);
+    Handlers[sig] = reinterpret_cast<OrbisKernelExceptionHandler>(
+        act ? act->__sigaction_handler.sigaction : nullptr);
 #else
+    s32 native_sig = OrbisToNativeSignal(sig);
     if (native_sig == SIGVTALRM) {
         LOG_ERROR(Lib_Kernel, "Guest is attempting to use the HLE-reserved signal {}!", sig);
         *__Error() = POSIX_EINVAL;
@@ -431,7 +433,10 @@ int PS4_SYSV_ABI sceKernelRaiseException(PthreadT thread, int signum) {
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
     s32 ret = posix_pthread_kill(thread, signum);
-    return ErrnoToSceKernelError(ret);
+    if (ret < 0) {
+        return ErrnoToSceKernelError(ret);
+    }
+    return ret;
 }
 
 s32 PS4_SYSV_ABI sceKernelDebugRaiseException(s32 error, s64 unk) {

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "common/assert.h"
+#include "core/libraries/kernel/kernel.h"
 #include "core/libraries/kernel/orbis_error.h"
 #include "core/libraries/kernel/threads/exception.h"
 #include "core/libraries/kernel/threads/pthread.h"
@@ -13,23 +14,25 @@
 #else
 #include <csignal>
 #endif
+#include <unordered_set>
+#include <core/libraries/kernel/posix_error.h>
 
 namespace Libraries::Kernel {
 
 #ifdef _WIN32
 
 // Windows doesn't have native versions of these, and we don't need to use them either.
-static s32 NativeToOrbisSignal(s32 s) {
+s32 NativeToOrbisSignal(s32 s) {
     return s;
 }
 
-static s32 OrbisToNativeSignal(s32 s) {
+s32 OrbisToNativeSignal(s32 s) {
     return s;
 }
 
 #else
 
-static s32 NativeToOrbisSignal(s32 s) {
+s32 NativeToOrbisSignal(s32 s) {
     switch (s) {
     case SIGHUP:
         return POSIX_SIGHUP;
@@ -89,12 +92,19 @@ static s32 NativeToOrbisSignal(s32 s) {
         return POSIX_SIGUSR1;
     case SIGUSR2:
         return POSIX_SIGUSR2;
+    case _SIGEMT:
+        return POSIX_SIGEMT;
+    case _SIGINFO:
+        return POSIX_SIGINFO;
     default:
+        if (s > 0 && s < 128) {
+            return s;
+        }
         UNREACHABLE_MSG("Unknown signal {}", s);
     }
 }
 
-static s32 OrbisToNativeSignal(s32 s) {
+s32 OrbisToNativeSignal(s32 s) {
     switch (s) {
     case POSIX_SIGHUP:
         return SIGHUP;
@@ -108,6 +118,8 @@ static s32 OrbisToNativeSignal(s32 s) {
         return SIGTRAP;
     case POSIX_SIGABRT:
         return SIGABRT;
+    case POSIX_SIGEMT:
+        return _SIGEMT;
     case POSIX_SIGFPE:
         return SIGFPE;
     case POSIX_SIGKILL:
@@ -150,22 +162,27 @@ static s32 OrbisToNativeSignal(s32 s) {
         return SIGPROF;
     case POSIX_SIGWINCH:
         return SIGWINCH;
+    case POSIX_SIGINFO:
+        return _SIGINFO;
     case POSIX_SIGUSR1:
         return SIGUSR1;
     case POSIX_SIGUSR2:
         return SIGUSR2;
     default:
+        if (s > 0 && s < 128) {
+            return s;
+        }
         UNREACHABLE_MSG("Unknown signal {}", s);
     }
 }
 
 #endif
 
-std::array<SceKernelExceptionHandler, 32> Handlers{};
+std::array<OrbisKernelExceptionHandler, 130> Handlers{};
 
 #ifndef _WIN64
 void SigactionHandler(int native_signum, siginfo_t* inf, ucontext_t* raw_context) {
-    const auto handler = Handlers[native_signum];
+    const auto handler = Handlers[NativeToOrbisSignal(native_signum)];
     if (handler) {
         auto ctx = Ucontext{};
 #ifdef __APPLE__
@@ -214,6 +231,8 @@ void SigactionHandler(int native_signum, siginfo_t* inf, ucontext_t* raw_context
         ctx.uc_mcontext.mc_addr = reinterpret_cast<uint64_t>(inf->si_addr);
 #endif
         handler(NativeToOrbisSignal(native_signum), &ctx);
+    } else {
+        UNREACHABLE_MSG("Unhandled exception");
     }
 }
 #else
@@ -221,7 +240,7 @@ void ExceptionHandler(void* arg1, void* arg2, void* arg3, PCONTEXT context) {
     const char* thrName = (char*)arg1;
     int native_signum = reinterpret_cast<uintptr_t>(arg2);
     LOG_INFO(Lib_Kernel, "Exception raised successfully on thread '{}'", thrName);
-    const auto handler = Handlers[native_signum];
+    const auto handler = Handlers[NativeToOrbisSignal(native_signum)];
     if (handler) {
         auto ctx = Ucontext{};
         ctx.uc_mcontext.mc_r8 = context->R8;
@@ -243,21 +262,115 @@ void ExceptionHandler(void* arg1, void* arg2, void* arg3, PCONTEXT context) {
         ctx.uc_mcontext.mc_fs = context->SegFs;
         ctx.uc_mcontext.mc_gs = context->SegGs;
         handler(NativeToOrbisSignal(native_signum), &ctx);
+    } else {
+        UNREACHABLE_MSG("Unhandled exception");
     }
 }
 #endif
 
-int PS4_SYSV_ABI sceKernelInstallExceptionHandler(s32 signum, SceKernelExceptionHandler handler) {
-    if (signum > POSIX_SIGUSR2) {
+s32 PS4_SYSV_ABI posix_sigemptyset(Sigset* s) {
+    s->bits[0] = 0;
+    s->bits[1] = 0;
+    return 0;
+}
+
+s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
+    if (sig < 1 || sig > 128 || sig == POSIX_SIGTHR || sig == POSIX_SIGKILL ||
+        sig == POSIX_SIGSTOP) {
+        *__Error() = POSIX_EINVAL;
+        return ORBIS_FAIL;
+    }
+    s32 native_sig = OrbisToNativeSignal(sig);
+    if (native_sig == SIGVTALRM) {
+        LOG_ERROR(Lib_Kernel, "Guest is attempting to use the HLE-reserved signal {}!", sig);
+        *__Error() = POSIX_EINVAL;
+        return ORBIS_FAIL;
+    }
+#ifdef _WIN32
+    LOG_ERROR(Lib_Kernel, "(STUBBED) called, sig: {}", sig);
+    return ORBIS_OK;
+#else
+    struct sigaction native_act{};
+    if (act) {
+        native_act.sa_flags = SA_SIGINFO | SA_RESTART;
+        native_act.sa_sigaction =
+            reinterpret_cast<decltype(native_act.sa_sigaction)>(act->__sigaction_handler.sigaction);
+        if (act->sa_mask.bits[0] != 0) {
+            LOG_ERROR(Lib_Kernel, "Unhandled sa_mask: {:x}", act->sa_mask.bits[0]);
+        }
+    }
+    struct sigaction native_oact{};
+    if (act) {
+        native_oact.sa_flags = SA_SIGINFO | SA_RESTART;
+        native_oact.sa_sigaction = reinterpret_cast<decltype(native_oact.sa_sigaction)>(
+            act->__sigaction_handler.sigaction);
+        if (act->sa_mask.bits[0] != 0) {
+            LOG_ERROR(Lib_Kernel, "Unhandled sa_mask: {:x}", act->sa_mask.bits[0]);
+        }
+    }
+    Handlers[sig] = reinterpret_cast<OrbisKernelExceptionHandler>(
+        act ? act->__sigaction_handler.sigaction : nullptr);
+
+    if (native_sig == SIGSEGV || native_sig == SIGBUS || native_sig == SIGILL) {
+        return ORBIS_OK; // These are handled in Core::SignalHandler
+    }
+    sigaction(native_sig, &native_act, &native_oact);
+
+    return ORBIS_OK;
+#endif
+}
+
+s32 PS4_SYSV_ABI posix_pthread_kill(PthreadT thread, s32 sig) {
+    if (sig < 1 || sig > 128) { // off-by-one error?
+        *__Error() = POSIX_EINVAL;
+        return ORBIS_FAIL;
+    }
+    if (sig == 128) {
+        LOG_WARNING(Lib_Kernel, "sig {} can be raised for some reason but we don't do that here",
+                    sig);
+        *__Error() = POSIX_EINVAL;
+        return ORBIS_FAIL;
+    }
+    LOG_WARNING(Lib_Kernel, "Raising signal {} on thread '{}'", sig, thread->name);
+    int const native_signum = OrbisToNativeSignal(sig);
+#ifndef _WIN64
+    const auto pthr = reinterpret_cast<pthread_t>(thread->native_thr.GetHandle());
+    const auto ret = pthread_kill(pthr, native_signum);
+    if (ret != 0) {
+        LOG_ERROR(Kernel, "Failed to send exception signal to thread '{}': {}", thread->name,
+                  strerror(errno));
+    }
+#else
+    USER_APC_OPTION option;
+    option.UserApcFlags = QueueUserApcFlagsSpecialUserApc;
+
+    u64 res = NtQueueApcThreadEx(reinterpret_cast<HANDLE>(thread->native_thr.GetHandle()), option,
+                                 ExceptionHandler, (void*)thread->name.c_str(),
+                                 (void*)(s64)native_signum, nullptr);
+    ASSERT(res == 0);
+#endif
+    return ORBIS_OK;
+}
+
+// libkernel has a check in sceKernelInstallExceptionHandler and sceKernelRemoveExceptionHandler for
+// validating if the application requested a handler for an allowed signal or not. However, that is
+// just a wrapper for sigaction, which itself does not have any such restrictions, and therefore
+// this check is ridiculously trivial to go around. This, however, means that we need to support all
+// 127 - 3 possible signals, even if realistically, only homebrew will use most of them.
+static std::unordered_set<s32> orbis_allowed_signals{
+    POSIX_SIGHUP, POSIX_SIGILL, POSIX_SIGFPE, POSIX_SIGBUS, POSIX_SIGSEGV, POSIX_SIGUSR1,
+};
+
+int PS4_SYSV_ABI sceKernelInstallExceptionHandler(s32 signum, OrbisKernelExceptionHandler handler) {
+    if (!orbis_allowed_signals.contains(signum)) {
         return ORBIS_KERNEL_ERROR_EINVAL;
+    }
+    if (Handlers[signum] != nullptr) {
+        return ORBIS_KERNEL_ERROR_EAGAIN;
     }
     LOG_INFO(Lib_Kernel, "Installing signal handler for {}", signum);
     int const native_signum = OrbisToNativeSignal(signum);
-#ifdef __APPLE__
-    ASSERT_MSG(native_signum != SIGVTALRM, "SIGVTALRM is HLE-reserved on macOS!");
-#endif
-    ASSERT_MSG(!Handlers[native_signum], "Invalid parameters");
-    Handlers[native_signum] = handler;
+    Handlers[signum] = handler;
 #ifndef _WIN64
     if (native_signum == SIGSEGV || native_signum == SIGBUS || native_signum == SIGILL) {
         return ORBIS_OK; // These are handled in Core::SignalHandler
@@ -266,21 +379,22 @@ int PS4_SYSV_ABI sceKernelInstallExceptionHandler(s32 signum, SceKernelException
     act.sa_flags = SA_SIGINFO | SA_RESTART;
     act.sa_sigaction = reinterpret_cast<decltype(act.sa_sigaction)>(SigactionHandler);
     sigemptyset(&act.sa_mask);
-    sigaction(native_signum, &act, nullptr);
+    s32 ret = sigaction(native_signum, &act, nullptr);
+    if (ret < 0) {
+        LOG_ERROR(Lib_Kernel, "Failed to add handler for signal {}: {}", signum, strerror(errno));
+        SetPosixErrno(errno);
+        return ErrnoToSceKernelError(*__Error());
+    }
 #endif
     return ORBIS_OK;
 }
 
 int PS4_SYSV_ABI sceKernelRemoveExceptionHandler(s32 signum) {
-    if (signum > POSIX_SIGUSR2) {
+    if (!orbis_allowed_signals.contains(signum)) {
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
     int const native_signum = OrbisToNativeSignal(signum);
-    if (!Handlers[native_signum]) {
-        LOG_WARNING(Lib_Kernel, "removing non-installed handler for signum {}", signum);
-        return ORBIS_KERNEL_ERROR_EINVAL;
-    }
-    Handlers[native_signum] = nullptr;
+    Handlers[signum] = nullptr;
 #ifndef _WIN64
     if (native_signum == SIGSEGV || native_signum == SIGBUS || native_signum == SIGILL) {
         struct sigaction action{};
@@ -295,7 +409,13 @@ int PS4_SYSV_ABI sceKernelRemoveExceptionHandler(s32 signum) {
         act.sa_flags = SA_SIGINFO | SA_RESTART;
         act.sa_sigaction = nullptr;
         sigemptyset(&act.sa_mask);
-        sigaction(native_signum, &act, nullptr);
+        s32 ret = sigaction(native_signum, &act, nullptr);
+        if (ret < 0) {
+            LOG_ERROR(Lib_Kernel, "Failed to remove handler for signal {}: {}", signum,
+                      strerror(errno));
+            SetPosixErrno(errno);
+            return ErrnoToSceKernelError(*__Error());
+        }
     }
 #endif
     return ORBIS_OK;
@@ -352,6 +472,13 @@ void RegisterException(Core::Loader::SymbolsResolver* sym) {
                  sceKernelDebugRaiseExceptionOnReleaseMode);
     LIB_FUNCTION("WkwEd3N7w0Y", "libkernel", 1, "libkernel", sceKernelInstallExceptionHandler);
     LIB_FUNCTION("Qhv5ARAoOEc", "libkernel", 1, "libkernel", sceKernelRemoveExceptionHandler);
+
+    LIB_FUNCTION("KiJEPEWRyUY", "libkernel", 1, "libkernel", posix_sigaction);
+    LIB_FUNCTION("+F7C-hdk7+E", "libkernel", 1, "libkernel", posix_sigemptyset);
+    LIB_FUNCTION("yH-uQW3LbX0", "libkernel", 1, "libkernel", posix_pthread_kill);
+    LIB_FUNCTION("KiJEPEWRyUY", "libScePosix", 1, "libkernel", posix_sigaction);
+    LIB_FUNCTION("+F7C-hdk7+E", "libScePosix", 1, "libkernel", posix_sigemptyset);
+    LIB_FUNCTION("yH-uQW3LbX0", "libScePosix", 1, "libkernel", posix_pthread_kill);
 }
 
 } // namespace Libraries::Kernel

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -285,14 +285,14 @@ s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
         return ORBIS_FAIL;
     }
     s32 native_sig = OrbisToNativeSignal(sig);
+#ifdef _WIN32
+    LOG_ERROR(Lib_Kernel, "(STUBBED) called, sig: {}", sig);
+#else
     if (native_sig == SIGVTALRM) {
         LOG_ERROR(Lib_Kernel, "Guest is attempting to use the HLE-reserved signal {}!", sig);
         *__Error() = POSIX_EINVAL;
         return ORBIS_FAIL;
     }
-#ifdef _WIN32
-    LOG_ERROR(Lib_Kernel, "(STUBBED) called, sig: {}", sig);
-#else
     LOG_INFO(Lib_Kernel, "called, sig: {}", sig);
     struct sigaction native_act{};
     if (act) {
@@ -371,13 +371,14 @@ int PS4_SYSV_ABI sceKernelInstallExceptionHandler(s32 signum, OrbisKernelExcepti
     }
     LOG_INFO(Lib_Kernel, "Installing signal handler for {}", signum);
     Sigaction act = {};
-    act.sa_flags = SA_SIGINFO | SA_RESTART;
+    act.sa_flags = POSIX_SA_SIGINFO | POSIX_SA_RESTART;
     act.__sigaction_handler.sigaction =
         reinterpret_cast<decltype(act.__sigaction_handler.sigaction)>(SigactionHandler);
     posix_sigemptyset(&act.sa_mask);
     s32 ret = posix_sigaction(signum, &act, nullptr);
     if (ret < 0) {
-        LOG_ERROR(Lib_Kernel, "Failed to add handler for signal {}: {}", signum, strerror(*__Error()));
+        LOG_ERROR(Lib_Kernel, "Failed to add handler for signal {}: {}", signum,
+                  strerror(*__Error()));
         return ErrnoToSceKernelError(*__Error());
     }
     return ORBIS_OK;
@@ -390,12 +391,13 @@ int PS4_SYSV_ABI sceKernelRemoveExceptionHandler(s32 signum) {
     int const native_signum = OrbisToNativeSignal(signum);
     Handlers[signum] = nullptr;
     Sigaction act = {};
-    act.sa_flags = SA_SIGINFO;
+    act.sa_flags = POSIX_SA_SIGINFO;
     act.__sigaction_handler.sigaction = nullptr;
     posix_sigemptyset(&act.sa_mask);
     s32 ret = posix_sigaction(signum, &act, nullptr);
     if (ret < 0) {
-        LOG_ERROR(Lib_Kernel, "Failed to remove handler for signal {}: {}", signum, strerror(*__Error()));
+        LOG_ERROR(Lib_Kernel, "Failed to remove handler for signal {}: {}", signum,
+                  strerror(*__Error()));
         return ErrnoToSceKernelError(*__Error());
     }
     return ORBIS_OK;

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -293,12 +293,28 @@ s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
         *__Error() = POSIX_EINVAL;
         return ORBIS_FAIL;
     }
-    LOG_INFO(Lib_Kernel, "called, sig: {}", sig);
+#ifndef __APPLE__
+    if (native_sig >= __SIGRTMIN && native_sig < SIGRTMIN) {
+        LOG_ERROR(Lib_Kernel, "Guest is attempting to use the HLE libc-reserved signal {}!", sig);
+        *__Error() = POSIX_EINVAL;
+        return ORBIS_FAIL;
+    }
+#else
+    if (native_sig > SIGUSR2) {
+        LOG_ERROR(Lib_Kernel,
+                  "Guest is attempting to use SIGRT signals, which aren't available on this "
+                  "platform (signal: {})!",
+                  sig);
+        *__Error() = POSIX_EINVAL;
+        return ORBIS_FAIL;
+    }
+#endif
+    LOG_INFO(Lib_Kernel, "called, sig: {}, native sig: {}", sig, native_sig);
     struct sigaction native_act{};
     if (act) {
         native_act.sa_flags = act->sa_flags; // todo check compatibility, on Linux it seems fine
         native_act.sa_sigaction =
-            reinterpret_cast<decltype(native_act.sa_sigaction)>(act->__sigaction_handler.sigaction);
+            reinterpret_cast<decltype(native_act.sa_sigaction)>(SigactionHandler);
         if (act->sa_mask.bits[0] != 0) {
             LOG_ERROR(Lib_Kernel, "Unhandled sa_mask: {:x}", act->sa_mask.bits[0]);
         }
@@ -318,7 +334,11 @@ s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
     if (native_sig == SIGSEGV || native_sig == SIGBUS || native_sig == SIGILL) {
         return ORBIS_OK; // These are handled in Core::SignalHandler
     }
-    s32 ret = sigaction(native_sig, &native_act, &native_oact);
+    if (native_sig > 127) {
+        LOG_WARNING(Lib_Kernel, "We can't install a handler for native signal {}!", native_sig);
+        return ORBIS_OK;
+    }
+    s32 ret = sigaction(native_sig, act ? &native_act : nullptr, oact ? &native_oact : nullptr);
     if (ret < 0) {
         LOG_ERROR(Lib_Kernel, "sigaction failed: {}", strerror(errno));
         *__Error() = ErrnoToSceKernelError(errno);
@@ -373,7 +393,7 @@ int PS4_SYSV_ABI sceKernelInstallExceptionHandler(s32 signum, OrbisKernelExcepti
     Sigaction act = {};
     act.sa_flags = POSIX_SA_SIGINFO | POSIX_SA_RESTART;
     act.__sigaction_handler.sigaction =
-        reinterpret_cast<decltype(act.__sigaction_handler.sigaction)>(SigactionHandler);
+        reinterpret_cast<decltype(act.__sigaction_handler.sigaction)>(handler);
     posix_sigemptyset(&act.sa_mask);
     s32 ret = posix_sigaction(signum, &act, nullptr);
     if (ret < 0) {

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -317,6 +317,7 @@ s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
             LOG_ERROR(Lib_Kernel, "Unhandled sa_mask: {:x}", act->sa_mask.bits[0]);
         }
     }
+    auto const prev_handler = Handlers[sig];
     Handlers[sig] = reinterpret_cast<OrbisKernelExceptionHandler>(
         act ? act->__sigaction_handler.sigaction : nullptr);
 
@@ -332,8 +333,7 @@ s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
     if (oact) {
         oact->sa_flags = native_oact.sa_flags;
         oact->__sigaction_handler.sigaction =
-            reinterpret_cast<decltype(oact->__sigaction_handler.sigaction)>(
-                native_oact.sa_sigaction);
+            reinterpret_cast<decltype(oact->__sigaction_handler.sigaction)>(prev_handler);
         if (native_oact.sa_mask.__val[0] != 0) {
             LOG_ERROR(Lib_Kernel, "Unhandled sa_mask: {:x}", native_oact.sa_mask.__val[0]);
         }

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -4,6 +4,7 @@
 #include "common/assert.h"
 #include "core/libraries/kernel/kernel.h"
 #include "core/libraries/kernel/orbis_error.h"
+#include "core/libraries/kernel/posix_error.h"
 #include "core/libraries/kernel/threads/exception.h"
 #include "core/libraries/kernel/threads/pthread.h"
 #include "core/libraries/libs.h"
@@ -15,7 +16,6 @@
 #include <csignal>
 #endif
 #include <unordered_set>
-#include <core/libraries/kernel/posix_error.h>
 
 namespace Libraries::Kernel {
 
@@ -182,6 +182,10 @@ s32 OrbisToNativeSignal(s32 s) {
 
 #endif
 
+#ifdef __APPLE__
+#define sigisemptyset(x) (*(x) == 0)
+#endif
+
 std::array<OrbisKernelExceptionHandler, 130> Handlers{};
 
 #ifndef _WIN64
@@ -319,7 +323,7 @@ s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
         native_act.sa_flags = act->sa_flags; // todo check compatibility, on Linux it seems fine
         native_act.sa_sigaction =
             reinterpret_cast<decltype(native_act.sa_sigaction)>(SigactionHandler);
-        if (posix_sigisemptyset(&act->sa_mask)) {
+        if (!posix_sigisemptyset(&act->sa_mask)) {
             LOG_ERROR(Lib_Kernel, "Unhandled sa_mask: {:x}", act->sa_mask.bits[0]);
         }
     }
@@ -340,7 +344,7 @@ s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
         oact->sa_flags = native_oact.sa_flags;
         oact->__sigaction_handler.sigaction =
             reinterpret_cast<decltype(oact->__sigaction_handler.sigaction)>(prev_handler);
-        if (sigisemptyset(&native_oact.sa_mask)) {
+        if (!sigisemptyset(&native_oact.sa_mask)) {
             LOG_ERROR(Lib_Kernel, "Unhandled sa_mask");
         }
     }

--- a/src/core/libraries/kernel/threads/exception.h
+++ b/src/core/libraries/kernel/threads/exception.h
@@ -137,8 +137,8 @@ struct Siginfo {
      * FreeBSD signal handler.
      */
     int _si_code;           /* signal code */
-    s32 _si_pid;          /* sending process */
-    u32 _si_uid;          /* sender's ruid */
+    s32 _si_pid;            /* sending process */
+    u32 _si_uid;            /* sender's ruid */
     int _si_status;         /* exit value */
     void* _si_addr;         /* faulting instruction */
     union Sigval _si_value; /* signal value */

--- a/src/core/libraries/kernel/threads/exception.h
+++ b/src/core/libraries/kernel/threads/exception.h
@@ -11,7 +11,7 @@ class SymbolsResolver;
 
 namespace Libraries::Kernel {
 
-using SceKernelExceptionHandler = PS4_SYSV_ABI void (*)(int, void*);
+using OrbisKernelExceptionHandler = PS4_SYSV_ABI void (*)(int, void*);
 
 constexpr s32 POSIX_SIGHUP = 1;
 constexpr s32 POSIX_SIGINT = 2;
@@ -46,6 +46,9 @@ constexpr s32 POSIX_SIGUSR1 = 30;
 constexpr s32 POSIX_SIGUSR2 = 31;
 constexpr s32 POSIX_SIGTHR = 32;
 constexpr s32 POSIX_SIGLIBRT = 33;
+
+constexpr s32 _SIGEMT = 128;
+constexpr s32 _SIGINFO = 129;
 
 struct Mcontext {
     u64 mc_onstack;
@@ -101,16 +104,73 @@ struct Sigset {
     u64 bits[2];
 };
 
+union Sigval {
+    /* Members as suggested by Annex C of POSIX 1003.1b. */
+    int sival_int;
+    void* sival_ptr;
+    /* 6.0 compatibility */
+    int sigval_int;
+    void* sigval_ptr;
+};
+
+struct Siginfo {
+    int _si_signo; /* signal number */
+    int _si_errno; /* errno association */
+    /*
+     * Cause of signal, one of the SI_ macros or signal-specific
+     * values, i.e. one of the FPE_... values for SIGFPE.  This
+     * value is equivalent to the second argument to an old-style
+     * FreeBSD signal handler.
+     */
+    int _si_code;           /* signal code */
+    pid_t _si_pid;          /* sending process */
+    uid_t _si_uid;          /* sender's ruid */
+    int _si_status;         /* exit value */
+    void* _si_addr;         /* faulting instruction */
+    union Sigval _si_value; /* signal value */
+    union {
+        struct {
+            int _trapno; /* machine specific trap code */
+        } _fault;
+        struct {
+            int _timerid;
+            int _overrun;
+        } _timer;
+        struct {
+            int _mqd;
+        } _mesgq;
+        struct {
+            long _band; /* band event for SIGPOLL */
+        } _poll;        /* was this ever used ? */
+        struct {
+            long __spare1__;
+            int __spare2__[7];
+        } __spare__;
+    } _reason;
+};
+
+struct Sigaction {
+    union {
+        void (*handler)(int);
+        void (*sigaction)(int, struct Siginfo*, void*);
+    } __sigaction_handler;
+    int sa_flags;
+    Sigset sa_mask;
+};
+
 struct Ucontext {
     struct Sigset uc_sigmask;
     int field1_0x10[12];
-    struct Mcontext uc_mcontext;
-    struct Ucontext* uc_link;
-    struct ExStack uc_stack;
+    Mcontext uc_mcontext;
+    Ucontext* uc_link;
+    ExStack uc_stack;
     int uc_flags;
     int __spare[4];
     int field7_0x4f4[3];
 };
+
+s32 NativeToOrbisSignal(s32 s);
+s32 OrbisToNativeSignal(s32 s);
 
 void RegisterException(Core::Loader::SymbolsResolver* sym);
 

--- a/src/core/libraries/kernel/threads/exception.h
+++ b/src/core/libraries/kernel/threads/exception.h
@@ -50,7 +50,7 @@ constexpr s32 POSIX_SIGLIBRT = 33;
 #ifdef __linux__
 constexpr s32 _SIGEMT = 128;
 constexpr s32 _SIGINFO = 129;
-#else
+#elif !defined(_WIN32)
 constexpr s32 _SIGEMT = SIGEMT;
 constexpr s32 _SIGINFO = SIGINFO;
 #endif
@@ -137,8 +137,8 @@ struct Siginfo {
      * FreeBSD signal handler.
      */
     int _si_code;           /* signal code */
-    pid_t _si_pid;          /* sending process */
-    uid_t _si_uid;          /* sender's ruid */
+    s32 _si_pid;          /* sending process */
+    u32 _si_uid;          /* sender's ruid */
     int _si_status;         /* exit value */
     void* _si_addr;         /* faulting instruction */
     union Sigval _si_value; /* signal value */

--- a/src/core/libraries/kernel/threads/exception.h
+++ b/src/core/libraries/kernel/threads/exception.h
@@ -47,8 +47,22 @@ constexpr s32 POSIX_SIGUSR2 = 31;
 constexpr s32 POSIX_SIGTHR = 32;
 constexpr s32 POSIX_SIGLIBRT = 33;
 
+#ifdef __linux__
 constexpr s32 _SIGEMT = 128;
 constexpr s32 _SIGINFO = 129;
+#else
+constexpr s32 _SIGEMT = SIGEMT;
+constexpr s32 _SIGINFO = SIGINFO;
+#endif
+
+constexpr s32 POSIX_SA_NOCLDSTOP = 1;
+constexpr s32 POSIX_SA_NOCLDWAIT = 2;
+constexpr s32 POSIX_SA_SIGINFO = 4;
+constexpr s32 POSIX_SA_ONSTACK = 0x08000000;
+constexpr s32 POSIX_SA_RESTART = 0x10000000;
+constexpr s32 POSIX_SA_NODEFER = 0x40000000;
+constexpr s32 POSIX_SA_RESETHAND = 0x80000000;
+constexpr s32 POSIX_SA_RESTORER = 0x04000000;
 
 struct Mcontext {
     u64 mc_onstack;

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -665,6 +665,7 @@ void RegisterThread(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("Z4QosVuAsA0", "libkernel", 1, "libkernel", posix_pthread_once);
     LIB_FUNCTION("EotR8a3ASf4", "libkernel", 1, "libkernel", posix_pthread_self);
     LIB_FUNCTION("OxhIB8LB-PQ", "libkernel", 1, "libkernel", posix_pthread_create);
+    LIB_FUNCTION("Jmi+9w9u0E4", "libkernel", 1, "libkernel", posix_pthread_create_name_np);
     LIB_FUNCTION("lZzFeSxPl08", "libkernel", 1, "libkernel", posix_pthread_setcancelstate);
     LIB_FUNCTION("CBNtXOoef-E", "libkernel", 1, "libkernel", posix_sched_get_priority_max);
     LIB_FUNCTION("m0iS6jNsXds", "libkernel", 1, "libkernel", posix_sched_get_priority_min);

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -21,6 +21,10 @@
 #include "core/tls.h"
 #include "ipc/ipc.h"
 
+#ifndef _WIN32
+#include <signal.h>
+#endif
+
 namespace Core {
 
 static PS4_SYSV_ABI void ProgramExitFunc() {
@@ -106,6 +110,11 @@ void Linker::Execute(const std::vector<std::string>& args) {
 
     main_thread.Run([this, module, &args](std::stop_token) {
         Common::SetCurrentThreadName("Game:Main");
+#ifndef _WIN32 // Clear any existing signal mask for game threads.
+        sigset_t emptyset;
+        sigemptyset(&emptyset);
+        pthread_sigmask(SIG_SETMASK, &emptyset, nullptr);
+#endif
         if (auto& ipc = IPC::Instance()) {
             ipc.WaitForStart();
         }

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -21,7 +21,7 @@
 #ifndef _WIN32
 namespace Libraries::Kernel {
 void SigactionHandler(int native_signum, siginfo_t* inf, ucontext_t* raw_context);
-extern std::array<SceKernelExceptionHandler, 32> Handlers;
+extern std::array<OrbisKernelExceptionHandler, 32> Handlers;
 } // namespace Libraries::Kernel
 #endif
 
@@ -86,7 +86,7 @@ void SignalHandler(int sig, siginfo_t* info, void* raw_context) {
         if (!signals->DispatchAccessViolation(raw_context, info->si_addr)) {
             // If the guest has installed a custom signal handler, and the access violation didn't
             // come from HLE memory tracking, pass the signal on
-            if (Libraries::Kernel::Handlers[sig]) {
+            if (Libraries::Kernel::Handlers[Libraries::Kernel::NativeToOrbisSignal(sig)]) {
                 Libraries::Kernel::SigactionHandler(sig, info,
                                                     reinterpret_cast<ucontext_t*>(raw_context));
                 return;
@@ -99,7 +99,7 @@ void SignalHandler(int sig, siginfo_t* info, void* raw_context) {
     }
     case SIGILL:
         if (!signals->DispatchIllegalInstruction(raw_context)) {
-            if (Libraries::Kernel::Handlers[sig]) {
+            if (Libraries::Kernel::Handlers[Libraries::Kernel::NativeToOrbisSignal(sig)]) {
                 Libraries::Kernel::SigactionHandler(sig, info,
                                                     reinterpret_cast<ucontext_t*>(raw_context));
                 return;

--- a/src/core/signals.h
+++ b/src/core/signals.h
@@ -10,10 +10,8 @@
 
 #ifdef _WIN32
 #define SIGSLEEP -1
-#elif defined(__APPLE__)
-#define SIGSLEEP SIGVTALRM
 #else
-#define SIGSLEEP SIGRTMAX
+#define SIGSLEEP SIGVTALRM
 #endif
 namespace Core {
 


### PR DESCRIPTION
This PR technically addresses issues where games would crash on trying to remove a signal handler on signals with not yet registered handlers, but it also adds posix_sigemptyset, posix_sigaction and posix_sigkill, and refactors the sce wrappers for them to use those, plus it also fixes a few other miscallenous bugs from the previous iteration that came from me not testing thoroughly enough, and no one else giving a shit since this isn't something commercial games use much. I've tested this extensively on Linux, but Windows and macOS still need verification.