### PR TITLE
Nix flake changes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -110,6 +110,8 @@
             libxkbcommon
             libGL
             libuuid
+            miniz
+            libressl
           ];
 
           defaultFlags = [

--- a/flake.nix
+++ b/flake.nix
@@ -152,7 +152,7 @@
             nativeBuildInputs = nativeInputs;
             buildInputs = buildInputs;
             cmakeFlags = [
-              "-DCMAKE_BUILD_TYPE=Release"
+              "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
             ] ++ [defaultFlags];
           };
         };


### PR DESCRIPTION
- Added miniz and libressl as dependencies
- Replaced Release with RelWithDebInfo for Nix CMake Flags 