### PR TITLE
Core: Let guest override argv[0]

### DIFF
--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -320,6 +320,8 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
         if (args.size() > 32) {
             LOG_ERROR(Loader, "Too many game arguments, only passing the first 32");
         }
+    } else {
+        args.insert(args.begin(), guest_eboot_path);
     }
 
     std::filesystem::path mods_folder = game_folder;
@@ -482,7 +484,6 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
         });
     }
 
-    args.insert(args.begin(), guest_eboot_path);
     linker->Execute(args);
 
     window->InitTimers();


### PR DESCRIPTION
Fixes Uncharted: The Nathan Drake Collection hanging when loading Uncharted 2 or 3. Also aligns with hardware tests.