### PR TITLE
CI: Update actions/cache due to Node 20 deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel $env:NUMBER_OF_PROCESSORS
 
     - name: Upload Windows SDL artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: shadps4-win64-sdl-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}
         path: ${{github.workspace}}/build/shadPS4.exe
@@ -150,7 +150,7 @@ jobs:
         mv ${{github.workspace}}/build/shadps4 upload
         mv ${{github.workspace}}/build/MoltenVK_icd.json upload
         mv ${{github.workspace}}/build/libMoltenVK.dylib upload
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: shadps4-macos-sdl-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}
         path: upload/
@@ -200,7 +200,7 @@ jobs:
       run: |
         ls -la ${{ github.workspace }}/build/shadps4
     
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: shadps4-ubuntu64-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}
         path: ${{ github.workspace }}/build/shadps4
@@ -211,7 +211,7 @@ jobs:
     - name: Package and Upload Linux SDL artifact
       run: |
         tar cf shadps4-linux-sdl.tar.gz -C ${{github.workspace}}/build shadps4
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: shadps4-linux-sdl-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}
         path: Shadps4-sdl.AppImage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
         submodules: recursive
 
     - name: Cache CMake Configuration
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       env:
           cache-name: ${{ runner.os }}-sdl-ninja-cache-cmake-configuration
       with:
@@ -118,7 +118,7 @@ jobs:
         xcode-version: latest
 
     - name: Cache CMake Configuration
-      uses: actions/cache@v4 
+      uses: actions/cache@v5
       env: 
           cache-name: ${{ runner.os }}-sdl-cache-cmake-configuration
       with: 
@@ -172,7 +172,7 @@ jobs:
       run: sudo apt-get update && sudo apt install -y libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 clang-19 mold build-essential libasound2-dev libpulse-dev libopenal-dev libudev-dev libxcursor-dev libxi-dev libxss-dev libxtst-dev
 
     - name: Cache CMake Configuration
-      uses: actions/cache@v4 
+      uses: actions/cache@v5
       env: 
           cache-name: ${{ runner.os }}-sdl-cache-cmake-configuration
       with: 
@@ -228,7 +228,7 @@ jobs:
       run: sudo apt-get update && sudo apt install -y libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libglfw3-dev libgles2-mesa-dev libfuse2 gcc-14 mold build-essential libasound2-dev libpulse-dev libopenal-dev libudev-dev libxcursor-dev libxi-dev libxss-dev libxtst-dev
 
     - name: Cache CMake Configuration
-      uses: actions/cache@v4 
+      uses: actions/cache@v5
       env: 
           cache-name: ${{ runner.os }}-sdl-gcc-cache-cmake-configuration
       with: 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,14 +26,14 @@ jobs:
     runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - uses: fsfe/reuse-action@v5
 
   clang-format:
     runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Install
@@ -54,7 +54,7 @@ jobs:
       shorthash: ${{ steps.vars.outputs.shorthash }}
       fullhash: ${{ steps.vars.outputs.fullhash }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Get date and git hash
       id: vars
       run: |
@@ -69,7 +69,7 @@ jobs:
     runs-on: windows-2025
     needs: get-info
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         submodules: recursive
 
@@ -108,7 +108,7 @@ jobs:
     runs-on: macos-15
     needs: get-info
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         submodules: recursive
 
@@ -159,7 +159,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: get-info
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         submodules: recursive
 
@@ -220,7 +220,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: get-info
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         submodules: recursive
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,7 +258,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download all artifacts
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v8
       with:
         path: ./artifacts
 


### PR DESCRIPTION
Currently the actions builds are triggering a [Node 20 deprecation warning](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

The actions in question are `actions/cache@v4` and `hendrikmuhs/ccache-action@v1.2.19`. 

This PR updates: 
- `actions/cache` to v5

While I was in there I also updated:
- `actions/upload-artifact` to v6
- `actions/download-artifact` to v8
- `actions/checkout` to v6

(These changes weren't necessary to fix the issue, but I thought I'd update them while I was in there...)

Note: 
After the PR, the warning  will still trigger because `hendrikmuhs/ccache-action` has not yet been updated. 
We can update it after [this PR](https://github.com/hendrikmuhs/ccache-action/pull/427) is merged. 



### Testing 

- Ensure the CI passes