### PR TITLE
file_sys: apply case-insensitive search to mods_path on GNU/Linux and macOS

### DIFF
--- a/src/core/file_sys/fs.cpp
+++ b/src/core/file_sys/fs.cpp
@@ -159,6 +159,13 @@ std::filesystem::path MntPoints::GetHostPath(std::string_view path, bool* is_rea
         return std::optional<std::filesystem::path>(current_path);
     };
 
+    if ((corrected_path.starts_with("/app0") || corrected_path.starts_with("/hostapp")) &&
+        path_type != HostPathType::Base) {
+        if (const auto path = search(mods_path)) {
+            return *path;
+        }
+    }
+
     if (path_type != HostPathType::Base && !ignore_game_patches) {
         if (const auto path = search(patch_path)) {
             return *path;


### PR DESCRIPTION
## Problem

The case-insensitive fallback `search()` in `GetHostPath` (`src/core/file_sys/fs.cpp`) is only invoked for `patch_path` and `host_path`. The `exists()` check that decides whether to return `mods_path` is strictly case-sensitive.

As a consequence, on filesystems where `NeedsCaseInsensitiveSearch` is true (GNU/Linux, macOS), files inside `mods_path` are not found whenever the capitalization of any folder or file in the mod does not exactly match the guest path requested by the game. The lookup falls through to `host_path` (the unmodded installation), where the modded files do not exist either, so the mod's contribution is silently lost. Case mismatches of this kind are common in practice because the PS4 filesystem is case-insensitive.

## Repro

Game: Bloodborne (CUSA03173).
Mod: Debug Menu Restoration. The mod ships e.g. `dvdroot_ps4/adhoc/font/DbgFont14h.ccm` and `dvdroot_ps4/adhoc/FontShader/debugFont_vs.vpo` (mixed case) under `CUSA03173-mods/`. The game requests these paths in lowercase (`adhoc/font/dbgfont14h.ccm`, `adhoc/fontshader/debugfont_vs.vpo`).

Without this patch, no `open` calls against `/app0/dvdroot_ps4/adhoc/...` appear in the log at all even though `Files found in game mods folder` is logged at startup, and the game crashes shortly after the debug menu is activated:

```
[Debug] <Critical> (Game:Main) signals.cpp:96 SignalHandler: Unreachable code!
Unhandled access violation at code address 0x802382d83: Write to address 0x0
```

## Fix

Add a `search(mods_path)` pass mirroring the existing `search(patch_path)` and `search(host_path)` fallbacks, gated on the same `/app0` and `/hostapp` prefix condition used by the exact-match check above, and placed first to preserve mod > patch > base precedence.

## Tested

GNU/Linux (Gentoo, ext4), AMD RX 580 (RADV), with and without the mod active. With the patch, Debug Menu Restoration loads correctly through the `-mods` folder. The debug menu activates without crashing, fonts and shaders are rendered correctly, and the expected lowercase guest paths now resolve to the mixed-case files shipped by the mod:

```
[Kernel.Fs] file_system.cpp:78 open: path = /app0/dvdroot_ps4/adhoc/fontshader/debugfont_vs.vpo
[Kernel.Fs] file_system.cpp:78 open: path = /app0/dvdroot_ps4/adhoc/fontshader/debugfont_ps.ppo
[Kernel.Fs] file_system.cpp:78 open: path = /app0/dvdroot_ps4/adhoc/font/dbgfont14h.ccm
[Kernel.Fs] file_system.cpp:78 open: path = /app0/dvdroot_ps4/adhoc/font/dbgfont14h.tpf
```