### PR TITLE
Recompiler: Increase MAGIC_ENUM_RANGE_MAX define for new neo opcodes

### DIFF
--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -18,7 +18,7 @@
 
 #include <numbers>
 #define MAGIC_ENUM_RANGE_MIN 0
-#define MAGIC_ENUM_RANGE_MAX 1515
+#define MAGIC_ENUM_RANGE_MAX 2143
 #include <magic_enum/magic_enum.hpp>
 
 namespace Shader::Gcn {


### PR DESCRIPTION
The additional neo-mode opcodes warranted an increase in the number of opcodes in our opcodes enum. MAGIC_ENUM_RANGE_MAX needs increasing to fix logging the new neo-specific opcodes we're detecting.