### PR TITLE
Vulkan presenter reset CommandBuffer on *_scheduler

### DIFF
--- a/src/video_core/renderer_vulkan/vk_presenter.cpp
+++ b/src/video_core/renderer_vulkan/vk_presenter.cpp
@@ -137,7 +137,14 @@ Presenter::Presenter(Frontend::WindowSDL& window_, AmdGpu::Liverpool* liverpool_
 
 Presenter::~Presenter() {
     ImGui::Layer::RemoveLayer(Common::Singleton<Core::Devtools::Layer>::Instance());
+
     draw_scheduler.Finish();
+    present_scheduler.Finish();
+    flip_scheduler.Finish();
+    Check(draw_scheduler.CommandBuffer().reset());
+    Check(present_scheduler.CommandBuffer().reset());
+    Check(flip_scheduler.CommandBuffer().reset());
+
     const vk::Device device = instance.GetDevice();
     for (auto& frame : present_frames) {
         vmaDestroyImage(instance.GetAllocator(), frame.image, frame.allocation);


### PR DESCRIPTION
This fix an issue where images cant be destroyed because hold by CommandBuffer
```
[Render.Vulkan] <error> (shadPS4:Main) vk_platform.cpp:58 DebugUtilsCallback: VUID-vkDestroyImage-image-01000: vkDestroyImage(): can't be called on VkImage 0x850000000085[Frame image #2] that is currently in use by VkCommandBuffer 0x560ea08752c0[CommandPool: Command Buffer 2].
The Vulkan spec states: All submitted commands that refer to image, either directly or via a VkImageView, must have completed execution (https://docs.vulkan.org/spec/latest/chapters/resources.html#VUID-vkDestroyImage-image-01000)
```
Finish needed because of:
```
[Render.Vulkan] <error> (shadPS4:Main) vk_platform.cpp:58 DebugUtilsCallback: VUID-vkEndCommandBuffer-commandBuffer-00059: vkEndCommandBuffer(): Cannot be called for VkCommandBuffer 0x55c62bfbb580[CommandPool: Command Buffer 3] when it is not in a recording state, vkBeginCommandBuffer() must first be called.
The Vulkan spec states: commandBuffer must be in the recording state (https://docs.vulkan.org/spec/latest/chapters/cmdbuffers.html#VUID-vkEndCommandBuffer-commandBuffer-00059)
```