### PR TITLE
Lib.Sysmodule: Allow libSceSystemGesture LLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,12 +150,12 @@ The following firmware modules are supported and must be placed in shadPS4's `sy
 
 <div align="center">
 
-| Modules                 | Modules                 | Modules                 | Modules                 |  
-|-------------------------|-------------------------|-------------------------|-------------------------|  
-| libSceCesCs.sprx        | libSceFont.sprx         | libSceFontFt.sprx       | libSceFreeTypeOt.sprx   |
-| libSceJpegDec.sprx      | libSceJpegEnc.sprx      | libSceJson.sprx         | libSceJson2.sprx        |  
-| libSceLibcInternal.sprx | libSceNgs2.sprx         | libScePngEnc.sprx       | libSceRtc.sprx          |
-| libSceUlt.sprx          | libSceAudiodec.sprx     |                         |                         |
+| Modules                  | Modules                  | Modules                  | Modules                  |
+|--------------------------|--------------------------|--------------------------|--------------------------|
+| libSceAudiodec.sprx      | libSceCesCs.sprx         | libSceFont.sprx          | libSceFontFt.sprx        |
+| libSceFreeTypeOt.sprx    | libSceJpegDec.sprx       | libSceJpegEnc.sprx       | libSceJson.sprx          |
+| libSceJson2.sprx         | libSceLibcInternal.sprx  | libSceNgs2.sprx          | libScePngEnc.sprx        |
+| libSceRtc.sprx           | libSceSystemGesture.sprx | libSceUlt.sprx           |                          |
 </div>
 
 > [!Caution]

--- a/src/core/libraries/libs.cpp
+++ b/src/core/libraries/libs.cpp
@@ -63,7 +63,6 @@
 #include "core/libraries/system/posix.h"
 #include "core/libraries/system/systemservice.h"
 #include "core/libraries/system/userservice.h"
-#include "core/libraries/system_gesture/system_gesture.h"
 #include "core/libraries/ulobjmgr/ulobjmgr.h"
 #include "core/libraries/usbd/usbd.h"
 #include "core/libraries/videodec/videodec.h"
@@ -120,7 +119,6 @@ void InitHLELibs(Core::Loader::SymbolsResolver* sym) {
     Libraries::Random::RegisterLib(sym);
     Libraries::Usbd::RegisterLib(sym);
     Libraries::Pad::RegisterLib(sym);
-    Libraries::SystemGesture::RegisterLib(sym);
     Libraries::Ajm::RegisterLib(sym);
     Libraries::ErrorDialog::RegisterLib(sym);
     Libraries::ImeDialog::RegisterLib(sym);

--- a/src/core/libraries/sysmodule/sysmodule_internal.cpp
+++ b/src/core/libraries/sysmodule/sysmodule_internal.cpp
@@ -20,6 +20,7 @@
 #include "core/libraries/sysmodule/sysmodule_error.h"
 #include "core/libraries/sysmodule/sysmodule_internal.h"
 #include "core/libraries/sysmodule/sysmodule_table.h"
+#include "core/libraries/system_gesture/system_gesture.h"
 #include "core/linker.h"
 #include "emulator.h"
 
@@ -223,7 +224,8 @@ s32 loadModuleInternal(s32 index, s32 argc, const void* argv, s32* res_out) {
              {"libSceAudiodec.sprx", nullptr},
              {"libSceFont.sprx", &Libraries::Font::RegisterlibSceFont},
              {"libSceFontFt.sprx", &Libraries::FontFt::RegisterlibSceFontFt},
-             {"libSceFreeTypeOt.sprx", nullptr}});
+             {"libSceFreeTypeOt.sprx", nullptr},
+             {"libSceSystemGesture.sprx", &Libraries::SystemGesture::RegisterLib}});
 
         // Iterate through the allowed array
         const auto it = std::ranges::find_if(


### PR DESCRIPTION
Seems to be completely safe to LLE, based on all the decompiling I've done to try and HLE it.
Until I finish writing HLE for this thing, we might as well LLE it.