### PR TITLE
core: Re-implement blockpool for more accuracy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -788,6 +788,8 @@ set(CORE src/core/aerolib/stubs.cpp
          src/core/aerolib/aerolib.h
          src/core/address_space.cpp
          src/core/address_space.h
+         src/core/blockpool.cpp
+         src/core/blockpool.h
          src/core/file_sys/devices/base_device.cpp
          src/core/file_sys/devices/base_device.h
          src/core/file_sys/devices/ioccom.h

--- a/src/common/shared_first_mutex.h
+++ b/src/common/shared_first_mutex.h
@@ -12,13 +12,13 @@ namespace Common {
 class SharedFirstMutex {
 public:
     void lock() {
-        std::unique_lock<std::mutex> lock(mtx);
+        std::unique_lock lock(mtx);
         cv.wait(lock, [this]() { return !writer_active && readers == 0; });
         writer_active = true;
     }
 
     bool try_lock() {
-        std::lock_guard<std::mutex> lock(mtx);
+        std::lock_guard lock(mtx);
         if (writer_active || readers > 0) {
             return false;
         }
@@ -27,19 +27,19 @@ public:
     }
 
     void unlock() {
-        std::lock_guard<std::mutex> lock(mtx);
+        std::lock_guard lock(mtx);
         writer_active = false;
         cv.notify_all();
     }
 
     void lock_shared() {
-        std::unique_lock<std::mutex> lock(mtx);
+        std::unique_lock lock(mtx);
         cv.wait(lock, [this]() { return !writer_active; });
         ++readers;
     }
 
     void unlock_shared() {
-        std::lock_guard<std::mutex> lock(mtx);
+        std::lock_guard lock(mtx);
         if (--readers == 0) {
             cv.notify_all();
         }

--- a/src/core/blockpool.cpp
+++ b/src/core/blockpool.cpp
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <utility>
+#include "common/assert.h"
+#include "core/blockpool.h"
+#include "core/libraries/kernel/memory.h"
+
+namespace Core {
+
+bool Blockpool::Commit(u32 count, bool onion, bool writeback, u32* out_blocks) {
+    std::scoped_lock lk{mutex};
+
+    if (count > (cached.available_blocks + flushed.available_blocks)) {
+        return false;
+    }
+
+    while (count) {
+        if (onion) {
+            const u32 cached_available = cached.available_blocks;
+            if (count <= cached_available) {
+                cached.Allocate(count, out_blocks);
+            } else {
+                const u32 flushed_count = count - cached_available;
+                cached.Allocate(cached_available, out_blocks);
+                flushed.Allocate(flushed_count, out_blocks + cached_available);
+            }
+            break;
+        } else {
+            if (count <= flushed.available_blocks) {
+                flushed.Allocate(count, out_blocks);
+                break;
+            }
+            if (cached.available_blocks < 32) {
+                const u32 cached_count = count - flushed.available_blocks;
+                flushed.Allocate(flushed.allocated_blocks, out_blocks);
+                cached.Allocate(cached_count, out_blocks + flushed.allocated_blocks);
+                break;
+            }
+        }
+        Flush();
+    }
+
+    if (writeback) {
+        cached.allocated_blocks += count;
+    } else {
+        flushed.allocated_blocks += count;
+    }
+
+    return true;
+}
+
+void Blockpool::Decommit(DmemBlock* blocks, u32 count) {
+    std::scoped_lock lk{mutex};
+
+    while (count) {
+        Bitmap* bitmap;
+        if (blocks->writeback) {
+            --cached.allocated_blocks;
+            ++cached.available_blocks;
+            bitmap = &cached;
+        } else {
+            --flushed.allocated_blocks;
+            ++flushed.available_blocks;
+            bitmap = &flushed;
+        }
+        u32 block = blocks->block;
+        bitmap->bits_l0[block >> Bitmap::LEVEL_SHIFT] |= (u64{1} << (block & Bitmap::LEVEL_MASK));
+        block >>= Bitmap::LEVEL_SHIFT;
+        bitmap->bits_l1[block >> Bitmap::LEVEL_SHIFT] |= (u64{1} << (block & Bitmap::LEVEL_MASK));
+        block >>= Bitmap::LEVEL_SHIFT;
+        bitmap->bits_l2 |= (u64{1} << block);
+
+        blocks->raw = 0u;
+        ++blocks;
+        --count;
+    }
+}
+
+void Blockpool::Flush() {
+    for (u32 i = 0; i < flushed.bits_l0.size(); i++) {
+        flushed.bits_l0[i] |= std::exchange(cached.bits_l0[i], u64{0});
+    }
+    for (u32 i = 0; i < flushed.bits_l1.size(); i++) {
+        flushed.bits_l1[i] |= std::exchange(cached.bits_l1[i], u64{0});
+    }
+    flushed.bits_l2 |= std::exchange(cached.bits_l2, u64{0});
+}
+
+void Blockpool::Query(VAddr addr, VAddr base, u64 size, const DmemBlock* blocks,
+                      ::Libraries::Kernel::OrbisVirtualQueryInfo* info) {
+    u32 start = base;
+    u32 end = base + size;
+    // UNREACHABLE();
+    //  get _start and __end from name splay tree
+    u32 block_min = 0;
+    if (base <= start) {
+        block_min = Blockpool::ToBlocks(start - base);
+    }
+    u32 block_max = Blockpool::ToBlocks(size);
+    if ((end - base) <= size) {
+        block_max = Blockpool::ToBlocks(end - base);
+    }
+    const u32 query_block = Blockpool::ToBlocks(addr - base);
+    const auto vm_block = blocks[query_block];
+    u32 start_block = query_block;
+    u32 end_block = query_block;
+    if (!vm_block.valid) {
+        while (start_block > block_min && !blocks[start_block - 1].valid) {
+            --start_block;
+        }
+        while (end_block < block_max && !blocks[end_block + 1].valid) {
+            ++end_block;
+        }
+    } else {
+        while (start_block > block_min &&
+               blocks[start_block].Props() == blocks[query_block].Props()) {
+            --start_block;
+        }
+        while (end_block < block_max && blocks[end_block].Props() == blocks[query_block].Props()) {
+            ++end_block;
+        }
+    }
+    info->start = base + Blockpool::ToBytes(start_block);
+    info->end = base + Blockpool::ToBytes(end_block);
+    const u32 prot_cpu = (vm_block.prot_cpu >> 1) ? 3 : vm_block.prot_cpu & 1;
+    info->protection = (vm_block.prot_gpu << 4) | prot_cpu;
+    if (vm_block.valid) {
+        info->memory_type = 10;
+        if (!vm_block.writeback || vm_block.onion) {
+            info->memory_type = 0;
+        }
+        if (!vm_block.writeback && !vm_block.onion) {
+            info->memory_type = 3;
+        }
+    }
+    info->is_committed = vm_block.valid;
+    info->is_pooled = 1;
+    info->offset = info->start - base;
+}
+
+} // namespace Core

--- a/src/core/blockpool.h
+++ b/src/core/blockpool.h
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <bit>
+#include <map>
+#include <mutex>
+#include "common/assert.h"
+#include "common/types.h"
+
+namespace Libraries::Kernel {
+struct OrbisVirtualQueryInfo;
+}
+
+namespace Core {
+
+union DmemBlock {
+    u32 raw{};
+    struct {
+        u32 block : 21;
+        u32 unk1 : 1;
+        u32 onion : 1;
+        u32 writeback : 1;
+        u32 prot_cpu : 2;
+        u32 prot_gpu : 2;
+        u32 valid : 2;
+    };
+
+    u32 Props() const {
+        return raw & 0x3fc00000;
+    }
+};
+
+struct BlockStats {
+    u32 available_flushed_blocks;
+    u32 available_cached_blocks;
+    u32 allocated_flushed_blocks;
+    u32 allocated_cached_blocks;
+};
+
+class Blockpool {
+public:
+    static constexpr u32 BLOCK_SHIFT = 16;
+    static constexpr u32 BLOCK_SIZE = 1U << BLOCK_SHIFT;
+
+public:
+    explicit Blockpool() = default;
+    ~Blockpool() = default;
+
+    constexpr static u64 ToBlocks(VAddr addr) {
+        return addr >> BLOCK_SHIFT;
+    }
+
+    constexpr static u32 ToBytes(u64 blocks) {
+        return blocks << BLOCK_SHIFT;
+    }
+
+    BlockStats GetBlockStats() noexcept {
+        std::scoped_lock lk{mutex};
+        return BlockStats{
+            .available_flushed_blocks = flushed.available_blocks,
+            .available_cached_blocks = cached.available_blocks,
+            .allocated_flushed_blocks = flushed.allocated_blocks,
+            .allocated_cached_blocks = cached.allocated_blocks,
+        };
+    }
+
+    void Expand(PAddr dmem_addr, u64 size) {
+        std::scoped_lock lk{mutex};
+        flushed.Insert(dmem_addr >> BLOCK_SHIFT, size >> BLOCK_SHIFT);
+    }
+
+    bool Commit(u32 count, bool onion, bool writeback, u32* out_blocks);
+
+    void Decommit(DmemBlock* blocks, u32 count);
+
+    void Flush();
+
+    void Query(VAddr addr, VAddr base, u64 size, const DmemBlock* blocks,
+               ::Libraries::Kernel::OrbisVirtualQueryInfo* info);
+
+private:
+    struct Bitmap {
+        static constexpr u32 NUM_ENTRIES = 4096;
+        static constexpr u32 LEVEL_SHIFT = 6;
+        static constexpr u32 LEVEL_MASK = (1u << LEVEL_SHIFT) - 1;
+        static_assert(NUM_ENTRIES >> (LEVEL_SHIFT * 2) == 1);
+
+        constexpr void Allocate(u32 count, u32* out_blocks) {
+            while (count && bits_l2) {
+                const u32 l1_index = std::countr_zero(bits_l2);
+                const u32 l0_index =
+                    std::countr_zero(bits_l1[l1_index]) | (l1_index << LEVEL_SHIFT);
+
+                u64 entry = bits_l0[l0_index];
+                do {
+                    *(out_blocks++) = std::countr_zero(entry) | (l0_index << LEVEL_SHIFT);
+                    --available_blocks;
+                    entry = entry - 1 & entry;
+                    --count;
+                } while (entry && count != 0);
+                bits_l0[l0_index] = entry;
+
+                if (entry == 0) {
+                    bits_l1[l1_index] &= ~(u64{1} << (l0_index & LEVEL_MASK));
+                }
+                if (bits_l1[l1_index] == 0) {
+                    bits_l2 &= ~(u64{1} << l1_index);
+                }
+            }
+            ASSERT(count == 0);
+        }
+
+        constexpr void Insert(u32 start, u32 count) {
+            available_blocks += count;
+            for (auto* bits : {bits_l0.data(), bits_l1.data(), &bits_l2}) {
+                InsertLevel(start, count, bits);
+                start >>= LEVEL_SHIFT;
+                count = (count + LEVEL_MASK) >> LEVEL_SHIFT;
+            }
+        }
+
+        constexpr void InsertLevel(u32 start_bit, u32 num_bits, u64* bits) {
+            const u32 end_bit = start_bit + num_bits - 1;
+            const u32 start_index = start_bit >> LEVEL_SHIFT;
+            const u32 end_index = end_bit >> LEVEL_SHIFT;
+            bits[start_index] |= (~u64{0} >> (64 - std::min(num_bits, 64u)))
+                                 << (start_bit & LEVEL_MASK);
+            if (start_index == end_index) {
+                return;
+            }
+            for (u32 index = start_index + 1; index < end_index; ++index) {
+                bits[index] = ~u64{0};
+            }
+            bits[end_index] |= (~u64{0} >> (63 - (end_bit & LEVEL_MASK)));
+        };
+
+        u32 available_blocks;
+        u32 allocated_blocks;
+        std::array<u64, NUM_ENTRIES> bits_l0;
+        std::array<u64, (NUM_ENTRIES >> LEVEL_SHIFT)> bits_l1;
+        u64 bits_l2;
+    };
+
+    std::mutex mutex;
+    Bitmap cached{};
+    Bitmap flushed{};
+
+    struct NameEntry {
+        VAddr start;
+        VAddr end;
+        char name[32];
+    };
+    std::map<VAddr, NameEntry> name_tree;
+};
+
+} // namespace Core

--- a/src/core/devtools/widget/memory_map.cpp
+++ b/src/core/devtools/widget/memory_map.cpp
@@ -56,8 +56,7 @@ bool MemoryMapViewer::Iterator::DrawLine() {
     auto type = static_cast<::Libraries::Kernel::MemoryTypes>(m.memory_type);
     Text("%s", magic_enum::enum_name(type).data());
     TableNextColumn();
-    Text("%d",
-         m.dma_type == PhysicalMemoryType::Pooled || m.dma_type == PhysicalMemoryType::Committed);
+    Text("%d", m.dma_type == PhysicalMemoryType::Committed);
     ++dmem.it;
     return true;
 }

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -310,7 +310,7 @@ s32 PS4_SYSV_ABI sceKernelMapNamedFlexibleMemory(void** addr_in_out, u64 len, s3
     auto* memory = Core::Memory::Instance();
     const auto ret = memory->MapMemory(addr_in_out, in_addr, len, mem_prot, map_flags,
                                        Core::VMAType::Flexible, name);
-    LOG_INFO(Kernel_Vmm, "out_addr = {}", fmt::ptr(*addr_in_out));
+    LOG_INFO(Kernel_Vmm, "out_addr = {}, ret = {:#x}", fmt::ptr(*addr_in_out), ret);
     return ret;
 }
 
@@ -491,46 +491,49 @@ s32 PS4_SYSV_ABI sceKernelSetVirtualRangeName(const void* addr, u64 len, const c
     return ORBIS_OK;
 }
 
-s32 PS4_SYSV_ABI sceKernelMemoryPoolExpand(u64 searchStart, u64 searchEnd, u64 len, u64 alignment,
-                                           u64* physAddrOut) {
-    if (searchStart < 0 || searchEnd <= searchStart) {
+s32 PS4_SYSV_ABI sceKernelMemoryPoolExpand(u64 search_start, u64 search_end, u64 size,
+                                           u64 alignment, u64* phys_addr_out) {
+    if (search_start < 0 || search_end <= search_start) {
         LOG_ERROR(Kernel_Vmm, "Provided address range is invalid!");
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
-    if (len <= 0 || !Common::Is64KBAligned(len)) {
-        LOG_ERROR(Kernel_Vmm, "Provided length {:#x} is invalid!", len);
+    if (size <= 0 || !Common::Is64KBAligned(size)) {
+        LOG_ERROR(Kernel_Vmm, "Provided size {:#x} is invalid!", size);
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
     if (alignment != 0 && !Common::Is64KBAligned(alignment)) {
         LOG_ERROR(Kernel_Vmm, "Alignment {:#x} is invalid!", alignment);
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
-    if (physAddrOut == nullptr) {
+    if (phys_addr_out == nullptr) {
         LOG_ERROR(Kernel_Vmm, "Result physical address pointer is null!");
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
 
-    const bool is_in_range = searchEnd - searchStart >= len;
-    if (searchEnd <= searchStart || searchEnd < len || !is_in_range) {
+    const bool is_in_range = search_end - search_start >= size;
+    if (search_end <= search_start || search_end < size || !is_in_range) {
         LOG_ERROR(Kernel_Vmm,
                   "Provided address range is too small!"
-                  " searchStart = {:#x}, searchEnd = {:#x}, length = {:#x}",
-                  searchStart, searchEnd, len);
+                  " search_start = {:#x}, search_end = {:#x}, size = {:#x}",
+                  search_start, search_end, size);
         return ORBIS_KERNEL_ERROR_ENOMEM;
     }
 
     auto* memory = Core::Memory::Instance();
-    PAddr phys_addr = memory->PoolExpand(searchStart, searchEnd, len, alignment);
+    auto& blockpool = memory->GetBlockpool();
+    const PAddr phys_addr = memory->Allocate(search_start, search_end, size, alignment, 3);
     if (phys_addr == -1) {
         return ORBIS_KERNEL_ERROR_ENOMEM;
     }
+    blockpool.Expand(phys_addr, size);
 
-    *physAddrOut = static_cast<s64>(phys_addr);
+    *phys_addr_out = static_cast<s64>(phys_addr);
 
-    LOG_INFO(Kernel_Vmm,
-             "searchStart = {:#x}, searchEnd = {:#x}, len = {:#x}, alignment = {:#x}, physAddrOut "
-             "= {:#x}",
-             searchStart, searchEnd, len, alignment, phys_addr);
+    LOG_INFO(
+        Kernel_Vmm,
+        "search_start = {:#x}, search_end = {:#x}, len = {:#x}, alignment = {:#x}, physAddrOut "
+        "= {:#x}",
+        search_start, search_end, size, alignment, phys_addr);
     return ORBIS_OK;
 }
 
@@ -555,9 +558,11 @@ s32 PS4_SYSV_ABI sceKernelMemoryPoolReserve(void* addr_in, u64 len, u64 alignmen
     const auto map_flags = static_cast<Core::MemoryMapFlags>(flags);
     u64 map_alignment = alignment == 0 ? 2_MB : alignment;
 
-    return memory->MapMemory(addr_out, std::bit_cast<VAddr>(addr_in), len,
-                             Core::MemoryProt::NoAccess, map_flags, Core::VMAType::PoolReserved,
-                             "anon", false, -1, map_alignment);
+    const auto ret =
+        memory->MapMemory(addr_out, std::bit_cast<VAddr>(addr_in), len, Core::MemoryProt::NoAccess,
+                          map_flags, Core::VMAType::Pooled, "anon", false, -1, map_alignment);
+    LOG_INFO(Kernel_Vmm, "out_addr = {}, ret = {:#x}", fmt::ptr(*addr_out), ret);
+    return ret;
 }
 
 s32 PS4_SYSV_ABI sceKernelMemoryPoolCommit(void* addr, u64 len, s32 type, s32 prot, s32 flags) {
@@ -659,8 +664,14 @@ s32 PS4_SYSV_ABI sceKernelMemoryPoolGetBlockStats(OrbisKernelMemoryPoolBlockStat
                                                   u64 size) {
     LOG_WARNING(Kernel_Vmm, "called");
     auto* memory = Core::Memory::Instance();
+    auto& blockpool = memory->GetBlockpool();
+
+    const auto pool_stats = blockpool.GetBlockStats();
     OrbisKernelMemoryPoolBlockStats local_stats;
-    memory->GetMemoryPoolStats(&local_stats);
+    local_stats.available_flushed_blocks = pool_stats.available_flushed_blocks;
+    local_stats.available_cached_blocks = pool_stats.available_cached_blocks;
+    local_stats.allocated_flushed_blocks = pool_stats.allocated_flushed_blocks;
+    local_stats.allocated_cached_blocks = pool_stats.allocated_cached_blocks;
 
     u64 size_to_copy = size < sizeof(OrbisKernelMemoryPoolBlockStats)
                            ? size

--- a/src/core/libraries/kernel/memory.h
+++ b/src/core/libraries/kernel/memory.h
@@ -174,8 +174,6 @@ s32 PS4_SYSV_ABI sceKernelBatchMap2(OrbisKernelBatchMapEntry* entries, s32 numEn
 
 s32 PS4_SYSV_ABI sceKernelSetVirtualRangeName(const void* addr, u64 len, const char* name);
 
-s32 PS4_SYSV_ABI sceKernelMemoryPoolExpand(u64 searchStart, u64 searchEnd, u64 len, u64 alignment,
-                                           u64* physAddrOut);
 s32 PS4_SYSV_ABI sceKernelMemoryPoolReserve(void* addr_in, u64 len, u64 alignment, s32 flags,
                                             void** addr_out);
 s32 PS4_SYSV_ABI sceKernelMemoryPoolCommit(void* addr, u64 len, s32 type, s32 prot, s32 flags);

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -87,6 +87,23 @@ void MemoryManager::SetupMemoryRegions(u64 flexible_size, bool use_extended_mem1
              total_flexible_size, total_direct_size);
 }
 
+bool MemoryManager::IsValidMapping(const VAddr virtual_addr, const u64 size) {
+    const auto end_it = std::prev(vma_map.end());
+    const VAddr end_addr = end_it->first + end_it->second.size;
+
+    // If the address fails boundary checks, return early.
+    if (virtual_addr < vma_map.begin()->first || virtual_addr >= end_addr) {
+        return false;
+    }
+
+    // If size is zero and boundary checks succeed, then skip more robust checking
+    if (size == 0) {
+        return true;
+    }
+
+    return true;
+}
+
 u64 MemoryManager::ClampRangeSize(VAddr virtual_addr, u64 size) {
     static constexpr u64 MinSizeToClamp = 1_GB;
     // Dont bother with clamping if the size is small so we dont pay a map lookup on every buffer.
@@ -139,7 +156,7 @@ void MemoryManager::CopySparseMemory(VAddr virtual_addr, u8* dest, u64 size) {
 
     auto vma = FindVMA(virtual_addr);
     while (size) {
-        u64 copy_size = std::min<u64>(vma->second.size - (virtual_addr - vma->first), size);
+        const u64 copy_size = std::min<u64>(vma->second.size - (virtual_addr - vma->first), size);
         if (vma->second.IsMapped()) {
             std::memcpy(dest, std::bit_cast<const u8*>(virtual_addr), copy_size);
         } else {
@@ -152,89 +169,9 @@ void MemoryManager::CopySparseMemory(VAddr virtual_addr, u8* dest, u64 size) {
     }
 }
 
-bool MemoryManager::TryWriteBacking(void* address, const void* data, u64 size) {
-    const VAddr virtual_addr = std::bit_cast<VAddr>(address);
-    std::shared_lock lk{mutex};
-    ASSERT_MSG(IsValidMapping(virtual_addr, size), "Attempted to access invalid address {:#x}",
-               virtual_addr);
-
-    std::vector<VirtualMemoryArea> vmas_to_write;
-    auto current_vma = FindVMA(virtual_addr);
-    while (current_vma->second.Overlaps(virtual_addr, size)) {
-        if (!HasPhysicalBacking(current_vma->second)) {
-            break;
-        }
-        vmas_to_write.emplace_back(current_vma->second);
-        current_vma++;
-    }
-
-    if (vmas_to_write.empty()) {
-        return false;
-    }
-
-    for (auto& vma : vmas_to_write) {
-        auto start_in_vma = std::max<VAddr>(virtual_addr, vma.base) - vma.base;
-        auto phys_handle = std::prev(vma.phys_areas.upper_bound(start_in_vma));
-        for (; phys_handle != vma.phys_areas.end(); phys_handle++) {
-            if (!size) {
-                break;
-            }
-            const u64 start_in_dma =
-                std::max<u64>(start_in_vma, phys_handle->first) - phys_handle->first;
-            u8* backing = impl.BackingBase() + phys_handle->second.base + start_in_dma;
-            u64 copy_size = std::min<u64>(size, phys_handle->second.size - start_in_dma);
-            memcpy(backing, data, copy_size);
-            size -= copy_size;
-        }
-    }
-
-    return true;
-}
-
-PAddr MemoryManager::PoolExpand(PAddr search_start, PAddr search_end, u64 size, u64 alignment) {
-    std::scoped_lock lk{mutex, unmap_mutex};
-    alignment = alignment > 0 ? alignment : 64_KB;
-
-    auto dmem_area = FindDmemArea(search_start);
-    auto mapping_start = search_start > dmem_area->second.base
-                             ? Common::AlignUp(search_start, alignment)
-                             : Common::AlignUp(dmem_area->second.base, alignment);
-    auto mapping_end = mapping_start + size;
-
-    // Find the first free, large enough dmem area in the range.
-    while (dmem_area->second.dma_type != PhysicalMemoryType::Free ||
-           dmem_area->second.GetEnd() < mapping_end) {
-        // The current dmem_area isn't suitable, move to the next one.
-        dmem_area++;
-        if (dmem_area == dmem_map.end()) {
-            break;
-        }
-
-        // Update local variables based on the new dmem_area
-        mapping_start = Common::AlignUp(dmem_area->second.base, alignment);
-        mapping_end = mapping_start + size;
-    }
-
-    if (dmem_area == dmem_map.end()) {
-        // There are no suitable mappings in this range
-        LOG_ERROR(Kernel_Vmm, "Unable to find free direct memory area: size = {:#x}", size);
-        return -1;
-    }
-
-    // Add the allocated region to the list and commit its pages.
-    auto& area = CarvePhysArea(dmem_map, mapping_start, size)->second;
-    area.dma_type = PhysicalMemoryType::Pooled;
-    area.memory_type = 3;
-
-    // Track how much dmem was allocated for pools.
-    pool_budget += size;
-
-    return mapping_start;
-}
-
 PAddr MemoryManager::Allocate(PAddr search_start, PAddr search_end, u64 size, u64 alignment,
                               s32 memory_type) {
-    std::scoped_lock lk{mutex, unmap_mutex};
+    std::scoped_lock lk{mutex};
     alignment = alignment > 0 ? alignment : 16_KB;
 
     auto dmem_area = FindDmemArea(search_start);
@@ -281,37 +218,7 @@ s32 MemoryManager::Free(PAddr phys_addr, u64 size, bool is_checked) {
         return ORBIS_OK;
     }
 
-    std::scoped_lock lk{unmap_mutex};
-    // If this is a checked free, then all direct memory in range must be allocated.
-    std::vector<std::pair<PAddr, u64>> free_list;
-    u64 remaining_size = size;
-    auto phys_handle = FindDmemArea(phys_addr);
-    for (; phys_handle != dmem_map.end(); phys_handle++) {
-        if (remaining_size == 0) {
-            // Done searching
-            break;
-        }
-        auto& dmem_area = phys_handle->second;
-        if (dmem_area.dma_type == PhysicalMemoryType::Free) {
-            if (is_checked) {
-                // Checked frees will error if anything in the area isn't allocated.
-                // Unchecked frees will just ignore free areas.
-                LOG_ERROR(Kernel_Vmm, "Attempting to release a free dmem area");
-                return ORBIS_KERNEL_ERROR_ENOENT;
-            }
-            continue;
-        }
-
-        // Store physical address and size to release
-        const PAddr current_phys_addr = std::max<PAddr>(phys_addr, phys_handle->first);
-        const u64 start_in_dma = current_phys_addr - phys_handle->first;
-        const u64 size_in_dma =
-            std::min<u64>(remaining_size, phys_handle->second.size - start_in_dma);
-        free_list.emplace_back(current_phys_addr, size_in_dma);
-
-        // Track remaining size to free
-        remaining_size -= size_in_dma;
-    }
+    std::scoped_lock lk{mutex};
 
     // Release any dmem mappings that reference this physical block.
     std::vector<std::pair<VAddr, u64>> remove_list;
@@ -319,82 +226,71 @@ s32 MemoryManager::Free(PAddr phys_addr, u64 size, bool is_checked) {
         if (mapping.type != VMAType::Direct) {
             continue;
         }
-        for (auto& [offset_in_vma, phys_mapping] : mapping.phys_areas) {
-            if (phys_addr + size > phys_mapping.base &&
-                phys_addr < phys_mapping.base + phys_mapping.size) {
-                const u64 phys_offset =
-                    std::max<u64>(phys_mapping.base, phys_addr) - phys_mapping.base;
-                const VAddr addr_in_vma = mapping.base + offset_in_vma + phys_offset;
-                const u64 unmap_size = std::min<u64>(phys_mapping.size - phys_offset, size);
+        if (mapping.phys_base <= phys_addr && phys_addr < mapping.phys_base + mapping.size) {
+            const auto vma_start_offset = phys_addr - mapping.phys_base;
+            const auto addr_in_vma = mapping.base + vma_start_offset;
+            const auto size_in_vma =
+                mapping.size - vma_start_offset > size ? size : mapping.size - vma_start_offset;
 
-                // Unmapping might erase from vma_map. We can't do it here.
-                remove_list.emplace_back(addr_in_vma, unmap_size);
-            }
+            LOG_INFO(Kernel_Vmm, "Unmaping direct mapping {:#x} with size {:#x}", addr_in_vma,
+                     size_in_vma);
+            // Unmaping might erase from vma_map. We can't do it here.
+            remove_list.emplace_back(addr_in_vma, size_in_vma);
         }
     }
-
-    // Early unmap from GPU to avoid deadlocking.
-    for (auto& [addr, unmap_size] : remove_list) {
-        if (IsValidGpuMapping(addr, unmap_size)) {
-            rasterizer->UnmapMemory(addr, unmap_size);
-        }
-    }
-
-    // Acquire writer lock
-    std::scoped_lock lk2{mutex};
-
     for (const auto& [addr, size] : remove_list) {
-        LOG_INFO(Kernel_Vmm, "Unmapping direct mapping {:#x} with size {:#x}", addr, size);
         UnmapMemoryImpl(addr, size);
     }
 
     // Unmap all dmem areas within this area.
-    for (auto& [phys_addr, size] : free_list) {
+    auto phys_addr_to_search = phys_addr;
+    auto remaining_size = size;
+    auto dmem_area = FindDmemArea(phys_addr);
+    while (dmem_area != dmem_map.end() && remaining_size > 0) {
         // Carve a free dmem area in place of this one.
-        const auto dmem_handle = CarvePhysArea(dmem_map, phys_addr, size);
+        const auto start_phys_addr =
+            phys_addr > dmem_area->second.base ? phys_addr : dmem_area->second.base;
+        const auto offset_in_dma = start_phys_addr - dmem_area->second.base;
+        const auto size_in_dma = dmem_area->second.size - offset_in_dma > remaining_size
+                                     ? remaining_size
+                                     : dmem_area->second.size - offset_in_dma;
+        const auto dmem_handle = CarvePhysArea(dmem_map, start_phys_addr, size_in_dma);
         auto& new_dmem_area = dmem_handle->second;
         new_dmem_area.dma_type = PhysicalMemoryType::Free;
         new_dmem_area.memory_type = 0;
 
         // Merge the new dmem_area with dmem_map
         MergeAdjacent(dmem_map, dmem_handle);
+
+        // Get the next relevant dmem area.
+        phys_addr_to_search = phys_addr + size_in_dma;
+        remaining_size -= size_in_dma;
+        dmem_area = FindDmemArea(phys_addr_to_search);
     }
 
     return ORBIS_OK;
 }
 
 s32 MemoryManager::PoolCommit(VAddr virtual_addr, u64 size, MemoryProt prot, s32 mtype) {
-    std::scoped_lock lk{unmap_mutex};
-    std::unique_lock lk2{mutex};
-    ASSERT_MSG(IsValidMapping(virtual_addr, size), "Attempted to access invalid address {:#x}",
-               virtual_addr);
+    std::unique_lock lk{mutex};
 
-    // Input addresses to PoolCommit are treated as fixed, and have a constant alignment.
-    const u64 alignment = 64_KB;
-    VAddr mapped_addr = Common::AlignUp(virtual_addr, alignment);
-
-    auto& vma = FindVMA(mapped_addr)->second;
-    if (vma.type != VMAType::PoolReserved) {
+    auto& vma = FindVMA(virtual_addr)->second;
+    if (vma.type != VMAType::Pooled) {
         // If we're attempting to commit non-pooled memory, return EINVAL
-        LOG_ERROR(Kernel_Vmm, "Attempting to commit non-pooled memory at {:#x}", mapped_addr);
+        LOG_ERROR(Kernel_Vmm, "Attempting to commit non-pooled memory at {:#x}", virtual_addr);
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
 
-    if (!vma.Contains(mapped_addr, size)) {
+    if (!vma.Contains(virtual_addr, size)) {
         // If there's not enough space to commit, return EINVAL
         LOG_ERROR(Kernel_Vmm,
                   "Pooled region {:#x} to {:#x} is not large enough to commit from {:#x} to {:#x}",
-                  vma.base, vma.base + vma.size, mapped_addr, mapped_addr + size);
+                  vma.base, vma.base + vma.size, virtual_addr, virtual_addr + size);
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
 
-    if (pool_budget <= size) {
-        // If there isn't enough pooled memory to perform the mapping, return ENOMEM
-        LOG_ERROR(Kernel_Vmm, "Not enough pooled memory to perform mapping");
-        return ORBIS_KERNEL_ERROR_ENOMEM;
-    } else {
-        // Track how much pooled memory this commit will take
-        pool_budget -= size;
+    if (size == 0) {
+        return ORBIS_OK;
     }
 
     if (True(prot & MemoryProt::CpuWrite)) {
@@ -402,58 +298,114 @@ s32 MemoryManager::PoolCommit(VAddr virtual_addr, u64 size, MemoryProt prot, s32
         prot |= MemoryProt::CpuRead;
     }
 
-    // Create the virtual mapping for the commit
-    const auto new_vma_handle = CarveVMA(virtual_addr, size);
-    auto& new_vma = new_vma_handle->second;
-    new_vma.disallow_merge = false;
-    new_vma.prot = prot;
-    new_vma.name = "anon";
-    new_vma.type = Core::VMAType::Pooled;
-    new_vma.phys_areas.clear();
+    // Allocate needed physical blocks from the pool
+    const bool onion = mtype == 0;
+    const bool writeback = mtype != 3;
+    const u32 block_start = Blockpool::ToBlocks(virtual_addr - vma.base);
+    const u32 num_blocks = Blockpool::ToBlocks(size);
+    const u32 block_end = block_start + num_blocks;
 
-    // Find suitable physical addresses
-    auto handle = dmem_map.begin();
-    u64 remaining_size = size;
-    VAddr current_addr = mapped_addr;
-    while (handle != dmem_map.end() && remaining_size > 0) {
-        if (handle->second.dma_type != PhysicalMemoryType::Pooled) {
-            // Non-pooled means it's either not for pool use, or already committed.
-            handle++;
-            continue;
+    DmemBlock* vm_blocks = vma.blocks.data() + block_start;
+    std::array<u32, 32> dmem_blocks;
+    dmem_blocks.fill(std::numeric_limits<u32>::max());
+
+    for (u32 chunk = 0; chunk < num_blocks; chunk += 32) {
+        const u32 count = std::min(num_blocks - chunk, 32u);
+
+        if (!blockpool.Commit(count, onion, writeback, dmem_blocks.data())) {
+            // We run out of physical memory, revert our changes and error out
+            blockpool.Decommit(vm_blocks, chunk);
+            return ORBIS_KERNEL_ERROR_ENOMEM;
         }
 
-        // On PS4, commits can make sparse physical mappings.
-        u64 size_to_map = std::min<u64>(remaining_size, handle->second.size);
-
-        // Use the start of this area as the physical backing for this mapping.
-        const auto new_dmem_handle = CarvePhysArea(dmem_map, handle->second.base, size_to_map);
-        auto& new_dmem_area = new_dmem_handle->second;
-        new_dmem_area.dma_type = PhysicalMemoryType::Committed;
-        new_dmem_area.memory_type = mtype;
-
-        // Add the dmem area to this vma, merge it with any similar tracked areas.
-        new_vma.phys_areas[current_addr - mapped_addr] = new_dmem_handle->second;
-        MergeAdjacent(new_vma.phys_areas, new_vma.phys_areas.find(current_addr - mapped_addr));
-
-        // Perform an address space mapping for each physical area
-        void* out_addr = impl.Map(current_addr, size_to_map, new_dmem_area.base);
-        // Tracy memory tracking breaks from merging memory areas. Disabled for now.
-        // TRACK_ALLOC(out_addr, size_to_map, "VMEM");
-
-        handle = MergeAdjacent(dmem_map, new_dmem_handle);
-        current_addr += size_to_map;
-        remaining_size -= size_to_map;
-        handle++;
+        // Assign physical blocks to virtual memory
+        for (u32 i = 0; i < count; ++i) {
+            ASSERT_MSG(dmem_blocks[i] != std::numeric_limits<u32>::max());
+            vm_blocks[chunk + i] = DmemBlock{
+                .block = dmem_blocks[i],
+                .onion = onion,
+                .writeback = writeback,
+                .prot_cpu = u32(prot & MemoryProt::CpuReadWrite),
+                .prot_gpu = u32(prot & MemoryProt::GpuReadWrite) >> 4,
+                .valid = true,
+            };
+        }
     }
-    ASSERT_MSG(remaining_size == 0, "Failed to commit pooled memory");
 
-    // Merge this VMA with similar nearby areas
-    MergeAdjacent(vma_map, new_vma_handle);
+    u32 block{};
+    u32 pending_blocks{};
 
-    lk2.unlock();
-    if (IsValidGpuMapping(mapped_addr, size)) {
-        rasterizer->MapMemory(mapped_addr, size);
+    const auto map_memory = [&] {
+        const u32 start_block = block - pending_blocks + 1;
+        impl.Map(virtual_addr + Blockpool::ToBytes(start_block), Blockpool::ToBytes(pending_blocks),
+                 Blockpool::ToBytes(vm_blocks[start_block].block));
+        pending_blocks = 0;
+    };
+
+    // Defer mapping of physical pages to make failure case simpler
+    for (; block < num_blocks; ++block) {
+        ++pending_blocks;
+        if (block != num_blocks - 1 && (vm_blocks[block + 1].block - vm_blocks[block].block) != 1) {
+            map_memory();
+        }
     }
+    if (pending_blocks) {
+        --block;
+        map_memory();
+    }
+
+    lk.unlock();
+
+    if (IsValidGpuMapping(virtual_addr, size)) {
+        rasterizer->MapMemory(virtual_addr, size);
+    }
+
+    return ORBIS_OK;
+}
+
+s32 MemoryManager::PoolDecommit(VAddr virtual_addr, u64 size) {
+    std::unique_lock lk{mutex};
+
+    auto& vma = FindVMA(virtual_addr)->second;
+    if (vma.type != VMAType::Pooled) {
+        // If we're attempting to decommit non-pooled memory, return EINVAL
+        LOG_ERROR(Kernel_Vmm, "Attempting to decommit non-pooled memory at {:#x}", virtual_addr);
+        return ORBIS_KERNEL_ERROR_EINVAL;
+    }
+
+    if (!vma.Contains(virtual_addr, size)) {
+        // If there's not enough space to decommit, return EINVAL
+        LOG_ERROR(
+            Kernel_Vmm,
+            "Pooled region {:#x} to {:#x} is not large enough to decommit from {:#x} to {:#x}",
+            vma.base, vma.base + vma.size, virtual_addr, virtual_addr + size);
+        return ORBIS_KERNEL_ERROR_EINVAL;
+    }
+
+    if (size == 0) {
+        return ORBIS_OK;
+    }
+
+    lk.unlock();
+
+    // Perform early GPU unmap to avoid potential deadlocks
+    if (IsValidGpuMapping(virtual_addr, size)) {
+        rasterizer->UnmapMemory(virtual_addr, size);
+    }
+
+    lk.lock();
+
+    const u32 block_start = Blockpool::ToBlocks(virtual_addr - vma.base);
+    const u32 num_blocks = Blockpool::ToBlocks(size);
+    const u32 block_end = block_start + num_blocks;
+    DmemBlock* vm_blocks = vma.blocks.data() + block_start;
+
+    for (u32 chunk = 0; chunk < num_blocks; chunk += 2048) {
+        const u32 count = std::min(num_blocks - chunk, 2048u);
+        blockpool.Decommit(vm_blocks + chunk, count);
+    }
+
+    impl.Unmap(virtual_addr, size);
 
     return ORBIS_OK;
 }
@@ -495,7 +447,10 @@ MemoryManager::VMAHandle MemoryManager::CreateArea(VAddr virtual_addr, u64 size,
     new_vma.prot = prot;
     new_vma.name = name;
     new_vma.type = type;
-    new_vma.phys_areas.clear();
+    new_vma.phys_base = 0;
+    if (new_vma.type == VMAType::Pooled) {
+        new_vma.blocks.resize(Blockpool::ToBlocks(size));
+    }
     return new_vma_handle;
 }
 
@@ -511,7 +466,8 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
                   total_flexible_size - flexible_usage, size);
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
-    std::scoped_lock lk{unmap_mutex};
+
+    std::unique_lock lk{mutex};
 
     PhysHandle dmem_area;
     // Validate the requested physical address range
@@ -565,13 +521,14 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
         }
     }
 
+    lk.unlock();
+
     // Perform early GPU unmap to avoid potential deadlocks
     if (IsValidGpuMapping(virtual_addr, size)) {
         rasterizer->UnmapMemory(virtual_addr, size);
     }
 
-    // Acquire writer lock.
-    std::unique_lock lk2{mutex};
+    lk.lock();
 
     // Create VMA representing this mapping.
     auto new_vma_handle = CreateArea(virtual_addr, size, prot, flags, type, name, alignment);
@@ -602,8 +559,7 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
             new_fmem_area.dma_type = PhysicalMemoryType::Flexible;
 
             // Add the new area to the vma, merge it with any similar tracked areas.
-            new_vma.phys_areas[current_addr - mapped_addr] = new_fmem_handle->second;
-            MergeAdjacent(new_vma.phys_areas, new_vma.phys_areas.find(current_addr - mapped_addr));
+            new_vma.phys_base = handle->second.base;
 
             // Perform an address space mapping for each physical area
             void* out_addr = impl.Map(current_addr, size_to_map, new_fmem_area.base, is_exec);
@@ -618,37 +574,35 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
             remaining_size -= size_to_map;
             flexible_usage += size_to_map;
             handle++;
+            ASSERT_MSG(remaining_size == 0, "Failed to map physical memory");
+            break;
         }
-        ASSERT_MSG(remaining_size == 0, "Failed to map physical memory");
     } else if (type == VMAType::Direct) {
         // Map the physical memory for this direct memory mapping.
         auto current_phys_addr = phys_addr;
         u64 remaining_size = size;
         auto dmem_area = FindDmemArea(phys_addr);
-        while (dmem_area != dmem_map.end() && remaining_size > 0) {
-            // Carve a new dmem area in place of this one with the appropriate type.
-            // Ensure the carved area only covers the current dmem area.
-            const auto start_phys_addr = std::max<PAddr>(current_phys_addr, dmem_area->second.base);
-            const auto offset_in_dma = start_phys_addr - dmem_area->second.base;
-            const auto size_in_dma =
-                std::min<u64>(dmem_area->second.size - offset_in_dma, remaining_size);
-            const auto dmem_handle = CarvePhysArea(dmem_map, start_phys_addr, size_in_dma);
-            auto& new_dmem_area = dmem_handle->second;
-            new_dmem_area.dma_type = PhysicalMemoryType::Mapped;
+        // Carve a new dmem area in place of this one with the appropriate type.
+        // Ensure the carved area only covers the current dmem area.
+        const auto start_phys_addr = std::max<PAddr>(current_phys_addr, dmem_area->second.base);
+        const auto offset_in_dma = start_phys_addr - dmem_area->second.base;
+        const auto size_in_dma =
+            std::min<u64>(dmem_area->second.size - offset_in_dma, remaining_size);
+        const auto dmem_handle = CarvePhysArea(dmem_map, start_phys_addr, size_in_dma);
+        auto& new_dmem_area = dmem_handle->second;
+        new_dmem_area.dma_type = PhysicalMemoryType::Mapped;
 
-            // Add the dmem area to this vma, merge it with any similar tracked areas.
-            const u64 offset_in_vma = current_phys_addr - phys_addr;
-            new_vma.phys_areas[offset_in_vma] = dmem_handle->second;
-            MergeAdjacent(new_vma.phys_areas, new_vma.phys_areas.find(offset_in_vma));
+        // Add the dmem area to this vma, merge it with any similar tracked areas.
+        const u64 offset_in_vma = current_phys_addr - phys_addr;
+        new_vma.phys_base = start_phys_addr;
 
-            // Merge the new dmem_area with dmem_map
-            MergeAdjacent(dmem_map, dmem_handle);
+        // Merge the new dmem_area with dmem_map
+        MergeAdjacent(dmem_map, dmem_handle);
 
-            // Get the next relevant dmem area.
-            current_phys_addr += size_in_dma;
-            remaining_size -= size_in_dma;
-            dmem_area = FindDmemArea(current_phys_addr);
-        }
+        // Get the next relevant dmem area.
+        current_phys_addr += size_in_dma;
+        remaining_size -= size_in_dma;
+        dmem_area = FindDmemArea(current_phys_addr);
         ASSERT_MSG(remaining_size == 0, "Failed to map physical memory");
     }
 
@@ -659,7 +613,7 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
     }
 
     *out_addr = std::bit_cast<void*>(mapped_addr);
-    if (type != VMAType::Reserved && type != VMAType::PoolReserved) {
+    if (type != VMAType::Reserved && type != VMAType::Pooled) {
         // Flexible address space mappings were performed while finding direct memory areas.
         if (type != VMAType::Flexible) {
             impl.Map(mapped_addr, size, phys_addr, is_exec);
@@ -667,7 +621,7 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
             // TRACK_ALLOC(mapped_addr, size, "VMEM");
         }
 
-        lk2.unlock();
+        lk.unlock();
 
         // If this is not a reservation, then map to GPU and address space
         if (IsValidGpuMapping(mapped_addr, size)) {
@@ -681,7 +635,7 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
 s32 MemoryManager::MapFile(void** out_addr, VAddr virtual_addr, u64 size, MemoryProt prot,
                            MemoryMapFlags flags, s32 fd, s64 phys_addr) {
     uintptr_t handle = 0;
-    std::scoped_lock lk{unmap_mutex};
+
     // Get the file to map
     auto* h = Common::Singleton<Core::FileSys::HandleTable>::Instance();
     auto file = h->GetFile(fd);
@@ -721,6 +675,7 @@ s32 MemoryManager::MapFile(void** out_addr, VAddr virtual_addr, u64 size, Memory
     }
 
     if (True(flags & MemoryMapFlags::Fixed) && False(flags & MemoryMapFlags::NoOverwrite)) {
+        std::shared_lock lk{mutex};
         ASSERT_MSG(IsValidMapping(virtual_addr, size), "Attempted to access invalid address {:#x}",
                    virtual_addr);
         auto vma = FindVMA(virtual_addr)->second;
@@ -731,6 +686,7 @@ s32 MemoryManager::MapFile(void** out_addr, VAddr virtual_addr, u64 size, Memory
             return ORBIS_KERNEL_ERROR_ENOMEM;
         }
     } else if (False(flags & MemoryMapFlags::Fixed)) {
+        std::shared_lock lk{mutex};
         virtual_addr = virtual_addr == 0 ? DEFAULT_MAPPING_BASE : virtual_addr;
         virtual_addr = SearchFree(virtual_addr, size, 16_KB);
         if (virtual_addr == -1) {
@@ -761,95 +717,11 @@ s32 MemoryManager::MapFile(void** out_addr, VAddr virtual_addr, u64 size, Memory
     return ORBIS_OK;
 }
 
-s32 MemoryManager::PoolDecommit(VAddr virtual_addr, u64 size) {
-    std::scoped_lock lk{unmap_mutex};
-    ASSERT_MSG(IsValidMapping(virtual_addr, size), "Attempted to access invalid address {:#x}",
-               virtual_addr);
-
-    // Do an initial search to ensure this decommit is valid.
-    auto it = FindVMA(virtual_addr);
-    while (it != vma_map.end() && it->second.base + it->second.size <= virtual_addr + size) {
-        if (it->second.type != VMAType::PoolReserved && it->second.type != VMAType::Pooled) {
-            LOG_ERROR(Kernel_Vmm, "Attempting to decommit non-pooled memory!");
-            return ORBIS_KERNEL_ERROR_EINVAL;
-        }
-        it++;
-    }
-
-    // Perform early GPU unmap to avoid potential deadlocks
-    if (IsValidGpuMapping(virtual_addr, size)) {
-        rasterizer->UnmapMemory(virtual_addr, size);
-    }
-
-    // Aquire writer mutex
-    std::scoped_lock lk2{mutex};
-
-    // Loop through all vmas in the area, unmap them.
-    u64 remaining_size = size;
-    VAddr current_addr = virtual_addr;
-    while (remaining_size != 0) {
-        const auto handle = FindVMA(current_addr);
-        const auto& vma_base = handle->second;
-        const auto start_in_vma = current_addr - vma_base.base;
-        const auto size_in_vma = std::min<u64>(remaining_size, vma_base.size - start_in_vma);
-        if (vma_base.type == VMAType::Pooled) {
-            // Track how much pooled memory is decommitted
-            pool_budget += size_in_vma;
-
-            // Re-pool the direct memory used by this mapping
-            u64 size_to_free = size_in_vma;
-            auto phys_handle = std::prev(vma_base.phys_areas.upper_bound(start_in_vma));
-            while (phys_handle != vma_base.phys_areas.end() && size_to_free > 0) {
-                // Calculate physical memory offset, address, and size
-                u64 dma_offset =
-                    std::max<PAddr>(phys_handle->first, start_in_vma) - phys_handle->first;
-                PAddr phys_addr = phys_handle->second.base + dma_offset;
-                u64 size_in_dma =
-                    std::min<u64>(size_to_free, phys_handle->second.size - dma_offset);
-
-                // Create a new dmem area reflecting the pooled region
-                const auto new_dmem_handle = CarvePhysArea(dmem_map, phys_addr, size_in_dma);
-                auto& new_dmem_area = new_dmem_handle->second;
-                new_dmem_area.dma_type = PhysicalMemoryType::Pooled;
-
-                // Coalesce with nearby direct memory areas.
-                MergeAdjacent(dmem_map, new_dmem_handle);
-
-                // Increment loop
-                size_to_free -= size_in_dma;
-                phys_handle++;
-            }
-            ASSERT_MSG(size_to_free == 0, "Failed to decommit pooled memory");
-        }
-
-        // Mark region as pool reserved and attempt to coalesce it with neighbours.
-        const auto new_it = CarveVMA(current_addr, size_in_vma);
-        auto& vma = new_it->second;
-        vma.type = VMAType::PoolReserved;
-        vma.prot = MemoryProt::NoAccess;
-        vma.disallow_merge = false;
-        vma.name = "anon";
-        vma.phys_areas.clear();
-        MergeAdjacent(vma_map, new_it);
-
-        current_addr += size_in_vma;
-        remaining_size -= size_in_vma;
-    }
-
-    // Unmap from address space
-    impl.Unmap(virtual_addr, size);
-    // Tracy memory tracking breaks from merging memory areas. Disabled for now.
-    // TRACK_FREE(virtual_addr, "VMEM");
-
-    return ORBIS_OK;
-}
-
 s32 MemoryManager::UnmapMemory(VAddr virtual_addr, u64 size) {
     if (size == 0) {
         return ORBIS_OK;
     }
 
-    std::scoped_lock lk{unmap_mutex};
     // Align address and size appropriately
     virtual_addr = Common::AlignDown(virtual_addr, 16_KB);
     size = Common::AlignUp(size, 16_KB);
@@ -866,54 +738,53 @@ s32 MemoryManager::UnmapMemory(VAddr virtual_addr, u64 size) {
     return UnmapMemoryImpl(virtual_addr, size);
 }
 
-u64 MemoryManager::UnmapBytesFromEntry(VAddr virtual_addr, VirtualMemoryArea vma_base, u64 size) {
-    const auto start_in_vma = virtual_addr - vma_base.base;
-    const auto size_in_vma = std::min<u64>(vma_base.size - start_in_vma, size);
-    const auto vma_type = vma_base.type;
-    if (vma_base.type == VMAType::Free || vma_base.type == VMAType::Pooled) {
+u64 MemoryManager::UnmapBytesFromEntry(VAddr virtual_addr, const VirtualMemoryArea& vma_base,
+                                       u64 size) {
+    const auto type = vma_base.type;
+    const VAddr start_in_vma = virtual_addr - vma_base.base;
+    const u64 size_in_vma = std::min<u64>(vma_base.size - start_in_vma, size);
+
+    if (type == VMAType::Free) {
         return size_in_vma;
     }
 
-    VAddr current_addr = virtual_addr;
-    if (vma_base.phys_areas.size() > 0) {
-        u64 size_to_free = size_in_vma;
-        auto phys_handle = std::prev(vma_base.phys_areas.upper_bound(start_in_vma));
-        while (phys_handle != vma_base.phys_areas.end() && size_to_free > 0) {
-            // Calculate physical memory offset, address, and size
-            u64 dma_offset = std::max<PAddr>(phys_handle->first, start_in_vma) - phys_handle->first;
-            PAddr phys_addr = phys_handle->second.base + dma_offset;
-            u64 size_in_dma = std::min<u64>(size_to_free, phys_handle->second.size - dma_offset);
+    if (type == VMAType::Direct) {
+        // Unmap all direct memory areas covered by this unmap.
+        auto phys_addr = vma_base.phys_base + start_in_vma;
+        auto remaining_size = size_in_vma;
+        PhysHandle dmem_handle = FindDmemArea(phys_addr);
+        while (dmem_handle != dmem_map.end() && remaining_size > 0) {
+            const auto start_in_dma = phys_addr - dmem_handle->second.base;
+            const auto size_in_dma = dmem_handle->second.size - start_in_dma > remaining_size
+                                         ? remaining_size
+                                         : dmem_handle->second.size - start_in_dma;
+            dmem_handle = CarvePhysArea(dmem_map, phys_addr, size_in_dma);
+            auto& dmem_area = dmem_handle->second;
+            dmem_area.dma_type = PhysicalMemoryType::Allocated;
+            remaining_size -= dmem_area.size;
+            phys_addr += dmem_area.size;
 
-            // Create a new dmem area reflecting the pooled region
-            if (vma_type == VMAType::Direct) {
-                const auto new_dmem_handle = CarvePhysArea(dmem_map, phys_addr, size_in_dma);
-                auto& new_dmem_area = new_dmem_handle->second;
-                new_dmem_area.dma_type = PhysicalMemoryType::Allocated;
-
-                // Coalesce with nearby direct memory areas.
-                MergeAdjacent(dmem_map, new_dmem_handle);
-            } else if (vma_type == VMAType::Flexible) {
-                // Update fmem_map
-                const auto new_fmem_handle = CarvePhysArea(fmem_map, phys_addr, size_in_dma);
-                auto& new_fmem_area = new_fmem_handle->second;
-                new_fmem_area.dma_type = PhysicalMemoryType::Free;
-
-                // Coalesce with nearby flexible memory areas.
-                MergeAdjacent(fmem_map, new_fmem_handle);
-
-                // Zero out the old memory data
-                const auto unmap_hardware_address = impl.BackingBase() + phys_addr;
-                std::memset(unmap_hardware_address, 0, size_in_dma);
-
-                // Update flexible usage
-                flexible_usage -= size_in_dma;
-            }
-
-            // Increment through loop
-            size_to_free -= size_in_dma;
-            phys_handle++;
+            // Check if we can coalesce any dmem areas.
+            MergeAdjacent(dmem_map, dmem_handle);
+            dmem_handle = FindDmemArea(phys_addr);
         }
-        ASSERT_MSG(size_to_free == 0, "Failed to unmap physical memory");
+    }
+
+    if (type == VMAType::Flexible) {
+        flexible_usage -= size_in_vma;
+
+        // Now that there is a physical backing used for flexible memory,
+        // manually erase the contents before unmapping to prevent possible issues.
+        const auto unmap_hardware_address = impl.BackingBase() + vma_base.phys_base + start_in_vma;
+        std::memset(unmap_hardware_address, 0, size_in_vma);
+
+        // Address space unmap needs the physical_base from the start of the vma,
+        // so calculate the phys_base to unmap from here.
+        const auto unmap_phys_base = vma_base.phys_base + start_in_vma;
+        const auto new_fmem_handle = CarvePhysArea(fmem_map, unmap_phys_base, size_in_vma);
+        auto& new_fmem_area = new_fmem_handle->second;
+        new_fmem_area.dma_type = PhysicalMemoryType::Free;
+        MergeAdjacent(fmem_map, new_fmem_handle);
     }
 
     // Mark region as free and attempt to coalesce it with neighbours.
@@ -921,16 +792,19 @@ u64 MemoryManager::UnmapBytesFromEntry(VAddr virtual_addr, VirtualMemoryArea vma
     auto& vma = new_it->second;
     vma.type = VMAType::Free;
     vma.prot = MemoryProt::NoAccess;
-    vma.phys_areas.clear();
+    vma.phys_base = 0;
     vma.disallow_merge = false;
     vma.name = "";
     MergeAdjacent(vma_map, new_it);
 
-    if (vma_type != VMAType::Reserved && vma_type != VMAType::PoolReserved) {
+    if (type != VMAType::Reserved) {
+        // If this mapping has GPU access, unmap from GPU.
+        if (IsValidGpuMapping(virtual_addr, size)) {
+            rasterizer->UnmapMemory(virtual_addr, size);
+        }
         // Unmap the memory region.
         impl.Unmap(virtual_addr, size_in_vma);
-        // Tracy memory tracking breaks from merging memory areas. Disabled for now.
-        // TRACK_FREE(virtual_addr, "VMEM");
+        TRACK_FREE(virtual_addr, "VMEM");
     }
     return size_in_vma;
 }
@@ -984,7 +858,7 @@ s64 MemoryManager::ProtectBytes(VAddr addr, VirtualMemoryArea& vma_base, u64 siz
     const MemoryProt old_prot = vma_base.prot;
     const MemoryProt new_prot = prot;
 
-    if (vma_base.type == VMAType::Free || vma_base.type == VMAType::PoolReserved) {
+    if (vma_base.type == VMAType::Free) {
         // On PS4, protecting freed memory does nothing.
         return adjusted_size;
     }
@@ -1050,7 +924,7 @@ s32 MemoryManager::Protect(VAddr addr, u64 size, MemoryProt prot) {
     }
 
     // Ensure the range to modify is valid
-    std::scoped_lock lk{mutex, unmap_mutex};
+    std::scoped_lock lk{mutex};
     ASSERT_MSG(IsValidMapping(addr, size), "Attempted to access invalid address {:#x}", addr);
 
     // Appropriately restrict flags.
@@ -1093,6 +967,7 @@ s32 MemoryManager::VirtualQuery(VAddr addr, s32 flags,
 
     while (it != vma_map.end() && it->second.type == VMAType::Free && flags == 1) {
         ++it;
+        query_addr = it->first;
     }
     if (it == vma_map.end() || it->second.type == VMAType::Free) {
         LOG_WARNING(Kernel_Vmm, "VirtualQuery on free memory region");
@@ -1100,6 +975,15 @@ s32 MemoryManager::VirtualQuery(VAddr addr, s32 flags,
     }
 
     const auto& vma = it->second;
+
+    memset(info, 0, sizeof(*info));
+    strncpy(info->name, vma.name.data(), ::Libraries::Kernel::ORBIS_KERNEL_MAXIMUM_NAME_LENGTH);
+
+    if (vma.type == VMAType::Pooled) {
+        blockpool.Query(query_addr, vma.base, vma.size, vma.blocks.data(), info);
+        return ORBIS_OK;
+    }
+
     info->start = vma.base;
     info->end = vma.base + vma.size;
     info->offset = 0;
@@ -1107,16 +991,16 @@ s32 MemoryManager::VirtualQuery(VAddr addr, s32 flags,
     info->is_flexible = vma.type == VMAType::Flexible ? 1 : 0;
     info->is_direct = vma.type == VMAType::Direct ? 1 : 0;
     info->is_stack = vma.type == VMAType::Stack ? 1 : 0;
-    info->is_pooled = vma.type == VMAType::PoolReserved || vma.type == VMAType::Pooled ? 1 : 0;
     info->is_committed = vma.IsMapped() ? 1 : 0;
-    info->memory_type = 0;
+    info->memory_type = ::Libraries::Kernel::ORBIS_KERNEL_WB_ONION;
     if (vma.type == VMAType::Direct) {
         // Offset is only assigned for direct mappings.
-        ASSERT_MSG(vma.phys_areas.size() > 0, "No physical backing for direct mapping?");
-        info->offset = vma.phys_areas.begin()->second.base;
-        info->memory_type = vma.phys_areas.begin()->second.memory_type;
+        info->offset = vma.phys_base;
+        const auto dmem_it = FindDmemArea(vma.phys_base);
+        ASSERT_MSG(vma.phys_base <= dmem_it->second.GetEnd(), "vma.phys_base is not in dmem_map!");
+        info->memory_type = dmem_it->second.memory_type;
     }
-    if (vma.type == VMAType::Reserved || vma.type == VMAType::PoolReserved) {
+    if (vma.type == VMAType::Reserved) {
         // Protection is hidden from reserved mappings.
         info->protection = 0;
     }
@@ -1208,57 +1092,56 @@ s32 MemoryManager::DirectQueryAvailable(PAddr search_start, PAddr search_end, u6
 }
 
 s32 MemoryManager::SetDirectMemoryType(VAddr addr, u64 size, s32 memory_type) {
-    std::scoped_lock lk{mutex, unmap_mutex};
+    std::scoped_lock lk{mutex};
 
     ASSERT_MSG(IsValidMapping(addr, size), "Attempted to access invalid address {:#x}", addr);
 
     // Search through all VMAs covered by the provided range.
     // We aren't modifying these VMAs, so it's safe to iterate through them.
-    VAddr current_addr = addr;
-    u64 remaining_size = size;
+    auto remaining_size = size;
     auto vma_handle = FindVMA(addr);
-    while (vma_handle != vma_map.end() && remaining_size > 0) {
-        // Calculate position in vma
-        const VAddr start_in_vma = current_addr - vma_handle->second.base;
-        const u64 size_in_vma =
-            std::min<u64>(remaining_size, vma_handle->second.size - start_in_vma);
-
+    while (vma_handle != vma_map.end() && vma_handle->second.base < addr + size) {
+        if (vma_handle->second.type == VMAType::Pooled) {
+            LOG_WARNING(Kernel_Vmm, "Setting direct memory type on a pooled VMA is not supported");
+            continue;
+        }
         // Direct and Pooled mappings are the only ones with a memory type.
-        if (vma_handle->second.type == VMAType::Direct ||
-            vma_handle->second.type == VMAType::Pooled) {
-            // Split area to modify into a new VMA.
-            vma_handle = CarveVMA(current_addr, size_in_vma);
-            auto phys_handle = vma_handle->second.phys_areas.begin();
-            while (phys_handle != vma_handle->second.phys_areas.end()) {
-                // Update internal physical areas
-                phys_handle->second.memory_type = memory_type;
+        if (vma_handle->second.type == VMAType::Direct) {
+            // Calculate position in vma
+            const auto start_in_vma = addr - vma_handle->second.base;
+            const auto size_in_vma = vma_handle->second.size - start_in_vma;
+            auto phys_addr = vma_handle->second.phys_base + start_in_vma;
+            auto size_to_modify = remaining_size > size_in_vma ? size_in_vma : remaining_size;
 
-                // Carve a new dmem area in dmem_map, update memory type there
-                auto dmem_handle =
-                    CarvePhysArea(dmem_map, phys_handle->second.base, phys_handle->second.size);
+            // Loop through remaining dmem areas until the physical addresses represented
+            // are all adjusted.
+            PhysHandle dmem_handle = FindDmemArea(phys_addr);
+            while (dmem_handle != dmem_map.end() && size_in_vma >= size_to_modify &&
+                   size_to_modify > 0) {
+                const auto start_in_dma = phys_addr - dmem_handle->second.base;
+                const auto size_in_dma = dmem_handle->second.size - start_in_dma > size_to_modify
+                                             ? size_to_modify
+                                             : dmem_handle->second.size - start_in_dma;
+                dmem_handle = CarvePhysArea(dmem_map, phys_addr, size_in_dma);
                 auto& dmem_area = dmem_handle->second;
                 dmem_area.memory_type = memory_type;
+                size_to_modify -= dmem_area.size;
+                phys_addr += dmem_area.size;
 
-                // Increment phys_handle
-                phys_handle++;
+                // Check if we can coalesce any dmem areas now that the types are different.
+                MergeAdjacent(dmem_map, dmem_handle);
+                dmem_handle = FindDmemArea(phys_addr);
             }
         }
-        current_addr += size_in_vma;
-        remaining_size -= size_in_vma;
-
-        // Check if VMA can be merged with adjacent areas after modifications.
-        vma_handle = MergeAdjacent(vma_map, vma_handle);
-        if (vma_handle->second.base + vma_handle->second.size <= current_addr) {
-            // If we're now in the next VMA, then go to the next handle.
-            vma_handle++;
-        }
+        remaining_size -= vma_handle->second.size;
+        vma_handle++;
     }
 
     return ORBIS_OK;
 }
 
 void MemoryManager::NameVirtualRange(VAddr virtual_addr, u64 size, std::string_view name) {
-    std::scoped_lock lk{mutex, unmap_mutex};
+    std::scoped_lock lk{mutex};
 
     // Sizes are aligned up to the nearest 16_KB
     u64 aligned_size = Common::AlignUp(size, 16_KB);
@@ -1341,30 +1224,6 @@ s32 MemoryManager::IsStack(VAddr addr, void** start, void** end) {
     return ORBIS_OK;
 }
 
-s32 MemoryManager::GetMemoryPoolStats(::Libraries::Kernel::OrbisKernelMemoryPoolBlockStats* stats) {
-    std::shared_lock lk{mutex};
-
-    // Run through dmem_map, determine how much physical memory is currently committed
-    constexpr u64 block_size = 64_KB;
-    u64 committed_size = 0;
-
-    auto dma_handle = dmem_map.begin();
-    while (dma_handle != dmem_map.end()) {
-        if (dma_handle->second.dma_type == PhysicalMemoryType::Committed) {
-            committed_size += dma_handle->second.size;
-        }
-        dma_handle++;
-    }
-
-    stats->allocated_flushed_blocks = committed_size / block_size;
-    stats->available_flushed_blocks = committed_size / block_size;
-    // TODO: Determine how "cached blocks" work
-    stats->allocated_cached_blocks = 0;
-    stats->available_cached_blocks = 0;
-
-    return ORBIS_OK;
-}
-
 void MemoryManager::InvalidateMemory(const VAddr addr, const u64 size) const {
     if (rasterizer) {
         rasterizer->InvalidateMemory(addr, size);
@@ -1431,52 +1290,6 @@ VAddr MemoryManager::SearchFree(VAddr virtual_addr, u64 size, u32 alignment) {
     return -1;
 }
 
-MemoryManager::VMAHandle MemoryManager::MergeAdjacent(VMAMap& handle_map, VMAHandle iter) {
-    const auto next_vma = std::next(iter);
-    if (next_vma != handle_map.end() && iter->second.CanMergeWith(next_vma->second)) {
-        u64 base_offset = iter->second.size;
-        iter->second.size += next_vma->second.size;
-        for (auto& area : next_vma->second.phys_areas) {
-            iter->second.phys_areas[base_offset + area.first] = area.second;
-        }
-        handle_map.erase(next_vma);
-    }
-
-    if (iter != handle_map.begin()) {
-        auto prev_vma = std::prev(iter);
-        if (prev_vma->second.CanMergeWith(iter->second)) {
-            u64 base_offset = prev_vma->second.size;
-            prev_vma->second.size += iter->second.size;
-            for (auto& area : iter->second.phys_areas) {
-                prev_vma->second.phys_areas[base_offset + area.first] = area.second;
-            }
-            handle_map.erase(iter);
-            iter = prev_vma;
-        }
-    }
-
-    return iter;
-}
-
-MemoryManager::PhysHandle MemoryManager::MergeAdjacent(PhysMap& handle_map, PhysHandle iter) {
-    const auto next_vma = std::next(iter);
-    if (next_vma != handle_map.end() && iter->second.CanMergeWith(next_vma->second)) {
-        iter->second.size += next_vma->second.size;
-        handle_map.erase(next_vma);
-    }
-
-    if (iter != handle_map.begin()) {
-        auto prev_vma = std::prev(iter);
-        if (prev_vma->second.CanMergeWith(iter->second)) {
-            prev_vma->second.size += iter->second.size;
-            handle_map.erase(iter);
-            iter = prev_vma;
-        }
-    }
-
-    return iter;
-}
-
 MemoryManager::VMAHandle MemoryManager::CarveVMA(VAddr virtual_addr, u64 size) {
     auto vma_handle = FindVMA(virtual_addr);
 
@@ -1538,36 +1351,8 @@ MemoryManager::VMAHandle MemoryManager::Split(VMAHandle vma_handle, u64 offset_i
     new_vma.base += offset_in_vma;
     new_vma.size -= offset_in_vma;
 
-    if (HasPhysicalBacking(new_vma)) {
-        // Update physical areas map for both areas
-        new_vma.phys_areas.clear();
-
-        std::map<uintptr_t, PhysicalMemoryArea> old_vma_phys_areas;
-        for (auto& [offset, region] : old_vma.phys_areas) {
-            // Fully contained in first VMA
-            if (offset + region.size <= offset_in_vma) {
-                old_vma_phys_areas[offset] = region;
-            }
-            // Split between both VMAs
-            if (offset < offset_in_vma && offset + region.size > offset_in_vma) {
-                // Create region in old VMA
-                u64 size_in_old = offset_in_vma - offset;
-                old_vma_phys_areas[offset] = PhysicalMemoryArea{
-                    region.base, size_in_old, region.memory_type, region.dma_type};
-                // Create region in new VMA
-                PAddr new_base = region.base + size_in_old;
-                u64 size_in_new = region.size - size_in_old;
-                new_vma.phys_areas[0] =
-                    PhysicalMemoryArea{new_base, size_in_new, region.memory_type, region.dma_type};
-            }
-            // Fully contained in new VMA
-            if (offset >= offset_in_vma) {
-                new_vma.phys_areas[offset - offset_in_vma] = region;
-            }
-        }
-
-        // Set old_vma's physical areas map to the newly created map
-        old_vma.phys_areas = old_vma_phys_areas;
+    if (new_vma.HasPhysicalBacking()) {
+        new_vma.phys_base += offset_in_vma;
     }
 
     return vma_map.emplace_hint(std::next(vma_handle), new_vma.base, new_vma);

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -4,14 +4,17 @@
 #pragma once
 
 #include <map>
-#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <string_view>
+
+#include "common/assert.h"
 #include "common/enum.h"
 #include "common/shared_first_mutex.h"
 #include "common/singleton.h"
 #include "common/types.h"
 #include "core/address_space.h"
+#include "core/blockpool.h"
 #include "core/libraries/kernel/memory.h"
 
 namespace Vulkan {
@@ -61,9 +64,8 @@ enum class PhysicalMemoryType : u32 {
     Free = 0,
     Allocated = 1,
     Mapped = 2,
-    Pooled = 3,
-    Committed = 4,
-    Flexible = 5,
+    Committed = 3,
+    Flexible = 4,
 };
 
 struct PhysicalMemoryArea {
@@ -96,21 +98,21 @@ enum class VMAType : u32 {
     Direct = 2,
     Flexible = 3,
     Pooled = 4,
-    PoolReserved = 5,
-    Stack = 6,
-    Code = 7,
-    File = 8,
+    Stack = 5,
+    Code = 6,
+    File = 7,
 };
 
 struct VirtualMemoryArea {
     VAddr base = 0;
     u64 size = 0;
-    std::map<uintptr_t, PhysicalMemoryArea> phys_areas;
+    PAddr phys_base = 0;
     VMAType type = VMAType::Free;
     MemoryProt prot = MemoryProt::NoAccess;
     std::string name = "";
     s32 fd = 0;
     bool disallow_merge = false;
+    std::vector<DmemBlock> blocks;
 
     bool Contains(VAddr addr, u64 size) const {
         return addr >= base && (addr + size) <= (base + this->size);
@@ -125,7 +127,11 @@ struct VirtualMemoryArea {
     }
 
     bool IsMapped() const noexcept {
-        return type != VMAType::Free && type != VMAType::Reserved && type != VMAType::PoolReserved;
+        return type != VMAType::Free && type != VMAType::Reserved;
+    }
+
+    bool HasPhysicalBacking() const noexcept {
+        return type == VMAType::Direct || type == VMAType::Flexible || type == VMAType::Pooled;
     }
 
     bool CanMergeWith(VirtualMemoryArea& next) {
@@ -135,13 +141,9 @@ struct VirtualMemoryArea {
         if (base + size != next.base) {
             return false;
         }
-        if (type == VMAType::Direct && next.type == VMAType::Direct) {
-            auto& last_phys = std::prev(phys_areas.end())->second;
-            auto& first_next_phys = next.phys_areas.begin()->second;
-            if (last_phys.base + last_phys.size != first_next_phys.base ||
-                last_phys.memory_type != first_next_phys.memory_type) {
-                return false;
-            }
+        if ((type == VMAType::Direct || type == VMAType::Flexible) &&
+            phys_base + size != next.phys_base) {
+            return false;
         }
         if (prot != next.prot || type != next.type) {
             return false;
@@ -173,6 +175,10 @@ public:
         return impl;
     }
 
+    Blockpool& GetBlockpool() {
+        return blockpool;
+    }
+
     u64 GetTotalDirectSize() const {
         return total_direct_size;
     }
@@ -195,42 +201,31 @@ public:
         return virtual_addr + size < max_gpu_address;
     }
 
-    bool IsValidMapping(const VAddr virtual_addr, const u64 size = 0) {
-        const auto end_it = std::prev(vma_map.end());
-        const VAddr end_addr = end_it->first + end_it->second.size;
+    bool ForEachBackingRegion(VAddr virtual_addr, u64 size, auto&& func) {
+        std::shared_lock lk{mutex};
 
-        // If the address fails boundary checks, return early.
-        if (virtual_addr < vma_map.begin()->first || virtual_addr >= end_addr) {
-            return false;
-        }
-
-        // If size is zero and boundary checks succeed, then skip more robust checking
-        if (size == 0) {
-            return true;
-        }
-
-        // Now make sure the full address range is contained in vma_map.
-        auto vma_handle = FindVMA(virtual_addr);
-        auto addr_to_check = virtual_addr;
-        u64 size_to_validate = size;
-        while (vma_handle != vma_map.end() && size_to_validate > 0) {
-            const auto offset_in_vma = addr_to_check - vma_handle->second.base;
-            const auto size_in_vma =
-                std::min<u64>(vma_handle->second.size - offset_in_vma, size_to_validate);
-            size_to_validate -= size_in_vma;
-            addr_to_check += size_in_vma;
-            vma_handle++;
-
-            // Make sure there isn't any gap here
-            if (size_to_validate > 0 && vma_handle != vma_map.end() &&
-                addr_to_check != vma_handle->second.base) {
+        const VAddr base_addr = virtual_addr;
+        auto vma = FindVMA(virtual_addr);
+        while (vma->second.Overlaps(virtual_addr, size)) {
+            if (!vma->second.HasPhysicalBacking()) {
                 return false;
             }
+            if (vma->second.type == VMAType::Pooled) {
+                return false;
+            }
+            const u64 start_in_vma = virtual_addr - vma->first;
+            const u64 size_in_vma = std::min<u64>(vma->second.size - start_in_vma, size);
+            u8* backing = impl.BackingBase() + vma->second.phys_base + start_in_vma;
+            func(virtual_addr - base_addr, size_in_vma, backing);
+            size -= size_in_vma;
+            virtual_addr += size_in_vma;
+            ++vma;
         }
 
-        // If we reach this point and size to validate is not positive, then this mapping is valid.
-        return size_to_validate <= 0;
+        return true;
     }
+
+    bool IsValidMapping(const VAddr virtual_addr, const u64 size = 0);
 
     u64 ClampRangeSize(VAddr virtual_addr, u64 size);
 
@@ -238,11 +233,7 @@ public:
 
     void CopySparseMemory(VAddr source, u8* dest, u64 size);
 
-    bool TryWriteBacking(void* address, const void* data, u64 size);
-
     void SetupMemoryRegions(u64 flexible_size, bool use_extended_mem1, bool use_extended_mem2);
-
-    PAddr PoolExpand(PAddr search_start, PAddr search_end, u64 size, u64 alignment);
 
     PAddr Allocate(PAddr search_start, PAddr search_end, u64 size, u64 alignment, s32 memory_type);
 
@@ -284,8 +275,6 @@ public:
 
     void NameVirtualRange(VAddr virtual_addr, u64 size, std::string_view name);
 
-    s32 GetMemoryPoolStats(::Libraries::Kernel::OrbisKernelMemoryPoolBlockStats* stats);
-
     void InvalidateMemory(VAddr addr, u64 size) const;
 
 private:
@@ -301,19 +290,30 @@ private:
         return std::prev(fmem_map.upper_bound(target));
     }
 
-    bool HasPhysicalBacking(VirtualMemoryArea vma) {
-        return vma.type == VMAType::Direct || vma.type == VMAType::Flexible ||
-               vma.type == VMAType::Pooled;
-    }
-
     VMAHandle CreateArea(VAddr virtual_addr, u64 size, MemoryProt prot, MemoryMapFlags flags,
                          VMAType type, std::string_view name, u64 alignment);
 
     VAddr SearchFree(VAddr virtual_addr, u64 size, u32 alignment);
 
-    VMAHandle MergeAdjacent(VMAMap& map, VMAHandle iter);
+    template <typename Handle>
+    Handle MergeAdjacent(auto& handle_map, Handle iter) {
+        const auto next_vma = std::next(iter);
+        if (next_vma != handle_map.end() && iter->second.CanMergeWith(next_vma->second)) {
+            iter->second.size += next_vma->second.size;
+            handle_map.erase(next_vma);
+        }
 
-    PhysHandle MergeAdjacent(PhysMap& map, PhysHandle iter);
+        if (iter != handle_map.begin()) {
+            auto prev_vma = std::prev(iter);
+            if (prev_vma->second.CanMergeWith(iter->second)) {
+                prev_vma->second.size += iter->second.size;
+                handle_map.erase(iter);
+                iter = prev_vma;
+            }
+        }
+
+        return iter;
+    }
 
     VMAHandle CarveVMA(VAddr virtual_addr, u64 size);
 
@@ -323,7 +323,7 @@ private:
 
     PhysHandle Split(PhysMap& map, PhysHandle dmem_handle, u64 offset_in_area);
 
-    u64 UnmapBytesFromEntry(VAddr virtual_addr, VirtualMemoryArea vma_base, u64 size);
+    u64 UnmapBytesFromEntry(VAddr virtual_addr, const VirtualMemoryArea& vma_base, u64 size);
 
     s32 UnmapMemoryImpl(VAddr virtual_addr, u64 size);
 
@@ -332,12 +332,11 @@ private:
     PhysMap dmem_map;
     PhysMap fmem_map;
     VMAMap vma_map;
+    Blockpool blockpool;
     Common::SharedFirstMutex mutex{};
-    std::mutex unmap_mutex{};
     u64 total_direct_size{};
     u64 total_flexible_size{};
     u64 flexible_usage{};
-    u64 pool_budget{};
     s32 sdk_version{};
     Vulkan::Rasterizer* rasterizer{};
 

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -693,7 +693,12 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
                 const auto* event_eos = reinterpret_cast<const PM4CmdEventWriteEos*>(header);
                 event_eos->SignalFence([](void* address, u64 data, u32 num_bytes) {
                     auto* memory = Core::Memory::Instance();
-                    if (!memory->TryWriteBacking(address, &data, num_bytes)) {
+                    const VAddr virtual_addr = std::bit_cast<VAddr>(address);
+                    const bool wrote_backing = memory->ForEachBackingRegion(
+                        virtual_addr, num_bytes, [&](u64 offset, u64 size, u8* backing) {
+                            memcpy(backing, &data + offset, num_bytes);
+                        });
+                    if (!wrote_backing) {
                         memcpy(address, &data, num_bytes);
                     }
                 });
@@ -712,7 +717,12 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
                 event_eop->SignalFence(
                     [](void* address, u64 data, u32 num_bytes) {
                         auto* memory = Core::Memory::Instance();
-                        if (!memory->TryWriteBacking(address, &data, num_bytes)) {
+                        const VAddr virtual_addr = std::bit_cast<VAddr>(address);
+                        const bool wrote_backing = memory->ForEachBackingRegion(
+                            virtual_addr, num_bytes, [&](u64 offset, u64 size, u8* backing) {
+                                memcpy(backing, &data + offset, num_bytes);
+                            });
+                        if (!wrote_backing) {
                             memcpy(address, &data, num_bytes);
                         }
                     },

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -128,8 +128,10 @@ void BufferCache::DownloadBufferMemory(Buffer& buffer, VAddr device_addr, u64 si
         for (const auto& copy : copies) {
             const VAddr copy_device_addr = buffer.CpuAddr() + copy.srcOffset;
             const u64 dst_offset = copy.dstOffset - offset;
-            memory->TryWriteBacking(std::bit_cast<u8*>(copy_device_addr), download + dst_offset,
-                                    copy.size);
+            memory->ForEachBackingRegion(
+                copy_device_addr, copy.size, [&](u64 offset, u64 size, u8* backing) {
+                    std::memcpy(backing, download + dst_offset + offset, size);
+                });
         }
         memory_tracker->UnmarkRegionAsGpuModified(device_addr, size);
         if (is_write) {

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -125,8 +125,11 @@ void TextureCache::DownloadImageMemory(ImageId image_id) {
 
     scheduler.DeferPriorityOperation(
         [this, device_addr = image.info.guest_address, download, download_size] {
-            Core::Memory::Instance()->TryWriteBacking(std::bit_cast<u8*>(device_addr), download,
-                                                      download_size);
+            auto* memory = Core::Memory::Instance();
+            memory->ForEachBackingRegion(device_addr, download_size,
+                                         [&](u64 offset, u64 size, u8* backing) {
+                                             memcpy(backing, download + offset, size);
+                                         });
         });
 }
 


### PR DESCRIPTION
Removes the hacky phys_base handling that was added to handle sparse physical memory backing a VMA.
Now a blockpool retains a single VMA and separate tracking of managing of physical blocks, based on @red-prig kernel poking