### PR TITLE
Fix big picture crash on some compiled builds

### DIFF
--- a/src/imgui/big_picture.cpp
+++ b/src/imgui/big_picture.cpp
@@ -33,7 +33,7 @@ static std::vector<Game> gameVec = {};
 static float uiScale = 1.0f;
 static SDL_Renderer* renderer;
 
-void Launch() {
+void Launch(char* executableName) {
     if (!SDL_Init(SDL_INIT_VIDEO)) {
         LOG_ERROR(ImGui, "SDL_INIT_VIDEO Error: {}", SDL_GetError());
         SDL_Quit();
@@ -231,6 +231,7 @@ void Launch() {
 
     if (runEbootPath != "") {
         auto* emulator = Common::Singleton<Core::Emulator>::Instance();
+        emulator->executableName = executableName;
         emulator->Run(runEbootPath);
     }
 }

--- a/src/imgui/big_picture.h
+++ b/src/imgui/big_picture.h
@@ -16,7 +16,7 @@ struct Game {
     bool focusState;
 };
 
-void Launch();
+void Launch(char* executableName);
 void SetGameIcons(std::vector<Game>& games);
 void GetGameInfo(std::vector<Game>& games, bool AddGlobalSettings, SDL_Texture* texture = {});
 std::filesystem::path UpdateChecker(const std::string sceItem, std::filesystem::path game_folder);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -140,6 +140,11 @@ int main(int argc, char* argv[]) {
     Common::Log::g_should_append |= EmulatorSettings.IsLogAppend();
     Common::Log::Setup("shad_log.txt");
 
+    if (bigPicture) {
+        BigPictureMode::Launch();
+        return 0;
+    }
+
     // ---- Utility commands ----
     if (addGameFolder) {
         EmulatorSettings.AddGameInstallDir(*addGameFolder);
@@ -155,7 +160,7 @@ int main(int argc, char* argv[]) {
         return 0;
     }
 
-    if (!gamePath.has_value() && !bigPicture) {
+    if (!gamePath.has_value()) {
         if (!gameArgs.empty()) {
             gamePath = gameArgs.front();
             gameArgs.erase(gameArgs.begin());
@@ -212,20 +217,16 @@ int main(int argc, char* argv[]) {
                 break;
             }
         }
-        if (!found && !bigPicture) {
+        if (!found) {
             std::cerr << "Error: Game ID or file path not found: " << *gamePath << "\n";
             return 1;
         }
     }
 
-    if (bigPicture) {
-        BigPictureMode::Launch();
-    } else {
-        auto* emulator = Common::Singleton<Core::Emulator>::Instance();
-        emulator->executableName = argv[0];
-        emulator->waitForDebuggerBeforeRun = waitForDebugger;
-        emulator->Run(ebootPath, gameArgs, overrideRoot);
-    }
+    auto* emulator = Common::Singleton<Core::Emulator>::Instance();
+    emulator->executableName = argv[0];
+    emulator->waitForDebuggerBeforeRun = waitForDebugger;
+    emulator->Run(ebootPath, gameArgs, overrideRoot);
 
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,7 +141,7 @@ int main(int argc, char* argv[]) {
     Common::Log::Setup("shad_log.txt");
 
     if (bigPicture) {
-        BigPictureMode::Launch();
+        BigPictureMode::Launch(argv[0]);
         return 0;
     }
 


### PR DESCRIPTION
Some compiled builds were crashing on std::filesystem::path ebootPath(*gamePath) when passing arg -b for big picture mode - without any game arg it would be constructing from an empty optional.

Instead of adding a !has_value check for this, I think it's just cleaner to move launching big picture up before any other args are checked.  The other args aren't passed to Big picture mode anyway

EDIT: also added passing executable name which is needed for cases such as restarting the emulator when loading new elfs from a collection (ex: Uncharted collection)