### PR TITLE
Kernel.Vmm: Fix bugged iterator loops in SetDirectMemoryType and NameVirtualRange

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -1223,13 +1223,16 @@ s32 MemoryManager::SetDirectMemoryType(VAddr addr, u64 size, s32 memory_type) {
                 // Increment phys_handle
                 phys_handle++;
             }
-
-            // Check if VMA can be merged with adjacent areas after physical area modifications.
-            vma_handle = MergeAdjacent(vma_map, vma_handle);
         }
         current_addr += size_in_vma;
         remaining_size -= size_in_vma;
-        vma_handle++;
+
+        // Check if VMA can be merged with adjacent areas after modifications.
+        vma_handle = MergeAdjacent(vma_map, vma_handle);
+        if (vma_handle->second.base + vma_handle->second.size <= current_addr) {
+            // If we're now in the next VMA, then go to the next handle.
+            vma_handle++;
+        }
     }
 
     return ORBIS_OK;
@@ -1262,10 +1265,15 @@ void MemoryManager::NameVirtualRange(VAddr virtual_addr, u64 size, std::string_v
                 vma.name = name;
             }
         }
-        it = MergeAdjacent(vma_map, it);
         remaining_size -= size_in_vma;
         current_addr += size_in_vma;
-        it++;
+
+        // Check if VMA can be merged with adjacent areas after modifications.
+        it = MergeAdjacent(vma_map, it);
+        if (it->second.base + it->second.size <= current_addr) {
+            // If we're now in the next VMA, then go to the next handle.
+            it++;
+        }
     }
 }
 


### PR DESCRIPTION
It's possible we're merging with a later memory area. If that occurred here, we would end up iterating past where we need to be, which then messes up logic.

These checks (more specifically the one for SetDirectMemoryType) fixes the memory regression in Call of Duty®: WWII, and brings the title to menus.
<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/8d6816a2-d289-4b47-8514-785a40bc26e6" />
