### PR TITLE
Dont use logger after Shutdown

### DIFF
--- a/src/common/logging/log.cpp
+++ b/src/common/logging/log.cpp
@@ -242,7 +242,12 @@ void Shutdown() {
 }
 
 void Flush() {
-    g_shad_file_sink->flush();
-    g_console_sink->flush();
+    if (g_shad_file_sink != nullptr) {
+        g_shad_file_sink->flush();
+    }
+
+    if (g_console_sink != nullptr) {
+        g_console_sink->flush();
+    }
 }
 } // namespace Common::Log

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -37,7 +37,11 @@ void Flush();
 
 // Define the fmt lib macros
 #define LOG_GENERIC(log_class, log_level, ...)                                                     \
-    SPDLOG_LOGGER_CALL(Common::Log::ALL_LOGGERS[log_class], log_level, __VA_ARGS__)
+    do {                                                                                           \
+        if (auto logger = Common::Log::ALL_LOGGERS[log_class]) {                                   \
+            SPDLOG_LOGGER_CALL(logger, log_level, __VA_ARGS__);                                    \
+        }                                                                                          \
+    } while (false)
 
 #ifdef _DEBUG
 #define LOG_TRACE(log_class, ...)                                                                  \


### PR DESCRIPTION
Emulator::Restart calls Log::Shutdown then quick_exit (which calls Flush)
thanks to @StevenMiller123 for reporting and help reproduce
- [x] I test when the Windows build finishes