### PR TITLE
Lib.Audio3d: Implement sceAudio3dPortGetAttributesSupported based on currently handled attributes

### DIFF
--- a/src/core/libraries/audio3d/audio3d.cpp
+++ b/src/core/libraries/audio3d/audio3d.cpp
@@ -694,8 +694,19 @@ s32 PS4_SYSV_ABI sceAudio3dPortFreeState() {
     return ORBIS_OK;
 }
 
-s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported() {
+s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported(OrbisAudio3dPortId port_id,
+                                                      OrbisAudio3dAttributeId* capabilities,
+                                                      u32* num_capabilities) {
     LOG_ERROR(Lib_Audio3d, "(STUBBED) called");
+    if (!num_capabilities) {
+        return ORBIS_AUDIO3D_ERROR_INVALID_PARAMETER;
+    }
+
+    if (!state->ports.contains(port_id)) {
+        return ORBIS_AUDIO3D_ERROR_INVALID_PORT;
+    }
+
+    *num_capabilities = 0;
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/audio3d/audio3d.cpp
+++ b/src/core/libraries/audio3d/audio3d.cpp
@@ -709,6 +709,8 @@ s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported(OrbisAudio3dPortId port_id
     // We support three attributes, PCM, Gain, and ResetState
     // In the future, supported attributes should be stored in the port.
     if (capabilities) {
+        // Writes up to num_capabilities supported capabilities,
+        // then sets num_capabilities to how many were written.
         u32 caps_to_write = *num_capabilities;
         if (caps_to_write >= 1) {
             capabilities[0] = OrbisAudio3dAttributeId::ORBIS_AUDIO3D_ATTRIBUTE_PCM;
@@ -719,8 +721,11 @@ s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported(OrbisAudio3dPortId port_id
         if (caps_to_write >= 3) {
             capabilities[2] = OrbisAudio3dAttributeId::ORBIS_AUDIO3D_ATTRIBUTE_RESET_STATE;
         }
+        *num_capabilities = std::min<u32>(caps_to_write, 3);
+    } else {
+        // If capabilities is null, then just report the number of supported capabilities.
+        *num_capabilities = 3;
     }
-    *num_capabilities = 3;
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/audio3d/audio3d.cpp
+++ b/src/core/libraries/audio3d/audio3d.cpp
@@ -697,7 +697,7 @@ s32 PS4_SYSV_ABI sceAudio3dPortFreeState() {
 s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported(OrbisAudio3dPortId port_id,
                                                       OrbisAudio3dAttributeId* capabilities,
                                                       u32* num_capabilities) {
-    LOG_ERROR(Lib_Audio3d, "(STUBBED) called");
+    LOG_DEBUG(Lib_Audio3d, "called");
     if (!num_capabilities) {
         return ORBIS_AUDIO3D_ERROR_INVALID_PARAMETER;
     }
@@ -706,7 +706,21 @@ s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported(OrbisAudio3dPortId port_id
         return ORBIS_AUDIO3D_ERROR_INVALID_PORT;
     }
 
-    *num_capabilities = 0;
+    // We support three attributes, PCM, Gain, and ResetState
+    // In the future, supported attributes should be stored in the port.
+    if (capabilities) {
+        u32 caps_to_write = *num_capabilities;
+        if (caps_to_write >= 1) {
+            capabilities[0] = OrbisAudio3dAttributeId::ORBIS_AUDIO3D_ATTRIBUTE_PCM;
+        }
+        if (caps_to_write >= 2) {
+            capabilities[1] = OrbisAudio3dAttributeId::ORBIS_AUDIO3D_ATTRIBUTE_GAIN;
+        }
+        if (caps_to_write >= 3) {
+            capabilities[2] = OrbisAudio3dAttributeId::ORBIS_AUDIO3D_ATTRIBUTE_RESET_STATE;
+        }
+    }
+    *num_capabilities = 3;
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/audio3d/audio3d.h
+++ b/src/core/libraries/audio3d/audio3d.h
@@ -158,7 +158,9 @@ s32 PS4_SYSV_ABI sceAudio3dPortCreate();
 s32 PS4_SYSV_ABI sceAudio3dPortDestroy();
 s32 PS4_SYSV_ABI sceAudio3dPortFlush(OrbisAudio3dPortId port_id);
 s32 PS4_SYSV_ABI sceAudio3dPortFreeState();
-s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported();
+s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported(OrbisAudio3dPortId port_id,
+                                                      OrbisAudio3dAttributeId* capabilities,
+                                                      u32* num_capabilities);
 s32 PS4_SYSV_ABI sceAudio3dPortGetList();
 s32 PS4_SYSV_ABI sceAudio3dPortGetParameters();
 s32 PS4_SYSV_ABI sceAudio3dPortGetQueueLevel(OrbisAudio3dPortId port_id, u32* queue_level,

--- a/src/core/libraries/audio3d/audio3d_openal.cpp
+++ b/src/core/libraries/audio3d/audio3d_openal.cpp
@@ -694,8 +694,19 @@ s32 PS4_SYSV_ABI sceAudio3dPortFreeState() {
     return ORBIS_OK;
 }
 
-s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported() {
+s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported(OrbisAudio3dPortId port_id,
+                                                      OrbisAudio3dAttributeId* capabilities,
+                                                      u32* num_capabilities) {
     LOG_ERROR(Lib_Audio3d, "(STUBBED) called");
+    if (!num_capabilities) {
+        return ORBIS_AUDIO3D_ERROR_INVALID_PARAMETER;
+    }
+
+    if (!state->ports.contains(port_id)) {
+        return ORBIS_AUDIO3D_ERROR_INVALID_PORT;
+    }
+
+    *num_capabilities = 0;
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/audio3d/audio3d_openal.cpp
+++ b/src/core/libraries/audio3d/audio3d_openal.cpp
@@ -709,6 +709,8 @@ s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported(OrbisAudio3dPortId port_id
     // We support three attributes, PCM, Gain, and ResetState
     // In the future, supported attributes should be stored in the port.
     if (capabilities) {
+        // Writes up to num_capabilities supported capabilities,
+        // then sets num_capabilities to how many were written.
         u32 caps_to_write = *num_capabilities;
         if (caps_to_write >= 1) {
             capabilities[0] = OrbisAudio3dAttributeId::ORBIS_AUDIO3D_ATTRIBUTE_PCM;
@@ -719,8 +721,11 @@ s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported(OrbisAudio3dPortId port_id
         if (caps_to_write >= 3) {
             capabilities[2] = OrbisAudio3dAttributeId::ORBIS_AUDIO3D_ATTRIBUTE_RESET_STATE;
         }
+        *num_capabilities = std::min<u32>(caps_to_write, 3);
+    } else {
+        // If capabilities is null, then just report the number of supported capabilities.
+        *num_capabilities = 3;
     }
-    *num_capabilities = 3;
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/audio3d/audio3d_openal.cpp
+++ b/src/core/libraries/audio3d/audio3d_openal.cpp
@@ -697,7 +697,7 @@ s32 PS4_SYSV_ABI sceAudio3dPortFreeState() {
 s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported(OrbisAudio3dPortId port_id,
                                                       OrbisAudio3dAttributeId* capabilities,
                                                       u32* num_capabilities) {
-    LOG_ERROR(Lib_Audio3d, "(STUBBED) called");
+    LOG_DEBUG(Lib_Audio3d, "called");
     if (!num_capabilities) {
         return ORBIS_AUDIO3D_ERROR_INVALID_PARAMETER;
     }
@@ -706,7 +706,21 @@ s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported(OrbisAudio3dPortId port_id
         return ORBIS_AUDIO3D_ERROR_INVALID_PORT;
     }
 
-    *num_capabilities = 0;
+    // We support three attributes, PCM, Gain, and ResetState
+    // In the future, supported attributes should be stored in the port.
+    if (capabilities) {
+        u32 caps_to_write = *num_capabilities;
+        if (caps_to_write >= 1) {
+            capabilities[0] = OrbisAudio3dAttributeId::ORBIS_AUDIO3D_ATTRIBUTE_PCM;
+        }
+        if (caps_to_write >= 2) {
+            capabilities[1] = OrbisAudio3dAttributeId::ORBIS_AUDIO3D_ATTRIBUTE_GAIN;
+        }
+        if (caps_to_write >= 3) {
+            capabilities[2] = OrbisAudio3dAttributeId::ORBIS_AUDIO3D_ATTRIBUTE_RESET_STATE;
+        }
+    }
+    *num_capabilities = 3;
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/audio3d/audio3d_openal.h
+++ b/src/core/libraries/audio3d/audio3d_openal.h
@@ -156,7 +156,9 @@ s32 PS4_SYSV_ABI sceAudio3dPortCreate();
 s32 PS4_SYSV_ABI sceAudio3dPortDestroy();
 s32 PS4_SYSV_ABI sceAudio3dPortFlush(OrbisAudio3dPortId port_id);
 s32 PS4_SYSV_ABI sceAudio3dPortFreeState();
-s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported();
+s32 PS4_SYSV_ABI sceAudio3dPortGetAttributesSupported(OrbisAudio3dPortId port_id,
+                                                      OrbisAudio3dAttributeId* capabilities,
+                                                      u32* num_capabilities);
 s32 PS4_SYSV_ABI sceAudio3dPortGetList();
 s32 PS4_SYSV_ABI sceAudio3dPortGetParameters();
 s32 PS4_SYSV_ABI sceAudio3dPortGetQueueLevel(OrbisAudio3dPortId port_id, u32* queue_level,


### PR DESCRIPTION
Basically a revival of #3814 updated to match our current libSceAudio3d implementations.
This fixes updated versions of Battlefield V crashing on boot.