### PR TITLE
Flush log on terminate

### DIFF
--- a/src/common/logging/log.cpp
+++ b/src/common/logging/log.cpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <string>
+#include <fmt/std.h>
 
 #include "common/assert.h"
 #include "common/config.h"
@@ -14,6 +15,14 @@
 #ifdef _WIN32
 #include <Windows.h>
 #endif
+
+// return codes above 'standard'
+// https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes
+enum class ShadPs4ReturnCode : u32 {
+    TERMINATE_WITHOUT_EXCEPTION = 20'000,
+    TERMINATE_WITH_EXCEPTION = 20'001,
+    TERMINATE_WITH_UNKNOWN_EXCEPTION = 20'002,
+};
 
 namespace Common::Log {
 bool g_should_append = false;
@@ -169,6 +178,26 @@ void Setup(std::string_view log_filename) {
         already_registered = true;
         std::atexit(Shutdown);
         std::at_quick_exit(Flush);
+        std::set_terminate([]() {
+            try {
+                if (std::exception_ptr eptr{std::current_exception()}) {
+                    std::rethrow_exception(eptr);
+                }
+
+                LOG_CRITICAL(Debug, "Exiting without exception");
+
+                std::quick_exit(std::to_underlying(ShadPs4ReturnCode::TERMINATE_WITHOUT_EXCEPTION));
+            } catch (const std::exception& exception) {
+                LOG_CRITICAL(Debug, "Exception: {}", exception);
+
+                std::quick_exit(std::to_underlying(ShadPs4ReturnCode::TERMINATE_WITH_EXCEPTION));
+            } catch (...) {
+                LOG_CRITICAL(Debug, "Unknown exception caught");
+
+                std::quick_exit(
+                    std::to_underlying(ShadPs4ReturnCode::TERMINATE_WITH_UNKNOWN_EXCEPTION));
+            }
+        });
     }
 
 #ifdef _WIN32

--- a/src/common/logging/log.cpp
+++ b/src/common/logging/log.cpp
@@ -178,26 +178,7 @@ void Setup(std::string_view log_filename) {
         already_registered = true;
         std::atexit(Shutdown);
         std::at_quick_exit(Flush);
-        std::set_terminate([]() {
-            try {
-                if (std::exception_ptr eptr{std::current_exception()}) {
-                    std::rethrow_exception(eptr);
-                }
-
-                LOG_CRITICAL(Debug, "Exiting without exception");
-
-                std::quick_exit(std::to_underlying(ShadPs4ReturnCode::TERMINATE_WITHOUT_EXCEPTION));
-            } catch (const std::exception& exception) {
-                LOG_CRITICAL(Debug, "Exception: {}", exception);
-
-                std::quick_exit(std::to_underlying(ShadPs4ReturnCode::TERMINATE_WITH_EXCEPTION));
-            } catch (...) {
-                LOG_CRITICAL(Debug, "Unknown exception caught");
-
-                std::quick_exit(
-                    std::to_underlying(ShadPs4ReturnCode::TERMINATE_WITH_UNKNOWN_EXCEPTION));
-            }
-        });
+        std::set_terminate(Terminate);
     }
 
 #ifdef _WIN32
@@ -285,6 +266,26 @@ void Flush() {
 
     if (g_console_sink != nullptr) {
         g_console_sink->flush();
+    }
+}
+
+void Terminate() {
+    try {
+        if (std::exception_ptr eptr{std::current_exception()}) {
+            std::rethrow_exception(eptr);
+        }
+
+        LOG_CRITICAL(Debug, "Exiting without exception");
+
+        std::quick_exit(std::to_underlying(ShadPs4ReturnCode::TERMINATE_WITHOUT_EXCEPTION));
+    } catch (const std::exception& exception) {
+        LOG_CRITICAL(Debug, "Exception: {}", exception);
+
+        std::quick_exit(std::to_underlying(ShadPs4ReturnCode::TERMINATE_WITH_EXCEPTION));
+    } catch (...) {
+        LOG_CRITICAL(Debug, "Unknown exception caught");
+
+        std::quick_exit(std::to_underlying(ShadPs4ReturnCode::TERMINATE_WITH_UNKNOWN_EXCEPTION));
     }
 }
 } // namespace Common::Log

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -35,6 +35,8 @@ void Shutdown();
 
 void Flush();
 
+void Terminate();
+
 static constexpr std::array level_string_views{"Trace", "Debug",    "Info", "Warning",
                                                "Error", "Critical", "Off"};
 

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -198,6 +198,17 @@ int PS4_SYSV_ABI posix_pthread_detach(PthreadT pthread) {
 }
 
 #ifdef WIN32
+int filter(unsigned int code, struct _EXCEPTION_POINTERS* ep) {
+    // dont return EXCEPTION_CONTINUE_SEARCH to not truncate log
+    if (code != EXCEPTION_ACCESS_VIOLATION) {
+        LOG_CRITICAL(Debug, "unexpected SEH {} ep {}", code, fmt::ptr(ep));
+    }
+
+    return EXCEPTION_EXECUTE_HANDLER;
+}
+#endif
+
+#ifdef WIN32
 static DWORD RunThread(void* arg) {
 #else
 static void* RunThread(void* arg) {
@@ -210,14 +221,23 @@ static void* RunThread(void* arg) {
 
     curthread->native_thr.Initialize();
 
-    /* Run the current thread's start routine with argument: */
-    auto* const stack =
-        (void*)(((size_t)curthread->attr.stackaddr_attr + curthread->attr.stacksize_attr) & (~15));
-    void* ret = _runOnAnotherStack(curthread->arg, (void*)curthread->start_routine, stack);
+#ifdef WIN32
+    __try {
+#endif
+        /* Run the current thread's start routine with argument: */
+        auto* const stack =
+            (void*)(((size_t)curthread->attr.stackaddr_attr + curthread->attr.stacksize_attr) &
+                    (~15));
+        void* ret = _runOnAnotherStack(curthread->arg, (void*)curthread->start_routine, stack);
 
-    /* Remove thread from tracking */
-    DebugState.RemoveCurrentThreadFromGuestList();
-    posix_pthread_exit(ret);
+        /* Remove thread from tracking */
+        DebugState.RemoveCurrentThreadFromGuestList();
+        posix_pthread_exit(ret);
+#ifdef WIN32
+    } __except (filter(GetExceptionCode(), GetExceptionInformation())) {
+        std::terminate();
+    }
+#endif
 #ifdef WIN32
     return 0;
 #else

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -223,6 +223,7 @@ static void* RunThread(void* arg) {
 
 #ifdef WIN32
     __try {
+        std::set_terminate(Common::Log::Terminate);
 #endif
         /* Run the current thread's start routine with argument: */
         auto* const stack =

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -28,30 +28,49 @@
 
 namespace Core {
 
+#ifdef WIN32
+int filter(unsigned int code, struct _EXCEPTION_POINTERS* ep) {
+    // dont return EXCEPTION_CONTINUE_SEARCH to not truncate log
+    if (code != EXCEPTION_ACCESS_VIOLATION) {
+        LOG_CRITICAL(Debug, "unexpected SEH {} ep {}", code, fmt::ptr(ep));
+    }
+
+    return EXCEPTION_EXECUTE_HANDLER;
+}
+#endif
+
 static PS4_SYSV_ABI void ProgramExitFunc() {
     LOG_ERROR(Core_Linker, "Exit function called");
 }
 
 #ifdef ARCH_X86_64
 static PS4_SYSV_ABI void* RunMainEntry [[noreturn]] (EntryParams* params) {
-    // Start shared library modules
-    asm volatile("andq $-16, %%rsp\n" // Align to 16 bytes
-                 "subq $8, %%rsp\n"   // videoout_basic expects the stack to be misaligned
+#ifdef WIN32
+    __try {
+#endif
+        // Start shared library modules
+        asm volatile("andq $-16, %%rsp\n" // Align to 16 bytes
+                     "subq $8, %%rsp\n"   // videoout_basic expects the stack to be misaligned
 
-                 // Kernel also pushes some more things here during process init
-                 // at least: environment, auxv, possibly other things
+                     // Kernel also pushes some more things here during process init
+                     // at least: environment, auxv, possibly other things
 
-                 "pushq 8(%1)\n" // copy EntryParams to top of stack like the kernel does
-                 "pushq 0(%1)\n" // OpenOrbis expects to find it there
+                     "pushq 8(%1)\n" // copy EntryParams to top of stack like the kernel does
+                     "pushq 0(%1)\n" // OpenOrbis expects to find it there
 
-                 "movq %1, %%rdi\n" // also pass params and exit func
-                 "movq %2, %%rsi\n" // as before
+                     "movq %1, %%rdi\n" // also pass params and exit func
+                     "movq %2, %%rsi\n" // as before
 
-                 "jmp *%0\n" // can't use call here, as that would mangle the prepared stack.
-                             // there's no coming back
-                 :
-                 : "r"(params->entry_addr), "r"(params), "r"(ProgramExitFunc)
-                 : "rax", "rsi", "rdi");
+                     "jmp *%0\n" // can't use call here, as that would mangle the prepared stack.
+                                 // there's no coming back
+                     :
+                     : "r"(params->entry_addr), "r"(params), "r"(ProgramExitFunc)
+                     : "rax", "rsi", "rdi");
+#ifdef WIN32
+    } __except (filter(GetExceptionCode(), GetExceptionInformation())) {
+        std::terminate();
+    }
+#endif
     UNREACHABLE();
 }
 #endif

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -130,6 +130,8 @@ void Linker::Execute(const std::vector<std::string>& args) {
 
     main_thread.Run([this, module, &args](std::stop_token) {
         Common::SetCurrentThreadName("Game:Main");
+        std::set_terminate(Common::Log::Terminate);
+
 #ifndef _WIN32 // Clear any existing signal mask for game threads.
         sigset_t emptyset;
         sigemptyset(&emptyset);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,23 @@
 #endif
 #include <core/user_settings.h>
 
+#ifdef _WIN32
+LONG TopLevelExceptionHandler(_EXCEPTION_POINTERS* ExceptionInfo) {
+    DWORD code = 0;
+    PVOID address = nullptr;
+
+    if (ExceptionInfo != nullptr && ExceptionInfo->ExceptionRecord != nullptr) {
+        code = ExceptionInfo->ExceptionRecord->ExceptionCode;
+        address = ExceptionInfo->ExceptionRecord->ExceptionAddress;
+    }
+
+    LOG_CRITICAL(Debug, "Unhandled Exception code {} at 0x{}", code, address);
+    Common::Log::Flush();
+    std::terminate();
+    return EXCEPTION_EXECUTE_HANDLER;
+}
+#endif
+
 int main(int argc, char* argv[]) {
 #ifdef _WIN32
     SetConsoleOutputCP(CP_UTF8);
@@ -106,6 +123,9 @@ int main(int argc, char* argv[]) {
 
     // Start default log
     Common::Log::Setup("shad_log.txt");
+#ifdef _WIN32
+    SetUnhandledExceptionFilter(TopLevelExceptionHandler);
+#endif
 
     IPC::Instance().Init();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,7 @@ LONG TopLevelExceptionHandler(_EXCEPTION_POINTERS* ExceptionInfo) {
         address = ExceptionInfo->ExceptionRecord->ExceptionAddress;
     }
 
-    LOG_CRITICAL(Debug, "Unhandled Exception code {} at 0x{}", code, address);
+    LOG_CRITICAL(Debug, "Unhandled Exception code {} at {}", code, address);
     Common::Log::Flush();
     std::terminate();
     return EXCEPTION_EXECUTE_HANDLER;


### PR DESCRIPTION
Should fix log truncated but needs Windows + Intel test
https://github.com/shadps4-emu/shadPS4/issues/4387#issuecomment-4451200988

I dont know what will be logged between "Unknown exception caught" and "Exception: {}" because I dont know if MS exception extends std::exception

(If we wanted to do something more fancy: needs to wrap all our threads)
https://learn.microsoft.com/en-us/cpp/cpp/structured-exception-handling-c-cpp?view=msvc-170