### PR TITLE
cpu_patches: Log full instruction on JIT patch failure.

### DIFF
--- a/src/core/cpu_patches.cpp
+++ b/src/core/cpu_patches.cpp
@@ -788,10 +788,16 @@ static bool PatchesIllegalInstructionHandler(void* context) {
             ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT];
             const auto status =
                 Common::Decoder::Instance()->decodeInstruction(instruction, operands, code_address);
-            LOG_ERROR(Core, "Failed to patch address {:x} -- mnemonic: {}",
-                      reinterpret_cast<u64>(code_address),
-                      ZYAN_SUCCESS(status) ? ZydisMnemonicGetString(instruction.mnemonic)
-                                           : "Failed to decode");
+            if (ZYAN_SUCCESS(status)) {
+                const auto disassembled = Common::Decoder::Instance()->disassembleInst(
+                    instruction, operands, std::bit_cast<u64>(code_address));
+                LOG_ERROR(Core, "Failed to patch address {:x} -- mnemonic: {}, instruction: {}",
+                          reinterpret_cast<u64>(code_address),
+                          ZydisMnemonicGetString(instruction.mnemonic), disassembled);
+            } else {
+                LOG_ERROR(Core, "Failed to patch address {:x} -- mnemonic: (failed to decode)",
+                          reinterpret_cast<u64>(code_address));
+            }
             return false;
         }
     }


### PR DESCRIPTION
Should help in debugging illegal instruction exceptions.