### PR TITLE
Render.Recompiler: Fix debug asserts from FoldUnpack32x2

### DIFF
--- a/src/shader_recompiler/ir/passes/constant_propagation_pass.cpp
+++ b/src/shader_recompiler/ir/passes/constant_propagation_pass.cpp
@@ -196,7 +196,7 @@ void FoldUnpack32x2(IR::Block& block, IR::Inst& inst, IR::Opcode reverse) {
     const IR::Value value{inst.Arg(0)};
     if (value.IsImmediate()) {
         IR::IREmitter ir{block, IR::Block::InstructionList::s_iterator_to(inst)};
-        const auto value_lo = ir.Imm32(value.U32());
+        const auto value_lo = ir.Imm32(static_cast<u32>(value.U64()));
         const auto value_hi = ir.Imm32(static_cast<u32>(value.U64() >> 32));
         inst.ReplaceUsesWithAndRemove(ir.CompositeConstruct(value_lo, value_hi));
         return;


### PR DESCRIPTION
Any games that hit the new FoldUnpack32x2 would trigger a debug assert (on debug builds) because we were trying to get the U32 value of a U64. Avoid this by getting the U64 value and casting it to a u32 instead.