### PR TITLE
Do not split targets when tests are enabled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
         shell: bash
 
       - name: Build all tests
-        run: cmake --build build
+        run: cmake --build build --target tests
         shell: bash
 
       - name: Run tests with CTest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1128,8 +1128,6 @@ set(EMULATOR src/emulator.cpp
              src/sdl_window.cpp
 )
 
-if(NOT ENABLE_TESTS)
-
 add_executable(shadps4
     ${AUDIO_CORE}
     ${IMGUI}
@@ -1302,7 +1300,7 @@ endif()
 # Install rules
 install(TARGETS shadps4 BUNDLE DESTINATION .)
 
-else()
+if(ENABLE_TESTS)
     enable_testing()
-    add_subdirectory(tests)
+    add_subdirectory(tests EXCLUDE_FROM_ALL)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -193,9 +193,9 @@ endforeach()
 
 include(GoogleTest)
 
+add_custom_target(tests)
+
 foreach(t ${TEST_TARGETS})
-    gtest_discover_tests(${t}
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        PROPERTIES TIMEOUT 60
-    )
+    add_dependencies(tests ${t})
+    add_test(NAME ${t} COMMAND ${t})
 endforeach()

--- a/tests/gcn/gcn_test_runner.cpp
+++ b/tests/gcn/gcn_test_runner.cpp
@@ -7,7 +7,6 @@
 #include <array>
 #include <format>
 #include <memory>
-#include <mutex>
 #include <ranges>
 #include <string_view>
 #include <vector>
@@ -103,14 +102,11 @@ auto create_host_buffer(vk::Device dev, vk::PhysicalDevice pd, vk::DeviceSize si
     return buf;
 }
 
-std::mutex g_runner_mutex;
-std::unique_ptr<Runner> g_runner;
-
 } // namespace
 
 Runner::~Runner() {
     if (device_) {
-        device_.waitIdle();
+        std::ignore = device_.waitIdle();
         if (fence_)
             device_.destroyFence(fence_);
         if (pipeline_layout_)
@@ -125,15 +121,11 @@ Runner::~Runner() {
         instance_.destroy();
 }
 
-std::expected<Runner*, ErrorInfo> Runner::instance() {
-    std::lock_guard lock{g_runner_mutex};
-    if (g_runner)
-        return g_runner.get();
+std::expected<std::unique_ptr<Runner>, ErrorInfo> Runner::instance() {
     auto r = std::unique_ptr<Runner>(new Runner{});
     if (auto init = r->initialize(); !init)
         return std::unexpected(init.error());
-    g_runner = std::move(r);
-    return g_runner.get();
+    return r;
 }
 
 std::expected<void, ErrorInfo> Runner::initialize() {
@@ -358,8 +350,8 @@ std::expected<void, ErrorInfo> Runner::run_raw(std::span<const std::uint32_t> sp
     } sg{device_, shader};
 
     // Reset cached command buffer + fence --------------------------------
-    device_.resetFences(fence_);
-    command_buffer_.reset();
+    std::ignore = device_.resetFences(fence_);
+    std::ignore = command_buffer_.reset();
 
     if (command_buffer_.begin({
             .flags = vk::CommandBufferUsageFlagBits::eOneTimeSubmit,

--- a/tests/gcn/gcn_test_runner.hpp
+++ b/tests/gcn/gcn_test_runner.hpp
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <cstring>
 #include <expected>
+#include <memory>
 #include <span>
 #include <string>
 #include <type_traits>
@@ -41,7 +42,7 @@ struct ErrorInfo {
 
 class Runner {
 public:
-    static std::expected<Runner*, ErrorInfo> instance();
+    static std::expected<std::unique_ptr<Runner>, ErrorInfo> instance();
 
     std::expected<void, ErrorInfo> run_raw(
         std::span<const std::uint32_t> spirv,

--- a/tests/gcn/test_gcn_instructions.cpp
+++ b/tests/gcn/test_gcn_instructions.cpp
@@ -10,11 +10,24 @@
 #include "instructions.hpp"
 #include "translator.hpp"
 
+namespace {
+std::unique_ptr<gcn_test::Runner> runner;
+}
+
 class GcnTest : public ::testing::Test {
 protected:
     void SetUp() override {}
 
     void TearDown() override {}
+
+    static void SetUpTestSuite() {
+        runner = gcn_test::Runner::instance().value();
+    }
+
+    static void TearDownTestSuite() {
+        runner.reset();
+    }
+
 };
 
 struct F32x2 {
@@ -41,8 +54,6 @@ struct F32x2 {
 // }
 
 TEST_F(GcnTest, add_f32) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP2(OpcodeVOP2::V_ADD_F32, VOperand8::V0, SOperand9::V0, VOperand8::V1).Get());
     auto result = runner->run<float>(spirv, F32x2{1.5f, 6.0f});
 
@@ -51,8 +62,6 @@ TEST_F(GcnTest, add_f32) {
 }
 
 TEST_F(GcnTest, add_nan) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP2(OpcodeVOP2::V_ADD_F32, VOperand8::V0, SOperand9::V0, VOperand8::V1).Get());
     auto result = runner->run<float>(spirv, F32x2{1.0f, std::numeric_limits<float>::quiet_NaN()});
 
@@ -72,8 +81,6 @@ struct F16x2 {
 static_assert(sizeof(F16x2) == sizeof(float));
 
 TEST_F(GcnTest, add_f16) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP2(OpcodeVOP2::V_ADD_F16, VOperand8::V0, SOperand9::V0, VOperand8::V1).Get());
     auto result = runner->run<F16x2>(spirv, std::array{F16x2{half(1.0f)}, F16x2{half(1.0f)}});
 
@@ -82,8 +89,6 @@ TEST_F(GcnTest, add_f16) {
 }
 
 TEST_F(GcnTest, add_f16_clamp) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP3A(OpcodeVOP3::V_ADD_F16, VOperand8::V0, SOperand9::V0, SOperand9::V1).SetClamp(true).Get());
     auto result = runner->run<F16x2>(spirv, std::array{F16x2{half(1.0f)}, F16x2{half(1.0f)}});
 
@@ -92,8 +97,6 @@ TEST_F(GcnTest, add_f16_clamp) {
 }
 
 TEST_F(GcnTest, add_f16_neg) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP3A(OpcodeVOP3::V_ADD_F16, VOperand8::V0, SOperand9::V0, SOperand9::V1).SetNeg({true, true, false}).Get());
     auto result = runner->run<F16x2>(spirv, std::array{F16x2{half(1.0f)}, F16x2{half(1.0f)}});
 
@@ -102,8 +105,6 @@ TEST_F(GcnTest, add_f16_neg) {
 }
 
 TEST_F(GcnTest, add_f16_opsel_hi) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP3A(OpcodeVOP3::V_ADD_F16, VOperand8::V0, SOperand9::V0, SOperand9::V1).SetOpSel({true, true, false, true}).Get());
     auto result = runner->run<F16x2>(spirv, std::array{F16x2{half(1.0f), half(2.0f)}, F16x2{half(1.0f), half(2.0f)}});
 
@@ -113,8 +114,6 @@ TEST_F(GcnTest, add_f16_opsel_hi) {
 }
 
 TEST_F(GcnTest, sub_f16) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP2(OpcodeVOP2::V_SUB_F16, VOperand8::V0, SOperand9::V0, VOperand8::V1).Get());
     auto result = runner->run<F16x2>(spirv, std::array{F16x2{half(0.0f)}, F16x2{half(1.0f)}});
 
@@ -123,8 +122,6 @@ TEST_F(GcnTest, sub_f16) {
 }
 
 TEST_F(GcnTest, mul_legacy_nan) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP2(OpcodeVOP2::V_MUL_LEGACY_F32, VOperand8::V0, SOperand9::V0, VOperand8::V1).Get());
     auto result = runner->run<u32>(spirv, std::array{u32(0), u32(0x7fc00000)});
 
@@ -133,8 +130,6 @@ TEST_F(GcnTest, mul_legacy_nan) {
 }
 
 TEST_F(GcnTest, mul_nan) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP2(OpcodeVOP2::V_MUL_F32, VOperand8::V0, SOperand9::V0, VOperand8::V1).Get());
     auto result = runner->run<float>(spirv, std::array{u32(0), u32(0x7fc00000)});
 
@@ -143,8 +138,6 @@ TEST_F(GcnTest, mul_nan) {
 }
 
 TEST_F(GcnTest, min_legacy_nan) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP2(OpcodeVOP2::V_MIN_LEGACY_F32, VOperand8::V0, SOperand9::V0, VOperand8::V1).Get());
     auto result = runner->run<u32>(spirv, std::array{u32(0), u32(0x7fc00000)});
 
@@ -153,8 +146,6 @@ TEST_F(GcnTest, min_legacy_nan) {
 }
 
 TEST_F(GcnTest, min_nan) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP2(OpcodeVOP2::V_MIN_F32, VOperand8::V0, SOperand9::V0, VOperand8::V1).Get());
     auto result = runner->run<float>(spirv, std::array{u32(0), u32(0x7fc00000)});
 
@@ -163,8 +154,6 @@ TEST_F(GcnTest, min_nan) {
 }
 
 TEST_F(GcnTest, add3_u32_1) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP3A(OpcodeVOP3::V_ADD3_U32, VOperand8::V0, SOperand9::V0, SOperand9::V1, SOperand9::V2).Get());
     auto result = runner->run<u32>(spirv, std::array{0, 1, 2});
 
@@ -173,8 +162,7 @@ TEST_F(GcnTest, add3_u32_1) {
 }
 
 TEST_F(GcnTest, add3_u32_2) {
-    auto runner = gcn_test::Runner::instance().value();
-    auto big = 2000000000;
+   auto big = 2000000000;
 
     auto spirv = TranslateToSpirv(VOP3A(OpcodeVOP3::V_ADD3_U32, VOperand8::V0, SOperand9::V0, SOperand9::V1, SOperand9::V2).Get());
     auto result = runner->run<u32>(spirv, std::array{big, big, big});
@@ -184,8 +172,7 @@ TEST_F(GcnTest, add3_u32_2) {
 }
 
 TEST_F(GcnTest, add3_u32_3) {
-    auto runner = gcn_test::Runner::instance().value();
-    auto big = 2000000000;
+   auto big = 2000000000;
 
     auto spirv = TranslateToSpirv(VOP3A(OpcodeVOP3::V_ADD3_U32, VOperand8::V0, SOperand9::V0, SOperand9::V1, SOperand9::V2).SetClamp(true).Get());
     auto result = runner->run<u32>(spirv, std::array{big, big, big});
@@ -195,8 +182,6 @@ TEST_F(GcnTest, add3_u32_3) {
 }
 
 TEST_F(GcnTest, add3_u32_4) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP3A(OpcodeVOP3::V_ADD3_U32, VOperand8::V0, SOperand9::V0, SOperand9::V1, SOperand9::V2).SetNeg({1,0,0}).Get());
     auto result = runner->run<u32>(spirv, std::array{0, 1, 2});
 
@@ -205,8 +190,6 @@ TEST_F(GcnTest, add3_u32_4) {
 }
 
 TEST_F(GcnTest, or3_u32_1) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP3A(OpcodeVOP3::V_OR3_B32, VOperand8::V0, SOperand9::V0, SOperand9::V1, SOperand9::V2).Get());
     auto result = runner->run<u32>(spirv, std::array<u32,3>{0xF0F0F0F0, 0x07070707, 0x11111111});
 
@@ -215,8 +198,6 @@ TEST_F(GcnTest, or3_u32_1) {
 }
 
 TEST_F(GcnTest, or3_u32_2) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP3A(OpcodeVOP3::V_OR3_B32, VOperand8::V0, SOperand9::V0, SOperand9::V1, SOperand9::V2).Get());
     auto result = runner->run<u32>(spirv, std::array{0x07070707, 0x11111111, 0x40404040});
 
@@ -225,8 +206,7 @@ TEST_F(GcnTest, or3_u32_2) {
 }
 
 TEST_F(GcnTest, or3_u32_3) {
-    auto runner = gcn_test::Runner::instance().value();
-    auto big = 2000000000;
+   auto big = 2000000000;
 
     auto spirv = TranslateToSpirv(VOP3A(OpcodeVOP3::V_OR3_B32, VOperand8::V0, SOperand9::V0, SOperand9::V1, SOperand9::V2).SetClamp(true).Get());
     auto result = runner->run<u32>(spirv, std::array{0x07070707, 0x11111111, 0x40404040});
@@ -236,8 +216,6 @@ TEST_F(GcnTest, or3_u32_3) {
 }
 
 TEST_F(GcnTest, or3_u32_4) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP3A(OpcodeVOP3::V_OR3_B32, VOperand8::V0, SOperand9::V0, SOperand9::V1, SOperand9::V2).SetNeg({0,0,1}).Get());
     auto result = runner->run<u32>(spirv, std::array{0x07070707, 0x11111111, 0x40404040});
 
@@ -246,8 +224,6 @@ TEST_F(GcnTest, or3_u32_4) {
 }
 
 TEST_F(GcnTest, and_or_b32_1) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP3A(OpcodeVOP3::V_AND_OR_B32, VOperand8::V0, SOperand9::V0, SOperand9::V1, SOperand9::V2).Get());
     auto result = runner->run<u32>(spirv, std::array<u32,3>{0xF0F0F0F0, 0x07070707, 0x11111111});
 
@@ -256,8 +232,6 @@ TEST_F(GcnTest, and_or_b32_1) {
 }
 
 TEST_F(GcnTest, and_or_b32_2) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP3A(OpcodeVOP3::V_AND_OR_B32, VOperand8::V0, SOperand9::V0, SOperand9::V1, SOperand9::V2).SetOmod(Omod::Mul2).Get());
     auto result = runner->run<u32>(spirv, std::array{0x40404040, 0x40404040, 0x40404040});
 
@@ -266,8 +240,6 @@ TEST_F(GcnTest, and_or_b32_2) {
 }
 
 TEST_F(GcnTest, and_or_b32_3) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP3A(OpcodeVOP3::V_AND_OR_B32, VOperand8::V0, SOperand9::V0, SOperand9::V1, SOperand9::V2).SetClamp(true).Get());
     auto result = runner->run<u32>(spirv, std::array{0x40404040, 0x40404040, 0x40404040});
 
@@ -276,8 +248,6 @@ TEST_F(GcnTest, and_or_b32_3) {
 }
 
 TEST_F(GcnTest, and_or_b32_4) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP3A(OpcodeVOP3::V_AND_OR_B32, VOperand8::V0, SOperand9::V0, SOperand9::V1, SOperand9::V2).SetNeg({1,0,0}).Get());
     auto result = runner->run<u32>(spirv, std::array<u32,3>{0x07070707, 0x11111111, 0xF0F0F0F0});
 
@@ -286,8 +256,6 @@ TEST_F(GcnTest, and_or_b32_4) {
 }
 
 TEST_F(GcnTest, and_or_b32_5) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP3A(OpcodeVOP3::V_AND_OR_B32, VOperand8::V0, SOperand9::V0, SOperand9::V1, SOperand9::V2).SetNeg({1,0,0}).SetAbs({1,0,0}).Get());
     auto result = runner->run<u32>(spirv, std::array<u32,3>{0x77777777, 0xB0B0B0B0, 0x11111111});
 
@@ -296,8 +264,6 @@ TEST_F(GcnTest, and_or_b32_5) {
 }
 
 TEST_F(GcnTest, and_or_b32_6) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP3A(OpcodeVOP3::V_AND_OR_B32, VOperand8::V0, SOperand9::V0, SOperand9::V1, SOperand9::V2).SetOmod(Omod::Mul2).Get());
     auto result = runner->run<u32>(spirv, std::array<u32,3>{0x40404040, 0xB0B0B0B0, 0x11111111});
 
@@ -306,8 +272,6 @@ TEST_F(GcnTest, and_or_b32_6) {
 }
 
 TEST_F(GcnTest, and_or_b32_7) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP3A(OpcodeVOP3::V_AND_OR_B32, VOperand8::V0, SOperand9::V0, SOperand9::V1, SOperand9::V2).SetOmod(Omod::Div2).Get());
     auto result = runner->run<u32>(spirv, std::array<u32,3>{0xB0B0B0B0, 0x77777777, 0x40404040});
 
@@ -316,8 +280,6 @@ TEST_F(GcnTest, and_or_b32_7) {
 }
 
 TEST_F(GcnTest, and_or_b32_8) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto spirv = TranslateToSpirv(VOP3A(OpcodeVOP3::V_AND_OR_B32, VOperand8::V0, SOperand9::V0, SOperand9::V1, SOperand9::V2).SetAbs({1,1,0}).Get());
     auto result = runner->run<u32>(spirv, std::array<u32,3>{0xB0B0B0B0, 0x11111111, 0x11111111});
 
@@ -326,8 +288,6 @@ TEST_F(GcnTest, and_or_b32_8) {
 }
 
 TEST_F(GcnTest, mad_mix_f32_1) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto inst = VOP3P(OpcodeVOP3P::V_MAD_MIX_F32, VOperand8::V0, SOperand9::V0, SOperand9::V1, SOperand9::V2).SetOpSelHi({0}).Get();
     auto spirv = TranslateToSpirv(inst);
     auto result = runner->run<float>(spirv, std::array{2.0f, 3.0f, 4.0f});
@@ -337,8 +297,6 @@ TEST_F(GcnTest, mad_mix_f32_1) {
 }
 
 TEST_F(GcnTest, mad_mix_f32_2) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto inst = VOP3P(OpcodeVOP3P::V_MAD_MIX_F32, VOperand8::V0, SOperand9::V0, SOperand9::V1, SOperand9::V2).SetOpSelHi({1,1,0}).SetOpSel({1,0,0}).Get();
     auto spirv = TranslateToSpirv(inst);
     auto result = runner->run<float>(spirv, std::array<u32,3>{
@@ -350,8 +308,6 @@ TEST_F(GcnTest, mad_mix_f32_2) {
 }
 
 TEST_F(GcnTest, mad_mixlo_f16_1) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto inst = VOP3P(OpcodeVOP3P::V_MAD_MIXLO_F16, VOperand8::V0, SOperand9::V0, SOperand9::V1, SOperand9::V2).SetOpSelHi({1,1,0}).SetOpSel({1,0,0}).Get();
     auto spirv = TranslateToSpirv(inst);
     auto result = runner->run<F16x2>(spirv, std::array<u32,3>{
@@ -363,8 +319,6 @@ TEST_F(GcnTest, mad_mixlo_f16_1) {
 }
 
 TEST_F(GcnTest, mad_mixhi_f16_1) {
-    auto runner = gcn_test::Runner::instance().value();
-
     auto inst = VOP3P(OpcodeVOP3P::V_MAD_MIXHI_F16, VOperand8::V0, SOperand9::V0, SOperand9::V1, SOperand9::V2).SetOpSelHi({1,1,0}).SetOpSel({1,0,0}).Get();
     auto spirv = TranslateToSpirv(inst);
     auto result = runner->run<F16x2>(spirv, std::array<u32,3>{


### PR DESCRIPTION
ENABLE_TESTS now only enables tests and not removes the whole shadps4 executable from the configuration. This helps when switching back and forth between building tests and the emulator - previously I had to delete cache and reconfigure each time