### PR TITLE
gnmdriver: handle DingDong(vqid, 0)

### DIFF
--- a/src/core/libraries/gnmdriver/gnmdriver.cpp
+++ b/src/core/libraries/gnmdriver/gnmdriver.cpp
@@ -308,6 +308,10 @@ void PS4_SYSV_ABI sceGnmDingDong(u32 gnm_vqid, u32 next_offs_dw) {
 
     auto& offs_dw = asc_next_offs_dw[vqid];
 
+    if (next_offs_dw == offs_dw) {
+        return;
+    }
+
     if (next_offs_dw < offs_dw && next_offs_dw != 0) {
         // For cases if a submission is split at the end of the ring buffer, we need to submit it in
         // two parts to handle the wrap


### PR DESCRIPTION
When the rptr and wptr are equal, the ring is idle.
Per AMD ring buffer doc + sceGnmDingDong

Fixes false ''Invalid PM4 type 0'' in Devil May Cry 5(maybe some other titles) and brings the game to the menu.

<img width="1282" height="752" alt="obrazek" src="https://github.com/user-attachments/assets/749a3712-eb07-4094-a3bf-b455e5ed2087" />

Resident Evil 7 now ingame, confirmed by bigol
<img width="1282" height="752" alt="immagine" src="https://github.com/user-attachments/assets/00907572-bcd8-45a6-991a-bb82ccc81294" />


