### PR TITLE
chroe: fix building on fedora 44 / clang 22

### DIFF
--- a/documents/building-linux.md
+++ b/documents/building-linux.md
@@ -23,9 +23,10 @@ sudo apt install build-essential clang git cmake libasound2-dev \
 #### Fedora
 
 ```bash
-sudo dnf install clang git cmake libatomic alsa-lib-devel \
+sudo dnf install ninja-build clang git cmake libatomic alsa-lib-devel \
     pipewire-jack-audio-connection-kit-devel openal-soft-devel \
     openssl-devel libevdev-devel libudev-devel libXext-devel \
+    libXcursor-devel libXi-devel libXrandr-devel libXScrnSaver-devel \
     vulkan-devel vulkan-validation-layers libpng-devel libuuid-devel
 ```
 

--- a/src/core/debugger.cpp
+++ b/src/core/debugger.cpp
@@ -12,6 +12,7 @@
 #elif defined(__linux__)
 #include <filesystem>
 #include <fstream>
+#include <unistd.h>
 #elif defined(__APPLE__) || defined(__FreeBSD__)
 #include <errno.h>
 #include <signal.h>

--- a/src/core/tls.cpp
+++ b/src/core/tls.cpp
@@ -4,7 +4,6 @@
 #include <mutex>
 #include "common/arch.h"
 #include "common/assert.h"
-#include "common/types.h"
 #include "core/libraries/kernel/threads/pthread.h"
 #include "core/tls.h"
 
@@ -23,6 +22,8 @@
 #if defined(__linux__) && defined(ARCH_X86_64)
 #include <asm/prctl.h>
 #include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
 #endif
 
 namespace Core {


### PR DESCRIPTION
Fix building shadps4 on Fedora 44 (upcoming version).

Additionally, update documentation for building on Fedora (add missing packages).