### PR TITLE
Core: Minor code cleanup

### DIFF
--- a/src/common/logging/filter.cpp
+++ b/src/common/logging/filter.cpp
@@ -68,6 +68,7 @@ bool ParseFilterRule(Filter& instance, Iterator begin, Iterator end) {
     CLS(Common)                                                                                    \
     SUB(Common, Filesystem)                                                                        \
     SUB(Common, Memory)                                                                            \
+    CLS(KeyManager)                                                                                \
     CLS(Core)                                                                                      \
     SUB(Core, Linker)                                                                              \
     SUB(Core, Devices)                                                                             \
@@ -80,7 +81,6 @@ bool ParseFilterRule(Filter& instance, Iterator begin, Iterator end) {
     SUB(Kernel, Event)                                                                             \
     SUB(Kernel, Sce)                                                                               \
     CLS(Lib)                                                                                       \
-    SUB(Lib, LibC)                                                                                 \
     SUB(Lib, LibcInternal)                                                                         \
     SUB(Lib, Kernel)                                                                               \
     SUB(Lib, Pad)                                                                                  \
@@ -117,7 +117,6 @@ bool ParseFilterRule(Filter& instance, Iterator begin, Iterator end) {
     SUB(Lib, NpSnsFacebookDialog)                                                                  \
     SUB(Lib, NpPartner)                                                                            \
     SUB(Lib, Screenshot)                                                                           \
-    SUB(Lib, LibCInternal)                                                                         \
     SUB(Lib, AppContent)                                                                           \
     SUB(Lib, Rtc)                                                                                  \
     SUB(Lib, Rudp)                                                                                 \
@@ -163,8 +162,6 @@ bool ParseFilterRule(Filter& instance, Iterator begin, Iterator end) {
     CLS(ImGui)                                                                                     \
     CLS(Input)                                                                                     \
     CLS(Tty)                                                                                       \
-    CLS(KeyManager)                                                                                \
-    CLS(EmuSettings)                                                                               \
     CLS(Loader)
 
 // GetClassName is a macro defined by Windows.h, grrr...

--- a/src/common/logging/types.h
+++ b/src/common/logging/types.h
@@ -34,6 +34,7 @@ enum class Class : u8 {
     Common,                  ///< Library routines
     Common_Filesystem,       ///< Filesystem interface library
     Common_Memory,           ///< Memory mapping and management functions
+    KeyManager,              ///< Key management system
     Core,                    ///< LLE emulation core
     Core_Linker,             ///< The module linker
     Core_Devices,            ///< Devices emulation
@@ -44,10 +45,9 @@ enum class Class : u8 {
     Kernel_Fs,               ///< The filesystem implementation of the kernel.
     Kernel_Vmm,              ///< The virtual memory implementation of the kernel.
     Kernel_Event,            ///< The event management implementation of the kernel.
-    Kernel_Sce,              ///< The sony specific interfaces provided by the kernel.
+    Kernel_Sce,              ///< The Sony-specific interfaces provided by the kernel.
     Lib,                     ///< HLE implementation of system library. Each major library
                              ///< should have its own subclass.
-    Lib_LibC,                ///< The LibC implementation.
     Lib_LibcInternal,        ///< The LibcInternal implementation.
     Lib_Kernel,              ///< The LibKernel implementation.
     Lib_Pad,                 ///< The LibScePad implementation.
@@ -83,7 +83,6 @@ enum class Class : u8 {
     Lib_NpProfileDialog,     ///< The LibSceNpProfileDialog implementation
     Lib_NpSnsFacebookDialog, ///< The LibSceNpSnsFacebookDialog implementation
     Lib_Screenshot,          ///< The LibSceScreenshot implementation
-    Lib_LibCInternal,        ///< The LibCInternal implementation.
     Lib_AppContent,          ///< The LibSceAppContent implementation.
     Lib_Rtc,                 ///< The LibSceRtc implementation.
     Lib_Rudp,                ///< The LibSceRudp implementation.
@@ -131,8 +130,6 @@ enum class Class : u8 {
     Loader,                  ///< ROM loader
     Input,                   ///< Input emulation
     Tty,                     ///< Debug output from emu
-    KeyManager,              ///< Key management system
-    EmuSettings,             /// Emulator settings system
     Count                    ///< Total number of logging classes
 };
 

--- a/src/core/emulator_settings.cpp
+++ b/src/core/emulator_settings.cpp
@@ -363,8 +363,8 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
                 if (std::filesystem::exists(Common::FS::GetUserPath(Common::FS::PathType::UserDir) /
                                             "config.toml")) {
                     SDL_MessageBoxButtonData btns[2]{
-                        {0, 0, "Continue with defaults"},
-                        {0, 1, "Update automatically"},
+                        {0, 0, "Defaults"},
+                        {0, 1, "Update"},
                     };
                     SDL_MessageBoxData msg_box{
                         0,

--- a/src/core/emulator_settings.cpp
+++ b/src/core/emulator_settings.cpp
@@ -81,12 +81,12 @@ std::optional<T> get_optional(const toml::value& v, const std::string& key) {
 
 void EmulatorSettingsImpl::PrintChangedSummary(const std::vector<std::string>& changed) {
     if (changed.empty()) {
-        LOG_DEBUG(EmuSettings, "No game-specific overrides applied");
+        LOG_DEBUG(Config, "No game-specific overrides applied");
         return;
     }
-    LOG_DEBUG(EmuSettings, "Game-specific overrides applied:");
+    LOG_DEBUG(Config, "Game-specific overrides applied:");
     for (const auto& k : changed)
-        LOG_DEBUG(EmuSettings, "    * {}", k);
+        LOG_DEBUG(Config, "    * {}", k);
 }
 
 // ── Singleton ────────────────────────────────────────────────────────
@@ -212,7 +212,7 @@ void EmulatorSettingsImpl::ClearGameSpecificOverrides() {
     ClearGroupOverrides(m_audio);
     ClearGroupOverrides(m_gpu);
     ClearGroupOverrides(m_vulkan);
-    LOG_DEBUG(EmuSettings, "All game-specific overrides cleared");
+    LOG_DEBUG(Config, "All game-specific overrides cleared");
 }
 
 void EmulatorSettingsImpl::ResetGameSpecificValue(const std::string& key) {
@@ -238,7 +238,7 @@ void EmulatorSettingsImpl::ResetGameSpecificValue(const std::string& key) {
         return;
     if (tryGroup(m_vulkan))
         return;
-    LOG_WARNING(EmuSettings, "ResetGameSpecificValue: key '{}' not found", key);
+    LOG_WARNING(Config, "ResetGameSpecificValue: key '{}' not found", key);
 }
 
 bool EmulatorSettingsImpl::Save(const std::string& serial) {
@@ -276,7 +276,7 @@ bool EmulatorSettingsImpl::Save(const std::string& serial) {
 
             std::ofstream out(path);
             if (!out) {
-                LOG_ERROR(EmuSettings, "Failed to open game config for writing: {}", path.string());
+                LOG_ERROR(Config, "Failed to open game config for writing: {}", path.string());
                 return false;
             }
             out << std::setw(2) << j;
@@ -317,14 +317,14 @@ bool EmulatorSettingsImpl::Save(const std::string& serial) {
 
             std::ofstream out(path);
             if (!out) {
-                LOG_ERROR(EmuSettings, "Failed to open config for writing: {}", path.string());
+                LOG_ERROR(Config, "Failed to open config for writing: {}", path.string());
                 return false;
             }
             out << std::setw(2) << existing;
             return !out.fail();
         }
     } catch (const std::exception& e) {
-        LOG_ERROR(EmuSettings, "Error saving settings: {}", e.what());
+        LOG_ERROR(Config, "Error saving settings: {}", e.what());
         return false;
     }
 }
@@ -337,7 +337,7 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
             // ── Global config ──────────────────────────────────────────
             const auto userDir = Common::FS::GetUserPath(Common::FS::PathType::UserDir);
             const auto configPath = userDir / "config.json";
-            LOG_DEBUG(EmuSettings, "Loading global config from: {}", configPath.string());
+            LOG_DEBUG(Config, "Loading global config from: {}", configPath.string());
 
             if (std::ifstream in{configPath}; in.good()) {
                 json gj;
@@ -358,7 +358,7 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
                 mergeGroup(m_gpu, "GPU");
                 mergeGroup(m_vulkan, "Vulkan");
 
-                LOG_DEBUG(EmuSettings, "Global config loaded successfully");
+                LOG_DEBUG(Config, "Global config loaded successfully");
             } else {
                 if (std::filesystem::exists(Common::FS::GetUserPath(Common::FS::PathType::UserDir) /
                                             "config.toml")) {
@@ -392,7 +392,7 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
                         }
                     }
                 }
-                LOG_DEBUG(EmuSettings, "Global config not found - using defaults");
+                LOG_DEBUG(Config, "Global config not found - using defaults");
                 SetDefaultValues();
                 Save();
             }
@@ -408,16 +408,16 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
             // base configuration.
             const auto gamePath =
                 Common::FS::GetUserPath(Common::FS::PathType::CustomConfigs) / (serial + ".json");
-            LOG_DEBUG(EmuSettings, "Applying game config: {}", gamePath.string());
+            LOG_DEBUG(Config, "Applying game config: {}", gamePath.string());
 
             if (!std::filesystem::exists(gamePath)) {
-                LOG_DEBUG(EmuSettings, "No game-specific config found for {}", serial);
+                LOG_DEBUG(Config, "No game-specific config found for {}", serial);
                 return false;
             }
 
             std::ifstream in(gamePath);
             if (!in) {
-                LOG_ERROR(EmuSettings, "Failed to open game config: {}", gamePath.string());
+                LOG_ERROR(Config, "Failed to open game config: {}", gamePath.string());
                 return false;
             }
 
@@ -448,7 +448,7 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
             return true;
         }
     } catch (const std::exception& e) {
-        LOG_ERROR(EmuSettings, "Error loading settings: {}", e.what());
+        LOG_ERROR(Config, "Error loading settings: {}", e.what());
         return false;
     }
 }
@@ -611,7 +611,7 @@ bool EmulatorSettingsImpl::TransferSettings() {
             }
             s.install_dirs.value = settings_install_dirs;
         } catch (const std::exception& e) {
-            LOG_WARNING(EmuSettings, "Failed to transfer install directories: {}", e.what());
+            LOG_WARNING(Config, "Failed to transfer install directories: {}", e.what());
         }
 
         // Transfer addon install directory
@@ -627,7 +627,7 @@ bool EmulatorSettingsImpl::TransferSettings() {
                 }
             }
         } catch (const std::exception& e) {
-            LOG_WARNING(EmuSettings, "Failed to transfer addon install directory: {}", e.what());
+            LOG_WARNING(Config, "Failed to transfer addon install directory: {}", e.what());
         }
     }
 

--- a/src/core/emulator_settings.cpp
+++ b/src/core/emulator_settings.cpp
@@ -363,8 +363,8 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
                 if (std::filesystem::exists(Common::FS::GetUserPath(Common::FS::PathType::UserDir) /
                                             "config.toml")) {
                     SDL_MessageBoxButtonData btns[2]{
-                        {0, 0, "No"},
-                        {0, 1, "Yes"},
+                        {0, 0, "Continue with defaults"},
+                        {0, 1, "Update automatically"},
                     };
                     SDL_MessageBoxData msg_box{
                         0,

--- a/src/core/emulator_settings.h
+++ b/src/core/emulator_settings.h
@@ -112,26 +112,26 @@ inline OverrideItem make_override(const char* key, Setting<T> Struct::* member) 
     return OverrideItem{
         key,
         [member, key](void* base, const nlohmann::json& entry, std::vector<std::string>& changed) {
-            LOG_DEBUG(EmuSettings, "[make_override] Processing key: {}", key);
-            LOG_DEBUG(EmuSettings, "[make_override] Entry JSON: {}", entry.dump());
+            LOG_DEBUG(Config, "[make_override] Processing key: {}", key);
+            LOG_DEBUG(Config, "[make_override] Entry JSON: {}", entry.dump());
             Struct* obj = reinterpret_cast<Struct*>(base);
             Setting<T>& dst = obj->*member;
             try {
                 T newValue = entry.get<T>();
-                LOG_DEBUG(EmuSettings, "[make_override] Parsed value: {}", newValue);
-                LOG_DEBUG(EmuSettings, "[make_override] Current value: {}", dst.value);
+                LOG_DEBUG(Config, "[make_override] Parsed value: {}", newValue);
+                LOG_DEBUG(Config, "[make_override] Current value: {}", dst.value);
                 if (dst.value != newValue) {
                     std::ostringstream oss;
                     oss << key << " ( " << dst.value << " → " << newValue << " )";
                     changed.push_back(oss.str());
-                    LOG_DEBUG(EmuSettings, "[make_override] Recorded change: {}", oss.str());
+                    LOG_DEBUG(Config, "[make_override] Recorded change: {}", oss.str());
                 }
                 dst.game_specific_value = newValue;
-                LOG_DEBUG(EmuSettings, "[make_override] Successfully updated {}", key);
+                LOG_DEBUG(Config, "[make_override] Successfully updated {}", key);
             } catch (const std::exception& e) {
-                LOG_ERROR(EmuSettings, "[make_override] ERROR parsing {}: {}", key, e.what());
-                LOG_ERROR(EmuSettings, "[make_override] Entry was: {}", entry.dump());
-                LOG_ERROR(EmuSettings, "[make_override] Type name: {}", entry.type_name());
+                LOG_ERROR(Config, "[make_override] ERROR parsing {}: {}", key, e.what());
+                LOG_ERROR(Config, "[make_override] Entry was: {}", entry.dump());
+                LOG_ERROR(Config, "[make_override] Type name: {}", entry.type_name());
             }
         },
 

--- a/src/core/user_settings.cpp
+++ b/src/core/user_settings.cpp
@@ -44,13 +44,13 @@ bool UserSettingsImpl::Save() const {
 
         std::ofstream out(path);
         if (!out) {
-            LOG_ERROR(EmuSettings, "Failed to open user settings for writing: {}", path.string());
+            LOG_ERROR(Config, "Failed to open user settings for writing: {}", path.string());
             return false;
         }
         out << std::setw(2) << j;
         return !out.fail();
     } catch (const std::exception& e) {
-        LOG_ERROR(EmuSettings, "Error saving user settings: {}", e.what());
+        LOG_ERROR(Config, "Error saving user settings: {}", e.what());
         return false;
     }
 }
@@ -59,7 +59,7 @@ bool UserSettingsImpl::Load() {
     const auto path = Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "users.json";
     try {
         if (!std::filesystem::exists(path)) {
-            LOG_DEBUG(EmuSettings, "User settings file not found: {}", path.string());
+            LOG_DEBUG(Config, "User settings file not found: {}", path.string());
             // Create default user if no file exists
             if (m_userManager.GetUsers().user.empty()) {
                 m_userManager.GetUsers() = m_userManager.CreateDefaultUsers();
@@ -70,7 +70,7 @@ bool UserSettingsImpl::Load() {
 
         std::ifstream in(path);
         if (!in) {
-            LOG_ERROR(EmuSettings, "Failed to open user settings: {}", path.string());
+            LOG_ERROR(Config, "Failed to open user settings: {}", path.string());
             return false;
         }
 
@@ -97,10 +97,10 @@ bool UserSettingsImpl::Load() {
             Save();
         }
 
-        LOG_DEBUG(EmuSettings, "User settings loaded successfully");
+        LOG_DEBUG(Config, "User settings loaded successfully");
         return true;
     } catch (const std::exception& e) {
-        LOG_ERROR(EmuSettings, "Error loading user settings: {}", e.what());
+        LOG_ERROR(Config, "Error loading user settings: {}", e.what());
         // Fall back to defaults
         if (m_userManager.GetUsers().user.empty()) {
             m_userManager.GetUsers() = m_userManager.CreateDefaultUsers();


### PR DESCRIPTION
This PR does three harmless things:
1. Swap @georgemoralis's recent config rework to use the "Config" log class
2. Remove unused log classes
3. Change button labels on the config transfer dialog to improve clarity (swapped Yes/No to Update/Defaults).

I also fixed grammar for some ancient comments too, since it was bugging me a bit.