### PR TITLE
Lib.VideoOut: Properly clear handle data on sceVideoOutClose

### DIFF
--- a/src/core/libraries/videoout/driver.cpp
+++ b/src/core/libraries/videoout/driver.cpp
@@ -62,10 +62,26 @@ int VideoOutDriver::Open(const ServiceThreadParams* params) {
 void VideoOutDriver::Close(s32 handle) {
     std::scoped_lock lock{mutex};
 
+    // Mark as closed
     main_port.is_open = false;
     main_port.flip_rate = 0;
     main_port.prev_index = -1;
+
+    // Clear port information
+    std::memset(main_port.buffer_labels.data(), 0, sizeof(main_port.buffer_labels));
+    std::memset(main_port.groups.data(), 0, sizeof(main_port.groups));
+    std::memset(&main_port.flip_status, 0, sizeof(main_port.flip_status));
+    std::memset(&main_port.vblank_status, 0, sizeof(main_port.vblank_status));
+
+    // Re-initialize buffers
+    std::memset(main_port.buffer_slots.data(), 0, sizeof(main_port.buffer_slots));
+    for (auto& buffer : main_port.buffer_slots) {
+        buffer.group_index = -1;
+    }
+
+    // TODO: Remove events?
     ASSERT(main_port.flip_events.empty());
+    ASSERT(main_port.vblank_events.empty());
 }
 
 VideoOutPort* VideoOutDriver::GetPort(int handle) {


### PR DESCRIPTION
Previously, sceVideoOutClose was just marking the port as unopened, and resetting flip rate and previous index values. In Monster Hunter: World, with neo mode enabled and the game set to "Prioritize Resolution", the game goes through initial splash screens at 1080p, then closes the current video out handle. It then reruns the full video out handle setup, this time setting buffers to 1800p.

Since sceVideoOutClose wasn't clearing the handle data properly, the attempt to register 1800p buffers would return an error, and further flip attempts fail.

With this PR, Monster Hunter: World can reach menus with neo-mode enabled and the game set to "Prioritize Resolution". At least, it does after running the game enough times to bypass savedata-related hangs.
<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/8417605d-a252-4d18-a686-f61501519dff" />
