### PR TITLE
Kernel.Fs: Stub fstat on random devices

### DIFF
--- a/src/core/file_sys/devices/random_device.cpp
+++ b/src/core/file_sys/devices/random_device.cpp
@@ -53,6 +53,8 @@ s64 RandomDevice::read(void* buf, u64 nbytes) {
 
 s32 RandomDevice::fstat(Libraries::Kernel::OrbisKernelStat* sb) {
     LOG_ERROR(Kernel_Fs, "(STUBBED) called");
+    memset(sb, 0, sizeof(Libraries::Kernel::OrbisKernelStat));
+    sb->st_mode = 0000777u | 0020000u;
     return 0;
 }
 

--- a/src/core/file_sys/devices/random_device.cpp
+++ b/src/core/file_sys/devices/random_device.cpp
@@ -53,7 +53,7 @@ s64 RandomDevice::read(void* buf, u64 nbytes) {
 
 s32 RandomDevice::fstat(Libraries::Kernel::OrbisKernelStat* sb) {
     LOG_ERROR(Kernel_Fs, "(STUBBED) called");
-    memset(sb, 0, sizeof(Libraries::Kernel::OrbisKernelStat));
+    std::memset(sb, 0, sizeof(Libraries::Kernel::OrbisKernelStat));
     sb->st_mode = 0000777u | 0020000u;
     return 0;
 }

--- a/src/core/file_sys/devices/random_device.h
+++ b/src/core/file_sys/devices/random_device.h
@@ -4,6 +4,7 @@
 #pragma once
 #include <memory>
 #include "core/file_sys/devices/base_device.h"
+#include "core/libraries/kernel/file_system.h"
 
 namespace Core::Devices {
 

--- a/src/core/file_sys/devices/srandom_device.cpp
+++ b/src/core/file_sys/devices/srandom_device.cpp
@@ -53,7 +53,7 @@ s64 SRandomDevice::read(void* buf, u64 nbytes) {
 
 s32 SRandomDevice::fstat(Libraries::Kernel::OrbisKernelStat* sb) {
     LOG_ERROR(Kernel_Fs, "(STUBBED) called");
-    memset(sb, 0, sizeof(Libraries::Kernel::OrbisKernelStat));
+    std::memset(sb, 0, sizeof(Libraries::Kernel::OrbisKernelStat));
     sb->st_mode = 0000777u | 0020000u;
     return 0;
 }

--- a/src/core/file_sys/devices/srandom_device.cpp
+++ b/src/core/file_sys/devices/srandom_device.cpp
@@ -53,6 +53,8 @@ s64 SRandomDevice::read(void* buf, u64 nbytes) {
 
 s32 SRandomDevice::fstat(Libraries::Kernel::OrbisKernelStat* sb) {
     LOG_ERROR(Kernel_Fs, "(STUBBED) called");
+    memset(sb, 0, sizeof(Libraries::Kernel::OrbisKernelStat));
+    sb->st_mode = 0000777u | 0020000u;
     return 0;
 }
 

--- a/src/core/file_sys/devices/srandom_device.h
+++ b/src/core/file_sys/devices/srandom_device.h
@@ -4,6 +4,7 @@
 #pragma once
 #include <memory>
 #include "core/file_sys/devices/base_device.h"
+#include "core/libraries/kernel/file_system.h"
 
 namespace Core::Devices {
 

--- a/src/core/file_sys/devices/urandom_device.cpp
+++ b/src/core/file_sys/devices/urandom_device.cpp
@@ -53,6 +53,8 @@ s64 URandomDevice::read(void* buf, u64 nbytes) {
 
 s32 URandomDevice::fstat(Libraries::Kernel::OrbisKernelStat* sb) {
     LOG_ERROR(Kernel_Fs, "(STUBBED) called");
+    memset(sb, 0, sizeof(Libraries::Kernel::OrbisKernelStat));
+    sb->st_mode = 0000777u | 0020000u;
     return 0;
 }
 

--- a/src/core/file_sys/devices/urandom_device.cpp
+++ b/src/core/file_sys/devices/urandom_device.cpp
@@ -53,7 +53,7 @@ s64 URandomDevice::read(void* buf, u64 nbytes) {
 
 s32 URandomDevice::fstat(Libraries::Kernel::OrbisKernelStat* sb) {
     LOG_ERROR(Kernel_Fs, "(STUBBED) called");
-    memset(sb, 0, sizeof(Libraries::Kernel::OrbisKernelStat));
+    std::memset(sb, 0, sizeof(Libraries::Kernel::OrbisKernelStat));
     sb->st_mode = 0000777u | 0020000u;
     return 0;
 }

--- a/src/core/file_sys/devices/urandom_device.h
+++ b/src/core/file_sys/devices/urandom_device.h
@@ -4,6 +4,7 @@
 #pragma once
 #include <memory>
 #include "core/file_sys/devices/base_device.h"
+#include "core/libraries/kernel/file_system.h"
 
 namespace Core::Devices {
 


### PR DESCRIPTION
Apex Legends needs this (but for some reason, only crashes on Linux?)
Roblox also needs this if I remember right, but that has various other issues too.