### PR TITLE
build: Explicitly turn off AVX512

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ endif()
 if (ARCHITECTURE STREQUAL "x86_64")
     # Target x86-64-v3 CPU architecture as this is a good balance between supporting performance critical
     # instructions like AVX2 and maintaining support for older CPUs.
-    add_compile_options(-march=x86-64-v3)
+    add_compile_options(-march=x86-64-v3 -mno-avx512f)
 endif()
 
 if (APPLE AND ARCHITECTURE STREQUAL "x86_64" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")


### PR DESCRIPTION
Explicitly turning off AVX512 in the compile flags so that nothing can pick it up and build requiring it.

With this change, zlib (which was picking up AVX512) now says:
```
-- Performing Test HAVE_AVX2_INTRIN
-- Performing Test HAVE_AVX2_INTRIN - Success
-- Performing Test HAVE_AVX512_INTRIN
-- Performing Test HAVE_AVX512_INTRIN - Failed
-- Performing Test HAVE_AVX512VNNI_INTRIN
-- Performing Test HAVE_AVX512VNNI_INTRIN - Failed
-- Performing Test HAVE_VPCLMULQDQ_INTRIN
-- Performing Test HAVE_VPCLMULQDQ_INTRIN - Failed
-- Architecture-specific source files: arch/x86/chunkset_sse2.c;arch/x86/compare256_sse2.c;arch/x86/slide_hash_sse2.c;arch/x86/adler32_ssse3.c;arch/x86/chunkset_ssse3.c;arch/x86/adler32_sse42.c;arch/x86/crc32_pclmulqdq.c;arch/x86/slide_hash_avx2.c;arch/x86/chunkset_avx2.c;arch/x86/compare256_avx2.c;arch/x86/adler32_avx2.c
```