### PR TITLE
CI: Bump ccache-action due to Node 20 deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
       env:
         COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       run: ./.ci/clang-format.sh
-      
+
   get-info:
     runs-on: ubuntu-24.04
     outputs:
@@ -78,14 +78,14 @@ jobs:
       env:
           cache-name: ${{ runner.os }}-sdl-ninja-cache-cmake-configuration
       with:
-          path: | 
+          path: |
             ${{github.workspace}}/build
           key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
           restore-keys: |
             ${{ env.cache-name }}-
 
     - name: Cache CMake Build
-      uses: hendrikmuhs/ccache-action@v1.2.19
+      uses: hendrikmuhs/ccache-action@v1.2.21
       env:
           cache-name: ${{ runner.os }}-sdl-cache-cmake-build
       with:
@@ -119,17 +119,17 @@ jobs:
 
     - name: Cache CMake Configuration
       uses: actions/cache@v5
-      env: 
+      env:
           cache-name: ${{ runner.os }}-sdl-cache-cmake-configuration
-      with: 
-          path: |  
-            ${{github.workspace}}/build 
-          key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }} 
-          restore-keys: | 
-            ${{ env.cache-name }}- 
+      with:
+          path: |
+            ${{github.workspace}}/build
+          key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          restore-keys: |
+            ${{ env.cache-name }}-
 
     - name: Cache CMake Build
-      uses: hendrikmuhs/ccache-action@v1.2.19
+      uses: hendrikmuhs/ccache-action@v1.2.21
       env:
           cache-name: ${{runner.os}}-sdl-cache-cmake-build
       with:
@@ -173,17 +173,17 @@ jobs:
 
     - name: Cache CMake Configuration
       uses: actions/cache@v5
-      env: 
+      env:
           cache-name: ${{ runner.os }}-sdl-cache-cmake-configuration
-      with: 
-          path: |  
-            ${{github.workspace}}/build 
-          key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }} 
-          restore-keys: | 
-            ${{ env.cache-name }}- 
+      with:
+          path: |
+            ${{github.workspace}}/build
+          key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          restore-keys: |
+            ${{ env.cache-name }}-
 
     - name: Cache CMake Build
-      uses: hendrikmuhs/ccache-action@v1.2.19
+      uses: hendrikmuhs/ccache-action@v1.2.21
       env:
           cache-name: ${{ runner.os }}-sdl-cache-cmake-build
       with:
@@ -195,11 +195,11 @@ jobs:
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel $(nproc)
-  
-    - name: Package and Upload Linux(ubuntu64) SDL artifact 
+
+    - name: Package and Upload Linux(ubuntu64) SDL artifact
       run: |
         ls -la ${{ github.workspace }}/build/shadps4
-    
+
     - uses: actions/upload-artifact@v6
       with:
         name: shadps4-ubuntu64-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}
@@ -207,7 +207,7 @@ jobs:
 
     - name: Run AppImage packaging script
       run:  ./.github/linux-appimage-sdl.sh
-      
+
     - name: Package and Upload Linux SDL artifact
       run: |
         tar cf shadps4-linux-sdl.tar.gz -C ${{github.workspace}}/build shadps4
@@ -229,17 +229,17 @@ jobs:
 
     - name: Cache CMake Configuration
       uses: actions/cache@v5
-      env: 
+      env:
           cache-name: ${{ runner.os }}-sdl-gcc-cache-cmake-configuration
-      with: 
-          path: |  
-            ${{github.workspace}}/build 
-          key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }} 
-          restore-keys: | 
-            ${{ env.cache-name }}- 
+      with:
+          path: |
+            ${{github.workspace}}/build
+          key: ${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          restore-keys: |
+            ${{ env.cache-name }}-
 
     - name: Cache CMake Build
-      uses: hendrikmuhs/ccache-action@v1.2.19
+      uses: hendrikmuhs/ccache-action@v1.2.21
       env:
           cache-name: ${{ runner.os }}-sdl-gcc-cache-cmake-build
       with:
@@ -266,7 +266,7 @@ jobs:
       run: |
         chmod -R a+x ./artifacts/shadps4-linux-sdl-*
         chmod -R a+x ./artifacts/shadps4-macos-sdl-*
-  
+
     - name: Compress individual directories (without parent directory)
       run: |
         cd ./artifacts
@@ -277,7 +277,7 @@ jobs:
             (cd "$dir_name" && zip -r "../${dir_name}.zip" .)
           fi
         done
-  
+
     - name: Get latest release information
       id: get_latest_release
       env:
@@ -351,52 +351,52 @@ jobs:
           upload_url="https://uploads.github.com/repos/$REPO/releases/$release_id/assets?name=$filename"
           curl -X POST -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/octet-stream" --data-binary @"$file" "$upload_url"
         done
-        
+
     - name: Get current pre-release information
       env:
         GITHUB_TOKEN: ${{ secrets.SHADPS4_TOKEN_REPO }}
       run: |
         api_url="https://api.github.com/repos/${{ github.repository }}/releases"
-        
+
         # Get all releases (sorted by date)
         releases=$(curl -H "Authorization: token $GITHUB_TOKEN" "$api_url")
-        
+
         # Capture the most recent pre-release (assuming the first one is the latest)
         current_release=$(echo "$releases" | jq -c '.[] | select(.prerelease == true) | .published_at' | sort -r | head -n 1)
-        
+
         # Remove extra quotes from captured date
         current_release=$(echo $current_release | tr -d '"')
-                
+
         # Export the current published_at to be available for the next step
         echo "CURRENT_PUBLISHED_AT=$current_release" >> $GITHUB_ENV
-    
+
     - name: Delete old pre-releases and tags
       env:
         GITHUB_TOKEN: ${{ secrets.SHADPS4_TOKEN_REPO }}
       run: |
         api_url="https://api.github.com/repos/${{ github.repository }}/releases"
-        
+
         # Get current pre-releases
         releases=$(curl -H "Authorization: token $GITHUB_TOKEN" "$api_url")
-                
+
         # Remove extra quotes from captured date
         CURRENT_PUBLISHED_AT=$(echo $CURRENT_PUBLISHED_AT | tr -d '"')
-        
+
         # Convert CURRENT_PUBLISHED_AT para timestamp Unix
         current_published_ts=$(date -d "$CURRENT_PUBLISHED_AT" +%s)
-        
+
         # Identify pre-releases
         echo "$releases" | jq -c '.[] | select(.prerelease == true)' | while read -r release; do
           release_date=$(echo "$release" | jq -r '.published_at')
           release_id=$(echo "$release" | jq -r '.id')
           release_tag=$(echo "$release" | jq -r '.tag_name')
-          
+
           # Remove extra quotes from captured date
           release_date=$(echo $release_date | tr -d '"')
-          
+
           # Convert release_date para timestamp Unix
           release_date_ts=$(date -d "$release_date" +%s)
-                    
+
           # Compare timestamps and delete old pre-releases
           if [[ "$release_date_ts" -lt "$current_published_ts" ]]; then
             echo "Deleting old pre-release: $release_id from $release_date with tag: $release_tag"


### PR DESCRIPTION
Follow-up from #4128 

Bumps `cache-action` to v1.2.21

The deprecation warning should no longer appear for Windows and Linux builds.

The warning will still appear for the Mac build, since it also uses [`setup-xcode`](https://github.com/maxim-lobanov/setup-xcode) which has not been updated yet)