### PR TITLE
Don't print unresolved libc and libSceFios2 stubs

### DIFF
--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -361,8 +361,10 @@ bool Linker::Resolve(const std::string& name, Loader::SymbolType sym_type, Modul
         return_info->virtual_address = AeroLib::GetStub(sr.name.c_str());
         return_info->name = "Unknown !!!";
     }
-    LOG_WARNING(Core_Linker, "Linker: Stub resolved {} as {} (lib: {}, mod: {})", sr.name,
-                return_info->name, library->name, module->name);
+    if (library->name != "libc" && library->name != "libSceFios2") {
+        LOG_WARNING(Core_Linker, "Linker: Stub resolved {} as {} (lib: {}, mod: {})", sr.name,
+                    return_info->name, library->name, module->name);
+    }
     return false;
 }
 


### PR DESCRIPTION
For most people, this saves a few lines of unnecessary logging from their logs. For people who turned off identical log line grouping, this saves a few thousand lines of unnecessary logging from their logs.