### PR TITLE
Common: Restore old log filter behavior

### DIFF
--- a/documents/Debugging/Debugging.md
+++ b/documents/Debugging/Debugging.md
@@ -65,7 +65,7 @@ You can configure the emulator by editing the `config.toml` file found in the `u
     - When communicating about issues with games and the log messages aren't clear due to potentially confusing order, set this to `true` and send that log instead.
   - `filter`: Sets the logging category for various logging classes.
     - Format: `<class>:<level> ...`
-    - Multiple classes can be set by separating them with a space. (example: `Render:Warning Debug:Critical Lib.Pad:Error`)
+    - Multiple classes can be set by separating them with a space. (example: `Render:Warning Lib.Pad:Error`)
     - Sub-classes can be specified in the same format as seen in the console/log (such as `Core.Linker`).  
     - Valid log levels: `trace, debug, info, warning, error, critical, off` - in this order, setting a level silences all levels preceding it and logs every level after it.
     - Examples:

--- a/documents/Debugging/Debugging.md
+++ b/documents/Debugging/Debugging.md
@@ -64,13 +64,13 @@ You can configure the emulator by editing the `config.toml` file found in the `u
     - It can be beneficial to set this to `false` for better performance.
     - When communicating about issues with games and the log messages aren't clear due to potentially confusing order, set this to `true` and send that log instead.
   - `filter`: Sets the logging category for various logging classes.
-    - Format: `<class>=<level>,...`
-    - Multiple classes can be set by separating them with a comma. (example: `Render=warning,Debug=critical,Lib.Pad=error`)
+    - Format: `<class>:<level> ...`
+    - Multiple classes can be set by separating them with a space. (example: `Render:Warning Debug:Critical Lib.Pad:Error`)
     - Sub-classes can be specified in the same format as seen in the console/log (such as `Core.Linker`).  
-    - Valid log levels: `trace, debug, info, warning, error, critical` - in this order, setting a level silences all levels preceding it and logs every level after it.
+    - Valid log levels: `trace, debug, info, warning, error, critical, off` - in this order, setting a level silences all levels preceding it and logs every level after it.
     - Examples:
-      - If the log is being spammed with messages coming from Lib.Pad, you can use `Lib.Pad=critical` to only log critical-level messages.
-      - If you'd like to mute everything, but still want to receive messages from Vulkan rendering: `off,Render.Vulkan=info` (if you want critical at least `critical,Render.Vulkan=info`)
+      - If the log is being spammed with messages coming from Lib.Pad, you can use `Lib.Pad:Critical` to only log critical-level messages.
+      - If you'd like to mute everything, but still want to receive messages from Vulkan rendering: `*:Off Render.Vulkan:Info` (if you want critical at least `*:Critical Render.Vulkan:Info`)
   - `skipDuplicate`: Skip same lines with a `Skipped N duplicate messages..` message (`true`/`false`)
     - By default, the emulator will skip same lines for `maxSkipDuration` milliseconds.
   - `append`: Append log to the existing file (`true`/`false`)

--- a/src/common/logging/log.cpp
+++ b/src/common/logging/log.cpp
@@ -204,8 +204,10 @@ void Setup(std::string_view log_filename) {
             const auto class_level_pair =
                 std::views::split(class_level, ':') | std::ranges::to<std::vector<std::string>>();
 
-            if (class_level_pair.size() == 1) {
-                default_log_level = spdlog::level_from_str(class_level_pair.front() |
+            ASSERT_MSG(class_level_pair.size() == 2, "bad log filter provided");
+
+            if (class_level_pair.front()[0] == '*') {
+                default_log_level = spdlog::level_from_str(class_level_pair.back() |
                                                            std::ranges::to<std::string>());
             } else {
                 log_level_per_class[class_level_pair.front() | std::ranges::to<std::string>()] =
@@ -222,16 +224,10 @@ void Setup(std::string_view log_filename) {
                                    : (EmulatorSettings.IsLogSync() ? sinks : async_sink));
 
         if (EmulatorSettings.IsLogEnable()) {
-            const auto wildcard_it = log_level_per_class.find(std::string("*"));
             const auto level_it = log_level_per_class.find(std::string(name));
 
-            if (level_it != log_level_per_class.end()) {
-                logger->set_level(level_it->second);
-            } else if (wildcard_it != log_level_per_class.end()) {
-                logger->set_level(wildcard_it->second);
-            } else {
-                logger->set_level(default_log_level);
-            }
+            logger->set_level(level_it != log_level_per_class.end() ? level_it->second
+                                                                    : default_log_level);
         } else {
             logger->set_level(spdlog::level::off);
         }

--- a/src/common/logging/log.cpp
+++ b/src/common/logging/log.cpp
@@ -204,7 +204,10 @@ void Setup(std::string_view log_filename) {
             const auto class_level_pair =
                 std::views::split(class_level, ':') | std::ranges::to<std::vector<std::string>>();
 
-            ASSERT_MSG(class_level_pair.size() == 2, "bad log filter provided");
+            if (class_level_pair.size() != 2) {
+                std::cerr << "bad log filter provided" << std::endl;
+                continue;
+            }
 
             if (class_level_pair.front()[0] == '*') {
                 default_log_level = spdlog::level_from_str(class_level_pair.back() |

--- a/src/common/logging/log.cpp
+++ b/src/common/logging/log.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <cstdlib>
+#include <iostream>
 #include <string>
 
 #include "common/assert.h"

--- a/src/common/logging/log.cpp
+++ b/src/common/logging/log.cpp
@@ -200,9 +200,9 @@ void Setup(std::string_view log_filename) {
     std::unordered_map<std::string, spdlog::level> log_level_per_class;
 
     if (EmulatorSettings.IsLogEnable()) {
-        for (const auto class_level : std::views::split(EmulatorSettings.GetLogFilter(), ',')) {
+        for (const auto class_level : std::views::split(EmulatorSettings.GetLogFilter(), ' ')) {
             const auto class_level_pair =
-                std::views::split(class_level, '=') | std::ranges::to<std::vector<std::string>>();
+                std::views::split(class_level, ':') | std::ranges::to<std::vector<std::string>>();
 
             if (class_level_pair.size() == 1) {
                 default_log_level = spdlog::level_from_str(class_level_pair.front() |
@@ -222,10 +222,16 @@ void Setup(std::string_view log_filename) {
                                    : (EmulatorSettings.IsLogSync() ? sinks : async_sink));
 
         if (EmulatorSettings.IsLogEnable()) {
+            const auto wildcard_it = log_level_per_class.find(std::string("*"));
             const auto level_it = log_level_per_class.find(std::string(name));
 
-            logger->set_level(level_it != log_level_per_class.end() ? level_it->second
-                                                                    : default_log_level);
+            if (level_it != log_level_per_class.end()) {
+                logger->set_level(level_it->second);
+            } else if (wildcard_it != log_level_per_class.end()) {
+                logger->set_level(wildcard_it->second);
+            } else {
+                logger->set_level(default_log_level);
+            }
         } else {
             logger->set_level(spdlog::level::off);
         }


### PR DESCRIPTION
Not sure why this had to change in the first place, so this PR restores the old filter formatting, and brings back the old wildcard.

Would probably be good for @Niram7777 to review this, in case there's some good reason to keep the new filter format.