### PR TITLE
Vulkan fix sync issue

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -754,7 +754,8 @@ void Rasterizer::BindTextures(const Shader::Info& stage, Shader::Backend::Bindin
                               vk::AccessFlagBits2::eShaderRead |
                                   (image.info.props.is_depth
                                        ? vk::AccessFlagBits2::eDepthStencilAttachmentWrite
-                                       : vk::AccessFlagBits2::eColorAttachmentWrite),
+                                       : vk::AccessFlagBits2::eColorAttachmentWrite |
+                                             vk::AccessFlagBits2::eColorAttachmentRead),
                               {});
             } else {
                 if (is_storage) {


### PR DESCRIPTION
Probably never caused issue but it makes validation happy

> [Render.Vulkan] <Error> (shadPS4:GpuComm) vk_platform.cpp:57 DebugUtilsCallback: SYNC-HAZARD-READ-AFTER-WRITE: vkCmdBeginRendering(): READ_AFTER_WRITE hazard detected. vkCmdBeginRendering reads pRenderingInfo.pColorAttachments[0] (VkImageView 0x5f1a0000005f1a[ImageView 1920x1080x1 0x244980000:0x2aa9800 1:1 0:0 (Color)], loadOp VK_ATTACHMENT_LOAD_OP_LOAD), which was previously written during an image layout transition initiated by vkCmdPipelineBarrier2[gfx:0x213a04c50:DrawIndexAuto]. The current synchronization allows
VK_ACCESS_2_SHADER_READ_BIT accesses at VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT|VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT|VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT|VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT|VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT|VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT|VK_PIPELINE_STAGE_2_CLUSTER_CULLING_SHADER_BIT_HUAWEI, VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT accesses at VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT, but to prevent this hazard, it must allow VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT accesses at VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT.