### PR TITLE
Fix FSR crash on content area resize

### DIFF
--- a/src/video_core/renderer_vulkan/host_passes/fsr_pass.cpp
+++ b/src/video_core/renderer_vulkan/host_passes/fsr_pass.cpp
@@ -407,6 +407,13 @@ void FsrPass::ResizeAndInvalidate(u32 width, u32 height) {
 void FsrPass::CreateImages(Img& img) const {
     img.dirty = false;
 
+    // Destroy previous resources before re-creating at new size.
+    // Views first, then images (views reference the images).
+    img.intermediary_image_view.reset();
+    img.output_image_view.reset();
+    img.intermediary_image.Destroy();
+    img.output_image.Destroy();
+
     vk::ImageCreateInfo image_create_info{
         .imageType = vk::ImageType::e2D,
         .format = vk::Format::eR16G16B16A16Sfloat,

--- a/src/video_core/texture_cache/image.cpp
+++ b/src/video_core/texture_cache/image.cpp
@@ -82,6 +82,14 @@ UniqueImage::~UniqueImage() {
     }
 }
 
+void UniqueImage::Destroy() {
+    if (image) {
+        vmaDestroyImage(allocator, image, allocation);
+        image = vk::Image{};
+        allocation = {};
+    }
+}
+
 void UniqueImage::Create(const vk::ImageCreateInfo& image_ci) {
     this->image_ci = image_ci;
     ASSERT(!image);

--- a/src/video_core/texture_cache/image.h
+++ b/src/video_core/texture_cache/image.h
@@ -59,6 +59,8 @@ struct UniqueImage {
 
     void Create(const vk::ImageCreateInfo& image_ci);
 
+    void Destroy();
+
     operator vk::Image() const {
         return image;
     }


### PR DESCRIPTION
Any content area resize above game render resolution while FSR is active causes a crash. This happens because FSR tries to re-create its images at the new size without first releasing the existing ones.

Fixes #3794