### PR TITLE
renderer_vulkan: Fix additional validation errors

### DIFF
--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -26,15 +26,6 @@ static constexpr std::array LogicalStageToStageBit = {
     vk::ShaderStageFlagBits::eCompute,
 };
 
-static bool IsPrimitiveTopologyList(const vk::PrimitiveTopology topology) {
-    return topology == vk::PrimitiveTopology::ePointList ||
-           topology == vk::PrimitiveTopology::eLineList ||
-           topology == vk::PrimitiveTopology::eTriangleList ||
-           topology == vk::PrimitiveTopology::eLineListWithAdjacency ||
-           topology == vk::PrimitiveTopology::eTriangleListWithAdjacency ||
-           topology == vk::PrimitiveTopology::ePatchList;
-}
-
 GraphicsPipeline::GraphicsPipeline(
     const Instance& instance, Scheduler& scheduler, DescriptorHeap& desc_heap,
     const Shader::Profile& profile, const GraphicsPipelineKey& key_,

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -829,6 +829,7 @@ RenderState Rasterizer::BeginRendering(const GraphicsPipeline* pipeline) {
     for (auto cb = 0u; cb < state.num_color_attachments; ++cb) {
         auto& [image_id, desc] = cb_descs[cb];
         if (!image_id) {
+            state.color_attachments[cb] = {};
             continue;
         }
         auto* image = &texture_cache.GetImage(image_id);
@@ -1286,7 +1287,19 @@ void Rasterizer::UpdatePrimitiveState(const bool is_indexed) const {
     const auto& regs = liverpool->regs;
     auto& dynamic_state = scheduler.GetDynamicState();
 
-    const auto prim_restart = (regs.enable_primitive_restart & 1) != 0;
+    const auto is_list_topology = [](const AmdGpu::PrimitiveType type) {
+        const auto topology = LiverpoolToVK::PrimitiveType(type);
+        return topology == vk::PrimitiveTopology::ePointList ||
+               topology == vk::PrimitiveTopology::eLineList ||
+               topology == vk::PrimitiveTopology::eTriangleList ||
+               topology == vk::PrimitiveTopology::eLineListWithAdjacency ||
+               topology == vk::PrimitiveTopology::eTriangleListWithAdjacency ||
+               topology == vk::PrimitiveTopology::ePatchList;
+    };
+
+    const auto prim_restart =
+        (regs.enable_primitive_restart & 1) != 0 &&
+        (instance.IsListRestartSupported() || !is_list_topology(regs.primitive_type));
     ASSERT_MSG(!is_indexed || !prim_restart || regs.primitive_restart_index == 0xFFFF ||
                    regs.primitive_restart_index == 0xFFFFFFFF,
                "Primitive restart index other than -1 is not supported yet");


### PR DESCRIPTION
* Fix invalid color attachment data when an attachment is within width of `mrt_mask` but skipped.
* Restore logic to respect whether list primitive restart is supported.