### PR TITLE
Recompiler: Fix return type for ImageAtomicU32CmpSwap

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_atomic.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_atomic.cpp
@@ -147,7 +147,7 @@ Id ImageAtomicU32CmpSwap(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords
     const auto& texture = ctx.images[handle & 0xFFFF];
     const Id pointer{ctx.OpImageTexelPointer(ctx.image_u32, texture.id, coords, ctx.ConstU32(0U))};
     const auto [scope, semantics]{AtomicArgs(ctx)};
-    return (ctx.*atomic_func)(ctx.F32[1], pointer, scope, semantics, semantics, value, cmp_value);
+    return (ctx.*atomic_func)(ctx.U32[1], pointer, scope, semantics, semantics, value, cmp_value);
 }
 } // Anonymous namespace
 


### PR DESCRIPTION
I accidentally set the OpAtomicCompareExchange return type to be a float, which caused spirv validation errors in titles using IMAGE_ATOMIC_CMPSWAP.