### PR TITLE
Initial PS5 support (linker support + apmr + agc)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,6 +283,14 @@ set(AJM_LIB src/core/libraries/ajm/ajm.cpp
             src/core/libraries/ajm/ajm_mp3.h
 )
 
+set(AMPR_LIB src/core/libraries/ampr/ampr.cpp
+             src/core/libraries/ampr/ampr.h
+)
+
+set(AGC_LIB src/core/libraries/agc/agc.cpp
+            src/core/libraries/agc/agc.h
+)
+
 set(AUDIO_LIB src/core/libraries/audio/audioin.cpp
               src/core/libraries/audio/audioin.h
               src/core/libraries/audio/audioin_backend.h
@@ -834,6 +842,8 @@ set(CORE src/core/aerolib/stubs.cpp
          src/core/libraries/libs.h
          src/core/libraries/libs.cpp
          ${AJM_LIB}
+         ${AGC_LIB}
+         ${AMPR_LIB}
          ${AVPLAYER_LIB}
          ${AUDIO_LIB}
          ${GNM_LIB}

--- a/src/common/logging/classes.h
+++ b/src/common/logging/classes.h
@@ -28,6 +28,7 @@ constexpr auto Kernel_Sce = "Kernel.Sce";                           ///< The Son
 constexpr auto Kernel_Vmm = "Kernel.Vmm";                           ///< The virtual memory implementation of the kernel.
 constexpr auto KeyManager = "KeyManager";                           ///< Key management system
 constexpr auto Lib = "Lib";                                         ///< HLE implementation of system library. Each major library  should have its own subclass.
+constexpr auto Lib_Agc = "Lib.Agc";                                 ///< The LibSceAgc implementation.
 constexpr auto Lib_Ajm = "Lib.Ajm";                                 ///< The LibSceAjm implementation.
 constexpr auto Lib_AppContent = "Lib.AppContent";                   ///< The LibSceAppContent implementation.
 constexpr auto Lib_Audio3d = "Lib.Audio3d";                         ///< The LibSceAudio3d implementation.

--- a/src/common/logging/log.cpp
+++ b/src/common/logging/log.cpp
@@ -42,6 +42,7 @@ std::unordered_map<std::string_view, std::shared_ptr<spdlog::logger>> ALL_LOGGER
     {Class::Kernel_Vmm, nullptr},
     {Class::KeyManager, nullptr},
     {Class::Lib, nullptr},
+    {Class::Lib_Agc, nullptr},
     {Class::Lib_Ajm, nullptr},
     {Class::Lib_AppContent, nullptr},
     {Class::Lib_Audio3d, nullptr},

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -58,7 +58,7 @@ static constexpr u64 SystemReservedSize = SYSTEM_RESERVED_MAX - SYSTEM_RESERVED_
 static constexpr u64 UserSize = USER_MAX - USER_MIN + 1;
 
 // Required backing file size for mapping physical address space.
-static u64 BackingSize = ORBIS_KERNEL_TOTAL_MEM_DEV_PRO + ORBIS_KERNEL_FLEXIBLE_MEMORY_SIZE;
+static u64 BackingSize = ORBIS_KERNEL_TOTAL_MEM_PS5 + ORBIS_KERNEL_FLEXIBLE_MEMORY_SIZE;
 
 #ifdef _WIN32
 

--- a/src/core/aerolib/stubs.cpp
+++ b/src/core/aerolib/stubs.cpp
@@ -4,6 +4,9 @@
 #include "common/logging/log.h"
 #include "core/aerolib/aerolib.h"
 #include "core/aerolib/stubs.h"
+#include <mutex>
+#include <string>
+#include <unordered_map>
 
 namespace Core::AeroLib {
 
@@ -19,7 +22,7 @@ namespace Core::AeroLib {
 // and to longer compile / CI times
 //
 // Must match STUBS_LIST define
-constexpr u32 MAX_STUBS = 2048;
+constexpr u32 MAX_STUBS = 4096;
 
 u64 UnresolvedStub() {
     LOG_ERROR(Core, "Returning zero to {}", __builtin_return_address(0));
@@ -33,6 +36,8 @@ static u64 UnknownStub() {
 
 static const NidEntry* stub_nids[MAX_STUBS];
 static std::string stub_nids_unknown[MAX_STUBS];
+static std::unordered_map<std::string, u64> nid_stub_cache{};
+static std::mutex stub_mutex{};
 
 template <int stub_index>
 static u64 CommonStub() {
@@ -62,13 +67,24 @@ static u32 UsedStubEntries;
 #define XREP_512(x) XREP_256(x) XREP_256(x + 256)
 #define XREP_1024(x) XREP_512(x) XREP_512(x + 512)
 #define XREP_2048(x) XREP_1024(x) XREP_1024(x + 1024)
+#define XREP_4096(x) XREP_2048(x) XREP_2048(x + 2048)
 
-#define STUBS_LIST XREP_2048(0)
+#define STUBS_LIST XREP_4096(0)
 
 static u64 (*stub_handlers[MAX_STUBS])() = {STUBS_LIST};
 
 u64 GetStub(const char* nid) {
+    if (nid == nullptr || nid[0] == '\0') {
+        return (u64)&UnknownStub;
+    }
+    const std::string nid_key{nid};
+    std::scoped_lock lk{stub_mutex};
+    if (const auto it = nid_stub_cache.find(nid_key); it != nid_stub_cache.end()) {
+        return it->second;
+    }
+
     if (UsedStubEntries >= MAX_STUBS) {
+        LOG_ERROR(Core, "Stub slot exhausted for nid {} (max={})", nid_key, MAX_STUBS);
         return (u64)&UnknownStub;
     }
 
@@ -79,7 +95,9 @@ u64 GetStub(const char* nid) {
         stub_nids[UsedStubEntries] = entry;
     }
 
-    return (u64)stub_handlers[UsedStubEntries++];
+    const u64 stub_addr = (u64)stub_handlers[UsedStubEntries++];
+    nid_stub_cache.emplace(nid_key, stub_addr);
+    return stub_addr;
 }
 
 } // namespace Core::AeroLib

--- a/src/core/file_sys/directories/normal_directory.cpp
+++ b/src/core/file_sys/directories/normal_directory.cpp
@@ -107,16 +107,19 @@ void NormalDirectory::RebuildDirents() {
         sizeof(NormalDirectoryDirent::d_fileno) + sizeof(NormalDirectoryDirent::d_type) +
         sizeof(NormalDirectoryDirent::d_namlen) + sizeof(NormalDirectoryDirent::d_reclen);
 
-    u64 next_ceiling = 0;
+    u64 next_ceiling = 512;
     u64 dirent_offset = 0;
     u64 last_reclen_offset = 4;
+    bool has_previous_entry = false;
     dirent_cache_bin.clear();
-    dirent_cache_bin.reserve(512);
+    dirent_cache_bin.resize(next_ceiling);
+    std::fill(dirent_cache_bin.begin(), dirent_cache_bin.end(), 0);
 
     auto* mnt = Common::Singleton<Core::FileSys::MntPoints>::Instance();
 
     mnt->IterateDirectory(
-        guest_directory, [this, &next_ceiling, &dirent_offset, &last_reclen_offset](
+        guest_directory, [this, &next_ceiling, &dirent_offset, &last_reclen_offset,
+                          &has_previous_entry](
                              const std::filesystem::path& ent_path, const bool ent_is_file) {
             NormalDirectoryDirent tmp{};
             std::string leaf(ent_path.filename().string());
@@ -131,8 +134,10 @@ void NormalDirectory::RebuildDirents() {
             // next element may break 512 byte alignment
             if (tmp.d_reclen + dirent_offset > next_ceiling) {
                 // align previous dirent's size to the current ceiling
-                *reinterpret_cast<u16*>(static_cast<u8*>(dirent_cache_bin.data()) +
-                                        last_reclen_offset) += next_ceiling - dirent_offset;
+                if (has_previous_entry) {
+                    *reinterpret_cast<u16*>(static_cast<u8*>(dirent_cache_bin.data()) +
+                                            last_reclen_offset) += next_ceiling - dirent_offset;
+                }
                 // set writing pointer to the aligned start position (current ceiling)
                 dirent_offset = next_ceiling;
                 // move the ceiling up and zero-out the buffer
@@ -146,9 +151,16 @@ void NormalDirectory::RebuildDirents() {
             last_reclen_offset = dirent_offset + 4;
             memcpy(dirent_cache_bin.data() + dirent_offset, &tmp, tmp.d_reclen);
             dirent_offset += tmp.d_reclen;
+            has_previous_entry = true;
         });
 
     // last reclen, as before
+    if (!has_previous_entry) {
+        dirent_cache_bin.clear();
+        directory_size = 0;
+        return;
+    }
+
     *reinterpret_cast<u16*>(static_cast<u8*>(dirent_cache_bin.data()) + last_reclen_offset) +=
         next_ceiling - dirent_offset;
 

--- a/src/core/libraries/agc/agc.cpp
+++ b/src/core/libraries/agc/agc.cpp
@@ -1,0 +1,1154 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "common/logging/log.h"
+#include "common/types.h"
+#include "core/libraries/agc/agc.h"
+#include "core/libraries/error_codes.h"
+#include "core/libraries/gnmdriver/gnmdriver.h"
+#include "core/libraries/libs.h"
+
+#include <gcn/si_ci_vi_merged_offset.h>
+
+#include <array>
+#include <cstddef>
+#include <cstring>
+
+namespace Libraries::Agc {
+
+namespace {
+
+using namespace Pal::Gfx6;
+
+constexpr u32 Cx(u32 reg) {
+    return reg - 0xA000u;
+}
+
+constexpr u32 Sh(u32 reg) {
+    return reg - 0x2C00u;
+}
+
+constexpr u32 Uc(u32 reg) {
+    return reg - 0xC000u;
+}
+
+struct ShaderRegister {
+    u32 offset;
+    u32 value;
+};
+
+struct RegisterDefaultInfo {
+    u32 type;
+    ShaderRegister reg[16];
+};
+
+struct RegisterDefaults {
+    ShaderRegister** tbl0 = nullptr;
+    ShaderRegister** tbl1 = nullptr;
+    ShaderRegister** tbl2 = nullptr;
+    ShaderRegister** tbl3 = nullptr;
+    u64 unknown[2] = {};
+    u32* types = nullptr;
+    u32 count = 0;
+};
+
+struct CommandBuffer {
+    using Callback = bool(PS4_SYSV_ABI*)(CommandBuffer*, u32, void*);
+
+    u32* bottom;
+    u32* top;
+    u32* cursor_up;
+    u32* cursor_down;
+    Callback callback;
+    void* user_data;
+    u32 reserved_dw;
+
+    [[nodiscard]] u32 GetAvailableSizeDW() const {
+        const auto available = static_cast<u32>(cursor_down - cursor_up);
+        return available > reserved_dw ? available - reserved_dw : 0;
+    }
+
+    bool ReserveDW(u32 num_dw) {
+        if (num_dw <= GetAvailableSizeDW()) {
+            return true;
+        }
+        return callback != nullptr && callback(this, num_dw + reserved_dw, user_data) &&
+               num_dw <= GetAvailableSizeDW();
+    }
+
+    u32* AllocateDW(u32 num_dw) {
+        if (num_dw == 0 || !ReserveDW(num_dw)) {
+            return nullptr;
+        }
+        auto* result = cursor_up;
+        cursor_up += num_dw;
+        return result;
+    }
+};
+
+struct Packet {
+    u32* addr;
+    u32 dw_num;
+    u8 pad[4];
+};
+
+struct ShaderSharp {
+    u16 offset_dw : 15;
+    u16 size : 1;
+};
+
+struct ShaderUserData {
+    u16* direct_resource_offset;
+    ShaderSharp* sharp_resource_offset[4];
+    u16 eud_size_dw;
+    u16 srt_size_dw;
+    u16 direct_resource_count;
+    u16 sharp_resource_count[4];
+};
+
+struct ShaderRegisterRange {
+    u16 start;
+    u16 end;
+};
+
+struct ShaderDrawModifier {
+    u32 enbl_start_vertex_offset : 1;
+    u32 enbl_start_index_offset : 1;
+    u32 enbl_start_instance_offset : 1;
+    u32 enbl_draw_index : 1;
+    u32 enbl_user_vgprs : 1;
+    u32 render_target_slice_offset : 3;
+    u32 fuse_draws : 1;
+    u32 compiler_flags : 23;
+    u32 is_default : 1;
+    u32 reserved : 31;
+};
+
+struct ShaderSpecialRegs {
+    ShaderRegister ge_cntl;
+    ShaderRegister vgt_shader_stages_en;
+    u32 dispatch_modifier;
+    ShaderRegisterRange user_data_range;
+    ShaderDrawModifier draw_modifier;
+    ShaderRegister vgt_gs_out_prim_type;
+    ShaderRegister ge_user_vgpr_en;
+};
+
+struct ShaderSemantic {
+    u32 semantic : 8;
+    u32 hardware_mapping : 8;
+    u32 size_in_elements : 4;
+    u32 is_f16 : 2;
+    u32 is_flat_shaded : 1;
+    u32 is_linear : 1;
+    u32 is_custom : 1;
+    u32 static_vb_index : 1;
+    u32 static_attribute : 1;
+    u32 reserved : 1;
+    u32 default_value : 2;
+    u32 default_value_hi : 2;
+};
+
+struct Shader {
+    u32 file_header;
+    u32 version;
+    ShaderUserData* user_data;
+    const volatile void* code;
+    ShaderRegister* cx_registers;
+    ShaderRegister* sh_registers;
+    ShaderSpecialRegs* specials;
+    ShaderSemantic* input_semantics;
+    ShaderSemantic* output_semantics;
+    u32 header_size;
+    u32 shader_size;
+    u32 embedded_constant_buffer_size_dqw;
+    u32 target;
+    u32 num_input_semantics;
+    u16 scratch_size_dw_per_thread;
+    u16 num_output_semantics;
+    u16 special_sizes_bytes;
+    u8 type;
+    u8 num_cx_registers;
+    u8 num_sh_registers;
+};
+
+static_assert(offsetof(RegisterDefaults, count) == 0x38);
+static_assert(sizeof(ShaderRegister) == 0x8);
+static_assert(sizeof(ShaderUserData) == 0x38);
+static_assert(sizeof(ShaderDrawModifier) == sizeof(u64));
+
+#include "core/libraries/agc/agc_register_defaults.inc"
+
+template <std::size_t CxCount, std::size_t ShCount, std::size_t UcCount>
+struct DefaultRegisterTables {
+    static constexpr u32 TableCx = 0;
+    static constexpr u32 TableSh = 1;
+    static constexpr u32 TableUc = 2;
+    static constexpr std::size_t TotalCount = CxCount + ShCount + UcCount;
+
+    std::array<ShaderRegister*, CxCount> cx_regs{};
+    std::array<ShaderRegister*, ShCount> sh_regs{};
+    std::array<ShaderRegister*, UcCount> uc_regs{};
+    std::array<u32, TotalCount * 3> index{};
+    RegisterDefaults defaults{};
+
+    DefaultRegisterTables(RegisterDefaultInfo (&cx_info)[CxCount],
+                          RegisterDefaultInfo (&sh_info)[ShCount],
+                          RegisterDefaultInfo (&uc_info)[UcCount]) {
+        std::size_t dst = 0;
+        FillTable(cx_regs, cx_info, dst, TableCx);
+        FillTable(sh_regs, sh_info, dst, TableSh);
+        FillTable(uc_regs, uc_info, dst, TableUc);
+
+        defaults.tbl0 = cx_regs.data();
+        defaults.tbl1 = sh_regs.data();
+        defaults.tbl2 = uc_regs.data();
+        defaults.types = index.data();
+        defaults.count = static_cast<u32>(TotalCount);
+    }
+
+    template <std::size_t Count>
+    void FillTable(std::array<ShaderRegister*, Count>& dst, RegisterDefaultInfo (&src)[Count],
+                   std::size_t& index_dst, u32 table_id) {
+        for (std::size_t i = 0; i < Count; ++i) {
+            dst[i] = src[i].reg;
+            index[index_dst++] = src[i].type;
+            index[index_dst++] = static_cast<u32>(i) * 4u + table_id;
+            index[index_dst++] = 0;
+        }
+    }
+};
+
+DefaultRegisterTables g_reg_defaults2{g_cx_reg_info1, g_sh_reg_info1, g_uc_reg_info1};
+DefaultRegisterTables g_reg_defaults2_internal{g_cx_reg_info2, g_sh_reg_info2, g_uc_reg_info2};
+
+constexpr u32 Pm4Packet(u32 len, u32 op, u32 custom_r = 0) {
+    return 0xC0000000u | (((len - 2u) & 0x3fffu) << 16u) | ((op & 0xffu) << 8u) |
+           ((custom_r & 0x3fu) << 2u);
+}
+
+constexpr u32 Pm4ItNop = 0x10;
+constexpr u32 Pm4ItIndexBase = 0x26;
+constexpr u32 Pm4ItIndexType = 0x2A;
+constexpr u32 Pm4ItSetShReg = 0x76;
+constexpr u32 Pm4CustomZero = 0x00;
+constexpr u32 Pm4CustomDrawReset = 0x05;
+constexpr u32 Pm4CustomShRegsIndirect = 0x11;
+constexpr u32 Pm4CustomCxRegsIndirect = 0x12;
+constexpr u32 Pm4CustomUcRegsIndirect = 0x13;
+constexpr u32 Pm4CustomFlip = 0x17;
+constexpr u32 RegGeCntl = 0x25B;
+constexpr u32 RegGeUserVgprEn = 0x262;
+
+RegisterDefaults* GetRegisterDefaults(u32 version, bool internal) {
+    if (version != 8) {
+        LOG_ERROR(Lib_Agc, "sceAgcGetRegisterDefaults2{} unsupported version {}",
+                  internal ? "Internal" : "", version);
+        return nullptr;
+    }
+
+    return internal ? &g_reg_defaults2_internal.defaults : &g_reg_defaults2.defaults;
+}
+
+template <typename T>
+void RelocateRelativePointer(T*& ptr) {
+    if (ptr != nullptr) {
+        ptr = reinterpret_cast<T*>(reinterpret_cast<uintptr_t>(&ptr) + reinterpret_cast<uintptr_t>(ptr));
+    }
+}
+
+} // namespace
+
+s32 PS4_SYSV_ABI sceAgcInit2Maybe(u32* state, u32 version) {
+    LOG_INFO(Lib_Agc, "sceAgcInit2Maybe(state = {}, version = {})", fmt::ptr(state), version);
+
+    if (state == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcInit2Maybe called with null state");
+        return ORBIS_OK;
+    }
+
+    if (version != 8) {
+        LOG_ERROR(Lib_Agc, "sceAgcInit2Maybe unsupported version {}", version);
+    }
+
+    return ORBIS_OK;
+}
+
+void* PS4_SYSV_ABI sceAgcGetRegisterDefaults2(u32 version) {
+    LOG_INFO(Lib_Agc, "sceAgcGetRegisterDefaults2(version = {})", version);
+    return GetRegisterDefaults(version, false);
+}
+
+void* PS4_SYSV_ABI sceAgcGetRegisterDefaults2Internal(u32 version) {
+    LOG_INFO(Lib_Agc, "sceAgcGetRegisterDefaults2Internal(version = {})", version);
+    return GetRegisterDefaults(version, true);
+}
+
+s32 PS4_SYSV_ABI sceAgcCreateShader(Shader** dst, void* header, const volatile void* code) {
+    LOG_INFO(Lib_Agc, "sceAgcCreateShader(dst = {}, header = {}, code = {})", fmt::ptr(dst),
+             fmt::ptr(header), fmt::ptr(code));
+
+    if (dst == nullptr || header == nullptr || code == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcCreateShader called with null argument");
+        return ORBIS_OK;
+    }
+
+    auto* shader = static_cast<Shader*>(header);
+
+    RelocateRelativePointer(shader->cx_registers);
+    RelocateRelativePointer(shader->sh_registers);
+    RelocateRelativePointer(shader->user_data);
+    RelocateRelativePointer(shader->specials);
+    RelocateRelativePointer(shader->input_semantics);
+    RelocateRelativePointer(shader->output_semantics);
+
+    if (shader->user_data != nullptr) {
+        RelocateRelativePointer(shader->user_data->direct_resource_offset);
+        for (auto& offset : shader->user_data->sharp_resource_offset) {
+            RelocateRelativePointer(offset);
+        }
+    }
+
+    shader->code = code;
+
+    if (shader->file_header != 0x34333231 || shader->version != 0x18) {
+        LOG_ERROR(Lib_Agc, "Unsupported shader header {:#x}, version {:#x}", shader->file_header,
+                  shader->version);
+        *dst = shader;
+        return ORBIS_OK;
+    }
+
+    const u64 base = reinterpret_cast<u64>(code);
+    if ((base & 0xFFFF0000000000FFull) != 0) {
+        LOG_ERROR(Lib_Agc, "Unsupported shader code address {:#x}", base);
+        *dst = shader;
+        return ORBIS_OK;
+    }
+
+    if (shader->num_sh_registers >= 2 && shader->sh_registers != nullptr) {
+        const u32 lo = static_cast<u32>((base >> 8u) & 0xffffffffu);
+        const u32 hi = static_cast<u32>((base >> 40u) & 0xffu);
+
+        if (shader->type == 2 && shader->sh_registers[0].offset == Sh(mmSPI_SHADER_PGM_LO_ES) &&
+            shader->sh_registers[1].offset == Sh(mmSPI_SHADER_PGM_HI_ES)) {
+            shader->sh_registers[0].value = lo;
+            shader->sh_registers[1].value = hi;
+        } else if (shader->type == 1 &&
+                   shader->sh_registers[0].offset == Sh(mmSPI_SHADER_PGM_LO_PS) &&
+                   shader->sh_registers[1].offset == Sh(mmSPI_SHADER_PGM_HI_PS)) {
+            shader->sh_registers[0].value = lo;
+            shader->sh_registers[1].value = hi;
+        } else {
+            LOG_ERROR(Lib_Agc, "Unsupported shader type {} or register layout", shader->type);
+        }
+    }
+
+    *dst = shader;
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceAgcCreateInterpolantMapping(ShaderRegister* regs, const Shader* gs,
+                                                const Shader* ps) {
+    LOG_INFO(Lib_Agc, "sceAgcCreateInterpolantMapping(regs = {}, gs = {}, ps = {})",
+             fmt::ptr(regs), fmt::ptr(gs), fmt::ptr(ps));
+
+    if (regs == nullptr || gs == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcCreateInterpolantMapping called with null argument");
+        return ORBIS_OK;
+    }
+
+    if (gs->type != 2 || (ps != nullptr && ps->type != 1)) {
+        LOG_ERROR(Lib_Agc, "Unsupported shader types gs = {}, ps = {}", gs->type,
+                  ps != nullptr ? ps->type : 0xff);
+    }
+    if (ps != nullptr && gs->num_output_semantics != ps->num_input_semantics) {
+        LOG_ERROR(Lib_Agc, "GS output semantic count {} does not match PS input semantic count {}",
+                  gs->num_output_semantics, ps->num_input_semantics);
+    }
+    if (ps != nullptr && ps->num_output_semantics != 0) {
+        LOG_ERROR(Lib_Agc, "Unexpected PS output semantic count {}", ps->num_output_semantics);
+    }
+
+    for (u32 i = 0; i < 32; ++i) {
+        regs[i].offset = Cx(mmSPI_PS_INPUT_CNTL_0) + i;
+        regs[i].value = 0;
+
+        if (i >= gs->num_output_semantics) {
+            continue;
+        }
+
+        bool flat = false;
+        if (ps != nullptr && i < ps->num_input_semantics) {
+            flat = ps->input_semantics[i].is_flat_shaded != 0;
+        }
+
+        regs[i].value = i | (flat ? 0x400u : 0u);
+    }
+
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceAgcGetDataPacketPayloadAddress(u32** addr, u32* cmd, s32 type) {
+    LOG_INFO(Lib_Agc, "sceAgcGetDataPacketPayloadAddress(addr = {}, cmd = {}, type = {})",
+             fmt::ptr(addr), fmt::ptr(cmd), type);
+
+    if (addr == nullptr || cmd == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcGetDataPacketPayloadAddress called with null argument");
+        return ORBIS_OK;
+    }
+    if (type != 1) {
+        LOG_ERROR(Lib_Agc, "Unsupported data packet payload type {}", type);
+        *addr = nullptr;
+        return ORBIS_OK;
+    }
+
+    *addr = cmd + 2;
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceAgcSetCxRegIndirectPatchSetAddress(u32* cmd,
+                                                       const volatile ShaderRegister* regs) {
+    LOG_INFO(Lib_Agc, "sceAgcSetCxRegIndirectPatchSetAddress(cmd = {}, regs = {})",
+             fmt::ptr(cmd), fmt::ptr(const_cast<const ShaderRegister*>(regs)));
+
+    if (cmd == nullptr || regs == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcSetCxRegIndirectPatchSetAddress called with null argument");
+        return ORBIS_OK;
+    }
+
+    const auto addr = reinterpret_cast<u64>(regs);
+    cmd[2] = static_cast<u32>(addr);
+    cmd[3] = static_cast<u32>(addr >> 32u);
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceAgcSetCxRegIndirectPatchAddRegisters(u32* cmd, u32 numRegs) {
+    LOG_INFO(Lib_Agc, "sceAgcSetCxRegIndirectPatchAddRegisters(cmd = {}, numRegs = {})",
+             fmt::ptr(cmd), numRegs);
+
+    if (cmd == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcSetCxRegIndirectPatchAddRegisters called with null command");
+        return ORBIS_OK;
+    }
+
+    cmd[1] += numRegs;
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceAgcSetShRegIndirectPatchSetAddress(u32* cmd,
+                                                       const volatile ShaderRegister* regs) {
+    LOG_INFO(Lib_Agc, "sceAgcSetShRegIndirectPatchSetAddress(cmd = {}, regs = {})",
+             fmt::ptr(cmd), fmt::ptr(const_cast<const ShaderRegister*>(regs)));
+
+    if (cmd == nullptr || regs == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcSetShRegIndirectPatchSetAddress called with null argument");
+        return ORBIS_OK;
+    }
+
+    const auto addr = reinterpret_cast<u64>(regs);
+    cmd[2] = static_cast<u32>(addr);
+    cmd[3] = static_cast<u32>(addr >> 32u);
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceAgcSetShRegIndirectPatchAddRegisters(u32* cmd, u32 numRegs) {
+    LOG_INFO(Lib_Agc, "sceAgcSetShRegIndirectPatchAddRegisters(cmd = {}, numRegs = {})",
+             fmt::ptr(cmd), numRegs);
+
+    if (cmd == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcSetShRegIndirectPatchAddRegisters called with null command");
+        return ORBIS_OK;
+    }
+
+    cmd[1] += numRegs;
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceAgcSetUcRegIndirectPatchSetAddress(u32* cmd,
+                                                       const volatile ShaderRegister* regs) {
+    LOG_INFO(Lib_Agc, "sceAgcSetUcRegIndirectPatchSetAddress(cmd = {}, regs = {})",
+             fmt::ptr(cmd), fmt::ptr(const_cast<const ShaderRegister*>(regs)));
+
+    if (cmd == nullptr || regs == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcSetUcRegIndirectPatchSetAddress called with null argument");
+        return ORBIS_OK;
+    }
+
+    const auto addr = reinterpret_cast<u64>(regs);
+    cmd[2] = static_cast<u32>(addr);
+    cmd[3] = static_cast<u32>(addr >> 32u);
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceAgcSetUcRegIndirectPatchAddRegisters(u32* cmd, u32 numRegs) {
+    LOG_INFO(Lib_Agc, "sceAgcSetUcRegIndirectPatchAddRegisters(cmd = {}, numRegs = {})",
+             fmt::ptr(cmd), numRegs);
+
+    if (cmd == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcSetUcRegIndirectPatchAddRegisters called with null command");
+        return ORBIS_OK;
+    }
+
+    cmd[1] += numRegs;
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceAgcSuspendPoint() {
+    LOG_INFO(Lib_Agc, "sceAgcSuspendPoint()");
+    return Libraries::GnmDriver::sceGnmSubmitDone();
+}
+
+s32 PS4_SYSV_ABI sceAgcCreatePrimState(ShaderRegister* cxRegs, ShaderRegister* ucRegs,
+                                       const Shader* hs, const Shader* gs, u32 primType) {
+    LOG_INFO(Lib_Agc, "sceAgcCreatePrimState(cxRegs = {}, ucRegs = {}, hs = {}, gs = {}, "
+                      "primType = {})",
+             fmt::ptr(cxRegs), fmt::ptr(ucRegs), fmt::ptr(hs), fmt::ptr(gs), primType);
+
+    if (cxRegs == nullptr || ucRegs == nullptr || gs == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcCreatePrimState called with null argument");
+        return ORBIS_OK;
+    }
+    if (hs != nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcCreatePrimState does not support HS yet");
+    }
+    if (gs->type != 2 || gs->specials == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcCreatePrimState unsupported GS shader");
+    }
+
+    cxRegs[0] = gs->specials->vgt_shader_stages_en;
+    cxRegs[1] = gs->specials->vgt_gs_out_prim_type;
+
+    ucRegs[0] = gs->specials->ge_cntl;
+    ucRegs[1] = gs->specials->ge_user_vgpr_en;
+    ucRegs[2].offset = Uc(mmVGT_PRIMITIVE_TYPE__CI__VI);
+    ucRegs[2].value = primType;
+
+    return ORBIS_OK;
+}
+
+u32* PS4_SYSV_ABI sceAgcCbSetShRegisterRangeDirect(CommandBuffer* buf, u32 offset,
+                                                   const u32* values, u32 numValues) {
+    LOG_INFO(Lib_Agc,
+             "sceAgcCbSetShRegisterRangeDirect(buf = {}, offset = {:#x}, values = {}, "
+             "numValues = {})",
+             fmt::ptr(buf), offset, fmt::ptr(values), numValues);
+
+    if (buf == nullptr || numValues == 0 || offset == 0 || offset > 0x3ffu) {
+        LOG_ERROR(Lib_Agc, "sceAgcCbSetShRegisterRangeDirect invalid arguments");
+        return nullptr;
+    }
+
+    auto* marker = buf->AllocateDW(2);
+    if (marker == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcCbSetShRegisterRangeDirect failed to allocate marker");
+        return nullptr;
+    }
+    marker[0] = Pm4Packet(2, Pm4ItNop, Pm4CustomZero);
+    marker[1] = 0x6875000d;
+
+    auto* cmd = buf->AllocateDW(numValues + 2);
+    if (cmd == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcCbSetShRegisterRangeDirect failed to allocate command");
+        return nullptr;
+    }
+
+    cmd[0] = Pm4Packet(numValues + 2, Pm4ItSetShReg);
+    cmd[1] = offset;
+    if (values == nullptr) {
+        std::memset(cmd + 2, 0, static_cast<std::size_t>(numValues) * sizeof(u32));
+    } else {
+        std::memcpy(cmd + 2, values, static_cast<std::size_t>(numValues) * sizeof(u32));
+    }
+
+    return cmd;
+}
+
+u32* PS4_SYSV_ABI sceAgcDcbResetQueue(CommandBuffer* buf, u32 op, u32 state) {
+    LOG_INFO(Lib_Agc, "sceAgcDcbResetQueue(buf = {}, op = {:#x}, state = {:#x})",
+             fmt::ptr(buf), op, state);
+
+    if (buf == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcDcbResetQueue called with null command buffer");
+        return nullptr;
+    }
+    if (op != 0x3ff || state != 0) {
+        LOG_ERROR(Lib_Agc, "sceAgcDcbResetQueue unsupported op/state");
+    }
+
+    auto* cmd = buf->AllocateDW(2);
+    if (cmd == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcDcbResetQueue failed to allocate command");
+        return nullptr;
+    }
+
+    cmd[0] = Pm4Packet(2, Pm4ItNop, Pm4CustomDrawReset);
+    cmd[1] = 0;
+    return cmd;
+}
+
+u32* PS4_SYSV_ABI sceAgcDcbSetCxRegistersIndirect(CommandBuffer* buf,
+                                                  const volatile ShaderRegister* regs,
+                                                  u32 numRegs) {
+    LOG_INFO(Lib_Agc, "sceAgcDcbSetCxRegistersIndirect(buf = {}, regs = {}, numRegs = {})",
+             fmt::ptr(buf), fmt::ptr(const_cast<const ShaderRegister*>(regs)), numRegs);
+
+    if (buf == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcDcbSetCxRegistersIndirect called with null command buffer");
+        return nullptr;
+    }
+
+    auto* cmd = buf->AllocateDW(4);
+    if (cmd == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcDcbSetCxRegistersIndirect failed to allocate command");
+        return nullptr;
+    }
+
+    const auto addr = reinterpret_cast<u64>(regs);
+    cmd[0] = Pm4Packet(4, Pm4ItNop, Pm4CustomCxRegsIndirect);
+    cmd[1] = numRegs;
+    cmd[2] = static_cast<u32>(addr);
+    cmd[3] = static_cast<u32>(addr >> 32u);
+
+    return cmd;
+}
+
+u32* PS4_SYSV_ABI sceAgcDcbSetShRegistersIndirect(CommandBuffer* buf,
+                                                  const volatile ShaderRegister* regs,
+                                                  u32 numRegs) {
+    LOG_INFO(Lib_Agc, "sceAgcDcbSetShRegistersIndirect(buf = {}, regs = {}, numRegs = {})",
+             fmt::ptr(buf), fmt::ptr(const_cast<const ShaderRegister*>(regs)), numRegs);
+
+    if (buf == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcDcbSetShRegistersIndirect called with null command buffer");
+        return nullptr;
+    }
+
+    auto* cmd = buf->AllocateDW(4);
+    if (cmd == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcDcbSetShRegistersIndirect failed to allocate command");
+        return nullptr;
+    }
+
+    const auto addr = reinterpret_cast<u64>(regs);
+    cmd[0] = Pm4Packet(4, Pm4ItNop, Pm4CustomShRegsIndirect);
+    cmd[1] = numRegs;
+    cmd[2] = static_cast<u32>(addr);
+    cmd[3] = static_cast<u32>(addr >> 32u);
+
+    return cmd;
+}
+
+u32* PS4_SYSV_ABI sceAgcDcbSetUcRegistersIndirect(CommandBuffer* buf,
+                                                   const volatile ShaderRegister* regs,
+                                                   u32 numRegs) {
+    LOG_INFO(Lib_Agc, "sceAgcDcbSetUcRegistersIndirect(buf = {}, regs = {}, numRegs = {})",
+             fmt::ptr(buf), fmt::ptr(const_cast<const ShaderRegister*>(regs)), numRegs);
+
+    if (buf == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcDcbSetUcRegistersIndirect called with null command buffer");
+        return nullptr;
+    }
+
+    auto* cmd = buf->AllocateDW(4);
+    if (cmd == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcDcbSetUcRegistersIndirect failed to allocate command");
+        return nullptr;
+    }
+
+    const auto addr = reinterpret_cast<u64>(regs);
+    cmd[0] = Pm4Packet(4, Pm4ItNop, Pm4CustomUcRegsIndirect);
+    cmd[1] = numRegs;
+    cmd[2] = static_cast<u32>(addr);
+    cmd[3] = static_cast<u32>(addr >> 32u);
+
+    return cmd;
+}
+
+u32* PS4_SYSV_ABI sceAgcDcbSetIndexSize(CommandBuffer* buf, u8 indexSize, u8 cachePolicy) {
+    LOG_INFO(Lib_Agc, "sceAgcDcbSetIndexSize(buf = {}, indexSize = {}, cachePolicy = {})",
+             fmt::ptr(buf), static_cast<u32>(indexSize), static_cast<u32>(cachePolicy));
+
+    if (buf == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcDcbSetIndexSize called with null command buffer");
+        return nullptr;
+    }
+    if (cachePolicy != 0) {
+        LOG_ERROR(Lib_Agc, "sceAgcDcbSetIndexSize unsupported cache policy {}",
+                  static_cast<u32>(cachePolicy));
+    }
+    if (indexSize > 1) {
+        LOG_ERROR(Lib_Agc, "sceAgcDcbSetIndexSize unsupported index size {}",
+                  static_cast<u32>(indexSize));
+    }
+
+    auto* cmd = buf->AllocateDW(2);
+    if (cmd == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcDcbSetIndexSize failed to allocate command");
+        return nullptr;
+    }
+
+    cmd[0] = Pm4Packet(2, Pm4ItIndexType);
+    cmd[1] = indexSize;
+    return cmd;
+}
+
+u32* PS4_SYSV_ABI sceAgcDcbSetIndexBuffer(CommandBuffer* buf, uintptr_t indexAddr) {
+    LOG_INFO(Lib_Agc, "sceAgcDcbSetIndexBuffer(buf = {}, indexAddr = {:#x})", fmt::ptr(buf),
+             indexAddr);
+
+    if (buf == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcDcbSetIndexBuffer called with null command buffer");
+        return nullptr;
+    }
+    if ((indexAddr & 1u) != 0) {
+        LOG_ERROR(Lib_Agc, "sceAgcDcbSetIndexBuffer called with unaligned address {:#x}",
+                  indexAddr);
+    }
+
+    auto* cmd = buf->AllocateDW(3);
+    if (cmd == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcDcbSetIndexBuffer failed to allocate command");
+        return nullptr;
+    }
+
+    cmd[0] = Pm4Packet(3, Pm4ItIndexBase);
+    cmd[1] = static_cast<u32>(indexAddr);
+    cmd[2] = static_cast<u32>(indexAddr >> 32u);
+    return cmd;
+}
+
+u32 PS4_SYSV_ABI sceAgcDcbSetIndexBufferGetSize() {
+    LOG_INFO(Lib_Agc, "sceAgcDcbSetIndexBufferGetSize()");
+    return 3;
+}
+
+u32* PS4_SYSV_ABI sceAgcDcbDrawIndexOffset(CommandBuffer* buf, u32 indexOffset, u32 indexCount,
+                                           u64 modifier) {
+    ShaderDrawModifier drawModifier{};
+    std::memcpy(&drawModifier, &modifier, sizeof(drawModifier));
+
+    LOG_INFO(Lib_Agc,
+             "sceAgcDcbDrawIndexOffset(buf = {}, indexOffset = {}, indexCount = {}, "
+             "modifier = {:#018x})",
+             fmt::ptr(buf), indexOffset, indexCount, modifier);
+    LOG_INFO(Lib_Agc,
+             "sceAgcDcbDrawIndexOffset modifier: enbl_start_vertex_offset = {}, "
+             "enbl_start_index_offset = {}, enbl_start_instance_offset = {}, "
+             "enbl_draw_index = {}, enbl_user_vgprs = {}, render_target_slice_offset = {}, "
+             "fuse_draws = {}, compiler_flags = {:#x}, is_default = {}, reserved = {:#x}",
+             static_cast<u32>(drawModifier.enbl_start_vertex_offset),
+             static_cast<u32>(drawModifier.enbl_start_index_offset),
+             static_cast<u32>(drawModifier.enbl_start_instance_offset),
+             static_cast<u32>(drawModifier.enbl_draw_index),
+             static_cast<u32>(drawModifier.enbl_user_vgprs),
+             static_cast<u32>(drawModifier.render_target_slice_offset),
+             static_cast<u32>(drawModifier.fuse_draws),
+             static_cast<u32>(drawModifier.compiler_flags),
+             static_cast<u32>(drawModifier.is_default), static_cast<u32>(drawModifier.reserved));
+
+    if (buf == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcDcbDrawIndexOffset called with null command buffer");
+        return nullptr;
+    }
+    if ((modifier >> 32u) != 0) {
+        LOG_ERROR(Lib_Agc, "sceAgcDcbDrawIndexOffset ignores high modifier bits {:#x}",
+                  static_cast<u32>(modifier >> 32u));
+    }
+
+    constexpr u32 PacketSizeDw = 9;
+    auto* cmd = buf->AllocateDW(PacketSizeDw);
+    if (cmd == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcDcbDrawIndexOffset failed to allocate command");
+        return nullptr;
+    }
+
+    const auto ret = Libraries::GnmDriver::sceGnmDrawIndexOffset(
+        cmd, PacketSizeDw, indexOffset, indexCount, static_cast<u32>(modifier));
+    if (ret != ORBIS_OK) {
+        LOG_ERROR(Lib_Agc, "sceAgcDcbDrawIndexOffset failed to write packet: {}", ret);
+        return cmd;
+    }
+
+    LOG_INFO(Lib_Agc,
+             "sceAgcDcbDrawIndexOffset packet: [{:#010x}, {:#010x}, {:#010x}, {:#010x}, "
+             "{:#010x}, {:#010x}, {:#010x}, {:#010x}, {:#010x}]",
+             cmd[0], cmd[1], cmd[2], cmd[3], cmd[4], cmd[5], cmd[6], cmd[7], cmd[8]);
+    return cmd;
+}
+
+u32* PS4_SYSV_ABI sceAgcDcbSetFlip(CommandBuffer* buf, u32 videoOutHandle,
+                                   s32 displayBufferIndex, u32 flipMode, s64 flipArg) {
+    LOG_INFO(Lib_Agc,
+             "sceAgcDcbSetFlip(buf = {}, videoOutHandle = {}, displayBufferIndex = {}, "
+             "flipMode = {}, flipArg = {})",
+             fmt::ptr(buf), videoOutHandle, displayBufferIndex, flipMode, flipArg);
+
+    if (buf == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcDcbSetFlip called with null command buffer");
+        return nullptr;
+    }
+
+    auto* cmd = buf->AllocateDW(6);
+    if (cmd == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcDcbSetFlip failed to allocate command");
+        return nullptr;
+    }
+
+    const auto arg = static_cast<u64>(flipArg);
+    cmd[0] = Pm4Packet(6, Pm4ItNop, Pm4CustomFlip);
+    cmd[1] = videoOutHandle;
+    cmd[2] = static_cast<u32>(displayBufferIndex);
+    cmd[3] = flipMode;
+    cmd[4] = static_cast<u32>(arg);
+    cmd[5] = static_cast<u32>(arg >> 32u);
+
+    return cmd;
+}
+
+s32 PS4_SYSV_ABI sceAgcDriverSubmitDcb(const Packet* packet) {
+    LOG_INFO(Lib_Agc, "sceAgcDriverSubmitDcb(packet = {})", fmt::ptr(packet));
+
+    if (packet == nullptr || packet->addr == nullptr) {
+        LOG_ERROR(Lib_Agc, "sceAgcDriverSubmitDcb called with null packet");
+        return ORBIS_OK;
+    }
+    if (packet->pad[0] != 0) {
+        LOG_ERROR(Lib_Agc, "sceAgcDriverSubmitDcb unexpected packet padding");
+    }
+
+    const u32* dcbAddrs[] = {packet->addr};
+    u32 dcbSizes[] = {static_cast<u32>(packet->dw_num * sizeof(u32))};
+    return Libraries::GnmDriver::sceGnmSubmitCommandBuffers(1, dcbAddrs, dcbSizes, nullptr,
+                                                            nullptr);
+}
+
+#define AGC_FUNCTIONS                                                                          \
+    X("KT-hTp-Ch14", sceAgcAcbAcquireMem)                                                     \
+    X("ewobAQeMo5k", sceAgcAcbAcquireMemGetSize)                                              \
+    X("cduV1f0dcGQ", sceAgcAcbAtomicGds)                                                      \
+    X("hcIxS8pmXF4", sceAgcAcbAtomicGdsGetSize)                                               \
+    X("XKKuA6VkSRc", sceAgcAcbAtomicMem)                                                      \
+    X("da1Sm8-QDoU", sceAgcAcbAtomicMemGetSize)                                               \
+    X("qyM2bxYFPAk", sceAgcAcbCondExec)                                                       \
+    X("ozKzBP4aki4", sceAgcAcbCondExecGetSize)                                                \
+    X("qzMN2XKGA4k", sceAgcAcbCopyData)                                                       \
+    X("CbQh3DKMSno", sceAgcAcbCopyDataGetSize)                                                \
+    X("j3EtxFkSIhQ", sceAgcAcbDispatchIndirect)                                               \
+    X("PxKWV2fVAps", sceAgcAcbDispatchIndirectGetSize)                                        \
+    X("-RnpfpxIhec", sceAgcAcbDmaData)                                                        \
+    X("M0ttm8h7SKA", sceAgcAcbDmaDataGetSize)                                                 \
+    X("cFazmnXpJOE", sceAgcAcbEventWrite)                                                     \
+    X("Y-5vneiBtzk", sceAgcAcbEventWriteGetSize)                                              \
+    X("e1DFTg+Sd8U", sceAgcAcbJump)                                                           \
+    X("b-oySn+G2tE", sceAgcAcbJumpGetSize)                                                    \
+    X("q4VuU-QsLOE", sceAgcAcbMemSemaphore)                                                   \
+    X("6mFxkVqdmbQ", sceAgcAcbPopMarker)                                                      \
+    X("szG7hz2yEhA", sceAgcAcbPrimeUtcl2)                                                     \
+    X("eCjKaqeeQ5s", sceAgcAcbPrimeUtcl2GetSize)                                              \
+    X("cpCILPya5Zk", sceAgcAcbPushMarker)                                                     \
+    X("F8NLhWvFemI", sceAgcAcbQueueEndOfShaderActionGetSize)                                  \
+    X("JrtiDtKeS38", sceAgcAcbResetQueue)                                                     \
+    X("DwICrVxerkY", sceAgcAcbRewind)                                                         \
+    X("0ZOG0jc9nRg", sceAgcAcbRewindGetSize)                                                  \
+    X("ebixW91gpPw", sceAgcAcbSetFlip)                                                        \
+    X("xAeBOa0A3kk", sceAgcAcbSetMarker)                                                      \
+    X("opR1JeJZCBU", sceAgcAcbSetWorkloadComplete)                                            \
+    X("rVOmPz2RBlg", sceAgcAcbSetWorkloadsActive)                                             \
+    X("idlaArvdXEs", sceAgcAcbWaitOnAddressGetSize)                                           \
+    X("htn36gPnBk4", sceAgcAcbWaitRegMem)                                                     \
+    X("GPbUp9jXQa8", sceAgcAcbWaitUntilSafeForRendering)                                      \
+    X("eZ4+17OQz4Q", sceAgcAcbWriteData)                                                      \
+    X("3ZWa3AoyWZQ", sceAgcAsyncCondExecPatchSetCommandAddress)                               \
+    X("k-JpyR2dYAM", sceAgcAsyncCondExecPatchSetEnd)                                          \
+    X("eWaWyFegzgQ", sceAgcAsyncRewindPatchSetRewindState)                                    \
+    X("GXBlM-ekzrI", sceAgcBranchPatchSetCompareAddress)                                      \
+    X("QmfvaYpsOcI", sceAgcBranchPatchSetElseTarget)                                          \
+    X("xb8VgcXQhvI", sceAgcBranchPatchSetThenTarget)                                          \
+    X("w1KFAHVqpaU", sceAgcCbBranch)                                                          \
+    X("uZW-mqsxkrM", sceAgcCbBranchGetSize)                                                   \
+    X("7toV+elXqNM", sceAgcCbCondWrite)                                                       \
+    X("FuVbkyKlf+s", sceAgcCbCondWriteGetSize)                                                \
+    X("k3GhuSNmBLU", sceAgcCbDispatch)                                                        \
+    X("Abendgtz+3o", sceAgcCbDispatchGetSize)                                                 \
+    X("vHX9guneRBY", sceAgcCbMemSemaphore)                                                    \
+    X("LtTouSCZjHM", sceAgcCbNop)                                                             \
+    X("t7PlZ9nt5Lc", sceAgcCbNopGetSize)                                                      \
+    X("hL7C0IRpWZI", sceAgcCbQueueEndOfPipeActionGetSize)                                     \
+    X("wr23dPKyWc0", sceAgcCbReleaseMem)                                                      \
+    X("bxGoVxpdSPQ", sceAgcCbSetShRegisterRangeDirectGetSize)                                 \
+    X("UZbQjYAwwXM", sceAgcCbSetShRegistersDirect)                                            \
+    X("yUBESvCCJ4I", sceAgcCbSetShRegistersDirectGetSize)                                     \
+    X("MDLD5Ly94Xk", sceAgcCbSetUcRegisterRangeDirect)                                        \
+    X("JOWmDrl+j20", sceAgcCbSetUcRegisterRangeDirectGetSize)                                 \
+    X("03RZmELWWzw", sceAgcCbSetUcRegistersDirect)                                            \
+    X("TGEZzUWLbrc", sceAgcCbSetUcRegistersDirectGetSize)                                     \
+    X("YWTKOju587o", sceAgcCondExecPatchSetCommandAddress)                                    \
+    X("ORWsxIbk4TE", sceAgcCondExecPatchSetEnd)                                               \
+    X("57labkp+rSQ", sceAgcDcbAcquireMem)                                                     \
+    X("-vnlTPPXPrw", sceAgcDcbAcquireMemGetSize)                                              \
+    X("pH3-dfRpfA0", sceAgcDcbAtomicGds)                                                      \
+    X("1tB0xkLNjcw", sceAgcDcbAtomicGdsGetSize)                                               \
+    X("1-gUn1PI4Sw", sceAgcDcbAtomicMem)                                                      \
+    X("oz6zQq1JwCE", sceAgcDcbAtomicMemGetSize)                                               \
+    X("ms1xVoZ-Vwc", sceAgcDcbBeginOcclusionQueryGetSize)                                     \
+    X("PxEFhy0d5v8", sceAgcDcbClearState)                                                     \
+    X("BIPexNBSGog", sceAgcDcbCondExec)                                                       \
+    X("ou16V5hh5sg", sceAgcDcbCondExecGetSize)                                                \
+    X("HabmgqPwPw0", sceAgcDcbContextStateOp)                                                 \
+    X("H6vHS5cidSA", sceAgcDcbContextStateOpGetSize)                                          \
+    X("1rZSWUv1IRc", sceAgcDcbCopyData)                                                       \
+    X("b5u0Jzm8TF8", sceAgcDcbCopyDataGetSize)                                                \
+    X("CtB+A9-VxO0", sceAgcDcbDispatchIndirect)                                               \
+    X("w8HVkEeXPv8", sceAgcDcbDispatchIndirectGetSize)                                        \
+    X("WmAc2MEj6Io", sceAgcDcbDmaData)                                                        \
+    X("2ccJz9LQI+w", sceAgcDcbDmaDataGetSize)                                                 \
+    X("q88lQ+GP5Yk", sceAgcDcbDrawIndex)                                                      \
+    X("Yw0jKSqop+E", sceAgcDcbDrawIndexAuto)                                                  \
+    X("WrdP9Zxx3lQ", sceAgcDcbDrawIndexAutoGetSize)                                           \
+    X("6ee9Hd3EWXQ", sceAgcDcbDrawIndexGetSize)                                               \
+    X("t1vNu082-jM", sceAgcDcbDrawIndexIndirect)                                              \
+    X("mStuvI0zOtc", sceAgcDcbDrawIndexIndirectGetSize)                                       \
+    X("ypVBz4uPKcQ", sceAgcDcbDrawIndexIndirectMulti)                                         \
+    X("r98I08t+LOg", sceAgcDcbDrawIndexIndirectMultiGetSize)                                  \
+    X("Rlx+bykm0r0", sceAgcDcbDrawIndexMultiInstanced)                                        \
+    X("mR9j7+SfM34", sceAgcDcbDrawIndexMultiInstancedGetSize)                                 \
+    X("qMlfB1ZhMDc", sceAgcDcbDrawIndexOffsetGetSize)                                         \
+    X("1q1titRBL6o", sceAgcDcbDrawIndirect)                                                   \
+    X("cxPZ4Wgvdj8", sceAgcDcbDrawIndirectGetSize)                                            \
+    X("kUlvghKs-mA", sceAgcDcbDrawIndirectMulti)                                              \
+    X("pYoKs3lPy88", sceAgcDcbDrawIndirectMultiGetSize)                                       \
+    X("P1CugZ99Uzc", sceAgcDcbEndOcclusionQueryGetSize)                                       \
+    X("aJf+j5yntiU", sceAgcDcbEventWrite)                                                     \
+    X("C4l9fB17t8w", sceAgcDcbEventWriteGetSize)                                              \
+    X("vuSXe69VILM", sceAgcDcbGetLodStats)                                                    \
+    X("rUuVjyR+Rd4", sceAgcDcbGetLodStatsGetSize)                                             \
+    X("xSAR0LTcRKM", sceAgcDcbJump)                                                           \
+    X("VEGu4dixjUg", sceAgcDcbJumpGetSize)                                                    \
+    X("G0jrLdvEqDw", sceAgcDcbMemSemaphore)                                                   \
+    X("H7uZqCoNuWk", sceAgcDcbPopMarker)                                                      \
+    X("jt3pl7EN17o", sceAgcDcbPrimeUtcl2)                                                     \
+    X("KjPeVduz6jU", sceAgcDcbPrimeUtcl2GetSize)                                              \
+    X("+kSrjIVxKFE", sceAgcDcbPushMarker)                                                     \
+    X("zg6u-N6Otxs", sceAgcDcbQueueEndOfShaderActionGetSize)                                  \
+    X("zfcxg-ewMK8", sceAgcDcbRewind)                                                         \
+    X("QIXCsbipds0", sceAgcDcbRewindGetSize)                                                  \
+    X("9S4noWrUI0s", sceAgcDcbSetBaseDispatchIndirectArgsGetSize)                             \
+    X("MMlmJAL7N5w", sceAgcDcbSetBaseDrawIndirectArgsGetSize)                                 \
+    X("RmaJwLtc8rY", sceAgcDcbSetBaseIndirectArgs)                                            \
+    X("yheJGN-ay+A", sceAgcDcbSetBoolPredicationEnableGetSize)                                \
+    X("73ZZdojLIgs", sceAgcDcbSetCfRegisterDirect)                                            \
+    X("BVFg3CWU6Eo", sceAgcDcbSetCfRegisterRangeDirect)                                       \
+    X("LHFXRrlTPD8", sceAgcDcbSetCxRegisterDirect)                                            \
+    X("1DeUNpRIDDA", sceAgcDcbSetCxRegisterDirectGetSize)                                     \
+    X("GBCh3zCihoU", sceAgcDcbSetCxRegistersIndirectGetSize)                                  \
+    X("8N2tmT3jmC8", sceAgcDcbSetIndexCount)                                                  \
+    X("mljzuGDZRQ4", sceAgcDcbSetIndexCountGetSize)                                           \
+    X("0o3VDdtA6nM", sceAgcDcbSetIndexIndirectArgs)                                           \
+    X("AFIh8SQkYlQ", sceAgcDcbSetIndexIndirectArgsGetSize)                                    \
+    X("ca4KPvp0qLQ", sceAgcDcbSetIndexSizeGetSize)                                            \
+    X("QhCbS4X9Rl8", sceAgcDcbSetMarker)                                                      \
+    X("tSBxhAPyytQ", sceAgcDcbSetNumInstances)                                                \
+    X("6DFuRKT4C9w", sceAgcDcbSetNumInstancesGetSize)                                         \
+    X("bbFueFP+J4k", sceAgcDcbSetPredication)                                                 \
+    X("vLrBL8DQiz8", sceAgcDcbSetPredicationDisableGetSize)                                   \
+    X("pFLArOT53+w", sceAgcDcbSetShRegisterDirect)                                            \
+    X("QhPDD513V0w", sceAgcDcbSetShRegisterDirectGetSize)                                     \
+    X("nNlUtdDDvZ0", sceAgcDcbSetShRegistersIndirectGetSize)                                  \
+    X("w4-d0n60hdo", sceAgcDcbSetUcRegisterDirect)                                            \
+    X("aP1Ki9G3++4", sceAgcDcbSetUcRegisterDirectGetSize)                                     \
+    X("UQGTw4xRlcM", sceAgcDcbSetUcRegistersIndirectGetSize)                                  \
+    X("hEK26Wdny6s", sceAgcDcbSetWorkloadComplete)                                            \
+    X("LFSPFmGc9Hg", sceAgcDcbSetWorkloadsActive)                                             \
+    X("XN+Iuu7XsM8", sceAgcDcbSetZPassPredicationEnableGetSize)                               \
+    X("u2T2DiA5hRI", sceAgcDcbStallCommandBufferParser)                                       \
+    X("+u6dKSLWM2o", sceAgcDcbStallCommandBufferParserGetSize)                                \
+    X("43WJ08sSugE", sceAgcDcbWaitOnAddressGetSize)                                           \
+    X("VmW0Tdpy420", sceAgcDcbWaitRegMem)                                                     \
+    X("MWiElSNE8j8", sceAgcDcbWaitUntilSafeForRendering)                                      \
+    X("i1jyy49AjXU", sceAgcDcbWriteData)                                                      \
+    X("p9tI+yTvx68", sceAgcDcbWriteDataGetSize)                                               \
+    X("IxYiarKlXxM", sceAgcDmaDataPatchSetDstAddressOrOffset)                                 \
+    X("cdDRpqcFGbU", sceAgcDmaDataPatchSetSrcAddressOrOffsetOrImmediate)                      \
+    X("nApJjpKNBl4", sceAgcFuseShaderHalves)                                                  \
+    X("nQT5kYLv0cg", sceAgcGetFusedShaderSize)                                                \
+    X("Lkf86B98qPc", sceAgcGetPacketSize)                                                     \
+    X("Wi82ArQtAwg", sceAgcGetRegisterDefaults)                                               \
+    X("uIwxsqDlHRc", sceAgcGetRegisterDefaultsInternal)                                       \
+    X("kW3GLb7QfPg", sceAgcInit)                                                              \
+    X("2BS4EtAaF28", sceAgcJumpPatchSetTarget)                                                \
+    X("MqAdbRMdNz4", sceAgcLinkShaders)                                                       \
+    X("0fWWK5uG9rQ", sceAgcQueueEndOfPipeActionPatchAddress)                                  \
+    X("MlEw1feXcjg", sceAgcQueueEndOfPipeActionPatchData)                                     \
+    X("J8YCgfKAMQs", sceAgcQueueEndOfPipeActionPatchGcrCntl)                                  \
+    X("T9fjQIINoeE", sceAgcQueueEndOfPipeActionPatchType)                                     \
+    X("ziVA3whp3p4", sceAgcRewindPatchSetRewindState)                                         \
+    X("whb1RL7K4Ss", sceAgcSetCxRegIndirectPatchSetNumRegisters)                              \
+    X("K2mciNVxUCE", sceAgcSetNop)                                                            \
+    X("w6Dj1VJt5qY", sceAgcSetPacketPredication)                                              \
+    X("n8vgpaQg6dA", sceAgcSetRangePredication)                                               \
+    X("nCUgItdN2ms", sceAgcSetShRegIndirectPatchSetNumRegisters)                              \
+    X("-DtvmQ-tgEA", sceAgcSetSubmitMode)                                                     \
+    X("fRG-JOH5+sI", sceAgcSetUcRegIndirectPatchSetNumRegisters)                              \
+    X("b+fis+WZ3Ig", sceAgcSuspendPointAndCheckStatus)                                        \
+    X("SbuY2jN+axQ", sceAgcUpdateInterpolantMapping)                                          \
+    X("Y3ymLfZ1384", sceAgcUpdatePrimState)                                                    \
+    X("3KDcnM3lrcU", sceAgcWaitRegMemPatchAddress)                                            \
+    X("n485EBnIWmk", sceAgcWaitRegMemPatchCompareFunction)                                    \
+    X("hXAnLgDHCoI", sceAgcWaitRegMemPatchMask)                                               \
+    X("7nOoijNPvEU", sceAgcWaitRegMemPatchReference)
+
+#define AGC_DRIVER_FUNCTIONS                                                                   \
+    X("MetMOQVd8HY", sceAgcDriverAcquireRazorACQ)                                             \
+    X("w2rJhmD+dsE", sceAgcDriverAddEqEvent)                                                  \
+    X("AhGvpITrf4M", sceAgcDriverAgrSubmitDcb)                                                \
+    X("+T8Xo6LtFJI", sceAgcDriverAgrSubmitMultiDcbs)                                          \
+    X("zP4ZNlXLBVg", sceAgcDriverCreateQueue)                                                 \
+    X("1DXIHxWHZAQ", sceAgcDriverCwsrResumeAcq)                                               \
+    X("SOAMmdlyaIc", sceAgcDriverCwsrSuspendAcq)                                              \
+    X("1BUTwixUG5Y", sceAgcDriverDebugHardwareStatus)                                         \
+    X("DL2RXaXOy88", sceAgcDriverDeleteEqEvent)                                               \
+    X("XNbrdwCsZ9A", sceAgcDriverDestroyQueue)                                                \
+    X("5l3IfCFJxBs", sceAgcDriverFindResourcesPublic)                                        \
+    X("Zw7uUVPulbw", sceAgcDriverGetEqContextId)                                              \
+    X("5CdQTZIQPxM", sceAgcDriverGetEqEventType)                                              \
+    X("g68eYcZS7PY", sceAgcDriverGetGpuRefClks)                                               \
+    X("r28hEh6cNH0", sceAgcDriverGetHsOffchipParam)                                          \
+    X("LepGrgk77sM", sceAgcDriverGetOwnerName)                                                \
+    X("Pqxglq1oKec", sceAgcDriverGetPaDebugInterfaceVersion)                                  \
+    X("CP-kVAMmWVw", sceAgcDriverGetRegShadowInfo)                                           \
+    X("ME1eUot7+Qw", sceAgcDriverGetRegShadowInfoAgr)                                        \
+    X("Um-jkyDy9rI", sceAgcDriverGetReservedDmemForAgc)                                      \
+    X("NghWEUXp1qM", sceAgcDriverGetResourceBaseAddressAndSizeInBytes)                        \
+    X("M9yBzRKkjPc", sceAgcDriverGetResourceName)                                             \
+    X("mXn+K9E-wOA", sceAgcDriverGetResourceShaderGuid)                                      \
+    X("rI9lNAXPMIw", sceAgcDriverGetResourceType)                                            \
+    X("ls4jfY576lw", sceAgcDriverGetResourceUserData)                                        \
+    X("2PrsbRYyZi4", sceAgcDriverGetSetFlipPacketSizeInDwords)                                \
+    X("WNyjOWq8-Vk", sceAgcDriverGetSetWorkloadCompletePacketSize)                            \
+    X("gyVTZWyySpM", sceAgcDriverGetSetWorkloadsActivePacketSize)                             \
+    X("e-YMQ+2tj9M", sceAgcDriverGetTFRing)                                                   \
+    X("xDPdCurOujQ", sceAgcDriverGetTraceInitiator)                                           \
+    X("0MtUJ3BpGhE", sceAgcDriverGetWaitRenderingPacketSizeInDwords)                          \
+    X("t8PLXbBCiRA", sceAgcDriverGetWorkloadStreamInfo)                                       \
+    X("C2yjkNdzbW4", sceAgcDriverIDHSSubmit)                                                  \
+    X("F0Y42t-3e18", sceAgcDriverInitResourceRegistration)                                    \
+    X("Ddwk4gLT5j0", sceAgcDriverIsCaptureInProgress)                                        \
+    X("qspAL8bgcBY", sceAgcDriverIsSubmitValidationEnabled)                                   \
+    X("+TN0oRTBxJQ", sceAgcDriverIsTraceInProgress)                                           \
+    X("04JRU1Uf8Ms", sceAgcDriverModuleRegistration)                                          \
+    X("nR6xhiFsOoc", sceAgcDriverNotifyDefaultStates)                                         \
+    X("aCfbPzyjU90", sceAgcDriverPassInfoDownward)                                            \
+    X("lYz7vbL4W4A", sceAgcDriverPatchClearState)                                             \
+    X("AOLcoIkQDgM", sceAgcDriverQueryResourceRegistrationUserMemoryRequirements)             \
+    X("emP3ckeS2uo", sceAgcDriverRegisterGdsResource)                                         \
+    X("X-Nm5KLREeg", sceAgcDriverRegisterOwner)                                               \
+    X("W5z4eZrjEas", sceAgcDriverRegisterResource)                                            \
+    X("3AyTaWcF-H8", sceAgcDriverRegisterWorkloadStream)                                      \
+    X("SAfhzJPcjuk", sceAgcDriverRequestCaptureStart)                                         \
+    X("FOwvmNlFLjM", sceAgcDriverRequestCaptureStop)                                          \
+    X("cwbxjPSJ7WQ", sceAgcDriverSetFlip)                                                     \
+    X("MM4IZSEYytQ", sceAgcDriverSetHsOffchipParam)                                           \
+    X("DPcAnsOlTQs", sceAgcDriverSetHsOffchipParamDirect)                                     \
+    X("VOMSpd9+vxU", sceAgcDriverSetResourceUserData)                                         \
+    X("XlNp7jzGiPo", sceAgcDriverSetTFRing)                                                   \
+    X("i6bfTi13ApA", sceAgcDriverSetWorkloadComplete)                                         \
+    X("UM9b9NunSrE", sceAgcDriverSetWorkloadsActive)                                          \
+    X("Vlaj1gwmIFA", sceAgcDriverSetupAsyncGraphics)                                          \
+    X("Hj4eWnDektQ", sceAgcDriverSetupRegisterShadow)                                         \
+    X("gSRnr79F8tQ", sceAgcDriverSubmitAcb)                                                   \
+    X("b4fpgH5ZXxQ", sceAgcDriverSubmitCommandBuffer)                                         \
+    X("HF3YllT3mXU", sceAgcDriverSubmitMultiAcbs)                                             \
+    X("Fj7r9EHzF38", sceAgcDriverSubmitMultiCommandBuffers)                                   \
+    X("xmWi73o1BR0", sceAgcDriverSubmitMultiCommandBuffersDirect)                             \
+    X("6UzEidRZwkg", sceAgcDriverSubmitMultiDcbs)                                             \
+    X("lOYHtoUcJD4", sceAgcDriverSubmitToHDRScopesACQ)                                        \
+    X("jJyVJyhi5h8", sceAgcDriverSubmitToRazorACQ)                                            \
+    X("QcmHLO2n7mk", sceAgcDriverSuspendPointSubmit)                                          \
+    X("ZV04pRl7cWU", sceAgcDriverSuspendPointSubmitDirect)                                    \
+    X("x3K61sY5m8Q", sceAgcDriverSysEnableSubmitDone45Exception)                              \
+    X("kuE1uTiWfuk", sceAgcDriverSysGetClientNumber)                                          \
+    X("ftf-xlfBQpo", sceAgcDriverSysIsGameClosed)                                             \
+    X("BbI8si4o-fA", sceAgcDriverSysSubmitFlipHandleProxy)                                    \
+    X("UM8rn9hRWrY", sceAgcDriverTmpInitIdhs)                                                 \
+    X("Xq5WmbwPTnQ", sceAgcDriverTriggerCapture)                                              \
+    X("SCoAN5fYlUM", sceAgcDriverUnregisterAllResourcesForOwner)                              \
+    X("ZLJk9r2+2Aw", sceAgcDriverUnregisterOwnerAndResources)                                 \
+    X("pWLG7WOpVcw", sceAgcDriverUnregisterResource)                                          \
+    X("n5ElQVYsU1A", sceAgcDriverUnregisterWorkloadStream)                                    \
+    X("VhLnEiTuuWo", sceAgcDriverUserDataGetPacketSize)                                       \
+    X("t30LG1ibIJE", sceAgcDriverUserDataImmediateWrite)                                      \
+    X("-vc-xL+G8u0", sceAgcDriverUserDataWritePacket)                                         \
+    X("LEnn-4ARRJM", sceAgcDriverUserDataWritePopMarker)                                      \
+    X("+b34-CLWc0s", sceAgcDriverUserDataWritePushMarker)                                     \
+    X("zmw2uVSEj94", sceAgcDriverUserDataWriteSetMarker)                                      \
+    X("u8BkdHb1+Po", sceAgcDriverWaitUntilSafeForRendering)                                   \
+    X("OYBiWgeGpPo", sceAgcSdmaClose)                                                         \
+    X("CmlLiND79W8", sceAgcSdmaConstFill)                                                     \
+    X("7HmaD1MaWQs", sceAgcSdmaCopyLinear)                                                    \
+    X("DBZMYLxXRYA", sceAgcSdmaCopyTiledBC)                                                   \
+    X("hBsEOmOR3qQ", sceAgcSdmaCopyTiledGen2)                                                 \
+    X("oWyZFLUVjcI", sceAgcSdmaCopyWindowBC)                                                  \
+    X("f4aTpX9UhD0", sceAgcSdmaCopyWindowGen2)                                                \
+    X("GOP1R6vumsg", sceAgcSdmaFlush)                                                         \
+    X("aYySApdZmtE", sceAgcSdmaOpen)                                                          \
+    X("scA1QSh8cfE", sceAgcSdmaSetTileModesBC)
+
+#define X(nid, function)                                                                        \
+    s32 PS4_SYSV_ABI function() {                                                               \
+        LOG_ERROR(Lib_Agc, "{} (STUBBED) called", #function);                                  \
+        return ORBIS_OK;                                                                        \
+    }
+AGC_FUNCTIONS
+AGC_DRIVER_FUNCTIONS
+#undef X
+
+void RegisterLib(Core::Loader::SymbolsResolver* sym) {
+#define X(nid, function) LIB_FUNCTION(nid, "libSceAgc", 1, "libSceAgc", function);
+    AGC_FUNCTIONS
+#undef X
+    LIB_FUNCTION("2JtWUUiYBXs", "libSceAgc", 1, "libSceAgc", sceAgcGetRegisterDefaults2);
+    LIB_FUNCTION("wRbq6ZjNop4", "libSceAgc", 1, "libSceAgc", sceAgcGetRegisterDefaults2Internal);
+    LIB_FUNCTION("23LRUSvYu1M", "libSceAgc", 1, "libSceAgc", sceAgcInit2Maybe);
+    LIB_FUNCTION("f3dg2CSgRKY", "libSceAgc", 1, "libSceAgc", sceAgcCreateShader);
+    LIB_FUNCTION("pdEV7bI6COI", "libSceAgc", 1, "libSceAgc", sceAgcCreateInterpolantMapping);
+    LIB_FUNCTION("HV4j+E0MBHE", "libSceAgc", 1, "libSceAgc", sceAgcCreateInterpolantMapping);
+    LIB_FUNCTION("CQsSq6l6+kA", "libSceAgc", 1, "libSceAgc", sceAgcGetDataPacketPayloadAddress);
+    LIB_FUNCTION("V++UgBtQhn0", "libSceAgc", 1, "libSceAgc", sceAgcGetDataPacketPayloadAddress);
+    LIB_FUNCTION("ZvwO9euwYzc", "libSceAgc", 1, "libSceAgc", sceAgcDcbSetCxRegistersIndirect);
+    LIB_FUNCTION("vcmNN+AAXnY", "libSceAgc", 1, "libSceAgc",
+                 sceAgcSetCxRegIndirectPatchSetAddress);
+    LIB_FUNCTION("d-6uF9sZDIU", "libSceAgc", 1, "libSceAgc",
+                 sceAgcSetCxRegIndirectPatchAddRegisters);
+    LIB_FUNCTION("D9sr1xGUriE", "libSceAgc", 1, "libSceAgc", sceAgcCreatePrimState);
+    LIB_FUNCTION("n2fD4A+pb+g", "libSceAgc", 1, "libSceAgc",
+                 sceAgcCbSetShRegisterRangeDirect);
+    LIB_FUNCTION("TRO721eVt4g", "libSceAgc", 1, "libSceAgc", sceAgcDcbResetQueue);
+    LIB_FUNCTION("-HOOCn0JY48", "libSceAgc", 1, "libSceAgc",
+                 sceAgcDcbSetShRegistersIndirect);
+    LIB_FUNCTION("Qrj4c+61z4A", "libSceAgc", 1, "libSceAgc",
+                 sceAgcSetShRegIndirectPatchSetAddress);
+    LIB_FUNCTION("z2duB-hHQSM", "libSceAgc", 1, "libSceAgc",
+                 sceAgcSetShRegIndirectPatchAddRegisters);
+    LIB_FUNCTION("YUeqkyT7mEQ", "libSceAgc", 1, "libSceAgc", sceAgcDcbSetFlip);
+    LIB_FUNCTION("hvUfkUIQcOE", "libSceAgc", 1, "libSceAgc",
+                 sceAgcDcbSetUcRegistersIndirect);
+    LIB_FUNCTION("6lNcCp+fxi4", "libSceAgc", 1, "libSceAgc",
+                 sceAgcSetUcRegIndirectPatchSetAddress);
+    LIB_FUNCTION("vRoArM9zaIk", "libSceAgc", 1, "libSceAgc",
+                 sceAgcSetUcRegIndirectPatchAddRegisters);
+    LIB_FUNCTION("h9z6+0hEydk", "libSceAgc", 1, "libSceAgc", sceAgcSuspendPoint);
+    LIB_FUNCTION("B+aG9DUnTKA", "libSceAgc", 1, "libSceAgc", sceAgcDcbDrawIndexOffset);
+    LIB_FUNCTION("l4fM9K-Lyks", "libSceAgc", 1, "libSceAgc", sceAgcDcbSetIndexBuffer);
+    LIB_FUNCTION("j4emHHndCPY", "libSceAgc", 1, "libSceAgc", sceAgcDcbSetIndexBufferGetSize);
+    LIB_FUNCTION("GIIW2J37e70", "libSceAgc", 1, "libSceAgc", sceAgcDcbSetIndexSize);
+#define X(nid, function) LIB_FUNCTION(nid, "libSceAgcDriver", 1, "libSceAgcDriver", function);
+    AGC_DRIVER_FUNCTIONS
+#undef X
+    LIB_FUNCTION("UglJIZjGssM", "libSceAgcDriver", 1, "libSceAgcDriver",
+                 sceAgcDriverSubmitDcb);
+}
+
+#undef AGC_FUNCTIONS
+#undef AGC_DRIVER_FUNCTIONS
+
+} // namespace Libraries::Agc

--- a/src/core/libraries/agc/agc.h
+++ b/src/core/libraries/agc/agc.h
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+namespace Core::Loader {
+class SymbolsResolver;
+}
+
+namespace Libraries::Agc {
+
+void RegisterLib(Core::Loader::SymbolsResolver* sym);
+
+} // namespace Libraries::Agc

--- a/src/core/libraries/agc/agc_register_defaults.inc
+++ b/src/core/libraries/agc/agc_register_defaults.inc
@@ -1,0 +1,379 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+static RegisterDefaultInfo g_cx_reg_info1[] = {
+    /* 0 */ {0xE24F806D, {{Cx(mmCB_COLOR_CONTROL), 0x00cc0010}}},
+    /* 1 */ {0xF6C28182, {{Cx(mmCB_DCC_CONTROL__VI), 0x00000000}}},
+    /* 2 */ {0x6F6E55A5, {{0x00000104u, 0x00000000}}},
+    /* 3 */ {0x0BC65DA4, {{Cx(mmCB_SHADER_MASK), 0x00000000}}},
+    /* 4 */ {0x9E5AD592, {{Cx(mmCB_TARGET_MASK), 0x00000000}}},
+    /* 5 */ {0xBB513B98, {{Cx(mmDB_ALPHA_TO_MASK), 0x0000aa00}}},
+    /* 6 */ {0xAB64B23B, {{Cx(mmDB_COUNT_CONTROL), 0x00000000}}},
+    /* 7 */ {0x53C39964, {{Cx(mmDB_DEPTH_CONTROL), 0x00000000}}},
+    /* 8 */ {0x01396B11, {{Cx(mmDB_EQAA), 0x00000000}}},
+    /* 9 */ {0x7D42019A, {{Cx(mmDB_RENDER_CONTROL), 0x00000000}}},
+    /* 10 */ {0x3548F523, {{0x00000006u, 0x00000000}}},
+    /* 11 */ {0xF43AD28A, {{0x0000001Fu, 0x00000000}}},
+    /* 12 */ {0x6DE4C312, {{Cx(mmDB_SHADER_CONTROL), 0x00000000}}},
+    /* 13 */ {0x00A77AE0, {{Cx(mmDB_SRESULTS_COMPARE_STATE0), 0x00000000}}},
+    /* 14 */ {0x00A779B7, {{Cx(mmDB_SRESULTS_COMPARE_STATE1), 0x00000000}}},
+    /* 15 */ {0x5100100C, {{Cx(mmDB_STENCILREFMASK), 0x00000000}}},
+    /* 16 */ {0x59958BBA, {{Cx(mmDB_STENCILREFMASK_BF), 0x00000000}}},
+    /* 17 */ {0x0C06F17C, {{Cx(mmDB_STENCIL_CONTROL), 0x00000000}}},
+    /* 18 */ {0x6F104B72, {{0x000001FFu, 0x00000000}}},
+    /* 19 */ {0x25C70D9C, {{Cx(mmPA_CL_CLIP_CNTL), 0x00000000}}},
+    /* 20 */ {0x3881201E, {{0x0000020Du, 0x00000000}}},
+    /* 21 */ {0x09AFDDAF, {{Cx(mmPA_CL_VTE_CNTL), 0x0000043f}}},
+    /* 22 */ {0x367D63CF, {{Cx(mmPA_SC_AA_CONFIG), 0x00000000}}},
+    /* 23 */ {0x43707DB8, {{Cx(mmPA_SC_CLIPRECT_RULE), 0x0000ffff}}},
+    /* 24 */ {0xF6AE26BA, {{0x00000313u, 0x00000000}}},
+    /* 25 */ {0x1B917652, {{0x800003FEu, 0x00000000}}},
+    /* 26 */ {0x94B1E4F7, {{0x000000EAu, 0x00000000}}},
+    /* 27 */ {0xE3661B6C, {{0x000000E9u, 0x00000000}}},
+    /* 28 */ {0x1EB8D73A, {{Cx(mmPA_SC_MODE_CNTL_0), 0x00000002}}},
+    /* 29 */ {0x15051FA3, {{Cx(mmPA_SC_MODE_CNTL_1), 0x00000000}}},
+    /* 30 */ {0x9C51A7F1, {{0x000000E8u, 0x00000000}}},
+    /* 31 */ {0xA20EFC70, {{Cx(mmPA_SC_WINDOW_OFFSET), 0x00000000}}},
+    /* 32 */ {0x0EC09F6E, {{0x00000211u, 0x00000000}}},
+    /* 33 */ {0x34A7D6D3, {{0x00000210u, 0x00000000}}},
+    /* 34 */ {0xCE831B94, {{Cx(mmPA_SU_HARDWARE_SCREEN_OFFSET), 0x00000000}}},
+    /* 35 */ {0x5CC72A74, {{Cx(mmPA_SU_LINE_CNTL), 0x00000008}}},
+    /* 36 */ {0x3B77713C, {{Cx(mmPA_SU_POINT_MINMAX), 0xffff0000}}},
+    /* 37 */ {0x40F64410, {{Cx(mmPA_SU_POINT_SIZE), 0x00080008}}},
+    /* 38 */ {0x69441268, {{Cx(mmPA_SU_POLY_OFFSET_CLAMP), 0x00000000}}},
+    /* 39 */ {0x2E418B83, {{Cx(mmPA_SU_POLY_OFFSET_DB_FMT_CNTL), 0x000001e9}}},
+    /* 40 */ {0xA00D0C8D, {{Cx(mmPA_SU_SC_MODE_CNTL), 0x00000240}}},
+    /* 41 */ {0xB1289FB3, {{0x0000020Cu, 0x00000001}}},
+    /* 42 */ {0x144832FB, {{Cx(mmPA_SU_VTX_CNTL), 0x0000002d}}},
+    /* 43 */ {0x9890D9FA, {{Cx(mmSPI_TMPRING_SIZE), 0x00000000}}},
+    /* 44 */ {0x9016FAF1, {{0x000002A6u, 0x00000000}}},
+    /* 45 */ {0x4B73CE27, {{Cx(mmVGT_GS_MAX_VERT_OUT), 0x00000400}}},
+    /* 46 */ {0x5F5A3E7B, {{Cx(mmVGT_GS_OUT_PRIM_TYPE), 0x00000002}}},
+    /* 47 */ {0xD4AF3A51, {{Cx(mmVGT_LS_HS_CONFIG), 0x00000000}}},
+    /* 48 */ {0x6CF4F543, {{Cx(mmVGT_PRIMITIVEID_RESET), 0xffffffff}}},
+    /* 49 */ {0x5FB86CCB, {{Cx(mmVGT_PRIMITIVEID_EN), 0x00000000}}},
+    /* 50 */ {0xEDEFA188, {{Cx(mmVGT_REUSE_OFF), 0x00000000}}},
+    /* 51 */ {0xD0DE9EE6, {{Cx(mmVGT_SHADER_STAGES_EN), 0x00000000}}},
+    /* 52 */ {0xC5831803, {{Cx(mmVGT_TESS_DISTRIBUTION__VI), 0x88101000}}},
+    /* 53 */ {0x8E6DE84B, {{Cx(mmVGT_TF_PARAM), 0x00000000}}},
+    /* 54 */
+    {0xD0771662,
+     {
+         {Cx(mmPA_SC_CENTROID_PRIORITY_0), 0x00000000},
+         {Cx(mmPA_SC_CENTROID_PRIORITY_1), 0x00000000},
+     }},
+    /* 55 */ {0x569F7444, {{Cx(mmPA_SC_AA_SAMPLE_LOCS_PIXEL_X0Y0_0), 0x00000000}}},
+    /* 56 */
+    {0x5C6637CD,
+     {
+         {Cx(mmPA_SC_AA_MASK_X0Y0_X1Y0), 0xffffffff},
+         {Cx(mmPA_SC_AA_MASK_X0Y1_X1Y1), 0xffffffff},
+     }},
+    /* 57 */
+    {0xCAE3E690,
+     {
+         {0x00000311u, 0x00000002},
+         {0x00000312u, 0x03ff0080},
+     }},
+    /* 58 */
+    {0x43FBD769,
+     {
+         {Cx(mmCB_BLEND_RED), 0x00000000},
+         {Cx(mmCB_BLEND_BLUE), 0x00000000},
+         {Cx(mmCB_BLEND_GREEN), 0x00000000},
+         {Cx(mmCB_BLEND_ALPHA), 0x00000000},
+     }},
+    /* 59 */ {0xEF550356, {{Cx(mmCB_BLEND0_CONTROL), 0x20010001}}},
+    /* 60 */
+    {0x8F52E279,
+     {
+         {Cx(mmTA_BC_BASE_ADDR), 0x00000000},
+         {Cx(mmTA_BC_BASE_ADDR_HI__CI__VI), 0x00000000},
+     }},
+    /* 61 */
+    {0x1F2D8149,
+     {
+         {Cx(mmPA_SC_CLIPRECT_0_TL), 0x00000000},
+         {Cx(mmPA_SC_CLIPRECT_0_BR), 0x20002000},
+     }},
+    /* 62 */ {0x853D0614, {{0x800003FFu, 0x00000000}}},
+    /* 63 */
+    {0x4413C6F9,
+     {
+         {Cx(mmDB_DEPTH_BOUNDS_MIN), 0x00000000},
+         {Cx(mmDB_DEPTH_BOUNDS_MAX), 0x00000000},
+     }},
+    /* 64 */
+    {0x67096014,
+     {
+         {Cx(mmDB_Z_INFO), 0x80000000},
+         {Cx(mmDB_STENCIL_INFO), 0x20000000},
+         {Cx(mmDB_Z_READ_BASE), 0x00000000},
+         {Cx(mmDB_STENCIL_READ_BASE), 0x00000000},
+         {Cx(mmDB_Z_WRITE_BASE), 0x00000000},
+         {Cx(mmDB_STENCIL_WRITE_BASE), 0x00000000},
+         {0x0000001Au, 0x00000000},
+         {0x0000001Bu, 0x00000000},
+         {0x0000001Cu, 0x00000000},
+         {0x0000001Du, 0x00000000},
+         {0x0000001Eu, 0x00000000},
+         {Cx(mmDB_DEPTH_VIEW), 0x00000000},
+         {Cx(mmDB_HTILE_DATA_BASE), 0x00000000},
+         {0x00000007u, 0x00000000},
+         {Cx(mmDB_DEPTH_CLEAR), 0x00000000},
+         {Cx(mmDB_STENCIL_CLEAR), 0x00000000},
+     }},
+    /* 65 */
+    {0x88F5E915,
+     {
+         {0x000000EBu, 0xff00ff00},
+         {0x000000ECu, 0x00000000},
+     }},
+    /* 66 */
+    {0x033F1EFF,
+     {
+         {0x800003FCu, 0x00000000},
+         {0x800003FDu, 0x00000000},
+     }},
+    /* 67 */
+    {0x918106BB,
+     {
+         {Cx(mmPA_SC_GENERIC_SCISSOR_TL), 0x80000000},
+         {Cx(mmPA_SC_GENERIC_SCISSOR_BR), 0x40004000},
+     }},
+    /* 68 */
+    {0x95F0E7AC,
+     {
+         {Cx(mmPA_CL_GB_VERT_CLIP_ADJ), 0x4e7e0000},
+         {Cx(mmPA_CL_GB_VERT_DISC_ADJ), 0x4e7e0000},
+         {Cx(mmPA_CL_GB_HORZ_CLIP_ADJ), 0x4e7e0000},
+         {Cx(mmPA_CL_GB_HORZ_DISC_ADJ), 0x4e7e0000},
+     }},
+    /* 69 */
+    {0xB48CBAB2,
+     {
+         {Cx(mmPA_SU_POLY_OFFSET_BACK_SCALE), 0x00000000},
+         {Cx(mmPA_SU_POLY_OFFSET_BACK_OFFSET), 0x00000000},
+     }},
+    /* 70 */
+    {0x05BB3BC6,
+     {
+         {Cx(mmPA_SU_POLY_OFFSET_FRONT_SCALE), 0x00000000},
+         {Cx(mmPA_SU_POLY_OFFSET_FRONT_OFFSET), 0x00000000},
+     }},
+    /* 71 */
+    {0x94FABA07,
+     {
+         {Cx(mmDB_RENDER_OVERRIDE), 0x00000000},
+         {Cx(mmDB_RENDER_OVERRIDE2), 0x00000000},
+     }},
+    /* 72 */
+    {0x38E92C91,
+     {
+         {Cx(mmCB_COLOR0_BASE), 0x00000000},
+         {Cx(mmCB_COLOR0_VIEW), 0x00000000},
+         {Cx(mmCB_COLOR0_INFO), 0x00000000},
+         {Cx(mmCB_COLOR0_ATTRIB), 0x00000000},
+         {Cx(mmCB_COLOR0_DCC_CONTROL__VI), 0x00000048},
+         {Cx(mmCB_COLOR0_CMASK), 0x00000000},
+         {Cx(mmCB_COLOR0_FMASK), 0x00000000},
+         {Cx(mmCB_COLOR0_CLEAR_WORD0), 0x00000000},
+         {Cx(mmCB_COLOR0_CLEAR_WORD1), 0x00000000},
+         {Cx(mmCB_COLOR0_DCC_BASE__VI), 0x00000000},
+         {0x00000390u, 0x00000000},
+         {0x00000398u, 0x00000000},
+         {0x000003A0u, 0x00000000},
+         {0x000003A8u, 0x00000000},
+         {0x000003B0u, 0x00000000},
+         {0x000003B8u, 0x0006c000},
+     }},
+    /* 73 */
+    {0x0B177B43,
+     {
+         {Cx(mmPA_SC_SCREEN_SCISSOR_TL), 0x00000000},
+         {Cx(mmPA_SC_SCREEN_SCISSOR_BR), 0x40004000},
+     }},
+    /* 74 */ {0x48531062, {{Cx(mmSPI_PS_INPUT_CNTL_0), 0x00000000}}},
+    /* 75 */
+    {0xAAA964B9,
+     {
+         {Cx(mmPA_CL_UCP_0_X), 0x00000000},
+         {Cx(mmPA_CL_UCP_0_Y), 0x00000000},
+         {Cx(mmPA_CL_UCP_0_Z), 0x00000000},
+         {Cx(mmPA_CL_UCP_0_W), 0x00000000},
+     }},
+    /* 76 */
+    {0x7690AF6F,
+     {
+         {Cx(mmPA_CL_VPORT_XSCALE), 0x4e7e0000},
+         {Cx(mmPA_CL_VPORT_YSCALE), 0x4e7e0000},
+         {Cx(mmPA_CL_VPORT_ZSCALE), 0x4e7e0000},
+         {Cx(mmPA_CL_VPORT_XOFFSET), 0x00000000},
+         {Cx(mmPA_CL_VPORT_YOFFSET), 0x00000000},
+         {Cx(mmPA_CL_VPORT_ZOFFSET), 0x00000000},
+         {Cx(mmPA_SC_VPORT_SCISSOR_0_TL), 0x80000000},
+         {Cx(mmPA_SC_VPORT_SCISSOR_0_BR), 0x40004000},
+         {Cx(mmPA_SC_VPORT_ZMIN_0), 0x00000000},
+         {Cx(mmPA_SC_VPORT_ZMAX_0), 0x00000000},
+     }},
+    /* 77 */
+    {0x078D7060,
+     {
+         {Cx(mmPA_SC_WINDOW_SCISSOR_TL), 0x80000000},
+         {Cx(mmPA_SC_WINDOW_SCISSOR_BR), 0x40004000},
+     }},
+};
+
+static RegisterDefaultInfo g_sh_reg_info1[] = {
+    /* 0 */ {0x5D6E3EC7, {{Sh(mmCOMPUTE_PGM_RSRC1), 0x00000000}}},
+    /* 1 */ {0x57E7079A, {{Sh(mmCOMPUTE_PGM_RSRC2), 0x00000000}}},
+    /* 2 */ {0x7467FAFD, {{0x00000228u, 0x00000000}}},
+    /* 3 */ {0x9E826B50, {{Sh(mmCOMPUTE_RESOURCE_LIMITS), 0x00000000}}},
+    /* 4 */ {0xDC484F18, {{Sh(mmCOMPUTE_TMPRING_SIZE), 0x00000000}}},
+    /* 5 */ {0x5DA8BCA3, {{Sh(mmSPI_SHADER_PGM_RSRC1_GS), 0x00000000}}},
+    /* 6 */ {0x5CA726D8, {{Sh(mmSPI_SHADER_PGM_RSRC1_HS), 0x00000000}}},
+    /* 7 */ {0x5DD28360, {{Sh(mmSPI_SHADER_PGM_RSRC1_PS), 0x00000000}}},
+    /* 8 */ {0x57EFA0BE, {{Sh(mmSPI_SHADER_PGM_RSRC2_GS), 0x00000000}}},
+    /* 9 */ {0x502363D5, {{Sh(mmSPI_SHADER_PGM_RSRC2_HS), 0x00000000}}},
+    /* 10 */ {0x506D14BD, {{Sh(mmSPI_SHADER_PGM_RSRC2_PS), 0x00000000}}},
+    /* 11 */ {0xB2609506, {{0x00000224u, 0x00000000}}},
+    /* 12 */
+    {0x9E5CFB8A,
+     {
+         {Sh(mmSPI_SHADER_PGM_RSRC3_HS__CI__VI), 0x00000000},
+         {Sh(mmSPI_SHADER_PGM_RSRC3_GS__CI__VI), 0x00000000},
+         {Sh(mmSPI_SHADER_PGM_RSRC3_PS__CI__VI), 0x00000000},
+     }},
+    /* 13 */
+    {0xC918DF3E,
+     {
+         {Sh(mmCOMPUTE_PGM_LO), 0x00000000},
+         {Sh(mmCOMPUTE_PGM_HI), 0x00000000},
+     }},
+    /* 14 */
+    {0xC9751C9C,
+     {
+         {Sh(mmSPI_SHADER_PGM_LO_ES), 0x00000000},
+         {Sh(mmSPI_SHADER_PGM_HI_ES), 0x00000000},
+     }},
+    /* 15 */
+    {0xC97EF77A,
+     {
+         {Sh(mmSPI_SHADER_PGM_LO_GS), 0x00000000},
+         {Sh(mmSPI_SHADER_PGM_HI_GS), 0x00000000},
+     }},
+    /* 16 */
+    {0xC927C6B9,
+     {
+         {Sh(mmSPI_SHADER_PGM_LO_HS), 0x00000000},
+         {Sh(mmSPI_SHADER_PGM_HI_HS), 0x00000000},
+     }},
+    /* 17 */
+    {0xC92A1EC5,
+     {
+         {Sh(mmSPI_SHADER_PGM_LO_LS), 0x00000000},
+         {Sh(mmSPI_SHADER_PGM_HI_LS), 0x00000000},
+     }},
+    /* 18 */
+    {0xC9E01B31,
+     {
+         {Sh(mmSPI_SHADER_PGM_LO_PS), 0x00000000},
+         {Sh(mmSPI_SHADER_PGM_HI_PS), 0x00000000},
+     }},
+    /* 19 */ {0x50685F29, {{0x800002FFu, 0x00000000}}},
+    /* 20 */ {0xB26219CA, {{0x000000B2u, 0x00000000}}},
+    /* 21 */ {0xB25B6CF9, {{0x00000132u, 0x00000000}}},
+    /* 22 */ {0xB2F86101, {{0x00000032u, 0x00000000}}},
+    /* 23 */
+    {0x07E3B155,
+     {
+         {0x00000082u, 0x00000000},
+         {0x00000083u, 0x00000000},
+     }},
+    /* 24 */
+    {0x07E383C6,
+     {
+         {0x00000102u, 0x00000000},
+         {0x00000103u, 0x00000000},
+     }},
+    /* 25 */ {0xBDA98653, {{Sh(mmCOMPUTE_USER_DATA_0), 0x00000000}}},
+    /* 26 */ {0xBDBD1D0F, {{Sh(mmSPI_SHADER_USER_DATA_GS_0), 0x00000000}}},
+    /* 27 */ {0xBD946FD4, {{Sh(mmSPI_SHADER_USER_DATA_HS_0), 0x00000000}}},
+    /* 28 */ {0xBDF02A4C, {{Sh(mmSPI_SHADER_USER_DATA_PS_0), 0x00000000}}},
+};
+
+static RegisterDefaultInfo g_uc_reg_info1[] = {
+    /* 0 */ {0x19E93E85, {{Uc(mmGDS_OA_ADDRESS__CI__VI), 0x00000000}}},
+    /* 1 */ {0x3B5C2AF3, {{Uc(mmGDS_OA_CNTL__CI__VI), 0x00000000}}},
+    /* 2 */ {0x47974A35, {{Uc(mmGDS_OA_COUNTER__CI__VI), 0x00000000}}},
+    /* 3 */ {0x105971C2, {{0x0000025Bu, 0x00000000}}},
+    /* 4 */ {0x7D137765, {{0x0000024Au, 0x00000000}}},
+    /* 5 */ {0xD187FEBC, {{0x0000024Bu, 0x00000000}}},
+    /* 6 */ {0x12F854AC, {{0x0000025Fu, 0x00000000}}},
+    /* 7 */ {0x40D49AD1, {{0x00000262u, 0x00000000}}},
+    /* 8 */ {0x8C0923DA, {{0x80003FF4u, 0x00000000}}},
+    /* 9 */ {0xBB8DF494, {{0x80003FFDu, 0x00000000}}},
+    /* 10 */ {0xF6D8A76E, {{0x00000382u, 0x40000040}}},
+    /* 11 */ {0x7620F1E9, {{0x00000248u, 0x00000000}}},
+    /* 12 */ {0x9EBFAB10, {{Uc(mmVGT_PRIMITIVE_TYPE__CI__VI), 0x00000000}}},
+    /* 13 */
+    {0x98A09D0E,
+     {
+         {Uc(mmTA_CS_BC_BASE_ADDR__CI__VI), 0x00000000},
+         {Uc(mmTA_CS_BC_BASE_ADDR_HI__CI__VI), 0x00000000},
+     }},
+    /* 14 */
+    {0x195D37D2,
+     {
+         {0x80003FF5u, 0x00000000},
+         {0x80003FF6u, 0x00000000},
+     }},
+    /* 15 */
+    {0xF9EC4F85,
+     {
+         {0x80003FF7u, 0x00000000},
+         {0x80003FF8u, 0x00000000},
+         {0x80003FF9u, 0x00000000},
+         {0x80003FFAu, 0x00000000},
+     }},
+    /* 16 */
+    {0x4626B750,
+     {
+         {0x80003FFBu, 0x00000000},
+         {0x80003FFCu, 0x00000000},
+     }},
+    /* 17 */ {0x4CC673A0, {{0x80003FFEu, 0x00000000}}},
+    /* 18 */ {0xDE5B3431, {{0x80003FFFu, 0x00000000}}},
+    /* 19 */ {0x036AC8A6, {{0x0000025Cu, 0x00000000}}},
+};
+
+static RegisterDefaultInfo g_cx_reg_info2[] = {
+    /* 0 */ {0x8FB4EDB5, {{0x0000000Eu, 0x00000000}}},
+    /* 1 */ {0xB994AD29, {{Cx(mmDB_HTILE_SURFACE), 0x00000000}}},
+    /* 2 */ {0xD427322F, {{0x00000314u, 0x00000000}}},
+    /* 3 */ {0xF58FEA31, {{Cx(mmSPI_INTERP_CONTROL_0), 0x00000000}}},
+};
+
+static RegisterDefaultInfo g_sh_reg_info2[] = {
+    /* 0 */ {0x6AC156EF, {{0x00000216u, 0x00000000}}},
+    /* 1 */ {0x6AC15610, {{0x00000217u, 0x00000000}}},
+    /* 2 */ {0x6AC15009, {{0x00000219u, 0x00000000}}},
+    /* 3 */ {0x6AC153BA, {{0x0000021Au, 0x00000000}}},
+    /* 4 */ {0xBE7DCD73, {{0x0000027Du, 0x00000000}}},
+    /* 5 */ {0x0C4B1438, {{0x0000022Au, 0x00000000}}},
+    /* 6 */ {0xDB00D71A, {{Sh(mmCOMPUTE_START_X), 0x00000000}}},
+    /* 7 */ {0xDB00D249, {{Sh(mmCOMPUTE_START_Y), 0x00000000}}},
+    /* 8 */ {0xDB00EC60, {{Sh(mmCOMPUTE_START_Z), 0x00000000}}},
+    /* 9 */ {0x0C4D6FE4, {{0x00000080u, 0x00000000}}},
+    /* 10 */ {0x0C4A80EF, {{0x00000100u, 0x00000000}}},
+    /* 11 */ {0x0DD283E7, {{0x00000006u, 0x00000000}}},
+    /* 12 */ {0xC620E68C, {{0x00000081u, 0x00000000}}},
+    /* 13 */ {0xC67EFACF, {{0x00000101u, 0x00000000}}},
+    /* 14 */ {0xD9E6D9F7, {{0x00000001u, 0x00000000}}},
+};
+
+static RegisterDefaultInfo g_uc_reg_info2[] = {
+    /* 0 */ {0x31F34B9F, {{Uc(mmVGT_HS_OFFCHIP_PARAM__CI__VI), 0x00000000}}},
+    /* 1 */ {0xAC0F9E76, {{0x80003FFFu, 0x00000000}}},
+    /* 2 */ {0x929FD95D, {{Uc(mmVGT_TF_MEMORY_BASE__CI__VI), 0x00000000}}},
+};

--- a/src/core/libraries/ampr/ampr.cpp
+++ b/src/core/libraries/ampr/ampr.cpp
@@ -1,0 +1,380 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "core/libraries/ampr/ampr.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <mutex>
+#include <unordered_map>
+
+#include "common/logging/log.h"
+#include "common/types.h"
+#include "core/libraries/error_codes.h"
+#include "core/libraries/kernel/file_system.h"
+#include "core/libraries/kernel/orbis_error.h"
+#include "core/libraries/libs.h"
+#include "core/linker.h"
+#include "core/memory.h"
+
+namespace Libraries::Ampr {
+namespace {
+
+constexpr u64 CommandBufferHeaderSize = 0x28;
+constexpr u64 CommandBufferSelfOffset = 0x00;
+constexpr u64 CommandBufferDataOffset = 0x08;
+constexpr u64 CommandBufferSizeOffset = 0x10;
+constexpr u64 CommandBufferAux0Offset = 0x18;
+constexpr u64 CommandBufferAux1Offset = 0x20;
+constexpr u64 ReadFileRecordSize = 0x30;
+
+struct CommandBufferState {
+    VAddr buffer = 0;
+    u64 size = 0;
+    u64 write_offset = 0;
+};
+
+std::mutex g_command_buffer_mutex;
+std::unordered_map<VAddr, CommandBufferState> g_command_buffers;
+
+bool IsValidGuestRange(VAddr addr, u64 size) {
+    if (size == 0) {
+        return true;
+    }
+    return addr != 0 && Core::Memory::Instance()->IsValidMapping(addr, size);
+}
+
+template <typename T>
+bool WriteGuest(VAddr addr, const T& value) {
+    if (!IsValidGuestRange(addr, sizeof(T))) {
+        return false;
+    }
+    std::memcpy(reinterpret_cast<void*>(addr), &value, sizeof(T));
+    return true;
+}
+
+template <typename T>
+bool ReadGuest(VAddr addr, T& value) {
+    if (!IsValidGuestRange(addr, sizeof(T))) {
+        return false;
+    }
+    std::memcpy(&value, reinterpret_cast<const void*>(addr), sizeof(T));
+    return true;
+}
+
+bool WriteVisibleCommandBufferPointers(VAddr command_buffer, VAddr buffer, u64 size) {
+    return WriteGuest(command_buffer + CommandBufferSelfOffset, command_buffer) &&
+           WriteGuest(command_buffer + CommandBufferDataOffset, buffer) &&
+           WriteGuest(command_buffer + CommandBufferSizeOffset, size);
+}
+
+bool WriteCommandBufferPointers(VAddr command_buffer, VAddr buffer, u64 size, u64 write_offset = 0) {
+    if (!WriteVisibleCommandBufferPointers(command_buffer, buffer, size)) {
+        return false;
+    }
+
+    std::scoped_lock lock{g_command_buffer_mutex};
+    auto& state = g_command_buffers[command_buffer];
+    state.buffer = buffer;
+    state.size = size;
+    state.write_offset = write_offset;
+    return true;
+}
+
+bool InitializeCommandBuffer(VAddr command_buffer, VAddr buffer, u64 size, u64 aux0, u64 aux1,
+                             bool clear) {
+    if (clear) {
+        if (!IsValidGuestRange(command_buffer, CommandBufferHeaderSize)) {
+            return false;
+        }
+        std::memset(reinterpret_cast<void*>(command_buffer), 0, CommandBufferHeaderSize);
+    }
+
+    return WriteGuest(command_buffer + CommandBufferSelfOffset, command_buffer) &&
+           WriteGuest(command_buffer + CommandBufferAux0Offset, aux0) &&
+           WriteGuest(command_buffer + CommandBufferAux1Offset, aux1) &&
+           WriteCommandBufferPointers(command_buffer, buffer, size);
+}
+
+bool TryGetCommandBufferState(VAddr command_buffer, CommandBufferState& out) {
+    {
+        std::scoped_lock lock{g_command_buffer_mutex};
+        const auto it = g_command_buffers.find(command_buffer);
+        if (it != g_command_buffers.end()) {
+            out = it->second;
+            return true;
+        }
+    }
+
+    VAddr buffer = 0;
+    u64 size = 0;
+    if (!ReadGuest(command_buffer + CommandBufferDataOffset, buffer) ||
+        !ReadGuest(command_buffer + CommandBufferSizeOffset, size)) {
+        return false;
+    }
+
+    out.buffer = buffer;
+    out.size = size;
+    out.write_offset = 0;
+    std::scoped_lock lock{g_command_buffer_mutex};
+    g_command_buffers[command_buffer] = out;
+    return true;
+}
+
+s32 ReadHostFileToGuest(const std::filesystem::path& host_path, u64 file_offset, VAddr destination,
+                        u64 size, u64& bytes_read) {
+    bytes_read = 0;
+    if (size == 0) {
+        return ORBIS_OK;
+    }
+    if (file_offset > static_cast<u64>(std::numeric_limits<s64>::max()) ||
+        !IsValidGuestRange(destination, size)) {
+        return ORBIS_KERNEL_ERROR_EFAULT;
+    }
+
+    std::ifstream stream{host_path, std::ios::binary};
+    if (!stream) {
+        return ORBIS_KERNEL_ERROR_ENOENT;
+    }
+
+    stream.seekg(0, std::ios::end);
+    const auto file_size = stream.tellg();
+    if (file_size <= 0 || file_offset >= static_cast<u64>(file_size)) {
+        return ORBIS_OK;
+    }
+    stream.seekg(static_cast<std::streamoff>(file_offset), std::ios::beg);
+
+    std::array<char, 64 * 1024> buffer{};
+    while (bytes_read < size && stream) {
+        const auto request =
+            static_cast<std::streamsize>(std::min<u64>(buffer.size(), size - bytes_read));
+        stream.read(buffer.data(), request);
+        const auto read = stream.gcount();
+        if (read <= 0) {
+            break;
+        }
+        std::memcpy(reinterpret_cast<void*>(destination + bytes_read), buffer.data(),
+                    static_cast<std::size_t>(read));
+        bytes_read += static_cast<u64>(read);
+    }
+    return ORBIS_OK;
+}
+
+bool AppendReadFileRecord(VAddr command_buffer, u32 file_id, VAddr destination, u64 size,
+                          u64 file_offset, u64 bytes_read) {
+    std::array<u8, ReadFileRecordSize> record{};
+    *reinterpret_cast<u32*>(&record[0x00]) = 1;
+    *reinterpret_cast<u32*>(&record[0x04]) = file_id;
+    *reinterpret_cast<u64*>(&record[0x08]) = destination;
+    *reinterpret_cast<u64*>(&record[0x10]) = size;
+    *reinterpret_cast<u64*>(&record[0x18]) = file_offset;
+    *reinterpret_cast<u64*>(&record[0x20]) = bytes_read;
+
+    std::scoped_lock lock{g_command_buffer_mutex};
+    auto it = g_command_buffers.find(command_buffer);
+    if (it == g_command_buffers.end()) {
+        CommandBufferState state;
+        if (!ReadGuest(command_buffer + CommandBufferDataOffset, state.buffer) ||
+            !ReadGuest(command_buffer + CommandBufferSizeOffset, state.size)) {
+            return false;
+        }
+        it = g_command_buffers.emplace(command_buffer, state).first;
+    }
+
+    auto& state = it->second;
+    if (state.buffer == 0 || state.write_offset + ReadFileRecordSize > state.size ||
+        !IsValidGuestRange(state.buffer + state.write_offset, ReadFileRecordSize)) {
+        return false;
+    }
+
+    std::memcpy(reinterpret_cast<void*>(state.buffer + state.write_offset), record.data(),
+                record.size());
+    state.write_offset += ReadFileRecordSize;
+    return true;
+}
+
+} // namespace
+
+void* PS4_SYSV_ABI sceAmprCommandBufferConstructor(void* command_buffer, void* buffer, u64 size) {
+    if (!Core::IsGlobalPs5RuntimeMode() || command_buffer == nullptr) {
+        return nullptr;
+    }
+    const auto command_buffer_addr = reinterpret_cast<VAddr>(command_buffer);
+    if (!InitializeCommandBuffer(command_buffer_addr, reinterpret_cast<VAddr>(buffer), size, 0, 0,
+                                 true)) {
+        return nullptr;
+    }
+    return command_buffer;
+}
+
+void* PS4_SYSV_ABI sceAmprAprCommandBufferConstructor(void* command_buffer, u64 aux0, u64 aux1) {
+    if (!Core::IsGlobalPs5RuntimeMode() || command_buffer == nullptr) {
+        return nullptr;
+    }
+
+    const auto command_buffer_addr = reinterpret_cast<VAddr>(command_buffer);
+    VAddr buffer = 0;
+    u64 size = 0;
+    ReadGuest(command_buffer_addr + CommandBufferDataOffset, buffer);
+    ReadGuest(command_buffer_addr + CommandBufferSizeOffset, size);
+    if (!InitializeCommandBuffer(command_buffer_addr, buffer, size, aux0, aux1, false)) {
+        return nullptr;
+    }
+    return command_buffer;
+}
+
+s32 PS4_SYSV_ABI sceAmprAprCommandBufferDestructor(void* command_buffer) {
+    if (!Core::IsGlobalPs5RuntimeMode() || command_buffer == nullptr) {
+        return ORBIS_OK;
+    }
+    const auto command_buffer_addr = reinterpret_cast<VAddr>(command_buffer);
+    if (!WriteGuest<u64>(command_buffer_addr + CommandBufferAux0Offset, 0) ||
+        !WriteGuest<u64>(command_buffer_addr + CommandBufferAux1Offset, 0)) {
+        return ORBIS_KERNEL_ERROR_EFAULT;
+    }
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceAmprCommandBufferDestructor(void* command_buffer) {
+    if (!Core::IsGlobalPs5RuntimeMode() || command_buffer == nullptr) {
+        return ORBIS_OK;
+    }
+    const auto command_buffer_addr = reinterpret_cast<VAddr>(command_buffer);
+    if (!WriteVisibleCommandBufferPointers(command_buffer_addr, 0, 0)) {
+        return ORBIS_KERNEL_ERROR_EFAULT;
+    }
+    std::scoped_lock lock{g_command_buffer_mutex};
+    g_command_buffers.erase(command_buffer_addr);
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceAmprCommandBufferSetBuffer(void* command_buffer, void* buffer, u64 size) {
+    if (!Core::IsGlobalPs5RuntimeMode() || command_buffer == nullptr) {
+        return ORBIS_KERNEL_ERROR_EINVAL;
+    }
+    if (!WriteCommandBufferPointers(reinterpret_cast<VAddr>(command_buffer),
+                                    reinterpret_cast<VAddr>(buffer), size)) {
+        return ORBIS_KERNEL_ERROR_EFAULT;
+    }
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceAmprCommandBufferReset(void* command_buffer) {
+    if (!Core::IsGlobalPs5RuntimeMode() || command_buffer == nullptr) {
+        return ORBIS_KERNEL_ERROR_EINVAL;
+    }
+    const auto command_buffer_addr = reinterpret_cast<VAddr>(command_buffer);
+    CommandBufferState state;
+    if (!TryGetCommandBufferState(command_buffer_addr, state) ||
+        !WriteCommandBufferPointers(command_buffer_addr, state.buffer, state.size)) {
+        return ORBIS_KERNEL_ERROR_EFAULT;
+    }
+    return ORBIS_OK;
+}
+
+void* PS4_SYSV_ABI sceAmprCommandBufferClearBuffer(void* command_buffer) {
+    if (!Core::IsGlobalPs5RuntimeMode() || command_buffer == nullptr) {
+        return nullptr;
+    }
+    const auto command_buffer_addr = reinterpret_cast<VAddr>(command_buffer);
+    CommandBufferState state;
+    if (!TryGetCommandBufferState(command_buffer_addr, state) ||
+        !WriteVisibleCommandBufferPointers(command_buffer_addr, 0, 0)) {
+        return nullptr;
+    }
+    std::scoped_lock lock{g_command_buffer_mutex};
+    g_command_buffers.erase(command_buffer_addr);
+    return reinterpret_cast<void*>(state.buffer);
+}
+
+s32 PS4_SYSV_ABI sceAmprAprCommandBufferReadFile(void* command_buffer, u64, u64, u32 file_id,
+                                                 void* destination, u64 size, u64 file_offset) {
+    if (!Core::IsGlobalPs5RuntimeMode() || command_buffer == nullptr ||
+        (destination == nullptr && size != 0)) {
+        return ORBIS_KERNEL_ERROR_EINVAL;
+    }
+
+    std::filesystem::path host_path;
+    if (!Libraries::Kernel::TryGetAprHostPath(file_id, host_path) ||
+        !std::filesystem::is_regular_file(host_path)) {
+        LOG_WARNING(Lib_Kernel, "AMPR read_file missing file id {:#x}", file_id);
+        return ORBIS_KERNEL_ERROR_ENOENT;
+    }
+
+    u64 bytes_read = 0;
+    const auto result =
+        ReadHostFileToGuest(host_path, file_offset, reinterpret_cast<VAddr>(destination), size,
+                            bytes_read);
+    if (result != ORBIS_OK) {
+        return result;
+    }
+    if (!AppendReadFileRecord(reinterpret_cast<VAddr>(command_buffer), file_id,
+                              reinterpret_cast<VAddr>(destination), size, file_offset, bytes_read)) {
+        return ORBIS_KERNEL_ERROR_EFAULT;
+    }
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceAmprAmmSubmitCommandBuffer(void* command_buffer, u64 arg1, u64 arg2, u64 arg3,
+                                               u64 arg4, u64 arg5) {
+    if (!Core::IsGlobalPs5RuntimeMode()) {
+        return ORBIS_KERNEL_ERROR_ENOSYS;
+    }
+    std::fprintf(stderr,
+                 "sceAmprAmmSubmitCommandBuffer cb=%p a1=0x%llx a2=0x%llx "
+                 "a3=0x%llx a4=0x%llx a5=0x%llx -> 0\n",
+                 command_buffer, static_cast<unsigned long long>(arg1),
+                 static_cast<unsigned long long>(arg2), static_cast<unsigned long long>(arg3),
+                 static_cast<unsigned long long>(arg4), static_cast<unsigned long long>(arg5));
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceAmprAmmWaitCommandBufferCompletion(u64 submission_id, u64 arg1, void* result,
+                                                       u64 arg3, u64 arg4, u64 arg5) {
+    if (!Core::IsGlobalPs5RuntimeMode()) {
+        return ORBIS_KERNEL_ERROR_ENOSYS;
+    }
+    if (result != nullptr && IsValidGuestRange(reinterpret_cast<VAddr>(result), sizeof(u64))) {
+        *reinterpret_cast<u64*>(result) = 0;
+    }
+    std::fprintf(stderr,
+                 "sceAmprAmmWaitCommandBufferCompletion id=0x%llx a1=0x%llx "
+                 "result=%p a3=0x%llx a4=0x%llx a5=0x%llx -> 0\n",
+                 static_cast<unsigned long long>(submission_id),
+                 static_cast<unsigned long long>(arg1), result,
+                 static_cast<unsigned long long>(arg3), static_cast<unsigned long long>(arg4),
+                 static_cast<unsigned long long>(arg5));
+    return ORBIS_OK;
+}
+
+void RegisterLib(Core::Loader::SymbolsResolver* sym) {
+    if (!Core::IsGlobalPs5RuntimeMode()) {
+        return;
+    }
+
+    LIB_FUNCTION("8aI7R7WaOlc", "libSceAmpr", 1, "libSceAmpr", sceAmprCommandBufferConstructor);
+    LIB_FUNCTION("a8uLzYY--tM", "libSceAmpr", 1, "libSceAmpr",
+                 sceAmprAprCommandBufferConstructor);
+    LIB_FUNCTION("Qs1xtplKo0U", "libSceAmpr", 1, "libSceAmpr",
+                 sceAmprAprCommandBufferDestructor);
+    LIB_FUNCTION("GuchCTefuZw", "libSceAmpr", 1, "libSceAmpr", sceAmprCommandBufferDestructor);
+    LIB_FUNCTION("N-FSPA4S3nI", "libSceAmpr", 1, "libSceAmpr", sceAmprCommandBufferSetBuffer);
+    LIB_FUNCTION("baQO9ez2gL4", "libSceAmpr", 1, "libSceAmpr", sceAmprCommandBufferReset);
+    LIB_FUNCTION("ULvXMDz56po", "libSceAmpr", 1, "libSceAmpr", sceAmprCommandBufferClearBuffer);
+    LIB_FUNCTION("mQ16-QdKv7k", "libSceAmpr", 1, "libSceAmpr",
+                 sceAmprAprCommandBufferReadFile);
+    LIB_FUNCTION("lwS-7y3jcBI", "libSceAmpr", 1, "libSceAmpr",
+                 sceAmprAmmSubmitCommandBuffer);
+    LIB_FUNCTION("OJf3vCckPAM", "libSceAmpr", 1, "libSceAmpr",
+                 sceAmprAmmSubmitCommandBuffer);
+    LIB_FUNCTION("NnKhlMJtIsI", "libSceAmpr", 1, "libSceAmpr",
+                 sceAmprAmmSubmitCommandBuffer);
+    LIB_FUNCTION("HXymib4T8gc", "libSceAmpr", 1, "libSceAmpr",
+                 sceAmprAmmWaitCommandBufferCompletion);
+}
+
+} // namespace Libraries::Ampr

--- a/src/core/libraries/ampr/ampr.h
+++ b/src/core/libraries/ampr/ampr.h
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+namespace Core::Loader {
+class SymbolsResolver;
+}
+
+namespace Libraries::Ampr {
+
+void RegisterLib(Core::Loader::SymbolsResolver* sym);
+
+} // namespace Libraries::Ampr

--- a/src/core/libraries/app_content/app_content.cpp
+++ b/src/core/libraries/app_content/app_content.cpp
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <cmath>
+#include <cstring>
 
 #include "app_content.h"
 #include "common/assert.h"
+#include "common/elf_info.h"
 #include "common/logging/log.h"
 #include "common/singleton.h"
 #include "core/emulator_settings.h"
@@ -13,6 +15,7 @@
 #include "core/libraries/app_content/app_content_error.h"
 #include "core/libraries/libs.h"
 #include "core/libraries/system/systemservice.h"
+#include "core/linker.h"
 
 namespace Libraries::AppContent {
 
@@ -280,11 +283,19 @@ int PS4_SYSV_ABI sceAppContentGetRegion() {
 int PS4_SYSV_ABI sceAppContentInitialize(const OrbisAppContentInitParam* initParam,
                                          OrbisAppContentBootParam* bootParam) {
     LOG_ERROR(Lib_AppContent, "(DUMMY) called");
+    if (bootParam != nullptr) {
+        std::memset(bootParam, 0, sizeof(*bootParam));
+    }
+
     auto* param_sfo = Common::Singleton<PSF>::Instance();
 
     const auto addons_dir = EmulatorSettings.GetAddonInstallDir();
     if (const auto value = param_sfo->GetString("TITLE_ID"); value.has_value()) {
         title_id = *value;
+    } else if (Core::IsGlobalPs5RuntimeMode()) {
+        title_id = std::string{Common::ElfInfo::Instance().GameSerial()};
+        LOG_WARNING(Lib_AppContent,
+                    "PS5 mode: TITLE_ID missing from PSF, using game serial {}", title_id);
     } else {
         UNREACHABLE_MSG("Failed to get TITLE_ID");
     }

--- a/src/core/libraries/kernel/equeue.cpp
+++ b/src/core/libraries/kernel/equeue.cpp
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: Copyright 2024-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <cstdio>
 #include <thread>
+#include <fmt/core.h>
 #include <magic_enum/magic_enum.hpp>
 
 #include "common/assert.h"
@@ -15,6 +17,7 @@
 #include "core/libraries/kernel/posix_error.h"
 #include "core/libraries/kernel/time.h"
 #include "core/libraries/libs.h"
+#include "core/linker.h"
 
 namespace Libraries::Kernel {
 
@@ -642,6 +645,68 @@ u64 PS4_SYSV_ABI sceKernelGetEventData(const OrbisKernelEvent* ev) {
     return ev->data;
 }
 
+s32 PS4_SYSV_ABI sceKernelAddAmprEvent(OrbisKernelEqueue eq, int id, void* udata) {
+    if (Core::IsGlobalPs5RuntimeMode()) {
+        LOG_INFO(Kernel_Event, "PS5 mode: sceKernelAddAmprEvent eq={} id={} udata={}", eq,
+                 id, fmt::ptr(udata));
+        if (kqueues.contains(eq)) {
+            EqueueEvent event{};
+            event.event.ident = id;
+            event.event.filter = OrbisKernelEvent::Filter::User;
+            event.event.flags = OrbisKernelEvent::Flags::Add;
+            event.event.fflags = 0;
+            event.event.data = 0;
+            event.event.udata = udata;
+            kqueues[eq]->AddEvent(event);
+        }
+        return ORBIS_OK;
+    }
+    return ORBIS_KERNEL_ERROR_ENOSYS;
+}
+
+s32 PS4_SYSV_ABI sceKernelAddAmprSystemEvent(OrbisKernelEqueue eq, int id, void* udata) {
+    if (Core::IsGlobalPs5RuntimeMode()) {
+        LOG_INFO(Kernel_Event,
+                 "PS5 mode: sceKernelAddAmprSystemEvent eq={} id={} udata={}", eq, id,
+                 fmt::ptr(udata));
+        if (kqueues.contains(eq)) {
+            EqueueEvent event{};
+            event.event.ident = id;
+            event.event.filter = OrbisKernelEvent::Filter::User;
+            event.event.flags = OrbisKernelEvent::Flags::Add;
+            event.event.fflags = 0;
+            event.event.data = 0;
+            event.event.udata = udata;
+            kqueues[eq]->AddEvent(event);
+        }
+        return ORBIS_OK;
+    }
+    return ORBIS_KERNEL_ERROR_ENOSYS;
+}
+
+s32 PS4_SYSV_ABI sceKernelDeleteAmprEvent(OrbisKernelEqueue eq, int id) {
+    if (Core::IsGlobalPs5RuntimeMode()) {
+        LOG_INFO(Kernel_Event, "PS5 mode: sceKernelDeleteAmprEvent eq={} id={}", eq, id);
+        if (kqueues.contains(eq)) {
+            kqueues[eq]->RemoveEvent(id, OrbisKernelEvent::Filter::User);
+        }
+        return ORBIS_OK;
+    }
+    return ORBIS_KERNEL_ERROR_ENOSYS;
+}
+
+s32 PS4_SYSV_ABI sceKernelDeleteAmprSystemEvent(OrbisKernelEqueue eq, int id) {
+    if (Core::IsGlobalPs5RuntimeMode()) {
+        LOG_INFO(Kernel_Event, "PS5 mode: sceKernelDeleteAmprSystemEvent eq={} id={}", eq,
+                 id);
+        if (kqueues.contains(eq)) {
+            kqueues[eq]->RemoveEvent(id, OrbisKernelEvent::Filter::User);
+        }
+        return ORBIS_OK;
+    }
+    return ORBIS_KERNEL_ERROR_ENOSYS;
+}
+
 void RegisterEventQueue(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("nh2IFMgKTv8", "libScePosix", 1, "libkernel", posix_kqueue);
     LIB_FUNCTION("RW-GEfpnsqg", "libScePosix", 1, "libkernel", posix_kevent);
@@ -660,6 +725,13 @@ void RegisterEventQueue(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("mJ7aghmgvfc", "libkernel", 1, "libkernel", sceKernelGetEventId);
     LIB_FUNCTION("23CPPI1tyBY", "libkernel", 1, "libkernel", sceKernelGetEventFilter);
     LIB_FUNCTION("kwGyyjohI50", "libkernel", 1, "libkernel", sceKernelGetEventData);
+    if (Core::IsGlobalPs5RuntimeMode()) {
+        LIB_FUNCTION("bBfz7kMF2Ho", "libkernel", 1, "libkernel", sceKernelAddAmprEvent);
+        LIB_FUNCTION("vuae5JPNt9A", "libkernel", 1, "libkernel", sceKernelAddAmprSystemEvent);
+        LIB_FUNCTION("bMmid3pfyjo", "libkernel", 1, "libkernel", sceKernelDeleteAmprEvent);
+        LIB_FUNCTION("Ij+ryuEClXQ", "libkernel", 1, "libkernel",
+                     sceKernelDeleteAmprSystemEvent);
+    }
 }
 
 } // namespace Libraries::Kernel

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <map>
+#include <cctype>
+#include <cstdio>
+#include <limits>
+#include <mutex>
 #include <ranges>
+#include <unordered_map>
 #include <magic_enum/magic_enum.hpp>
 
 #include "common/assert.h"
@@ -26,6 +31,7 @@
 #include "core/libraries/kernel/posix_error.h"
 #include "core/libraries/libs.h"
 #include "core/libraries/network/sockets.h"
+#include "core/linker.h"
 #include "core/memory.h"
 #include "kernel.h"
 
@@ -73,6 +79,31 @@ static std::map<std::string, FactoryDevice> available_device = {
 };
 
 namespace Libraries::Kernel {
+
+static std::mutex g_apr_file_registry_mutex;
+static std::unordered_map<u32, fs::path> g_apr_file_registry;
+
+//Need to fix!
+static bool IsPs5SyntheticUnrealProjectPath(std::string_view path) {
+    if (!Core::IsGlobalPs5RuntimeMode()) {
+        return false;
+    }
+    std::string lower_path(path);
+    std::ranges::transform(lower_path, lower_path.begin(),
+                           [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return lower_path.ends_with(".uproject");
+}
+
+//Need to fix!
+static bool IsPs5OptionalUnrealDirectory(std::string_view path) {
+    if (!Core::IsGlobalPs5RuntimeMode()) {
+        return false;
+    }
+    std::string lower_path(path);
+    std::ranges::transform(lower_path, lower_path.begin(),
+                           [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return lower_path.ends_with("/deepfiles") || lower_path.ends_with("/paks");
+}
 
 s32 PS4_SYSV_ABI open(const char* raw_path, s32 flags, u16 mode) {
     LOG_INFO(Kernel_Fs, "path = {} flags = {:#x} mode = {:#o}", raw_path, flags, mode);
@@ -155,6 +186,16 @@ s32 PS4_SYSV_ABI open(const char* raw_path, s32 flags, u16 mode) {
             Common::FS::IOFile out(file->m_host_name, Common::FS::FileAccessMode::Create);
         }
     } else if (!exists) {
+        if (directory && IsPs5OptionalUnrealDirectory(path)) {
+            file->type = Core::FileSys::FileType::Directory;
+            file->is_opened = true;
+            if (file->m_guest_name.starts_with("/app0")) {
+                file->directory = Core::Directories::PfsDirectory::Create(file->m_guest_name);
+            } else {
+                file->directory = Core::Directories::NormalDirectory::Create(file->m_guest_name);
+            }
+            return handle;
+        }
         // If we're not creating a file, and it doesn't exist, return ENOENT
         h->DeleteHandle(handle);
         *__Error() = POSIX_ENOENT;
@@ -676,6 +717,14 @@ s32 PS4_SYSV_ABI posix_stat(const char* path, OrbisKernelStat* sb) {
     const bool is_dir = fs::is_directory(path_name);
     const bool is_file = fs::is_regular_file(path_name);
     if (!is_dir && !is_file) {
+        if (IsPs5SyntheticUnrealProjectPath(path)) {
+            std::memset(sb, 0, sizeof(OrbisKernelStat));
+            sb->st_mode = 0000777u | 0100000u;
+            sb->st_size = 2;
+            sb->st_blksize = 512;
+            sb->st_blocks = 1;
+            return ORBIS_OK;
+        }
         *__Error() = POSIX_ENOENT;
         return -1;
     }
@@ -1512,6 +1561,127 @@ s32 PS4_SYSV_ABI posix_select(s32 nfds, fd_set* readfds, fd_set* writefds, fd_se
 }
 #endif
 
+static u32 ComputeAprFileId(std::string_view guest_path) {
+    u32 hash = 2166136261u;
+    for (const char ch : guest_path) {
+        hash ^= static_cast<u8>(ch);
+        hash *= 16777619u;
+    }
+    return hash;
+}
+
+static void RegisterAprHostPath(u32 file_id, const fs::path& host_path) {
+    std::scoped_lock lock{g_apr_file_registry_mutex};
+    g_apr_file_registry[file_id] = host_path;
+}
+
+bool TryGetAprHostPath(u32 file_id, fs::path& out) {
+    std::scoped_lock lock{g_apr_file_registry_mutex};
+    const auto it = g_apr_file_registry.find(file_id);
+    if (it == g_apr_file_registry.end()) {
+        return false;
+    }
+    out = it->second;
+    return true;
+}
+
+static bool TryReadGuestCString(VAddr addr, std::string& out) {
+    auto* memory = Core::Memory::Instance();
+    if (!memory->IsValidMapping(addr, 1)) {
+        return false;
+    }
+
+    out.clear();
+    for (u32 i = 0; i < ORBIS_MAX_PATH; i++) {
+        if (!memory->IsValidMapping(addr + i, 1)) {
+            return false;
+        }
+        const char ch = *reinterpret_cast<const char*>(addr + i);
+        if (ch == '\0') {
+            return !out.empty();
+        }
+        out.push_back(ch);
+    }
+    return false;
+}
+
+static bool TryReadAprPathPointer(VAddr pointer_addr, std::string& out) {
+    auto* memory = Core::Memory::Instance();
+    if (!memory->IsValidMapping(pointer_addr, sizeof(VAddr))) {
+        return false;
+    }
+    const VAddr candidate = *reinterpret_cast<const VAddr*>(pointer_addr);
+    return candidate != 0 && TryReadGuestCString(candidate, out);
+}
+
+static bool TryResolveAprFilepath(VAddr path_list, u64 index, std::string& out) {
+    if (TryReadAprPathPointer(path_list + index * sizeof(VAddr), out)) {
+        return true;
+    }
+    if (index != 0) {
+        return false;
+    }
+    if (TryReadGuestCString(path_list, out)) {
+        return true;
+    }
+    for (u64 offset = 0; offset < 0x40; offset += sizeof(VAddr)) {
+        if (TryReadAprPathPointer(path_list + offset, out)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+s32 PS4_SYSV_ABI sceKernelAprResolveFilepathsToIdsAndFileSizes(const void* path_list, u64 count,
+                                                               u32* ids, u32* sizes) {
+    if (!Core::IsGlobalPs5RuntimeMode()) {
+        return ORBIS_KERNEL_ERROR_ENOSYS;
+    }
+    if (path_list == nullptr || count == 0 || sizes == nullptr || count > 1024) {
+        return ORBIS_KERNEL_ERROR_EINVAL;
+    }
+
+    auto* memory = Core::Memory::Instance();
+    auto* mnt = Common::Singleton<Core::FileSys::MntPoints>::Instance();
+    const VAddr path_list_addr = reinterpret_cast<VAddr>(path_list);
+    for (u64 i = 0; i < count; i++) {
+        std::string guest_path;
+        if (!TryResolveAprFilepath(path_list_addr, i, guest_path)) {
+            return ORBIS_KERNEL_ERROR_EFAULT;
+        }
+
+        const auto host_path = mnt->GetHostPath(guest_path);
+        u32 file_size = 0;
+        if (fs::is_directory(host_path)) {
+            file_size = 0x10000;
+        } else if (fs::is_regular_file(host_path)) {
+            const auto size = fs::file_size(host_path);
+            file_size = size > std::numeric_limits<u32>::max()
+                            ? std::numeric_limits<u32>::max()
+                            : static_cast<u32>(size);
+        } else {
+            LOG_WARNING(Kernel_Fs, "APR resolve failed for missing path {}", guest_path);
+            return ORBIS_KERNEL_ERROR_ENOENT;
+        }
+
+        if (ids != nullptr) {
+            const VAddr out_id = reinterpret_cast<VAddr>(&ids[i]);
+            if (!memory->IsValidMapping(out_id, sizeof(u32))) {
+                return ORBIS_KERNEL_ERROR_EFAULT;
+            }
+            ids[i] = ComputeAprFileId(guest_path);
+            RegisterAprHostPath(ids[i], host_path);
+        }
+
+        const VAddr out_size = reinterpret_cast<VAddr>(&sizes[i]);
+        if (!memory->IsValidMapping(out_size, sizeof(u32))) {
+            return ORBIS_KERNEL_ERROR_EFAULT;
+        }
+        sizes[i] = file_size;
+    }
+    return ORBIS_OK;
+}
+
 void RegisterFileSystem(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("6c3rCVE-fTU", "libkernel", 1, "libkernel", open);
     LIB_FUNCTION("wuCroIGjt2g", "libScePosix", 1, "libkernel", posix_open);
@@ -1573,6 +1743,10 @@ void RegisterFileSystem(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("AUXVxWeJU-A", "libkernel", 1, "libkernel", sceKernelUnlink);
     LIB_FUNCTION("T8fER+tIGgk", "libScePosix", 1, "libkernel", posix_select);
     LIB_FUNCTION("T8fER+tIGgk", "libkernel", 1, "libkernel", posix_select);
+    if (Core::IsGlobalPs5RuntimeMode()) {
+        LIB_FUNCTION("gEpBkcwxUjw", "libkernel", 1, "libkernel",
+                     sceKernelAprResolveFilepathsToIdsAndFileSizes);
+    }
 }
 
 } // namespace Libraries::Kernel

--- a/src/core/libraries/kernel/file_system.h
+++ b/src/core/libraries/kernel/file_system.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <filesystem>
+
 #include "common/types.h"
 #include "core/libraries/kernel/time.h"
 
@@ -72,6 +74,7 @@ s64 PS4_SYSV_ABI sceKernelWrite(s32 fd, const void* buf, u64 nbytes);
 s64 PS4_SYSV_ABI sceKernelRead(s32 fd, void* buf, u64 nbytes);
 s64 PS4_SYSV_ABI sceKernelPread(s32 fd, void* buf, u64 nbytes, s64 offset);
 s64 PS4_SYSV_ABI sceKernelPwrite(s32 fd, void* buf, u64 nbytes, s64 offset);
+bool TryGetAprHostPath(u32 file_id, std::filesystem::path& out);
 void RegisterFileSystem(Core::Loader::SymbolsResolver* sym);
 
 } // namespace Libraries::Kernel

--- a/src/core/libraries/kernel/kernel.cpp
+++ b/src/core/libraries/kernel/kernel.cpp
@@ -1,7 +1,12 @@
 // SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <array>
+#include <atomic>
+#include <cstdio>
+#include <mutex>
 #include <thread>
+#include <unordered_map>
 #include <boost/asio/io_context.hpp>
 
 #include "common/assert.h"
@@ -27,6 +32,9 @@
 #include "core/libraries/kernel/time.h"
 #include "core/libraries/libs.h"
 #include "core/libraries/network/sys_net.h"
+#include "core/linker.h"
+#include "core/tls.h"
+#include "core/memory.h"
 
 #ifdef _WIN64
 #include <Rpc.h>
@@ -42,6 +50,16 @@
 namespace Libraries::Kernel {
 
 static u64 g_stack_chk_guard = 0xDEADBEEF54321ABC; // dummy return
+static u64 g_thread_atexit_count_callback = 0;
+static u64 g_thread_atexit_report_callback = 0;
+static u64 g_thread_dtors_callback = 0;
+static std::atomic<s32> g_thread_atexit_count = 0;
+static u64 g_coredump_handler = 0;
+static u64 g_coredump_handler_context = 0;
+static std::atomic<u32> g_next_apr_submission_id = 1;
+static std::mutex g_apr_submission_mutex;
+static std::unordered_map<u32, VAddr> g_apr_submissions;
+static thread_local std::array<u8, 0x68> g_sanitizer_new_replace_fallback{};
 
 boost::asio::io_context io_context;
 static std::mutex m_asio_req;
@@ -298,6 +316,147 @@ s32 PS4_SYSV_ABI sceKernelGetAppInfo(s32 pid, OrbisKernelAppInfo* app_info) {
     return ORBIS_OK;
 }
 
+s32 PS4_SYSV_ABI _sceKernelSetThreadAtexitCount(u64 callback) {
+    g_thread_atexit_count_callback = callback;
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI _sceKernelSetThreadAtexitReport(u64 callback) {
+    g_thread_atexit_report_callback = callback;
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI _sceKernelSetThreadDtors(u64 callback) {
+    g_thread_dtors_callback = callback;
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI _sceKernelRtldThreadAtexitIncrement() {
+    ++g_thread_atexit_count;
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI _sceKernelRtldThreadAtexitDecrement() {
+    --g_thread_atexit_count;
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceCoredumpRegisterCoredumpHandler(u64 handler, u64 context) {
+    g_coredump_handler = handler;
+    g_coredump_handler_context = context;
+    return ORBIS_OK;
+}
+
+static bool IsValidGuestRange(VAddr addr, u64 size) {
+    if (size == 0) {
+        return true;
+    }
+    return addr != 0 && Core::Memory::Instance()->IsValidMapping(addr, size);
+}
+
+static u32 AllocateAprSubmissionId(VAddr command_buffer) {
+    u32 id = g_next_apr_submission_id.fetch_add(1);
+    if (id == 0) {
+        id = g_next_apr_submission_id.fetch_add(1);
+    }
+    std::scoped_lock lock{g_apr_submission_mutex};
+    g_apr_submissions[id] = command_buffer;
+    return id;
+}
+
+static s32 WriteAprResult(void* result) {
+    if (result == nullptr) {
+        return ORBIS_OK;
+    }
+    const auto addr = reinterpret_cast<VAddr>(result);
+    if (!IsValidGuestRange(addr, sizeof(u64))) {
+        return ORBIS_KERNEL_ERROR_EFAULT;
+    }
+    *reinterpret_cast<u64*>(result) = 0;
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceKernelAprSubmitCommandBufferAndGetResult(void* command_buffer, u64,
+                                                             void* result,
+                                                             u32* out_submission_id) {
+    if (!Core::IsGlobalPs5RuntimeMode() || command_buffer == nullptr) {
+        return ORBIS_KERNEL_ERROR_EINVAL;
+    }
+    const u32 id = AllocateAprSubmissionId(reinterpret_cast<VAddr>(command_buffer));
+    if (out_submission_id != nullptr) {
+        if (!IsValidGuestRange(reinterpret_cast<VAddr>(out_submission_id), sizeof(u32))) {
+            return ORBIS_KERNEL_ERROR_EFAULT;
+        }
+        *out_submission_id = id;
+    }
+    return WriteAprResult(result);
+}
+
+s32 PS4_SYSV_ABI sceKernelAprWaitCommandBuffer(u32 submission_id, u64, void* result) {
+    if (!Core::IsGlobalPs5RuntimeMode()) {
+        return ORBIS_KERNEL_ERROR_ENOSYS;
+    }
+    {
+        std::scoped_lock lock{g_apr_submission_mutex};
+        if (g_apr_submissions.erase(submission_id) == 0) {
+            LOG_WARNING(Kernel, "PS5 mode: APR wait for unknown submission id {:#x}; "
+                                "treating as completed",
+                        submission_id);
+        }
+    }
+    return WriteAprResult(result);
+}
+
+s32 PS4_SYSV_ABI sceKernelWaitCommandBufferCompletion(u64 submission_id, u64 arg1, void* result,
+                                                      u64 arg3, u64 arg4, u64 arg5) {
+    if (!Core::IsGlobalPs5RuntimeMode()) {
+        return ORBIS_KERNEL_ERROR_ENOSYS;
+    }
+    const auto write_result = WriteAprResult(result);
+    return write_result;
+}
+
+s32 PS4_SYSV_ABI sceKernelAprSubmitCommandBuffer(void* command_buffer, u64) {
+    if (!Core::IsGlobalPs5RuntimeMode() || command_buffer == nullptr) {
+        return ORBIS_KERNEL_ERROR_EINVAL;
+    }
+    AllocateAprSubmissionId(reinterpret_cast<VAddr>(command_buffer));
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI sceKernelAprSubmitCommandBufferAndGetId(void* command_buffer, u64,
+                                                         u32* out_submission_id) {
+    if (!Core::IsGlobalPs5RuntimeMode() || command_buffer == nullptr ||
+        out_submission_id == nullptr) {
+        return ORBIS_KERNEL_ERROR_EINVAL;
+    }
+    if (!IsValidGuestRange(reinterpret_cast<VAddr>(out_submission_id), sizeof(u32))) {
+        return ORBIS_KERNEL_ERROR_EFAULT;
+    }
+    *out_submission_id = AllocateAprSubmissionId(reinterpret_cast<VAddr>(command_buffer));
+    return ORBIS_OK;
+}
+
+void* PS4_SYSV_ABI sceKernelGetSanitizerNewReplaceExternal() {
+    if (!Core::IsGlobalPs5RuntimeMode()) {
+        return nullptr;
+    }
+
+    constexpr u64 TlsNewReplaceOffset = 0x300;
+    constexpr u64 NewReplaceSize = 0x68;
+    VAddr address = 0;
+    if (auto* tcb = Core::GetTcbBase(); tcb != nullptr) {
+        address = reinterpret_cast<VAddr>(tcb) + TlsNewReplaceOffset;
+    }
+    if (!IsValidGuestRange(address, NewReplaceSize)) {
+        address = reinterpret_cast<VAddr>(g_sanitizer_new_replace_fallback.data());
+    }
+
+    std::memset(reinterpret_cast<void*>(address), 0, NewReplaceSize);
+    *reinterpret_cast<u64*>(address) = NewReplaceSize;
+    return reinterpret_cast<void*>(address);
+}
+
 // Nominally: long sysconf(int name);
 u64 PS4_SYSV_ABI posix_sysconf(s32 name) {
     switch (name) {
@@ -497,6 +656,32 @@ void RegisterLib(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("ca7v6Cxulzs", "libkernel", 1, "libkernel", sceKernelSetGPO);
     LIB_FUNCTION("iKJMWrAumPE", "libkernel", 1, "libkernel", getargc);
     LIB_FUNCTION("FJmglmTMdr4", "libkernel", 1, "libkernel", getargv);
+
+    if (Core::IsGlobalPs5RuntimeMode()) {
+        LIB_FUNCTION("pB-yGZ2nQ9o", "libkernel", 1, "libkernel",
+                     _sceKernelSetThreadAtexitCount);
+        LIB_FUNCTION("WhCc1w3EhSI", "libkernel", 1, "libkernel",
+                     _sceKernelSetThreadAtexitReport);
+        LIB_FUNCTION("rNhWz+lvOMU", "libkernel", 1, "libkernel", _sceKernelSetThreadDtors);
+        LIB_FUNCTION("Tz4RNUCBbGI", "libkernel", 1, "libkernel",
+                     _sceKernelRtldThreadAtexitIncrement);
+        LIB_FUNCTION("8OnWXlgQlvo", "libkernel", 1, "libkernel",
+                     _sceKernelRtldThreadAtexitDecrement);
+        LIB_FUNCTION("8zLSfEfW5AU", "libSceCoredump", 1, "libSceCoredump",
+                     sceCoredumpRegisterCoredumpHandler);
+        LIB_FUNCTION("ASoW5WE-UPo", "libkernel", 1, "libkernel",
+                     sceKernelAprSubmitCommandBufferAndGetResult);
+        LIB_FUNCTION("rqwFKI4PAiM", "libkernel", 1, "libkernel",
+                     sceKernelAprWaitCommandBuffer);
+        LIB_FUNCTION("eE4Szl8sil8", "libkernel", 1, "libkernel",
+                     sceKernelAprSubmitCommandBuffer);
+        LIB_FUNCTION("qvMUCyyaCSI", "libkernel", 1, "libkernel",
+                     sceKernelAprSubmitCommandBufferAndGetId);
+        LIB_FUNCTION("3GqBPApWgPY", "libkernel", 1, "libkernel",
+                     sceKernelWaitCommandBufferCompletion);
+        LIB_FUNCTION("bnZxYgAFeA0", "libkernel", 1, "libkernel",
+                     sceKernelGetSanitizerNewReplaceExternal);
+    }
 }
 
 } // namespace Libraries::Kernel

--- a/src/core/libraries/kernel/memory.cpp
+++ b/src/core/libraries/kernel/memory.cpp
@@ -16,6 +16,7 @@
 #include "core/libraries/libs.h"
 #include "core/linker.h"
 #include "core/memory.h"
+#include <atomic>
 
 namespace Libraries::Kernel {
 
@@ -36,6 +37,7 @@ s32 PS4_SYSV_ABI sceKernelEnableDmemAliasing() {
 
 s32 PS4_SYSV_ABI sceKernelAllocateDirectMemory(s64 searchStart, s64 searchEnd, u64 len,
                                                u64 alignment, s32 memoryType, s64* physAddrOut) {
+    s32 alloc_memory_type = memoryType;
     if (searchStart < 0 || searchEnd < 0) {
         LOG_ERROR(Kernel_Vmm, "Invalid parameters!");
         return ORBIS_KERNEL_ERROR_EINVAL;
@@ -48,7 +50,10 @@ s32 PS4_SYSV_ABI sceKernelAllocateDirectMemory(s64 searchStart, s64 searchEnd, u
         LOG_ERROR(Kernel_Vmm, "Alignment {:#x} is invalid!", alignment);
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
-    if (memoryType > 10) {
+    if (memoryType == 0xC && Core::IsGlobalPs5RuntimeMode()) {
+        // keep direct memory type 0xC as-is.
+        alloc_memory_type = memoryType;
+    } else if (memoryType > 10) {
         LOG_ERROR(Kernel_Vmm, "Memory type {:#x} is invalid!", memoryType);
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
@@ -67,7 +72,7 @@ s32 PS4_SYSV_ABI sceKernelAllocateDirectMemory(s64 searchStart, s64 searchEnd, u
     }
 
     auto* memory = Core::Memory::Instance();
-    PAddr phys_addr = memory->Allocate(searchStart, searchEnd, len, alignment, memoryType);
+    PAddr phys_addr = memory->Allocate(searchStart, searchEnd, len, alignment, alloc_memory_type);
     if (phys_addr == -1) {
         return ORBIS_KERNEL_ERROR_EAGAIN;
     }
@@ -77,7 +82,7 @@ s32 PS4_SYSV_ABI sceKernelAllocateDirectMemory(s64 searchStart, s64 searchEnd, u
     LOG_INFO(Kernel_Vmm,
              "searchStart = {:#x}, searchEnd = {:#x}, len = {:#x}, "
              "alignment = {:#x}, memoryType = {:#x}, physAddrOut = {:#x}",
-             searchStart, searchEnd, len, alignment, memoryType, phys_addr);
+             searchStart, searchEnd, len, alignment, alloc_memory_type, phys_addr);
 
     return ORBIS_OK;
 }
@@ -209,7 +214,7 @@ s32 PS4_SYSV_ABI sceKernelMapNamedDirectMemory(void** addr, u64 len, s32 prot, s
     }
 
     const auto mem_prot = static_cast<Core::MemoryProt>(prot);
-    if (True(mem_prot & Core::MemoryProt::CpuExec)) {
+    if (True(mem_prot & Core::MemoryProt::CpuExec) && !Core::IsGlobalPs5RuntimeMode()) {
         LOG_ERROR(Kernel_Vmm, "Executable permissions are not allowed.");
         return ORBIS_KERNEL_ERROR_EACCES;
     }
@@ -262,7 +267,7 @@ s32 PS4_SYSV_ABI sceKernelMapDirectMemory2(void** addr, u64 len, s32 type, s32 p
     }
 
     const auto mem_prot = static_cast<Core::MemoryProt>(prot);
-    if (True(mem_prot & Core::MemoryProt::CpuExec)) {
+    if (True(mem_prot & Core::MemoryProt::CpuExec) && !Core::IsGlobalPs5RuntimeMode()) {
         LOG_ERROR(Kernel_Vmm, "Executable permissions are not allowed.");
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
@@ -571,7 +576,7 @@ s32 PS4_SYSV_ABI sceKernelMemoryPoolCommit(void* addr, u64 len, s32 type, s32 pr
     }
 
     const auto mem_prot = static_cast<Core::MemoryProt>(prot);
-    if (True(mem_prot & Core::MemoryProt::CpuExec)) {
+    if (True(mem_prot & Core::MemoryProt::CpuExec) && !Core::IsGlobalPs5RuntimeMode()) {
         LOG_ERROR(Kernel_Vmm, "Executable permissions are not allowed.");
         return ORBIS_KERNEL_ERROR_EINVAL;
     }

--- a/src/core/libraries/kernel/memory.h
+++ b/src/core/libraries/kernel/memory.h
@@ -11,6 +11,8 @@ constexpr u64 ORBIS_KERNEL_TOTAL_MEM_PRO = 5888_MB;
 constexpr u64 ORBIS_KERNEL_TOTAL_MEM_DEV = 6656_MB;
 // TODO: This value needs confirmation
 constexpr u64 ORBIS_KERNEL_TOTAL_MEM_DEV_PRO = 7936_MB;
+// PS5 has 16 GB of unified physical memory.
+constexpr u64 ORBIS_KERNEL_TOTAL_MEM_PS5 = 16_GB;
 
 constexpr u64 ORBIS_KERNEL_FLEXIBLE_MEMORY_BASE = 64_MB;
 constexpr u64 ORBIS_KERNEL_FLEXIBLE_MEMORY_SIZE = 512_MB;

--- a/src/core/libraries/kernel/threads/mutex.cpp
+++ b/src/core/libraries/kernel/threads/mutex.cpp
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <thread>
+#include <atomic>
+#include <cstdio>
 #include "common/assert.h"
 #include "common/types.h"
 #include "core/libraries/kernel/kernel.h"
 #include "core/libraries/kernel/posix_error.h"
 #include "core/libraries/kernel/threads/pthread.h"
 #include "core/libraries/libs.h"
+#include "core/linker.h"
 
 namespace Libraries::Kernel {
 
@@ -98,7 +101,7 @@ s32 PS4_SYSV_ABI posix_pthread_mutex_init(PthreadMutexT* mutex,
 s32 PS4_SYSV_ABI scePthreadMutexInit(PthreadMutexT* mutex, const PthreadMutexAttrT* mutex_attr,
                                      const char* name) {
     return MutexInit(mutex, mutex_attr ? *mutex_attr : nullptr, name);
-}
+    }
 
 s32 PS4_SYSV_ABI posix_pthread_mutex_destroy(PthreadMutexT* mutex) {
     PthreadMutexT m = *mutex;
@@ -152,6 +155,10 @@ s32 PthreadMutex::SelfLock(const OrbisKernelTimespec* abstime, u64 usec) {
     switch (Type()) {
     case PthreadMutexType::ErrorCheck:
     case PthreadMutexType::AdaptiveNp: {
+        if (Core::IsGlobalPs5RuntimeMode() && Type() == PthreadMutexType::AdaptiveNp && !abstime) {
+            m_count++;
+            return 0;
+        }
         if (abstime) {
             return DoSleep();
         }
@@ -162,6 +169,10 @@ s32 PthreadMutex::SelfLock(const OrbisKernelTimespec* abstime, u64 usec) {
         return POSIX_EDEADLK;
     }
     case PthreadMutexType::Normal: {
+        if (Core::IsGlobalPs5RuntimeMode() && !abstime) {
+            m_count++;
+            return 0;
+        }
         /*
          * What SS2 define as a 'normal' mutex.  Intentionally
          * deadlock on attempts to get a lock you already own.
@@ -278,7 +289,11 @@ s32 PthreadMutex::Unlock() {
         return POSIX_EPERM;
     }
 
-    if (Type() == PthreadMutexType::Recursive && m_count > 0) [[unlikely]] {
+    if (Core::IsGlobalPs5RuntimeMode() &&
+        (Type() == PthreadMutexType::Normal || Type() == PthreadMutexType::AdaptiveNp) &&
+        m_count > 0) [[unlikely]] {
+        m_count--;
+    } else if (Type() == PthreadMutexType::Recursive && m_count > 0) [[unlikely]] {
         m_count--;
     } else {
         const bool deferred = True(m_flags & PthreadMutexFlags::Deferred);
@@ -396,6 +411,10 @@ s32 PS4_SYSV_ABI posix_pthread_mutexattr_gettype(PthreadMutexAttrT* attr, Pthrea
 s32 PS4_SYSV_ABI posix_pthread_mutexattr_destroy(PthreadMutexAttrT* attr) {
     if (attr == nullptr || *attr == nullptr) {
         return POSIX_EINVAL;
+    }
+    if (Core::IsGlobalPs5RuntimeMode()) {
+        // PS5 runtime paths may keep using attr handles after destroy?.
+        return 0;
     }
     delete *attr;
     *attr = nullptr;

--- a/src/core/libraries/libc_internal/libc_internal_memory.cpp
+++ b/src/core/libraries/libc_internal/libc_internal_memory.cpp
@@ -17,6 +17,10 @@ void* PS4_SYSV_ABI internal_memcpy(void* dest, const void* src, size_t n) {
     return std::memcpy(dest, src, n);
 }
 
+void* PS4_SYSV_ABI internal_memmove(void* dest, const void* src, size_t n) {
+    return std::memmove(dest, src, n);
+}
+
 s32 PS4_SYSV_ABI internal_memcpy_s(void* dest, size_t destsz, const void* src, size_t count) {
 #ifdef _WIN64
     return memcpy_s(dest, destsz, src, count);
@@ -34,6 +38,7 @@ void RegisterlibSceLibcInternalMemory(Core::Loader::SymbolsResolver* sym) {
 
     LIB_FUNCTION("NFLs+dRJGNg", "libSceLibcInternal", 1, "libSceLibcInternal", internal_memcpy_s);
     LIB_FUNCTION("Q3VBxCXhUHs", "libSceLibcInternal", 1, "libSceLibcInternal", internal_memcpy);
+    LIB_FUNCTION("+P6FRGH4LfA", "libSceLibcInternal", 1, "libSceLibcInternal", internal_memmove);
     LIB_FUNCTION("8zTFvBIAIN8", "libSceLibcInternal", 1, "libSceLibcInternal", internal_memset);
     LIB_FUNCTION("DfivPArhucg", "libSceLibcInternal", 1, "libSceLibcInternal", internal_memcmp);
 }

--- a/src/core/libraries/libc_internal/libc_internal_str.cpp
+++ b/src/core/libraries/libc_internal/libc_internal_str.cpp
@@ -60,6 +60,13 @@ const char* PS4_SYSV_ABI internal_strchr(const char* str, int c) {
     return std::strchr(str, c);
 }
 
+char* PS4_SYSV_ABI internal_strrchr(const char* str, int c) {
+    if (str == nullptr) {
+        return nullptr;
+    }
+    return const_cast<char*>(std::strrchr(str, c));
+}
+
 void RegisterlibSceLibcInternalStr(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("5Xa2ACNECdo", "libSceLibcInternal", 1, "libSceLibcInternal", internal_strcpy_s);
     LIB_FUNCTION("K+gcnFFJKVc", "libSceLibcInternal", 1, "libSceLibcInternal", internal_strcat_s);
@@ -70,6 +77,7 @@ void RegisterlibSceLibcInternalStr(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("YNzNkJzYqEg", "libSceLibcInternal", 1, "libSceLibcInternal", internal_strncpy_s);
     LIB_FUNCTION("Ls4tzzhimqQ", "libSceLibcInternal", 1, "libSceLibcInternal", internal_strcat);
     LIB_FUNCTION("ob5xAW4ln-0", "libSceLibcInternal", 1, "libSceLibcInternal", internal_strchr);
+    LIB_FUNCTION("9yDWMxEFdJU", "libSceLibcInternal", 1, "libSceLibcInternal", internal_strrchr);
 }
 
 } // namespace Libraries::LibcInternal

--- a/src/core/libraries/libc_internal/libc_internal_threads.cpp
+++ b/src/core/libraries/libc_internal/libc_internal_threads.cpp
@@ -4,6 +4,7 @@
 #include "core/libraries/kernel/threads.h"
 #include "core/libraries/libc_internal/libc_internal_threads.h"
 #include "core/libraries/libs.h"
+#include "core/linker.h"
 
 namespace Libraries::LibcInternal {
 
@@ -40,6 +41,29 @@ s32 PS4_SYSV_ABI internal__Mtxinit(Libraries::Kernel::PthreadMutexT* mtx, const 
     return 1;
 }
 
+s32 PS4_SYSV_ABI internal__MtxinitPs5(Libraries::Kernel::PthreadMutexT* mtx, s32 type) {
+    Libraries::Kernel::PthreadMutexAttrT attr{};
+    s32 result = Libraries::Kernel::posix_pthread_mutexattr_init(&attr);
+    if (result != 0) {
+        return 1;
+    }
+
+    // PS5 libc uses a type  _Mtx_init ABI here. 
+    // A recursive native mutex avoids self-lock stalls in CRT startup.
+    result = Libraries::Kernel::posix_pthread_mutexattr_settype(
+        &attr, Libraries::Kernel::PthreadMutexType::Recursive);
+
+    s32 mtx_init_result = result;
+    if (result == 0) {
+        char mtx_name[0x20];
+        std::snprintf(mtx_name, sizeof(mtx_name), "SceLibcI_%d", type);
+        mtx_init_result = Libraries::Kernel::scePthreadMutexInit(mtx, &attr, mtx_name);
+    }
+
+    result = Libraries::Kernel::posix_pthread_mutexattr_destroy(&attr);
+    return (mtx_init_result == 0 && result == 0) ? 0 : 1;
+}
+
 s32 PS4_SYSV_ABI internal__Mtxlock(Libraries::Kernel::PthreadMutexT* mtx) {
     s32 result = Libraries::Kernel::posix_pthread_mutex_lock(mtx);
     return result != 0;
@@ -57,6 +81,13 @@ s32 PS4_SYSV_ABI internal__Mtxdst(Libraries::Kernel::PthreadMutexT* mtx) {
 
 void RegisterlibSceLibcInternalThreads(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("z7STeF6abuU", "libSceLibcInternal", 1, "libSceLibcInternal", internal__Mtxinit);
+    if (Core::IsGlobalPs5RuntimeMode()) {
+        LIB_FUNCTION("YaHc3GS7y7g", "libSceLibcInternal", 1, "libSceLibcInternal",
+                     internal__MtxinitPs5);
+    } else {
+        LIB_FUNCTION("YaHc3GS7y7g", "libSceLibcInternal", 1, "libSceLibcInternal",
+                     internal__Mtxinit);
+    }
     LIB_FUNCTION("pE4Ot3CffW0", "libSceLibcInternal", 1, "libSceLibcInternal", internal__Mtxlock);
     LIB_FUNCTION("cMwgSSmpE5o", "libSceLibcInternal", 1, "libSceLibcInternal", internal__Mtxunlock);
     LIB_FUNCTION("LaPaA6mYA38", "libSceLibcInternal", 1, "libSceLibcInternal", internal__Mtxdst);

--- a/src/core/libraries/libs.cpp
+++ b/src/core/libraries/libs.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "core/libraries/ajm/ajm.h"
+#include "core/libraries/agc/agc.h"
+#include "core/libraries/ampr/ampr.h"
 #include "core/libraries/app_content/app_content.h"
 #include "core/libraries/audio/audioin.h"
 #include "core/libraries/audio/audioout.h"
@@ -51,6 +53,7 @@
 #include "core/libraries/random/random.h"
 #include "core/libraries/razor_cpu/razor_cpu.h"
 #include "core/libraries/remote_play/remoteplay.h"
+#include "core/libraries/rtc/rtc.h"
 #include "core/libraries/rudp/rudp.h"
 #include "core/libraries/save_data/dialog/savedatadialog.h"
 #include "core/libraries/save_data/savedata.h"
@@ -72,6 +75,7 @@
 #include "core/libraries/vr_tracker/vr_tracker.h"
 #include "core/libraries/web_browser_dialog/webbrowserdialog.h"
 #include "core/libraries/zlib/zlib_sce.h"
+#include "core/linker.h"
 #include "fiber/fiber.h"
 
 namespace Libraries {
@@ -80,6 +84,11 @@ void InitHLELibs(Core::Loader::SymbolsResolver* sym) {
     LOG_INFO(Lib_Kernel, "Initializing HLE libraries");
     Libraries::Kernel::RegisterLib(sym);
     Libraries::LibcInternal::ForceRegisterLib(sym);
+    if (Core::IsGlobalPs5RuntimeMode()) {
+        Libraries::Ampr::RegisterLib(sym);
+        Libraries::Rtc::RegisterLib(sym);
+        Libraries::Agc::RegisterLib(sym);
+    }
     Libraries::GnmDriver::RegisterLib(sym);
     Libraries::VideoOut::RegisterLib(sym);
     Libraries::UserService::RegisterLib(sym);

--- a/src/core/libraries/sysmodule/sysmodule_internal.cpp
+++ b/src/core/libraries/sysmodule/sysmodule_internal.cpp
@@ -6,6 +6,7 @@
 #include "common/logging/log.h"
 #include "core/emulator_settings.h"
 #include "core/file_sys/fs.h"
+#include "core/libraries/app_content/app_content.h"
 #include "core/libraries/disc_map/disc_map.h"
 #include "core/libraries/font/font.h"
 #include "core/libraries/font/fontft.h"
@@ -125,6 +126,35 @@ s32 loadModuleInternal(s32 index, s32 argc, const void* argv, s32* res_out) {
     OrbisSysmoduleModuleInternal& mod = g_modules_array[index];
     if (mod.is_loaded > 0) {
         mod.is_loaded++;
+        return ORBIS_OK;
+    }
+
+    if (Core::IsGlobalPs5RuntimeMode()) {
+        static s32 ps5_stub_handle = 0x5000;
+        bool registered_hle = false;
+        auto& hle_symbols = linker->GetHLESymbols();
+        if (std::strcmp(mod.name, "libSceAppContent") == 0) {
+            Libraries::AppContent::RegisterLib(&hle_symbols);
+            registered_hle = true;
+        } else if (std::strcmp(mod.name, "libSceRtc") == 0) {
+            Libraries::Rtc::RegisterLib(&hle_symbols);
+            registered_hle = true;
+        } else if (std::strcmp(mod.name, "libSceLibcInternal") == 0) {
+            Libraries::LibcInternal::RegisterLib(&hle_symbols);
+            registered_hle = true;
+        }
+
+        if (registered_hle) {
+            linker->RelocateAllImports();
+        }
+        mod.handle = ps5_stub_handle++;
+        mod.is_loaded++;
+        if (res_out != nullptr) {
+            *res_out = ORBIS_OK;
+        }
+        LOG_INFO(Lib_SysModule,
+                 "PS5 mode: satisfied sysmodule {} with HLE/stub handle {:#x}",
+                 mod.name, mod.handle);
         return ORBIS_OK;
     }
 

--- a/src/core/libraries/videoout/buffer.h
+++ b/src/core/libraries/videoout/buffer.h
@@ -60,9 +60,30 @@ struct BufferAttribute {
     u64 reserved1;
 };
 
+struct BufferAttribute2 {
+    u32 reserved0;
+    TilingMode tiling_mode;
+    s32 aspect_ratio;
+    u32 width;
+    u32 height;
+    u32 pitch_in_pixel;
+    u64 option;
+    u64 pixel_format;
+    u64 dcc_cb_register_clear_color;
+    u32 dcc_control;
+    u32 pad0;
+    u64 reserved1[3];
+};
+
 struct BufferAttributeGroup {
     bool is_occupied;
     BufferAttribute attrib;
+};
+
+struct VideoOutBuffers {
+    const void* data;
+    const void* metadata;
+    const void* reserved[2];
 };
 
 struct VideoOutBuffer {

--- a/src/core/libraries/videoout/video_out.cpp
+++ b/src/core/libraries/videoout/video_out.cpp
@@ -19,6 +19,10 @@ namespace Libraries::VideoOut {
 
 static std::unique_ptr<VideoOutDriver> driver;
 
+static PixelFormat ConvertPixelFormat2(u64 pixelFormat) {
+    return static_cast<PixelFormat>((pixelFormat >> 32u) | ((pixelFormat >> 16u) & 0xffffu));
+}
+
 void PS4_SYSV_ABI sceVideoOutSetBufferAttribute(BufferAttribute* attribute, PixelFormat pixelFormat,
                                                 u32 tilingMode, u32 aspectRatio, u32 width,
                                                 u32 height, u32 pitchInPixel) {
@@ -36,6 +40,27 @@ void PS4_SYSV_ABI sceVideoOutSetBufferAttribute(BufferAttribute* attribute, Pixe
     attribute->height = height;
     attribute->pitch_in_pixel = pitchInPixel;
     attribute->option = SCE_VIDEO_OUT_BUFFER_ATTRIBUTE_OPTION_NONE;
+}
+
+void PS4_SYSV_ABI sceVideoOutSetBufferAttribute2(BufferAttribute2* attribute, u64 pixelFormat,
+                                                 u32 tilingMode, u32 width, u32 height,
+                                                 u64 option, u32 dccControl,
+                                                 u64 dccCbRegisterClearColor) {
+    LOG_INFO(Lib_VideoOut,
+             "pixelFormat = {:#x}, tilingMode = {}, width = {}, height = {}, option = {:#x}, "
+             "dccControl = {:#x}, dccCbRegisterClearColor = {:#x}",
+             pixelFormat, tilingMode, width, height, option, dccControl, dccCbRegisterClearColor);
+
+    std::memset(attribute, 0, sizeof(BufferAttribute2));
+    attribute->pixel_format = pixelFormat;
+    attribute->tiling_mode = static_cast<TilingMode>(tilingMode);
+    attribute->aspect_ratio = 0;
+    attribute->width = width;
+    attribute->height = height;
+    attribute->pitch_in_pixel = 0;
+    attribute->option = option;
+    attribute->dcc_control = dccControl;
+    attribute->dcc_cb_register_clear_color = dccCbRegisterClearColor;
 }
 
 s32 PS4_SYSV_ABI sceVideoOutAddFlipEvent(Kernel::OrbisKernelEqueue eq, s32 handle, void* udata) {
@@ -136,6 +161,86 @@ s32 PS4_SYSV_ABI sceVideoOutRegisterBuffers(s32 handle, s32 startIndex, void* co
     }
 
     return driver->RegisterBuffers(port, startIndex, addresses, bufferNum, attribute);
+}
+
+s32 PS4_SYSV_ABI sceVideoOutRegisterBuffers2(s32 handle, s32 setIndex, s32 bufferIndexStart,
+                                             const VideoOutBuffers* buffers, s32 bufferNum,
+                                             const BufferAttribute2* attribute, s32 category,
+                                             void* option) {
+    if (!buffers) {
+        LOG_ERROR(Lib_VideoOut, "Buffers are null");
+        return ORBIS_VIDEO_OUT_ERROR_INVALID_ADDRESS;
+    }
+    if (!attribute) {
+        LOG_ERROR(Lib_VideoOut, "Attribute is null");
+        return ORBIS_VIDEO_OUT_ERROR_INVALID_OPTION;
+    }
+
+    auto* port = driver->GetPort(handle);
+    if (!port || !port->is_open) {
+        LOG_ERROR(Lib_VideoOut, "Invalid handle = {}", handle);
+        return ORBIS_VIDEO_OUT_ERROR_INVALID_HANDLE;
+    }
+
+    if (bufferIndexStart < 0 || bufferIndexStart > MaxDisplayBuffers || bufferNum < 1 ||
+        bufferNum > MaxDisplayBuffers || bufferIndexStart + bufferNum > MaxDisplayBuffers) {
+        LOG_ERROR(Lib_VideoOut,
+                  "Invalid buffer range bufferIndexStart = {}, bufferNum = {}", bufferIndexStart,
+                  bufferNum);
+        return ORBIS_VIDEO_OUT_ERROR_INVALID_VALUE;
+    }
+
+    if (option != nullptr || category != 0) {
+        LOG_ERROR(Lib_VideoOut, "Unsupported category = {}, option = {}", category, fmt::ptr(option));
+        return ORBIS_VIDEO_OUT_ERROR_INVALID_OPTION;
+    }
+    if (attribute->reserved0 != 0 || attribute->pad0 != 0 || attribute->reserved1[0] != 0 ||
+        attribute->reserved1[1] != 0 || attribute->reserved1[2] != 0) {
+        LOG_ERROR(Lib_VideoOut, "Invalid reserved members");
+        return ORBIS_VIDEO_OUT_ERROR_INVALID_VALUE;
+    }
+    if (attribute->dcc_control != 0 || attribute->dcc_cb_register_clear_color != 0) {
+        LOG_ERROR(Lib_VideoOut, "DCC attributes are not supported");
+        return ORBIS_VIDEO_OUT_ERROR_INVALID_VALUE;
+    }
+    if (attribute->pitch_in_pixel != 0) {
+        LOG_ERROR(Lib_VideoOut, "Invalid pitchInPixel = {}", attribute->pitch_in_pixel);
+        return ORBIS_VIDEO_OUT_ERROR_INVALID_PITCH;
+    }
+    if (attribute->option != SCE_VIDEO_OUT_BUFFER_ATTRIBUTE_OPTION_NONE &&
+        attribute->option != SCE_VIDEO_OUT_BUFFER_ATTRIBUTE_OPTION_STRICT_COLORIMETRY) {
+        LOG_ERROR(Lib_VideoOut, "Invalid option = {:#x}", attribute->option);
+        return ORBIS_VIDEO_OUT_ERROR_INVALID_OPTION;
+    }
+
+    std::array<void*, MaxDisplayBuffers> addresses{};
+    for (s32 i = 0; i < bufferNum; ++i) {
+        if (buffers[i].metadata != nullptr) {
+            LOG_ERROR(Lib_VideoOut, "Metadata buffers are not supported");
+            return ORBIS_VIDEO_OUT_ERROR_INVALID_ADDRESS;
+        }
+        addresses[i] = const_cast<void*>(buffers[i].data);
+    }
+
+    const BufferAttribute normalized = {
+        .pixel_format = ConvertPixelFormat2(attribute->pixel_format),
+        .tiling_mode = attribute->tiling_mode,
+        .aspect_ratio = attribute->aspect_ratio,
+        .width = attribute->width,
+        .height = attribute->height,
+        .pitch_in_pixel = attribute->width,
+        .option = static_cast<u32>(attribute->option),
+        .reserved0 = 0,
+        .reserved1 = 0,
+    };
+
+    LOG_INFO(Lib_VideoOut,
+             "setIndex = {}, bufferIndexStart = {}, bufferNum = {}, pixelFormat = {:#x}",
+             setIndex, bufferIndexStart, bufferNum, attribute->pixel_format);
+
+    const s32 result =
+        driver->RegisterBuffers(port, bufferIndexStart, addresses.data(), bufferNum, &normalized);
+    return result >= 0 ? ORBIS_OK : result;
 }
 
 s32 PS4_SYSV_ABI sceVideoOutSetFlipRate(s32 handle, s32 rate) {
@@ -461,11 +566,15 @@ void RegisterLib(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("SbU3dwp80lQ", "libSceVideoOut", 1, "libSceVideoOut", sceVideoOutGetFlipStatus);
     LIB_FUNCTION("U46NwOiJpys", "libSceVideoOut", 1, "libSceVideoOut", sceVideoOutSubmitFlip);
     LIB_FUNCTION("w3BY+tAEiQY", "libSceVideoOut", 1, "libSceVideoOut", sceVideoOutRegisterBuffers);
+    LIB_FUNCTION("rKBUtgRrtbk", "libSceVideoOut", 1, "libSceVideoOut",
+                 sceVideoOutRegisterBuffers2);
     LIB_FUNCTION("HXzjK9yI30k", "libSceVideoOut", 1, "libSceVideoOut", sceVideoOutAddFlipEvent);
     LIB_FUNCTION("Xru92wHJRmg", "libSceVideoOut", 1, "libSceVideoOut", sceVideoOutAddVblankEvent);
     LIB_FUNCTION("CBiu4mCE1DA", "libSceVideoOut", 1, "libSceVideoOut", sceVideoOutSetFlipRate);
     LIB_FUNCTION("i6-sR91Wt-4", "libSceVideoOut", 1, "libSceVideoOut",
                  sceVideoOutSetBufferAttribute);
+    LIB_FUNCTION("PjS5uASwcV8", "libSceVideoOut", 1, "libSceVideoOut",
+                 sceVideoOutSetBufferAttribute2);
     LIB_FUNCTION("6kPnj51T62Y", "libSceVideoOut", 1, "libSceVideoOut",
                  sceVideoOutGetResolutionStatus);
     LIB_FUNCTION("Up36PTk687E", "libSceVideoOut", 1, "libSceVideoOut", sceVideoOutOpen);

--- a/src/core/libraries/videoout/video_out.h
+++ b/src/core/libraries/videoout/video_out.h
@@ -119,10 +119,18 @@ struct OrbisVideoOutEventData {
 void PS4_SYSV_ABI sceVideoOutSetBufferAttribute(BufferAttribute* attribute, PixelFormat pixelFormat,
                                                 u32 tilingMode, u32 aspectRatio, u32 width,
                                                 u32 height, u32 pitchInPixel);
+void PS4_SYSV_ABI sceVideoOutSetBufferAttribute2(BufferAttribute2* attribute, u64 pixelFormat,
+                                                 u32 tilingMode, u32 width, u32 height,
+                                                 u64 option, u32 dccControl,
+                                                 u64 dccCbRegisterClearColor);
 s32 PS4_SYSV_ABI sceVideoOutAddFlipEvent(Kernel::OrbisKernelEqueue eq, s32 handle, void* udata);
 s32 PS4_SYSV_ABI sceVideoOutAddVblankEvent(Kernel::OrbisKernelEqueue eq, s32 handle, void* udata);
 s32 PS4_SYSV_ABI sceVideoOutRegisterBuffers(s32 handle, s32 startIndex, void* const* addresses,
                                             s32 bufferNum, const BufferAttribute* attribute);
+s32 PS4_SYSV_ABI sceVideoOutRegisterBuffers2(s32 handle, s32 setIndex, s32 bufferIndexStart,
+                                             const VideoOutBuffers* buffers, s32 bufferNum,
+                                             const BufferAttribute2* attribute, s32 category,
+                                             void* option);
 s32 PS4_SYSV_ABI sceVideoOutGetBufferLabelAddress(s32 handle, uintptr_t* label_addr);
 s32 PS4_SYSV_ABI sceVideoOutSetFlipRate(s32 handle, s32 rate);
 s32 PS4_SYSV_ABI sceVideoOutIsFlipPending(s32 handle);

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -25,11 +25,77 @@
 #ifndef _WIN32
 #include <signal.h>
 #endif
+#include <atomic>
+#include <set>
+#include <cstdio>
 
 namespace Core {
 
+static std::atomic<RuntimePlatform> g_runtime_platform{RuntimePlatform::PS4};
+
+void SetGlobalRuntimePlatform(RuntimePlatform platform) noexcept {
+    g_runtime_platform.store(platform, std::memory_order_relaxed);
+}
+
+RuntimePlatform GetGlobalRuntimePlatform() noexcept {
+    return g_runtime_platform.load(std::memory_order_relaxed);
+}
+
+bool IsGlobalPs5RuntimeMode() noexcept {
+    return GetGlobalRuntimePlatform() == RuntimePlatform::PS5;
+}
+
 static PS4_SYSV_ABI void ProgramExitFunc() {
     LOG_ERROR(Core_Linker, "Exit function called");
+}
+
+static bool IsLibcLibraryName(std::string_view name) {
+    return name == "libc" || name == "libSceLibcInternal" || name == "libSceLibcInternalExt";
+}
+
+static bool IsLibcModuleFileName(std::string_view name) {
+    if (name.ends_with(".sprx")) {
+        name.remove_suffix(5);
+    } else if (name.ends_with(".prx")) {
+        name.remove_suffix(4);
+    }
+    return IsLibcLibraryName(name);
+}
+
+static bool IsLibcSymbolRecord(const Loader::SymbolRecord& record) {
+    const auto ids = Common::SplitString(record.name, '#');
+    return ids.size() >= 2 && IsLibcLibraryName(ids[1]);
+}
+
+static bool IsRuntimeSymbolNameMatch(std::string_view symbol, std::string_view candidate) {
+    if (symbol == candidate) {
+        return true;
+    }
+    if (!symbol.empty() && symbol.front() == '_' && symbol.substr(1) == candidate) {
+        return true;
+    }
+    return !candidate.empty() && candidate.front() == '_' && candidate.substr(1) == symbol;
+}
+
+static Loader::SymbolType LoaderSymbolTypeFromElf(u8 type) {
+    switch (type) {
+    case STT_FUN:
+        return Loader::SymbolType::Function;
+    case STT_OBJECT:
+        return Loader::SymbolType::Object;
+    case STT_NOTYPE:
+        return Loader::SymbolType::NoType;
+    default:
+        return Loader::SymbolType::Unknown;
+    }
+}
+
+static bool IsRuntimeSymbolTypeCompatible(u8 type, Loader::SymbolType preferred_type) {
+    if (preferred_type == Loader::SymbolType::Unknown) {
+        return type == STT_FUN || type == STT_OBJECT || type == STT_NOTYPE;
+    }
+    return LoaderSymbolTypeFromElf(type) == preferred_type ||
+           (preferred_type == Loader::SymbolType::Function && type == STT_NOTYPE);
 }
 
 #ifdef ARCH_X86_64
@@ -54,15 +120,41 @@ static PS4_SYSV_ABI void* RunMainEntry [[noreturn]] (EntryParams* params) {
                  : "rax", "rsi", "rdi");
     UNREACHABLE();
 }
+
+static PS4_SYSV_ABI void* RunMainEntryPs5 [[noreturn]] (Ps5EntryParams* params) {
+    // PS5 entry frame process bootstrap:
+    // [0x00]=argc(u32), [0x04]=padding(u32), [0x08]=argv0(char*), [0x10]=0, [0x18]=0.
+    // Guest receives rdi=&entry_params and rsi=exit handler.
+    asm volatile("andq $-16, %%rsp\n"
+                 "subq $8, %%rsp\n"
+                 "pushq 8(%1)\n" // argv0
+                 "pushq 0(%1)\n" // argc|padding
+                 "movq %1, %%rdi\n"
+                 "movq %2, %%rsi\n"
+                 "jmp *%0\n"
+                 :
+                 : "r"(params->entry_addr), "r"(params), "r"(ProgramExitFunc)
+                 : "rax", "rsi", "rdi");
+    UNREACHABLE();
+}
 #endif
 
 Linker::Linker() : memory{Memory::Instance()} {}
 
 Linker::~Linker() = default;
 
+void Linker::SetRuntimePlatform(RuntimePlatform platform) noexcept {
+    runtime_platform = platform;
+    SetGlobalRuntimePlatform(platform);
+}
+
 void Linker::Execute(const std::vector<std::string>& args) {
     if (EmulatorSettings.IsDebugDump()) {
         DebugDump();
+    }
+
+    if (IsPs5RuntimeMode()) {
+        PreloadPs5AdjacentModules();
     }
 
     // Calculate static TLS size.
@@ -78,33 +170,37 @@ void Linker::Execute(const std::vector<std::string>& args) {
     u64 fmem_size = ORBIS_KERNEL_FLEXIBLE_MEMORY_SIZE;
     bool use_extended_mem1 = true, use_extended_mem2 = true;
 
-    const auto* proc_param = GetProcParam();
-    ASSERT(proc_param);
+    if (!IsPs5RuntimeMode()) {
+        const auto* proc_param = GetProcParam();
+        ASSERT(proc_param);
 
-    Core::OrbisKernelMemParam mem_param{};
-    if (proc_param->size >= offsetof(OrbisProcParam, mem_param) + sizeof(OrbisKernelMemParam*)) {
-        if (proc_param->mem_param) {
-            mem_param = *proc_param->mem_param;
-            if (mem_param.size >=
-                offsetof(OrbisKernelMemParam, flexible_memory_size) + sizeof(u64*)) {
-                if (const auto* flexible_size = mem_param.flexible_memory_size) {
-                    fmem_size = *flexible_size + ORBIS_KERNEL_FLEXIBLE_MEMORY_BASE;
+        Core::OrbisKernelMemParam mem_param{};
+        if (proc_param->size >= offsetof(OrbisProcParam, mem_param) + sizeof(OrbisKernelMemParam*)) {
+            if (proc_param->mem_param) {
+                mem_param = *proc_param->mem_param;
+                if (mem_param.size >=
+                    offsetof(OrbisKernelMemParam, flexible_memory_size) + sizeof(u64*)) {
+                    if (const auto* flexible_size = mem_param.flexible_memory_size) {
+                        fmem_size = *flexible_size + ORBIS_KERNEL_FLEXIBLE_MEMORY_BASE;
+                    }
                 }
             }
         }
-    }
 
-    if (mem_param.size < offsetof(OrbisKernelMemParam, extended_memory_1) + sizeof(u64*)) {
-        mem_param.extended_memory_1 = nullptr;
-    }
-    if (mem_param.size < offsetof(OrbisKernelMemParam, extended_memory_2) + sizeof(u64*)) {
-        mem_param.extended_memory_2 = nullptr;
-    }
+        if (mem_param.size < offsetof(OrbisKernelMemParam, extended_memory_1) + sizeof(u64*)) {
+            mem_param.extended_memory_1 = nullptr;
+        }
+        if (mem_param.size < offsetof(OrbisKernelMemParam, extended_memory_2) + sizeof(u64*)) {
+            mem_param.extended_memory_2 = nullptr;
+        }
 
-    const u64 sdk_ver = proc_param->sdk_version;
-    if (sdk_ver < Common::ElfInfo::FW_50) {
-        use_extended_mem1 = mem_param.extended_memory_1 ? *mem_param.extended_memory_1 : false;
-        use_extended_mem2 = mem_param.extended_memory_2 ? *mem_param.extended_memory_2 : false;
+        const u64 sdk_ver = proc_param->sdk_version;
+        if (sdk_ver < Common::ElfInfo::FW_50) {
+            use_extended_mem1 = mem_param.extended_memory_1 ? *mem_param.extended_memory_1 : false;
+            use_extended_mem2 = mem_param.extended_memory_2 ? *mem_param.extended_memory_2 : false;
+        }
+    } else {
+        LOG_INFO(Core_Linker, "PS5 mode enabled: using default memory region layout");
     }
 
     memory->SetupMemoryRegions(fmem_size, use_extended_mem1, use_extended_mem2);
@@ -120,34 +216,58 @@ void Linker::Execute(const std::vector<std::string>& args) {
             ipc.WaitForStart();
         }
 
-        // Have libSceSysmodule preload our libraries.
-        Libraries::SysModule::sceSysmodulePreloadModuleForLibkernel();
+        if (!IsPs5RuntimeMode()) {
+            // Have libSceSysmodule preload our libraries.
+            Libraries::SysModule::sceSysmodulePreloadModuleForLibkernel();
 
-        // Simulate libSceGnmDriver initialization, which maps a chunk of direct memory.
-        // Some games fail without accurately emulating this behavior.
-        s64 phys_addr{};
-        s32 result = Libraries::Kernel::sceKernelAllocateDirectMemory(
-            0, Libraries::Kernel::sceKernelGetDirectMemorySize(), 0x10000, 0x10000, 3, &phys_addr);
-        if (result == 0) {
-            void* addr{reinterpret_cast<void*>(0xfe0000000)};
-            result = Libraries::Kernel::sceKernelMapNamedDirectMemory(
-                &addr, 0x10000, 0x13, 0, phys_addr, 0x10000, "SceGnmDriver");
+            // Simulate libSceGnmDriver initialization, which maps a chunk of direct memory.
+            // Some games fail without accurately emulating this behavior.
+            s64 phys_addr{};
+            s32 result = Libraries::Kernel::sceKernelAllocateDirectMemory(
+                0, Libraries::Kernel::sceKernelGetDirectMemorySize(), 0x10000, 0x10000, 3,
+                &phys_addr);
+            if (result == 0) {
+                void* addr{reinterpret_cast<void*>(0xfe0000000)};
+                result = Libraries::Kernel::sceKernelMapNamedDirectMemory(
+                    &addr, 0x10000, 0x13, 0, phys_addr, 0x10000, "SceGnmDriver");
+            }
+            ASSERT_MSG(result == 0, "Unable to emulate libSceGnmDriver initialization");
+        } else {
+            LOG_INFO(Core_Linker,
+                     "PS5 mode enabled: skipping PS4 sysmodule preload and SceGnmDriver init");
+            StartPs5PreloadedModules();
         }
-        ASSERT_MSG(result == 0, "Unable to emulate libSceGnmDriver initialization");
 
         // Start main module.
         EntryParams& params = Libraries::Kernel::entry_params;
         params.argc = 1;
-        params.argv[0] = "eboot.bin";
+        std::fill(std::begin(params.argv_storage), std::end(params.argv_storage), nullptr);
+        params.argv_storage[0] = "eboot.bin";
+        params.argv = params.argv_storage;
         if (!args.empty()) {
-            constexpr int MaxArgs = sizeof(params.argv) / sizeof(params.argv[0]);
+            constexpr int MaxArgs =
+                static_cast<int>(sizeof(params.argv_storage) / sizeof(params.argv_storage[0]));
             params.argc = std::min<int>(args.size(), MaxArgs);
             for (int i = 0; i < params.argc; i++) {
-                params.argv[i] = args[i].c_str();
+                params.argv_storage[i] = args[i].c_str();
             }
         }
         params.entry_addr = module->GetEntryAddress();
-        RunMainEntry(&params);
+        if (IsPs5RuntimeMode()) {
+            Ps5EntryParams ps5_params{};
+            ps5_params.argc = 1;
+            ps5_params.padding = 0;
+            ps5_params.argv0 = "eboot.bin";
+            ps5_params.reserved0 = 0;
+            ps5_params.reserved1 = 0;
+            ps5_params.entry_addr = params.entry_addr;
+            LOG_INFO(Core_Linker,
+                     "PS5 mode: entering guest");
+            RunMainEntryPs5(&ps5_params);
+            return;
+        } else {
+            RunMainEntry(&params);
+        }
     });
 }
 
@@ -159,7 +279,7 @@ s32 Linker::LoadModule(const std::filesystem::path& elf_name, bool is_dynamic) {
         return -1;
     }
 
-    auto module = std::make_unique<Module>(memory, elf_name, max_tls_index);
+    auto module = std::make_unique<Module>(memory, elf_name, max_tls_index, IsPs5RuntimeMode());
     if (!module->IsValid()) {
         LOG_ERROR(Core_Linker, "Provided file {} is not valid ELF file", elf_name.string());
         return -1;
@@ -317,6 +437,74 @@ const Module* Linker::FindExportedModule(const ModuleInfo& module, const Library
 
 bool Linker::Resolve(const std::string& name, Loader::SymbolType sym_type, Module* m,
                      Loader::SymbolRecord* return_info) {
+    const auto resolve_from_loaded_exports_by_nid =
+        [this, sym_type](std::string_view nid) -> const Loader::SymbolRecord* {
+        for (const auto& loaded_module : m_modules) {
+            if (!loaded_module || loaded_module->export_sym.GetSize() == 0) {
+                continue;
+            }
+            if (const auto* record = loaded_module->export_sym.FindSymbolByNid(nid, sym_type)) {
+                return record;
+            }
+        }
+        return nullptr;
+    };
+
+    const auto resolve_from_loaded_runtime_symbol =
+        [this, sym_type](std::string_view nid, Loader::SymbolRecord* out,
+                         bool libc_modules_only) -> bool {
+        const auto* aeronid = AeroLib::FindByNid(std::string{nid}.c_str());
+        const std::string_view export_name = aeronid ? std::string_view{aeronid->name} : nid;
+
+        for (const auto& loaded_module : m_modules) {
+            if (!loaded_module || !loaded_module->dynamic_info.symbol_table ||
+                !loaded_module->dynamic_info.str_table ||
+                loaded_module->dynamic_info.symbol_table_total_size == 0) {
+                continue;
+            }
+            if (libc_modules_only && !IsLibcModuleFileName(loaded_module->name)) {
+                continue;
+            }
+
+            for (auto* sym = loaded_module->dynamic_info.symbol_table;
+                 reinterpret_cast<u8*>(sym) <
+                 reinterpret_cast<u8*>(loaded_module->dynamic_info.symbol_table) +
+                     loaded_module->dynamic_info.symbol_table_total_size;
+                 sym++) {
+                const u8 bind = sym->GetBind();
+                const u8 type = sym->GetType();
+                if ((bind != STB_GLOBAL && bind != STB_WEAK) || sym->st_value == 0 ||
+                    sym->st_name == 0 || !IsRuntimeSymbolTypeCompatible(type, sym_type)) {
+                    continue;
+                }
+
+                const std::string_view symbol_name{
+                    loaded_module->dynamic_info.str_table + sym->st_name};
+                const size_t nid_sep = symbol_name.find('#');
+                const std::string_view symbol_nid =
+                    nid_sep == std::string_view::npos ? symbol_name : symbol_name.substr(0, nid_sep);
+                if (symbol_nid != nid && !IsRuntimeSymbolNameMatch(symbol_name, export_name)) {
+                    continue;
+                }
+
+                const VAddr address = sym->st_value >= loaded_module->GetBaseAddress()
+                                          ? sym->st_value
+                                          : sym->st_value + loaded_module->GetBaseAddress();
+                if (address < 0x10000) {
+                    continue;
+                }
+
+                const auto loader_type = LoaderSymbolTypeFromElf(type);
+                out->name = std::string(symbol_name) + "#runtime#0#" + loaded_module->name + "#" +
+                            std::string(Loader::SymbolsResolver::SymbolTypeToS(loader_type));
+                out->nid_name = std::string(export_name);
+                out->virtual_address = address;
+                return true;
+            }
+        }
+        return false;
+    };
+
     const auto ids = Common::SplitString(name, '#');
     if (ids.size() != 3) {
         return_info->virtual_address = 0;
@@ -327,6 +515,57 @@ bool Linker::Resolve(const std::string& name, Loader::SymbolType sym_type, Modul
 
     const LibraryInfo* library = m->FindLibrary(ids[1]);
     const ModuleInfo* module = m->FindModule(ids[2]);
+    if ((!library || !module) && IsPs5RuntimeMode()) {
+        const auto* hle_record = m_hle_symbols.FindSymbolByNid(ids.at(0), sym_type);
+        {
+            if (const auto* export_record = resolve_from_loaded_exports_by_nid(ids.at(0));
+                export_record &&
+                (IsLibcSymbolRecord(*export_record) ||
+                 (hle_record && IsLibcSymbolRecord(*hle_record)))) {
+                *return_info = *export_record;
+                LOG_INFO(Core_Linker,
+                         "PS5 mode: resolved libc by module-export NID fallback {} -> {} "
+                         "(missing lib/module metadata: lib_id='{}', mod_id='{}')",
+                         ids.at(0), return_info->name, ids.at(1), ids.at(2));
+                return true;
+            }
+            if (hle_record && IsLibcSymbolRecord(*hle_record) &&
+                resolve_from_loaded_runtime_symbol(ids.at(0), return_info, true)) {
+                LOG_INFO(Core_Linker,
+                         "PS5 mode: resolved libc by runtime symbol {} -> {} "
+                         "(missing lib/module metadata: lib_id='{}', mod_id='{}')",
+                         ids.at(0), return_info->name, ids.at(1), ids.at(2));
+                return true;
+            }
+            if (!hle_record &&
+                resolve_from_loaded_runtime_symbol(ids.at(0), return_info, true)) {
+                LOG_INFO(Core_Linker,
+                         "PS5 mode: resolved libc by runtime symbol {} -> {} "
+                         "(missing lib/module metadata: lib_id='{}', mod_id='{}')",
+                         ids.at(0), return_info->name, ids.at(1), ids.at(2));
+                return true;
+            }
+        }
+        if (hle_record) {
+            *return_info = *hle_record;
+            LOG_INFO(Core_Linker,
+                     "PS5 mode: resolved by NID-only fallback {} -> {} "
+                     "(missing lib/module metadata: lib_id='{}', mod_id='{}')",
+                     ids.at(0), return_info->name, ids.at(1), ids.at(2));
+            return true;
+        }
+        if (const auto* export_record = resolve_from_loaded_exports_by_nid(ids.at(0))) {
+            *return_info = *export_record;
+            LOG_INFO(Core_Linker,
+                     "PS5 mode: resolved by module-export NID fallback {} -> {} "
+                     "(missing lib/module metadata: lib_id='{}', mod_id='{}')",
+                     ids.at(0), return_info->name, ids.at(1), ids.at(2));
+            return true;
+        }
+        return_info->virtual_address = AeroLib::GetStub(ids.at(0).c_str());
+        return_info->name = "Unknown !!!";
+        return false;
+    }
     ASSERT_MSG(library && module, "Unable to find library and module");
 
     Loader::SymbolResolver sr{};
@@ -336,10 +575,64 @@ bool Linker::Resolve(const std::string& name, Loader::SymbolType sym_type, Modul
     sr.module = module->name;
     sr.type = sym_type;
 
+    if (IsPs5RuntimeMode() && IsLibcLibraryName(sr.library)) {
+        if (const auto* p = FindExportedModule(*module, *library); p && p->export_sym.GetSize() > 0) {
+            if (const auto* record = p->export_sym.FindSymbol(sr)) {
+                *return_info = *record;
+                LOG_INFO(Core_Linker, "PS5 mode: resolved libc from loaded module {} -> {}",
+                         sr.name, return_info->name);
+                return true;
+            }
+        }
+        if (const auto* export_record = resolve_from_loaded_exports_by_nid(sr.name);
+            export_record && IsLibcSymbolRecord(*export_record)) {
+            *return_info = *export_record;
+            LOG_INFO(Core_Linker,
+                     "PS5 mode: resolved libc by module-export NID fallback {} -> {} "
+                     "(requested lib={}, mod={})",
+                     sr.name, return_info->name, sr.library, sr.module);
+            return true;
+        }
+        if (resolve_from_loaded_runtime_symbol(sr.name, return_info, true)) {
+            LOG_INFO(Core_Linker,
+                     "PS5 mode: resolved libc by runtime symbol {} -> {} "
+                     "(requested lib={}, mod={})",
+                     sr.name, return_info->name, sr.library, sr.module);
+            return true;
+        }
+    }
+
     const auto* record = m_hle_symbols.FindSymbol(sr);
     if (record) {
         *return_info = *record;
         Core::Devtools::Widget::ModuleList::AddModule(sr.library);
+        return true;
+    }
+
+    if (IsPs5RuntimeMode()) {
+        if (const auto* nid_record = m_hle_symbols.FindSymbolByNid(sr.name, sym_type)) {
+            *return_info = *nid_record;
+            LOG_INFO(Core_Linker,
+                     "PS5 mode: resolved by NID-only fallback {} -> {} "
+                     "(requested lib={}, mod={})",
+                     sr.name, return_info->name, sr.library, sr.module);
+            return true;
+        }
+        if (const auto* export_record = resolve_from_loaded_exports_by_nid(sr.name)) {
+            *return_info = *export_record;
+            LOG_INFO(Core_Linker,
+                     "PS5 mode: resolved by module-export NID fallback {} -> {} "
+                     "(requested lib={}, mod={})",
+                     sr.name, return_info->name, sr.library, sr.module);
+            return true;
+        }
+    }
+
+    if (IsLibcLibraryName(sr.library) &&
+        resolve_from_loaded_runtime_symbol(sr.name, return_info, true)) {
+        LOG_INFO(Core_Linker,
+                 "Resolved libc by loaded runtime symbol {} -> {} (requested lib={}, mod={})",
+                 sr.name, return_info->name, sr.library, sr.module);
         return true;
     }
 
@@ -459,6 +752,103 @@ void Linker::DebugDump() {
         elf.ElfHeaderDebugDump(filepath / "elfHeader.txt");
         elf.PHeaderDebugDump(filepath / "elfPHeaders.txt");
     }
+}
+
+void Linker::PreloadPs5AdjacentModules() {
+    if (m_modules.empty()) {
+        return;
+    }
+
+    const std::filesystem::path game_root = m_modules[0]->file.parent_path();
+    if (game_root.empty()) {
+        return;
+    }
+
+    static constexpr std::array<const char*, 2> CandidateDirs = {"sce_module", "sce_modules"};
+    static constexpr std::array<const char*, 2> SkipModules = {"libkernel.prx", "libkernel_sys.prx"};
+
+    std::vector<std::filesystem::path> preload_paths{};
+    for (const char* dir_name : CandidateDirs) {
+        const auto dir_path = game_root / dir_name;
+        if (!std::filesystem::exists(dir_path) || !std::filesystem::is_directory(dir_path)) {
+            continue;
+        }
+        for (const auto& entry : std::filesystem::directory_iterator(dir_path)) {
+            if (!entry.is_regular_file()) {
+                continue;
+            }
+            const auto ext = Common::ToLower(entry.path().extension().string());
+            if (ext != ".prx" && ext != ".sprx") {
+                continue;
+            }
+            const auto file_name = Common::ToLower(entry.path().filename().string());
+            if (std::ranges::contains(SkipModules, file_name)) {
+                continue;
+            }
+            if (!std::ranges::contains(preload_paths, entry.path())) {
+                preload_paths.emplace_back(entry.path());
+            }
+        }
+    }
+    std::ranges::sort(preload_paths, [](const auto& lhs, const auto& rhs) {
+        return Common::ToLower(lhs.filename().string()) < Common::ToLower(rhs.filename().string());
+    });
+
+    if (preload_paths.empty()) {
+        LOG_INFO(Core_Linker, "PS5 mode: no adjacent sce_module PRX/SPRX to preload");
+        return;
+    }
+
+    u32 loaded_count = 0;
+    for (const auto& module_path : preload_paths) {
+        if (FindByName(module_path) != static_cast<u32>(-1)) {
+            continue;
+        }
+
+        const s32 handle = LoadModule(module_path, true);
+        if (handle < 0) {
+            LOG_WARNING(Core_Linker, "PS5 mode: failed to preload {}", module_path.string());
+            continue;
+        }
+
+        Module* module = GetModule(handle);
+        if (!module) {
+            continue;
+        }
+
+        if (module->tls.image_size != 0) {
+            AdvanceGenerationCounter();
+        }
+        loaded_count++;
+    }
+
+    LOG_INFO(Core_Linker,
+             "PS5 mode: adjacent module preload summary loaded={}", loaded_count);
+}
+
+void Linker::StartPs5PreloadedModules() {
+    u32 started_count = 0;
+    u32 start_failures = 0;
+    for (size_t i = 1; i < m_modules.size(); i++) {
+        Module* module = m_modules[i].get();
+        if (!module || module->dynamic_info.init_virtual_addr == 0) {
+            continue;
+        }
+
+        auto* param = module->GetProcParam<OrbisProcParam*>();
+        ASSERT_MSG(!param || param->size >= 0x18, "Invalid module param size: {}", param->size);
+        const s32 start_result = module->Start(0, nullptr, param);
+        if (start_result != ORBIS_OK) {
+            start_failures++;
+            LOG_WARNING(Core_Linker, "PS5 mode: module {} start returned {}", module->name,
+                        start_result);
+        }
+        started_count++;
+    }
+
+    LOG_INFO(Core_Linker,
+             "PS5 mode: preloaded module start summary started={}, start_failures={}",
+             started_count, start_failures);
 }
 
 } // namespace Core

--- a/src/core/linker.h
+++ b/src/core/linker.h
@@ -15,6 +15,15 @@ struct DynamicModuleInfo;
 class Linker;
 class MemoryManager;
 
+enum class RuntimePlatform : u8 {
+    PS4 = 0,
+    PS5 = 1,
+};
+
+void SetGlobalRuntimePlatform(RuntimePlatform platform) noexcept;
+RuntimePlatform GetGlobalRuntimePlatform() noexcept;
+bool IsGlobalPs5RuntimeMode() noexcept;
+
 struct OrbisKernelMemParam {
     u64 size;
     u64* extended_page_table;
@@ -49,7 +58,17 @@ class Linker;
 struct EntryParams {
     int argc;
     u32 padding;
-    const char* argv[33];
+    const char** argv;
+    const char* argv_storage[33];
+    VAddr entry_addr;
+};
+
+struct Ps5EntryParams {
+    u32 argc;
+    u32 padding;
+    const char* argv0;
+    u64 reserved0;
+    u64 reserved1;
     VAddr entry_addr;
 };
 
@@ -135,6 +154,16 @@ public:
         heap_api = reinterpret_cast<AppHeapAPI>(func);
     }
 
+    void SetRuntimePlatform(RuntimePlatform platform) noexcept;
+
+    RuntimePlatform GetRuntimePlatform() const noexcept {
+        return runtime_platform;
+    }
+
+    bool IsPs5RuntimeMode() const noexcept {
+        return runtime_platform == RuntimePlatform::PS5;
+    }
+
     void AdvanceGenerationCounter() noexcept {
         dtv_generation_counter++;
     }
@@ -156,6 +185,8 @@ public:
 
 private:
     const Module* FindExportedModule(const ModuleInfo& m, const LibraryInfo& l);
+    void PreloadPs5AdjacentModules();
+    void StartPs5PreloadedModules();
 
     MemoryManager* memory;
     Libraries::Kernel::Thread main_thread;
@@ -165,6 +196,7 @@ private:
     u32 max_tls_index{};
     u32 num_static_modules{};
     AppHeapAPI heap_api{};
+    RuntimePlatform runtime_platform{RuntimePlatform::PS4};
     std::vector<std::unique_ptr<Module>> m_modules;
     Loader::SymbolsResolver m_hle_symbols{};
 };

--- a/src/core/loader/elf.cpp
+++ b/src/core/loader/elf.cpp
@@ -238,15 +238,30 @@ bool Elf::IsSelfFile() const {
         return false;
     }
 
-    if (m_self.version != 0x00 || m_self.mode != 0x01 || m_self.endian != 0x01 ||
-        m_self.attributes != 0x12) [[unlikely]] {
-        LOG_INFO(Loader, "Unknown SELF file");
+    if (m_self.endian != 0x01) [[unlikely]] {
+        LOG_INFO(Loader, "Unknown SELF file endian = {:#x}", m_self.endian);
         return false;
     }
 
-    if (m_self.category != 0x01 || m_self.program_type != 0x01) [[unlikely]] {
-        LOG_INFO(Loader, "Unknown SELF file");
-        return false;
+    if (!ps5_runtime_mode) {
+        if (m_self.version != 0x00 || m_self.mode != 0x01 || m_self.attributes != 0x12) [[unlikely]] {
+            LOG_INFO(Loader, "Unknown SELF file");
+            return false;
+        }
+
+        if (m_self.category != 0x01 || m_self.program_type != 0x01) [[unlikely]] {
+            LOG_INFO(Loader, "Unknown SELF file");
+            return false;
+        }
+    } else {
+        if (m_self.version != 0x00 || m_self.mode != 0x01 || m_self.attributes != 0x12 ||
+            m_self.category != 0x01 || m_self.program_type != 0x01) {
+            LOG_WARNING(Loader,
+                        "PS5 mode accepted non-PS4 SELF header fields "
+                        "(version={:#x}, mode={:#x}, attr={:#x}, category={:#x}, program={:#x})",
+                        m_self.version, m_self.mode, m_self.attributes, m_self.category,
+                        m_self.program_type);
+        }
     }
 
     return true;
@@ -278,16 +293,30 @@ bool Elf::IsElfFile() const {
         return false;
     }
 
-    if (m_elf_header.e_ident.ei_osabi != ELF_OSABI_FREEBSD) {
-        LOG_INFO(Loader, "e_ident[EI_OSABI] expected 0x09 is ({:#x})",
-                 static_cast<u32>(m_elf_header.e_ident.ei_osabi));
-        return false;
-    }
+    if (!ps5_runtime_mode) {
+        if (m_elf_header.e_ident.ei_osabi != ELF_OSABI_FREEBSD) {
+            LOG_INFO(Loader, "e_ident[EI_OSABI] expected 0x09 is ({:#x})",
+                     static_cast<u32>(m_elf_header.e_ident.ei_osabi));
+            return false;
+        }
 
-    if (m_elf_header.e_ident.ei_abiversion != ELF_ABI_VERSION_AMDGPU_HSA_V2) {
-        LOG_INFO(Loader, "e_ident[EI_ABIVERSION] expected 0x00 is ({:#x})",
-                 static_cast<u32>(m_elf_header.e_ident.ei_abiversion));
-        return false;
+        if (m_elf_header.e_ident.ei_abiversion != ELF_ABI_VERSION_AMDGPU_HSA_V2) {
+            LOG_INFO(Loader, "e_ident[EI_ABIVERSION] expected 0x00 is ({:#x})",
+                     static_cast<u32>(m_elf_header.e_ident.ei_abiversion));
+            return false;
+        }
+    } else {
+        if (m_elf_header.e_ident.ei_osabi != ELF_OSABI_FREEBSD) {
+            LOG_WARNING(Loader, "PS5 mode accepting non-FreeBSD EI_OSABI ({:#x})",
+                        static_cast<u32>(m_elf_header.e_ident.ei_osabi));
+        }
+        if (m_elf_header.e_ident.ei_abiversion != ELF_ABI_VERSION_AMDGPU_HSA_V2 &&
+            m_elf_header.e_ident.ei_abiversion != ELF_ABI_VERSION_AMDGPU_HSA_V3 &&
+            m_elf_header.e_ident.ei_abiversion != ELF_ABI_VERSION_AMDGPU_HSA_V4 &&
+            m_elf_header.e_ident.ei_abiversion != ELF_ABI_VERSION_AMDGPU_HSA_V5) {
+            LOG_WARNING(Loader, "PS5 mode encountered unknown EI_ABIVERSION ({:#x})",
+                        static_cast<u32>(m_elf_header.e_ident.ei_abiversion));
+        }
     }
 
     if (m_elf_header.e_type != ET_SCE_DYNEXEC && m_elf_header.e_type != ET_SCE_DYNAMIC &&

--- a/src/core/loader/elf.h
+++ b/src/core/loader/elf.h
@@ -465,6 +465,14 @@ public:
     Elf() = default;
     ~Elf();
 
+    void SetPs5RuntimeMode(bool enable) {
+        ps5_runtime_mode = enable;
+    }
+
+    bool IsPs5RuntimeMode() const noexcept {
+        return ps5_runtime_mode;
+    }
+
     void Open(const std::filesystem::path& file_name);
     bool IsSelfFile() const;
     bool IsElfFile() const;
@@ -508,6 +516,7 @@ public:
     void PHeaderDebugDump(const std::filesystem::path& file_name);
 
 private:
+    bool ps5_runtime_mode{};
     Common::FS::IOFile m_f{};
     bool is_self{};
     self_header m_self{};

--- a/src/core/loader/symbols_resolver.cpp
+++ b/src/core/loader/symbols_resolver.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <fmt/format.h>
+#include <array>
 #include "common/io_file.h"
 #include "common/string_util.h"
 #include "common/types.h"
@@ -28,6 +29,54 @@ const SymbolRecord* SymbolsResolver::FindSymbol(const SymbolResolver& s) const {
     }
 
     // LOG_INFO(Core_Linker, "Unresolved! {}", name);
+    return nullptr;
+}
+
+const SymbolRecord* SymbolsResolver::FindSymbolByNid(std::string_view nid,
+                                                      SymbolType preferred_type) const {
+    if (nid.empty()) {
+        return nullptr;
+    }
+
+    const auto find_by_type = [&](SymbolType type) -> const SymbolRecord* {
+        for (const auto& symbol : m_symbols) {
+            const std::string_view full_name{symbol.name};
+            const size_t first_sep = full_name.find('#');
+            if (first_sep == std::string_view::npos || full_name.substr(0, first_sep) != nid) {
+                continue;
+            }
+            if (type == SymbolType::Unknown) {
+                return &symbol;
+            }
+            const size_t last_sep = full_name.rfind('#');
+            if (last_sep == std::string_view::npos) {
+                continue;
+            }
+            if (full_name.substr(last_sep + 1) == SymbolTypeToS(type)) {
+                return &symbol;
+            }
+        }
+        return nullptr;
+    };
+
+    if (const auto* record = find_by_type(preferred_type)) {
+        return record;
+    }
+
+    static constexpr std::array<SymbolType, 4> FallbackTypes = {
+        SymbolType::Function,
+        SymbolType::Object,
+        SymbolType::NoType,
+        SymbolType::Unknown,
+    };
+    for (const auto type : FallbackTypes) {
+        if (type == preferred_type) {
+            continue;
+        }
+        if (const auto* record = find_by_type(type)) {
+            return record;
+        }
+    }
     return nullptr;
 }
 

--- a/src/core/loader/symbols_resolver.h
+++ b/src/core/loader/symbols_resolver.h
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <span>
 #include <string>
+#include <string_view>
 #include <vector>
 #include "common/assert.h"
 #include "common/types.h"
@@ -42,6 +43,7 @@ public:
 
     void AddSymbol(const SymbolResolver& s, u64 virtual_addr);
     const SymbolRecord* FindSymbol(const SymbolResolver& s) const;
+    const SymbolRecord* FindSymbolByNid(std::string_view nid, SymbolType preferred_type) const;
 
     void DebugDump(const std::filesystem::path& file_name);
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -10,8 +10,11 @@
 #include "core/libraries/kernel/memory.h"
 #include "core/libraries/kernel/orbis_error.h"
 #include "core/libraries/kernel/process.h"
+#include "core/linker.h"
 #include "core/memory.h"
 #include "video_core/renderer_vulkan/vk_rasterizer.h"
+
+#include <cstdio>
 
 namespace Core {
 
@@ -53,7 +56,9 @@ void MemoryManager::SetupMemoryRegions(u64 flexible_size, bool use_extended_mem1
     // Calculate actual direct and flexible memory sizes
     const bool is_neo = ::Libraries::Kernel::sceKernelIsNeoMode();
     auto total_size = is_neo ? ORBIS_KERNEL_TOTAL_MEM_PRO : ORBIS_KERNEL_TOTAL_MEM;
-    if (EmulatorSettings.IsDevKit()) {
+    if (Core::IsGlobalPs5RuntimeMode()) {
+        total_size = ORBIS_KERNEL_TOTAL_MEM_PS5;
+    } else if (EmulatorSettings.IsDevKit()) {
         total_size = is_neo ? ORBIS_KERNEL_TOTAL_MEM_DEV_PRO : ORBIS_KERNEL_TOTAL_MEM_DEV;
     }
     s32 extra_dmem = EmulatorSettings.GetExtraDmemInMBytes();
@@ -63,10 +68,10 @@ void MemoryManager::SetupMemoryRegions(u64 flexible_size, bool use_extended_mem1
                     extra_dmem, total_size, total_size + extra_dmem * 1_MB);
         total_size += extra_dmem * 1_MB;
     }
-    if (!use_extended_mem1 && is_neo) {
+    if (!Core::IsGlobalPs5RuntimeMode() && !use_extended_mem1 && is_neo) {
         total_size -= 256_MB;
     }
-    if (!use_extended_mem2 && !is_neo) {
+    if (!Core::IsGlobalPs5RuntimeMode() && !use_extended_mem2 && !is_neo) {
         total_size -= 128_MB;
     }
 
@@ -76,15 +81,29 @@ void MemoryManager::SetupMemoryRegions(u64 flexible_size, bool use_extended_mem1
     u64 old_direct_size = total_direct_size;
     total_direct_size = total_size - flexible_size;
 
-    // Limit direct memory space to match actual limit
-    auto last_dmem_area = FindDmemArea(total_direct_size);
-    ASSERT_MSG(last_dmem_area->second.dma_type == PhysicalMemoryType::Free &&
-                   last_dmem_area->second.size >= old_direct_size - total_direct_size,
-               "Unable to shrink dmem map");
-    last_dmem_area->second.size -= (old_direct_size - total_direct_size);
+    if (total_direct_size > old_direct_size) {
+        auto last_dmem_area = std::prev(dmem_map.end());
+        ASSERT_MSG(last_dmem_area->second.dma_type == PhysicalMemoryType::Free &&
+                       last_dmem_area->second.GetEnd() == old_direct_size,
+                   "Unable to grow dmem map");
+        last_dmem_area->second.size += total_direct_size - old_direct_size;
+    } else {
+        // Limit direct memory space to match actual limit.
+        auto last_dmem_area = FindDmemArea(total_direct_size);
+        ASSERT_MSG(last_dmem_area->second.dma_type == PhysicalMemoryType::Free &&
+                       last_dmem_area->second.size >= old_direct_size - total_direct_size,
+                   "Unable to shrink dmem map");
+        last_dmem_area->second.size -= (old_direct_size - total_direct_size);
+    }
 
     LOG_INFO(Kernel_Vmm, "Configured memory regions: flexible size = {:#x}, direct size = {:#x}",
              total_flexible_size, total_direct_size);
+    if (Core::IsGlobalPs5RuntimeMode()) {
+        std::fprintf(stderr,
+                     "Configured PS5 memory: flexible=0x%llx direct=0x%llx\n",
+                     static_cast<unsigned long long>(total_flexible_size),
+                     static_cast<unsigned long long>(total_direct_size));
+    }
 }
 
 u64 MemoryManager::ClampRangeSize(VAddr virtual_addr, u64 size) {
@@ -397,7 +416,7 @@ s32 MemoryManager::PoolCommit(VAddr virtual_addr, u64 size, MemoryProt prot, s32
         pool_budget -= size;
     }
 
-    if (True(prot & MemoryProt::CpuWrite)) {
+    if (!Core::IsGlobalPs5RuntimeMode() && True(prot & MemoryProt::CpuWrite)) {
         // On PS4, read is appended to write mappings.
         prot |= MemoryProt::CpuRead;
     }
@@ -485,7 +504,7 @@ MemoryManager::VMAHandle MemoryManager::CreateArea(VAddr virtual_addr, u64 size,
     const auto new_vma_handle = CarveVMA(virtual_addr, size);
     auto& new_vma = new_vma_handle->second;
     const bool is_exec = True(prot & MemoryProt::CpuExec);
-    if (True(prot & MemoryProt::CpuWrite)) {
+    if (!Core::IsGlobalPs5RuntimeMode() && True(prot & MemoryProt::CpuWrite)) {
         // On PS4, read is appended to write mappings.
         prot |= MemoryProt::CpuRead;
     }
@@ -695,7 +714,7 @@ s32 MemoryManager::MapFile(void** out_addr, VAddr virtual_addr, u64 size, Memory
         return ORBIS_KERNEL_ERROR_EBADF;
     }
 
-    if (True(prot & MemoryProt::CpuWrite)) {
+    if (!Core::IsGlobalPs5RuntimeMode() && True(prot & MemoryProt::CpuWrite)) {
         // On PS4, read is appended to write mappings.
         prot |= MemoryProt::CpuRead;
     }
@@ -989,7 +1008,7 @@ s64 MemoryManager::ProtectBytes(VAddr addr, VirtualMemoryArea& vma_base, u64 siz
         return adjusted_size;
     }
 
-    if (True(prot & MemoryProt::CpuWrite)) {
+    if (!Core::IsGlobalPs5RuntimeMode() && True(prot & MemoryProt::CpuWrite)) {
         // On PS4, read is appended to write mappings.
         prot |= MemoryProt::CpuRead;
     }
@@ -1016,8 +1035,9 @@ s64 MemoryManager::ProtectBytes(VAddr addr, VirtualMemoryArea& vma_base, u64 siz
         perms |= Core::MemoryPermission::ReadWrite;
     }
 
-    if (vma_base.type == VMAType::Direct || vma_base.type == VMAType::Pooled ||
-        vma_base.type == VMAType::File) {
+    if (!Core::IsGlobalPs5RuntimeMode() &&
+        (vma_base.type == VMAType::Direct || vma_base.type == VMAType::Pooled ||
+         vma_base.type == VMAType::File)) {
         // On PS4, execute permissions are hidden from direct memory and file mappings.
         // Tests show that execute permissions still apply, so handle this after reading perms.
         prot &= ~MemoryProt::CpuExec;
@@ -1091,8 +1111,19 @@ s32 MemoryManager::VirtualQuery(VAddr addr, s32 flags,
     std::shared_lock lk{mutex};
     auto it = FindVMA(query_addr);
 
-    while (it != vma_map.end() && it->second.type == VMAType::Free && flags == 1) {
-        ++it;
+    if (Core::IsGlobalPs5RuntimeMode() && flags == 1) {
+        const bool contains_query =
+            it != vma_map.end() && it->second.Contains(query_addr, 1);
+        if (!contains_query && it != vma_map.end() && it->second.base <= query_addr) {
+            ++it;
+        }
+        while (it != vma_map.end() && it->second.type == VMAType::Free) {
+            ++it;
+        }
+    } else {
+        while (it != vma_map.end() && it->second.type == VMAType::Free && flags == 1) {
+            ++it;
+        }
     }
     if (it == vma_map.end() || it->second.type == VMAType::Free) {
         LOG_WARNING(Kernel_Vmm, "VirtualQuery on free memory region");

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -15,6 +15,7 @@
 #include "core/memory.h"
 #include "core/module.h"
 #include "core/tls.h"
+#include <cstdio>
 
 namespace Core {
 
@@ -83,8 +84,11 @@ static std::string StringToNid(std::string_view symbol) {
     return dst;
 }
 
-Module::Module(Core::MemoryManager* memory_, const std::filesystem::path& file_, u32& max_tls_index)
-    : memory{memory_}, file{file_}, name{file.filename().string()} {
+Module::Module(Core::MemoryManager* memory_, const std::filesystem::path& file_, u32& max_tls_index,
+               bool ps5_runtime_mode)
+    : memory{memory_}, file{file_}, name{file.filename().string()},
+      is_ps5_runtime_mode{ps5_runtime_mode} {
+    elf.SetPs5RuntimeMode(is_ps5_runtime_mode);
     elf.Open(file);
     if (elf.IsElfFile()) {
         LoadModuleToMemory(max_tls_index);
@@ -97,7 +101,19 @@ Module::~Module() = default;
 
 s32 Module::Start(u64 args, const void* argp, void* param) {
     LOG_INFO(Core_Linker, "Module started : {}", name);
-    const VAddr addr = dynamic_info.init_virtual_addr + GetBaseAddress();
+    const VAddr addr =
+        is_ps5_runtime_mode && dynamic_info.init_virtual_addr >= GetBaseAddress()
+            ? dynamic_info.init_virtual_addr
+            : dynamic_info.init_virtual_addr + GetBaseAddress();
+    if (is_ps5_runtime_mode && addr < 0x10000) {
+        LOG_INFO(Core_Linker,
+                 "PS5 mode: skipping low DT_INIT for module {} (addr={:#x})", name,
+                 dynamic_info.init_virtual_addr);
+        return ORBIS_OK;
+    }
+    if (is_ps5_runtime_mode) {
+        LOG_INFO(Core_Linker, "PS5 mode: starting module {} DT_INIT at {:#x}", name, addr);
+    }
     return reinterpret_cast<EntryFunc>(addr)(args, argp, param);
 }
 
@@ -134,11 +150,14 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
     LOG_INFO(Core_Linker, "base_virtual_addr ......: {:#018x}", base_virtual_addr);
     LOG_INFO(Core_Linker, "base_size ..............: {:#018x}", base_size);
     LOG_INFO(Core_Linker, "aligned_base_size ......: {:#018x}", aligned_base_size);
+    std::vector<std::pair<VAddr, VAddr>> ps5_mapped_ranges{};
 
-    const auto add_segment = [this](const elf_program_header& phdr, bool do_map = true) {
+    const auto add_segment = [this, &ps5_mapped_ranges](const elf_program_header& phdr,
+                                                         bool do_map = true) {
         const VAddr segment_vaddr = base_virtual_addr + phdr.p_vaddr;
         void* segment_addr = std::bit_cast<void*>(segment_vaddr);
         const u64 segment_size = GetAlignedSize(phdr);
+        const VAddr segment_end = segment_vaddr + segment_size;
         if (do_map) {
             // Convert ELF flags to memory prot.
             auto segment_prot = MemoryProt::NoAccess;
@@ -151,14 +170,77 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
             if ((phdr.p_flags & PF_EXEC) != 0) {
                 segment_prot |= MemoryProt::CpuExec;
             }
+            if (is_ps5_runtime_mode && segment_prot == MemoryProt::NoAccess && phdr.p_filesz != 0) {
+                // PS5 binaries may expose loadable file-backed segments with no PF_* bits.
+                // Mapping these as NoAccess creates unbacked map regions that are fragile to split.
+                // Keep this PS5-only and writable so the segment payload can be loaded reliably.
+                segment_prot = MemoryProt::CpuReadWrite;
+            }
 
-            // Map module segments
-            const auto memory_type = IsSystemLib() ? VMAType::Code : VMAType::Flexible;
-            s32 result = memory->MapMemory(&segment_addr, segment_vaddr, segment_size, segment_prot,
-                                           MemoryMapFlags::Fixed, memory_type, name);
-            ASSERT_MSG(result == ORBIS_OK, "Failed to map segment at {:#x} for module {}",
-                       segment_vaddr, name);
-            elf.LoadSegment(segment_vaddr, phdr.p_offset, phdr.p_filesz);
+            bool mapped_in_existing_ps5_range = false;
+            if (is_ps5_runtime_mode) {
+                mapped_in_existing_ps5_range = std::ranges::any_of(
+                    ps5_mapped_ranges,
+                    [segment_vaddr, segment_end](const std::pair<VAddr, VAddr>& mapped_range) {
+                        return mapped_range.first <= segment_vaddr &&
+                               segment_end <= mapped_range.second;
+                    });
+            }
+
+            VAddr mapped_segment_vaddr = segment_vaddr;
+            u64 mapped_segment_size = segment_size;
+#ifdef _WIN32
+            if (is_ps5_runtime_mode) {
+                // Some PS5 PT_LOAD virtual addresses are not page-aligned.
+                // Align to host page granularity to keep it valid.
+                constexpr u64 HostPlaceholderGranularity = 0x1000;
+                mapped_segment_vaddr = Common::AlignDown(segment_vaddr, HostPlaceholderGranularity);
+                mapped_segment_size =
+                    Common::AlignUp(segment_end - mapped_segment_vaddr, HostPlaceholderGranularity);
+            }
+#endif
+            if (!mapped_in_existing_ps5_range) {
+                const auto memory_type = IsSystemLib() ? VMAType::Code : VMAType::Flexible;
+                s32 result =
+                    memory->MapMemory(&segment_addr, mapped_segment_vaddr, mapped_segment_size,
+                                      segment_prot, MemoryMapFlags::Fixed, memory_type, name);
+                ASSERT_MSG(result == ORBIS_OK, "Failed to map segment at {:#x} for module {}",
+                           mapped_segment_vaddr, name);
+                if (is_ps5_runtime_mode) {
+                    ps5_mapped_ranges.emplace_back(mapped_segment_vaddr,
+                                                   mapped_segment_vaddr + mapped_segment_size);
+                }
+            } else {
+                LOG_INFO(Core_Linker,
+                         "PS5 mode: segment range [{:#x}, {:#x}) already mapped, skipping "
+                         "remap",
+                         segment_vaddr, segment_end);
+            }
+
+            if (phdr.p_filesz != 0) {
+                if (is_ps5_runtime_mode && !True(segment_prot & MemoryProt::CpuWrite)) {
+                    const auto load_prot =
+                        segment_prot | MemoryProt::CpuRead | MemoryProt::CpuWrite;
+                    s32 result = memory->Protect(segment_vaddr, segment_size, load_prot);
+                    ASSERT_MSG(result == ORBIS_OK,
+                               "Failed to set temporary load protections at {:#x} for module {}",
+                               segment_vaddr, name);
+                    elf.LoadSegment(segment_vaddr, phdr.p_offset, phdr.p_filesz);
+                    if (!mapped_in_existing_ps5_range) {
+                        result = memory->Protect(segment_vaddr, segment_size, segment_prot);
+                        ASSERT_MSG(result == ORBIS_OK,
+                                   "Failed to restore segment protections at {:#x} for module {}",
+                                   segment_vaddr, name);
+                        if (is_ps5_runtime_mode && True(segment_prot & MemoryProt::CpuExec)) {
+                            memory->GetAddressSpace().Protect(mapped_segment_vaddr,
+                                                               mapped_segment_size,
+                                                               MemoryPermission::ReadWriteExecute);
+                        }
+                    }
+                } else {
+                    elf.LoadSegment(segment_vaddr, phdr.p_offset, phdr.p_filesz);
+                }
+            }
         }
         if (info.num_segments < 4) {
             auto& segment = info.segments[info.num_segments++];
@@ -198,6 +280,16 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
 #endif
             break;
         }
+        case PT_GNU_RELRO:
+            if (is_ps5_runtime_mode) {
+                LOG_INFO(Core_Linker,
+                         "PS5 mode: accepting PT_GNU_RELRO descriptor at {:#018x}, "
+                         "size={:#018x}",
+                         elf_pheader[i].p_vaddr + base_virtual_addr, elf_pheader[i].p_memsz);
+                break;
+            }
+            LOG_ERROR(Core_Linker, "Unimplemented type {}", header_type);
+            break;
         case PT_DYNAMIC:
             add_segment(elf_pheader[i], false);
             if (elf_pheader[i].p_filesz != 0) {
@@ -263,26 +355,80 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
 }
 
 void Module::LoadDynamicInfo() {
+    constexpr s64 DT_STD_PLTGOT = 0x00000003;
+    constexpr s64 DT_STD_STRTAB = 0x00000005;
+    constexpr s64 DT_STD_SYMTAB = 0x00000006;
+    constexpr s64 DT_STD_RELASZ = 0x00000008;
+    constexpr s64 DT_STD_RELAENT = 0x00000009;
+    constexpr s64 DT_STD_STRSZ = 0x0000000a;
+    constexpr s64 DT_STD_SYMENT = 0x0000000b;
+    constexpr s64 DT_STD_PLTREL = 0x00000014;
+    constexpr s64 DT_STD_JMPREL = 0x00000017;
+    constexpr s64 DT_STD_PLTRELSZ = 0x00000002;
+
+    std::vector<u64> deferred_needed_offsets{};
+    const auto resolve_dynamic_ptr = [this](u64 value) -> u8* {
+        // PS4 dynlib metadata uses offsets in PT_SCE_DYNLIBDATA.
+        if (value < m_dynamic_data.size()) {
+            return m_dynamic_data.data() + value;
+        }
+        if (is_ps5_runtime_mode) {
+            // PS5 metadata often uses image-relative virtual addresses.
+            const VAddr image_addr = base_virtual_addr + value;
+            if (image_addr >= base_virtual_addr && image_addr < base_virtual_addr + aligned_base_size) {
+                return reinterpret_cast<u8*>(image_addr);
+            }
+        }
+        return nullptr;
+    };
+
     for (const auto* dyn = reinterpret_cast<elf_dynamic*>(m_dynamic.data()); dyn->d_tag != DT_NULL;
          dyn++) {
         switch (dyn->d_tag) {
         case DT_SCE_HASH: // Offset of the hash table.
-            dynamic_info.hash_table =
-                reinterpret_cast<void*>(m_dynamic_data.data() + dyn->d_un.d_ptr);
+            if (const auto* ptr = resolve_dynamic_ptr(dyn->d_un.d_ptr)) {
+                dynamic_info.hash_table = const_cast<u8*>(ptr);
+            }
             break;
         case DT_SCE_HASHSZ: // Size of the hash table
             dynamic_info.hash_table_size = dyn->d_un.d_val;
             break;
+        case DT_STD_STRTAB:
+            if (is_ps5_runtime_mode) {
+                if (const auto* ptr = resolve_dynamic_ptr(dyn->d_un.d_ptr)) {
+                    dynamic_info.str_table = reinterpret_cast<char*>(const_cast<u8*>(ptr));
+                }
+            }
+            break;
+        case DT_STD_STRSZ:
+            if (is_ps5_runtime_mode && dynamic_info.str_table_size == 0) {
+                dynamic_info.str_table_size = dyn->d_un.d_val;
+            }
+            break;
         case DT_SCE_STRTAB: // Offset of the string table.
-            dynamic_info.str_table =
-                reinterpret_cast<char*>(m_dynamic_data.data() + dyn->d_un.d_ptr);
+            if (const auto* ptr = resolve_dynamic_ptr(dyn->d_un.d_ptr)) {
+                dynamic_info.str_table = reinterpret_cast<char*>(const_cast<u8*>(ptr));
+            }
             break;
         case DT_SCE_STRSZ: // Size of the string table.
             dynamic_info.str_table_size = dyn->d_un.d_val;
             break;
+        case DT_STD_SYMTAB:
+            if (is_ps5_runtime_mode) {
+                if (const auto* ptr = resolve_dynamic_ptr(dyn->d_un.d_ptr)) {
+                    dynamic_info.symbol_table = reinterpret_cast<elf_symbol*>(const_cast<u8*>(ptr));
+                }
+            }
+            break;
         case DT_SCE_SYMTAB: // Offset of the symbol table.
-            dynamic_info.symbol_table =
-                reinterpret_cast<elf_symbol*>(m_dynamic_data.data() + dyn->d_un.d_ptr);
+            if (const auto* ptr = resolve_dynamic_ptr(dyn->d_un.d_ptr)) {
+                dynamic_info.symbol_table = reinterpret_cast<elf_symbol*>(const_cast<u8*>(ptr));
+            }
+            break;
+        case DT_STD_SYMENT:
+            if (is_ps5_runtime_mode && dynamic_info.symbol_table_entries_size == 0) {
+                dynamic_info.symbol_table_entries_size = dyn->d_un.d_val;
+            }
             break;
         case DT_SCE_SYMTABSZ: // Size of the symbol table.
             dynamic_info.symbol_table_total_size = dyn->d_un.d_val;
@@ -296,12 +442,37 @@ void Module::LoadDynamicInfo() {
         case DT_SCE_PLTGOT: // Offset of the global offset table.
             dynamic_info.pltgot_virtual_addr = dyn->d_un.d_ptr;
             break;
+        case DT_STD_PLTGOT:
+            if (is_ps5_runtime_mode && dynamic_info.pltgot_virtual_addr == 0) {
+                dynamic_info.pltgot_virtual_addr = dyn->d_un.d_ptr;
+            }
+            break;
+        case DT_STD_JMPREL:
+            if (is_ps5_runtime_mode) {
+                if (const auto* ptr = resolve_dynamic_ptr(dyn->d_un.d_ptr)) {
+                    dynamic_info.jmp_relocation_table =
+                        reinterpret_cast<elf_relocation*>(const_cast<u8*>(ptr));
+                }
+            }
+            break;
         case DT_SCE_JMPREL: // Offset of the table containing jump slots.
-            dynamic_info.jmp_relocation_table =
-                reinterpret_cast<elf_relocation*>(m_dynamic_data.data() + dyn->d_un.d_ptr);
+            if (const auto* ptr = resolve_dynamic_ptr(dyn->d_un.d_ptr)) {
+                dynamic_info.jmp_relocation_table =
+                    reinterpret_cast<elf_relocation*>(const_cast<u8*>(ptr));
+            }
+            break;
+        case DT_STD_PLTRELSZ:
+            if (is_ps5_runtime_mode && dynamic_info.jmp_relocation_table_size == 0) {
+                dynamic_info.jmp_relocation_table_size = dyn->d_un.d_val;
+            }
             break;
         case DT_SCE_PLTRELSZ: // Size of the global offset table.
             dynamic_info.jmp_relocation_table_size = dyn->d_un.d_val;
+            break;
+        case DT_STD_PLTREL:
+            if (is_ps5_runtime_mode && dynamic_info.jmp_relocation_type == 0) {
+                dynamic_info.jmp_relocation_type = dyn->d_un.d_val;
+            }
             break;
         case DT_SCE_PLTREL: // The type of relocations in the relocation table. Should be DT_RELA
             dynamic_info.jmp_relocation_type = dyn->d_un.d_val;
@@ -309,12 +480,32 @@ void Module::LoadDynamicInfo() {
                 LOG_WARNING(Core_Linker, "DT_SCE_PLTREL is NOT DT_RELA should check!");
             }
             break;
+        case DT_RELA:
+            if (is_ps5_runtime_mode) {
+                if (const auto* ptr = resolve_dynamic_ptr(dyn->d_un.d_ptr)) {
+                    dynamic_info.relocation_table =
+                        reinterpret_cast<elf_relocation*>(const_cast<u8*>(ptr));
+                }
+            }
+            break;
         case DT_SCE_RELA: // Offset of the relocation table.
-            dynamic_info.relocation_table =
-                reinterpret_cast<elf_relocation*>(m_dynamic_data.data() + dyn->d_un.d_ptr);
+            if (const auto* ptr = resolve_dynamic_ptr(dyn->d_un.d_ptr)) {
+                dynamic_info.relocation_table =
+                    reinterpret_cast<elf_relocation*>(const_cast<u8*>(ptr));
+            }
+            break;
+        case DT_STD_RELASZ:
+            if (is_ps5_runtime_mode && dynamic_info.relocation_table_size == 0) {
+                dynamic_info.relocation_table_size = dyn->d_un.d_val;
+            }
             break;
         case DT_SCE_RELASZ: // Size of the relocation table.
             dynamic_info.relocation_table_size = dyn->d_un.d_val;
+            break;
+        case DT_STD_RELAENT:
+            if (is_ps5_runtime_mode && dynamic_info.relocation_table_entries_size == 0) {
+                dynamic_info.relocation_table_entries_size = dyn->d_un.d_val;
+            }
             break;
         case DT_SCE_RELAENT: // The size of relocation table entries.
             dynamic_info.relocation_table_entries_size = dyn->d_un.d_val;
@@ -364,6 +555,8 @@ void Module::LoadDynamicInfo() {
             // In theory this should already be filled from about just make a test case
             if (dynamic_info.str_table) {
                 dynamic_info.needed.push_back(dynamic_info.str_table + dyn->d_un.d_val);
+            } else if (is_ps5_runtime_mode) {
+                deferred_needed_offsets.push_back(dyn->d_un.d_val);
             } else {
                 LOG_ERROR(Core_Linker, "DT_NEEDED str table is not loaded should check!");
             }
@@ -423,6 +616,19 @@ void Module::LoadDynamicInfo() {
             LOG_INFO(Core_Linker, "unsupported dynamic tag ..........: {:#018x}", dyn->d_tag);
         }
     }
+
+    if (is_ps5_runtime_mode && dynamic_info.symbol_table_total_size == 0 &&
+        dynamic_info.symbol_table && dynamic_info.str_table &&
+        dynamic_info.str_table > reinterpret_cast<char*>(dynamic_info.symbol_table)) {
+        dynamic_info.symbol_table_total_size = reinterpret_cast<u8*>(dynamic_info.str_table) -
+                                               reinterpret_cast<u8*>(dynamic_info.symbol_table);
+    }
+    if (is_ps5_runtime_mode && dynamic_info.str_table && !deferred_needed_offsets.empty()) {
+        for (const auto needed_offset : deferred_needed_offsets) {
+            dynamic_info.needed.push_back(dynamic_info.str_table + needed_offset);
+        }
+    }
+
     const u32 relabits_num = dynamic_info.relocation_table_size / sizeof(elf_relocation) +
                              dynamic_info.jmp_relocation_table_size / sizeof(elf_relocation);
     rela_bits.resize((relabits_num + 7) / 8);
@@ -450,7 +656,12 @@ void Module::LoadSymbols() {
 
             const auto* library = FindLibrary(ids[1]);
             const auto* module = FindModule(ids[2]);
-            ASSERT_MSG(library && module, "Unable to find library and module");
+            if (!library || !module) {
+                if (is_ps5_runtime_mode) {
+                    continue;
+                }
+                ASSERT_MSG(library && module, "Unable to find library and module");
+            }
             if ((bind != STB_GLOBAL && bind != STB_WEAK) ||
                 (type != STT_FUN && type != STT_OBJECT) || export_func != (sym->st_value != 0)) {
                 continue;

--- a/src/core/module.h
+++ b/src/core/module.h
@@ -142,7 +142,7 @@ class MemoryManager;
 class Module {
 public:
     explicit Module(Core::MemoryManager* memory, const std::filesystem::path& file,
-                    u32& max_tls_index);
+                    u32& max_tls_index, bool ps5_runtime_mode = false);
     ~Module();
 
     VAddr GetBaseAddress() const noexcept {
@@ -242,6 +242,7 @@ public:
     ThreadLocalImage tls{};
     OrbisKernelModuleInfo info{};
     std::vector<u8> rela_bits;
+    bool is_ps5_runtime_mode{};
 };
 
 } // namespace Core

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <cstdio>
 #include <set>
 #include <sstream>
 #include <fmt/core.h>
@@ -32,12 +33,14 @@
 #include "core/file_format/psf.h"
 #include "core/file_format/trp.h"
 #include "core/file_sys/fs.h"
+#include "core/loader/elf.h"
 #include "core/libraries/kernel/kernel.h"
 #include "core/libraries/libs.h"
 #include "core/libraries/np/np_trophy.h"
 #include "core/libraries/save_data/save_backup.h"
 #include "core/linker.h"
 #include "core/memory.h"
+#include "core/signals.h"
 #include "core/user_settings.h"
 #include "emulator.h"
 #include "video_core/cache_storage.h"
@@ -89,6 +92,55 @@ s32 ReadCompiledSdkVersion(const std::filesystem::path& file) {
         return param.sdk_version;
     }
     return 0;
+}
+
+static bool TryReadExecutableElfHeader(const std::filesystem::path& file_path, elf_header& out_header) {
+    Common::FS::IOFile file(file_path, Common::FS::FileAccessMode::Read);
+    if (!file.IsOpen()) {
+        return false;
+    }
+
+    self_header self{};
+    if (!file.ReadObject(self)) {
+        return false;
+    }
+
+    if (self.magic == self_header::signature) {
+        const u64 elf_offset =
+            sizeof(self_header) + static_cast<u64>(self.segment_count) * sizeof(self_segment_header);
+        if (!file.Seek(static_cast<s64>(elf_offset), Common::FS::SeekOrigin::SetOrigin)) {
+            return false;
+        }
+    } else if (!file.Seek(0, Common::FS::SeekOrigin::SetOrigin)) {
+        return false;
+    }
+
+    return file.ReadObject(out_header);
+}
+
+static bool DetectPs5ExecutableAbi(const std::filesystem::path& file_path, u8* abi_version_out) {
+    elf_header header{};
+    if (!TryReadExecutableElfHeader(file_path, header)) {
+        if (abi_version_out != nullptr) {
+            *abi_version_out = 0xff;
+        }
+        return false;
+    }
+
+    const auto& ident = header.e_ident;
+    if (ident.magic[EI_MAG0] != ELFMAG0 || ident.magic[EI_MAG1] != ELFMAG1 ||
+        ident.magic[EI_MAG2] != ELFMAG2 || ident.magic[EI_MAG3] != ELFMAG3) {
+        if (abi_version_out != nullptr) {
+            *abi_version_out = 0xff;
+        }
+        return false;
+    }
+
+    if (abi_version_out != nullptr) {
+        *abi_version_out = static_cast<u8>(ident.ei_abiversion);
+    }
+
+    return ident.ei_abiversion == ELF_ABI_VERSION_AMDGPU_HSA_V4;
 }
 
 void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
@@ -336,6 +388,22 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
     memory = Core::Memory::Instance();
     controllers = Common::Singleton<Input::GameControllers>::Instance();
     linker = Common::Singleton<Core::Linker>::Instance();
+
+    u8 elf_abi_version = 0xff;
+    const bool ps5_runtime_mode = DetectPs5ExecutableAbi(eboot_path, &elf_abi_version);
+    linker->SetRuntimePlatform(ps5_runtime_mode ? Core::RuntimePlatform::PS5
+                                                : Core::RuntimePlatform::PS4);
+    if (elf_abi_version != 0xff) {
+        LOG_INFO(Loader, "Executable EI_ABIVERSION: {:#x}", elf_abi_version);
+    } else {
+        LOG_WARNING(Loader, "Unable to detect executable EI_ABIVERSION, defaulting to PS4 mode");
+    }
+    if (ps5_runtime_mode) {
+        LOG_INFO(Loader, "Detected PS5 ABI executable: enabling PS5 mode");
+
+        // Ensure vectored exception hooks are active before PS5 guest entry,
+        (void)Core::Signals::Instance();
+    }
 
     // Load renderdoc module
     VideoCore::LoadRenderDoc();


### PR DESCRIPTION
Added an initial implementation of PS5 ELF linker support with basic apmr and agc GPU functionality to further progress in-game.
Tested with two games: **PPSA10112** and **PPSA02929**. Both go in-game. One (an Unreal Engine 4 title) crashes with an out-of-memory error, while the other progresses deep into gameplay (shader compilation, audio playback, and rendering). Screenshots are included.
<img width="1202" height="602" alt="Screenshot 2026-05-02 205023" src="https://github.com/user-attachments/assets/43b8335e-f8cf-4fea-a159-b8e65c7d3c83" />
<img width="1120" height="458" alt="Screenshot 2026-05-02 204933" src="https://github.com/user-attachments/assets/922c2730-7cb3-473d-8927-4edcde937022" />

**PPSA02929** attempts to compile shaders, but I don't have any experience with GPU/shader reversing.
Introduced a custom switch (Core::IsGlobalPs5RuntimeMode()) to differentiate between PS4 and PS5 modes.