### PR TITLE
Vblank frequency setting fix + utf 8 encoding for paths

### DIFF
--- a/src/core/emulator_settings.cpp
+++ b/src/core/emulator_settings.cpp
@@ -25,10 +25,13 @@ namespace nlohmann {
 template <>
 struct adl_serializer<std::filesystem::path> {
     static void to_json(json& j, const std::filesystem::path& p) {
-        j = p.string();
+        const auto u8 = p.u8string();
+        j = std::string(reinterpret_cast<const char*>(u8.data()), u8.size());
     }
     static void from_json(const json& j, std::filesystem::path& p) {
-        p = j.get<std::string>();
+        const std::string s = j.get<std::string>();
+        p = std::filesystem::path(
+            std::u8string_view(reinterpret_cast<const char8_t*>(s.data()), s.size()));
     }
 };
 } // namespace nlohmann

--- a/src/core/emulator_settings.h
+++ b/src/core/emulator_settings.h
@@ -594,16 +594,17 @@ public:
     SETTING_FORWARD_BOOL_READONLY(m_gpu, PatchShaders, patch_shaders)
 
     u32 GetVblankFrequency() {
-        if (m_gpu.vblank_frequency.value < 60) {
-            m_gpu.vblank_frequency.value = 60;
+        if (m_gpu.vblank_frequency.value < 30) {
+            return 30;
         }
-        return m_gpu.vblank_frequency.value;
+        return m_gpu.vblank_frequency.get();
     }
-    void SetVblankFrequency(const u32& v) {
-        if (v < 60) {
-            m_gpu.vblank_frequency.value = 60;
+    void SetVblankFrequency(const u32& v, bool is_specific = false) {
+        u32 val = v < 30 ? 30 : v;
+        if (is_specific) {
+            m_gpu.vblank_frequency.game_specific_value = val;
         } else {
-            m_gpu.vblank_frequency.value = v;
+            m_gpu.vblank_frequency.value = val;
         }
     }
 


### PR DESCRIPTION
Fixes vblank frequency setting on the new emulator_settings class

1) Get function previously only returned base value, changed this to get().

2) Set function not actually setting the values

3) changed the limit to 60 instead of 30 as some users can use this as an fps cap of sorts, and some may find it useful to cap at lower values 

Edit: also adding the code to force utf-8 encoding upon json serialization / deserialization for path strings