### PR TITLE
Add Visual Studio 2022 ClangCL build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -575,13 +575,31 @@ set(USBD_LIB src/core/libraries/usbd/usbd.cpp
              src/core/libraries/usbd/emulated/skylander.h
 )
 
-set(FIBER_LIB src/core/libraries/fiber/fiber_context.s
-              src/core/libraries/fiber/fiber.cpp
-              src/core/libraries/fiber/fiber.h
-              src/core/libraries/fiber/fiber_error.h
-)
-
-set_source_files_properties(src/core/libraries/fiber/fiber_context.s PROPERTIES COMPILE_OPTIONS -Wno-unused-command-line-argument)
+if (WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # ClangCL: assemble GAS .s file via custom command
+    set(FIBER_ASM_SRC "${CMAKE_CURRENT_SOURCE_DIR}/src/core/libraries/fiber/fiber_context.s")
+    set(FIBER_ASM_OBJ "${CMAKE_CURRENT_BINARY_DIR}/fiber_context.obj")
+    add_custom_command(
+        OUTPUT ${FIBER_ASM_OBJ}
+        COMMAND ${CMAKE_C_COMPILER} -c -o ${FIBER_ASM_OBJ} ${FIBER_ASM_SRC}
+        DEPENDS ${FIBER_ASM_SRC}
+        COMMENT "Assembling fiber_context.s"
+    )
+    add_custom_target(fiber_asm DEPENDS ${FIBER_ASM_OBJ})
+    set(FIBER_LIB src/core/libraries/fiber/fiber.cpp
+                  src/core/libraries/fiber/fiber.h
+                  src/core/libraries/fiber/fiber_error.h
+    )
+    set(FIBER_ASM_LINK_OBJ ${FIBER_ASM_OBJ})
+else()
+    set(FIBER_LIB src/core/libraries/fiber/fiber_context.s
+                  src/core/libraries/fiber/fiber.cpp
+                  src/core/libraries/fiber/fiber.h
+                  src/core/libraries/fiber/fiber_error.h
+    )
+    set_source_files_properties(src/core/libraries/fiber/fiber_context.s PROPERTIES COMPILE_OPTIONS -Wno-unused-command-line-argument)
+    set(FIBER_ASM_LINK_OBJ "")
+endif()
 
 set(VDEC_LIB src/core/libraries/videodec/videodec2_impl.cpp
              src/core/libraries/videodec/videodec2_impl.h
@@ -1136,6 +1154,12 @@ add_executable(shadps4
 )
 
 create_target_directory_groups(shadps4)
+
+# Link fiber assembly object on Windows/ClangCL
+if (FIBER_ASM_LINK_OBJ)
+    add_dependencies(shadps4 fiber_asm)
+    target_link_libraries(shadps4 PRIVATE ${FIBER_ASM_LINK_OBJ})
+endif()
 
 target_link_libraries(shadps4 PRIVATE magic_enum::magic_enum fmt::fmt toml11::toml11 tsl::robin_map xbyak::xbyak Tracy::TracyClient RenderDoc::API FFmpeg::ffmpeg Dear_ImGui gcn half::half ZLIB::ZLIB PNG::PNG)
 target_link_libraries(shadps4 PRIVATE Boost::headers GPUOpen::VulkanMemoryAllocator LibAtrac9 sirit Vulkan::Headers xxHash::xxhash Zydis::Zydis glslang::glslang SDL3::SDL3 SDL3_mixer::SDL3_mixer pugixml::pugixml)


### PR DESCRIPTION
## Summary
- Enable building shadPS4 with **Visual Studio 2022** using the **ClangCL toolset** (`-T ClangCL`)
- Fix GAS assembly (`fiber_context.s`) compilation on Windows by using a custom build command for ClangCL, since the VS build system cannot assemble `.s` files directly

### How to build (step by step)


### Step 0: Open Developer Command Prompt for VS 2022  (search for it in Start Menu) and run:
 
**Prerequisites:** Visual Studio 2022 with **C++ Clang tools for Windows** component installed.

**Step 1:** Clone with submodules
```
git clone --recurse-submodules https://github.com/shadps4-emu/shadPS4.git

cd shadPS4
```

If you already cloned without `--recurse-submodules`, run this to download all dependencies:
make sure you are in cd shadPS4
```
git submodule update --init --recursive
```
> **Why?** shadPS4 depends on many external libraries (boost, fmt, ffmpeg, zlib, imgui, etc.) stored as git submodules in the `externals/` folder. Without this step, those folders will be empty and CMake will fail.

**Step 2:** in **Developer Command Prompt for VS 2022**
make sure you are in cd shadPS4
```
cmake -S . -B build -G "Visual Studio 17 2022" -T ClangCL -A x64
```

**Step 3:** Open `build/shadPS4.sln` in Visual Studio 2022

**Step 4:** In **Solution Explorer**, right-click on **shadps4** and select **"Set as Startup Project"**

**Step 5:** Select your build configuration (e.g. **Release | x64**) from the toolbar, then press **Ctrl+B** or go to **Build > Build Solution**

**Step 6:**  Select **Local Windows Debugger**  or **press F5 to**  start the application.
 
## Test plan
- [x] Verified solution generates successfully with CMake
- [x] Verified project compiles without errors using ClangCL toolset
- [x] Verified shadPS4.exe runs successfully after build
- [x] Non-ClangCL builds (GCC/Clang on Linux) are unaffected — changes are guarded by `WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "Clang"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)