### PR TITLE
NpTrophy: respect emulator settings home directory for trophies

### DIFF
--- a/src/core/libraries/np/np_trophy.cpp
+++ b/src/core/libraries/np/np_trophy.cpp
@@ -222,8 +222,8 @@ s32 PS4_SYSV_ABI sceNpTrophyCreateContext(OrbisNpTrophyContext* context,
     const std::string np_comm_id = Common::ElfInfo::Instance().GetNpCommIds()[service_label];
     const auto trophy_base =
         Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "trophy" / np_comm_id;
-    ctx.xml_save_file = Common::FS::GetUserPath(Common::FS::PathType::HomeDir) /
-                        std::to_string(user_id) / "trophy" / (np_comm_id + ".xml");
+    ctx.xml_save_file =
+        EmulatorSettings.GetHomeDir() / std::to_string(user_id) / "trophy" / (np_comm_id + ".xml");
     ctx.xml_dir = trophy_base / "Xml";
     ctx.icons_dir = trophy_base / "Icons";
     ctx.trophy_xml_path = GetTrophyXmlPath(ctx.xml_dir, EmulatorSettings.GetConsoleLanguage());

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -318,9 +318,9 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
                 }
             }
             for (User user : UserSettings.GetUserManager().GetValidUsers()) {
-                auto const user_trophy_file =
-                    Common::FS::GetUserPath(Common::FS::PathType::HomeDir) /
-                    std::to_string(user.user_id) / "trophy" / (npCommId + ".xml");
+                auto const user_trophy_file = EmulatorSettings.GetHomeDir() /
+                                              std::to_string(user.user_id) / "trophy" /
+                                              (npCommId + ".xml");
                 if (!std::filesystem::exists(user_trophy_file)) {
                     auto temp = user_trophy_file.parent_path();
                     std::filesystem::create_directories(temp);


### PR DESCRIPTION
Emulator currently uses default homedir for user trophies regardless of setting.

I think this should be all that's needed to fix it, seems to work ok from cursory testing