### PR TITLE
For OpImageFetch, do not provide both Lod and Sample operands

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
@@ -226,7 +226,12 @@ Id EmitImageRead(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id lod
     Id texel;
     if (!texture.is_storage) {
         const Id image = ctx.OpLoad(texture.image_type, texture.id);
-        operands.Add(spv::ImageOperandsMask::Lod, lod);
+        if (texture.view_type != AmdGpu::ImageType::Color2DMsaa) {
+            if (Sirit::ValidId(ms)) {
+                LOG_ERROR(Render_Recompiler, "image is not MS but ms operand is provided");
+            }
+            operands.Add(spv::ImageOperandsMask::Lod, lod);
+        }
         texel = ctx.OpImageFetch(color_type, image, coords, operands.mask, operands.operands);
     } else {
         Id image_ptr = texture.id;

--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -1051,7 +1051,7 @@ void PatchImageSampleArgs(IR::Block& block, IR::Inst& inst, Info& info,
 
     auto texel = [&] -> IR::Value {
         if (is_msaa) {
-            return ir.ImageRead(handle, coords, ir.Imm32(0U), ir.Imm32(0U), inst_info);
+            return ir.ImageRead(handle, coords, {}, ir.Imm32(0U), inst_info);
         }
         if (inst_info.is_gather) {
             if (inst_info.is_depth) {


### PR DESCRIPTION
An attempt to fix a Vulkan validation error:
```
[Render.Vulkan] <Error> (shadPS4:GpuComm) vk_platform.cpp:57 DebugUtilsCallback: VUID-VkShaderModuleCreateInfo-pCode-08737: vkCreateShaderModule(): pCreateInfo->pCode (spirv-val produced an error):
Image Operand Lod requires 'MS' parameter to be 0
  %131 = OpImageFetch %f32vec4_id %130 %129 Lod|Sample %u32_id_0 %u32_id_0
```