### PR TITLE
Make thread TidCounter atomic

### DIFF
--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -242,7 +242,7 @@ int PS4_SYSV_ABI posix_pthread_create_name_np(PthreadT* thread, const PthreadAtt
         new_thread->attr.sched_policy = curthread->attr.sched_policy;
     }
 
-    static int TidCounter = 1;
+    static std::atomic<int> TidCounter = 1;
     new_thread->tid = ++TidCounter;
 
     if (new_thread->attr.stackaddr_attr == nullptr) {


### PR DESCRIPTION
From what I understand, `posix_pthread_create()` is called by the game code itself => we have no guarantees these calls can't happen concurrently on 2 different game threads => the TidCounter should be atomic.