### PR TITLE
Fix: crash when double unregister

### DIFF
--- a/src/core/libraries/kernel/threads/condvar.cpp
+++ b/src/core/libraries/kernel/threads/condvar.cpp
@@ -141,7 +141,7 @@ int PthreadCond::Wait(PthreadMutexT* mutex, const OrbisKernelTimespec* abstime, 
             has_user_waiters = SleepqRemove(sq, curthread);
             break;
         }
-        UNREACHABLE();
+        continue;
     }
     SleepqUnlock(this);
     curthread->mutex_obj = nullptr;

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -827,8 +827,9 @@ void TextureCache::RegisterImage(ImageId image_id) {
 
 void TextureCache::UnregisterImage(ImageId image_id) {
     Image& image = slot_images[image_id];
-    ASSERT_MSG(True(image.flags & ImageFlagBits::Registered),
-               "Trying to unregister an already unregistered image");
+    if (False(image.flags & ImageFlagBits::Registered)) {
+        return;
+    }
     image.flags &= ~ImageFlagBits::Registered;
     lru_cache.Free(image.lru_id);
     total_used_memory -= Common::AlignUp(image.info.guest_size, 1024);


### PR DESCRIPTION
prevent crash when double unregistering texture cache