### PR TITLE
libraries/ult: Implement initial libSceUlt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,6 +578,11 @@ set(FIBER_LIB src/core/libraries/fiber/fiber_context.s
               src/core/libraries/fiber/fiber_error.h
 )
 
+set(ULT_LIB src/core/libraries/ult/ult.cpp
+             src/core/libraries/ult/ult.h
+             src/core/libraries/ult/ult_error.h
+)
+
 set_source_files_properties(src/core/libraries/fiber/fiber_context.s PROPERTIES COMPILE_OPTIONS -Wno-unused-command-line-argument)
 
 set(VDEC_LIB src/core/libraries/videodec/videodec2_impl.cpp
@@ -854,6 +859,7 @@ set(CORE src/core/aerolib/stubs.cpp
          ${MISC_LIBS}
          ${IME_LIB}
          ${FIBER_LIB}
+         ${ULT_LIB}
          ${VDEC_LIB}
          ${VR_LIBS}
          ${CAMERA_LIBS}

--- a/src/common/logging/filter.cpp
+++ b/src/common/logging/filter.cpp
@@ -138,6 +138,7 @@ bool ParseFilterRule(Filter& instance, Iterator begin, Iterator end) {
     SUB(Lib, Remoteplay)                                                                           \
     SUB(Lib, SharePlay)                                                                            \
     SUB(Lib, Fiber)                                                                                \
+    SUB(Lib, Ult)                                                                                  \
     SUB(Lib, Vdec2)                                                                                \
     SUB(Lib, Videodec)                                                                             \
     SUB(Lib, RazorCpu)                                                                             \

--- a/src/common/logging/types.h
+++ b/src/common/logging/types.h
@@ -104,6 +104,7 @@ enum class Class : u8 {
     Lib_Remoteplay,          ///< The LibSceRemotePlay implementation
     Lib_SharePlay,           ///< The LibSceSharePlay implemenation
     Lib_Fiber,               ///< The LibSceFiber implementation.
+    Lib_Ult,                 ///< The LibUlt implementation.
     Lib_Vdec2,               ///< The LibSceVideodec2 implementation.
     Lib_Videodec,            ///< The LibSceVideodec implementation.
     Lib_Voice,               ///< The LibSceVoice implementation.

--- a/src/core/libraries/libs.cpp
+++ b/src/core/libraries/libs.cpp
@@ -73,6 +73,7 @@
 #include "core/libraries/web_browser_dialog/webbrowserdialog.h"
 #include "core/libraries/zlib/zlib_sce.h"
 #include "fiber/fiber.h"
+#include "core/libraries/ult/ult.h"
 
 namespace Libraries {
 
@@ -137,6 +138,7 @@ void InitHLELibs(Core::Loader::SymbolsResolver* sym) {
     Libraries::RazorCpu::RegisterLib(sym);
     Libraries::Move::RegisterLib(sym);
     Libraries::Fiber::RegisterLib(sym);
+    Libraries::Ult::RegisterlibSceUlt(sym);
     Libraries::Mouse::RegisterLib(sym);
     Libraries::WebBrowserDialog::RegisterLib(sym);
     Libraries::Zlib::RegisterLib(sym);

--- a/src/core/libraries/ult/ult.cpp
+++ b/src/core/libraries/ult/ult.cpp
@@ -1,0 +1,252 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <condition_variable>
+#include <cstring>
+#include <deque>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "common/logging/log.h"
+#include "core/libraries/libs.h"
+#include "core/libraries/ult/ult.h"
+#include "core/libraries/ult/ult_error.h"
+
+namespace Libraries::Ult {
+
+// Internal thread-safe queue implementation
+struct UltQueueInternal {
+    std::mutex mtx;
+    std::condition_variable cv_not_empty;
+    std::condition_variable cv_not_full;
+    std::deque<std::vector<u8>> items;
+    u32 data_size;
+    u32 max_items;
+    bool destroyed = false;
+
+    UltQueueInternal(u32 data_size_, u32 max_items_)
+        : data_size(data_size_), max_items(max_items_) {}
+};
+
+s32 PS4_SYSV_ABI sceUltInitialize() {
+    LOG_INFO(Lib_Ult, "called");
+    return ORBIS_OK;
+}
+
+// --- Waiting Queue Resource Pool ---
+
+s32 PS4_SYSV_ABI sceUltWaitingQueueResourcePoolGetWorkAreaSize(u32 numThreads) {
+    LOG_DEBUG(Lib_Ult, "numThreads = {}", numThreads);
+    // Return a reasonable work area size. The game allocates this much memory
+    // and passes it to the create function. We don't actually use it since
+    // we use std library synchronization primitives internally.
+    return static_cast<s32>(sizeof(UltWaitingQueueResourcePool) + numThreads * 64);
+}
+
+s32 PS4_SYSV_ABI _sceUltWaitingQueueResourcePoolCreate(UltWaitingQueueResourcePool* pool,
+                                                       const char* name, u32 numThreads,
+                                                       void* workArea, void* optParam) {
+    LOG_INFO(Lib_Ult, "name = {}, numThreads = {}", name ? name : "<null>", numThreads);
+    if (!pool) {
+        return SCE_ULT_ERROR_NULL;
+    }
+    pool->num_threads = numThreads;
+    pool->initialized = true;
+    return ORBIS_OK;
+}
+
+// --- Queue Data Resource Pool ---
+
+s32 PS4_SYSV_ABI sceUltQueueDataResourcePoolGetWorkAreaSize(u32 numData, u32 dataSize) {
+    LOG_DEBUG(Lib_Ult, "numData = {}, dataSize = {}", numData, dataSize);
+    return static_cast<s32>(sizeof(UltQueueDataResourcePool) + numData * dataSize + 256);
+}
+
+s32 PS4_SYSV_ABI _sceUltQueueDataResourcePoolCreate(UltQueueDataResourcePool* pool,
+                                                    const char* name, u32 numData, u32 dataSize,
+                                                    void* workArea, void* optParam) {
+    LOG_INFO(Lib_Ult, "name = {}, numData = {}, dataSize = {}", name ? name : "<null>", numData,
+             dataSize);
+    if (!pool) {
+        return SCE_ULT_ERROR_NULL;
+    }
+    pool->num_data = numData;
+    pool->data_size = dataSize;
+    pool->initialized = true;
+    return ORBIS_OK;
+}
+
+// --- Queue ---
+
+s32 PS4_SYSV_ABI _sceUltQueueCreate(UltQueue* queue, const char* name, u32 dataSize, u32 numData,
+                                    UltWaitingQueueResourcePool* waitPool,
+                                    UltQueueDataResourcePool* dataPool, void* optParam) {
+    LOG_INFO(Lib_Ult, "name = {}, dataSize = {}, numData = {}", name ? name : "<null>", dataSize,
+             numData);
+    if (!queue) {
+        return SCE_ULT_ERROR_NULL;
+    }
+    queue->internal = new UltQueueInternal(dataSize, numData);
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceUltQueuePush(UltQueue* queue, const void* data) {
+    if (!queue || !queue->internal || !data) {
+        LOG_ERROR(Lib_Ult, "null parameter");
+        return SCE_ULT_ERROR_NULL;
+    }
+
+    auto* q = queue->internal;
+    std::unique_lock lock(q->mtx);
+
+    // Wait until there's space or queue is destroyed
+    q->cv_not_full.wait(lock, [&] { return q->items.size() < q->max_items || q->destroyed; });
+
+    if (q->destroyed) {
+        return SCE_ULT_ERROR_STATE;
+    }
+
+    // Copy data into the queue
+    std::vector<u8> item(q->data_size);
+    std::memcpy(item.data(), data, q->data_size);
+    q->items.push_back(std::move(item));
+
+    lock.unlock();
+    q->cv_not_empty.notify_one();
+
+    LOG_TRACE(Lib_Ult, "pushed item, queue size = {}", q->items.size());
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceUltQueuePop(UltQueue* queue, void* data) {
+    if (!queue || !queue->internal || !data) {
+        LOG_ERROR(Lib_Ult, "null parameter");
+        return SCE_ULT_ERROR_NULL;
+    }
+
+    auto* q = queue->internal;
+    std::unique_lock lock(q->mtx);
+
+    // Wait until there's data or queue is destroyed
+    q->cv_not_empty.wait(lock, [&] { return !q->items.empty() || q->destroyed; });
+
+    if (q->destroyed && q->items.empty()) {
+        return SCE_ULT_ERROR_STATE;
+    }
+
+    // Copy data out of the queue
+    auto& item = q->items.front();
+    std::memcpy(data, item.data(), q->data_size);
+    q->items.pop_front();
+
+    lock.unlock();
+    q->cv_not_full.notify_one();
+
+    LOG_TRACE(Lib_Ult, "popped item, queue size = {}", q->items.size());
+    return ORBIS_OK;
+}
+
+// --- Ulthread Runtime ---
+
+s32 PS4_SYSV_ABI _sceUltUlthreadRuntimeOptParamInitialize(UltUlthreadRuntimeOptParam* param) {
+    LOG_DEBUG(Lib_Ult, "called");
+    if (!param) {
+        return SCE_ULT_ERROR_NULL;
+    }
+    std::memset(param, 0, sizeof(UltUlthreadRuntimeOptParam));
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceUltUlthreadRuntimeGetWorkAreaSize(u32 numThread, u32 stackSize) {
+    LOG_DEBUG(Lib_Ult, "numThread = {}, stackSize = {}", numThread, stackSize);
+    return static_cast<s32>(sizeof(UltUlthreadRuntime) + numThread * 128);
+}
+
+s32 PS4_SYSV_ABI _sceUltUlthreadRuntimeCreate(UltUlthreadRuntime* runtime, const char* name,
+                                              u32 numThread, u32 stackSize, void* workArea,
+                                              void* optParam) {
+    LOG_INFO(Lib_Ult, "name = {}, numThread = {}, stackSize = {}", name ? name : "<null>",
+             numThread, stackSize);
+    if (!runtime) {
+        return SCE_ULT_ERROR_NULL;
+    }
+    runtime->num_threads = numThread;
+    runtime->stack_size = stackSize;
+    runtime->initialized = true;
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceUltUlthreadRuntimeDestroy(UltUlthreadRuntime* runtime) {
+    LOG_INFO(Lib_Ult, "called");
+    if (!runtime) {
+        return SCE_ULT_ERROR_NULL;
+    }
+    runtime->initialized = false;
+    return ORBIS_OK;
+}
+
+// --- Ulthread ---
+
+s32 PS4_SYSV_ABI _sceUltUlthreadCreate(UltUlthread* thread, const char* name, void (*entry)(void*),
+                                       void* arg, void* context, u32 stackSize,
+                                       UltUlthreadRuntime* runtime, void* optParam) {
+    LOG_INFO(Lib_Ult, "name = {}, stackSize = {}", name ? name : "<null>", stackSize);
+    if (!thread || !entry) {
+        return SCE_ULT_ERROR_NULL;
+    }
+
+    // Launch as a real host thread. ULT threads on PS4 are cooperative lightweight
+    // threads, but for now a real thread should work for compatibility.
+    auto* t = new std::thread(entry, arg);
+    thread->handle = t;
+    thread->joined = false;
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceUltUlthreadJoin(UltUlthread* thread, s32* status) {
+    LOG_INFO(Lib_Ult, "called");
+    if (!thread) {
+        return SCE_ULT_ERROR_NULL;
+    }
+    if (thread->handle && !thread->joined) {
+        auto* t = static_cast<std::thread*>(thread->handle);
+        if (t->joinable()) {
+            t->join();
+        }
+        delete t;
+        thread->handle = nullptr;
+        thread->joined = true;
+    }
+    if (status) {
+        *status = 0;
+    }
+    return ORBIS_OK;
+}
+
+void RegisterlibSceUlt(Core::Loader::SymbolsResolver* sym) {
+    LIB_FUNCTION("hZIg1EWGsHM", "libSceUlt", 1, "libSceUlt", sceUltInitialize);
+
+    LIB_FUNCTION("WIWV1Qd7PFU", "libSceUlt", 1, "libSceUlt",
+                 sceUltWaitingQueueResourcePoolGetWorkAreaSize);
+    LIB_FUNCTION("YiHujOG9vXY", "libSceUlt", 1, "libSceUlt", _sceUltWaitingQueueResourcePoolCreate);
+
+    LIB_FUNCTION("evj9YPkS8s4", "libSceUlt", 1, "libSceUlt",
+                 sceUltQueueDataResourcePoolGetWorkAreaSize);
+    LIB_FUNCTION("TFHm6-N6vks", "libSceUlt", 1, "libSceUlt", _sceUltQueueDataResourcePoolCreate);
+
+    LIB_FUNCTION("9Y5keOvb6ok", "libSceUlt", 1, "libSceUlt", _sceUltQueueCreate);
+    LIB_FUNCTION("dUwpX3e5NDE", "libSceUlt", 1, "libSceUlt", sceUltQueuePush);
+    LIB_FUNCTION("RVSq2tsm2yw", "libSceUlt", 1, "libSceUlt", sceUltQueuePop);
+
+    LIB_FUNCTION("V2u3WLrwh64", "libSceUlt", 1, "libSceUlt",
+                 _sceUltUlthreadRuntimeOptParamInitialize);
+    LIB_FUNCTION("grs2pbc2awM", "libSceUlt", 1, "libSceUlt", sceUltUlthreadRuntimeGetWorkAreaSize);
+    LIB_FUNCTION("jw9FkZBXo-g", "libSceUlt", 1, "libSceUlt", _sceUltUlthreadRuntimeCreate);
+    LIB_FUNCTION("-gxcs521SvA", "libSceUlt", 1, "libSceUlt", sceUltUlthreadRuntimeDestroy);
+
+    LIB_FUNCTION("znI3q8S7KQ4", "libSceUlt", 1, "libSceUlt", _sceUltUlthreadCreate);
+    LIB_FUNCTION("gCeAI57LGgI", "libSceUlt", 1, "libSceUlt", sceUltUlthreadJoin);
+}
+
+} // namespace Libraries::Ult

--- a/src/core/libraries/ult/ult.h
+++ b/src/core/libraries/ult/ult.h
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "common/types.h"
+
+namespace Core::Loader {
+class SymbolsResolver;
+}
+
+namespace Libraries::Ult {
+
+// Opaque handles - the game allocates these and passes pointers to them.
+// We store our internal state at the start of the game-provided memory.
+
+struct UltWaitingQueueResourcePool {
+    u32 num_threads;
+    bool initialized;
+};
+
+struct UltQueueDataResourcePool {
+    u32 num_data;
+    u32 data_size;
+    bool initialized;
+};
+
+// Forward declaration of internal queue implementation
+struct UltQueueInternal;
+
+struct UltQueue {
+    UltQueueInternal* internal;
+};
+
+struct UltUlthreadRuntimeOptParam {
+    u64 reserved[8];
+};
+
+struct UltUlthreadRuntime {
+    u32 num_threads;
+    u32 stack_size;
+    bool initialized;
+};
+
+struct UltUlthread {
+    void* handle; // platform thread handle
+    bool joined;
+};
+
+// Library initialization
+s32 PS4_SYSV_ABI sceUltInitialize();
+
+// Waiting queue resource pool
+s32 PS4_SYSV_ABI sceUltWaitingQueueResourcePoolGetWorkAreaSize(u32 numThreads);
+s32 PS4_SYSV_ABI _sceUltWaitingQueueResourcePoolCreate(UltWaitingQueueResourcePool* pool,
+                                                       const char* name, u32 numThreads,
+                                                       void* workArea, void* optParam);
+
+// Queue data resource pool
+s32 PS4_SYSV_ABI sceUltQueueDataResourcePoolGetWorkAreaSize(u32 numData, u32 dataSize);
+s32 PS4_SYSV_ABI _sceUltQueueDataResourcePoolCreate(UltQueueDataResourcePool* pool,
+                                                    const char* name, u32 numData, u32 dataSize,
+                                                    void* workArea, void* optParam);
+
+// Queue operations
+s32 PS4_SYSV_ABI _sceUltQueueCreate(UltQueue* queue, const char* name, u32 dataSize, u32 numData,
+                                    UltWaitingQueueResourcePool* waitPool,
+                                    UltQueueDataResourcePool* dataPool, void* optParam);
+s32 PS4_SYSV_ABI sceUltQueuePush(UltQueue* queue, const void* data);
+s32 PS4_SYSV_ABI sceUltQueuePop(UltQueue* queue, void* data);
+
+// Ulthread runtime
+s32 PS4_SYSV_ABI _sceUltUlthreadRuntimeOptParamInitialize(UltUlthreadRuntimeOptParam* param);
+s32 PS4_SYSV_ABI sceUltUlthreadRuntimeGetWorkAreaSize(u32 numThread, u32 stackSize);
+s32 PS4_SYSV_ABI _sceUltUlthreadRuntimeCreate(UltUlthreadRuntime* runtime, const char* name,
+                                              u32 numThread, u32 stackSize, void* workArea,
+                                              void* optParam);
+s32 PS4_SYSV_ABI sceUltUlthreadRuntimeDestroy(UltUlthreadRuntime* runtime);
+
+// Ulthread
+s32 PS4_SYSV_ABI _sceUltUlthreadCreate(UltUlthread* thread, const char* name, void (*entry)(void*),
+                                       void* arg, void* context, u32 stackSize,
+                                       UltUlthreadRuntime* runtime, void* optParam);
+s32 PS4_SYSV_ABI sceUltUlthreadJoin(UltUlthread* thread, s32* status);
+
+void RegisterlibSceUlt(Core::Loader::SymbolsResolver* sym);
+
+} // namespace Libraries::Ult

--- a/src/core/libraries/ult/ult_error.h
+++ b/src/core/libraries/ult/ult_error.h
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+constexpr int ORBIS_OK = 0;
+constexpr int SCE_ULT_ERROR_NULL = 0x80810001;
+constexpr int SCE_ULT_ERROR_ALIGNMENT = 0x80810002;
+constexpr int SCE_ULT_ERROR_RANGE = 0x80810003;
+constexpr int SCE_ULT_ERROR_INVALID = 0x80810004;
+constexpr int SCE_ULT_ERROR_PERMISSION = 0x80810005;
+constexpr int SCE_ULT_ERROR_STATE = 0x80810006;
+constexpr int SCE_ULT_ERROR_BUSY = 0x80810007;
+constexpr int SCE_ULT_ERROR_AGAIN = 0x80810008;
+constexpr int SCE_ULT_ERROR_FATAL = 0x80810009;
+constexpr int SCE_ULT_ERROR_NODATA = 0x8081000A;


### PR DESCRIPTION
Adds a basic implementation of the PS4 User-Level Threading library.

Implemented:
- sceUltInitialize
- WaitingQueueResourcePool create/work area size
- QueueDataResourcePool create/work area size
- Queue create/push/pop
- UlthreadRuntime create/destroy/work area size/opt param initialize
- Ulthread create/join

ULT threads are mapped to host threads for now. Queue synchronization uses std::mutex and std::condition_variable. This is sufficient to get libSceUlt-dependent titles past initialization.

Tested with Dead or Alive Xtreme 3 Fortune (CUSA04555), which previously crashed on launch due to missing ULT symbols and now boots in-game.