### PR TITLE
CI: Silence some warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,10 +106,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libc++-dev libc++abi-dev ninja-build libx11-dev libxext-dev libwayland-dev libdecor-0-dev libxkbcommon-dev libxcursor-dev libxi-dev libxss-dev libxtst-dev libxrandr-dev libxfixes-dev libudev-dev uuid-dev uuid-dev
 
-      - name: Install dependencies (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          brew install ninja
+      # - name: Install dependencies (macOS)
+      #   if: runner.os == 'macOS'
+      #   run: |
+      #     brew install
 
       - name: Configure CMake
         run: |


### PR DESCRIPTION
Resolves: 

- Using deprecated `checkout@v4` in the C++ tests
- Trying to install ninja, which comes pre-installed in the runner already

Since ninja is the only macOS dependency and isn't needed, I've just commented out the install dependency step instead of removing it so it can be easily added back in the future if needed. 