### PR TITLE
[CI] Use VS 2026

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
         shell: bash
 
   windows-sdl:
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     needs: get-info
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
Updating CI runner for using VS 2026 because it’s the latest stable release (newer STL + Windows SDK).