### PR TITLE
core: simplify sysv_abi wrappers for MinGW-w64 GCC

### DIFF
--- a/src/core/libraries/kernel/kernel.h
+++ b/src/core/libraries/kernel/kernel.h
@@ -21,11 +21,11 @@ const char* PS4_SYSV_ABI sceKernelGetFsSandboxRandomWord();
 
 extern Core::EntryParams entry_params;
 
-template <class F, F f>
+template <auto f>
 struct OrbisWrapperImpl;
 
 template <class R, class... Args, PS4_SYSV_ABI R (*f)(Args...)>
-struct OrbisWrapperImpl<PS4_SYSV_ABI R (*)(Args...), f> {
+struct OrbisWrapperImpl<f> {
     static R PS4_SYSV_ABI wrap(Args... args) {
         u32 ret = f(args...);
         if (ret != 0) {
@@ -35,7 +35,7 @@ struct OrbisWrapperImpl<PS4_SYSV_ABI R (*)(Args...), f> {
     }
 };
 
-#define ORBIS(func) (Libraries::Kernel::OrbisWrapperImpl<decltype(&(func)), func>::wrap)
+#define ORBIS(func) (Libraries::Kernel::OrbisWrapperImpl<func>::wrap)
 
 #define CURRENT_FIRMWARE_VERSION 0x13500011
 

--- a/src/core/libraries/kernel/threads.h
+++ b/src/core/libraries/kernel/threads.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include "common/polyfill_thread.h"
 #include "core/libraries/kernel/threads/pthread.h"
+#include "core/tls.h"
 
 namespace Core::Loader {
 class SymbolsResolver;

--- a/src/core/tls.h
+++ b/src/core/tls.h
@@ -45,16 +45,16 @@ Tcb* GetTcbBase();
 /// Makes sure TLS is initialized for the thread before entering guest.
 void InitializeTLS();
 
-template <class F, F f>
+template <auto f>
 struct HostCallWrapperImpl;
 
 template <class ReturnType, class... Args, PS4_SYSV_ABI ReturnType (*func)(Args...)>
-struct HostCallWrapperImpl<PS4_SYSV_ABI ReturnType (*)(Args...), func> {
+struct HostCallWrapperImpl<func> {
     static ReturnType PS4_SYSV_ABI wrap(Args... args) {
         return func(args...);
     }
 };
 
-#define HOST_CALL(func) (Core::HostCallWrapperImpl<decltype(&(func)), func>::wrap)
+#define HOST_CALL(func) (Core::HostCallWrapperImpl<func>::wrap)
 
 } // namespace Core


### PR DESCRIPTION
Use template <auto f> for HostCallWrapperImpl and OrbisWrapperImpl instead of passing the function type and value separately.

This keeps the wrapper behavior the same while matching the form MinGW-w64 GCC accepts.

---
This PR makes GCC on Windows able to build shadps4. You need [my patch](https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=b0f09b72d9e1783e8ccaf2d8c1c72b03e3973f0b), that is already upstream and that I plan to backport to MSYS2 GCC 16.1.

The problem with the templates is AFAIU the fact that GCC is more strict than Clang and takes the ABI attribute into account when matching templates.