### PR TITLE
Lib.Pad: Remove special pad errors

### DIFF
--- a/src/core/libraries/pad/pad.cpp
+++ b/src/core/libraries/pad/pad.cpp
@@ -288,13 +288,6 @@ int PS4_SYSV_ABI scePadOpen(Libraries::UserService::OrbisUserServiceUserId userI
     if (type == ORBIS_PAD_PORT_TYPE_REMOTE_CONTROL) {
         return ORBIS_PAD_ERROR_INVALID_ARG;
     }
-    if (EmulatorSettings.IsUsingSpecialPad()) {
-        if (type != ORBIS_PAD_PORT_TYPE_SPECIAL)
-            return ORBIS_PAD_ERROR_DEVICE_NOT_CONNECTED;
-    } else {
-        if (type != ORBIS_PAD_PORT_TYPE_STANDARD)
-            return ORBIS_PAD_ERROR_DEVICE_NOT_CONNECTED;
-    }
     auto u = UserManagement.GetUserByID(userId);
     if (!u) {
         return ORBIS_DEVICE_SERVICE_ERROR_USER_NOT_LOGIN;
@@ -311,13 +304,6 @@ int PS4_SYSV_ABI scePadOpen(Libraries::UserService::OrbisUserServiceUserId userI
 int PS4_SYSV_ABI scePadOpenExt(Libraries::UserService::OrbisUserServiceUserId userId, s32 type,
                                s32 index, const OrbisPadOpenExtParam* pParam) {
     LOG_ERROR(Lib_Pad, "(STUBBED) called");
-    if (EmulatorSettings.IsUsingSpecialPad()) {
-        if (type != ORBIS_PAD_PORT_TYPE_SPECIAL)
-            return ORBIS_PAD_ERROR_DEVICE_NOT_CONNECTED;
-    } else {
-        if (type != ORBIS_PAD_PORT_TYPE_STANDARD && type != ORBIS_PAD_PORT_TYPE_REMOTE_CONTROL)
-            return ORBIS_PAD_ERROR_DEVICE_NOT_CONNECTED;
-    }
     auto u = UserManagement.GetUserByID(userId);
     if (!u) {
         return ORBIS_DEVICE_SERVICE_ERROR_USER_NOT_LOGIN;


### PR DESCRIPTION
I'm not sure where this sort of check should exist, but it's certainly not in scePadOpen. Removing these fixes the input regressions in several Unity titles after #4027.

This needs testing with titles that actually used special pads (if I remember right, this hack was for Rock Band titles?)