### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel $env:NUMBER_OF_PROCESSORS
 
     - name: Upload Windows SDL artifact
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: shadps4-win64-sdl-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}
         path: ${{github.workspace}}/build/shadPS4.exe
@@ -150,7 +150,7 @@ jobs:
         mv ${{github.workspace}}/build/shadps4 upload
         mv ${{github.workspace}}/build/MoltenVK_icd.json upload
         mv ${{github.workspace}}/build/libMoltenVK.dylib upload
-    - uses: actions/upload-artifact@v6
+    - uses: actions/upload-artifact@v7
       with:
         name: shadps4-macos-sdl-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}
         path: upload/
@@ -200,7 +200,7 @@ jobs:
       run: |
         ls -la ${{ github.workspace }}/build/shadps4
 
-    - uses: actions/upload-artifact@v6
+    - uses: actions/upload-artifact@v7
       with:
         name: shadps4-ubuntu64-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}
         path: ${{ github.workspace }}/build/shadps4
@@ -211,7 +211,7 @@ jobs:
     - name: Package and Upload Linux SDL artifact
       run: |
         tar cf shadps4-linux-sdl.tar.gz -C ${{github.workspace}}/build shadps4
-    - uses: actions/upload-artifact@v6
+    - uses: actions/upload-artifact@v7
       with:
         name: shadps4-linux-sdl-${{ needs.get-info.outputs.date }}-${{ needs.get-info.outputs.shorthash }}
         path: Shadps4-sdl.AppImage


### PR DESCRIPTION
Upgrades GitHub Actions to versions that support Node 24, since Node 20 is reaching EOL in April 2026.

## Changes

| Action | Old Version(s) | New Version | Compare | Files |
|--------|---------------|-------------|---------|-------|
| `actions/upload-artifact` | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [`v7`](https://github.com/actions/upload-artifact/releases/tag/v7) | [Diff](https://github.com/actions/upload-artifact/compare/v6...v7) | build.yml |
## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will default to Node 24 starting June 2nd, 2026.

- Node 20 EOL: April 2026
- Node 24 becomes default: June 2nd, 2026

## Notes

Worth running the workflows on a branch before merging to make sure everything still works.
