### PR TITLE
shader_recompiler: Implement reg type tracking

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_atomic.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_atomic.cpp
@@ -444,12 +444,35 @@ Id EmitImageAtomicCmpSwap32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coo
                                  &Sirit::Module::OpAtomicCompareExchange);
 }
 
-Id EmitDataAppend(EmitContext& ctx, u32 gds_addr, u32 binding) {
-    UNREACHABLE_MSG("SPIR-V Instruction");
+static Id DataAppendConsume(EmitContext& ctx, auto&& atomic_op) {
+    const auto last_label = ctx.last_label;
+    const Id subgroup_scope{ctx.ConstU32(static_cast<u32>(spv::Scope::Subgroup))};
+    const Id exec{ctx.OpGroupNonUniformBallot(ctx.U32[4], subgroup_scope, ctx.true_value)};
+    const Id elect_cond{ctx.OpGroupNonUniformElect(ctx.U1[1], subgroup_scope)};
+    const Id append_label{ctx.OpLabel()};
+    const Id merge_label{ctx.OpLabel()};
+    ctx.OpSelectionMerge(merge_label, spv::SelectionControlMask::MaskNone);
+    ctx.OpBranchConditional(elect_cond, append_label, merge_label);
+    ctx.AddLabel(append_label);
+    const Id exec_bits{ctx.OpGroupNonUniformBallotBitCount(ctx.U32[1], subgroup_scope,
+                                                           spv::GroupOperation::Reduce, exec)};
+    const Id rtnval{atomic_op(exec_bits)};
+    ctx.OpBranch(merge_label);
+    ctx.AddLabel(merge_label);
+    Id base{ctx.OpPhi(ctx.U32[1], ctx.u32_zero_value, last_label, rtnval, append_label)};
+    return ctx.OpGroupNonUniformBroadcastFirst(ctx.U32[1], subgroup_scope, base);
 }
 
-Id EmitDataConsume(EmitContext& ctx, u32 gds_addr, u32 binding) {
-    UNREACHABLE_MSG("SPIR-V Instruction");
+Id EmitDataAppend(EmitContext& ctx, u32 gds_addr, u32 handle) {
+    return DataAppendConsume(ctx, [&](Id exec_bits) {
+        return EmitBufferAtomicIAdd32(ctx, nullptr, handle, ctx.ConstU32(gds_addr), exec_bits);
+    });
+}
+
+Id EmitDataConsume(EmitContext& ctx, u32 gds_addr, u32 handle) {
+    return DataAppendConsume(ctx, [&](Id exec_bits) {
+        return EmitBufferAtomicISub32(ctx, nullptr, handle, ctx.ConstU32(gds_addr), exec_bits);
+    });
 }
 
 } // namespace Shader::Backend::SPIRV

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -175,24 +175,19 @@ Id EmitGetAttributeU32(EmitContext& ctx, IR::Attribute attr, u32 comp) {
         ASSERT(ctx.info.l_stage == LogicalStage::Geometry ||
                ctx.info.l_stage == LogicalStage::TessellationControl);
         return ctx.OpLoad(ctx.U32[1], ctx.invocation_id);
+    case IR::Attribute::SubgroupLtMask:
+        return ctx.OpLoad(
+            ctx.U32[1], ctx.OpAccessChain(ctx.input_u32, ctx.subgroup_lt_mask, ctx.ConstU32(comp)));
     case IR::Attribute::PatchVertices:
         ASSERT(ctx.info.l_stage == LogicalStage::TessellationControl);
         return ctx.OpLoad(ctx.U32[1], ctx.patch_vertices);
     case IR::Attribute::PackedHullInvocationInfo: {
         ASSERT(ctx.info.l_stage == LogicalStage::TessellationControl);
-        // [0:8]: patch id within VGT
-        // [8:12]: output control point id
-        // But 0:8 should be treated as 0 for attribute addressing purposes
         if (ctx.runtime_info.hs_info.IsPassthrough()) {
-            // Gcn shader would run with 1 thread, but we need to run a thread for
-            // each output control point.
-            // If Gcn shader uses this value, we should make sure all threads in the
-            // Vulkan shader use 0
-            return ctx.ConstU32(0u);
-        } else {
-            const Id invocation_id = ctx.OpLoad(ctx.U32[1], ctx.invocation_id);
-            return ctx.OpShiftLeftLogical(ctx.U32[1], invocation_id, ctx.ConstU32(8u));
+            return ctx.u32_zero_value;
         }
+        const Id invocation_id = ctx.OpLoad(ctx.U32[1], ctx.invocation_id);
+        return ctx.OpShiftLeftLogical(ctx.U32[1], invocation_id, ctx.ConstU32(8u));
     }
     default:
         UNREACHABLE_MSG("Read U32 attribute {}", attr);

--- a/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
@@ -470,6 +470,7 @@ Id EmitReadLane(EmitContext& ctx, Id value, Id lane);
 Id EmitWriteLane(EmitContext& ctx, Id value, Id write_value, u32 lane);
 Id EmitBallot(EmitContext& ctx, Id bit);
 Id EmitBallotFindLsb(EmitContext& ctx, Id mask);
+Id EmitInverseBallot(EmitContext& ctx, Id mask);
 Id EmitGroupAny(EmitContext& ctx, Id bit);
 Id EmitDataAppend(EmitContext& ctx, u32 gds_addr, u32 binding);
 Id EmitDataConsume(EmitContext& ctx, u32 gds_addr, u32 binding);

--- a/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
@@ -381,6 +381,7 @@ Id EmitUGreaterThanEqual64(EmitContext& ctx, Id lhs, Id rhs);
 Id EmitLogicalOr(EmitContext& ctx, Id a, Id b);
 Id EmitLogicalAnd(EmitContext& ctx, Id a, Id b);
 Id EmitLogicalXor(EmitContext& ctx, Id a, Id b);
+Id EmitLogicalXNor(EmitContext& ctx, Id a, Id b);
 Id EmitLogicalNot(EmitContext& ctx, Id value);
 Id EmitConvertS16F32(EmitContext& ctx, Id value);
 Id EmitConvertS16F64(EmitContext& ctx, Id value);

--- a/src/shader_recompiler/backend/spirv/emit_spirv_logical.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_logical.cpp
@@ -18,6 +18,10 @@ Id EmitLogicalXor(EmitContext& ctx, Id a, Id b) {
     return ctx.OpLogicalNotEqual(ctx.U1[1], a, b);
 }
 
+Id EmitLogicalXNor(EmitContext& ctx, Id a, Id b) {
+    return ctx.OpLogicalEqual(ctx.U1[1], a, b);
+}
+
 Id EmitLogicalNot(EmitContext& ctx, Id value) {
     return ctx.OpLogicalNot(ctx.U1[1], value);
 }

--- a/src/shader_recompiler/backend/spirv/emit_spirv_warp.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_warp.cpp
@@ -6,7 +6,7 @@
 
 namespace Shader::Backend::SPIRV {
 
-Id SubgroupScope(EmitContext& ctx) {
+static Id SubgroupScope(EmitContext& ctx) {
     return ctx.ConstU32(static_cast<u32>(spv::Scope::Subgroup));
 }
 
@@ -40,6 +40,10 @@ Id EmitBallot(EmitContext& ctx, Id bit) {
 
 Id EmitBallotFindLsb(EmitContext& ctx, Id mask) {
     return ctx.OpGroupNonUniformBallotFindLSB(ctx.U32[1], SubgroupScope(ctx), mask);
+}
+
+Id EmitInverseBallot(EmitContext& ctx, Id mask) {
+    return ctx.OpGroupNonUniformInverseBallot(ctx.U1[1], SubgroupScope(ctx), mask);
 }
 
 Id EmitGroupAny(EmitContext& ctx, Id bit) {

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -340,6 +340,10 @@ void EmitContext::DefineInputs() {
             U32[1], spv::BuiltIn::SubgroupLocalInvocationId, spv::StorageClass::Input);
         Decorate(subgroup_local_invocation_id, spv::Decoration::Flat);
     }
+    if (info.loads.GetAny(IR::Attribute::SubgroupLtMask)) {
+        subgroup_lt_mask =
+            DefineVariable(U32[4], spv::BuiltIn::SubgroupLtMask, spv::StorageClass::Input);
+    }
     switch (l_stage) {
     case LogicalStage::Vertex: {
         vertex_index = DefineVariable(U32[1], spv::BuiltIn::VertexIndex, spv::StorageClass::Input);

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -273,6 +273,7 @@ public:
     Id local_invocation_id{};
     Id invocation_id{};
     Id subgroup_local_invocation_id{};
+    Id subgroup_lt_mask{};
     Id image_u32{};
     Id image_f32{};
 

--- a/src/shader_recompiler/frontend/control_flow_graph.cpp
+++ b/src/shader_recompiler/frontend/control_flow_graph.cpp
@@ -110,6 +110,7 @@ CFG::CFG(Common::ObjectPool<Block>& block_pool_, std::span<const GcnInst> inst_l
     EmitBlocks();
     LinkBlocks();
     SplitDivergenceScopes();
+    ComputePredecessors();
 }
 
 void CFG::EmitLabels() {
@@ -352,6 +353,18 @@ void CFG::LinkBlocks() {
             block.end_class = EndClass::Exit;
         } else {
             UNREACHABLE();
+        }
+    }
+}
+
+void CFG::ComputePredecessors() {
+    // For each block, register it as a predecessor of its successors.
+    for (auto& block : blocks) {
+        if (block.branch_true) {
+            block.branch_true->pred.push_back(&block);
+        }
+        if (block.branch_false && block.branch_false != block.branch_true) {
+            block.branch_false->pred.push_back(&block);
         }
     }
 }

--- a/src/shader_recompiler/frontend/control_flow_graph.h
+++ b/src/shader_recompiler/frontend/control_flow_graph.h
@@ -40,6 +40,7 @@ struct Block : Hook {
     IR::Condition cond{};
     GcnInst end_inst{};
     EndClass end_class{};
+    boost::container::small_vector<Block*, 2> pred;
     Block* branch_true{};
     Block* branch_false{};
     bool is_dummy{};
@@ -58,6 +59,7 @@ private:
     void EmitBlocks();
     void LinkBlocks();
     void SplitDivergenceScopes();
+    void ComputePredecessors();
 
     void AddLabel(Label address) {
         const auto it = std::ranges::find(labels, address);

--- a/src/shader_recompiler/frontend/translate/data_share.cpp
+++ b/src/shader_recompiler/frontend/translate/data_share.cpp
@@ -91,13 +91,7 @@ void Translator::EmitDataShare(const GcnInst& inst) {
 
 void Translator::V_READFIRSTLANE_B32(const GcnInst& inst) {
     const IR::U32 value{GetSrc(inst.src[0])};
-
-    if (info.l_stage == LogicalStage::Compute ||
-        info.l_stage == LogicalStage::TessellationControl) {
-        SetDst(inst.dst[0], ir.ReadFirstLane(value));
-    } else {
-        SetDst(inst.dst[0], value);
-    }
+    SetDst(inst.dst[0], ir.ReadFirstLane(value));
 }
 
 void Translator::V_READLANE_B32(const GcnInst& inst) {

--- a/src/shader_recompiler/frontend/translate/scalar_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_alu.cpp
@@ -95,7 +95,7 @@ void Translator::EmitScalarAlu(const GcnInst& inst) {
 
             // SOP1
         case Opcode::S_MOV_B32:
-            return S_MOV(inst);
+            return S_MOV_B32(inst);
         case Opcode::S_MOV_B64:
             return S_MOV_B64(inst);
         case Opcode::S_NOT_B64:
@@ -503,7 +503,7 @@ void Translator::S_MULK_I32(const GcnInst& inst) {
 
 // SOP1
 
-void Translator::S_MOV(const GcnInst& inst) {
+void Translator::S_MOV_B32(const GcnInst& inst) {
     if (inst.dst[0].field == OperandField::ScalarGPR) {
         if (inst.src[0].field == OperandField::ExecLo) {
             ir.SetThreadBitScalarReg(IR::ScalarReg(inst.dst[0].code), ir.GetExec());
@@ -516,16 +516,16 @@ void Translator::S_MOV(const GcnInst& inst) {
 }
 
 void Translator::S_MOV_B64(const GcnInst& inst) {
-    // Moving SGPR to SGPR is used for thread masks, like most operations, but it can also be used
-    // for moving sharps.
-    if (inst.dst[0].field == OperandField::ScalarGPR &&
-        inst.src[0].field == OperandField::ScalarGPR) {
-        ir.SetScalarReg(IR::ScalarReg(inst.dst[0].code),
-                        ir.GetScalarReg(IR::ScalarReg(inst.src[0].code)));
-        ir.SetScalarReg(IR::ScalarReg(inst.dst[0].code + 1),
-                        ir.GetScalarReg(IR::ScalarReg(inst.src[0].code + 1)));
+    auto mov_type = GetRegType(inst.src[0]);
+    if (mov_type == RegType::Undefined) {
+        mov_type = GetRegType(inst.dst[0]);
+        ASSERT_MSG(mov_type != RegType::Undefined, "Cannot deduce reg space of MOV instruction");
     }
-    SetDst1(inst.dst[0], GetSrc1(inst.src[0]));
+    if (mov_type == RegType::Scalar) {
+        SetDst64(inst.dst[0], GetSrc64(inst.src[0]));
+    } else {
+        SetDst1(inst.dst[0], GetSrc1(inst.src[0]));
+    }
 }
 
 void Translator::S_NOT_B64(const GcnInst& inst) {
@@ -591,9 +591,6 @@ void Translator::S_BITSET_B32(const GcnInst& inst, u32 bit_value) {
 }
 
 void Translator::S_SAVEEXEC_B64(NegateMode negate, bool is_or, const GcnInst& inst) {
-    // This instruction normally operates on 64-bit data (EXEC, VCC, SGPRs)
-    // However here we flatten it to 1-bit EXEC and 1-bit VCC. For the destination
-    // SGPR we have a special IR opcode for SPGRs that act as thread masks.
     IR::U1 exec{ir.GetExec()};
     const IR::U1 src{GetSrc1(inst.src[0])};
     SetDst1(inst.dst[0], exec);

--- a/src/shader_recompiler/frontend/translate/scalar_flow.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_flow.cpp
@@ -46,9 +46,7 @@ void Translator::S_BARRIER() {
 }
 
 void Translator::S_GETPC_B64(const GcnInst& inst) {
-    const IR::ScalarReg dst{inst.dst[0].code};
-    ir.SetScalarReg(dst, ir.Imm32(pc));
-    ir.SetScalarReg(dst + 1, ir.Imm32(0));
+    SetDst64(inst.dst[0], ir.Imm64(u64{pc}));
 }
 
 void Translator::S_SENDMSG(const GcnInst& inst) {

--- a/src/shader_recompiler/frontend/translate/scalar_memory.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_memory.cpp
@@ -55,6 +55,7 @@ void Translator::S_LOAD_DWORD(int num_dwords, const GcnInst& inst) {
     for (u32 i = 0; i < num_dwords; i++) {
         IR::U32 index = ir.IAdd(dword_offset, ir.Imm32(i));
         ir.SetScalarReg(dst_reg + i, ir.ReadConst(base, index));
+        type->scalar[inst.dst[0].code + i] = RegType::Scalar;
     }
 }
 
@@ -81,6 +82,7 @@ void Translator::S_BUFFER_LOAD_DWORD(int num_dwords, const GcnInst& inst) {
     for (u32 i = 0; i < num_dwords; i++) {
         const IR::U32 index = ir.IAdd(dword_offset, ir.Imm32(i));
         ir.SetScalarReg(dst_reg + i, ir.ReadConstBuffer(vsharp, index, buffer_info));
+        type->scalar[inst.dst[0].code + i] = RegType::Scalar;
     }
 }
 

--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -4,6 +4,7 @@
 #include "common/io_file.h"
 #include "common/path_util.h"
 #include "core/emulator_settings.h"
+#include "shader_recompiler/frontend/control_flow_graph.h"
 #include "shader_recompiler/frontend/decode.h"
 #include "shader_recompiler/frontend/fetch_shader.h"
 #include "shader_recompiler/frontend/translate/translate.h"
@@ -249,11 +250,39 @@ IR::VectorReg Translator::GetScratchVgpr(u32 offset) {
     const auto [it, is_new] = vgpr_map.try_emplace(offset);
     if (is_new) {
         ASSERT_MSG(next_vgpr_num < 256, "Out of VGPRs");
-        const auto new_vgpr = static_cast<IR::VectorReg>(next_vgpr_num++);
-        it->second = new_vgpr;
+        it->second = static_cast<IR::VectorReg>(next_vgpr_num++);
     }
     return it->second;
 };
+
+Translator::RegType Translator::GetRegType(const InstOperand& operand) const {
+    if (operand.field == OperandField::ScalarGPR) {
+        return type->scalar[operand.code];
+    }
+    if (operand.field == OperandField::VccLo || operand.field == OperandField::VccHi) {
+        return type->vcc;
+    }
+    if (operand.field == OperandField::ExecLo) {
+        return RegType::ThreadBitLo;
+    }
+    if (operand.field == OperandField::ExecHi) {
+        return RegType::ThreadBitHi;
+    }
+    // These are literals used for thread bit operations so force caller to check another argument
+    // to confirm
+    if (operand.field == OperandField::ConstZero) {
+        return RegType::Undefined;
+    }
+    if (operand.field == OperandField::SignedConstIntNeg &&
+        (-s32(operand.code) + SignedConstIntNegMin - 1) == -1) {
+        return RegType::Undefined;
+    }
+    if (operand.field == OperandField::LiteralConst &&
+        (operand.code == 0 || operand.code == std::numeric_limits<u32>::max())) {
+        return RegType::Undefined;
+    }
+    return RegType::Scalar;
+}
 
 IR::U1 Translator::GetSrc1(const InstOperand& operand) {
     switch (operand.field) {
@@ -293,7 +322,21 @@ T Translator::GetSrc(const InstOperand& operand) {
     T value{};
     switch (operand.field) {
     case OperandField::ScalarGPR:
-        value = ir.GetScalarReg<T>(IR::ScalarReg(operand.code));
+        if (type->scalar[operand.code] == RegType::Scalar) {
+            value = ir.GetScalarReg<T>(IR::ScalarReg(operand.code));
+        } else if (type->scalar[operand.code] == RegType::ThreadBitLo ||
+                   type->scalar[operand.code] == RegType::ThreadBitHi) {
+            const auto reg = ir.GetThreadBitScalarReg(IR::ScalarReg(operand.code));
+            const auto bits = IR::U32{ir.CompositeExtract(
+                ir.Ballot(reg), type->scalar[operand.code] == RegType::ThreadBitHi)};
+            if constexpr (is_float) {
+                value = ir.BitCast<T, IR::U32>(bits);
+            } else {
+                value = bits;
+            }
+        } else {
+            UNREACHABLE();
+        }
         break;
     case OperandField::VectorGPR:
         value = ir.GetVectorReg<T>(IR::VectorReg(operand.code));
@@ -334,20 +377,28 @@ T Translator::GetSrc(const InstOperand& operand) {
     case OperandField::ConstFloatNeg_4_0:
         value = get_imm(-4.0f);
         break;
-    case OperandField::VccLo:
+    case OperandField::VccLo: {
+        const IR::U32 vcc_lo = type->vcc == RegType::ThreadBitLo
+                                   ? IR::U32{ir.CompositeExtract(ir.Ballot(ir.GetVcc()), 0)}
+                                   : ir.GetVccLo();
         if constexpr (is_float) {
-            value = ir.BitCast<IR::F32>(ir.GetVccLo());
+            value = ir.BitCast<IR::F32>(vcc_lo);
         } else {
-            value = ir.GetVccLo();
+            value = vcc_lo;
         }
         break;
-    case OperandField::VccHi:
+    }
+    case OperandField::VccHi: {
+        const IR::U32 vcc_hi = type->vcc == RegType::ThreadBitLo
+                                   ? IR::U32{ir.CompositeExtract(ir.Ballot(ir.GetVcc()), 1)}
+                                   : ir.GetVccHi();
         if constexpr (is_float) {
-            value = ir.BitCast<IR::F32>(ir.GetVccHi());
+            value = ir.BitCast<IR::F32>(vcc_hi);
         } else {
-            value = ir.GetVccHi();
+            value = vcc_hi;
         }
         break;
+    }
     case OperandField::M0:
         if constexpr (is_float) {
             value = ir.BitCast<IR::F32>(ir.GetM0());
@@ -360,6 +411,22 @@ T Translator::GetSrc(const InstOperand& operand) {
             UNREACHABLE();
         } else {
             value = ir.BitCast<IR::U32>(ir.GetScc());
+        }
+        break;
+    case OperandField::ExecLo:
+        if constexpr (is_float) {
+            UNREACHABLE();
+        } else {
+            LOG_WARNING(Render_Recompiler, "ExecLo source used");
+            value = IR::U32{ir.CompositeExtract(ir.Ballot(ir.GetExec()), 0)};
+        }
+        break;
+    case OperandField::ExecHi:
+        if constexpr (is_float) {
+            UNREACHABLE();
+        } else {
+            LOG_WARNING(Render_Recompiler, "ExecHi source used");
+            value = IR::U32{ir.CompositeExtract(ir.Ballot(ir.GetExec()), 1)};
         }
         break;
     default:
@@ -402,8 +469,19 @@ T Translator::GetSrc64(const InstOperand& operand) {
     T value{};
     switch (operand.field) {
     case OperandField::ScalarGPR: {
-        const auto value_lo = ir.GetScalarReg(IR::ScalarReg(operand.code));
-        const auto value_hi = ir.GetScalarReg(IR::ScalarReg(operand.code + 1));
+        IR::U32 value_lo, value_hi;
+        if (type->scalar[operand.code] == RegType::Scalar) {
+            value_lo = ir.GetScalarReg(IR::ScalarReg(operand.code));
+            value_hi = ir.GetScalarReg(IR::ScalarReg(operand.code + 1));
+        } else if (type->scalar[operand.code] == RegType::ThreadBitLo &&
+                   type->scalar[operand.code + 1] == RegType::ThreadBitHi) {
+            const auto value_bits =
+                ir.Ballot(ir.GetThreadBitScalarReg(IR::ScalarReg(operand.code)));
+            value_lo = IR::U32{ir.CompositeExtract(value_bits, 0)};
+            value_hi = IR::U32{ir.CompositeExtract(value_bits, 1)};
+        } else {
+            UNREACHABLE_MSG("Undefined scalar type");
+        }
         if constexpr (is_float) {
             value = ir.PackDouble2x32(ir.CompositeConstruct(value_lo, value_hi));
         } else {
@@ -457,14 +535,25 @@ T Translator::GetSrc64(const InstOperand& operand) {
     case OperandField::ConstFloatNeg_4_0:
         value = get_imm(-4.0);
         break;
-    case OperandField::VccLo:
-        if constexpr (is_float) {
-            value = ir.PackDouble2x32(ir.CompositeConstruct(ir.GetVccLo(), ir.GetVccHi()));
+    case OperandField::VccLo: {
+        IR::U32 value_lo, value_hi;
+        if (type->vcc == RegType::Scalar) {
+            value_lo = ir.GetVccLo();
+            value_hi = ir.GetVccHi();
+        } else if (type->vcc == RegType::ThreadBitLo) {
+            const auto value_bits = ir.Ballot(ir.GetVcc());
+            value_lo = IR::U32{ir.CompositeExtract(value_bits, 0)};
+            value_hi = IR::U32{ir.CompositeExtract(value_bits, 1)};
         } else {
-            value = ir.PackUint2x32(ir.CompositeConstruct(ir.GetVccLo(), ir.GetVccHi()));
+            UNREACHABLE();
+        }
+        if constexpr (is_float) {
+            value = ir.PackDouble2x32(ir.CompositeConstruct(value_lo, value_hi));
+        } else {
+            value = ir.PackUint2x32(ir.CompositeConstruct(value_lo, value_hi));
         }
         break;
-    case OperandField::VccHi:
+    }
     default:
         UNREACHABLE();
     }
@@ -503,9 +592,12 @@ template IR::F64 Translator::GetSrc64<IR::F64>(const InstOperand&);
 void Translator::SetDst1(const InstOperand& operand, const IR::U1& value) {
     switch (operand.field) {
     case OperandField::VccLo:
+        type->vcc = RegType::ThreadBitLo;
         ir.SetVcc(value);
         break;
     case OperandField::ScalarGPR:
+        type->scalar[operand.code] = RegType::ThreadBitLo;
+        type->scalar[operand.code + 1] = RegType::ThreadBitHi;
         ir.SetThreadBitScalarReg(IR::ScalarReg(operand.code), value);
         break;
     case OperandField::ExecLo:
@@ -529,12 +621,15 @@ void Translator::SetDst(const InstOperand& operand, const IR::U32F32& value) {
 
     switch (operand.field) {
     case OperandField::ScalarGPR:
+        type->scalar[operand.code] = RegType::Scalar;
         return ir.SetScalarReg(IR::ScalarReg(operand.code), result);
     case OperandField::VectorGPR:
         return ir.SetVectorReg(IR::VectorReg(operand.code), result);
     case OperandField::VccLo:
+        type->vcc = RegType::Scalar;
         return ir.SetVccLo(result);
     case OperandField::VccHi:
+        type->vcc = RegType::Scalar;
         return ir.SetVccHi(result);
     case OperandField::M0:
         return ir.SetM0(result);
@@ -563,20 +658,25 @@ void Translator::SetDst64(const InstOperand& operand, const IR::U64F64& value_ra
     const IR::U32 hi{ir.CompositeExtract(unpacked, 1U)};
     switch (operand.field) {
     case OperandField::ScalarGPR:
+        type->scalar[operand.code] = RegType::Scalar;
+        type->scalar[operand.code + 1] = RegType::Scalar;
         ir.SetScalarReg(IR::ScalarReg(operand.code + 1), hi);
         return ir.SetScalarReg(IR::ScalarReg(operand.code), lo);
     case OperandField::VectorGPR:
         ir.SetVectorReg(IR::VectorReg(operand.code + 1), hi);
         return ir.SetVectorReg(IR::VectorReg(operand.code), lo);
     case OperandField::VccLo:
+        type->vcc = RegType::Scalar;
         ir.SetVccLo(lo);
         return ir.SetVccHi(hi);
-    case OperandField::VccHi:
-        UNREACHABLE();
     case OperandField::M0:
         break;
+    case OperandField::ExecLo:
+        ir.SetExec(ir.InverseBallot(
+            ir.CompositeConstruct(unpacked, ir.CompositeConstruct(ir.Imm32(0u), ir.Imm32(0u)))));
+        break;
     default:
-        UNREACHABLE();
+        UNREACHABLE_MSG("Unknown field {}", u32(operand.field));
     }
 }
 
@@ -650,6 +750,31 @@ void Translator::Translate(IR::Block* block, u32 start_pc, std::span<const GcnIn
         return;
     }
     ir = IR::IREmitter{*block, block->begin()};
+    const auto* cfg_block = block->cfg_block;
+    type = &block_types[cfg_block];
+    // Find a predecessor that has been processed and has type information
+    for (auto* pred_block : block->cfg_block->pred) {
+        const auto it = block_types.find(pred_block);
+        if (it != block_types.end()) {
+            *type = it->second;
+            break;
+        }
+    }
+    // Match types with other predecessors. If the type mismatches set it to undefined
+    for (auto* pred_block : block->cfg_block->pred) {
+        const auto it = block_types.find(pred_block);
+        if (it == block_types.end()) {
+            continue;
+        }
+        for (u32 i = 0; i < it->second.scalar.size(); i++) {
+            if (type->scalar[i] != it->second.scalar[i]) {
+                type->scalar[i] = RegType::Undefined;
+            }
+        }
+        if (type->vcc != it->second.vcc) {
+            type->vcc = RegType::Undefined;
+        }
+    }
     pc = start_pc;
     for (const auto& inst : inst_list) {
         pc += inst.length;

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -115,7 +115,7 @@ public:
     void S_MULK_I32(const GcnInst& inst);
 
     // SOP1
-    void S_MOV(const GcnInst& inst);
+    void S_MOV_B32(const GcnInst& inst);
     void S_MOV_B64(const GcnInst& inst);
     void S_NOT_B64(const GcnInst& inst);
     void S_BREV_B32(const GcnInst& inst);
@@ -185,7 +185,7 @@ public:
     void V_CVT_PKRTZ_F16_F32(const GcnInst& inst);
 
     // VOP1
-    void V_MOV(const GcnInst& inst);
+    void V_MOV_B32(const GcnInst& inst);
     void V_READFIRSTLANE_B32(const GcnInst& inst);
     void V_CVT_I32_F64(const GcnInst& inst);
     void V_CVT_F64_I32(const GcnInst& inst);
@@ -331,6 +331,14 @@ private:
 
     IR::VectorReg GetScratchVgpr(u32 offset);
 
+    enum class RegType : u8 {
+        Scalar,
+        ThreadBitLo,
+        ThreadBitHi,
+        Undefined,
+    };
+    RegType GetRegType(const InstOperand& operand) const;
+
 private:
     IR::IREmitter ir;
     Info& info;
@@ -341,6 +349,12 @@ private:
     std::array<IR::Attribute, MaxInterpVgpr> vgpr_to_interp{};
     bool opcode_missing = false;
     u32 pc{};
+    struct RegsType {
+        std::array<RegType, IR::NumScalarRegs> scalar{};
+        RegType vcc{};
+    };
+    std::unordered_map<const Gcn::Block*, RegsType> block_types;
+    RegsType* type{};
 };
 
 } // namespace Shader::Gcn

--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -1102,6 +1102,14 @@ void Translator::V_CMP_U64(ConditionOp op, bool is_signed, bool set_exec, const 
             return ir.IEqual(src0, src1);
         case ConditionOp::LG:
             return ir.INotEqual(src0, src1);
+        case ConditionOp::GT:
+            return ir.IGreaterThan(src0, src1, is_signed);
+        case ConditionOp::LT:
+            return ir.ILessThan(src0, src1, is_signed);
+        case ConditionOp::LE:
+            return ir.ILessThanEqual(src0, src1, is_signed);
+        case ConditionOp::GE:
+            return ir.IGreaterThanEqual(src0, src1, is_signed);
         default:
             UNREACHABLE_MSG("Unsupported V_CMP_U64 condition operation: {}", u32(op));
         }

--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -103,7 +103,7 @@ void Translator::EmitVectorAlu(const GcnInst& inst) {
 
         // VOP1
     case Opcode::V_MOV_B32:
-        return V_MOV(inst);
+        return V_MOV_B32(inst);
     case Opcode::V_READFIRSTLANE_B32:
         return V_READFIRSTLANE_B32(inst);
     case Opcode::V_CVT_I32_F64:
@@ -456,10 +456,8 @@ void Translator::EmitVectorAlu(const GcnInst& inst) {
 // VOP2
 
 void Translator::V_CNDMASK_B32(const GcnInst& inst) {
-    const IR::ScalarReg flag_reg{inst.src[2].code};
-    const IR::U1 flag = inst.src[2].field == OperandField::ScalarGPR
-                            ? ir.GetThreadBitScalarReg(flag_reg)
-                            : ir.GetVcc();
+    const IR::U1 flag{inst.src[2].field == OperandField::Undefined ? ir.GetVcc()
+                                                                   : GetSrc1(inst.src[2])};
     const IR::Value result =
         ir.Select(flag, GetSrc<IR::F32>(inst.src[1]), GetSrc<IR::F32>(inst.src[0]));
     SetDst(inst.dst[0], IR::U32F32{result});
@@ -620,35 +618,9 @@ void Translator::V_BCNT_U32_B32(const GcnInst& inst) {
 }
 
 void Translator::V_MBCNT_U32_B32(bool is_low, const GcnInst& inst) {
-    if (!is_low) {
-        // v_mbcnt_hi_u32_b32 vX, -1, 0
-        if (inst.src[0].field == OperandField::SignedConstIntNeg && inst.src[0].code == 193 &&
-            inst.src[1].field == OperandField::ConstZero) {
-            return;
-        }
-        // v_mbcnt_hi_u32_b32 vX, exec_hi, 0/vZ
-        if ((inst.src[0].field == OperandField::ExecHi ||
-             inst.src[0].field == OperandField::VccHi ||
-             inst.src[0].field == OperandField::ScalarGPR) &&
-            (inst.src[1].field == OperandField::ConstZero ||
-             inst.src[1].field == OperandField::VectorGPR)) {
-            return SetDst(inst.dst[0], GetSrc(inst.src[1]));
-        }
-        UNREACHABLE();
-    } else {
-        // v_mbcnt_lo_u32_b32 vY, -1, vX
-        // used combined with above to fetch lane id in non-compute stages
-        if (inst.src[0].field == OperandField::SignedConstIntNeg && inst.src[0].code == 193) {
-            return SetDst(inst.dst[0], ir.LaneId());
-        }
-        // v_mbcnt_lo_u32_b32 vY, exec_lo, vX
-        // used combined with above for append buffer indexing.
-        if (inst.src[0].field == OperandField::ExecLo || inst.src[0].field == OperandField::VccLo ||
-            inst.src[0].field == OperandField::ScalarGPR) {
-            return SetDst(inst.dst[0], GetSrc(inst.src[1]));
-        }
-        UNREACHABLE();
-    }
+    const IR::U32 thread_mask{ir.GetAttributeU32(IR::Attribute::SubgroupLtMask, is_low ? 0 : 1)};
+    SetDst(inst.dst[0], ir.IAdd(ir.BitCount(ir.BitwiseAnd(GetSrc(inst.src[0]), thread_mask)),
+                                GetSrc(inst.src[1])));
 }
 
 void Translator::V_ADD_I32(const GcnInst& inst) {
@@ -748,7 +720,7 @@ void Translator::V_CVT_PKRTZ_F16_F32(const GcnInst& inst) {
 
 // VOP1
 
-void Translator::V_MOV(const GcnInst& inst) {
+void Translator::V_MOV_B32(const GcnInst& inst) {
     SetDst(inst.dst[0], GetSrc<IR::F32>(inst.src[0]));
 }
 
@@ -1122,38 +1094,18 @@ void Translator::V_CMP_U32(ConditionOp op, bool is_signed, bool set_exec, const 
 }
 
 void Translator::V_CMP_U64(ConditionOp op, bool is_signed, bool set_exec, const GcnInst& inst) {
-    const bool is_zero = inst.src[1].field == OperandField::ConstZero;
-    const bool is_neg_one = inst.src[1].field == OperandField::SignedConstIntNeg;
-    ASSERT(is_zero || is_neg_one);
-    if (is_neg_one) {
-        ASSERT_MSG(-s32(inst.src[1].code) + SignedConstIntNegMin - 1 == -1,
-                   "SignedConstIntNeg must be -1");
-    }
-
-    const IR::U1 src0 = [&] {
-        switch (inst.src[0].field) {
-        case OperandField::ScalarGPR:
-            return ir.GetThreadBitScalarReg(IR::ScalarReg(inst.src[0].code));
-        case OperandField::VccLo:
-            return ir.GetVcc();
-        default:
-            UNREACHABLE_MSG("src0 = {}", u32(inst.src[0].field));
-        }
-    }();
+    const IR::U64 src0{GetSrc64(inst.src[0])};
+    const IR::U64 src1{GetSrc64(inst.src[1])};
     const IR::U1 result = [&] {
         switch (op) {
         case ConditionOp::EQ:
-            return is_zero ? ir.LogicalNot(src0) : src0;
-        case ConditionOp::LG: // NE
-            return is_zero ? src0 : ir.LogicalNot(src0);
-        case ConditionOp::GT:
-            ASSERT(is_zero);
-            return ir.GroupAny(ir.GetThreadBitScalarReg(IR::ScalarReg(inst.src[0].code)));
+            return ir.IEqual(src0, src1);
+        case ConditionOp::LG:
+            return ir.INotEqual(src0, src1);
         default:
             UNREACHABLE_MSG("Unsupported V_CMP_U64 condition operation: {}", u32(op));
         }
     }();
-
     if (is_signed) {
         UNREACHABLE_MSG("V_CMP_U64 with signed integers is not supported");
     }

--- a/src/shader_recompiler/ir/attribute.cpp
+++ b/src/shader_recompiler/ir/attribute.cpp
@@ -166,6 +166,8 @@ std::string NameOf(Attribute attribute) {
         return "SampleMask";
     case Attribute::PackedAncillary:
         return "PackedAncillary";
+    case Attribute::SubgroupLtMask:
+        return "SubgroupLtMask";
     default:
         break;
     }

--- a/src/shader_recompiler/ir/attribute.h
+++ b/src/shader_recompiler/ir/attribute.h
@@ -91,6 +91,7 @@ enum class Attribute : u64 {
     StencilRef = 94,
     SampleMask = 95,
     PackedAncillary = 96,
+    SubgroupLtMask = 97,
     Max,
 };
 

--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -672,6 +672,10 @@ U32 IREmitter::BallotFindLsb(const Value& mask) {
     return Inst<U32>(Opcode::BallotFindLsb, mask);
 }
 
+U1 IREmitter::InverseBallot(const Value& mask) {
+    return Inst<U1>(Opcode::InverseBallot, mask);
+}
+
 U1 IREmitter::GroupAny(const U1& bit) {
     return Inst<U1>(Opcode::GroupAny, bit);
 }

--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -1813,6 +1813,10 @@ U1 IREmitter::LogicalXor(const U1& a, const U1& b) {
     return Inst<U1>(Opcode::LogicalXor, a, b);
 }
 
+U1 IREmitter::LogicalXNor(const U1& a, const U1& b) {
+    return Inst<U1>(Opcode::LogicalXNor, a, b);
+}
+
 U1 IREmitter::LogicalNot(const U1& value) {
     return Inst<U1>(Opcode::LogicalNot, value);
 }

--- a/src/shader_recompiler/ir/ir_emitter.h
+++ b/src/shader_recompiler/ir/ir_emitter.h
@@ -180,6 +180,7 @@ public:
     [[nodiscard]] U32 WriteLane(const U32& value, const U32& write_value, const U32& lane);
     [[nodiscard]] Value Ballot(const U1& bit);
     [[nodiscard]] U32 BallotFindLsb(const Value& mask);
+    [[nodiscard]] U1 InverseBallot(const Value& mask);
     [[nodiscard]] U1 GroupAny(const U1& bit);
 
     [[nodiscard]] Value CompositeConstruct(const Value& e1, const Value& e2);

--- a/src/shader_recompiler/ir/ir_emitter.h
+++ b/src/shader_recompiler/ir/ir_emitter.h
@@ -319,6 +319,7 @@ public:
     [[nodiscard]] U1 LogicalOr(const U1& a, const U1& b);
     [[nodiscard]] U1 LogicalAnd(const U1& a, const U1& b);
     [[nodiscard]] U1 LogicalXor(const U1& a, const U1& b);
+    [[nodiscard]] U1 LogicalXNor(const U1& a, const U1& b);
     [[nodiscard]] U1 LogicalNot(const U1& value);
 
     [[nodiscard]] U32U64 ConvertFToS(size_t bitsize, const F32F64& value);

--- a/src/shader_recompiler/ir/opcodes.inc
+++ b/src/shader_recompiler/ir/opcodes.inc
@@ -452,6 +452,7 @@ OPCODE(ReadLane,                                            U32,            U32,
 OPCODE(WriteLane,                                           U32,            U32,            U32,            U32                                             )
 OPCODE(Ballot,                                              U32x4,          U1,                                                                             )
 OPCODE(BallotFindLsb,                                       U32,            U32x4,                                                                          )
+OPCODE(InverseBallot,                                       U1,             U32x4,                                                                          )
 OPCODE(DataAppend,                                          U32,            U32,            U32                                                             )
 OPCODE(DataConsume,                                         U32,            U32,            U32                                                             )
 OPCODE(GroupAny,                                            U1,             U1,                                                                             )

--- a/src/shader_recompiler/ir/opcodes.inc
+++ b/src/shader_recompiler/ir/opcodes.inc
@@ -387,6 +387,7 @@ OPCODE(UGreaterThanEqual64,                                 U1,             U64,
 OPCODE(LogicalOr,                                           U1,             U1,             U1,                                                             )
 OPCODE(LogicalAnd,                                          U1,             U1,             U1,                                                             )
 OPCODE(LogicalXor,                                          U1,             U1,             U1,                                                             )
+OPCODE(LogicalXNor,                                         U1,             U1,             U1,                                                             )
 OPCODE(LogicalNot,                                          U1,             U1,                                                                             )
 
 // Conversion operations

--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -703,13 +703,9 @@ void PatchGlobalDataShareAccess(IR::Block& block, IR::Inst& inst, Info& info,
             gds_addr = m0_val & 0xFFFF;
         }
 
-        // Patch instruction to GDS buffer atomic increment/decrement.
-        const IR::U32 handle = ir.Imm32(binding);
-        const IR::U32 index = ir.Imm32(gds_addr >> 2);
-        const bool is_append = inst.GetOpcode() == IR::Opcode::DataAppend;
-        const IR::Value prev = is_append ? ir.BufferAtomicInc(handle, index, {})
-                                         : ir.BufferAtomicDec(handle, index, {});
-        inst.ReplaceUsesWithAndRemove(prev);
+        // Patch instruction.
+        inst.SetArg(0, ir.Imm32(gds_addr >> 2));
+        inst.SetArg(1, ir.Imm32(binding));
     } else {
         // Convert shared memory opcode to storage buffer atomic to GDS buffer.
         auto& buffer = info.buffers[binding];

--- a/src/shader_recompiler/ir/passes/shader_info_collection_pass.cpp
+++ b/src/shader_recompiler/ir/passes/shader_info_collection_pass.cpp
@@ -123,6 +123,10 @@ void Visit(Info& info, const IR::Inst& inst) {
     case IR::Opcode::BufferAtomicUMin64:
         info.uses_buffer_int64_atomics = true;
         break;
+    case IR::Opcode::DataAppend:
+    case IR::Opcode::DataConsume:
+        info.uses_group_ballot = true;
+        [[fallthrough]];
     case IR::Opcode::LaneId:
         info.uses_lane_id = true;
         break;


### PR DESCRIPTION
In the GCN architecture general purpose registers are mostly 32-bit wide, with the exception of VCC which is 64-bit (though its lower and upper 32-bit parts can also be used as registers). EXEC is also 64-bit and is used to modify the control flow of instructions, but its technically not general purpose even though most instructions can write to or read from it. With it being a 64-bit register, its manipulation is usually done with 64-bit arithmetic instructions.

For the simplicity of the generated code the recompiler has the concept of thread-bit type, which in the guest code is a subgroup-shared 64-bit bitmask meant to be stored into EXEC at some point, but in IR its represented as a boolean condition local to each thread. This makes resulting code more sane.

To avoid fighting the IR type system, even though the scalar and thread-bit SGPRs/VCC are the same registers, they are treated as separate register spaces in SSA. That works because guest shaders will not mix and match them. A thread-bit mask will be generated by specific instructions like V_CMP, consumed and then the SGPRs will be overwritten by scalar operations.

However cases have started to appear where this separation is breached or certain instructions which are ambiguous in nature, where its not certain which register space could be used. Some of these are the MBCNT instructions and the CMP_U64 family of instructions. The former until this point also wasn't actually implemented, rather substituted with a heuristic implementation suited to most of its practical uses. This PR replaces the heuristic with an actual implementation as well and adjusts DataAppend/DataConsume to work with the new implementation is mimics how the HW instruction works. The previous heuristic generated much cleaner code, but I believe the cost is negligible. 

Type tracking is done as simply as possible, reg state is kept in a per CFG block structure. For each new CFG block, all processed predecessors are checked to "inherit" the state. If there are multiple predecessors the states are compared, if the state of a reg mismatches, its set as undefined (its expected the new block should not touch it then or overwrite the value to a defined type)