### PR TITLE
psf file format: close file after Encode()

### DIFF
--- a/src/core/file_format/psf.cpp
+++ b/src/core/file_format/psf.cpp
@@ -113,6 +113,7 @@ bool PSF::Encode(const std::filesystem::path& filepath) const {
         LOG_ERROR(Core, "Failed to write PSF file. Written {} Expected {}", written,
                   psf_buffer.size());
     }
+    file.Close();
     return written == psf_buffer.size();
 }
 


### PR DESCRIPTION
"The Last Guardian" game rewrites psf file in every save, so I got "permission denied" during saving game (file was not closed after previous save).