### PR TITLE
Kernel.Vmm: Fix protection check for file mappings

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -702,7 +702,7 @@ s32 MemoryManager::MapFile(void** out_addr, VAddr virtual_addr, u64 size, Memory
 
     handle = file->f.GetFileMapping();
 
-    if (False(file->f.GetAccessMode() & Common::FS::FileAccessMode::Write) ||
+    if (False(file->f.GetAccessMode() & Common::FS::FileAccessMode::Write) &&
         False(file->f.GetAccessMode() & Common::FS::FileAccessMode::Append)) {
         // If the file does not have write access, ensure prot does not contain write
         // permissions. On real hardware, these mappings succeed, but the memory cannot be


### PR DESCRIPTION
Credits to @raphaelthegreat for spotting this. Both Append and Write modes are forms of write access, we should only remove write permissions if neither are present.