### PR TITLE
camera: Fix firmware check

### DIFF
--- a/src/core/libraries/camera/camera.cpp
+++ b/src/core/libraries/camera/camera.cpp
@@ -329,7 +329,7 @@ s32 PS4_SYSV_ABI sceCameraGetExposureGain(s32 handle, OrbisCameraChannel channel
 
     // Return default parameters
     exposure_gain->exposureControl = 0;
-    exposure_gain->exposure = 83;
+    exposure_gain->exposure = 20;
     exposure_gain->gain = 100;
     exposure_gain->mode = 0;
     return ORBIS_OK;
@@ -1007,7 +1007,7 @@ s32 PS4_SYSV_ABI sceCameraStart(s32 handle, OrbisCameraStartParameter* param) {
     if (!g_library_opened) {
         return ORBIS_CAMERA_ERROR_NOT_OPEN;
     }
-    if (g_firmware_version >= Common::ElfInfo::FW_250 &&
+    if (g_firmware_version <= Common::ElfInfo::FW_250 &&
         (param->formatLevel[0] >= 0xf || param->formatLevel[1] >= 0xf ||
          (param->formatLevel[0] | param->formatLevel[1]) == 0)) {
         return ORBIS_CAMERA_ERROR_FORMAT_UNKNOWN;


### PR DESCRIPTION
This makes Tearaway Unfolded successfully open the PS4 camera, although the game still doesn't get far enough to actually see the camera output.