### PR TITLE
Set AccessFlagBits::eNone for PresentSrcKHR image layout

### DIFF
--- a/src/video_core/renderer_vulkan/vk_presenter.cpp
+++ b/src/video_core/renderer_vulkan/vk_presenter.cpp
@@ -1043,7 +1043,7 @@ void Presenter::Present(Frame* frame, bool is_reusing_frame) {
                                                     : vk::ImageLayout::eColorAttachmentOptimal;
         const vk::ImageMemoryBarrier post_barrier{
             .srcAccessMask = post_src_access_mask,
-            .dstAccessMask = vk::AccessFlagBits::eMemoryRead,
+            .dstAccessMask = vk::AccessFlagBits::eNone,
             .oldLayout = post_old_layout,
             .newLayout = vk::ImageLayout::ePresentSrcKHR,
             .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,


### PR DESCRIPTION
Fixes a BestPractices warning:

```
Validation Warning: [ BestPractices-ImageBarrierAccessLayout ] | MessageID = 0xf35d019f
vkCmdPipelineBarrier(): pImageMemoryBarriers[0] image is VkImage 0x90000000009[Swapchain Image 0] and accessMask is VK_ACCESS_2_MEMORY_READ_BIT, but for layout VK_IMAGE_LAYOUT_PRESENT_SRC_KHR expected accessMask are VkAccessFlags2(0).
Objects: 1
    [0] VkImage 0x90000000009[Swapchain Image 0]
```