### PR TITLE
Further additions to flake

### DIFF
--- a/documents/building-linux.md
+++ b/documents/building-linux.md
@@ -57,7 +57,7 @@ nix-shell shell.nix
 #### Nix Flake Development Shell
 ```bash
 nix develop
-cmake -S . -B build/ -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON  
+cmake -S . -B build/
 ln -s ./build/compile_commands.json .
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -114,9 +114,20 @@
             libressl
           ];
 
-          defaultFlags = [
-            "-DCMAKE_INSTALL_PREFIX=$out"
-          ];
+          build = {debugSymbols ? true, buildFlags}: pkgsLinux.stdenv.mkDerivation (finalAttrs: {
+            pname = "shadps4";
+            version = "git";
+            system = "x86_64-linux";
+            src = ./.;
+
+            dontStrip = !debugSymbols;
+
+            nativeBuildInputs = nativeInputs;
+            buildInputs = buildInputs;
+            cmakeFlags = [
+              "-DCMAKE_INSTALL_PREFIX=$out"
+            ] ++ [ buildFlags ];
+          });
         in
         {
           debug = pkgsLinux.stdenv.mkDerivation {

--- a/flake.nix
+++ b/flake.nix
@@ -123,50 +123,13 @@
 
             nativeBuildInputs = nativeInputs;
             buildInputs = buildInputs;
-            cmakeFlags = [
-              "-DCMAKE_INSTALL_PREFIX=$out"
-            ] ++ [ buildFlags ];
+            cmakeFlags = buildFlags; 
           });
         in
         {
-          debug = pkgsLinux.stdenv.mkDerivation {
-            pname = "${execName}";
-            version = "git";
-            system = "x86_64-linux";
-            src = ./.;
-            dontStrip = true;
-
-            nativeBuildInputs = nativeInputs;
-            buildInputs = buildInputs;
-            cmakeFlags = [
-              "-DCMAKE_BUILD_TYPE=Debug"
-            ] ++ [defaultFlags];
-          };
-          release = pkgsLinux.stdenv.mkDerivation {
-            pname = "${execName}";
-            version = "git";
-            system = "x86_64-linux";
-            src = ./.;
-
-            nativeBuildInputs = nativeInputs;
-            buildInputs = buildInputs;
-            cmakeFlags = [
-              "-DCMAKE_BUILD_TYPE=Release"
-            ] ++ [defaultFlags];
-          };
-          releaseWithDebugInfo = pkgsLinux.stdenv.mkDerivation {
-            pname = "${execName}";
-            version = "git";
-            system = "x86_64-linux";
-            src = ./.;
-            dontStrip = true;
-
-            nativeBuildInputs = nativeInputs;
-            buildInputs = buildInputs;
-            cmakeFlags = [
-              "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
-            ] ++ [defaultFlags];
-          };
+          debug = build{buildFlags = ["-DCMAKE_BUILD_TYPE=Debug"]};
+          release = build{debugSymbols = false, buildFlags = ["-DCMAKE_BUILD_TYPE=Release"]};
+          releaseWithDebugInfo = build{buildFlags = ["-DCMAKE_BUILD_TYPE=RelWithDebInfo"]};
         };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,6 @@
 
       linux =
         let
-          execName = "shadps4";
           nativeInputs = with pkgsLinux; [
             cmake
             ninja

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
           renderdoc
           gef
           strace
+          perf
 
           openal
           zlib.dev

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,8 @@
       pkgsLinux = nixpkgs.legacyPackages.x86_64-linux;
     in
     {
+      formatter.x86_64-linux = pkgsLinux.nixpkgs-fmt;
+
       devShells.x86_64-linux.default = pkgsLinux.mkShell.override { stdenv = pkgsLinux.clangStdenv; } {
         packages = with pkgsLinux; [
           clang-tools

--- a/flake.nix
+++ b/flake.nix
@@ -115,7 +115,7 @@
 
           build = {debugSymbols ? true, buildFlags}: pkgsLinux.clangStdenv.mkDerivation {
             pname = "shadps4";
-            version = "git";
+            version = "15.1";
             system = "x86_64-linux";
             src = ./.;
 

--- a/flake.nix
+++ b/flake.nix
@@ -113,7 +113,7 @@
             libressl
           ];
 
-          build = {debugSymbols ? true, buildFlags}: pkgsLinux.stdenv.mkDerivation {
+          build = {debugSymbols ? true, buildFlags}: pkgsLinux.clangStdenv.mkDerivation {
             pname = "shadps4";
             version = "git";
             system = "x86_64-linux";

--- a/flake.nix
+++ b/flake.nix
@@ -123,7 +123,7 @@
             system = "x86_64-linux";
             src = ./.;
 
-            dontStrip = !debugSymbols;
+            dontStrip = if debugSymbols then true else false;
 
             nativeBuildInputs = nativeInputs;
             buildInputs = buildInputs;

--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,10 @@
         shellHook = ''
           echo "Entering shadPS4 development shell!"
         '';
+        
+        CMAKE_C_COMPILER=clang;
+        CMAKE_CXX_COMPILER=clang++;
+        CMAKE_EXPORT_COMPILE_COMMANDS=ON;
       };
 
       linux =

--- a/flake.nix
+++ b/flake.nix
@@ -71,9 +71,9 @@
           echo "Entering shadPS4 development shell!"
         '';
         
-        CMAKE_C_COMPILER=clang;
-        CMAKE_CXX_COMPILER=clang++;
-        CMAKE_EXPORT_COMPILE_COMMANDS=ON;
+        CMAKE_C_COMPILER="clang";
+        CMAKE_CXX_COMPILER="clang++";
+        CMAKE_EXPORT_COMPILE_COMMANDS="ON";
       };
 
       linux =

--- a/flake.nix
+++ b/flake.nix
@@ -70,10 +70,10 @@
         shellHook = ''
           echo "Entering shadPS4 development shell!"
         '';
-        
-        CMAKE_C_COMPILER="clang";
-        CMAKE_CXX_COMPILER="clang++";
-        CMAKE_EXPORT_COMPILE_COMMANDS="ON";
+
+        CMAKE_C_COMPILER = "clang";
+        CMAKE_CXX_COMPILER = "clang++";
+        CMAKE_EXPORT_COMPILE_COMMANDS = "ON";
       };
 
       linux =
@@ -120,7 +120,7 @@
             libressl
           ];
 
-          build = {debugSymbols ? true, buildFlags}: pkgsLinux.clangStdenv.mkDerivation {
+          build = { debugSymbols ? true, buildFlags }: pkgsLinux.clangStdenv.mkDerivation {
             pname = "shadps4";
             version = "15.1";
             system = "x86_64-linux";
@@ -130,13 +130,13 @@
 
             nativeBuildInputs = nativeInputs;
             buildInputs = buildInputs;
-            cmakeFlags = buildFlags; 
+            cmakeFlags = buildFlags;
           };
         in
         {
-          debug = build{buildFlags = ["-DCMAKE_BUILD_TYPE=Debug"];};
-          release = build{debugSymbols = false; buildFlags = ["-DCMAKE_BUILD_TYPE=Release"];};
-          releaseWithDebugInfo = build{buildFlags = ["-DCMAKE_BUILD_TYPE=RelWithDebInfo"];};
+          debug = build { buildFlags = [ "-DCMAKE_BUILD_TYPE=Debug" ]; };
+          release = build { debugSymbols = false; buildFlags = [ "-DCMAKE_BUILD_TYPE=Release" ]; };
+          releaseWithDebugInfo = build { buildFlags = [ "-DCMAKE_BUILD_TYPE=RelWithDebInfo" ]; };
         };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -113,7 +113,7 @@
             libressl
           ];
 
-          build = {debugSymbols ? true, buildFlags}: pkgsLinux.stdenv.mkDerivation (finalAttrs: {
+          build = {debugSymbols ? true, buildFlags}: pkgsLinux.stdenv.mkDerivation {
             pname = "shadps4";
             version = "git";
             system = "x86_64-linux";
@@ -124,7 +124,7 @@
             nativeBuildInputs = nativeInputs;
             buildInputs = buildInputs;
             cmakeFlags = buildFlags; 
-          });
+          };
         in
         {
           debug = build{buildFlags = ["-DCMAKE_BUILD_TYPE=Debug"]};

--- a/flake.nix
+++ b/flake.nix
@@ -127,9 +127,9 @@
           };
         in
         {
-          debug = build{buildFlags = ["-DCMAKE_BUILD_TYPE=Debug"]};
-          release = build{debugSymbols = false, buildFlags = ["-DCMAKE_BUILD_TYPE=Release"]};
-          releaseWithDebugInfo = build{buildFlags = ["-DCMAKE_BUILD_TYPE=RelWithDebInfo"]};
+          debug = build{buildFlags = ["-DCMAKE_BUILD_TYPE=Debug"];};
+          release = build{debugSymbols = false; buildFlags = ["-DCMAKE_BUILD_TYPE=Release"];};
+          releaseWithDebugInfo = build{buildFlags = ["-DCMAKE_BUILD_TYPE=RelWithDebInfo"];};
         };
     };
 }


### PR DESCRIPTION
- Wrapper function for cleaning up derivation duplicate code.
- Derivations should now build with a Clang std environment, instead of the default gcc to match normal build instructions.
- Set environment variables for CMake configure auto set inside the development shell.
- Added package perf to the development shell.
- Added Nix formatter.