### PR TITLE
Recompiler: Use num_records to check if an inline buffer exists

### DIFF
--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -506,7 +506,7 @@ void PatchBufferSharp(IR::Block& block, IR::Inst& inst, Info& info, Descriptors&
         // is used to define an inline buffer resource
         std::array<u64, 2> raw;
         // Keep relative address, we'll do fixup of the address at buffer fetch later
-        raw[0] = (handle->Arg(0).U32() | u64(handle->Arg(1).U32()) << 32);
+        raw[0] = handle->Arg(0).U32() | u64(handle->Arg(1).U32()) << 32;
         raw[1] = handle->Arg(2).U32() | u64(handle->Arg(3).U32()) << 32;
         const auto buffer = std::bit_cast<AmdGpu::Buffer>(raw);
         buffer_binding = descriptors.Add(BufferResource{

--- a/src/shader_recompiler/resource.h
+++ b/src/shader_recompiler/resource.h
@@ -56,7 +56,7 @@ struct BufferResource {
         AmdGpu::Buffer buffer{};
         if (inline_cbuf) {
             buffer = inline_cbuf;
-            if (inline_cbuf.base_address > 1) {
+            if (inline_cbuf.base_address != 1) {
                 buffer.base_address += info.pgm_base; // address fixup
             }
         } else {

--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -49,7 +49,7 @@ struct Buffer {
     }
 
     operator bool() const noexcept {
-        return base_address != 0;
+        return num_records != 0;
     }
 
     bool operator==(const Buffer& other) const noexcept {


### PR DESCRIPTION
After #3816, we store inline buffers with their relative address, instead of the absolute address.
Some games create inline buffers with a relative address of 0, and after this change, those inline buffers would no longer detect properly (causing an attempt to read a sharp from sharp_idx = -1, which is hardcoded for inline buffers).

This PR changes our buffer bool() operator to check against num_records instead, which is usually non-zero (as zero would imply a buffer of 0 size). This fixes the regression in The Last of Us Remastered.

I'm not sure if this is a valid change, mainly since I don't know if there's a reason a game might intentionally register a buffer with 0 size (in which case, the check would need to be against all fields, or we'd need to check for inline buffers some other way).