### PR TITLE
Core: Reduce address space size for FreeBSD

### DIFF
--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -45,6 +45,9 @@ constexpr VAddr USER_MIN = 0x1000000000ULL;
 #if defined(__linux__)
 // Linux maps the shadPS4 executable around here, so limit the user maximum
 constexpr VAddr USER_MAX = 0x54FFFFFFFFFFULL;
+#elif defined(__FreeBSD__)
+// FreeBSD address space is extremely volatile, keep this lower for safety.
+constexpr VAddr USER_MAX = 0xFFFFFFFFFFFULL;
 #else
 constexpr VAddr USER_MAX = 0x5FFFFFFFFFFFULL;
 #endif


### PR DESCRIPTION
The FreeBSD address space seems to be extremely volatile, so mmap with our larger USER_MAX size typically fails, particularly when running outside debuggers.
Seems like there's still some weirdness going on that prevents running outside debuggers, but this helps.