### PR TITLE
Core: Fix file position after read-only file mmaps

### DIFF
--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -241,19 +241,28 @@ struct AddressSpace::Impl {
         if (phys_addr != -1) {
             HANDLE backing = fd != -1 ? reinterpret_cast<HANDLE>(fd) : backing_handle;
             if (fd != -1 && prot == PAGE_READONLY) {
+                // Allocate the memory for the mapping
                 DWORD resultvar;
                 ptr = VirtualAlloc2(process, reinterpret_cast<PVOID>(virtual_addr), size,
                                     MEM_RESERVE | MEM_COMMIT | MEM_REPLACE_PLACEHOLDER,
                                     PAGE_READWRITE, nullptr, 0);
 
-                // phys_addr serves as an offset for file mmaps.
+                // Use ReadFile to read file contents into the memory area.
                 // Create an OVERLAPPED with the offset, then supply that to ReadFile
                 OVERLAPPED param{};
                 // Offset is the least-significant 32 bits, OffsetHigh is the most-significant.
-                param.Offset = phys_addr & 0xffffffffull;
-                param.OffsetHigh = (phys_addr & 0xffffffff00000000ull) >> 32;
+                param.Offset = offset & 0xffffffffull;
+                param.OffsetHigh = (offset & 0xffffffff00000000ull) >> 32;
                 bool ret = ReadFile(backing, ptr, size, &resultvar, &param);
                 ASSERT_MSG(ret, "ReadFile failed. {}", Common::GetLastErrorMsg());
+
+                // ReadFile moves the file pointer, restore it with SetFilePointer
+                s64 size_to_move = -size;
+                LONG size_low = size_to_move & 0xffffffffull;
+                LONG size_high = (size_to_move & 0xffffffff00000000ull) >> 32;
+                ret = SetFilePointer(backing, size_low, &size_high, FILE_CURRENT);
+
+                // Protect the memory area appropriately
                 ret = VirtualProtect(ptr, size, prot, &resultvar);
                 ASSERT_MSG(ret, "VirtualProtect failed. {}", Common::GetLastErrorMsg());
             } else {

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -248,11 +248,11 @@ struct AddressSpace::Impl {
                                     PAGE_READWRITE, nullptr, 0);
 
                 // Use ReadFile to read file contents into the memory area.
-                // Create an OVERLAPPED with the offset, then supply that to ReadFile
+                // Create an OVERLAPPED with the file offset, then supply that to ReadFile
                 OVERLAPPED param{};
                 // Offset is the least-significant 32 bits, OffsetHigh is the most-significant.
-                param.Offset = offset & 0xffffffffull;
-                param.OffsetHigh = (offset & 0xffffffff00000000ull) >> 32;
+                param.Offset = phys_addr & 0xffffffffull;
+                param.OffsetHigh = (phys_addr & 0xffffffff00000000ull) >> 32;
                 bool ret = ReadFile(backing, ptr, size, &resultvar, &param);
                 ASSERT_MSG(ret, "ReadFile failed. {}", Common::GetLastErrorMsg());
 


### PR DESCRIPTION
This whole branch of logic is completely wrong, but I plan to fix that up separately in preparation for the upcoming memory rewrite.