### PR TITLE
Vulkan device destroy images_view on Swapchain::Destroy

### DIFF
--- a/src/video_core/renderer_vulkan/vk_swapchain.cpp
+++ b/src/video_core/renderer_vulkan/vk_swapchain.cpp
@@ -261,6 +261,12 @@ void Swapchain::Destroy() {
         LOG_WARNING(Render_Vulkan, "Failed to wait for device to become idle: {}",
                     vk::to_string(wait_result));
     }
+
+    for (auto& image_view : images_view) {
+        device.destroyImageView(image_view);
+    }
+    images_view.clear();
+
     if (swapchain) {
         device.destroySwapchainKHR(swapchain);
     }


### PR DESCRIPTION
```
Validation Error: [ VUID-vkDestroyDevice-device-05137 ] | MessageID = 0x4872eaa0
vkDestroyDevice(): Object Tracking - For VkDevice 0x55ac6bd22670, VkImageView 0x250000000025[Swapchain ImageView 1] has not been destroyed.
The Vulkan spec states: All child objects created on device that can be destroyed or freed must have been destroyed or freed prior to destroying device (https://docs.vulkan.org/spec/latest/chapters/devsandqueues.html#VUID-vkDestroyDevice-device-05137)
Objects: 1
    [0] VkImageView 0x250000000025[Swapchain ImageView 1]

Validation Error: [ VUID-vkDestroyDevice-device-05137 ] | MessageID = 0x4872eaa0
vkDestroyDevice(): Object Tracking - For VkDevice 0x55ac6bd22670, VkImageView 0x240000000024[Swapchain ImageView 0] has not been destroyed.
The Vulkan spec states: All child objects created on device that can be destroyed or freed must have been destroyed or freed prior to destroying device (https://docs.vulkan.org/spec/latest/chapters/devsandqueues.html#VUID-vkDestroyDevice-device-05137)
Objects: 1
    [0] VkImageView 0x240000000024[Swapchain ImageView 0]

Validation Error: [ VUID-vkDestroyDevice-device-05137 ] | MessageID = 0x4872eaa0
vkDestroyDevice(): Object Tracking - For VkDevice 0x55ac6bd22670, VkImageView 0x270000000027[Swapchain ImageView 3] has not been destroyed.
The Vulkan spec states: All child objects created on device that can be destroyed or freed must have been destroyed or freed prior to destroying device (https://docs.vulkan.org/spec/latest/chapters/devsandqueues.html#VUID-vkDestroyDevice-device-05137)
Objects: 1
    [0] VkImageView 0x270000000027[Swapchain ImageView 3]

Validation Error: [ VUID-vkDestroyDevice-device-05137 ] | MessageID = 0x4872eaa0
vkDestroyDevice(): Object Tracking - For VkDevice 0x55ac6bd22670, VkImageView 0x260000000026[Swapchain ImageView 2] has not been destroyed.
The Vulkan spec states: All child objects created on device that can be destroyed or freed must have been destroyed or freed prior to destroying device (https://docs.vulkan.org/spec/latest/chapters/devsandqueues.html#VUID-vkDestroyDevice-device-05137)
Objects: 1
    [0] VkImageView 0x260000000026[Swapchain ImageView 2]
```