### PR TITLE
Fixes to memory mapping on Windows

### DIFF
--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -257,9 +257,20 @@ struct AddressSpace::Impl {
                 ret = VirtualProtect(ptr, size, prot, &resultvar);
                 ASSERT_MSG(ret, "VirtualProtect failed. {}", Common::GetLastErrorMsg());
             } else {
-                ptr = MapViewOfFile3(backing, process, reinterpret_cast<PVOID>(virtual_addr),
-                                     phys_addr, size, MEM_REPLACE_PLACEHOLDER, prot, nullptr, 0);
-                ASSERT_MSG(ptr, "MapViewOfFile3 failed. {}", Common::GetLastErrorMsg());
+                if (prot == PAGE_NOACCESS) {
+                    DWORD resultvar;
+                    ptr = MapViewOfFile3(backing, process, reinterpret_cast<PVOID>(virtual_addr),
+                                         phys_addr, size, MEM_REPLACE_PLACEHOLDER, PAGE_READWRITE,
+                                         nullptr, 0);
+                    ASSERT_MSG(ptr, "MapViewOfFile3 failed. {}", Common::GetLastErrorMsg());
+                    bool ret = VirtualProtect(ptr, size, prot, &resultvar);
+                    ASSERT_MSG(ret, "VirtualProtect failed. {}", Common::GetLastErrorMsg());
+                } else {
+                    ptr =
+                        MapViewOfFile3(backing, process, reinterpret_cast<PVOID>(virtual_addr),
+                                       phys_addr, size, MEM_REPLACE_PLACEHOLDER, prot, nullptr, 0);
+                    ASSERT_MSG(ptr, "MapViewOfFile3 failed. {}", Common::GetLastErrorMsg());
+                }
             }
         } else {
             ptr =


### PR DESCRIPTION
The previous PR (#4389) works on Linux fine, but I just got my build environment set up on Windows and it doesn't like mapping files with PAGE_NOACCESS. This adds a case to the mapping to map as read/write, and then protect the page after mapping, following the same logic as the allocation above. This allows the mapping to work, and the PSP emulation to continue.

@StevenMiller123 you should look at this in case I've done something silly,

Failed boot: [CUSA41018.log](https://github.com/user-attachments/files/27579520/CUSA41018.log)
Successful boot: [CUSA41018.log](https://github.com/user-attachments/files/27579490/CUSA41018.log)
