### PR TITLE
Fix Vulkan physical-device auto-selection comparator to satisfy strict weak ordering

### DIFF
--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -116,13 +116,20 @@ Instance::Instance(Frontend::WindowSDL& window, s32 physical_device_index,
         std::sort(properties2.begin(), properties2.end(), [](const auto& left, const auto& right) {
             const vk::PhysicalDeviceProperties& left_prop = std::get<1>(left).properties;
             const vk::PhysicalDeviceProperties& right_prop = std::get<1>(right).properties;
-            if (left_prop.apiVersion >= TargetVulkanApiVersion &&
-                right_prop.apiVersion < TargetVulkanApiVersion) {
-                return true;
+            const bool left_supports_api = left_prop.apiVersion >= TargetVulkanApiVersion;
+            const bool right_supports_api = right_prop.apiVersion >= TargetVulkanApiVersion;
+            if (left_supports_api != right_supports_api) {
+                return left_supports_api;
             }
-            if (left_prop.deviceType != right_prop.deviceType) {
-                return left_prop.deviceType == vk::PhysicalDeviceType::eDiscreteGpu;
+
+            const bool left_is_discrete =
+                left_prop.deviceType == vk::PhysicalDeviceType::eDiscreteGpu;
+            const bool right_is_discrete =
+                right_prop.deviceType == vk::PhysicalDeviceType::eDiscreteGpu;
+            if (left_is_discrete != right_is_discrete) {
+                return left_is_discrete;
             }
+
             constexpr auto get_mem = [](const vk::PhysicalDeviceMemoryProperties& mem) -> size_t {
                 size_t max = 0;
                 for (u32 i = 0; i < mem.memoryHeapCount; i++) {


### PR DESCRIPTION
## Summary

This PR fixes the comparator used for Vulkan physical-device auto-selection.

That comparator is passed to `std::sort`, but it does not satisfy strict weak ordering:

1. the Vulkan API threshold preference is asymmetric
2. the device-type preference makes differing non-discrete types mutually equivalent, while still ordering same-type non-discrete devices by memory size

As a result, the sort can produce contradictory comparisons, and the auto-selection path has undefined behavior.

The intended priority appears to be:

1. Prefer devices meeting `TargetVulkanApiVersion`
2. Then prefer discrete GPUs
3. Then prefer larger device-local memory

but the current implementation does not encode those priorities as a valid ordering relation.

It makes both the Vulkan-API and discrete-GPU comparisons explicit and symmetric before the memory fallback, while preserving the original intended priority order.

## Violation Witness

### Witness 1: Vulkan API threshold asymmetry

Let the target API be Vulkan 1.3.

Consider two devices:

1. `A`: `apiVersion < TargetVulkanApiVersion`, same device type as `B`, larger device-local memory
2. `B`: `apiVersion >= TargetVulkanApiVersion`, same device type as `A`, smaller device-local memory

With the current comparator:

https://github.com/shadps4-emu/shadPS4/blob/5a15eb4d94332d6e11847a4ae067e2ad69b4036b/src/video_core/renderer_vulkan/vk_instance.cpp#L119-L122

1. `cmp(B, A) == true`
   because `B` satisfies the Vulkan API threshold and `A` does not
2. `cmp(A, B) == true`
   because the API-specific early return does not trigger in this direction, the device types are the same, and the comparator falls through to the memory comparison where `A` wins

So the comparator can report both `A < B` and `B < A`.

### Witness 2: non-discrete device-type equivalence is not transitive

Consider three devices with the same Vulkan API support status:

1. `A`: integrated GPU with 8 GB device-local memory
2. `B`: CPU or virtual GPU with 4 GB device-local memory
3. `C`: integrated GPU with 2 GB device-local memory

With the current comparator:

https://github.com/shadps4-emu/shadPS4/blob/5a15eb4d94332d6e11847a4ae067e2ad69b4036b/src/video_core/renderer_vulkan/vk_instance.cpp#L123-L125

1. `cmp(A, B) == false` and `cmp(B, A) == false`
   because the device types differ, and neither side is discrete
2. `cmp(B, C) == false` and `cmp(C, B) == false`
   for the same reason
3. `cmp(A, C) == true`
   because both are integrated GPUs, so the comparator falls through to the memory comparison and prefers `A`

So `A ~ B` and `B ~ C`, but not `A ~ C`, which violates transitivity of equivalence and therefore strict weak ordering.

## Potential Outcomes

Possible downstream effects include:

1. Undefined behavior in `std::sort`, which may cause out-of-bound read/write and potential crash.
2. Unstable or implementation-dependent device ordering
3. Wrong Vulkan physical-device selection during automatic startup
4. Selecting a less suitable non-discrete device because the comparator does not consistently express its intended priority order

This kind of bug can remain latent for a long time because many systems expose only one practical Vulkan device, or only device combinations that do not hit a contradictory comparison.

## Related Issues

I checked the public tracker for likely symptom-level matches.

- #232

## Fix

The current patch is:

1. Make the Vulkan API support comparison symmetric
2. Make the discrete-GPU preference symmetric
3. Preserve the existing memory-size fallback

That keeps the original selection intent and makes the comparator valid for use with `std::sort`.
