### PR TITLE
Update current firmware version

### DIFF
--- a/src/core/libraries/kernel/kernel.h
+++ b/src/core/libraries/kernel/kernel.h
@@ -37,7 +37,7 @@ struct OrbisWrapperImpl<PS4_SYSV_ABI R (*)(Args...), f> {
 
 #define ORBIS(func) (Libraries::Kernel::OrbisWrapperImpl<decltype(&(func)), func>::wrap)
 
-#define CURRENT_FIRMWARE_VERSION 0x13020011
+#define CURRENT_FIRMWARE_VERSION 0x13500011
 
 s32* PS4_SYSV_ABI __Error();
 


### PR DESCRIPTION
We've improved the messages and usability on some screens.
We also patched the PlayStation Vue userland exploit by removing its system license that used to be preinstalled on the system, and we also patched yet another bug in BD-J.