### PR TITLE
GS: Only use number of comps if greater than VERT_ITEMSIZE

### DIFF
--- a/src/shader_recompiler/ir/passes/ring_access_elimination.cpp
+++ b/src/shader_recompiler/ir/passes/ring_access_elimination.cpp
@@ -105,7 +105,7 @@ void RingAccessElimination(const IR::Program& program, const RuntimeInfo& runtim
             output_vertices = info.gs_copy_data.output_vertices;
         }
         u32 dwords_per_vertex = gs_info.out_vertex_data_size;
-        if (info.gs_copy_data.num_comps && info.gs_copy_data.num_comps != dwords_per_vertex) {
+        if (info.gs_copy_data.num_comps && info.gs_copy_data.num_comps > dwords_per_vertex) {
             LOG_WARNING(Render_Vulkan,
                         "VERT_ITEMSIZE {} is different than actual number of dwords per vertex {}",
                         dwords_per_vertex, info.gs_copy_data.num_comps);


### PR DESCRIPTION
Should fix regressions from https://github.com/shadps4-emu/shadPS4/pull/4213