### PR TITLE
Vulkan add VK_EXT_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS

### DIFF
--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -289,6 +289,8 @@ bool Instance::CreateDevice() {
     amd_shader_trinary_minmax = add_extension(VK_AMD_SHADER_TRINARY_MINMAX_EXTENSION_NAME);
     nv_framebuffer_mixed_samples = add_extension(VK_NV_FRAMEBUFFER_MIXED_SAMPLES_EXTENSION_NAME);
     amd_mixed_attachment_samples = add_extension(VK_AMD_MIXED_ATTACHMENT_SAMPLES_EXTENSION_NAME);
+    vk_ext_dynamic_rendering_unused_attachments =
+        add_extension(VK_EXT_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_EXTENSION_NAME);
     shader_atomic_float = add_extension(VK_EXT_SHADER_ATOMIC_FLOAT_EXTENSION_NAME);
     shader_atomic_float2 = add_extension(VK_EXT_SHADER_ATOMIC_FLOAT_2_EXTENSION_NAME);
     if (shader_atomic_float2) {
@@ -490,6 +492,8 @@ bool Instance::CreateDevice() {
             .workgroupMemoryExplicitLayout16BitAccess =
                 workgroup_memory_explicit_layout_features.workgroupMemoryExplicitLayout16BitAccess,
         },
+        vk::PhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT{
+            .dynamicRenderingUnusedAttachments = true},
 #ifdef __APPLE__
         vk::PhysicalDevicePortabilitySubsetFeaturesKHR{
             .constantAlphaColorBlendFactors = portability_features.constantAlphaColorBlendFactors,

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -512,6 +512,7 @@ private:
     bool amd_shader_trinary_minmax{};
     bool nv_framebuffer_mixed_samples{};
     bool amd_mixed_attachment_samples{};
+    bool vk_ext_dynamic_rendering_unused_attachments{};
     bool shader_atomic_float{};
     bool shader_atomic_float2{};
     bool workgroup_memory_explicit_layout{};


### PR DESCRIPTION
will fix when different formats are mixed

> [Render.Vulkan] <Error> (shadPS4:GpuComm) vk_platform.cpp:57 DebugUtilsCallback: VUID-vkCmdDrawIndexed-dynamicRenderingUnusedAttachments-08914: vkCmdDrawIndexed(): VkRenderingInfo::pDepthAttachment->imageView format (VK_FORMAT_D32_SFLOAT_S8_UINT) must match the corresponding format in VkPipelineRenderingCreateInfo::depthAttachmentFormat (VK_FORMAT_D32_SFLOAT).
The Vulkan spec states: If current render pass instance was begun with vkCmdBeginRendering, the dynamicRenderingUnusedAttachments feature is not enabled, and VkRenderingInfo::pDepthAttachment->imageView was not VK_NULL_HANDLE, the value of VkPipelineRenderingCreateInfo::depthAttachmentFormat used to create the bound graphics pipeline must be equal to the VkFormat used to create VkRenderingInfo::pDepthAttachment->imageView (https://docs.vulkan.org/spec/latest/chapters/drawing.html#VUID-vkCmdDrawIndexed-dynamicRenderingUnusedAttachments-08914)