### PR TITLE
Do not crash on encountering an unknown option in PosixSocket::SetSocketOptions

### DIFF
--- a/src/core/libraries/network/posix_sockets.cpp
+++ b/src/core/libraries/network/posix_sockets.cpp
@@ -590,7 +590,7 @@ int PosixSocket::SetSocketOptions(int level, int optname, const void* optval, u3
         }
     }
 
-    UNREACHABLE_MSG("Unknown level ={} optname ={}", level, optname);
+    LOG_ERROR(Lib_Net, "Unknown level ={} optname ={}", level, optname);
     return 0;
 }
 

--- a/src/core/libraries/network/posix_sockets.cpp
+++ b/src/core/libraries/network/posix_sockets.cpp
@@ -560,6 +560,9 @@ int PosixSocket::SetSocketOptions(int level, int optname, const void* optval, u3
             return ConvertReturnErrorCode(ioctl(sock, FIONBIO, &sockopt_so_nbio));
 #endif
         }
+        case ORBIS_NET_SO_ACCEPTTIMEO:
+            LOG_ERROR(Lib_Net, "Unhandled option ORBIS_NET_SO_ACCEPTTIMEO");
+            return ORBIS_OK;
         }
     } else if (native_level == IPPROTO_IP) {
         switch (optname) {
@@ -590,7 +593,7 @@ int PosixSocket::SetSocketOptions(int level, int optname, const void* optval, u3
         }
     }
 
-    LOG_ERROR(Lib_Net, "Unknown level ={} optname ={}", level, optname);
+    UNREACHABLE_MSG("Unknown level ={} optname ={}", level, optname);
     return 0;
 }
 


### PR DESCRIPTION
This makes Vue After Free not crash on opening its remote payload sender connection.