### PR TITLE
Lib.SysModule: Relocate imports on HLE loads

### DIFF
--- a/src/core/libraries/sysmodule/sysmodule_internal.cpp
+++ b/src/core/libraries/sysmodule/sysmodule_internal.cpp
@@ -252,6 +252,10 @@ s32 loadModuleInternal(s32 index, s32 argc, const void* argv, s32* res_out) {
             if (init_func) {
                 LOG_INFO(Loader, "Can't Load {} switching to HLE", mod_name);
                 init_func(&linker->GetHLESymbols());
+
+                // When loading HLEs, we need to relocate imports
+                // This ensures later module loads can see our HLE functions.
+                linker->RelocateAllImports();
             } else {
                 LOG_INFO(Loader, "No HLE available for {} module", mod_name);
             }

--- a/src/core/linker.h
+++ b/src/core/linker.h
@@ -125,11 +125,10 @@ public:
         }
     }
 
-    void LoadSharedLibraries() {
+    void RelocateAllImports() {
+        std::scoped_lock lk{mutex};
         for (auto& module : m_modules) {
-            if (module->IsSharedLib()) {
-                module->Start(0, nullptr, nullptr);
-            }
+            Relocate(module.get());
         }
     }
 


### PR DESCRIPTION
Now that dynamic HLE loads happen after the eboot loads, HLEs for most "preload" modules wouldn't detect if you didn't have libSceRtc dumped. This was because we only actually relocate modules when either running Linker::LoadStartModule, or during Linker::Execute. For users without a dumped libSceRtc.sprx, and in games that don't load additional modules during gameplay, most HLEs wouldn't properly relocate, since the symbols were loaded after the last round of module relocations.

This should (unfortunately) fix a recent regression in Bloodborne.