### PR TITLE
Implement sceGnmInsertDingDongMarker

### DIFF
--- a/src/core/libraries/gnmdriver/gnmdriver.cpp
+++ b/src/core/libraries/gnmdriver/gnmdriver.cpp
@@ -1045,8 +1045,13 @@ void PS4_SYSV_ABI sceGnmGpuPaDebugLeave() {
     // Not available in retail firmware
 }
 
-int PS4_SYSV_ABI sceGnmInsertDingDongMarker() {
-    LOG_ERROR(Lib_GnmDriver, "(STUBBED) called");
+s32 PS4_SYSV_ABI sceGnmInsertDingDongMarker(u32* cmdbuf, u32 size) {
+    LOG_TRACE(Lib_GnmDriver, "called");
+
+    if (cmdbuf == nullptr || size != 4) {
+        return -1;
+    }
+    WritePacket<PM4ItOpcode::Nop>(cmdbuf, PM4ShaderType::ShaderGraphics, 0u, 0u, 0u);
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/gnmdriver/gnmdriver.h
+++ b/src/core/libraries/gnmdriver/gnmdriver.h
@@ -110,7 +110,7 @@ int PS4_SYSV_ABI sceGnmGetShaderStatus();
 VAddr PS4_SYSV_ABI sceGnmGetTheTessellationFactorRingBufferBaseAddress();
 void PS4_SYSV_ABI sceGnmGpuPaDebugEnter();
 void PS4_SYSV_ABI sceGnmGpuPaDebugLeave();
-int PS4_SYSV_ABI sceGnmInsertDingDongMarker();
+s32 PS4_SYSV_ABI sceGnmInsertDingDongMarker(u32* cmdbuf, u32 size);
 s32 PS4_SYSV_ABI sceGnmInsertPopMarker(u32* cmdbuf, u32 size);
 s32 PS4_SYSV_ABI sceGnmInsertPushColorMarker(u32* cmdbuf, u32 size, const char* marker, u32 color);
 s32 PS4_SYSV_ABI sceGnmInsertPushMarker(u32* cmdbuf, u32 size, const char* marker);


### PR DESCRIPTION
Use in Marvel's Avengers.
Stub returned ORBIS_OK without writing. Game advanced its ACB write pointer by 4 dwords expecting a marker. Parser hit zeros, faulted on PM4 type-0. 
Now returns -1 on bad args, otherwise writes a 4-dword type-3 NOP and returns 0. No PM4 type-0 crash.