### PR TITLE
Vulkan device destroy DescriptorPool on Shutdown

### DIFF
--- a/src/imgui/renderer/imgui_impl_vulkan.cpp
+++ b/src/imgui/renderer/imgui_impl_vulkan.cpp
@@ -1219,6 +1219,10 @@ void ImGuiImplVulkanDestroyDeviceObjects() {
         v.device.destroyDescriptorSetLayout(bd->descriptor_set_layout, v.allocator);
         bd->descriptor_set_layout = VK_NULL_HANDLE;
     }
+    if (bd->descriptor_pool) {
+        v.device.destroyDescriptorPool(bd->descriptor_pool, v.allocator);
+        bd->descriptor_pool = VK_NULL_HANDLE;
+    }
     if (bd->pipeline_layout) {
         v.device.destroyPipelineLayout(bd->pipeline_layout, v.allocator);
         bd->pipeline_layout = VK_NULL_HANDLE;


### PR DESCRIPTION
```
Validation Error: [ VUID-vkDestroyDevice-device-05137 ] | MessageID = 0x4872eaa0
vkDestroyDevice(): Object Tracking - For VkDevice 0x55ac6bd22670, VkDescriptorPool 0x300000000030 has not been destroyed.
The Vulkan spec states: All child objects created on device that can be destroyed or freed must have been destroyed or freed prior to destroying device (https://docs.vulkan.org/spec/latest/chapters/devsandqueues.html#VUID-vkDestroyDevice-device-05137)
Objects: 1
    [0] VkDescriptorPool 0x300000000030
```
