### PR TITLE
Change ASSERT macros to be do while loops instead of lambdas to preserve original function names in the log

### DIFF
--- a/src/common/assert.h
+++ b/src/common/assert.h
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2013 Dolphin Emulator Project
 // SPDX-FileCopyrightText: 2014 Citra Emulator Project
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once

--- a/src/common/assert.h
+++ b/src/common/assert.h
@@ -20,20 +20,20 @@ void assert_fail_impl();
 #endif
 
 #define ASSERT(_a_)                                                                                \
-    ([&]() SHAD_NO_INLINE {                                                                        \
+    do {                                                                                           \
         if (!(_a_)) [[unlikely]] {                                                                 \
             LOG_CRITICAL(Debug, "Assertion Failed!");                                              \
             assert_fail_impl();                                                                    \
         }                                                                                          \
-    }())
+    } while (false)
 
 #define ASSERT_MSG(_a_, ...)                                                                       \
-    ([&]() SHAD_NO_INLINE {                                                                        \
+    do {                                                                                           \
         if (!(_a_)) [[unlikely]] {                                                                 \
             LOG_CRITICAL(Debug, "Assertion Failed!\n" __VA_ARGS__);                                \
             assert_fail_impl();                                                                    \
         }                                                                                          \
-    }())
+    } while (false)
 
 #define UNREACHABLE()                                                                              \
     do {                                                                                           \


### PR DESCRIPTION
Recompilation speeds will be horrendous due to me touching a header that's used literally everywhere, but it is what it is.