### PR TITLE
Uber web_api module fix

### DIFF
--- a/src/core/libraries/np/np_web_api_internal.cpp
+++ b/src/core/libraries/np/np_web_api_internal.cpp
@@ -452,7 +452,7 @@ s32 createRequest(s32 titleUserCtxId, const char* pApiGroup, const char* pPath,
     }
 
     s64 user_ctx_id = static_cast<s64>(titleUserCtxId);
-    s32 request_id = (user_ctx_id << 0x20) | g_request_count;
+    s64 request_id = (user_ctx_id << 0x20) | g_request_count;
     while (user_context->requests.contains(request_id)) {
         request_id--;
     }


### PR DESCRIPTION
fixed truncate of request_id data . All findAndValidateContext context was creating nullptr context and was returning ORBIS_NP_WEBAPI_ERROR_LIB_CONTEXT_NOT_FOUND . Now at least it will go further :D