### PR TITLE
Revert quad/rect list parameter forwarding changes

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_quad_rect.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_quad_rect.cpp
@@ -12,9 +12,8 @@ using Sirit::Id;
 constexpr u32 SPIRV_VERSION_1_5 = 0x00010500;
 
 struct QuadRectListEmitter : public Sirit::Module {
-    explicit QuadRectListEmitter(const VertexRuntimeInfo& vs_info_,
-                                 const FragmentRuntimeInfo& fs_info_)
-        : Sirit::Module{SPIRV_VERSION_1_5}, vs_info{vs_info_}, fs_info{fs_info_} {
+    explicit QuadRectListEmitter(const FragmentRuntimeInfo& fs_info_)
+        : Sirit::Module{SPIRV_VERSION_1_5}, fs_info{fs_info_} {
         void_id = TypeVoid();
         bool_id = TypeBool();
         float_id = TypeFloat(32);
@@ -253,9 +252,8 @@ private:
         } else {
             gl_per_vertex = AddOutput(gl_per_vertex_type);
         }
-        const auto num_forwards = std::min(vs_info.num_exports, fs_info.num_inputs);
-        outputs.reserve(num_forwards);
-        for (int i = 0; i < num_forwards; i++) {
+        outputs.reserve(fs_info.num_inputs);
+        for (int i = 0; i < fs_info.num_inputs; i++) {
             const auto& input = fs_info.inputs[i];
             if (input.IsDefault()) {
                 continue;
@@ -278,10 +276,8 @@ private:
         const Id gl_per_vertex_array{TypeArray(gl_per_vertex_type, Constant(uint_id, 32U))};
         gl_in = AddInput(gl_per_vertex_array);
         const Id float_arr{TypeArray(vec4_id, Int(32))};
-
-        const auto num_forwards = std::min(vs_info.num_exports, fs_info.num_inputs);
-        inputs.reserve(num_forwards);
-        for (int i = 0; i < num_forwards; i++) {
+        inputs.reserve(fs_info.num_inputs);
+        for (int i = 0; i < fs_info.num_inputs; i++) {
             const auto& input = fs_info.inputs[i];
             if (input.IsDefault()) {
                 continue;
@@ -292,7 +288,6 @@ private:
     }
 
 private:
-    VertexRuntimeInfo vs_info;
     FragmentRuntimeInfo fs_info;
     Id main;
     Id void_id;
@@ -324,9 +319,8 @@ private:
     std::vector<Id> interfaces;
 };
 
-std::vector<u32> EmitAuxilaryTessShader(AuxShaderType type, const VertexRuntimeInfo& vs_info,
-                                        const FragmentRuntimeInfo& fs_info) {
-    QuadRectListEmitter ctx{vs_info, fs_info};
+std::vector<u32> EmitAuxilaryTessShader(AuxShaderType type, const FragmentRuntimeInfo& fs_info) {
+    QuadRectListEmitter ctx{fs_info};
     switch (type) {
     case AuxShaderType::RectListTCS:
         ctx.EmitRectListTCS();

--- a/src/shader_recompiler/backend/spirv/emit_spirv_quad_rect.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_quad_rect.cpp
@@ -25,11 +25,9 @@ struct QuadRectListEmitter : public Sirit::Module {
         vec3_id = TypeVector(float_id, 3);
         vec4_id = TypeVector(float_id, 4);
 
-        float_zero = Constant(float_id, 0.0f);
         float_one = Constant(float_id, 1.0f);
         float_min_one = Constant(float_id, -1.0f);
         int_zero = Constant(int_id, 0);
-        vec4_zero = ConstantComposite(vec4_id, float_zero, float_zero, float_zero, float_zero);
 
         const Id float_arr{TypeArray(float_id, Constant(uint_id, 1U))};
         gl_per_vertex_type = TypeStruct(vec4_id, float_id, float_arr, float_arr);
@@ -192,14 +190,8 @@ struct QuadRectListEmitter : public Sirit::Module {
         OpStore(OpAccessChain(output_vec4, gl_per_vertex, Int(0)), position);
 
         // out_paramN = in_paramN[index];
-        for (int i = 0; i < outputs.size(); i++) {
-            Id param;
-            if (i < inputs.size()) {
-                param = OpLoad(vec4_id, OpAccessChain(input_vec4, inputs[i], index));
-            } else {
-                // Not enough inputs to forward, use dummy value.
-                param = vec4_zero;
-            }
+        for (int i = 0; i < inputs.size(); i++) {
+            const Id param{OpLoad(vec4_id, OpAccessChain(input_vec4, inputs[i], index))};
             OpStore(outputs[i], param);
         }
 
@@ -245,7 +237,6 @@ private:
     }
 
     void DefineOutputs(spv::ExecutionModel model) {
-        auto num_forwards = vs_info.num_exports;
         if (model == spv::ExecutionModel::TessellationControl) {
             const Id gl_per_vertex_array{TypeArray(gl_per_vertex_type, Constant(uint_id, 4U))};
             gl_out = AddOutput(gl_per_vertex_array);
@@ -261,10 +252,8 @@ private:
             Decorate(gl_tess_level_outer, spv::Decoration::Patch);
         } else {
             gl_per_vertex = AddOutput(gl_per_vertex_type);
-            // Tessellation eval stage comes before fragment, output number of forwards it will
-            // actually accept.
-            num_forwards = fs_info.num_inputs;
         }
+        const auto num_forwards = std::min(vs_info.num_exports, fs_info.num_inputs);
         outputs.reserve(num_forwards);
         for (int i = 0; i < num_forwards; i++) {
             const auto& input = fs_info.inputs[i];
@@ -290,7 +279,7 @@ private:
         gl_in = AddInput(gl_per_vertex_array);
         const Id float_arr{TypeArray(vec4_id, Int(32))};
 
-        const auto num_forwards = vs_info.num_exports;
+        const auto num_forwards = std::min(vs_info.num_exports, fs_info.num_inputs);
         inputs.reserve(num_forwards);
         for (int i = 0; i < num_forwards; i++) {
             const auto& input = fs_info.inputs[i];
@@ -315,11 +304,9 @@ private:
     Id vec2_id;
     Id vec3_id;
     Id vec4_id;
-    Id float_zero;
     Id float_one;
     Id float_min_one;
     Id int_zero;
-    Id vec4_zero;
     Id gl_per_vertex_type;
     Id gl_in;
     union {

--- a/src/shader_recompiler/backend/spirv/emit_spirv_quad_rect.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_quad_rect.h
@@ -8,8 +8,7 @@
 
 namespace Shader {
 struct FragmentRuntimeInfo;
-struct VertexRuntimeInfo;
-} // namespace Shader
+}
 
 namespace Shader::Backend::SPIRV {
 
@@ -20,7 +19,6 @@ enum class AuxShaderType : u32 {
 };
 
 [[nodiscard]] std::vector<u32> EmitAuxilaryTessShader(AuxShaderType type,
-                                                      const VertexRuntimeInfo& vs_info,
                                                       const FragmentRuntimeInfo& fs_info);
 
 } // namespace Shader::Backend::SPIRV

--- a/src/shader_recompiler/ir/passes/inject_clip_distance_attributes.cpp
+++ b/src/shader_recompiler/ir/passes/inject_clip_distance_attributes.cpp
@@ -5,19 +5,10 @@
 #include "shader_recompiler/ir/basic_block.h"
 #include "shader_recompiler/ir/ir_emitter.h"
 #include "shader_recompiler/ir/program.h"
-#include "shader_recompiler/profile.h"
 
 namespace Shader {
 
-void InjectClipDistanceAttributes(IR::Program& program, RuntimeInfo& runtime_info,
-                                  const Profile& profile) {
-    if (program.info.stage == Stage::Vertex && profile.needs_clip_distance_emulation &&
-        program.info.stores.GetAny(IR::Attribute::ClipDistance)) {
-        // Increment to include the added clip distance export.
-        ++runtime_info.vs_info.num_exports;
-        return;
-    }
-
+void InjectClipDistanceAttributes(IR::Program& program, RuntimeInfo& runtime_info) {
     auto& info = runtime_info.fs_info;
 
     if (!info.clip_distance_emulation || program.info.l_stage != LogicalStage::Fragment) {

--- a/src/shader_recompiler/ir/passes/ir_passes.h
+++ b/src/shader_recompiler/ir/passes/ir_passes.h
@@ -8,8 +8,7 @@
 
 namespace Shader {
 struct Profile;
-void InjectClipDistanceAttributes(IR::Program& program, RuntimeInfo& runtime_info,
-                                  const Profile& profile);
+void InjectClipDistanceAttributes(IR::Program& program, RuntimeInfo& runtime_info);
 } // namespace Shader
 
 namespace Shader::Optimization {

--- a/src/shader_recompiler/recompiler.cpp
+++ b/src/shader_recompiler/recompiler.cpp
@@ -61,7 +61,7 @@ IR::Program TranslateProgram(const std::span<const u32>& code, Pools& pools, Inf
 
     // On NVIDIA GPUs HW interpolation of clip distance values seems broken, and we need to emulate
     // it with expensive discard in PS.
-    Shader::InjectClipDistanceAttributes(program, runtime_info, profile);
+    Shader::InjectClipDistanceAttributes(program, runtime_info);
 
     // Run optimization passes
     if (!profile.support_float64) {

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -95,7 +95,6 @@ using OutputMap = std::array<Output, 4>;
 
 struct VertexRuntimeInfo : protected CommonEsVsRuntimeInfo {
     u32 num_outputs;
-    u32 num_exports;
     std::array<OutputMap, 3> outputs;
     bool tess_emulated_primitive{};
     bool emulate_depth_negative_one_to_one{};

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -193,9 +193,8 @@ GraphicsPipeline::GraphicsPipeline(
     } else if (is_rect_list || is_quad_list) {
         const auto type = is_quad_list ? AuxShaderType::QuadListTCS : AuxShaderType::RectListTCS;
         if (!preloading) {
-            const auto& vs_info = runtime_infos[u32(Shader::LogicalStage::Vertex)].vs_info;
             const auto& fs_info = runtime_infos[u32(Shader::LogicalStage::Fragment)].fs_info;
-            sdata.tcs = Shader::Backend::SPIRV::EmitAuxilaryTessShader(type, vs_info, fs_info);
+            sdata.tcs = Shader::Backend::SPIRV::EmitAuxilaryTessShader(type, fs_info);
         }
         shader_stages.emplace_back(vk::PipelineShaderStageCreateInfo{
             .stage = vk::ShaderStageFlagBits::eTessellationControl,
@@ -212,10 +211,9 @@ GraphicsPipeline::GraphicsPipeline(
         });
     } else if (is_rect_list || is_quad_list) {
         if (!preloading) {
-            const auto& vs_info = runtime_infos[u32(Shader::LogicalStage::Vertex)].vs_info;
             const auto& fs_info = runtime_infos[u32(Shader::LogicalStage::Fragment)].fs_info;
             sdata.tes = Shader::Backend::SPIRV::EmitAuxilaryTessShader(
-                AuxShaderType::PassthroughTES, vs_info, fs_info);
+                AuxShaderType::PassthroughTES, fs_info);
         }
         shader_stages.emplace_back(vk::PipelineShaderStageCreateInfo{
             .stage = vk::ShaderStageFlagBits::eTessellationEvaluation,

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -134,7 +134,6 @@ const Shader::RuntimeInfo& PipelineCache::BuildRuntimeInfo(Stage stage, LogicalS
         info.vs_info.step_rate_0 = regs.vgt_instance_step_rate_0;
         info.vs_info.step_rate_1 = regs.vgt_instance_step_rate_1;
         info.vs_info.num_outputs = MapOutputs(info.vs_info.outputs, regs.vs_output_control);
-        info.vs_info.num_exports = regs.vs_output_config.NumExports();
         info.vs_info.emulate_depth_negative_one_to_one =
             !instance.IsDepthClipControlSupported() &&
             regs.clipper_control.clip_space == AmdGpu::ClipSpace::MinusWToW;


### PR DESCRIPTION
Still facing issues even after equaling the input/output parameter counts, just going to revert these and we'll need to accept the original validation issue for now.