### PR TITLE
misc: Fix initializer order warnings

### DIFF
--- a/src/core/tls.cpp
+++ b/src/core/tls.cpp
@@ -119,16 +119,16 @@ void SetTcbBase(void* image_address) {
     // Create an LDT entry for the TCB.
     ldt_entry ldt{};
     ldt.data = {
+        .limit00 = static_cast<u16>(ldt_block_size - 1),
         .base00 = static_cast<u16>(addr),
         .base16 = static_cast<u8>(addr >> 16),
-        .base24 = static_cast<u8>(addr >> 24),
-        .limit00 = static_cast<u16>(ldt_block_size - 1),
-        .limit16 = 0,
         .type = DESC_DATA_WRITE,
         .dpl = 3,     // User accessible
         .present = 1, // Segment present
+        .limit16 = 0,
         .stksz = DESC_DATA_32B,
         .granular = DESC_GRAN_BYTE,
+        .base24 = static_cast<u8>(addr >> 24),
     };
     int ret = i386_set_ldt(ldt_index, &ldt, 1);
     ASSERT_MSG(ret == ldt_index,

--- a/src/video_core/renderer_vulkan/vk_platform.cpp
+++ b/src/video_core/renderer_vulkan/vk_platform.cpp
@@ -419,14 +419,14 @@ vk::UniqueInstance CreateInstance(Frontend::WindowSystemType window_type, bool e
 
     vk::StructureChain<vk::InstanceCreateInfo, vk::LayerSettingsCreateInfoEXT> instance_ci_chain = {
         vk::InstanceCreateInfo{
+#ifdef __APPLE__
+            .flags = vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR,
+#endif
             .pApplicationInfo = &application_info,
             .enabledLayerCount = static_cast<u32>(layers.size()),
             .ppEnabledLayerNames = layers.data(),
             .enabledExtensionCount = static_cast<u32>(extensions.size()),
             .ppEnabledExtensionNames = extensions.data(),
-#ifdef __APPLE__
-            .flags = vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR,
-#endif
         },
         vk::LayerSettingsCreateInfoEXT{
             .settingCount = layer_setings.size(),


### PR DESCRIPTION
Fix some initializer order compiler warnings showing up now on macOS.