### PR TITLE
ImGui:: Add position and icon arguments for notifications

### DIFF
--- a/src/imgui/notifications_layer.cpp
+++ b/src/imgui/notifications_layer.cpp
@@ -18,14 +18,14 @@ std::mutex queueMtx;
 NotificationsUI::NotificationsUI(NotificationInfo info) {
     AddLayer(this);
 
-    if (shadIcon.GetTexture().im_id == nullptr) {
+    if (icon.GetTexture().im_id == nullptr) {
         auto resource = cmrc::res::get_filesystem();
         auto file = resource.open("src/images/shadps4.png");
         std::vector<u8> imgdata = std::vector<u8>(file.begin(), file.end());
-        shadIcon = ImGui::RefCountedTexture::DecodePngTexture(imgdata);
+        icon = ImGui::RefCountedTexture::DecodePngTexture(imgdata);
     }
 
-    currentNotification = info;
+    currentInfo = info;
 
     // Resetting the animation
     elapsed_time = 0.0f; // Resetting animation time
@@ -38,32 +38,54 @@ NotificationsUI::~NotificationsUI() {
 
 void NotificationsUI::Draw() {
     auto& io = ImGui::GetIO();
-    currentNotification.timer -= io.DeltaTime;
+    currentInfo.timer -= io.DeltaTime;
 
     float AdjustWidth = io.DisplaySize.x / 1920;
     float AdjustHeight = io.DisplaySize.y / 1080;
-
     ImVec2 padding = ImGui::GetStyle().WindowPadding;
+
     float wrapWidth = 300 * AdjustWidth - padding.x * 2; // 350 window size - 50 image size
     float textHeight =
-        ImGui::CalcTextSize(currentNotification.message.c_str(), nullptr, false, wrapWidth).y;
-
+        ImGui::CalcTextSize(currentInfo.message.c_str(), nullptr, false, wrapWidth).y;
     ImVec2 window_size{(350 * AdjustWidth),
                        std::max({70 * AdjustHeight, (textHeight + padding.y * 2.0f)})};
 
     elapsed_time += io.DeltaTime;
     float progress = std::min(elapsed_time / animation_duration, 1.0f);
     float final_pos_x, start_x;
+    float height;
 
+    if (currentInfo.position == position::TopLeft) {
+        start_x = -window_size.x;
+        final_pos_x = 20 * AdjustWidth;
+        height = 20 * AdjustHeight;
+    } else if (currentInfo.position == position::TopRight) {
+        start_x = io.DisplaySize.x;
+        final_pos_x = io.DisplaySize.x - window_size.x - 20 * AdjustWidth;
+        height = 20 * AdjustHeight;
+    } else if (currentInfo.position == position::BottomLeft) {
+        start_x = -window_size.x;
+        final_pos_x = 20 * AdjustWidth;
+        height = io.DisplaySize.y - window_size.y - 20 * AdjustHeight;
+    } else if (currentInfo.position == position::BottomRight) {
+        start_x = io.DisplaySize.x;
+        final_pos_x = io.DisplaySize.x - window_size.x - 20 * AdjustWidth;
+        height = io.DisplaySize.y - window_size.y - 20 * AdjustHeight;
+    }
+
+    ImVec2 current_pos = ImVec2(start_x + (final_pos_x - start_x) * progress, height);
+    ImGui::SetNextWindowPos(current_pos);
+
+    /*
     start_x = io.DisplaySize.x;
     final_pos_x = io.DisplaySize.x - window_size.x - 20 * AdjustWidth;
     ImVec2 current_pos = ImVec2(start_x + (final_pos_x - start_x) * progress,
                                 io.DisplaySize.y - window_size.y - 50 * AdjustHeight);
-    ImGui::SetNextWindowPos(current_pos);
+    */
 
     // If the remaining time of the notif is less than or equal to 1 second, the fade-out begins.
-    if (currentNotification.timer <= 1.0f) {
-        float fade_out_time = 1.0f - (currentNotification.timer / 1.0f);
+    if (currentInfo.timer <= 1.0f) {
+        float fade_out_time = 1.0f - (currentInfo.timer / 1.0f);
         fade_opacity = 1.0f - fade_out_time;
     } else {
         // Fade in , 0 to 1
@@ -83,19 +105,18 @@ void NotificationsUI::Draw() {
                          ImGuiWindowFlags_NoInputs)) {
         ImGui::GetColorU32(ImVec4{0.7f});
 
-        if (shadIcon.GetTexture().im_id) {
-            ImGui::Image(shadIcon.GetTexture().im_id,
-                         ImVec2((50 * AdjustWidth), (50 * AdjustHeight)));
+        if (icon.GetTexture().im_id) {
+            ImGui::Image(icon.GetTexture().im_id, ImVec2((50 * AdjustWidth), (50 * AdjustHeight)));
         }
         ImGui::SameLine();
 
-        ImGui::TextWrapped("%s", currentNotification.message.c_str());
+        ImGui::TextWrapped("%s", currentInfo.message.c_str());
     }
 
     ImGui::PopStyleVar();
     ImGui::End();
 
-    if (currentNotification.timer <= 0) {
+    if (currentInfo.timer <= 0) {
         std::lock_guard<std::mutex> lock(queueMtx);
         if (!notif_queue.empty()) {
             NotificationInfo next = notif_queue.front();
@@ -107,12 +128,13 @@ void NotificationsUI::Draw() {
     }
 }
 
-void QueueNotification(std::string message, float timer) {
+void QueueNotification(std::string message, float timer, position position) {
     std::lock_guard<std::mutex> lock(queueMtx);
 
     NotificationInfo info;
     info.message = message;
     info.timer = timer;
+    info.position = position;
 
     if (!current_notif.has_value()) {
         current_notif.emplace(info);

--- a/src/imgui/notifications_layer.cpp
+++ b/src/imgui/notifications_layer.cpp
@@ -4,6 +4,7 @@
 #include <cmrc/cmrc.hpp>
 #include <imgui.h>
 #include <queue>
+#include <stb_image.h>
 
 #include "imgui/imgui_std.h"
 #include "notifications_layer.h"
@@ -15,16 +16,15 @@ std::optional<NotificationsUI> current_notif;
 std::queue<NotificationInfo> notif_queue;
 std::mutex queueMtx;
 
+const std::map<shadNotifications::icon, std::string> iconMap = {
+    {shadNotifications::icon::shadPS4, "src/images/shadps4.png"},
+    {shadNotifications::icon::Settings, "src/images/big_picture/settings.png"},
+    {shadNotifications::icon::Profiles, "src/images/big_picture/profiles.png"},
+    {shadNotifications::icon::Input, "src/images/big_picture/controller.png"},
+};
+
 NotificationsUI::NotificationsUI(NotificationInfo info) {
     AddLayer(this);
-
-    if (icon.GetTexture().im_id == nullptr) {
-        auto resource = cmrc::res::get_filesystem();
-        auto file = resource.open("src/images/shadps4.png");
-        std::vector<u8> imgdata = std::vector<u8>(file.begin(), file.end());
-        icon = ImGui::RefCountedTexture::DecodePngTexture(imgdata);
-    }
-
     currentInfo = info;
 
     // Resetting the animation
@@ -76,13 +76,6 @@ void NotificationsUI::Draw() {
     ImVec2 current_pos = ImVec2(start_x + (final_pos_x - start_x) * progress, height);
     ImGui::SetNextWindowPos(current_pos);
 
-    /*
-    start_x = io.DisplaySize.x;
-    final_pos_x = io.DisplaySize.x - window_size.x - 20 * AdjustWidth;
-    ImVec2 current_pos = ImVec2(start_x + (final_pos_x - start_x) * progress,
-                                io.DisplaySize.y - window_size.y - 50 * AdjustHeight);
-    */
-
     // If the remaining time of the notif is less than or equal to 1 second, the fade-out begins.
     if (currentInfo.timer <= 1.0f) {
         float fade_out_time = 1.0f - (currentInfo.timer / 1.0f);
@@ -105,11 +98,17 @@ void NotificationsUI::Draw() {
                          ImGuiWindowFlags_NoInputs)) {
         ImGui::GetColorU32(ImVec4{0.7f});
 
-        if (icon.GetTexture().im_id) {
-            ImGui::Image(icon.GetTexture().im_id, ImVec2((50 * AdjustWidth), (50 * AdjustHeight)));
+        if (currentInfo.icon.GetTexture().im_id) {
+            if (currentInfo.addIconBackground) {
+                ImVec2 pos = ImGui::GetCursorScreenPos();
+                ImGui::GetWindowDrawList()->AddRectFilled(
+                    pos, ImVec2(pos.x + 50 * AdjustWidth, pos.y + 50 * AdjustHeight),
+                    IM_COL32(211, 211, 211, 255));
+            }
+            ImGui::Image(currentInfo.icon.GetTexture().im_id,
+                         ImVec2((50 * AdjustWidth), (50 * AdjustHeight)));
         }
         ImGui::SameLine();
-
         ImGui::TextWrapped("%s", currentInfo.message.c_str());
     }
 
@@ -128,13 +127,31 @@ void NotificationsUI::Draw() {
     }
 }
 
-void QueueNotification(std::string message, float timer, position position) {
+void QueueNotification(std::string message, float timer, position position, icon icon) {
+    auto resource = cmrc::res::get_filesystem();
+    std::string resourceString = iconMap.at(icon);
+    auto file = resource.open(resourceString);
+    std::vector<u8> imgdata = std::vector<u8>(file.begin(), file.end());
+
+    bool addBackground = false;
+    if (icon == shadNotifications::icon::Input || icon == shadNotifications::icon::Settings ||
+        icon == shadNotifications::icon::Profiles) {
+        addBackground = true;
+    }
+
+    QueueNotification(message, timer, position, imgdata, addBackground);
+}
+
+void QueueNotification(std::string message, float timer, position position, std::vector<u8> pngData,
+                       bool addBackground) {
     std::lock_guard<std::mutex> lock(queueMtx);
 
     NotificationInfo info;
     info.message = message;
     info.timer = timer;
     info.position = position;
+    info.icon = ImGui::RefCountedTexture::DecodePngTexture(pngData);
+    info.addIconBackground = addBackground;
 
     if (!current_notif.has_value()) {
         current_notif.emplace(info);

--- a/src/imgui/notifications_layer.cpp
+++ b/src/imgui/notifications_layer.cpp
@@ -4,7 +4,6 @@
 #include <cmrc/cmrc.hpp>
 #include <imgui.h>
 #include <queue>
-#include <stb_image.h>
 
 #include "imgui/imgui_std.h"
 #include "notifications_layer.h"
@@ -16,11 +15,11 @@ std::optional<NotificationsUI> current_notif;
 std::queue<NotificationInfo> notif_queue;
 std::mutex queueMtx;
 
-const std::map<shadNotifications::icon, std::string> iconMap = {
-    {shadNotifications::icon::shadPS4, "src/images/shadps4.png"},
-    {shadNotifications::icon::Settings, "src/images/big_picture/settings.png"},
-    {shadNotifications::icon::Profiles, "src/images/big_picture/profiles.png"},
-    {shadNotifications::icon::Input, "src/images/big_picture/controller.png"},
+const std::map<shadNotifications::stockIcons, std::string> iconMap = {
+    {shadNotifications::stockIcons::shadPS4, "src/images/shadps4.png"},
+    {shadNotifications::stockIcons::Settings, "src/images/big_picture/settings.png"},
+    {shadNotifications::stockIcons::Profiles, "src/images/big_picture/profiles.png"},
+    {shadNotifications::stockIcons::Input, "src/images/big_picture/controller.png"},
 };
 
 NotificationsUI::NotificationsUI(NotificationInfo info) {
@@ -55,19 +54,19 @@ void NotificationsUI::Draw() {
     float final_pos_x, start_x;
     float height;
 
-    if (currentInfo.position == position::TopLeft) {
+    if (currentInfo.pos == position::TopLeft) {
         start_x = -window_size.x;
         final_pos_x = 20 * AdjustWidth;
         height = 20 * AdjustHeight;
-    } else if (currentInfo.position == position::TopRight) {
+    } else if (currentInfo.pos == position::TopRight) {
         start_x = io.DisplaySize.x;
         final_pos_x = io.DisplaySize.x - window_size.x - 20 * AdjustWidth;
         height = 20 * AdjustHeight;
-    } else if (currentInfo.position == position::BottomLeft) {
+    } else if (currentInfo.pos == position::BottomLeft) {
         start_x = -window_size.x;
         final_pos_x = 20 * AdjustWidth;
         height = io.DisplaySize.y - window_size.y - 20 * AdjustHeight;
-    } else if (currentInfo.position == position::BottomRight) {
+    } else if (currentInfo.pos == position::BottomRight) {
         start_x = io.DisplaySize.x;
         final_pos_x = io.DisplaySize.x - window_size.x - 20 * AdjustWidth;
         height = io.DisplaySize.y - window_size.y - 20 * AdjustHeight;
@@ -127,29 +126,29 @@ void NotificationsUI::Draw() {
     }
 }
 
-void QueueNotification(std::string message, float timer, position position, icon icon) {
+void QueueNotification(std::string message, float timer, position pos, stockIcons icon) {
     auto resource = cmrc::res::get_filesystem();
-    std::string resourceString = iconMap.at(icon);
-    auto file = resource.open(resourceString);
+    auto file = resource.open(iconMap.at(icon));
     std::vector<u8> imgdata = std::vector<u8>(file.begin(), file.end());
 
     bool addBackground = false;
-    if (icon == shadNotifications::icon::Input || icon == shadNotifications::icon::Settings ||
-        icon == shadNotifications::icon::Profiles) {
+    if (icon == shadNotifications::stockIcons::Input ||
+        icon == shadNotifications::stockIcons::Settings ||
+        icon == shadNotifications::stockIcons::Profiles) {
         addBackground = true;
     }
 
-    QueueNotification(message, timer, position, imgdata, addBackground);
+    QueueNotification(message, timer, pos, imgdata, addBackground);
 }
 
-void QueueNotification(std::string message, float timer, position position, std::vector<u8> pngData,
+void QueueNotification(std::string message, float timer, position pos, std::vector<u8> pngData,
                        bool addBackground) {
     std::lock_guard<std::mutex> lock(queueMtx);
 
     NotificationInfo info;
     info.message = message;
     info.timer = timer;
-    info.position = position;
+    info.pos = pos;
     info.icon = ImGui::RefCountedTexture::DecodePngTexture(pngData);
     info.addIconBackground = addBackground;
 

--- a/src/imgui/notifications_layer.h
+++ b/src/imgui/notifications_layer.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <map>
-
 #include "imgui/imgui_layer.h"
 #include "imgui/imgui_texture.h"
 
@@ -17,22 +15,22 @@ enum class position {
     BottomRight,
 };
 
-enum class icon {
+enum class stockIcons {
     shadPS4,
     Settings,
     Profiles,
     Input,
 };
 
-struct NotificationInfo {
-    std::string message;
-    float timer;
-    position position;
-    ImGui::RefCountedTexture icon;
-    bool addIconBackground; // adds gray background (mostly for black icons)
-};
-
 class NotificationsUI final : public ImGui::Layer {
+    struct NotificationInfo {
+        std::string message;
+        float timer;
+        position pos;
+        ImGui::RefCountedTexture icon;
+        bool addIconBackground; // adds gray background (mostly for black icons)
+    };
+
 public:
     NotificationsUI(NotificationInfo info);
     ~NotificationsUI() override;
@@ -49,9 +47,9 @@ private:
     float elapsed_time = 0.0f;             // Animation time
 };
 
-void QueueNotification(std::string message, float timer, position position,
-                       icon = shadNotifications::icon::shadPS4);
-void QueueNotification(std::string message, float timer, position position, std::vector<u8> pngData,
+void QueueNotification(std::string message, float timer, position pos,
+                       stockIcons = shadNotifications::stockIcons::shadPS4);
+void QueueNotification(std::string message, float timer, position pos, std::vector<u8> pngData,
                        bool iconBackground = false);
 
 }; // namespace shadNotifications

--- a/src/imgui/notifications_layer.h
+++ b/src/imgui/notifications_layer.h
@@ -22,15 +22,15 @@ enum class stockIcons {
     Input,
 };
 
-class NotificationsUI final : public ImGui::Layer {
-    struct NotificationInfo {
-        std::string message;
-        float timer;
-        position pos;
-        ImGui::RefCountedTexture icon;
-        bool addIconBackground; // adds gray background (mostly for black icons)
-    };
+struct NotificationInfo {
+    std::string message;
+    float timer;
+    position pos;
+    ImGui::RefCountedTexture icon;
+    bool addIconBackground; // adds gray background (mostly for black icons)
+};
 
+class NotificationsUI final : public ImGui::Layer {
 public:
     NotificationsUI(NotificationInfo info);
     ~NotificationsUI() override;

--- a/src/imgui/notifications_layer.h
+++ b/src/imgui/notifications_layer.h
@@ -8,9 +8,17 @@
 
 namespace shadNotifications {
 
+enum class position {
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
+};
+
 struct NotificationInfo {
     std::string message;
     float timer;
+    position position;
 };
 
 class NotificationsUI final : public ImGui::Layer {
@@ -21,8 +29,8 @@ public:
     void Draw() override;
 
 private:
-    ImGui::RefCountedTexture shadIcon;
-    NotificationInfo currentNotification;
+    ImGui::RefCountedTexture icon;
+    NotificationInfo currentInfo;
 
     // notification animation
     const float animation_duration = 0.5f; // Animation duration
@@ -31,6 +39,6 @@ private:
     float elapsed_time = 0.0f;             // Animation time
 };
 
-void QueueNotification(std::string message, float timer);
+void QueueNotification(std::string message, float timer, position position);
 
 }; // namespace shadNotifications

--- a/src/imgui/notifications_layer.h
+++ b/src/imgui/notifications_layer.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <map>
+
 #include "imgui/imgui_layer.h"
 #include "imgui/imgui_texture.h"
 
@@ -15,10 +17,19 @@ enum class position {
     BottomRight,
 };
 
+enum class icon {
+    shadPS4,
+    Settings,
+    Profiles,
+    Input,
+};
+
 struct NotificationInfo {
     std::string message;
     float timer;
     position position;
+    ImGui::RefCountedTexture icon;
+    bool addIconBackground; // adds gray background (mostly for black icons)
 };
 
 class NotificationsUI final : public ImGui::Layer {
@@ -29,7 +40,6 @@ public:
     void Draw() override;
 
 private:
-    ImGui::RefCountedTexture icon;
     NotificationInfo currentInfo;
 
     // notification animation
@@ -39,6 +49,9 @@ private:
     float elapsed_time = 0.0f;             // Animation time
 };
 
-void QueueNotification(std::string message, float timer, position position);
+void QueueNotification(std::string message, float timer, position position,
+                       icon = shadNotifications::icon::shadPS4);
+void QueueNotification(std::string message, float timer, position position, std::vector<u8> pngData,
+                       bool iconBackground = false);
 
 }; // namespace shadNotifications

--- a/src/video_core/renderer_vulkan/vk_presenter.cpp
+++ b/src/video_core/renderer_vulkan/vk_presenter.cpp
@@ -453,7 +453,8 @@ static void SavePendingScreenshots(const std::vector<ScreenshotReadback>& readba
         }
 
         LOG_INFO(Render_Vulkan, "Saved screenshot: {}", primary_path.string());
-        shadNotifications::QueueNotification("Saved screenshot:\n" + primary_path.string(), 3.0f);
+        shadNotifications::QueueNotification("Saved screenshot:\n" + primary_path.string(), 3.0f,
+                                             shadNotifications::position::TopRight);
 
         for (size_t i = 1; i < readback.paths.size(); ++i) {
             const auto& path = readback.paths[i];
@@ -469,7 +470,8 @@ static void SavePendingScreenshots(const std::vector<ScreenshotReadback>& readba
             }
 
             LOG_INFO(Render_Vulkan, "Saved screenshot: {}", path.string());
-            shadNotifications::QueueNotification("Saved screenshot:\n" + path.string(), 3.0f);
+            shadNotifications::QueueNotification("Saved screenshot:\n" + path.string(), 3.0f,
+                                                 shadNotifications::position::TopRight);
         }
     }
 }

--- a/src/video_core/renderer_vulkan/vk_presenter.cpp
+++ b/src/video_core/renderer_vulkan/vk_presenter.cpp
@@ -453,8 +453,15 @@ static void SavePendingScreenshots(const std::vector<ScreenshotReadback>& readba
         }
 
         LOG_INFO(Render_Vulkan, "Saved screenshot: {}", primary_path.string());
+
+        std::ifstream file(primary_path, std::ios::binary);
+        std::vector<u8> imgdata;
+        if (file) {
+            imgdata = std::vector<u8>(std::istreambuf_iterator<char>(file),
+                                      std::istreambuf_iterator<char>());
+        }
         shadNotifications::QueueNotification("Saved screenshot:\n" + primary_path.string(), 3.0f,
-                                             shadNotifications::position::TopRight);
+                                             shadNotifications::position::BottomRight, imgdata);
 
         for (size_t i = 1; i < readback.paths.size(); ++i) {
             const auto& path = readback.paths[i];
@@ -470,8 +477,14 @@ static void SavePendingScreenshots(const std::vector<ScreenshotReadback>& readba
             }
 
             LOG_INFO(Render_Vulkan, "Saved screenshot: {}", path.string());
+            std::ifstream file(path, std::ios::binary);
+            std::vector<u8> imgdata;
+            if (file) {
+                imgdata = std::vector<u8>(std::istreambuf_iterator<char>(file),
+                                          std::istreambuf_iterator<char>());
+            }
             shadNotifications::QueueNotification("Saved screenshot:\n" + path.string(), 3.0f,
-                                                 shadNotifications::position::TopRight);
+                                                 shadNotifications::position::BottomRight, imgdata);
         }
     }
 }


### PR DESCRIPTION
Adds position argument (any corner) and icon arguments (an enum with a few of our embedded images, feel free to just add icons as you wish). Also added a flag to add a gray background to the icon (since most of the embedded images we have are black).

A png byte array can also be passed instead of the icon enum, so any custom icon can work as well. I used this in the screenshot notification, so the screenshot png itself is used as the icon for the notification, as seen here:

<img width="2560" height="1369" alt="CUSA19610_20260509_213612_529_hud_000006" src="https://github.com/user-attachments/assets/68017a68-277f-4c2f-9810-29b5a9fd1db1" />
