### PR TITLE
Libs: Proper names for some functions

### DIFF
--- a/src/core/libraries/pad/pad.cpp
+++ b/src/core/libraries/pad/pad.cpp
@@ -556,6 +556,11 @@ int PS4_SYSV_ABI scePadResetOrientationForTracker() {
     return ORBIS_OK;
 }
 
+int PS4_SYSV_ABI scePadSetAngularVelocityBiasCorrectionState() {
+    LOG_ERROR(Lib_Pad, "(STUBBED) called");
+    return ORBIS_OK;
+}
+
 int PS4_SYSV_ABI scePadSetAngularVelocityDeadbandState(s32 handle, bool bEnable) {
     LOG_ERROR(Lib_Pad, "(STUBBED) called");
     return ORBIS_OK;
@@ -753,11 +758,6 @@ int PS4_SYSV_ABI scePadVirtualDeviceInsertData() {
     return ORBIS_OK;
 }
 
-int PS4_SYSV_ABI Func_28B998C7D8A3DA1D() {
-    LOG_ERROR(Lib_Pad, "(STUBBED) called");
-    return ORBIS_OK;
-}
-
 int PS4_SYSV_ABI Func_298D21481F94C9FA() {
     LOG_ERROR(Lib_Pad, "(STUBBED) called");
     return ORBIS_OK;
@@ -836,6 +836,7 @@ void RegisterLib(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("+Yp6+orqf1M", "libScePad", 1, "libScePad", scePadResetLightBarAllByPortType);
     LIB_FUNCTION("rIZnR6eSpvk", "libScePad", 1, "libScePad", scePadResetOrientation);
     LIB_FUNCTION("jbAqAvLEP4A", "libScePad", 1, "libScePad", scePadResetOrientationForTracker);
+    LIB_FUNCTION("KLmYx9ij2h0", "libScePad", 1, "libScePad", scePadSetAngularVelocityBiasCorrectionState);
     LIB_FUNCTION("r44mAxdSG+U", "libScePad", 1, "libScePad", scePadSetAngularVelocityDeadbandState);
     LIB_FUNCTION("ew647HuKi2Y", "libScePad", 1, "libScePad", scePadSetAutoPowerOffCount);
     LIB_FUNCTION("MbTt1EHYCTg", "libScePad", 1, "libScePad", scePadSetButtonRemappingInfo);
@@ -870,7 +871,6 @@ void RegisterLib(Core::Loader::SymbolsResolver* sym) {
                  scePadVirtualDeviceDisableButtonRemapping);
     LIB_FUNCTION("LKXfw7VJYqg", "libScePad", 1, "libScePad", scePadVirtualDeviceGetRemoteSetting);
     LIB_FUNCTION("IWOyO5jKuZg", "libScePad", 1, "libScePad", scePadVirtualDeviceInsertData);
-    LIB_FUNCTION("KLmYx9ij2h0", "libScePad", 1, "libScePad", Func_28B998C7D8A3DA1D);
     LIB_FUNCTION("KY0hSB+Uyfo", "libScePad", 1, "libScePad", Func_298D21481F94C9FA);
     LIB_FUNCTION("UeUUvNOgXKU", "libScePad", 1, "libScePad", Func_51E514BCD3A05CA5);
     LIB_FUNCTION("ickjfjk9okM", "libScePad", 1, "libScePad", Func_89C9237E393DA243);

--- a/src/core/libraries/pad/pad.cpp
+++ b/src/core/libraries/pad/pad.cpp
@@ -836,7 +836,8 @@ void RegisterLib(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("+Yp6+orqf1M", "libScePad", 1, "libScePad", scePadResetLightBarAllByPortType);
     LIB_FUNCTION("rIZnR6eSpvk", "libScePad", 1, "libScePad", scePadResetOrientation);
     LIB_FUNCTION("jbAqAvLEP4A", "libScePad", 1, "libScePad", scePadResetOrientationForTracker);
-    LIB_FUNCTION("KLmYx9ij2h0", "libScePad", 1, "libScePad", scePadSetAngularVelocityBiasCorrectionState);
+    LIB_FUNCTION("KLmYx9ij2h0", "libScePad", 1, "libScePad",
+                 scePadSetAngularVelocityBiasCorrectionState);
     LIB_FUNCTION("r44mAxdSG+U", "libScePad", 1, "libScePad", scePadSetAngularVelocityDeadbandState);
     LIB_FUNCTION("ew647HuKi2Y", "libScePad", 1, "libScePad", scePadSetAutoPowerOffCount);
     LIB_FUNCTION("MbTt1EHYCTg", "libScePad", 1, "libScePad", scePadSetButtonRemappingInfo);

--- a/src/core/libraries/ulobjmgr/ulobjmgr.cpp
+++ b/src/core/libraries/ulobjmgr/ulobjmgr.cpp
@@ -9,7 +9,7 @@
 
 namespace Libraries::Ulobjmgr {
 
-s32 PS4_SYSV_ABI Func_046DBA8411A2365C(u64 arg0, s32 arg1, u32* arg2) {
+s32 PS4_SYSV_ABI _sceUlobjmgrRegisterObject(u64 arg0, s32 arg1, u32* arg2) {
     if (arg0 == 0 || arg1 == 0 || arg2 == nullptr) {
         return POSIX_EINVAL;
     }
@@ -17,14 +17,14 @@ s32 PS4_SYSV_ABI Func_046DBA8411A2365C(u64 arg0, s32 arg1, u32* arg2) {
     return ORBIS_OK;
 }
 
-s32 PS4_SYSV_ABI Func_1D9F50D9CFB8054E() {
-    return ORBIS_OK;
-}
-
-s32 PS4_SYSV_ABI Func_4A67FE7D435B94F7(u32 arg0) {
+s32 PS4_SYSV_ABI _sceUlobjmgrUnregisterObject(u32 arg0) {
     if (arg0 >= 0x4000) {
         return POSIX_EINVAL;
     }
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI Func_1D9F50D9CFB8054E() {
     return ORBIS_OK;
 }
 
@@ -36,9 +36,9 @@ s32 PS4_SYSV_ABI Func_4B07893BBB77A649(u64 arg0) {
 }
 
 void RegisterLib(Core::Loader::SymbolsResolver* sym) {
-    LIB_FUNCTION("BG26hBGiNlw", "ulobjmgr", 1, "ulobjmgr", Func_046DBA8411A2365C);
+    LIB_FUNCTION("BG26hBGiNlw", "ulobjmgr", 1, "ulobjmgr", _sceUlobjmgrRegisterObject);
+    LIB_FUNCTION("Smf+fUNblPc", "ulobjmgr", 1, "ulobjmgr", _sceUlobjmgrUnregisterObject);
     LIB_FUNCTION("HZ9Q2c+4BU4", "ulobjmgr", 1, "ulobjmgr", Func_1D9F50D9CFB8054E);
-    LIB_FUNCTION("Smf+fUNblPc", "ulobjmgr", 1, "ulobjmgr", Func_4A67FE7D435B94F7);
     LIB_FUNCTION("SweJO7t3pkk", "ulobjmgr", 1, "ulobjmgr", Func_4B07893BBB77A649);
 };
 


### PR DESCRIPTION
Replaces hex names with recently found proper names: `scePadSetAngularVelocityBiasCorrectionState`, `_sceUlobjmgrRegisterObject`, and `_sceUlobjmgrUnregisterObject`