### PR TITLE
CMake: support Visual Studio 2022 ClangCL generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -575,13 +575,32 @@ set(USBD_LIB src/core/libraries/usbd/usbd.cpp
              src/core/libraries/usbd/emulated/skylander.h
 )
 
-set(FIBER_LIB src/core/libraries/fiber/fiber_context.s
-              src/core/libraries/fiber/fiber.cpp
-              src/core/libraries/fiber/fiber.h
-              src/core/libraries/fiber/fiber_error.h
-)
-
-set_source_files_properties(src/core/libraries/fiber/fiber_context.s PROPERTIES COMPILE_OPTIONS -Wno-unused-command-line-argument)
+if (WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_GENERATOR MATCHES "Visual Studio")
+    # Visual Studio generator with ClangCL: assemble GAS .s file via custom command
+    # since the VS build system cannot handle .s files directly.
+    set(FIBER_ASM_SRC "${CMAKE_CURRENT_SOURCE_DIR}/src/core/libraries/fiber/fiber_context.s")
+    set(FIBER_ASM_OBJ "${CMAKE_CURRENT_BINARY_DIR}/fiber_context.obj")
+    add_custom_command(
+        OUTPUT ${FIBER_ASM_OBJ}
+        COMMAND ${CMAKE_C_COMPILER} -c -o ${FIBER_ASM_OBJ} ${FIBER_ASM_SRC}
+        DEPENDS ${FIBER_ASM_SRC}
+        COMMENT "Assembling fiber_context.s with Clang"
+    )
+    add_custom_target(fiber_asm DEPENDS ${FIBER_ASM_OBJ})
+    set(FIBER_LIB src/core/libraries/fiber/fiber.cpp
+                  src/core/libraries/fiber/fiber.h
+                  src/core/libraries/fiber/fiber_error.h
+    )
+    set(FIBER_ASM_LINK_OBJ ${FIBER_ASM_OBJ})
+else()
+    set(FIBER_LIB src/core/libraries/fiber/fiber_context.s
+                  src/core/libraries/fiber/fiber.cpp
+                  src/core/libraries/fiber/fiber.h
+                  src/core/libraries/fiber/fiber_error.h
+    )
+    set_source_files_properties(src/core/libraries/fiber/fiber_context.s PROPERTIES COMPILE_OPTIONS -Wno-unused-command-line-argument)
+    set(FIBER_ASM_LINK_OBJ "")
+endif()
 
 set(VDEC_LIB src/core/libraries/videodec/videodec2_impl.cpp
              src/core/libraries/videodec/videodec2_impl.h
@@ -1136,6 +1155,12 @@ add_executable(shadps4
 )
 
 create_target_directory_groups(shadps4)
+
+# Link fiber assembly object when built via custom command (VS ClangCL)
+if (FIBER_ASM_LINK_OBJ)
+    add_dependencies(shadps4 fiber_asm)
+    target_link_libraries(shadps4 PRIVATE ${FIBER_ASM_LINK_OBJ})
+endif()
 
 target_link_libraries(shadps4 PRIVATE magic_enum::magic_enum fmt::fmt toml11::toml11 tsl::robin_map xbyak::xbyak Tracy::TracyClient RenderDoc::API FFmpeg::ffmpeg Dear_ImGui gcn half::half ZLIB::ZLIB PNG::PNG)
 target_link_libraries(shadps4 PRIVATE Boost::headers GPUOpen::VulkanMemoryAllocator LibAtrac9 sirit Vulkan::Headers xxHash::xxhash Zydis::Zydis glslang::glslang SDL3::SDL3 SDL3_mixer::SDL3_mixer pugixml::pugixml)


### PR DESCRIPTION
## Summary

- Fix GAS assembly (`fiber_context.s`) compilation on Windows by using a custom build command for ClangCL, since the VS build system cannot assemble `.s` files directly
- **Ninja and other generators are completely unaffected** — the fix only activates when `CMAKE_GENERATOR` matches `"Visual Studio"`


## Why

This allows developers to use the Visual Studio 2022 IDE with full debugging support (breakpoints, IntelliSense, F5 to run) while still compiling with **Clang** via the ClangCL toolset. shadPS4's requirement for Clang is fully met.

## How to build (step by step)

**Prerequisites:** Visual Studio 2022 with **C++ Clang tools for Windows** component installed.

### Step 0
Open **Developer Command Prompt for VS 2022** (search for it in Start Menu).

### Step 1: Clone with submodules

```bash
git clone --recurse-submodules https://github.com/shadps4-emu/shadPS4.git
cd shadPS4
```

If you already cloned without `--recurse-submodules`, run this to download all dependencies (make sure you are in `cd shadPS4`):

```bash
git submodule update --init --recursive
```

> **Why?** shadPS4 depends on many external libraries (boost, fmt, ffmpeg, zlib, imgui, etc.) stored as git submodules in the `externals/` folder. Without this step, those folders will be empty and CMake will fail.

### Step 2: Generate the Visual Studio solution

In Developer Command Prompt for VS 2022 (make sure you are in `cd shadPS4`):

```bash
cmake -S . -B build -G "Visual Studio 17 2022" -T ClangCL -A x64
```

### Step 3
Open `build/shadPS4.sln` in Visual Studio 2022.

### Step 4
In Solution Explorer, right-click on **shadps4** and select **"Set as Startup Project"**.

### Step 5
Select your build configuration (e.g. **Release | x64**) from the toolbar, then press **Ctrl+B** or go to **Build > Build Solution**.

### Step 6
Select **Local Windows Debugger** or press **F5** to start the application.

## What changed in CMakeLists.txt

When `WIN32 AND Clang AND Visual Studio generator`:
1. `fiber_context.s` is assembled via `add_custom_command` using Clang directly
2. The resulting `.obj` is linked into `shadps4` via `target_link_libraries`

Otherwise (Ninja, Make, etc.): behavior is identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)