### PR TITLE
shader_recompiler: Only forward declared number of vertex inputs.

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_quad_rect.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_quad_rect.cpp
@@ -12,8 +12,9 @@ using Sirit::Id;
 constexpr u32 SPIRV_VERSION_1_5 = 0x00010500;
 
 struct QuadRectListEmitter : public Sirit::Module {
-    explicit QuadRectListEmitter(const FragmentRuntimeInfo& fs_info_)
-        : Sirit::Module{SPIRV_VERSION_1_5}, fs_info{fs_info_} {
+    explicit QuadRectListEmitter(const VertexRuntimeInfo& vs_info_,
+                                 const FragmentRuntimeInfo& fs_info_)
+        : Sirit::Module{SPIRV_VERSION_1_5}, vs_info{vs_info_}, fs_info{fs_info_} {
         void_id = TypeVoid();
         bool_id = TypeBool();
         float_id = TypeFloat(32);
@@ -252,8 +253,9 @@ private:
         } else {
             gl_per_vertex = AddOutput(gl_per_vertex_type);
         }
-        outputs.reserve(fs_info.num_inputs);
-        for (int i = 0; i < fs_info.num_inputs; i++) {
+        const auto num_forwards = std::min(vs_info.num_exports, fs_info.num_inputs);
+        outputs.reserve(num_forwards);
+        for (int i = 0; i < num_forwards; i++) {
             const auto& input = fs_info.inputs[i];
             if (input.IsDefault()) {
                 continue;
@@ -276,8 +278,10 @@ private:
         const Id gl_per_vertex_array{TypeArray(gl_per_vertex_type, Constant(uint_id, 32U))};
         gl_in = AddInput(gl_per_vertex_array);
         const Id float_arr{TypeArray(vec4_id, Int(32))};
-        inputs.reserve(fs_info.num_inputs);
-        for (int i = 0; i < fs_info.num_inputs; i++) {
+
+        const auto num_forwards = std::min(vs_info.num_exports, fs_info.num_inputs);
+        inputs.reserve(num_forwards);
+        for (int i = 0; i < num_forwards; i++) {
             const auto& input = fs_info.inputs[i];
             if (input.IsDefault()) {
                 continue;
@@ -288,6 +292,7 @@ private:
     }
 
 private:
+    VertexRuntimeInfo vs_info;
     FragmentRuntimeInfo fs_info;
     Id main;
     Id void_id;
@@ -319,8 +324,9 @@ private:
     std::vector<Id> interfaces;
 };
 
-std::vector<u32> EmitAuxilaryTessShader(AuxShaderType type, const FragmentRuntimeInfo& fs_info) {
-    QuadRectListEmitter ctx{fs_info};
+std::vector<u32> EmitAuxilaryTessShader(AuxShaderType type, const VertexRuntimeInfo& vs_info,
+                                        const FragmentRuntimeInfo& fs_info) {
+    QuadRectListEmitter ctx{vs_info, fs_info};
     switch (type) {
     case AuxShaderType::RectListTCS:
         ctx.EmitRectListTCS();

--- a/src/shader_recompiler/backend/spirv/emit_spirv_quad_rect.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_quad_rect.h
@@ -8,7 +8,8 @@
 
 namespace Shader {
 struct FragmentRuntimeInfo;
-}
+struct VertexRuntimeInfo;
+} // namespace Shader
 
 namespace Shader::Backend::SPIRV {
 
@@ -19,6 +20,7 @@ enum class AuxShaderType : u32 {
 };
 
 [[nodiscard]] std::vector<u32> EmitAuxilaryTessShader(AuxShaderType type,
+                                                      const VertexRuntimeInfo& vs_info,
                                                       const FragmentRuntimeInfo& fs_info);
 
 } // namespace Shader::Backend::SPIRV

--- a/src/shader_recompiler/ir/passes/inject_clip_distance_attributes.cpp
+++ b/src/shader_recompiler/ir/passes/inject_clip_distance_attributes.cpp
@@ -5,10 +5,19 @@
 #include "shader_recompiler/ir/basic_block.h"
 #include "shader_recompiler/ir/ir_emitter.h"
 #include "shader_recompiler/ir/program.h"
+#include "shader_recompiler/profile.h"
 
 namespace Shader {
 
-void InjectClipDistanceAttributes(IR::Program& program, RuntimeInfo& runtime_info) {
+void InjectClipDistanceAttributes(IR::Program& program, RuntimeInfo& runtime_info,
+                                  const Profile& profile) {
+    if (program.info.stage == Stage::Vertex && profile.needs_clip_distance_emulation &&
+        program.info.stores.GetAny(IR::Attribute::ClipDistance)) {
+        // Increment to include the added clip distance export.
+        ++runtime_info.vs_info.num_exports;
+        return;
+    }
+
     auto& info = runtime_info.fs_info;
 
     if (!info.clip_distance_emulation || program.info.l_stage != LogicalStage::Fragment) {

--- a/src/shader_recompiler/ir/passes/ir_passes.h
+++ b/src/shader_recompiler/ir/passes/ir_passes.h
@@ -8,7 +8,8 @@
 
 namespace Shader {
 struct Profile;
-void InjectClipDistanceAttributes(IR::Program& program, RuntimeInfo& runtime_info);
+void InjectClipDistanceAttributes(IR::Program& program, RuntimeInfo& runtime_info,
+                                  const Profile& profile);
 } // namespace Shader
 
 namespace Shader::Optimization {

--- a/src/shader_recompiler/recompiler.cpp
+++ b/src/shader_recompiler/recompiler.cpp
@@ -61,7 +61,7 @@ IR::Program TranslateProgram(const std::span<const u32>& code, Pools& pools, Inf
 
     // On NVIDIA GPUs HW interpolation of clip distance values seems broken, and we need to emulate
     // it with expensive discard in PS.
-    Shader::InjectClipDistanceAttributes(program, runtime_info);
+    Shader::InjectClipDistanceAttributes(program, runtime_info, profile);
 
     // Run optimization passes
     if (!profile.support_float64) {

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -81,6 +81,7 @@ using OutputMap = std::array<Output, 4>;
 
 struct VertexRuntimeInfo {
     u32 num_outputs;
+    u32 num_exports;
     std::array<OutputMap, 3> outputs;
     bool tess_emulated_primitive{};
     bool emulate_depth_negative_one_to_one{};

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -193,8 +193,9 @@ GraphicsPipeline::GraphicsPipeline(
     } else if (is_rect_list || is_quad_list) {
         const auto type = is_quad_list ? AuxShaderType::QuadListTCS : AuxShaderType::RectListTCS;
         if (!preloading) {
+            const auto& vs_info = runtime_infos[u32(Shader::LogicalStage::Vertex)].vs_info;
             const auto& fs_info = runtime_infos[u32(Shader::LogicalStage::Fragment)].fs_info;
-            sdata.tcs = Shader::Backend::SPIRV::EmitAuxilaryTessShader(type, fs_info);
+            sdata.tcs = Shader::Backend::SPIRV::EmitAuxilaryTessShader(type, vs_info, fs_info);
         }
         shader_stages.emplace_back(vk::PipelineShaderStageCreateInfo{
             .stage = vk::ShaderStageFlagBits::eTessellationControl,
@@ -211,9 +212,10 @@ GraphicsPipeline::GraphicsPipeline(
         });
     } else if (is_rect_list || is_quad_list) {
         if (!preloading) {
+            const auto& vs_info = runtime_infos[u32(Shader::LogicalStage::Vertex)].vs_info;
             const auto& fs_info = runtime_infos[u32(Shader::LogicalStage::Fragment)].fs_info;
             sdata.tes = Shader::Backend::SPIRV::EmitAuxilaryTessShader(
-                AuxShaderType::PassthroughTES, fs_info);
+                AuxShaderType::PassthroughTES, vs_info, fs_info);
         }
         shader_stages.emplace_back(vk::PipelineShaderStageCreateInfo{
             .stage = vk::ShaderStageFlagBits::eTessellationEvaluation,

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -127,6 +127,7 @@ const Shader::RuntimeInfo& PipelineCache::BuildRuntimeInfo(Stage stage, LogicalS
         info.vs_info.step_rate_0 = regs.vgt_instance_step_rate_0;
         info.vs_info.step_rate_1 = regs.vgt_instance_step_rate_1;
         info.vs_info.num_outputs = MapOutputs(info.vs_info.outputs, regs.vs_output_control);
+        info.vs_info.num_exports = regs.vs_output_config.NumExports();
         info.vs_info.emulate_depth_negative_one_to_one =
             !instance.IsDepthClipControlSupported() &&
             regs.clipper_control.clip_space == AmdGpu::ClipSpace::MinusWToW;


### PR DESCRIPTION
Use the declared number of vertex exports in determining how many parameters to forward from vertex to fragment in generated rect/quad list tessellation control shaders. In my testing this value was accurate to the actual number of vertex exports.

Fixes instances of the following validation error (e.g. in Bloodborne):
```
VUID-RuntimeSpirv-OpEntryPoint-08743: vkCreateGraphicsPipelines(): pCreateInfos[0] (SPIR-V Interface) VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT has a declared Input at Location 1 Component 0  but the previous stage (VK_SHADER_STAGE_VERTEX_BIT) has no Output declared there.
The input variable is:
  pointer to Input -> array[32] of vec4 of float32
The Vulkan spec states: Any user-defined variables shared between the OpEntryPoint of two shader stages, and declared with Input as its Storage Class for the subsequent shader stage, must have all Location slots and Component words declared in the preceding shader stage's OpEntryPoint with Output as the Storage Class (https://vulkan.lunarg.com/doc/view/1.4.341.0/mac/antora/spec/latest/appendices/spirvenv.html#VUID-RuntimeSpirv-OpEntryPoint-08743)

```