### PR TITLE
GS fixes

### DIFF
--- a/src/shader_recompiler/frontend/copy_shader.cpp
+++ b/src/shader_recompiler/frontend/copy_shader.cpp
@@ -79,6 +79,7 @@ CopyShaderData ParseCopyShader(std::span<const u32> code) {
                 ASSERT(sources[index] != -1);
                 offsets[inst.src[1].code] += sources[index];
             }
+            data.num_comps++;
             break;
         }
         default:

--- a/src/shader_recompiler/frontend/copy_shader.cpp
+++ b/src/shader_recompiler/frontend/copy_shader.cpp
@@ -45,6 +45,14 @@ CopyShaderData ParseCopyShader(std::span<const u32> code) {
             sources[inst.dst[0].code] += inst.control.sopk.simm;
             break;
         }
+        case Gcn::Opcode::S_BFM_B32: {
+            ASSERT(inst.src[0].field == Gcn::OperandField::SignedConstIntPos &&
+                   inst.src[1].field == Gcn::OperandField::SignedConstIntPos);
+            const auto src0 = inst.src[0].code - Gcn::OperandFieldRange::SignedConstIntPosMin + 1;
+            const auto src1 = inst.src[1].code - Gcn::OperandFieldRange::SignedConstIntPosMin + 1;
+            sources[inst.dst[0].code] = ((1 << src0) - 1) << src1;
+            break;
+        }
         case Gcn::Opcode::EXP: {
             const auto& exp = inst.control.exp;
             const IR::Attribute semantic = static_cast<IR::Attribute>(exp.target);

--- a/src/shader_recompiler/frontend/copy_shader.h
+++ b/src/shader_recompiler/frontend/copy_shader.h
@@ -15,6 +15,7 @@ struct CopyShaderData {
     std::map<u32, std::pair<Shader::IR::Attribute, u32>> attr_map;
     u32 num_attrs{0};
     u32 output_vertices{0};
+    u32 num_comps{0};
 };
 
 CopyShaderData ParseCopyShader(std::span<const u32> code);

--- a/src/shader_recompiler/ir/passes/ring_access_elimination.cpp
+++ b/src/shader_recompiler/ir/passes/ring_access_elimination.cpp
@@ -104,6 +104,13 @@ void RingAccessElimination(const IR::Program& program, const RuntimeInfo& runtim
                         output_vertices, info.gs_copy_data.output_vertices);
             output_vertices = info.gs_copy_data.output_vertices;
         }
+        u32 dwords_per_vertex = gs_info.out_vertex_data_size;
+        if (info.gs_copy_data.num_comps && info.gs_copy_data.num_comps != dwords_per_vertex) {
+            LOG_WARNING(Render_Vulkan,
+                        "VERT_ITEMSIZE {} is different than actual number of dwords per vertex {}",
+                        dwords_per_vertex, info.gs_copy_data.num_comps);
+            dwords_per_vertex = info.gs_copy_data.num_comps;
+        }
 
         ForEachInstruction([&](IR::IREmitter& ir, IR::Inst& inst) {
             const auto opcode = inst.GetOpcode();
@@ -139,7 +146,7 @@ void RingAccessElimination(const IR::Program& program, const RuntimeInfo& runtim
                 const auto offset = inst.Flags<IR::BufferInstInfo>().inst_offset.Value();
                 const auto data = ir.BitCast<IR::F32>(IR::U32{inst.Arg(2)});
                 const auto comp_ofs = output_vertices * 4u;
-                const auto output_size = comp_ofs * gs_info.out_vertex_data_size;
+                const auto output_size = comp_ofs * dwords_per_vertex;
 
                 const auto vc_read_ofs = (((offset / comp_ofs) * comp_ofs) % output_size) * 16u;
                 const auto& it = info.gs_copy_data.attr_map.find(vc_read_ofs);


### PR DESCRIPTION
Figured out by @raphaelthegreat:
- handles S_BFM_B32 in a copy shader
- computes the number of dwords in a vertex by the number of loads in a copy shader, rather than VERT_ITEMSIZE set in the registers 