### PR TITLE
Addition of Nix flake development shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -418,3 +418,6 @@ FodyWeavers.xsd
 # JetBrains
 .idea
 cmake-build-*
+
+# Nix Result symlink
+result

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -22,6 +22,7 @@ path = [
     "documents/Screenshots/Linux/*",
     "documents/Screenshots/Windows/*",
     "externals/MoltenVK/MoltenVK_icd.json",
+    "flake.lock",
     "scripts/ps4_names.txt",
     "src/images/bronze.png",
     "src/images/gold.png",

--- a/documents/building-linux.md
+++ b/documents/building-linux.md
@@ -60,6 +60,10 @@ cmake -S . -B build/ -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMA
 ln -s ./build/compile_commands.json .
 ```
 
+#### Nix Flake Build
+```bash
+nix build .?submodules=1#debugLinux
+```
 #### Other Linux distributions
 
 You can try one of two methods:

--- a/documents/building-linux.md
+++ b/documents/building-linux.md
@@ -62,7 +62,13 @@ ln -s ./build/compile_commands.json .
 
 #### Nix Flake Build
 ```bash
-nix build .?submodules=1#debugLinux
+nix build .?submodules=1#linux.debug
+```
+```bash
+nix build .?submodules=1#linux.release
+```
+```bash
+nix build .?submodules=1#linux.releaseWithDebugInfo
 ```
 #### Other Linux distributions
 

--- a/documents/building-linux.md
+++ b/documents/building-linux.md
@@ -53,6 +53,13 @@ sudo zypper install clang git cmake libasound2 libpulse-devel \
 nix-shell shell.nix
 ```
 
+#### Nix Flake Development Shell
+```bash
+nix develop
+cmake -S . -B build/ -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON  
+ln -s ./build/compile_commands.json .
+```
+
 #### Other Linux distributions
 
 You can try one of two methods:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774386573,
+        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  description = "shadPS4 Nix Flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }: 
+  let
+    pkgsLinux = nixpkgs.legacyPackages.x86_64-linux;
+  in 
+  {
+    devShells.x86_64-linux.default = pkgsLinux.mkShell {
+      packages = with pkgsLinux; [
+        clang-tools
+        cmake
+        pkg-config
+        vulkan-tools
+        
+        renderdoc
+        gef
+        strace
+
+        sdl3.dev
+        openal
+        zlib.dev
+        libedit.dev
+        vulkan-headers
+        vulkan-utility-libraries
+        ffmpeg.dev
+        fmt.dev
+        glslang.dev
+        libxkbcommon
+        wayland.dev
+        libxcb.dev
+        stb
+        libpng.dev
+      ];
+
+      shellHook = ''
+        echo "Entering shadPS4 development shell!"
+      '';
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -143,6 +143,7 @@
           libs = with pkgsLinux; [
             libGL.out
             vulkan-loader.out
+            mesa
           ];
         in
         ''

--- a/flake.nix
+++ b/flake.nix
@@ -90,6 +90,7 @@
           magic-enum
           fmt
           eudev
+          makeWrapper
         ];
 
         buildInputs = with pkgsLinux; [
@@ -132,6 +133,19 @@
           "-DCMAKE_BUILD_TYPE=Debug"
           "-DCMAKE_INSTALL_PREFIX=$out"
         ];
+
+        postFixup = 
+        let
+          libs = with pkgsLinux; [
+            libGL.out
+            vulkan-loader.out
+          ];
+        in
+        ''
+          wrapProgram $out/bin/vulkan-app \
+            --set LD_LIBRARY_PATH ${pkgsLinux.lib.makeLibraryPath libs} \
+            --set SHADER_PATH "$out/bin/shaders"
+        '';
 
         #installPhase = ''
         #  runHook preInstall

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,6 @@
         gef
         strace
 
-        sdl3.dev
         openal
         zlib.dev
         libedit.dev
@@ -30,18 +29,40 @@
         ffmpeg.dev
         fmt.dev
         glslang.dev
-        libxkbcommon
         wayland.dev
-        libxcb.dev
         stb
         libpng.dev
+        
+        # Specific SDL3 dependencies:
+        sdl3.dev
+        alsa-lib
+        hidapi
+        ibus.dev
+        jack2.dev
+        libdecor.dev
+        libthai.dev
+        fribidi.dev
+        libxcb.dev
+        libGL.dev
+        libpulseaudio.dev
+        libusb1.dev
+        libx11.dev
+        libxcursor.dev
+        libxext
+        libxfixes.dev
+        libxi.dev
+        libxinerama.dev
+        libxkbcommon
+        libxrandr.dev
+        libxrender.dev
+        libxtst
+        pipewire.dev
+        libxscrnsaver
+        sndio
+      ];
 
-        libxcb
-        libxcb-util
-        libxcb-keysyms
-        libxcb-wm
-        wayland-protocols
-        libglvnd
+      LD_LIBRARY_PATH = pkgsLinux.lib.makeLibraryPath [
+        pkgsLinux.mesa
       ];
 
       shellHook = ''

--- a/flake.nix
+++ b/flake.nix
@@ -116,10 +116,16 @@
           wayland
           wayland-scanner
           libX11
+          libxrandr
+          libxext
+          libxcursor
+          libxi
+          libxscrnsaver
+          libxtst
+          libxcb
           libdecor
           libxkbcommon
           libGL
-          #mesa
           #util-linux
           libuuid
           #libedit
@@ -142,13 +148,12 @@
         let
           libs = with pkgsLinux; [
             libGL.out
-            vulkan-loader.out
             mesa
           ];
         in
         ''
           wrapProgram $out/bin/${exec_name} \
-            --set LD_LIBRARY_PATH ${pkgsLinux.lib.makeLibraryPath libs} \
+            --set LD_LIBRARY_PATH ${pkgsLinux.lib.makeLibraryPath libs}
         '';
 
         #installPhase = ''

--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,7 @@
       };
       
       debugLinux = pkgsLinux.stdenv.mkDerivation {
-        pname = "shadPS4";
+        pname = "shadps4";
         version = "git";
         system = "x86_64-linux";
         src = ./.;
@@ -130,14 +130,15 @@
 
         cmakeFlags = [
           "-DCMAKE_BUILD_TYPE=Debug"
+          "-DCMAKE_INSTALL_PREFIX=$out"
         ];
 
-        installPhase = ''
-          runHook preInstall
-          mkdir -p bin
-          cp shadPS4 bin/
-          runHook postInstall
-        '';
+        #installPhase = ''
+        #  runHook preInstall
+        #  mkdir -p bin
+        #  cp shadps4 $out/bin/
+        #  runHook postInstall
+        #'';
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
     pkgsLinux = nixpkgs.legacyPackages.x86_64-linux;
   in 
   {
-    devShells.x86_64-linux.default = pkgsLinux.mkShell {
+    devShells.x86_64-linux.default = pkgsLinux.mkShell.override {stdenv = pkgsLinux.clangStdenv; } {
       packages = with pkgsLinux; [
         clang-tools
         cmake

--- a/flake.nix
+++ b/flake.nix
@@ -74,5 +74,60 @@
           echo "Entering shadPS4 development shell!"
         '';
       };
+      
+      debugLinux = pkgsLinux.stdenv.mkDerivation {
+        pname = "shadPS4";
+        version = "git";
+        system = "x86_64-linux";
+        src = ./.;
+        dontStrip = true;
+
+        nativeBuildInputs = with pkgsLinux; [ 
+          cmake 
+          ninja
+          libcxx
+          pkg-config
+          boost
+          vulkan-headers
+          magic-enum
+          fmt
+        ];
+
+        buildInputs = with pkgsLinux; [
+          mesa
+          util-linux
+          libuuid
+          libedit
+          ffmpeg
+          sdl3
+          alsa-lib
+          libpulseaudio
+          libusb1
+          libxkbcommon
+          libgbm
+          ibusMinimal
+          libGL
+          libdecor
+          libdrm
+          jack2
+          pipewire
+          sndio
+          vulkan-loader
+          wayland
+          wayland-scanner
+          libX11
+        ];
+
+        cmakeFlags = [
+          "-DCMAKE_BUILD_TYPE=Debug"
+        ];
+
+        installPhase = ''
+          runHook preInstall
+          mkdir -p bin
+          cp shadPS4 bin/
+          runHook postInstall
+        '';
+      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
           wayland.dev
           stb
           libpng.dev
+          libuuid
 
           # Specific SDL3 dependencies:
           sdl3.dev

--- a/flake.nix
+++ b/flake.nix
@@ -112,8 +112,7 @@
             libuuid
           ];
 
-          cmakeFlags = [
-            "-DCMAKE_BUILD_TYPE=Debug"
+          defaultFlags = [
             "-DCMAKE_INSTALL_PREFIX=$out"
           ];
         in
@@ -127,7 +126,9 @@
 
             nativeBuildInputs = nativeInputs;
             buildInputs = buildInputs;
-            cmakeFlags = cmakeFlags;
+            cmakeFlags = [
+              "-DCMAKE_BUILD_TYPE=Debug"
+            ] ++ [defaultFlags];
           };
           release = pkgsLinux.stdenv.mkDerivation {
             pname = "${execName}";
@@ -137,7 +138,9 @@
 
             nativeBuildInputs = nativeInputs;
             buildInputs = buildInputs;
-            cmakeFlags = cmakeFlags;
+            cmakeFlags = [
+              "-DCMAKE_BUILD_TYPE=Release"
+            ] ++ [defaultFlags];
           };
           releaseWithDebugInfo = pkgsLinux.stdenv.mkDerivation {
             pname = "${execName}";
@@ -148,7 +151,9 @@
 
             nativeBuildInputs = nativeInputs;
             buildInputs = buildInputs;
-            cmakeFlags = cmakeFlags;
+            cmakeFlags = [
+              "-DCMAKE_BUILD_TYPE=Release"
+            ] ++ [defaultFlags];
           };
         };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,12 @@
         libxcb.dev
         stb
         libpng.dev
+
+        libxcb
+        xcb-util
+        libxcb-keysyms
+        libxcb-wm
+        wayland-protocols
       ];
 
       shellHook = ''

--- a/flake.nix
+++ b/flake.nix
@@ -75,8 +75,12 @@
         '';
       };
       
-      debugLinux = pkgsLinux.stdenv.mkDerivation {
-        pname = "shadps4";
+      debugLinux = 
+      let
+        exec_name = "shadps4";
+      in 
+      pkgsLinux.stdenv.mkDerivation {
+        pname = "${exec_name}";
         version = "git";
         system = "x86_64-linux";
         src = ./.;
@@ -142,9 +146,8 @@
           ];
         in
         ''
-          wrapProgram $out/bin/vulkan-app \
+          wrapProgram $out/bin/${exec_name} \
             --set LD_LIBRARY_PATH ${pkgsLinux.lib.makeLibraryPath libs} \
-            --set SHADER_PATH "$out/bin/shaders"
         '';
 
         #installPhase = ''

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,6 @@
           libpng.dev
           libuuid
 
-          # Specific SDL3 dependencies:
           sdl3.dev
           alsa-lib
           hidapi
@@ -65,103 +64,92 @@
           libxscrnsaver
           sndio
         ];
-
-        LD_LIBRARY_PATH = pkgsLinux.lib.makeLibraryPath [
-          pkgsLinux.mesa
-        ];
-
         shellHook = ''
           echo "Entering shadPS4 development shell!"
         '';
       };
-      
-      debugLinux = 
-      let
-        exec_name = "shadps4";
-      in 
-      pkgsLinux.stdenv.mkDerivation {
-        pname = "${exec_name}";
-        version = "git";
-        system = "x86_64-linux";
-        src = ./.;
-        dontStrip = true;
 
-        nativeBuildInputs = with pkgsLinux; [ 
-          cmake 
-          ninja
-          pkg-config
-          #libcxx
-          magic-enum
-          fmt
-          eudev
-          makeWrapper
-        ];
-
-        buildInputs = with pkgsLinux; [
-          boost
-          cli11
-          openal
-          nlohmann_json
-          vulkan-loader
-          vulkan-headers
-          vulkan-memory-allocator
-          toml11
-          zlib
-          zydis
-          pugixml
-          ffmpeg
-          libpulseaudio
-          pipewire
-          vulkan-loader
-          wayland
-          wayland-scanner
-          libX11
-          libxrandr
-          libxext
-          libxcursor
-          libxi
-          libxscrnsaver
-          libxtst
-          libxcb
-          libdecor
-          libxkbcommon
-          libGL
-          #util-linux
-          libuuid
-          #libedit
-          #sdl3
-          #alsa-lib
-          #libusb1
-          #libgbm
-          #ibusMinimal
-          #libdrm
-          #jack2
-          #sndio
-        ];
-
-        cmakeFlags = [
-          "-DCMAKE_BUILD_TYPE=Debug"
-          "-DCMAKE_INSTALL_PREFIX=$out"
-        ];
-
-        postFixup = 
+      linux =
         let
-          libs = with pkgsLinux; [
-            libGL.out
-            mesa
+          execName = "shadps4";
+          nativeInputs = with pkgsLinux; [
+            cmake
+            ninja
+            pkg-config
+            magic-enum
+            fmt
+            eudev
+          ];
+          buildInputs = with pkgsLinux; [
+            boost
+            cli11
+            openal
+            nlohmann_json
+            vulkan-loader
+            vulkan-headers
+            vulkan-memory-allocator
+            toml11
+            zlib
+            zydis
+            pugixml
+            ffmpeg
+            libpulseaudio
+            pipewire
+            vulkan-loader
+            wayland
+            wayland-scanner
+            libX11
+            libxrandr
+            libxext
+            libxcursor
+            libxi
+            libxscrnsaver
+            libxtst
+            libxcb
+            libdecor
+            libxkbcommon
+            libGL
+            libuuid
+          ];
+
+          cmakeFlags = [
+            "-DCMAKE_BUILD_TYPE=Debug"
+            "-DCMAKE_INSTALL_PREFIX=$out"
           ];
         in
-        ''
-          wrapProgram $out/bin/${exec_name} \
-            --set LD_LIBRARY_PATH ${pkgsLinux.lib.makeLibraryPath libs}
-        '';
+        {
+          debug = pkgsLinux.stdenv.mkDerivation {
+            pname = "${execName}";
+            version = "git";
+            system = "x86_64-linux";
+            src = ./.;
+            dontStrip = true;
 
-        #installPhase = ''
-        #  runHook preInstall
-        #  mkdir -p bin
-        #  cp shadps4 $out/bin/
-        #  runHook postInstall
-        #'';
-      };
+            nativeBuildInputs = nativeInputs;
+            buildInputs = buildInputs;
+            cmakeFlags = cmakeFlags;
+          };
+          release = pkgsLinux.stdenv.mkDerivation {
+            pname = "${execName}";
+            version = "git";
+            system = "x86_64-linux";
+            src = ./.;
+
+            nativeBuildInputs = nativeInputs;
+            buildInputs = buildInputs;
+            cmakeFlags = cmakeFlags;
+          };
+          releaseWithDebugInfo = pkgsLinux.stdenv.mkDerivation {
+            pname = "${execName}";
+            version = "git";
+            system = "x86_64-linux";
+            src = ./.;
+            dontStrip = true;
+
+            nativeBuildInputs = nativeInputs;
+            buildInputs = buildInputs;
+            cmakeFlags = cmakeFlags;
+          };
+        };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -37,10 +37,11 @@
         libpng.dev
 
         libxcb
-        xcb-util
+        libxcb-util
         libxcb-keysyms
         libxcb-wm
         wayland-protocols
+        libglvnd
       ];
 
       shellHook = ''

--- a/flake.nix
+++ b/flake.nix
@@ -5,69 +5,70 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
   };
 
-  outputs = { self, nixpkgs }: 
-  let
-    pkgsLinux = nixpkgs.legacyPackages.x86_64-linux;
-  in 
-  {
-    devShells.x86_64-linux.default = pkgsLinux.mkShell.override {stdenv = pkgsLinux.clangStdenv; } {
-      packages = with pkgsLinux; [
-        clang-tools
-        cmake
-        pkg-config
-        vulkan-tools
-        
-        renderdoc
-        gef
-        strace
+  outputs =
+    { self, nixpkgs }:
+    let
+      pkgsLinux = nixpkgs.legacyPackages.x86_64-linux;
+    in
+    {
+      devShells.x86_64-linux.default = pkgsLinux.mkShell.override { stdenv = pkgsLinux.clangStdenv; } {
+        packages = with pkgsLinux; [
+          clang-tools
+          cmake
+          pkg-config
+          vulkan-tools
 
-        openal
-        zlib.dev
-        libedit.dev
-        vulkan-headers
-        vulkan-utility-libraries
-        ffmpeg.dev
-        fmt.dev
-        glslang.dev
-        wayland.dev
-        stb
-        libpng.dev
-        
-        # Specific SDL3 dependencies:
-        sdl3.dev
-        alsa-lib
-        hidapi
-        ibus.dev
-        jack2.dev
-        libdecor.dev
-        libthai.dev
-        fribidi.dev
-        libxcb.dev
-        libGL.dev
-        libpulseaudio.dev
-        libusb1.dev
-        libx11.dev
-        libxcursor.dev
-        libxext
-        libxfixes.dev
-        libxi.dev
-        libxinerama.dev
-        libxkbcommon
-        libxrandr.dev
-        libxrender.dev
-        libxtst
-        pipewire.dev
-        libxscrnsaver
-        sndio
-      ];
+          renderdoc
+          gef
+          strace
 
-      LD_LIBRARY_PATH = pkgsLinux.lib.makeLibraryPath [
-        pkgsLinux.mesa
-      ];
+          openal
+          zlib.dev
+          libedit.dev
+          vulkan-headers
+          vulkan-utility-libraries
+          ffmpeg.dev
+          fmt.dev
+          glslang.dev
+          wayland.dev
+          stb
+          libpng.dev
 
-      shellHook = ''
-        echo "Entering shadPS4 development shell!"
-      '';
+          # Specific SDL3 dependencies:
+          sdl3.dev
+          alsa-lib
+          hidapi
+          ibus.dev
+          jack2.dev
+          libdecor.dev
+          libthai.dev
+          fribidi.dev
+          libxcb.dev
+          libGL.dev
+          libpulseaudio.dev
+          libusb1.dev
+          libx11.dev
+          libxcursor.dev
+          libxext
+          libxfixes.dev
+          libxi.dev
+          libxinerama.dev
+          libxkbcommon
+          libxrandr.dev
+          libxrender.dev
+          libxtst
+          pipewire.dev
+          libxscrnsaver
+          sndio
+        ];
+
+        LD_LIBRARY_PATH = pkgsLinux.lib.makeLibraryPath [
+          pkgsLinux.mesa
+        ];
+
+        shellHook = ''
+          echo "Entering shadPS4 development shell!"
+        '';
+      };
     };
-  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -85,37 +85,47 @@
         nativeBuildInputs = with pkgsLinux; [ 
           cmake 
           ninja
-          libcxx
           pkg-config
-          boost
-          vulkan-headers
+          #libcxx
           magic-enum
           fmt
+          eudev
         ];
 
         buildInputs = with pkgsLinux; [
-          mesa
-          util-linux
-          libuuid
-          libedit
+          boost
+          cli11
+          openal
+          nlohmann_json
+          vulkan-loader
+          vulkan-headers
+          vulkan-memory-allocator
+          toml11
+          zlib
+          zydis
+          pugixml
           ffmpeg
-          sdl3
-          alsa-lib
           libpulseaudio
-          libusb1
-          libxkbcommon
-          libgbm
-          ibusMinimal
-          libGL
-          libdecor
-          libdrm
-          jack2
           pipewire
-          sndio
           vulkan-loader
           wayland
           wayland-scanner
           libX11
+          libdecor
+          libxkbcommon
+          libGL
+          #mesa
+          #util-linux
+          libuuid
+          #libedit
+          #sdl3
+          #alsa-lib
+          #libusb1
+          #libgbm
+          #ibusMinimal
+          #libdrm
+          #jack2
+          #sndio
         ];
 
         cmakeFlags = [

--- a/flake.nix
+++ b/flake.nix
@@ -1,3 +1,6 @@
+## SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+## SPDX-License-Identifier: GPL-2.0-or-later
+
 {
   description = "shadPS4 Nix Flake";
 


### PR DESCRIPTION
Addition of a Nix flake development shell for easier IDE integration on Nix Flake systems. includes locking for pinning dependencies, clang tools for various formatting as well as integrated LSP and renderdoc / other various tools  for debugging. Includes instructions on how to make use of the development shell. 

Also provides derivations for building in debug, release and releaseWithDebugInfo modes. And instructions have been provided for the build commands in the building-linux documentation. Tested and working on a Linux NixOS system.

Thanks, 

Connor 