### PR TITLE
Lib.Pad: Avoid out-of-bounds array access when checking custom color for TV Remote

### DIFF
--- a/src/input/controller.h
+++ b/src/input/controller.h
@@ -201,6 +201,9 @@ public:
         controller_override_colors[i] = {r, g, b};
     }
     static std::optional<Colour> GetControllerCustomColor(s32 i) {
+        if (i >= controller_override_colors.size()) {
+            return {};
+        }
         return controller_override_colors[i];
     }
 };


### PR DESCRIPTION
Another case that comes up in My First Gran Turismo, the original fix for this game didn't fix this particular issue. Went unnoticed since there's no crashing outside debug builds.