### PR TITLE
Fix tls deallocation memory leak

### DIFF
--- a/src/core/aerolib/stubs.cpp
+++ b/src/core/aerolib/stubs.cpp
@@ -27,7 +27,7 @@ u64 UnresolvedStub() {
 }
 
 static u64 UnknownStub() {
-    LOG_ERROR(Core, "Returning zero to {}", __builtin_return_address(0));
+    LOG_ERROR(Core, "Stub: Unknown (missing nid) called, returning zero to {}", __builtin_return_address(0));
     return 0;
 }
 
@@ -67,16 +67,17 @@ static u32 UsedStubEntries;
 
 static u64 (*stub_handlers[MAX_STUBS])() = {STUBS_LIST};
 
-u64 GetStub(const char* nid) {
+u64 GetStub(const char* nid, const NidEntry*& out_nid_entry) {
     if (UsedStubEntries >= MAX_STUBS) {
+        out_nid_entry = nullptr;
         return (u64)&UnknownStub;
     }
 
-    const auto entry = FindByNid(nid);
-    if (!entry) {
+    out_nid_entry = FindByNid(nid);
+    if (!out_nid_entry) {
         stub_nids_unknown[UsedStubEntries] = nid;
     } else {
-        stub_nids[UsedStubEntries] = entry;
+        stub_nids[UsedStubEntries] = out_nid_entry;
     }
 
     return (u64)stub_handlers[UsedStubEntries++];

--- a/src/core/aerolib/stubs.h
+++ b/src/core/aerolib/stubs.h
@@ -9,6 +9,6 @@ namespace Core::AeroLib {
 
 u64 UnresolvedStub();
 
-u64 GetStub(const char* nid);
+u64 GetStub(const char* nid, const NidEntry*& out_nid_entry);
 
 } // namespace Core::AeroLib

--- a/src/core/libraries/kernel/threads/tcb.cpp
+++ b/src/core/libraries/kernel/threads/tcb.cpp
@@ -15,7 +15,36 @@ static constexpr size_t TlsTcbAlign = 0x20;
 
 static std::shared_mutex RtldLock;
 
-Core::Tcb* TcbCtor(Pthread* thread, int initial) {
+Core::Tcb* InitializeTLSForThread(Pthread* thread, int initial) {
+    // TLS memory layout per thread:
+    //
+    //  tls                       tcb
+    //   |                         |
+    //   v                         v
+    //   [ main module static TLS ][ TCB ]
+    //   ^                            |
+    //   |                         tcb_dtv
+    //   |                            |
+    //   |                            v
+    //   |                       [ DTV table                              ]
+    //   |                       [ [0] gen counter                        ]
+    //   |                       [ [1] num entries                        ]
+    //   +---------------------- [ [2] -> main module TLS (static block)  ]
+    //                           [ [3] -> module2 TLS (dynamic)           ] ---> [ separate heap block ] 
+    //                           [ [4] -> module3 TLS (dynamic)           ] ---> [ separate heap block ]
+    //                           ...
+    //                           [ [N] -> moduleN TLS (dynamic)           ] ---> [ separate heap block ]
+    //
+    // Static module TLS lives between tls and tcb, accessed via fixed negative
+    // offsets from tcb (x86-64 TLS ABI). Only the main module has
+    // static TLS - its size, image size, and offset from tcb are all equal (static_tls_size).
+    // 
+    // All other modules use dynamic allocation via TlsGetAddr.
+    // Dynamic module TLS blocks are allocated separately on first access and
+    // tracked in the DTV. 
+    // 
+    // The static TLS, the TCB, the dynamic blocks in the DTV table and the DTV table itself must all be freed on thread exit.
+
     std::scoped_lock lk{RtldLock};
 
     auto* linker = Common::Singleton<Core::Linker>::Instance();
@@ -61,9 +90,11 @@ Core::Tcb* TcbCtor(Pthread* thread, int initial) {
     return tcb;
 }
 
-void TcbDtor(Core::Tcb* oldtls) {
+void FreeTLSForThread(Core::Tcb* old_tls_tcb) {
+    // See "AllocateTLSForThread()" for the TLS memory model
+
     std::scoped_lock lk{RtldLock};
-    auto* dtv_table = oldtls->tcb_dtv;
+    auto* dtv_table = old_tls_tcb->tcb_dtv;
 
     auto* linker = Common::Singleton<Core::Linker>::Instance();
     const u32 max_tls_index = linker->MaxTlsIndex();
@@ -71,16 +102,20 @@ void TcbDtor(Core::Tcb* oldtls) {
     ASSERT_MSG(num_dtvs <= max_tls_index, "Out of bounds DTV access");
 
     const u32 static_tls_size = linker->StaticTlsSize();
-    const u8* tls_base = (const u8*)oldtls - static_tls_size;
+    u8* tls_base = (u8*)old_tls_tcb - static_tls_size;
 
-    for (int i = 1; i < num_dtvs; i++) {
+    // Free dynamic allocated TLS data from the DTV entries
+    for (int i = 1; i <= num_dtvs; i++) {
         u8* dtv_ptr = dtv_table[i + 1].pointer;
-        if (dtv_ptr && (dtv_ptr < tls_base || (const u8*)oldtls < dtv_ptr)) {
+        if (dtv_ptr && (dtv_ptr < tls_base || (const u8*)old_tls_tcb < dtv_ptr)) {
             linker->FreeTlsForNonPrimaryThread(dtv_ptr);
         }
     }
-
+    // Free the DTV table itself
     delete[] dtv_table;
+
+    // Free static TLS and TCB data
+    linker->FreeTlsForNonPrimaryThread(tls_base);
 }
 
 struct TlsIndex {

--- a/src/core/libraries/kernel/threads/tcb.cpp
+++ b/src/core/libraries/kernel/threads/tcb.cpp
@@ -20,7 +20,10 @@ Core::Tcb* TcbCtor(Pthread* thread, int initial) {
 
     auto* linker = Common::Singleton<Core::Linker>::Instance();
     auto* addr_out = linker->AllocateTlsForThread(initial);
-    ASSERT_MSG(addr_out, "Unable to allocate guest TCB");
+    if (!addr_out) {
+        LOG_ERROR(Core_Linker, "Unable to allocate guest TCB, TLS allocation failed!");
+        return nullptr;
+    }
 
     // Initialize allocated memory and allocate DTV table.
     const u32 num_dtvs = linker->MaxTlsIndex();

--- a/src/core/libraries/kernel/threads/thread_state.cpp
+++ b/src/core/libraries/kernel/threads/thread_state.cpp
@@ -15,8 +15,8 @@ namespace Libraries::Kernel {
 
 thread_local Pthread* g_curthread{};
 
-Core::Tcb* TcbCtor(Pthread* thread, int initial);
-void TcbDtor(Core::Tcb* oldtls);
+Core::Tcb* InitializeTLSForThread(Pthread* thread, int initial);
+void FreeTLSForThread(Core::Tcb* old_tls_tcb);
 
 ThreadState::ThreadState() {
     // Reserve memory for maximum amount of threads allowed.
@@ -96,9 +96,9 @@ Pthread* ThreadState::Alloc(Pthread* curthread) {
     Core::Tcb* tcb = nullptr;
     if (curthread != nullptr) {
         std::scoped_lock lk{tcb_lock};
-        tcb = TcbCtor(thread, 0 /* not initial tls */);
+        tcb = InitializeTLSForThread(thread, 0 /* not initial tls */);
     } else {
-        tcb = TcbCtor(thread, 1 /* initial tls */);
+        tcb = InitializeTLSForThread(thread, 1 /* initial tls */);
     }
     if (tcb != nullptr) {
         // Initialize thread struct memory to 0. This is safe since it will be constructed
@@ -118,9 +118,9 @@ Pthread* ThreadState::Alloc(Pthread* curthread) {
 void ThreadState::Free(Pthread* curthread, Pthread* thread) {
     if (curthread != nullptr) {
         std::scoped_lock lk{tcb_lock};
-        TcbDtor(thread->tcb);
+        FreeTLSForThread(thread->tcb);
     } else {
-        TcbDtor(thread->tcb);
+        FreeTLSForThread(thread->tcb);
     }
     thread->tcb = nullptr;
     std::destroy_at(thread);

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -353,12 +353,11 @@ bool Linker::Resolve(const std::string& name, Loader::SymbolType sym_type, Modul
         }
     }
 
-    const auto aeronid = AeroLib::FindByNid(sr.name.c_str());
-    if (aeronid) {
-        return_info->name = aeronid->name;
-        return_info->virtual_address = AeroLib::GetStub(aeronid->nid);
+    const AeroLib::NidEntry* aero_nid_entry = nullptr;
+    return_info->virtual_address = AeroLib::GetStub(sr.name.c_str(), aero_nid_entry);
+    if (aero_nid_entry) {
+        return_info->name = aero_nid_entry->name;
     } else {
-        return_info->virtual_address = AeroLib::GetStub(sr.name.c_str());
         return_info->name = "Unknown !!!";
     }
     LOG_WARNING(Core_Linker, "Linker: Stub resolved {} as {} (lib: {}, mod: {})", sr.name,


### PR DESCRIPTION
## The fix

Static TLS memory from the Main module + TCB memory isn't destroyed during `TcbDtor()` (now `FreeTLSForThread()`) destruction as it is never deleted, only the DTV (Dynamic Thread Vector) is deleted correctly. On the next `ThreadState::Alloc` -> `TcbCtor()` (now `InitializeTLSForThread()`) call, new static TLS + TCB memory would be allocated and the old static TLS + TCB memory would leak.

Fixed by properly freeing the static TLS + TCB memory inside `TcbDtor()` (now `FreeTLSForThread()`).

I also made the critical error into just a regular error, since we seem to have handling for null tcb inside `ThreadState::Alloc()`. Beyond that, it's up to the game to handle failed thread allocation gracefully - which may prevent a crash or at least delay it. Happy to revert this if the consensus is that failing to allocate TLS should always be considered unrecoverable.

## The goal

Hopefully solves [this](https://github.com/shadps4-emu/shadPS4/issues/4129).

I suspect what happened is that the memory pool got fragmented enough from the leaked static TLS + TCB allocations after enough time passed (and enough threads were created and destroyed), hence a TLS allocation eventually failed, hitting the assert at `TcbCtor()` for being unable to allocate guest TCB.

Played for 3 hours today with these changes on top of the [0.14.0 release](https://github.com/shadps4-emu/shadPS4/releases/tag/v.0.14.0), spawned way more threads (~3900 unique threads compared to my past crashes ~2500-2800 unique threads) during gameplay and didn't crash. Hopefully it wasn't just me being lucky 😅 

## Misc refactoring that is unrelated and should probably be in a separate PR but I am lazy.

Refactored some code around the stubs. Purpose was to avoid double look up with `AeroLib::FindByNid()` directly and then also inside `AeroLib::GetStub()`. It's doing binary search so it can't be that slow anyway but it seemed like a simple change so changed it.