### PR TITLE
Fix input regression in Driveclub

### DIFF
--- a/src/core/libraries/pad/pad.cpp
+++ b/src/core/libraries/pad/pad.cpp
@@ -143,6 +143,9 @@ int PS4_SYSV_ABI scePadGetExtControllerInformation(s32 handle,
     pInfo->capability = 0;
 
     auto res = scePadGetControllerInformation(handle, &pInfo->base);
+    if (!EmulatorSettings.IsUsingSpecialPad()) {
+        pInfo->base.connected = false;
+    }
     return res;
 }
 


### PR DESCRIPTION
https://github.com/shadps4-emu/shadPS4/pull/4265 broke inputs in at least the titular game, and this isn't a fully valid fix for that, and is more of a workaround, but until I make a real fix (that will unfortunately have to involve a semi-major refactor), this should at least silence the people complaining about this regression.