### PR TITLE
PoC: Wine, 39-bit VA and hex-emu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1238,13 +1238,6 @@ if (WIN32)
     else()
         target_link_options(shadps4 PRIVATE -Wl,--stack,2097152)
     endif()
-
-    # Change base image address
-    if (MSVC)
-        target_link_options(shadps4 PRIVATE /BASE:0x700000000000)
-    else()
-        target_link_options(shadps4 PRIVATE -Wl,--image-base=0x700000000000)
-    endif()
 endif()
 
 if (WIN32)

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -129,7 +129,7 @@ struct AddressSpace::Impl {
         s32 sdk_ver = Common::ElfInfo::Instance().CompiledSdkVer();
         if (os_version_info.dwBuildNumber <= AffectedBuildNumber ||
             sdk_ver >= Common::ElfInfo::FW_30) {
-            supported_user_max = 0x10000000000ULL;
+            supported_user_max = EmulatorSettings.GetSupportedUserMax();
             // Only log the message if we're restricting the user max due to operating system.
             // Since higher compiled SDK versions also get reduced max, we don't need to log there.
             if (sdk_ver < Common::ElfInfo::FW_30) {
@@ -141,7 +141,7 @@ struct AddressSpace::Impl {
         }
 
         // Determine the free address ranges we can access.
-        VAddr next_addr = SYSTEM_MANAGED_MIN;
+        VAddr next_addr = 0x80000000ULL;
         MEMORY_BASIC_INFORMATION info{};
         while (next_addr <= supported_user_max) {
             ASSERT_MSG(VirtualQuery(reinterpret_cast<PVOID>(next_addr), &info, sizeof(info)),

--- a/src/core/emulator_settings.cpp
+++ b/src/core/emulator_settings.cpp
@@ -71,6 +71,10 @@ std::optional<T> get_optional(const toml::value& v, const std::string& key) {
         if (it->second.is_boolean()) {
             return toml::get<bool>(it->second);
         }
+    } else if constexpr (std::is_same_v<T, u64>) {
+        if (it->second.is_integer()) {
+            return static_cast<u64>(toml::get<u64>(it->second));
+        }
     } else {
         static_assert([] { return false; }(), "Unsupported type in get_optional<T>");
     }

--- a/src/core/emulator_settings.h
+++ b/src/core/emulator_settings.h
@@ -179,6 +179,7 @@ struct GeneralSettings {
     Setting<bool> neo_mode{false};
     Setting<bool> dev_kit_mode{false};
     Setting<int> extra_dmem_in_mbytes{0};
+    Setting<u64> supported_user_max{0x7000000000};
     Setting<bool> psn_signed_in{false};
     Setting<bool> trophy_popup_disabled{false};
     Setting<double> trophy_notification_duration{6.0};
@@ -201,6 +202,8 @@ struct GeneralSettings {
             make_override<GeneralSettings>("dev_kit_mode", &GeneralSettings::dev_kit_mode),
             make_override<GeneralSettings>("extra_dmem_in_mbytes",
                                            &GeneralSettings::extra_dmem_in_mbytes),
+            make_override<GeneralSettings>("supported_user_max",
+                                           &GeneralSettings::supported_user_max),
             make_override<GeneralSettings>("psn_signed_in", &GeneralSettings::psn_signed_in),
             make_override<GeneralSettings>("trophy_popup_disabled",
                                            &GeneralSettings::trophy_popup_disabled),
@@ -219,11 +222,12 @@ struct GeneralSettings {
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(GeneralSettings, install_dirs, addon_install_dir, home_dir,
                                    sys_modules_dir, font_dir, volume_slider, neo_mode, dev_kit_mode,
-                                   extra_dmem_in_mbytes, psn_signed_in, trophy_popup_disabled,
-                                   trophy_notification_duration, log_filter, log_type, show_splash,
-                                   identical_log_grouped, trophy_notification_side,
-                                   connected_to_network, discord_rpc_enabled, show_fps_counter,
-                                   console_language, big_picture_scale)
+                                   extra_dmem_in_mbytes, supported_user_max, psn_signed_in,
+                                   trophy_popup_disabled, trophy_notification_duration, log_filter,
+                                   log_type, show_splash, identical_log_grouped,
+                                   trophy_notification_side, connected_to_network,
+                                   discord_rpc_enabled, show_fps_counter, console_language,
+                                   big_picture_scale)
 
 // -------------------------------
 // Debug settings
@@ -550,6 +554,7 @@ public:
     SETTING_FORWARD_BOOL(m_general, Neo, neo_mode)
     SETTING_FORWARD_BOOL(m_general, DevKit, dev_kit_mode)
     SETTING_FORWARD(m_general, ExtraDmemInMBytes, extra_dmem_in_mbytes)
+    SETTING_FORWARD(m_general, SupportedUserMax, supported_user_max)
     SETTING_FORWARD_BOOL(m_general, PSNSignedIn, psn_signed_in)
     SETTING_FORWARD_BOOL(m_general, TrophyPopupDisabled, trophy_popup_disabled)
     SETTING_FORWARD(m_general, TrophyNotificationDuration, trophy_notification_duration)

--- a/src/core/libraries/avplayer/avplayer_impl.cpp
+++ b/src/core/libraries/avplayer/avplayer_impl.cpp
@@ -12,28 +12,28 @@ void* PS4_SYSV_ABI AvPlayer::Allocate(void* handle, u32 alignment, u32 size) {
     const auto* const self = reinterpret_cast<AvPlayer*>(handle);
     const auto allocate = self->m_init_data_original.memory_replacement.allocate;
     const auto ptr = self->m_init_data_original.memory_replacement.object_ptr;
-    return allocate(ptr, alignment, size);
+    return Core::ExecuteGuest(allocate, ptr, alignment, size);
 }
 
 void PS4_SYSV_ABI AvPlayer::Deallocate(void* handle, void* memory) {
     const auto* const self = reinterpret_cast<AvPlayer*>(handle);
     const auto deallocate = self->m_init_data_original.memory_replacement.deallocate;
     const auto ptr = self->m_init_data_original.memory_replacement.object_ptr;
-    return deallocate(ptr, memory);
+    return Core::ExecuteGuest(deallocate, ptr, memory);
 }
 
 void* PS4_SYSV_ABI AvPlayer::AllocateTexture(void* handle, u32 alignment, u32 size) {
     const auto* const self = reinterpret_cast<AvPlayer*>(handle);
     const auto allocate = self->m_init_data_original.memory_replacement.allocate_texture;
     const auto ptr = self->m_init_data_original.memory_replacement.object_ptr;
-    return allocate(ptr, alignment, size);
+    return Core::ExecuteGuest(allocate, ptr, alignment, size);
 }
 
 void PS4_SYSV_ABI AvPlayer::DeallocateTexture(void* handle, void* memory) {
     const auto* const self = reinterpret_cast<AvPlayer*>(handle);
     const auto deallocate = self->m_init_data_original.memory_replacement.deallocate_texture;
     const auto ptr = self->m_init_data_original.memory_replacement.object_ptr;
-    return deallocate(ptr, memory);
+    return Core::ExecuteGuest(deallocate, ptr, memory);
 }
 
 int PS4_SYSV_ABI AvPlayer::OpenFile(void* handle, const char* filename) {
@@ -42,7 +42,7 @@ int PS4_SYSV_ABI AvPlayer::OpenFile(void* handle, const char* filename) {
 
     const auto open = self->m_init_data_original.file_replacement.open;
     const auto ptr = self->m_init_data_original.file_replacement.object_ptr;
-    return open(ptr, filename);
+    return Core::ExecuteGuest(open, ptr, filename);
 }
 
 int PS4_SYSV_ABI AvPlayer::CloseFile(void* handle) {
@@ -51,7 +51,7 @@ int PS4_SYSV_ABI AvPlayer::CloseFile(void* handle) {
 
     const auto close = self->m_init_data_original.file_replacement.close;
     const auto ptr = self->m_init_data_original.file_replacement.object_ptr;
-    return close(ptr);
+    return Core::ExecuteGuest(close, ptr);
 }
 
 int PS4_SYSV_ABI AvPlayer::ReadOffsetFile(void* handle, u8* buffer, u64 position, u32 length) {
@@ -60,7 +60,7 @@ int PS4_SYSV_ABI AvPlayer::ReadOffsetFile(void* handle, u8* buffer, u64 position
 
     const auto read_offset = self->m_init_data_original.file_replacement.read_offset;
     const auto ptr = self->m_init_data_original.file_replacement.object_ptr;
-    return read_offset(ptr, buffer, position, length);
+    return Core::ExecuteGuest(read_offset, ptr, buffer, position, length);
 }
 
 u64 PS4_SYSV_ABI AvPlayer::SizeFile(void* handle) {
@@ -69,7 +69,7 @@ u64 PS4_SYSV_ABI AvPlayer::SizeFile(void* handle) {
 
     const auto size = self->m_init_data_original.file_replacement.size;
     const auto ptr = self->m_init_data_original.file_replacement.object_ptr;
-    return size(ptr);
+    return Core::ExecuteGuest(size, ptr);
 }
 
 AvPlayerInitData AvPlayer::StubInitData(const AvPlayerInitData& data) {

--- a/src/core/libraries/avplayer/avplayer_state.cpp
+++ b/src/core/libraries/avplayer/avplayer_state.cpp
@@ -92,7 +92,7 @@ void AvPlayerState::DefaultEventCallback(void* opaque, AvPlayerEvents event_id, 
     const auto callback = self->m_event_replacement.event_callback;
     const auto ptr = self->m_event_replacement.object_ptr;
     if (callback != nullptr) {
-        callback(ptr, event_id, 0, event_data);
+        Core::ExecuteGuest(callback, ptr, event_id, 0, event_data);
     }
 }
 

--- a/src/core/libraries/ime/ime.cpp
+++ b/src/core/libraries/ime/ime.cpp
@@ -99,16 +99,16 @@ public:
         if (m_ime_mode) {
             OrbisImeParam param = m_param.ime;
             if (use_param_handler) {
-                param.handler(param.arg, event);
+                Core::ExecuteGuest(param.handler, param.arg, event);
             } else {
-                handler(param.arg, event);
+                Core::ExecuteGuest(handler, param.arg, event);
             }
         } else {
             OrbisImeKeyboardParam param = m_param.key;
             if (use_param_handler) {
-                param.handler(param.arg, event);
+                Core::ExecuteGuest(param.handler, param.arg, event);
             } else {
-                handler(param.arg, event);
+                Core::ExecuteGuest(handler, param.arg, event);
             }
         }
     }

--- a/src/core/libraries/ime/ime_dialog_ui.cpp
+++ b/src/core/libraries/ime/ime_dialog_ui.cpp
@@ -131,7 +131,8 @@ bool ImeDialogState::CallTextFilter() {
         return false;
     }
 
-    int ret = text_filter(out_text, &out_text_length, src_text, src_text_length);
+    int ret =
+        Core::ExecuteGuest(text_filter, out_text, &out_text_length, src_text, src_text_length);
 
     if (ret != 0) {
         return false;
@@ -152,7 +153,7 @@ bool ImeDialogState::CallKeyboardFilter(const OrbisImeKeycode* src_keycode, u16*
         return true;
     }
 
-    int ret = keyboard_filter(src_keycode, out_keycode, out_status, nullptr);
+    int ret = Core::ExecuteGuest(keyboard_filter, src_keycode, out_keycode, out_status, nullptr);
     return ret == 0;
 }
 

--- a/src/core/libraries/kernel/threads.cpp
+++ b/src/core/libraries/kernel/threads.cpp
@@ -7,17 +7,6 @@
 
 namespace Libraries::Kernel {
 
-void PS4_SYSV_ABI ClearStack() {
-    void* const stackaddr_attr = Libraries::Kernel::g_curthread->attr.stackaddr_attr;
-    void* volatile sp;
-    asm("mov %%rsp, %0" : "=rm"(sp));
-    // leave a safety net of 64 bytes for memset
-    const size_t size = ((uintptr_t)sp - (uintptr_t)stackaddr_attr) - 64;
-    void* volatile buf = alloca(size);
-    memset(buf, 0, size);
-    sp = nullptr;
-}
-
 void RegisterThreads(Core::Loader::SymbolsResolver* sym) {
     RegisterMutex(sym);
     RegisterCond(sym);

--- a/src/core/libraries/kernel/threads.h
+++ b/src/core/libraries/kernel/threads.h
@@ -27,7 +27,6 @@ int PS4_SYSV_ABI posix_pthread_create(PthreadT* thread, const PthreadAttrT* attr
                                       PthreadEntryFunc start_routine, void* arg);
 
 int PS4_SYSV_ABI posix_pthread_join(PthreadT pthread, void** thread_return);
-int PS4_SYSV_ABI posix_pthread_detach(PthreadT pthread);
 
 int PS4_SYSV_ABI posix_pthread_mutexattr_init(PthreadMutexAttrT* attr);
 int PS4_SYSV_ABI posix_pthread_mutexattr_settype(PthreadMutexAttrT* attr, PthreadMutexType type);
@@ -40,8 +39,6 @@ int PS4_SYSV_ABI posix_pthread_mutex_unlock(PthreadMutexT* mutex);
 int PS4_SYSV_ABI posix_pthread_mutex_destroy(PthreadMutexT* mutex);
 
 void RegisterThreads(Core::Loader::SymbolsResolver* sym);
-
-void PS4_SYSV_ABI ClearStack();
 
 class Thread {
 public:

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -420,7 +420,7 @@ s32 PS4_SYSV_ABI posix_pthread_kill(PthreadT thread, s32 sig) {
 
     u64 res = NtQueueApcThreadEx(reinterpret_cast<HANDLE>(thread->native_thr.GetHandle()), option,
                                  ExceptionHandler, (void*)thread->name.c_str(),
-                                 (void*)(s64)native_signum, nullptr);
+                                 (void*)native_signum, nullptr);
     ASSERT(res == 0);
 #endif
     return ORBIS_OK;

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -56,8 +56,6 @@ static void ExitThread() {
     curthread->tid.notify_all();
 
     curthread->native_thr.Exit();
-    UNREACHABLE();
-    /* Never reach! */
 }
 
 void PS4_SYSV_ABI posix_pthread_exit(void* status) {

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -197,17 +197,10 @@ static void RunThread(void* arg) {
     g_curthread = curthread;
     Common::SetCurrentThreadName(curthread->name.c_str());
     DebugState.AddCurrentThreadToGuestList();
-    Core::InitializeTLS();
-
-    curthread->native_thr.Initialize();
-
-    // Clear the stack before running the guest thread
-    if (False(g_curthread->attr.flags & PthreadAttrFlags::StackUser)) {
-        ClearStack();
-    }
 
     /* Run the current thread's start routine with argument: */
-    void* ret = curthread->start_routine(curthread->arg);
+    curthread->native_thr.Initialize();
+    void* ret = Core::ExecuteGuest(curthread->start_routine, curthread->arg);
 
     /* Remove thread from tracking */
     DebugState.RemoveCurrentThreadFromGuestList();

--- a/src/core/libraries/kernel/threads/pthread_spec.cpp
+++ b/src/core/libraries/kernel/threads/pthread_spec.cpp
@@ -85,7 +85,7 @@ void _thread_cleanupspecific() {
                  * destructor:
                  */
                 lk.unlock();
-                destructor(data);
+                Core::ExecuteGuest(destructor, data);
                 lk.lock();
             }
         }

--- a/src/core/libraries/network/net_ctl_obj.cpp
+++ b/src/core/libraries/network/net_ctl_obj.cpp
@@ -51,7 +51,7 @@ void NetCtlInternal::CheckCallback() {
                            : ORBIS_NET_CTL_EVENT_TYPE_DISCONNECTED;
     for (const auto [func, arg] : callbacks) {
         if (func != nullptr) {
-            func(event, arg);
+            Core::ExecuteGuest(func, event, arg);
         }
     }
 }
@@ -63,7 +63,7 @@ void NetCtlInternal::CheckNpToolkitCallback() {
                            : ORBIS_NET_CTL_EVENT_TYPE_DISCONNECTED;
     for (const auto [func, arg] : nptool_callbacks) {
         if (func != nullptr) {
-            func(event, arg);
+            Core::ExecuteGuest(func, event, arg);
         }
     }
 }

--- a/src/core/libraries/ngs2/ngs2.cpp
+++ b/src/core/libraries/ngs2/ngs2.cpp
@@ -160,13 +160,13 @@ s32 PS4_SYSV_ABI sceNgs2SystemCreateWithAllocator(const OrbisNgs2SystemOption* o
             result = SystemSetup(option, &bufferInfo, 0, 0);
             if (result >= 0) {
                 uintptr_t sysUserData = allocator->userData;
-                result = hostAlloc(&bufferInfo);
+                result = Core::ExecuteGuest(hostAlloc, &bufferInfo);
                 if (result >= 0) {
                     OrbisNgs2Handle* handleCopy = outHandle;
                     result = SystemSetup(option, &bufferInfo, hostFree, handleCopy);
                     if (result < 0) {
                         if (hostFree) {
-                            hostFree(&bufferInfo);
+                            Core::ExecuteGuest(hostFree, &bufferInfo);
                         }
                     }
                 }

--- a/src/core/libraries/usbd/emulated/dimensions.cpp
+++ b/src/core/libraries/usbd/emulated/dimensions.cpp
@@ -3,9 +3,6 @@
 
 #include "dimensions.h"
 
-#include "core/libraries/kernel/threads.h"
-#include "core/tls.h"
-
 #include <mutex>
 #include <thread>
 
@@ -622,46 +619,22 @@ libusb_transfer_status DimensionsBackend::HandleAsyncTransfer(libusb_transfer* t
     return LIBUSB_TRANSFER_COMPLETED;
 }
 
-struct WriteThreadArgs {
-    DimensionsBackend* self;
-    libusb_transfer* transfer;
-};
-
-void* PS4_SYSV_ABI DimensionsBackend::WriteThread(void* arg) {
-    auto* args = reinterpret_cast<WriteThreadArgs*>(arg);
-
-    auto* self = args->self;
-    auto* transfer = args->transfer;
-
-    self->HandleAsyncTransfer(transfer);
-
-    const u8 flags = transfer->flags;
-    transfer->status = LIBUSB_TRANSFER_COMPLETED;
-    transfer->actual_length = transfer->length;
-    if (transfer->callback) {
-        transfer->callback(transfer);
-    }
-    if (flags & LIBUSB_TRANSFER_FREE_TRANSFER) {
-        libusb_free_transfer(transfer);
-    }
-    delete args;
-    return nullptr;
-}
-
 s32 DimensionsBackend::SubmitTransfer(libusb_transfer* transfer) {
     if (transfer->endpoint == 0x01) {
-        using namespace Libraries::Kernel;
+        std::thread write_thread([this, transfer] {
+            HandleAsyncTransfer(transfer);
 
-        PthreadAttrT attr{};
-        posix_pthread_attr_init(&attr);
-        PthreadT thread{};
-        auto* args = new WriteThreadArgs();
-        args->self = this;
-        args->transfer = transfer;
-        posix_pthread_create(&thread, &attr, HOST_CALL(DimensionsBackend::WriteThread), args);
-        posix_pthread_attr_destroy(&attr);
-        posix_pthread_detach(thread);
-
+            const u8 flags = transfer->flags;
+            transfer->status = LIBUSB_TRANSFER_COMPLETED;
+            transfer->actual_length = transfer->length;
+            if (transfer->callback) {
+                transfer->callback(transfer);
+            }
+            if (flags & LIBUSB_TRANSFER_FREE_TRANSFER) {
+                libusb_free_transfer(transfer);
+            }
+        });
+        write_thread.detach();
         return LIBUSB_SUCCESS;
     }
 

--- a/src/core/libraries/usbd/emulated/dimensions.h
+++ b/src/core/libraries/usbd/emulated/dimensions.h
@@ -103,8 +103,6 @@ protected:
     std::queue<std::array<u8, 32>> m_queries;
 
 private:
-    static void* PS4_SYSV_ABI WriteThread(void* arg);
-
     std::shared_ptr<DimensionsToypad> m_dimensions_toypad = std::make_shared<DimensionsToypad>();
 
     std::array<u8, 9> m_endpoint_out_extra = {0x09, 0x21, 0x11, 0x01, 0x00, 0x01, 0x22, 0x1d, 0x00};

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -147,8 +147,7 @@ void Linker::Execute(const std::vector<std::string>& args) {
             }
         }
         params.entry_addr = module->GetEntryAddress();
-        Libraries::Kernel::ClearStack();
-        RunMainEntry(&params);
+        ExecuteGuest(RunMainEntry, &params);
     });
 }
 
@@ -394,7 +393,8 @@ void* Linker::TlsGetAddr(u64 module_index, u64 offset) {
     if (!addr) {
         // Module was just loaded by above code. Allocate TLS block for it.
         const u32 init_image_size = module->tls.init_image_size;
-        u8* dest = reinterpret_cast<u8*>(heap_api->heap_malloc(module->tls.image_size));
+        u8* dest = reinterpret_cast<u8*>(
+            Core::ExecuteGuest(heap_api->heap_malloc, module->tls.image_size));
         const u8* src = reinterpret_cast<const u8*>(module->tls.image_virtual_addr);
         std::memcpy(dest, src, init_image_size);
         std::memset(dest + init_image_size, 0, module->tls.image_size - init_image_size);
@@ -426,7 +426,7 @@ void* Linker::AllocateTlsForThread(bool is_primary) {
         ASSERT_MSG(ret == 0, "Unable to allocate TLS+TCB for the primary thread");
     } else {
         if (heap_api) {
-            addr_out = heap_api->heap_malloc(total_tls_size);
+            addr_out = Core::ExecuteGuest(heap_api->heap_malloc, total_tls_size);
         } else {
             addr_out = std::malloc(total_tls_size);
         }
@@ -436,7 +436,7 @@ void* Linker::AllocateTlsForThread(bool is_primary) {
 
 void Linker::FreeTlsForNonPrimaryThread(void* pointer) {
     if (heap_api) {
-        heap_api->heap_free(pointer);
+        Core::ExecuteGuest(heap_api->heap_free, pointer);
     } else {
         std::free(pointer);
     }

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -97,7 +97,7 @@ Module::~Module() = default;
 s32 Module::Start(u64 args, const void* argp, void* param) {
     LOG_INFO(Core_Linker, "Module started : {}", name);
     const VAddr addr = dynamic_info.init_virtual_addr + GetBaseAddress();
-    return reinterpret_cast<EntryFunc>(addr)(args, argp, param);
+    return ExecuteGuest(reinterpret_cast<EntryFunc>(addr), args, argp, param);
 }
 
 void Module::LoadModuleToMemory(u32& max_tls_index) {

--- a/src/core/thread.cpp
+++ b/src/core/thread.cpp
@@ -1,83 +1,31 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "common/alignment.h"
 #include "core/libraries/kernel/threads/pthread.h"
 #include "thread.h"
+
 #ifdef _WIN64
 #include <windows.h>
-#include "common/ntapi.h"
 #else
-#include <csignal>
 #include <pthread.h>
-#include <unistd.h>
-#include <xmmintrin.h>
 #endif
 
 namespace Core {
-
-static constexpr u32 ORBIS_MXCSR = 0x9fc0;
-static constexpr u32 ORBIS_FPUCW = 0x037f;
-
-#ifdef _WIN64
-#define KGDT64_R3_DATA (0x28)
-#define KGDT64_R3_CODE (0x30)
-#define KGDT64_R3_CMTEB (0x50)
-#define RPL_MASK (0x03)
-#define EFLAGS_INTERRUPT_MASK (0x200)
-
-void InitializeTeb(INITIAL_TEB* teb, const ::Libraries::Kernel::PthreadAttr* attr) {
-    teb->StackBase = (void*)((u64)attr->stackaddr_attr + attr->stacksize_attr);
-    teb->StackLimit = nullptr;
-    teb->StackAllocationBase = attr->stackaddr_attr;
-}
-
-void InitializeContext(CONTEXT* ctx, ThreadFunc func, void* arg,
-                       const ::Libraries::Kernel::PthreadAttr* attr) {
-    /* Note: The stack has to be reversed */
-    ctx->Rsp = (u64)attr->stackaddr_attr + attr->stacksize_attr;
-    ctx->Rbp = (u64)attr->stackaddr_attr + attr->stacksize_attr;
-    ctx->Rcx = (u64)arg;
-    ctx->Rip = (u64)func;
-
-    ctx->SegGs = KGDT64_R3_DATA | RPL_MASK;
-    ctx->SegEs = KGDT64_R3_DATA | RPL_MASK;
-    ctx->SegDs = KGDT64_R3_DATA | RPL_MASK;
-    ctx->SegCs = KGDT64_R3_CODE | RPL_MASK;
-    ctx->SegSs = KGDT64_R3_DATA | RPL_MASK;
-    ctx->SegFs = KGDT64_R3_CMTEB | RPL_MASK;
-
-    ctx->EFlags = 0x3000 | EFLAGS_INTERRUPT_MASK;
-
-    ctx->ContextFlags =
-        CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_SEGMENTS | CONTEXT_FLOATING_POINT;
-}
-#endif
 
 NativeThread::NativeThread() : native_handle{0} {}
 
 NativeThread::~NativeThread() {}
 
 int NativeThread::Create(ThreadFunc func, void* arg, const ::Libraries::Kernel::PthreadAttr* attr) {
-#ifndef _WIN64
+#ifdef _WIN64
+    native_handle = CreateThread(nullptr, 0, (LPTHREAD_START_ROUTINE)func, arg, 0, nullptr);
+    return native_handle ? 0 : -1;
+#else
     pthread_t* pthr = reinterpret_cast<pthread_t*>(&native_handle);
     pthread_attr_t pattr;
     pthread_attr_init(&pattr);
     pthread_attr_setstack(&pattr, attr->stackaddr_attr, attr->stacksize_attr);
     return pthread_create(pthr, &pattr, (PthreadFunc)func, arg);
-#else
-    CLIENT_ID clientId{};
-    INITIAL_TEB teb{};
-    CONTEXT ctx{};
-
-    clientId.UniqueProcess = GetCurrentProcess();
-    clientId.UniqueThread = GetCurrentThread();
-
-    InitializeTeb(&teb, attr);
-    InitializeContext(&ctx, func, arg, attr);
-
-    return NtCreateThread(&native_handle, THREAD_ALL_ACCESS, nullptr, GetCurrentProcess(),
-                          &clientId, &ctx, &teb, false);
 #endif
 }
 
@@ -86,65 +34,17 @@ void NativeThread::Exit() {
         return;
     }
 
-    tid = 0;
-
 #ifdef _WIN64
-    NtClose(native_handle);
+    CloseHandle(native_handle);
     native_handle = nullptr;
 
-    /* The Windows kernel will free the stack
-       given at thread creation via INITIAL_TEB
-       (StackAllocationBase) upon thread termination.
-
-       In earlier Windows versions (NT4 to Windows Server 2003),
-       you could get around this via disabling FreeStackOnTermination
-       on the TEB. This has been removed since then.
-
-       To avoid this, we must forcefully set the TEB
-       deallocation stack pointer to NULL so ZwFreeVirtualMemory fails
-       in the kernel and our stack is not freed.
-     */
-    auto* teb = reinterpret_cast<TEB*>(NtCurrentTeb());
-    teb->DeallocationStack = nullptr;
-
-    NtTerminateThread(nullptr, 0);
+    // We call this assuming the thread has finished execution.
+    ExitThread(0);
 #else
-    // Disable and free the signal stack.
-    constexpr stack_t sig_stack = {
-        .ss_flags = SS_DISABLE,
-    };
-    sigaltstack(&sig_stack, nullptr);
-
-    if (sig_stack_ptr) {
-        free(sig_stack_ptr);
-        sig_stack_ptr = nullptr;
-    }
-
     pthread_exit(nullptr);
 #endif
 }
 
-void NativeThread::Initialize() {
-    // Set MXCSR and FPUCW registers to the values used by Orbis.
-    _mm_setcsr(ORBIS_MXCSR);
-    asm volatile("fldcw %0" : : "m"(ORBIS_FPUCW));
-#if _WIN64
-    tid = GetCurrentThreadId();
-#else
-    tid = (u64)pthread_self();
-
-    // Set up an alternate signal handler stack to avoid overflowing small thread stacks.
-    const size_t page_size = getpagesize();
-    const size_t sig_stack_size = Common::AlignUp(std::max<size_t>(64_KB, MINSIGSTKSZ), page_size);
-    ASSERT_MSG(posix_memalign(&sig_stack_ptr, page_size, sig_stack_size) == 0,
-               "Failed to allocate signal stack: {}", errno);
-
-    stack_t sig_stack;
-    sig_stack.ss_sp = sig_stack_ptr;
-    sig_stack.ss_size = sig_stack_size;
-    sig_stack.ss_flags = 0;
-    ASSERT_MSG(sigaltstack(&sig_stack, nullptr) == 0, "Failed to set signal stack: {}", errno);
-#endif
-}
+void NativeThread::Initialize() {}
 
 } // namespace Core

--- a/src/core/tls.cpp
+++ b/src/core/tls.cpp
@@ -205,7 +205,7 @@ Tcb* GetTcbBase() {
 
 thread_local std::once_flag init_tls_flag;
 
-void InitializeTLS() {
+void EnsureThreadInitialized() {
     std::call_once(init_tls_flag, [] { SetTcbBase(Libraries::Kernel::g_curthread->tcb); });
 }
 

--- a/src/core/tls.h
+++ b/src/core/tls.h
@@ -43,7 +43,30 @@ void SetTcbBase(void* image_address);
 Tcb* GetTcbBase();
 
 /// Makes sure TLS is initialized for the thread before entering guest.
-void InitializeTLS();
+void EnsureThreadInitialized();
+
+template <size_t size>
+#ifdef __clang__
+__attribute__((optnone))
+#else
+__attribute__((optimize("O0")))
+#endif
+void ClearStack() {
+    volatile void* buf = alloca(size);
+    memset(const_cast<void*>(buf), 0, size);
+    buf = nullptr;
+}
+
+template <class ReturnType, class... FuncArgs, class... CallArgs>
+ReturnType ExecuteGuest(PS4_SYSV_ABI ReturnType (*func)(FuncArgs...), CallArgs&&... args) {
+    EnsureThreadInitialized();
+    // clear stack to avoid trash from EnsureThreadInitialized
+    auto* tcb = GetTcbBase();
+    if (tcb != nullptr && tcb->tcb_fiber == nullptr) {
+        ClearStack<12_KB>();
+    }
+    return func(std::forward<CallArgs>(args)...);
+}
 
 template <class F, F f>
 struct HostCallWrapperImpl;


### PR DESCRIPTION
## Summary
The proposed changes allow the emulator to boot some games on Wine, 39-bit VA and hex-emu. The changes can't be merged as they'll break a lot of games on anything that isn't Wine or 39-bit VA.

## Motivation
To prove that it's possible and document my findings.

## Proposed Changes
### 1. Replace NtCreateThread with CreateThread (partially reverts #1659)
Fixes Wine.
### 2. Revert initialize tls on thread creation (#4070)
Fixes Wine.
### 3. Remove image base address on Windows
Fixes hex-emu.
### 4. Add configurable supported user max
Changes supported user max to 0x7000000000 (448GB) and next addr to 0x80000000 (2GB). Fixes 39-bit VA.

## Games Tested
### 1. Sonic Mania
<img width="2400" height="1080" alt="1" src="https://github.com/user-attachments/assets/d07664e9-863c-465c-9937-7aed91e351fa" />

### 2. Minecraft: Playstation 4 Edition
<img width="2400" height="1080" alt="2" src="https://github.com/user-attachments/assets/f5f1fd87-2b27-447e-bf48-65a1da14ffef" />

### 3. Hatsune Miku: Project DIVA Future Tone
<img width="2400" height="1080" alt="3" src="https://github.com/user-attachments/assets/be28dc7a-d0da-45f8-abdd-cb3e4299b488" />

### 4. Gravity Rush Remastered
Without null gpu it gets device lost.
<img width="2400" height="1080" alt="4" src="https://github.com/user-attachments/assets/c9d0b9ef-1f02-425c-b4e5-5ba34e9376f5" />

### 5. AvPlayer Homebrew
<img width="2400" height="1080" alt="5" src="https://github.com/user-attachments/assets/cfd9345a-0cca-4ab6-8448-07e86d7a7b3c" />

## Any Other Things
Feel free to ask any questions or close this PR if it doesn't contribute to development in any way.