### PR TITLE
HOTFIX: set_color not defined

### DIFF
--- a/src/common/logging/log.cpp
+++ b/src/common/logging/log.cpp
@@ -170,8 +170,7 @@ void Setup(std::string_view log_filename) {
 
 #ifdef _WIN32
     if (EmulatorSettings.GetLogType() == "wincolor") {
-        g_console_sink =
-            UpdateColorLevels(std::make_shared<spdlog::sinks::wincolor_stdout_sink_mt>());
+        g_console_sink = std::make_shared<spdlog::sinks::wincolor_stdout_sink_mt>();
     } else {
         g_console_sink = std::make_shared<spdlog::sinks::msvc_sink_mt>();
     }


### PR DESCRIPTION
lld-link: error: undefined symbol: public: void __cdecl spdlog::sinks::wincolor_sink<class std::mutex>::set_color(enum spdlog::level, unsigned short)