### PR TITLE
Fixes regressions and issues causing PSP emulated games to not run.

### DIFF
--- a/src/core/libraries/app_content/app_content.cpp
+++ b/src/core/libraries/app_content/app_content.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <cmath>
-#include <cstring>
 
 #include "app_content.h"
 #include "common/assert.h"
@@ -401,9 +400,9 @@ int PS4_SYSV_ABI sceAppContentTemporaryDataMount2(OrbisAppContentTemporaryDataOp
     if (mountPoint == nullptr) {
         return ORBIS_APP_CONTENT_ERROR_PARAMETER;
     }
-    memset(mountPoint, 0, sizeof(OrbisAppContentMountPoint));
     static constexpr std::string_view TmpMount = "/temp0";
     TmpMount.copy(mountPoint->data, TmpMount.size());
+    mountPoint->data[TmpMount.size()] = '\0';
     LOG_INFO(Lib_AppContent, "sceAppContentTemporaryDataMount2: option = {}, mountPoint = {}",
              option, mountPoint->data);
     return ORBIS_OK;

--- a/src/core/libraries/app_content/app_content.cpp
+++ b/src/core/libraries/app_content/app_content.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <cmath>
+#include <cstring>
 
 #include "app_content.h"
 #include "common/assert.h"
@@ -400,6 +401,7 @@ int PS4_SYSV_ABI sceAppContentTemporaryDataMount2(OrbisAppContentTemporaryDataOp
     if (mountPoint == nullptr) {
         return ORBIS_APP_CONTENT_ERROR_PARAMETER;
     }
+    memset(mountPoint, 0, sizeof(OrbisAppContentMountPoint));
     static constexpr std::string_view TmpMount = "/temp0";
     TmpMount.copy(mountPoint->data, TmpMount.size());
     LOG_INFO(Lib_AppContent, "sceAppContentTemporaryDataMount2: option = {}, mountPoint = {}",

--- a/src/core/libraries/videodec/videodec2.cpp
+++ b/src/core/libraries/videodec/videodec2.cpp
@@ -230,7 +230,7 @@ s32 PS4_SYSV_ABI sceVideodec2GetPictureInfo(const OrbisVideodec2OutputInfo* outp
 }
 
 s32 PS4_SYSV_ABI sceVideodec2GetAvcPictureInfo(const OrbisVideodec2OutputInfo* outputInfo,
-                                            void* p1stPictureInfoOut, void* p2ndPictureInfoOut) {
+                                               void* p1stPictureInfoOut, void* p2ndPictureInfoOut) {
     LOG_TRACE(Lib_Vdec2, "called");
     return sceVideodec2GetPictureInfo(outputInfo, p1stPictureInfoOut, p2ndPictureInfoOut);
 }
@@ -252,7 +252,8 @@ void RegisterLib(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("wJXikG6QFN8", "libSceVideodec2", 1, "libSceVideodec2", sceVideodec2Reset);
     LIB_FUNCTION("NtXRa3dRzU0", "libSceVideodec2", 1, "libSceVideodec2",
                  sceVideodec2GetPictureInfo);
-    LIB_FUNCTION("kjrLbcyhEiw", "libSceVideodec2", 1, "libSceVideodec2", sceVideodec2GetAvcPictureInfo);
+    LIB_FUNCTION("kjrLbcyhEiw", "libSceVideodec2", 1, "libSceVideodec2",
+                 sceVideodec2GetAvcPictureInfo);
 }
 
 } // namespace Libraries::Videodec2

--- a/src/core/libraries/videodec/videodec2.cpp
+++ b/src/core/libraries/videodec/videodec2.cpp
@@ -229,6 +229,12 @@ s32 PS4_SYSV_ABI sceVideodec2GetPictureInfo(const OrbisVideodec2OutputInfo* outp
     return ORBIS_OK;
 }
 
+s32 PS4_SYSV_ABI sceVideodec2GetAvcPictureInfo(const OrbisVideodec2OutputInfo* outputInfo,
+                                            void* p1stPictureInfoOut, void* p2ndPictureInfoOut) {
+    LOG_TRACE(Lib_Vdec2, "called");
+    return sceVideodec2GetPictureInfo(outputInfo, p1stPictureInfoOut, p2ndPictureInfoOut);
+}
+
 void RegisterLib(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("RnDibcGCPKw", "libSceVideodec2", 1, "libSceVideodec2",
                  sceVideodec2QueryComputeMemoryInfo);
@@ -246,6 +252,7 @@ void RegisterLib(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("wJXikG6QFN8", "libSceVideodec2", 1, "libSceVideodec2", sceVideodec2Reset);
     LIB_FUNCTION("NtXRa3dRzU0", "libSceVideodec2", 1, "libSceVideodec2",
                  sceVideodec2GetPictureInfo);
+    LIB_FUNCTION("kjrLbcyhEiw", "libSceVideodec2", 1, "libSceVideodec2", sceVideodec2GetAvcPictureInfo);
 }
 
 } // namespace Libraries::Videodec2

--- a/src/core/libraries/videodec/videodec2.h
+++ b/src/core/libraries/videodec/videodec2.h
@@ -137,5 +137,8 @@ s32 PS4_SYSV_ABI sceVideodec2Reset(OrbisVideodec2Decoder decoder);
 s32 PS4_SYSV_ABI sceVideodec2GetPictureInfo(const OrbisVideodec2OutputInfo* outputInfo,
                                             void* p1stPictureInfo, void* p2ndPictureInfo);
 
+s32 PS4_SYSV_ABI sceVideodec2GetAvcPictureInfo(const OrbisVideodec2OutputInfo* outputInfo,
+                                               void* p1stPictureInfoOut, void* p2ndPictureInfoOut);
+
 void RegisterLib(Core::Loader::SymbolsResolver* sym);
 } // namespace Libraries::Videodec2

--- a/src/core/libraries/videodec/videodec2_impl.cpp
+++ b/src/core/libraries/videodec/videodec2_impl.cpp
@@ -133,7 +133,7 @@ s32 VdecDecoder::Decode(const OrbisVideodec2InputData& inputData,
 
         // Only set framePitchInBytes if the game uses the newer struct version.
         if (outputInfo.thisSize == sizeof(OrbisVideodec2OutputInfo)) {
-            outputInfo.framePitchInBytes = frame->linesize[0];
+            outputInfo.framePitchInBytes = frame->width;
         }
 
         if (outputInfo.isValid) {
@@ -201,7 +201,7 @@ s32 VdecDecoder::Flush(OrbisVideodec2FrameBuffer& frameBuffer,
         outputInfo.codecType = 1; // FIXME: Hardcoded to AVC
         outputInfo.frameWidth = frame->width;
         outputInfo.frameHeight = frame->height;
-        outputInfo.framePitch = frame->linesize[0];
+        outputInfo.framePitch = frame->width;
         outputInfo.frameBufferSize = frameBuffer.frameBufferSize;
         outputInfo.frameBuffer = frameBuffer.frameBuffer;
 
@@ -211,7 +211,7 @@ s32 VdecDecoder::Flush(OrbisVideodec2FrameBuffer& frameBuffer,
 
         // Only set framePitchInBytes if the game uses the newer struct version.
         if (outputInfo.thisSize == sizeof(OrbisVideodec2OutputInfo)) {
-            outputInfo.framePitchInBytes = frame->linesize[0];
+            outputInfo.framePitchInBytes = frame->width;
         }
 
         // FIXME: Should we add picture info here too?

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -550,7 +550,7 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
                    virtual_addr);
         auto vma = FindVMA(virtual_addr)->second;
         auto remaining_size = vma.base + vma.size - virtual_addr;
-        if (vma.IsMapped() || remaining_size < size) {
+        if (!vma.IsFree() || remaining_size < size) {
             LOG_ERROR(Kernel_Vmm, "Unable to map {:#x} bytes at address {:#x}", size, virtual_addr);
             return ORBIS_KERNEL_ERROR_ENOMEM;
         }
@@ -720,13 +720,13 @@ s32 MemoryManager::MapFile(void** out_addr, VAddr virtual_addr, u64 size, Memory
         prot &= ~MemoryProt::CpuExec;
     }
 
-    if (True(flags & MemoryMapFlags::Fixed) && False(flags & MemoryMapFlags::NoOverwrite)) {
+    if (True(flags & MemoryMapFlags::Fixed) && True(flags & MemoryMapFlags::NoOverwrite)) {
         ASSERT_MSG(IsValidMapping(virtual_addr, size), "Attempted to access invalid address {:#x}",
                    virtual_addr);
         auto vma = FindVMA(virtual_addr)->second;
 
         auto remaining_size = vma.base + vma.size - virtual_addr;
-        if (vma.IsMapped() || remaining_size < size) {
+        if (!vma.IsFree() || remaining_size < size) {
             LOG_ERROR(Kernel_Vmm, "Unable to map {:#x} bytes at address {:#x}", size, virtual_addr);
             return ORBIS_KERNEL_ERROR_ENOMEM;
         }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -550,7 +550,7 @@ s32 MemoryManager::MapMemory(void** out_addr, VAddr virtual_addr, u64 size, Memo
                    virtual_addr);
         auto vma = FindVMA(virtual_addr)->second;
         auto remaining_size = vma.base + vma.size - virtual_addr;
-        if (!vma.IsFree() || remaining_size < size) {
+        if (vma.IsMapped() || remaining_size < size) {
             LOG_ERROR(Kernel_Vmm, "Unable to map {:#x} bytes at address {:#x}", size, virtual_addr);
             return ORBIS_KERNEL_ERROR_ENOMEM;
         }
@@ -726,7 +726,7 @@ s32 MemoryManager::MapFile(void** out_addr, VAddr virtual_addr, u64 size, Memory
         auto vma = FindVMA(virtual_addr)->second;
 
         auto remaining_size = vma.base + vma.size - virtual_addr;
-        if (!vma.IsFree() || remaining_size < size) {
+        if (vma.IsMapped() || remaining_size < size) {
             LOG_ERROR(Kernel_Vmm, "Unable to map {:#x} bytes at address {:#x}", size, virtual_addr);
             return ORBIS_KERNEL_ERROR_ENOMEM;
         }

--- a/src/video_core/amdgpu/pixel_format.h
+++ b/src/video_core/amdgpu/pixel_format.h
@@ -264,10 +264,10 @@ constexpr CompMapping RemapSwizzle(const DataFormat format, const CompMapping sw
     case DataFormat::Format4_4_4_4: {
         // Remap to a more supported component order.
         CompMapping result;
-        result.r = swizzle.a;
-        result.g = swizzle.r;
-        result.b = swizzle.g;
-        result.a = swizzle.b;
+        result.r = swizzle.g;
+        result.g = swizzle.b;
+        result.b = swizzle.a;
+        result.a = swizzle.r;
         return result;
     }
     case DataFormat::Format5_6_5: {

--- a/src/video_core/amdgpu/pixel_format.h
+++ b/src/video_core/amdgpu/pixel_format.h
@@ -264,10 +264,10 @@ constexpr CompMapping RemapSwizzle(const DataFormat format, const CompMapping sw
     case DataFormat::Format4_4_4_4: {
         // Remap to a more supported component order.
         CompMapping result;
-        result.r = swizzle.g;
-        result.g = swizzle.b;
-        result.b = swizzle.a;
-        result.a = swizzle.r;
+        result.r = swizzle.a;
+        result.g = swizzle.r;
+        result.b = swizzle.g;
+        result.a = swizzle.b;
         return result;
     }
     case DataFormat::Format5_6_5: {

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -5,6 +5,7 @@
 
 #include "common/assert.h"
 #include "common/debug.h"
+#include "common/div_ceil.h"
 #include "common/scope_exit.h"
 #include "core/emulator_settings.h"
 #include "core/memory.h"
@@ -731,7 +732,10 @@ void TextureCache::RefreshImage(Image& image) {
         const auto addr = std::bit_cast<u8*>(image.info.guest_address);
         const u32 w = std::min(image.info.size.width, u32(8));
         const u32 h = std::min(image.info.size.height, u32(8));
-        const u32 size = w * h * image.info.num_bits >> (3 + image.info.props.is_block ? 4 : 0);
+
+        const u32 s_w = image.info.props.is_block ? Common::DivCeil(w, 4u) : w;
+        const u32 s_h = image.info.props.is_block ? Common::DivCeil(h, 4u) : h;
+        const u32 size = s_w * s_h * (image.info.num_bits / 8);
         const u64 hash = XXH3_64bits(addr, size);
         if (image.hash == hash) {
             image.flags &= ~ImageFlagBits::MaybeCpuDirty;


### PR DESCRIPTION
I hope you'll look these changes over and consider them, as I believe they fix core issues and are not hacks to make things work.

1. memory.cpp - Reserved Memory cannot be mapped, this seems to be incorrect and the PSP emulation relies on reserving then mapping memory at startup. This seems to be a core error in the emulation code, as reserved memory cannot be mapped.

2. appcontent.cpp - Temp directory output parameter may have garbage and the API is not null terminating the output, resulting in failures when the file path buffer is made into an invalid path name. This seems like a random issue, but managed to get this occurring on some games consistently.

3. videodec2_impl.cpp - Fix misaligned images when viewport is sized for PSP. This fixes garbage in movies on the PSP emulator, making the movies viewable, scaled correctly for the screen.  A lot of games work fine as linesize[0] == width but PSP moves are definitely not that case.

5.  videodec.cpp - Also implemented sceVideodec2GetAvcPictureInfo, which seems to be used over sceVideodec2GetPictureInfo by the PSP emulator.

6. texture_cache.cpp - Whie working on texutre transparency issues, i noticed that block texture size was not quite right while hashing, I think the revised code is more correct.

7. RGB4444 mapping was a strange swizzle, causing strange colors and lack of alpha transparency. I believe the swizzling order was incorrect and changing this makes textures no longer look strange.

 These changes combined allow Jean d'Arc, LocoRoco and Patapon (and possibly other PSP and enhanced PSP games) to run decently and with no visual corruption.