### PR TITLE
Fix compilation with mingw-w64

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -149,7 +149,7 @@ endif()
 # sirit
 add_subdirectory(sirit)
 if (WIN32)
-    target_compile_options(sirit PRIVATE "-Wno-error=unused-command-line-argument")
+    target_compile_options(sirit PRIVATE $<$<CXX_COMPILER_ID:Clang>:-Wno-error=unused-command-line-argument>)
 endif()
 
 # half

--- a/src/common/thread.cpp
+++ b/src/common/thread.cpp
@@ -170,7 +170,7 @@ bool AccurateSleep(const std::chrono::nanoseconds duration, std::chrono::nanosec
 
 #endif
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 
 // Sets the debugger-visible name of the current thread.
 void SetCurrentThreadName(const char* name) {
@@ -184,7 +184,7 @@ void SetThreadName(void* thread, const char* name) {
     SetThreadDescription(thread, UTF8ToUTF16W(name).data());
 }
 
-#else // !MSVC_VER, so must be POSIX threads
+#else // !_WIN32, so must be POSIX threads
 
 // MinGW with the POSIX threading model does not support pthread_setname_np
 #if !defined(_WIN32) || defined(_MSC_VER)

--- a/src/shader_recompiler/frontend/opcodes.h
+++ b/src/shader_recompiler/frontend/opcodes.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <magic_enum/magic_enum.hpp>
+
 #include "common/enum.h"
 #include "common/types.h"
 
@@ -2696,3 +2698,9 @@ struct SendMsgSimm {
 };
 
 } // namespace Shader::Gcn
+
+template <>
+struct magic_enum::customize::enum_range<Shader::Gcn::Opcode> {
+    static constexpr int min = static_cast<int>(Shader::Gcn::Opcode::S_ADD_U32);
+    static constexpr int max = static_cast<int>(Shader::Gcn::Opcode::V_MAD_MIXHI_F16);
+};

--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -17,8 +17,6 @@
 #include "video_core/amdgpu/resource.h"
 
 #include <numbers>
-#define MAGIC_ENUM_RANGE_MIN 0
-#define MAGIC_ENUM_RANGE_MAX 2143
 #include <magic_enum/magic_enum.hpp>
 
 namespace Shader::Gcn {


### PR DESCRIPTION
These changes are necessary to build shadps4 with mingw-w64. Some changes are needed for GCC and Clang, some are needed for GCC only.