### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     continue-on-error: true
     steps:
     - uses: actions/checkout@v6
-    - uses: fsfe/reuse-action@v5
+    - uses: fsfe/reuse-action@v6
 
   clang-format:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Bumps GitHub Actions to their latest versions for bug fixes and security patches.

## Changes

| Action | Old Version(s) | New Version | Compare | Files |
|--------|---------------|-------------|---------|-------|
| `fsfe/reuse-action` | [`v5`](https://github.com/fsfe/reuse-action/releases/tag/v5) | [`v6`](https://github.com/fsfe/reuse-action/releases/tag/v6) | [Diff](https://github.com/fsfe/reuse-action/compare/v5...v6) | build.yml |

## Notes

Worth running the workflows on a branch before merging to make sure everything still works.
