### PR TITLE
fix: use fallback np_comm_id when trophyIndexMap lookup fails

### DIFF
--- a/src/core/libraries/np/np_trophy.cpp
+++ b/src/core/libraries/np/np_trophy.cpp
@@ -225,9 +225,12 @@ s32 PS4_SYSV_ABI sceNpTrophyCreateContext(OrbisNpTrophyContext* context,
     if (it != trophyMap.end()) {
         np_comm_id = it->second;
     } else {
-        LOG_ERROR(Lib_NpTrophy, "No npCommId found for trophy index/service_label: {}",
-                  service_label);
-        return ORBIS_NP_TROPHY_ERROR_UNKNOWN;
+        // Trophy data may not be available (no npbind.dat, extraction failed, etc.).
+        // Fall back to a generated id rather than returning an error, which can
+        // cause the game to stop rendering (e.g. black screen after logo).
+        np_comm_id = std::string("np_comm_") + std::to_string(service_label);
+        LOG_WARNING(Lib_NpTrophy, "No npCommId found for trophy index/service_label: {}, using {}",
+                    service_label, np_comm_id);
     }
     const auto trophy_base =
         Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "trophy" / np_comm_id;


### PR DESCRIPTION
## Problem

GOW III Remastered (CUSA01715) shows black screen with no audio after the logo. The render loop and draw calls run normally (~14K draws/60 frames), but the final output is all black.

## Bisect

Bisected to 5b60b73e (added new trophies and saves dirs #4177). That commit initially crashed (out-of-bounds array access), which masked the black screen. The crash was later fixed in 1c8ace66 (fixed trophy extraction #4254), at which point the black screen became visible.

## Root cause

In sceNpTrophyCreateContext, when service_label is not found in trophyIndexMap (e.g. no npbind.dat or trophy data not extracted), the function returns ORBIS_NP_TROPHY_ERROR_UNKNOWN. The game calls CreateContext -> RegisterContext -> GetGameInfo during boot, and the failed context creation causes it to enter an error state and stop rendering.

## Fix

When npCommId is not found in trophyIndexMap, fall back to a generated id (np_comm_<index>) instead of returning an error, so the trophy context can be created normally.

## Test

CUSA01715 proceeds past the logo into the game with correct video and audio.

Note: this PR is for reference only.

[Claude Code . deepseek-v4-pro]