### PR TITLE
Compute->Texture Data Sync for God of War III

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1042,6 +1042,8 @@ set(VIDEO_CORE src/video_core/amdgpu/cb_db_extent.h
                src/video_core/renderer_vulkan/liverpool_to_vk.h
                src/video_core/renderer_vulkan/vk_common.cpp
                src/video_core/renderer_vulkan/vk_common.h
+               src/video_core/renderer_vulkan/vk_compute_download.cpp
+               src/video_core/renderer_vulkan/vk_compute_download.h
                src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
                src/video_core/renderer_vulkan/vk_compute_pipeline.h
                src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp

--- a/src/video_core/renderer_vulkan/vk_compute_download.cpp
+++ b/src/video_core/renderer_vulkan/vk_compute_download.cpp
@@ -5,9 +5,7 @@
 #include "common/logging/log.h"
 #include "core/memory.h"
 #include "video_core/renderer_vulkan/vk_compute_download.h"
-#include "video_core/renderer_vulkan/vk_instance.h"
 #include "video_core/renderer_vulkan/vk_scheduler.h"
-#include "video_core/renderer_vulkan/vk_platform.h"
 #include "video_core/texture_cache/image.h"
 #include "video_core/texture_cache/texture_cache.h"
 #include <vk_mem_alloc.h>
@@ -16,7 +14,7 @@ namespace Vulkan {
 
 namespace {
 struct PendingDownload {
-    vk::Fence fence{};
+    u64 download_tick{};     // scheduler tick when the copy was recorded
     VkBuffer staging_buffer{};
     VmaAllocation staging_alloc{};
     VmaAllocator vma_alloc{};
@@ -44,13 +42,9 @@ ComputeDownloadManager::ComputeDownloadManager(const Instance& instance,
     : m_impl(std::make_unique<Impl>(instance, scheduler, texture_cache)) {}
 
 ComputeDownloadManager::~ComputeDownloadManager() {
-    // Clean up any downloads that were never resolved (e.g. compute-only workloads).
-    auto device = m_impl->instance.GetDevice();
+    // Ensure GPU is done with all staging buffers before freeing them.
+    m_impl->scheduler.Finish();
     for (auto& dl : m_impl->pending_downloads) {
-        if (dl.fence) {
-            (void)device.waitForFences(dl.fence, true, UINT64_MAX);
-            device.destroyFence(dl.fence);
-        }
         vmaDestroyBuffer(dl.vma_alloc, dl.staging_buffer, dl.staging_alloc);
     }
 }
@@ -68,34 +62,28 @@ bool ComputeDownloadManager::IsEnabled() {
 }
 
 void ComputeDownloadManager::SyncOne(VideoCore::Image& storage_img, u32 grid_x, u32 grid_y) {
-    // Guard checks.
-    if (storage_img.info.guest_address == 0) {
-        static bool logged = false;
-        if (!logged) {
-            LOG_WARNING(Render, "[ComputeDownload] Storage image has null guest address, skip");
-            logged = true;
-        }
-        return;
-    }
-    if (storage_img.info.num_samples > 1) return; // multisampled — expected, no download
+    // GPU-only storage images (no guest address) are compute temporaries —
+    // they never need a guest-memory download. Expected, not a warning.
+    if (storage_img.info.guest_address == 0) return;
+    if (storage_img.info.num_samples > 1) return;
     const u32 bpp = storage_img.info.num_bits / 8u;
     if (bpp == 0 || storage_img.info.size.width == 0 || storage_img.info.size.height == 0) {
-        static bool logged = false;
-        if (!logged) {
-            LOG_WARNING(Render, "[ComputeDownload] Invalid dimensions ({}×{} bpp={}), skip",
-                        storage_img.info.size.width, storage_img.info.size.height, bpp);
-            logged = true;
-        }
+        LOG_WARNING(Render, "[ComputeDownload] Invalid dimensions ({}×{} bpp={}), skip",
+                    storage_img.info.size.width, storage_img.info.size.height, bpp);
         return;
     }
 
-    // NOTE: We do NOT check whether a texture currently overlaps this storage image.
-    // The typical pattern is "compute writes first, textures are created later at the
-    // same address" (A/B double-buffer swap). Conservatively always download.
+    // NOTE: We do NOT check whether a texture currently overlaps this storage image
+    // before initiating the download. The typical pattern is "compute writes first,
+    // textures are created later at the same address" (A/B double-buffer swap).
+    // Conservatively always download; overlapping textures will pick up the data when
+    // they are later created or refreshed via GpuDirty marking in InvalidateMemoryRange.
     //
     // This also assumes compute output is consumed by a graphics pipeline, not by
     // another compute dispatch binding a different ImageId at the same guest address.
-    // The known CS (ccdebd80f02a77aa) does not exhibit that pattern.
+    // If that occurs, the download may still be in flight and the second dispatch
+    // would sample stale guest memory. A general solution would need to resolve
+    // pending downloads before BindResources for compute pipelines.
 
     // Compute conservative dirty rect from dispatch grid dimensions.
     // Assumes each thread group covers at least 1 pixel; dirty rect never misses writes
@@ -134,7 +122,9 @@ void ComputeDownloadManager::SyncOne(VideoCore::Image& storage_img, u32 grid_x, 
         return;
     }
 
-    // Record GPU copy into current command buffer.
+    // Record GPU copy into the current command buffer WITHOUT flushing.
+    // The copy piggybacks on the CB and is submitted later in ResolvePending
+    // via scheduler.Wait(), together with any other accumulated work.
     const vk::BufferImageCopy copy_region = {
         .bufferOffset = 0,
         .bufferRowLength = img_w,
@@ -153,20 +143,13 @@ void ComputeDownloadManager::SyncOne(VideoCore::Image& storage_img, u32 grid_x, 
     std::span copies{&copy_region, 1};
     storage_img.Download(copies, staging_buffer, 0, download_size);
 
-    // Submit with fence (non-blocking).
-    // Each dispatch produces a separate submit, breaking command-buffer batching.
-    // The per-dispatch fence is required for async resolution: we need to know when
-    // THIS copy completes independently, so stale downloads can be discarded and
-    // fresh ones take precedence in ResolvePending's reverse iteration.
-    auto device = m_impl->instance.GetDevice();
-    vk::Fence fence = Check(device.createFence({}));
-    SubmitInfo info{};
-    info.AddSignal(fence);
-    m_impl->scheduler.Flush(info);
+    // Capture the tick that will be assigned to the next SubmitExecution (which will
+    // contain our copy). No Flush — the copy stays in the current command buffer and
+    // is submitted in batch with other work when ResolvePending calls Wait(tick).
+    const u64 download_tick = m_impl->scheduler.CurrentTick();
 
-    // Store pending download.
     m_impl->pending_downloads.push_back({
-        .fence = fence,
+        .download_tick = download_tick,
         .staging_buffer = staging_vk,
         .staging_alloc = allocation,
         .vma_alloc = vma_alloc,
@@ -204,30 +187,30 @@ void ComputeDownloadManager::SyncOne(VideoCore::Image& storage_img, u32 grid_x, 
 void ComputeDownloadManager::ResolvePending() {
     if (m_impl->pending_downloads.empty()) return;
 
-    auto device = m_impl->instance.GetDevice();
     // Process in reverse order: if multiple dispatches wrote to the same storage image,
     // the last dispatch (freshest data) is resolved first. Earlier downloads for the
     // same image fail validation and are discarded.
     for (size_t i = m_impl->pending_downloads.size(); i > 0; --i) {
         auto& dl = m_impl->pending_downloads[i - 1];
 
-        // Wait for GPU copy to complete (fence is usually already signaled).
-        if (dl.fence) {
-            if (device.getFenceStatus(dl.fence) != vk::Result::eSuccess) {
-                static bool logged = false;
-                if (!logged) {
-                    LOG_WARNING(Render,
-                                "[ComputeDownload] Fence not ready, blocking on waitForFences "
-                                "(async overlap insufficient between dispatch and draw)");
-                    logged = true;
-                }
+        // Submit the command buffer (if not already submitted) and wait for the GPU
+        // to complete all work up to and including our copy. If the CB was already
+        // flushed by other code (e.g. OnSubmit), the CB is already submitted and
+        // Wait returns quickly (GPU likely already done).
+        if (!m_impl->scheduler.IsFree(dl.download_tick)) {
+            static bool logged = false;
+            if (!logged) {
+                LOG_WARNING(Render,
+                            "[ComputeDownload] GPU not caught up, blocking on Wait "
+                            "(async overlap insufficient between dispatch and draw)");
+                logged = true;
             }
-            (void)device.waitForFences(dl.fence, true, UINT64_MAX);
-            device.destroyFence(dl.fence);
-            dl.fence = nullptr;
         }
+        m_impl->scheduler.Wait(dl.download_tick);
 
         // Verify the storage image still exists and still needs this download.
+        // Between dispatch and resolution the image may have been evicted,
+        // its guest address reused, or ComputeWritten cleared by another path.
         const u64 range_size = static_cast<u64>(dl.max_y) * dl.img_width * dl.bpp;
         bool valid = false;
         m_impl->texture_cache.ForEachImageInRegion(

--- a/src/video_core/renderer_vulkan/vk_compute_download.cpp
+++ b/src/video_core/renderer_vulkan/vk_compute_download.cpp
@@ -198,13 +198,9 @@ void ComputeDownloadManager::ResolvePending() {
         // flushed by other code (e.g. OnSubmit), the CB is already submitted and
         // Wait returns quickly (GPU likely already done).
         if (!m_impl->scheduler.IsFree(dl.download_tick)) {
-            static bool logged = false;
-            if (!logged) {
-                LOG_WARNING(Render,
-                            "[ComputeDownload] GPU not caught up, blocking on Wait "
-                            "(async overlap insufficient between dispatch and draw)");
-                logged = true;
-            }
+            LOG_WARNING(Render,
+                        "[ComputeDownload] GPU not caught up, blocking on Wait "
+                        "(async overlap insufficient between dispatch and draw)");
         }
         m_impl->scheduler.Wait(dl.download_tick);
 

--- a/src/video_core/renderer_vulkan/vk_compute_download.cpp
+++ b/src/video_core/renderer_vulkan/vk_compute_download.cpp
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "common/elf_info.h"
+#include "common/logging/log.h"
+#include "core/memory.h"
+#include "video_core/renderer_vulkan/vk_compute_download.h"
+#include "video_core/renderer_vulkan/vk_instance.h"
+#include "video_core/renderer_vulkan/vk_scheduler.h"
+#include "video_core/renderer_vulkan/vk_platform.h"
+#include "video_core/texture_cache/image.h"
+#include "video_core/texture_cache/texture_cache.h"
+#include <vk_mem_alloc.h>
+
+namespace Vulkan {
+
+namespace {
+struct PendingDownload {
+    vk::Fence fence{};
+    VkBuffer staging_buffer{};
+    VmaAllocation staging_alloc{};
+    VmaAllocator vma_alloc{};
+    u8* staging_ptr{};
+    VAddr guest_base{};
+    u32 img_width{};
+    u32 bpp{};
+    u32 min_x{};
+    u32 min_y{};
+    u32 max_x{};
+    u32 max_y{};
+};
+} // anonymous namespace
+
+struct ComputeDownloadManager::Impl {
+    const Instance& instance;
+    Scheduler& scheduler;
+    VideoCore::TextureCache& texture_cache;
+    std::vector<PendingDownload> pending_downloads;
+};
+
+ComputeDownloadManager::ComputeDownloadManager(const Instance& instance,
+                                               Scheduler& scheduler,
+                                               VideoCore::TextureCache& texture_cache)
+    : m_impl(std::make_unique<Impl>(instance, scheduler, texture_cache)) {}
+
+ComputeDownloadManager::~ComputeDownloadManager() {
+    // Clean up any downloads that were never resolved (e.g. compute-only workloads).
+    auto device = m_impl->instance.GetDevice();
+    for (auto& dl : m_impl->pending_downloads) {
+        if (dl.fence) {
+            (void)device.waitForFences(dl.fence, true, UINT64_MAX);
+            device.destroyFence(dl.fence);
+        }
+        vmaDestroyBuffer(dl.vma_alloc, dl.staging_buffer, dl.staging_alloc);
+    }
+}
+
+bool ComputeDownloadManager::IsEnabled() {
+    static const bool enabled = [] {
+        const auto serial = Common::ElfInfo::Instance().GameSerial();
+        const bool ok = serial == "CUSA01623" || serial == "CUSA01715" || serial == "CUSA01740";
+        if (ok) {
+            LOG_INFO(Render, "[ComputeDownload] Enabled for game {} (God of War III)", serial);
+        }
+        return ok;
+    }();
+    return enabled;
+}
+
+void ComputeDownloadManager::SyncOne(VideoCore::Image& storage_img, u32 grid_x, u32 grid_y) {
+    // Guard checks.
+    if (storage_img.info.guest_address == 0) {
+        LOG_WARNING(Render, "[ComputeDownload] Storage image has null guest address, skip");
+        return;
+    }
+    if (storage_img.info.num_samples > 1) return; // multisampled — expected, no download
+    const u32 bpp = storage_img.info.num_bits / 8u;
+    if (bpp == 0 || storage_img.info.size.width == 0 || storage_img.info.size.height == 0) {
+        LOG_WARNING(Render, "[ComputeDownload] Invalid dimensions ({}×{} bpp={}), skip",
+                    storage_img.info.size.width, storage_img.info.size.height, bpp);
+        return;
+    }
+
+    // NOTE: We do NOT check whether a texture currently overlaps this storage image.
+    // The typical pattern is "compute writes first, textures are created later at the
+    // same address" (A/B double-buffer swap). Conservatively always download.
+    //
+    // This also assumes compute output is consumed by a graphics pipeline, not by
+    // another compute dispatch binding a different ImageId at the same guest address.
+    // The known CS (ccdebd80f02a77aa) does not exhibit that pattern.
+
+    // Compute conservative dirty rect from dispatch grid dimensions.
+    const u32 img_w = static_cast<u32>(storage_img.info.size.width);
+    const u32 img_h = static_cast<u32>(storage_img.info.size.height);
+    const u32 block_w = std::max<u32>(1, (img_w + grid_x - 1) / grid_x);
+    const u32 block_h = std::max<u32>(1, (img_h + grid_y - 1) / grid_y);
+    const u32 dirty_w = std::min<u32>(grid_x * block_w, img_w);
+    const u32 dirty_h = std::min<u32>(grid_y * block_h, img_h);
+
+    // Allocate staging buffer (VMA, persistently mapped).
+    const u32 full_row_bytes = img_w * bpp;
+    const u32 download_size = dirty_h * full_row_bytes;
+
+    const VkBufferCreateInfo buffer_ci = {
+        .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .size = download_size,
+        .usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+    };
+    VmaAllocationCreateInfo alloc_ci = {};
+    alloc_ci.flags =
+        VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT;
+    alloc_ci.usage = VMA_MEMORY_USAGE_AUTO;
+
+    VmaAllocator vma_alloc = storage_img.backing->image.allocator;
+    VmaAllocation allocation = VK_NULL_HANDLE;
+    VmaAllocationInfo alloc_info{};
+    VkBuffer staging_vk = VK_NULL_HANDLE;
+    if (vmaCreateBuffer(vma_alloc, &buffer_ci, &alloc_ci, &staging_vk, &allocation,
+                        &alloc_info) != VK_SUCCESS) {
+        LOG_ERROR(Render, "[ComputeDownload] VMA staging allocation failed ({} bytes)",
+                  download_size);
+        return;
+    }
+
+    // Record GPU copy into current command buffer.
+    const vk::BufferImageCopy copy_region = {
+        .bufferOffset = 0,
+        .bufferRowLength = img_w,
+        .bufferImageHeight = 0,
+        .imageSubresource =
+            {
+                .aspectMask = storage_img.aspect_mask & ~vk::ImageAspectFlagBits::eStencil,
+                .mipLevel = 0,
+                .baseArrayLayer = 0,
+                .layerCount = 1,
+            },
+        .imageOffset = {0, 0, 0},
+        .imageExtent = {img_w, dirty_h, 1},
+    };
+    vk::Buffer staging_buffer{staging_vk};
+    std::span copies{&copy_region, 1};
+    storage_img.Download(copies, staging_buffer, 0, download_size);
+
+    // Submit with fence (non-blocking).
+    auto device = m_impl->instance.GetDevice();
+    vk::Fence fence = Check(device.createFence({}));
+    SubmitInfo info{};
+    info.AddSignal(fence);
+    m_impl->scheduler.Flush(info);
+
+    // Store pending download.
+    m_impl->pending_downloads.push_back({
+        .fence = fence,
+        .staging_buffer = staging_vk,
+        .staging_alloc = allocation,
+        .vma_alloc = vma_alloc,
+        .staging_ptr = static_cast<u8*>(alloc_info.pMappedData),
+        .guest_base = storage_img.info.guest_address,
+        .img_width = img_w,
+        .bpp = bpp,
+        .min_x = 0,
+        .min_y = 0,
+        .max_x = dirty_w,
+        .max_y = dirty_h,
+    });
+
+    // Set flags.
+    storage_img.flags |= VideoCore::ImageFlagBits::GpuModified |
+                         VideoCore::ImageFlagBits::ComputeWritten;
+    storage_img.flags &= ~VideoCore::ImageFlagBits::Dirty;
+
+    static constexpr size_t kMaxPendingDownloads = 10;
+    if (m_impl->pending_downloads.size() >= kMaxPendingDownloads) {
+        static bool overflow_logged = false;
+        if (!overflow_logged) {
+            LOG_ERROR(Render,
+                      "[ComputeDownload] {} pending downloads without resolution — "
+                      "no graphics draw between compute dispatches?",
+                      m_impl->pending_downloads.size());
+            overflow_logged = true;
+        }
+    }
+}
+
+void ComputeDownloadManager::ResolvePending() {
+    if (m_impl->pending_downloads.empty()) return;
+
+    auto device = m_impl->instance.GetDevice();
+    // Process in reverse order: if multiple dispatches wrote to the same storage image,
+    // the last dispatch (freshest data) is resolved first. Earlier downloads for the
+    // same image fail validation and are discarded.
+    for (size_t i = m_impl->pending_downloads.size(); i > 0; --i) {
+        auto& dl = m_impl->pending_downloads[i - 1];
+
+        // Wait for GPU copy to complete (fence is usually already signaled).
+        if (dl.fence) {
+            if (device.getFenceStatus(dl.fence) != vk::Result::eSuccess) {
+                static bool logged = false;
+                if (!logged) {
+                    LOG_WARNING(Render,
+                                "[ComputeDownload] Fence not ready, blocking on waitForFences "
+                                "(async overlap insufficient between dispatch and draw)");
+                    logged = true;
+                }
+            }
+            (void)device.waitForFences(dl.fence, true, UINT64_MAX);
+            device.destroyFence(dl.fence);
+            dl.fence = nullptr;
+        }
+
+        // Verify the storage image still exists and still needs this download.
+        const u64 range_size = static_cast<u64>(dl.max_y) * dl.img_width * dl.bpp;
+        bool valid = false;
+        m_impl->texture_cache.ForEachImageInRegion(
+            dl.guest_base, range_size,
+            [&](VideoCore::ImageId, VideoCore::Image& img) {
+                if (True(img.flags & VideoCore::ImageFlagBits::ComputeWritten)) {
+                    valid = true;
+                    return true;
+                }
+                return false;
+            });
+
+        if (!valid) {
+            LOG_WARNING(Render,
+                        "[ComputeDownload] Discarded: image at guest={:#018x} evicted "
+                        "or ComputeWritten cleared before memcpy",
+                        dl.guest_base);
+            vmaDestroyBuffer(dl.vma_alloc, dl.staging_buffer, dl.staging_alloc);
+            continue;
+        }
+
+        // Per-row memcpy from staging buffer to guest memory.
+        const u32 full_row_bytes = dl.img_width * dl.bpp;
+        const u32 rect_w_bytes = (dl.max_x - dl.min_x) * dl.bpp;
+        for (u32 row = dl.min_y; row < dl.max_y; ++row) {
+            const u32 src_off = row * full_row_bytes + dl.min_x * dl.bpp;
+            u8* dst = std::bit_cast<u8*>(dl.guest_base + src_off);
+            std::memcpy(dst, dl.staging_ptr + src_off, rect_w_bytes);
+        }
+
+        vmaDestroyBuffer(dl.vma_alloc, dl.staging_buffer, dl.staging_alloc);
+        m_impl->texture_cache.InvalidateMemoryRange(dl.guest_base, range_size);
+    }
+    m_impl->pending_downloads.clear();
+}
+
+} // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_compute_download.cpp
+++ b/src/video_core/renderer_vulkan/vk_compute_download.cpp
@@ -90,6 +90,9 @@ void ComputeDownloadManager::SyncOne(VideoCore::Image& storage_img, u32 grid_x, 
     // The known CS (ccdebd80f02a77aa) does not exhibit that pattern.
 
     // Compute conservative dirty rect from dispatch grid dimensions.
+    // Assumes each thread group covers at least 1 pixel; dirty rect never misses writes
+    // but may over-estimate for sparse grids. For the known CS (ccdebd80f02a77aa,
+    // local_size=8×8), grid always covers the full image → dirty = full image, zero waste.
     const u32 img_w = static_cast<u32>(storage_img.info.size.width);
     const u32 img_h = static_cast<u32>(storage_img.info.size.height);
     const u32 block_w = std::max<u32>(1, (img_w + grid_x - 1) / grid_x);
@@ -143,6 +146,10 @@ void ComputeDownloadManager::SyncOne(VideoCore::Image& storage_img, u32 grid_x, 
     storage_img.Download(copies, staging_buffer, 0, download_size);
 
     // Submit with fence (non-blocking).
+    // Each dispatch produces a separate submit, breaking command-buffer batching.
+    // The per-dispatch fence is required for async resolution: we need to know when
+    // THIS copy completes independently, so stale downloads can be discarded and
+    // fresh ones take precedence in ResolvePending's reverse iteration.
     auto device = m_impl->instance.GetDevice();
     vk::Fence fence = Check(device.createFence({}));
     SubmitInfo info{};
@@ -165,7 +172,10 @@ void ComputeDownloadManager::SyncOne(VideoCore::Image& storage_img, u32 grid_x, 
         .max_y = dirty_h,
     });
 
-    // Set flags.
+    // GpuModified: the storage VkImage is now authoritative (compute just wrote to it).
+    // ComputeWritten: marks image for Tartarus overlap detection in BindResources.
+    // Cleared Dirty because guest memory is now stale relative to the VkImage; any
+    // future refresh of this image must come from GPU, not guest memory.
     storage_img.flags |= VideoCore::ImageFlagBits::GpuModified |
                          VideoCore::ImageFlagBits::ComputeWritten;
     storage_img.flags &= ~VideoCore::ImageFlagBits::Dirty;
@@ -231,7 +241,9 @@ void ComputeDownloadManager::ResolvePending() {
             continue;
         }
 
-        // Per-row memcpy from staging buffer to guest memory.
+        // Per-row memcpy: only the dirty rect columns [min_x, max_x) are copied.
+        // Padding columns between max_x and img_width in guest memory are not touched
+        // — they may contain data belonging to other resources at adjacent addresses.
         const u32 full_row_bytes = dl.img_width * dl.bpp;
         const u32 rect_w_bytes = (dl.max_x - dl.min_x) * dl.bpp;
         for (u32 row = dl.min_y; row < dl.max_y; ++row) {
@@ -241,6 +253,9 @@ void ComputeDownloadManager::ResolvePending() {
         }
 
         vmaDestroyBuffer(dl.vma_alloc, dl.staging_buffer, dl.staging_alloc);
+        // Two-in-one: clears ComputeWritten from the storage image (download resolved)
+        // and marks all non-compute images in this range GpuDirty so they refresh from
+        // the now-updated guest memory on next bind.
         m_impl->texture_cache.InvalidateMemoryRange(dl.guest_base, range_size);
     }
     m_impl->pending_downloads.clear();

--- a/src/video_core/renderer_vulkan/vk_compute_download.cpp
+++ b/src/video_core/renderer_vulkan/vk_compute_download.cpp
@@ -70,14 +70,22 @@ bool ComputeDownloadManager::IsEnabled() {
 void ComputeDownloadManager::SyncOne(VideoCore::Image& storage_img, u32 grid_x, u32 grid_y) {
     // Guard checks.
     if (storage_img.info.guest_address == 0) {
-        LOG_WARNING(Render, "[ComputeDownload] Storage image has null guest address, skip");
+        static bool logged = false;
+        if (!logged) {
+            LOG_WARNING(Render, "[ComputeDownload] Storage image has null guest address, skip");
+            logged = true;
+        }
         return;
     }
     if (storage_img.info.num_samples > 1) return; // multisampled — expected, no download
     const u32 bpp = storage_img.info.num_bits / 8u;
     if (bpp == 0 || storage_img.info.size.width == 0 || storage_img.info.size.height == 0) {
-        LOG_WARNING(Render, "[ComputeDownload] Invalid dimensions ({}×{} bpp={}), skip",
-                    storage_img.info.size.width, storage_img.info.size.height, bpp);
+        static bool logged = false;
+        if (!logged) {
+            LOG_WARNING(Render, "[ComputeDownload] Invalid dimensions ({}×{} bpp={}), skip",
+                        storage_img.info.size.width, storage_img.info.size.height, bpp);
+            logged = true;
+        }
         return;
     }
 

--- a/src/video_core/renderer_vulkan/vk_compute_download.h
+++ b/src/video_core/renderer_vulkan/vk_compute_download.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <memory>
+
+namespace VideoCore {
+struct Image;
+class TextureCache;
+} // namespace VideoCore
+
+namespace Vulkan {
+
+class Instance;
+class Scheduler;
+
+/// Manages async GPU→guest-memory downloads for compute shader output.
+/// Only active for God of War III (CUSA01623 / CUSA01715 / CUSA01740).
+class ComputeDownloadManager {
+public:
+    ComputeDownloadManager(const Instance& instance, Scheduler& scheduler,
+                           VideoCore::TextureCache& texture_cache);
+    ~ComputeDownloadManager();
+
+    /// True for known GOW3 titles that use compute→texture aliasing.
+    static bool IsEnabled();
+
+    /// Initiate async download for one storage image written by a direct dispatch.
+    void SyncOne(VideoCore::Image& storage_img, u32 grid_x, u32 grid_y);
+
+    /// Resolve all pending downloads. Must be called before BindTextures.
+    void ResolvePending();
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> m_impl;
+};
+
+} // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -370,7 +370,10 @@ void Rasterizer::DispatchIndirect(VAddr address, u32 offset, u32 size) {
 
 void Rasterizer::SyncComputeStorageImages(u64 shader_hash, u32 grid_x, u32 grid_y, u32 grid_z) {
     if (!compute_download) return;
-    if (grid_x == 0 || grid_y == 0) return; // indirect dispatch — skip
+    if (grid_x == 0 || grid_y == 0) {
+        LOG_WARNING(Render, "[ComputeDownload] Indirect dispatch, grid unknown — skip");
+        return;
+    }
 
     for (const auto& [image_id, img_desc] : image_bindings) {
         if (img_desc.type != VideoCore::TextureCache::BindingType::Storage || !image_id) continue;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -372,18 +372,6 @@ void Rasterizer::SyncComputeStorageImages(u64 shader_hash, u32 grid_x, u32 grid_
     if (!compute_download) return;
     if (grid_x == 0 || grid_y == 0) return; // indirect dispatch — skip
 
-    // Only download for verified CS whose storage output is known to overlap with
-    // textures at a different format. Unconditionally downloading for every compute
-    // dispatch would add Flush + VMA + fence overhead on hot paths that don't need it.
-    static constexpr u64 kVerifiedCS[] = {
-        0xccdebd80f02a77aa, // R32 pixel copy, cascaded dispatch → BC3/BC1 texture overlap
-    };
-    bool verified = false;
-    for (u64 h : kVerifiedCS) {
-        if (shader_hash == h) { verified = true; break; }
-    }
-    if (!verified) return;
-
     for (const auto& [image_id, img_desc] : image_bindings) {
         if (img_desc.type != VideoCore::TextureCache::BindingType::Storage || !image_id) continue;
         auto& storage_img = texture_cache.GetImage(image_id);

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -412,8 +412,10 @@ bool Rasterizer::BindResources(const Pipeline* pipeline) {
         return false;
     }
 
-    // Resolve any pending compute downloads before binding textures,
-    // so RefreshImage reads the updated guest memory data.
+    // Resolve pending compute downloads before BindTextures so RefreshImage reads
+    // the updated guest memory. Must be called at this exact point: after the
+    // early-return guards but before the first BindTextures call below.
+    // Compute-only pipelines skip resolution — they don't trigger RefreshImage.
     if (!pipeline->IsCompute()) {
         ResolvePendingComputeDownloads();
     }

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -13,6 +13,7 @@
 #include "video_core/renderer_vulkan/vk_shader_hle.h"
 #include "video_core/texture_cache/image_view.h"
 #include "video_core/texture_cache/texture_cache.h"
+#include <vk_mem_alloc.h>
 
 #ifdef MemoryBarrier
 #undef MemoryBarrier
@@ -44,7 +45,17 @@ Rasterizer::Rasterizer(const Instance& instance_, Scheduler& scheduler_,
     memory->SetRasterizer(this);
 }
 
-Rasterizer::~Rasterizer() = default;
+Rasterizer::~Rasterizer() {
+    // Clean up any pending compute downloads that weren't resolved.
+    for (auto& dl : pending_compute_downloads) {
+        if (dl.fence) {
+            (void)instance.GetDevice().waitForFences(dl.fence, true, UINT64_MAX);
+            instance.GetDevice().destroyFence(dl.fence);
+        }
+        vmaDestroyBuffer(dl.vma_alloc, dl.staging_buffer, dl.staging_alloc);
+    }
+    pending_compute_downloads.clear();
+}
 
 void Rasterizer::CpSync() {
     scheduler.EndRendering();
@@ -364,43 +375,43 @@ void Rasterizer::DispatchIndirect(VAddr address, u32 offset, u32 size) {
 }
 
 void Rasterizer::SyncComputeStorageImages(u64 shader_hash, u32 grid_x, u32 grid_y, u32 grid_z) {
-    // Only download for verified CS to avoid corrupting guest memory with unverified output.
-    static constexpr u64 VERIFIED_CS[] = {
-        0xccdebd80f02a77aa, // R32 pixel copy, cascaded dispatch → BC3/BC1 texture overlap
-    };
-    bool is_verified = false;
-    for (u64 h : VERIFIED_CS) {
-        if (shader_hash == h) { is_verified = true; break; }
-    }
-    if (!is_verified) return;
-
-    const bool can_estimate = (grid_x > 0 && grid_y > 0);
+    // For indirect dispatch, grid parameters are unknown — skip download.
+    if (grid_x == 0 || grid_y == 0) return;
 
     for (const auto& [image_id, img_desc] : image_bindings) {
         if (img_desc.type != VideoCore::TextureCache::BindingType::Storage || !image_id) continue;
         auto& storage_img = texture_cache.GetImage(image_id);
-        storage_img.flags |= VideoCore::ImageFlagBits::GpuModified |
-                             VideoCore::ImageFlagBits::ComputeWritten;
-        storage_img.flags &= ~VideoCore::ImageFlagBits::Dirty;
 
+        // Guard checks.
         if (storage_img.info.guest_address == 0) {
-            LOG_ERROR(Render, "CS sync skip: null guest address shader={:016x}", shader_hash);
+            LOG_WARNING(Render, "[ComputeDownload] Storage image has null guest address, skip");
             continue;
         }
-        if (!can_estimate) {
-            LOG_ERROR(Render, "CS sync skip: indirect dispatch shader={:016x}", shader_hash);
-            continue;
-        }
-        if (storage_img.info.num_samples > 1) {
-            LOG_ERROR(Render, "CS sync skip: multisampled shader={:016x}", shader_hash);
-            continue;
-        }
+        if (storage_img.info.num_samples > 1) continue; // multisampled — expected, no download
         const u32 bpp = storage_img.info.num_bits / 8u;
         if (bpp == 0 || storage_img.info.size.width == 0 || storage_img.info.size.height == 0) {
-            LOG_ERROR(Render, "CS sync skip: invalid image shader={:016x}", shader_hash);
+            LOG_WARNING(Render, "[ComputeDownload] Invalid dimensions ({}×{} bpp={}), skip",
+                        storage_img.info.size.width, storage_img.info.size.height, bpp);
             continue;
         }
 
+        // NOTE: We do NOT check whether a texture currently overlaps this storage image
+        // before initiating the download. The typical pattern is "compute writes first,
+        // textures are created later at the same address" (e.g. A/B double-buffer swap).
+        // At dispatch time ForEachImageInRegion would find no overlap and skip the download,
+        // but the texture created moments later would then refresh stale guest memory.
+        // Conservatively always download; overlapping textures will pick up the data when
+        // they are later created or refreshed via GpuDirty marking in InvalidateMemoryRange.
+        //
+        // This also assumes the compute output is consumed by a graphics pipeline (texture
+        // Refresh via guest memory), not by a subsequent compute dispatch that binds a
+        // *different* ImageId at the same guest address. In that scenario the download may
+        // still be in flight and the second dispatch would sample stale guest memory.
+        // The known CS (ccdebd80f02a77aa) does not exhibit this pattern; a general solution
+        // would need to resolve pending downloads before BindResources for compute pipelines.
+
+        // Compute conservative dirty rect from dispatch grid dimensions.
+        // Each thread group covers at least 1 pixel — dirty rect never misses writes.
         const u32 img_w = static_cast<u32>(storage_img.info.size.width);
         const u32 img_h = static_cast<u32>(storage_img.info.size.height);
         const u32 block_w = std::max<u32>(1, (img_w + grid_x - 1) / grid_x);
@@ -408,10 +419,160 @@ void Rasterizer::SyncComputeStorageImages(u64 shader_hash, u32 grid_x, u32 grid_
         const u32 dirty_w = std::min<u32>(grid_x * block_w, img_w);
         const u32 dirty_h = std::min<u32>(grid_y * block_h, img_h);
 
-        storage_img.DownloadToGuest(0, 0, dirty_w, dirty_h);
-        storage_img.flags &= ~VideoCore::ImageFlagBits::ComputeWritten;
-        storage_img.flags &= ~VideoCore::ImageFlagBits::GpuModified;
+        // Allocate staging buffer (VMA, persistently mapped).
+        const u32 full_row_bytes = img_w * bpp;
+        const u32 download_size = dirty_h * full_row_bytes;
+
+        const VkBufferCreateInfo buffer_ci = {
+            .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+            .size = download_size,
+            .usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+            .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+        };
+        VmaAllocationCreateInfo alloc_ci = {};
+        alloc_ci.flags =
+            VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT;
+        alloc_ci.usage = VMA_MEMORY_USAGE_AUTO;
+
+        VmaAllocator vma_alloc = storage_img.backing->image.allocator;
+        VmaAllocation allocation = VK_NULL_HANDLE;
+        VmaAllocationInfo alloc_info{};
+        VkBuffer staging_vk = VK_NULL_HANDLE;
+        if (vmaCreateBuffer(vma_alloc, &buffer_ci, &alloc_ci, &staging_vk, &allocation,
+                            &alloc_info) != VK_SUCCESS) {
+            LOG_ERROR(Render, "[ComputeDownload] VMA staging allocation failed ({} bytes)",
+                      download_size);
+            continue;
+        }
+
+        // Record GPU copy into current command buffer (barriers handled by Image::Download).
+        const vk::BufferImageCopy copy_region = {
+            .bufferOffset = 0,
+            .bufferRowLength = img_w,
+            .bufferImageHeight = 0,
+            .imageSubresource =
+                {
+                    .aspectMask = storage_img.aspect_mask & ~vk::ImageAspectFlagBits::eStencil,
+                    .mipLevel = 0,
+                    .baseArrayLayer = 0,
+                    .layerCount = 1,
+                },
+            .imageOffset = {0, 0, 0},
+            .imageExtent = {img_w, dirty_h, 1},
+        };
+        vk::Buffer staging_buffer{staging_vk};
+        std::span copies{&copy_region, 1};
+        storage_img.Download(copies, staging_buffer, 0, download_size);
+
+        // Submit command buffer with fence (non-blocking — GPU copy runs asynchronously).
+        vk::Fence fence = Check(instance.GetDevice().createFence({}));
+        SubmitInfo info{};
+        info.AddSignal(fence);
+        scheduler.Flush(info);
+
+        // Store pending download for later resolution.
+        pending_compute_downloads.push_back({
+            .fence = fence,
+            .staging_buffer = staging_vk,
+            .staging_alloc = allocation,
+            .vma_alloc = vma_alloc,
+            .staging_ptr = static_cast<u8*>(alloc_info.pMappedData),
+            .guest_base = storage_img.info.guest_address,
+            .img_width = img_w,
+            .bpp = bpp,
+            .min_x = 0,
+            .min_y = 0,
+            .max_x = dirty_w,
+            .max_y = dirty_h,
+        });
+
+        static constexpr size_t kMaxPendingDownloads = 10;
+        if (pending_compute_downloads.size() >= kMaxPendingDownloads) {
+            static bool overflow_logged = false;
+            if (!overflow_logged) {
+                LOG_ERROR(Render,
+                          "[ComputeDownload] {} pending downloads without resolution — "
+                          "no graphics draw between compute dispatches?",
+                          pending_compute_downloads.size());
+                overflow_logged = true;
+            }
+        }
+
+        // Mark storage image as compute-written, no longer Dirty.
+        storage_img.flags |= VideoCore::ImageFlagBits::GpuModified |
+                             VideoCore::ImageFlagBits::ComputeWritten;
+        storage_img.flags &= ~VideoCore::ImageFlagBits::Dirty;
     }
+
+    // GpuDirty marking is deferred to ResolvePendingComputeDownloads (after memcpy),
+    // because InvalidateMemoryRange would clear ComputeWritten before the download resolves.
+}
+
+void Rasterizer::ResolvePendingComputeDownloads() {
+    if (pending_compute_downloads.empty()) return;
+
+    auto device = instance.GetDevice();
+    // Process in reverse order: if multiple dispatches wrote to the same storage image,
+    // the last dispatch (freshest data) is resolved first. Earlier downloads for the same
+    // image will fail validation (ComputeWritten already cleared) and be discarded.
+    for (size_t i = pending_compute_downloads.size(); i > 0; --i) {
+        auto& dl = pending_compute_downloads[i - 1];
+        // Wait for GPU copy to complete (fence is usually already signaled by now).
+        if (dl.fence) {
+            if (device.getFenceStatus(dl.fence) != vk::Result::eSuccess) {
+                static bool logged = false;
+                if (!logged) {
+                    LOG_WARNING(Render,
+                                "[ComputeDownload] Fence not ready, blocking on waitForFences "
+                                "(async overlap insufficient between dispatch and draw)");
+                    logged = true;
+                }
+            }
+            (void)device.waitForFences(dl.fence, true, UINT64_MAX);
+            device.destroyFence(dl.fence);
+            dl.fence = nullptr;
+        }
+
+        // Verify the storage image still exists and still needs this download.
+        // Between dispatch and resolution the image may have been evicted,
+        // its guest address reused, or ComputeWritten cleared by another path.
+        bool valid = false;
+        const u64 range_size = static_cast<u64>(dl.max_y) * dl.img_width * dl.bpp;
+        texture_cache.ForEachImageInRegion(
+            dl.guest_base, range_size,
+            [&](VideoCore::ImageId, VideoCore::Image& img) {
+                if (True(img.flags & VideoCore::ImageFlagBits::ComputeWritten)) {
+                    valid = true;
+                    return true; // found — stop searching
+                }
+                return false;
+            });
+
+        if (!valid) {
+            LOG_WARNING(Render,
+                        "[ComputeDownload] Discarded: image at guest={:#018x} evicted "
+                        "or ComputeWritten cleared before memcpy",
+                        dl.guest_base);
+            vmaDestroyBuffer(dl.vma_alloc, dl.staging_buffer, dl.staging_alloc);
+            continue;
+        }
+
+        // Per-row memcpy from staging buffer to guest memory.
+        const u32 full_row_bytes = dl.img_width * dl.bpp;
+        const u32 rect_w_bytes = (dl.max_x - dl.min_x) * dl.bpp;
+        for (u32 row = dl.min_y; row < dl.max_y; ++row) {
+            const u32 src_off = row * full_row_bytes + dl.min_x * dl.bpp;
+            u8* dst = std::bit_cast<u8*>(dl.guest_base + src_off);
+            std::memcpy(dst, dl.staging_ptr + src_off, rect_w_bytes);
+        }
+
+        // Free staging buffer.
+        vmaDestroyBuffer(dl.vma_alloc, dl.staging_buffer, dl.staging_alloc);
+
+        // Clear ComputeWritten from images overlapping this range (download is now done).
+        texture_cache.InvalidateMemoryRange(dl.guest_base, range_size);
+    }
+    pending_compute_downloads.clear();
 }
 
 u64 Rasterizer::Flush() {
@@ -441,6 +602,12 @@ bool Rasterizer::BindResources(const Pipeline* pipeline) {
         return false;
     }
 
+    // Resolve any pending compute downloads before binding textures,
+    // so RefreshImage reads the updated guest memory data.
+    if (!pipeline->IsCompute()) {
+        ResolvePendingComputeDownloads();
+    }
+
     set_write_index = 0;
     set_writes.clear();
     buffer_barriers.clear();
@@ -468,6 +635,9 @@ bool Rasterizer::BindResources(const Pipeline* pipeline) {
     }
 
     // Detect compute storage ↔ texture overlaps and mark textures Dirty for refresh.
+    // The actual download from GPU to guest memory was initiated in SyncComputeStorageImages
+    // and resolved by ResolvePendingComputeDownloads (called above). This callback handles
+    // textures created between the compute dispatch and this BindResources call.
     if (!pipeline->IsCompute()) {
         for (const auto& [tex_id, tex_desc] : all_images) {
             if (!tex_id) continue;
@@ -480,8 +650,8 @@ bool Rasterizer::BindResources(const Pipeline* pipeline) {
                     if (overlap_id == tex_id) return;
                     if (!True(overlap_img.flags & VideoCore::ImageFlagBits::ComputeWritten)) return;
                     if (overlap_img.info.pixel_format == tex_img.info.pixel_format) return;
+                    overlap_img.flags &= ~VideoCore::ImageFlagBits::ComputeWritten;
                     tex_img.flags |= VideoCore::ImageFlagBits::Dirty;
-                    // ComputeWritten is cleared in SyncComputeStorageImages after download.
                 });
         }
     }

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -8,12 +8,12 @@
 #include "video_core/amdgpu/liverpool.h"
 #include "video_core/renderer_vulkan/liverpool_to_vk.h"
 #include "video_core/renderer_vulkan/vk_instance.h"
+#include "video_core/renderer_vulkan/vk_compute_download.h"
 #include "video_core/renderer_vulkan/vk_rasterizer.h"
 #include "video_core/renderer_vulkan/vk_scheduler.h"
 #include "video_core/renderer_vulkan/vk_shader_hle.h"
 #include "video_core/texture_cache/image_view.h"
 #include "video_core/texture_cache/texture_cache.h"
-#include <vk_mem_alloc.h>
 
 #ifdef MemoryBarrier
 #undef MemoryBarrier
@@ -38,24 +38,18 @@ Rasterizer::Rasterizer(const Instance& instance_, Scheduler& scheduler_,
       buffer_cache{instance, scheduler, liverpool_, texture_cache, page_manager},
       texture_cache{instance, scheduler, liverpool_, buffer_cache, page_manager},
       liverpool{liverpool_}, memory{Core::Memory::Instance()},
-      pipeline_cache{instance, scheduler, liverpool} {
+      pipeline_cache{instance, scheduler, liverpool},
+      compute_download{ComputeDownloadManager::IsEnabled()
+                           ? std::make_unique<ComputeDownloadManager>(instance, scheduler,
+                                                                       texture_cache)
+                           : nullptr} {
     if (!EmulatorSettings.IsNullGPU()) {
         liverpool->BindRasterizer(this);
     }
     memory->SetRasterizer(this);
 }
 
-Rasterizer::~Rasterizer() {
-    // Clean up any pending compute downloads that weren't resolved.
-    for (auto& dl : pending_compute_downloads) {
-        if (dl.fence) {
-            (void)instance.GetDevice().waitForFences(dl.fence, true, UINT64_MAX);
-            instance.GetDevice().destroyFence(dl.fence);
-        }
-        vmaDestroyBuffer(dl.vma_alloc, dl.staging_buffer, dl.staging_alloc);
-    }
-    pending_compute_downloads.clear();
-}
+Rasterizer::~Rasterizer() = default;
 
 void Rasterizer::CpSync() {
     scheduler.EndRendering();
@@ -375,204 +369,20 @@ void Rasterizer::DispatchIndirect(VAddr address, u32 offset, u32 size) {
 }
 
 void Rasterizer::SyncComputeStorageImages(u64 shader_hash, u32 grid_x, u32 grid_y, u32 grid_z) {
-    // For indirect dispatch, grid parameters are unknown — skip download.
-    if (grid_x == 0 || grid_y == 0) return;
+    if (!compute_download) return;
+    if (grid_x == 0 || grid_y == 0) return; // indirect dispatch — skip
 
     for (const auto& [image_id, img_desc] : image_bindings) {
         if (img_desc.type != VideoCore::TextureCache::BindingType::Storage || !image_id) continue;
         auto& storage_img = texture_cache.GetImage(image_id);
-
-        // Guard checks.
-        if (storage_img.info.guest_address == 0) {
-            LOG_WARNING(Render, "[ComputeDownload] Storage image has null guest address, skip");
-            continue;
-        }
-        if (storage_img.info.num_samples > 1) continue; // multisampled — expected, no download
-        const u32 bpp = storage_img.info.num_bits / 8u;
-        if (bpp == 0 || storage_img.info.size.width == 0 || storage_img.info.size.height == 0) {
-            LOG_WARNING(Render, "[ComputeDownload] Invalid dimensions ({}×{} bpp={}), skip",
-                        storage_img.info.size.width, storage_img.info.size.height, bpp);
-            continue;
-        }
-
-        // NOTE: We do NOT check whether a texture currently overlaps this storage image
-        // before initiating the download. The typical pattern is "compute writes first,
-        // textures are created later at the same address" (e.g. A/B double-buffer swap).
-        // At dispatch time ForEachImageInRegion would find no overlap and skip the download,
-        // but the texture created moments later would then refresh stale guest memory.
-        // Conservatively always download; overlapping textures will pick up the data when
-        // they are later created or refreshed via GpuDirty marking in InvalidateMemoryRange.
-        //
-        // This also assumes the compute output is consumed by a graphics pipeline (texture
-        // Refresh via guest memory), not by a subsequent compute dispatch that binds a
-        // *different* ImageId at the same guest address. In that scenario the download may
-        // still be in flight and the second dispatch would sample stale guest memory.
-        // The known CS (ccdebd80f02a77aa) does not exhibit this pattern; a general solution
-        // would need to resolve pending downloads before BindResources for compute pipelines.
-
-        // Compute conservative dirty rect from dispatch grid dimensions.
-        // Each thread group covers at least 1 pixel — dirty rect never misses writes.
-        const u32 img_w = static_cast<u32>(storage_img.info.size.width);
-        const u32 img_h = static_cast<u32>(storage_img.info.size.height);
-        const u32 block_w = std::max<u32>(1, (img_w + grid_x - 1) / grid_x);
-        const u32 block_h = std::max<u32>(1, (img_h + grid_y - 1) / grid_y);
-        const u32 dirty_w = std::min<u32>(grid_x * block_w, img_w);
-        const u32 dirty_h = std::min<u32>(grid_y * block_h, img_h);
-
-        // Allocate staging buffer (VMA, persistently mapped).
-        const u32 full_row_bytes = img_w * bpp;
-        const u32 download_size = dirty_h * full_row_bytes;
-
-        const VkBufferCreateInfo buffer_ci = {
-            .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
-            .size = download_size,
-            .usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-            .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
-        };
-        VmaAllocationCreateInfo alloc_ci = {};
-        alloc_ci.flags =
-            VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT;
-        alloc_ci.usage = VMA_MEMORY_USAGE_AUTO;
-
-        VmaAllocator vma_alloc = storage_img.backing->image.allocator;
-        VmaAllocation allocation = VK_NULL_HANDLE;
-        VmaAllocationInfo alloc_info{};
-        VkBuffer staging_vk = VK_NULL_HANDLE;
-        if (vmaCreateBuffer(vma_alloc, &buffer_ci, &alloc_ci, &staging_vk, &allocation,
-                            &alloc_info) != VK_SUCCESS) {
-            LOG_ERROR(Render, "[ComputeDownload] VMA staging allocation failed ({} bytes)",
-                      download_size);
-            continue;
-        }
-
-        // Record GPU copy into current command buffer (barriers handled by Image::Download).
-        const vk::BufferImageCopy copy_region = {
-            .bufferOffset = 0,
-            .bufferRowLength = img_w,
-            .bufferImageHeight = 0,
-            .imageSubresource =
-                {
-                    .aspectMask = storage_img.aspect_mask & ~vk::ImageAspectFlagBits::eStencil,
-                    .mipLevel = 0,
-                    .baseArrayLayer = 0,
-                    .layerCount = 1,
-                },
-            .imageOffset = {0, 0, 0},
-            .imageExtent = {img_w, dirty_h, 1},
-        };
-        vk::Buffer staging_buffer{staging_vk};
-        std::span copies{&copy_region, 1};
-        storage_img.Download(copies, staging_buffer, 0, download_size);
-
-        // Submit command buffer with fence (non-blocking — GPU copy runs asynchronously).
-        vk::Fence fence = Check(instance.GetDevice().createFence({}));
-        SubmitInfo info{};
-        info.AddSignal(fence);
-        scheduler.Flush(info);
-
-        // Store pending download for later resolution.
-        pending_compute_downloads.push_back({
-            .fence = fence,
-            .staging_buffer = staging_vk,
-            .staging_alloc = allocation,
-            .vma_alloc = vma_alloc,
-            .staging_ptr = static_cast<u8*>(alloc_info.pMappedData),
-            .guest_base = storage_img.info.guest_address,
-            .img_width = img_w,
-            .bpp = bpp,
-            .min_x = 0,
-            .min_y = 0,
-            .max_x = dirty_w,
-            .max_y = dirty_h,
-        });
-
-        static constexpr size_t kMaxPendingDownloads = 10;
-        if (pending_compute_downloads.size() >= kMaxPendingDownloads) {
-            static bool overflow_logged = false;
-            if (!overflow_logged) {
-                LOG_ERROR(Render,
-                          "[ComputeDownload] {} pending downloads without resolution — "
-                          "no graphics draw between compute dispatches?",
-                          pending_compute_downloads.size());
-                overflow_logged = true;
-            }
-        }
-
-        // Mark storage image as compute-written, no longer Dirty.
-        storage_img.flags |= VideoCore::ImageFlagBits::GpuModified |
-                             VideoCore::ImageFlagBits::ComputeWritten;
-        storage_img.flags &= ~VideoCore::ImageFlagBits::Dirty;
+        compute_download->SyncOne(storage_img, grid_x, grid_y);
     }
-
-    // GpuDirty marking is deferred to ResolvePendingComputeDownloads (after memcpy),
-    // because InvalidateMemoryRange would clear ComputeWritten before the download resolves.
 }
 
 void Rasterizer::ResolvePendingComputeDownloads() {
-    if (pending_compute_downloads.empty()) return;
-
-    auto device = instance.GetDevice();
-    // Process in reverse order: if multiple dispatches wrote to the same storage image,
-    // the last dispatch (freshest data) is resolved first. Earlier downloads for the same
-    // image will fail validation (ComputeWritten already cleared) and be discarded.
-    for (size_t i = pending_compute_downloads.size(); i > 0; --i) {
-        auto& dl = pending_compute_downloads[i - 1];
-        // Wait for GPU copy to complete (fence is usually already signaled by now).
-        if (dl.fence) {
-            if (device.getFenceStatus(dl.fence) != vk::Result::eSuccess) {
-                static bool logged = false;
-                if (!logged) {
-                    LOG_WARNING(Render,
-                                "[ComputeDownload] Fence not ready, blocking on waitForFences "
-                                "(async overlap insufficient between dispatch and draw)");
-                    logged = true;
-                }
-            }
-            (void)device.waitForFences(dl.fence, true, UINT64_MAX);
-            device.destroyFence(dl.fence);
-            dl.fence = nullptr;
-        }
-
-        // Verify the storage image still exists and still needs this download.
-        // Between dispatch and resolution the image may have been evicted,
-        // its guest address reused, or ComputeWritten cleared by another path.
-        bool valid = false;
-        const u64 range_size = static_cast<u64>(dl.max_y) * dl.img_width * dl.bpp;
-        texture_cache.ForEachImageInRegion(
-            dl.guest_base, range_size,
-            [&](VideoCore::ImageId, VideoCore::Image& img) {
-                if (True(img.flags & VideoCore::ImageFlagBits::ComputeWritten)) {
-                    valid = true;
-                    return true; // found — stop searching
-                }
-                return false;
-            });
-
-        if (!valid) {
-            LOG_WARNING(Render,
-                        "[ComputeDownload] Discarded: image at guest={:#018x} evicted "
-                        "or ComputeWritten cleared before memcpy",
-                        dl.guest_base);
-            vmaDestroyBuffer(dl.vma_alloc, dl.staging_buffer, dl.staging_alloc);
-            continue;
-        }
-
-        // Per-row memcpy from staging buffer to guest memory.
-        const u32 full_row_bytes = dl.img_width * dl.bpp;
-        const u32 rect_w_bytes = (dl.max_x - dl.min_x) * dl.bpp;
-        for (u32 row = dl.min_y; row < dl.max_y; ++row) {
-            const u32 src_off = row * full_row_bytes + dl.min_x * dl.bpp;
-            u8* dst = std::bit_cast<u8*>(dl.guest_base + src_off);
-            std::memcpy(dst, dl.staging_ptr + src_off, rect_w_bytes);
-        }
-
-        // Free staging buffer.
-        vmaDestroyBuffer(dl.vma_alloc, dl.staging_buffer, dl.staging_alloc);
-
-        // Clear ComputeWritten from images overlapping this range (download is now done).
-        texture_cache.InvalidateMemoryRange(dl.guest_base, range_size);
+    if (compute_download) {
+        compute_download->ResolvePending();
     }
-    pending_compute_downloads.clear();
 }
 
 u64 Rasterizer::Flush() {

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -372,6 +372,18 @@ void Rasterizer::SyncComputeStorageImages(u64 shader_hash, u32 grid_x, u32 grid_
     if (!compute_download) return;
     if (grid_x == 0 || grid_y == 0) return; // indirect dispatch — skip
 
+    // Only download for verified CS whose storage output is known to overlap with
+    // textures at a different format. Unconditionally downloading for every compute
+    // dispatch would add Flush + VMA + fence overhead on hot paths that don't need it.
+    static constexpr u64 kVerifiedCS[] = {
+        0xccdebd80f02a77aa, // R32 pixel copy, cascaded dispatch → BC3/BC1 texture overlap
+    };
+    bool verified = false;
+    for (u64 h : kVerifiedCS) {
+        if (shader_hash == h) { verified = true; break; }
+    }
+    if (!verified) return;
+
     for (const auto& [image_id, img_desc] : image_bindings) {
         if (img_desc.type != VideoCore::TextureCache::BindingType::Storage || !image_id) continue;
         auto& storage_img = texture_cache.GetImage(image_id);

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -328,6 +328,8 @@ void Rasterizer::DispatchDirect() {
     cmdbuf.bindPipeline(vk::PipelineBindPoint::eCompute, pipeline->Handle());
     cmdbuf.dispatch(cs_program.dim_x, cs_program.dim_y, cs_program.dim_z);
 
+    SyncComputeStorageImages(cs.pgm_hash, cs_program.dim_x, cs_program.dim_y, cs_program.dim_z);
+
     ResetBindings();
 }
 
@@ -346,6 +348,7 @@ void Rasterizer::DispatchIndirect(VAddr address, u32 offset, u32 size) {
         return;
     }
 
+    const auto& cs = pipeline->GetStage(Shader::LogicalStage::Compute);
     const auto [buffer, base] = buffer_cache.ObtainBuffer(address + offset, size, false);
 
     scheduler.EndRendering();
@@ -355,7 +358,60 @@ void Rasterizer::DispatchIndirect(VAddr address, u32 offset, u32 size) {
     cmdbuf.bindPipeline(vk::PipelineBindPoint::eCompute, pipeline->Handle());
     cmdbuf.dispatchIndirect(buffer->Handle(), base);
 
+    SyncComputeStorageImages(cs.pgm_hash); // grid unknown for indirect
+
     ResetBindings();
+}
+
+void Rasterizer::SyncComputeStorageImages(u64 shader_hash, u32 grid_x, u32 grid_y, u32 grid_z) {
+    // Only download for verified CS to avoid corrupting guest memory with unverified output.
+    static constexpr u64 VERIFIED_CS[] = {
+        0xccdebd80f02a77aa, // R32 pixel copy, cascaded dispatch → BC3/BC1 texture overlap
+    };
+    bool is_verified = false;
+    for (u64 h : VERIFIED_CS) {
+        if (shader_hash == h) { is_verified = true; break; }
+    }
+    if (!is_verified) return;
+
+    const bool can_estimate = (grid_x > 0 && grid_y > 0);
+
+    for (const auto& [image_id, img_desc] : image_bindings) {
+        if (img_desc.type != VideoCore::TextureCache::BindingType::Storage || !image_id) continue;
+        auto& storage_img = texture_cache.GetImage(image_id);
+        storage_img.flags |= VideoCore::ImageFlagBits::GpuModified |
+                             VideoCore::ImageFlagBits::ComputeWritten;
+        storage_img.flags &= ~VideoCore::ImageFlagBits::Dirty;
+
+        if (storage_img.info.guest_address == 0) {
+            LOG_ERROR(Render, "CS sync skip: null guest address shader={:016x}", shader_hash);
+            continue;
+        }
+        if (!can_estimate) {
+            LOG_ERROR(Render, "CS sync skip: indirect dispatch shader={:016x}", shader_hash);
+            continue;
+        }
+        if (storage_img.info.num_samples > 1) {
+            LOG_ERROR(Render, "CS sync skip: multisampled shader={:016x}", shader_hash);
+            continue;
+        }
+        const u32 bpp = storage_img.info.num_bits / 8u;
+        if (bpp == 0 || storage_img.info.size.width == 0 || storage_img.info.size.height == 0) {
+            LOG_ERROR(Render, "CS sync skip: invalid image shader={:016x}", shader_hash);
+            continue;
+        }
+
+        const u32 img_w = static_cast<u32>(storage_img.info.size.width);
+        const u32 img_h = static_cast<u32>(storage_img.info.size.height);
+        const u32 block_w = std::max<u32>(1, (img_w + grid_x - 1) / grid_x);
+        const u32 block_h = std::max<u32>(1, (img_h + grid_y - 1) / grid_y);
+        const u32 dirty_w = std::min<u32>(grid_x * block_w, img_w);
+        const u32 dirty_h = std::min<u32>(grid_y * block_h, img_h);
+
+        storage_img.DownloadToGuest(0, 0, dirty_w, dirty_h);
+        storage_img.flags &= ~VideoCore::ImageFlagBits::ComputeWritten;
+        storage_img.flags &= ~VideoCore::ImageFlagBits::GpuModified;
+    }
 }
 
 u64 Rasterizer::Flush() {
@@ -396,6 +452,8 @@ bool Rasterizer::BindResources(const Pipeline* pipeline) {
     // Bind resource buffers and textures.
     Shader::Backend::Bindings binding{};
     push_data = MakeUserData(liverpool->regs);
+    // Accumulate all image bindings across stages (each BindTextures clears image_bindings).
+    boost::container::small_vector<ImageBindingInfo, Shader::NUM_IMAGES> all_images;
     for (const auto* stage : pipeline->GetStages()) {
         if (!stage) {
             continue;
@@ -405,7 +463,27 @@ bool Rasterizer::BindResources(const Pipeline* pipeline) {
         stage->PushUd(binding, push_data);
         BindBuffers(*stage, binding, push_data);
         BindTextures(*stage, binding);
+        all_images.insert(all_images.end(), image_bindings.begin(), image_bindings.end());
         uses_dma |= stage->uses_dma;
+    }
+
+    // Detect compute storage ↔ texture overlaps and mark textures Dirty for refresh.
+    if (!pipeline->IsCompute()) {
+        for (const auto& [tex_id, tex_desc] : all_images) {
+            if (!tex_id) continue;
+            auto& tex_img = texture_cache.GetImage(tex_id);
+            if (tex_img.info.props.is_depth) continue;
+            if (tex_img.info.num_samples > 1) continue;
+            texture_cache.ForEachImageInRegion(tex_img.info.guest_address,
+                tex_img.info.guest_size,
+                [&](VideoCore::ImageId overlap_id, VideoCore::Image& overlap_img) {
+                    if (overlap_id == tex_id) return;
+                    if (!True(overlap_img.flags & VideoCore::ImageFlagBits::ComputeWritten)) return;
+                    if (overlap_img.info.pixel_format == tex_img.info.pixel_format) return;
+                    tex_img.flags |= VideoCore::ImageFlagBits::Dirty;
+                    // ComputeWritten is cleared in SyncComputeStorageImages after download.
+                });
+        }
     }
 
     if (uses_dma) {

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include "common/recursive_lock.h"
 #include "common/shared_first_mutex.h"
 #include "video_core/buffer_cache/buffer_cache.h"
@@ -105,6 +107,7 @@ private:
 
     void SyncComputeStorageImages(u64 shader_hash = 0, u32 grid_x = 0, u32 grid_y = 0,
                                    u32 grid_z = 0);
+    void ResolvePendingComputeDownloads();
 
     void ResetBindings() {
         for (auto& image_id : bound_images) {
@@ -130,6 +133,22 @@ private:
     boost::icl::interval_set<VAddr> mapped_ranges;
     Common::SharedFirstMutex mapped_ranges_mutex;
     PipelineCache pipeline_cache;
+
+    struct PendingComputeDownload {
+        vk::Fence fence{};
+        VkBuffer staging_buffer{};
+        VmaAllocation staging_alloc{};
+        VmaAllocator vma_alloc{};
+        u8* staging_ptr{};
+        VAddr guest_base{};
+        u32 img_width{};
+        u32 bpp{};
+        u32 min_x{};
+        u32 min_y{};
+        u32 max_x{};
+        u32 max_y{};
+    };
+    std::vector<PendingComputeDownload> pending_compute_downloads;
 
     using RenderTargetInfo = std::pair<VideoCore::ImageId, VideoCore::TextureCache::ImageDesc>;
     std::array<RenderTargetInfo, AmdGpu::NUM_COLOR_BUFFERS> cb_descs;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -103,6 +103,9 @@ private:
     void BindTextures(const Shader::Info& stage, Shader::Backend::Bindings& binding);
     bool BindResources(const Pipeline* pipeline);
 
+    void SyncComputeStorageImages(u64 shader_hash = 0, u32 grid_x = 0, u32 grid_y = 0,
+                                   u32 grid_z = 0);
+
     void ResetBindings() {
         for (auto& image_id : bound_images) {
             texture_cache.GetImage(image_id).binding = {};

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <vector>
-
 #include "common/recursive_lock.h"
 #include "common/shared_first_mutex.h"
 #include "video_core/buffer_cache/buffer_cache.h"
@@ -133,22 +131,7 @@ private:
     boost::icl::interval_set<VAddr> mapped_ranges;
     Common::SharedFirstMutex mapped_ranges_mutex;
     PipelineCache pipeline_cache;
-
-    struct PendingComputeDownload {
-        vk::Fence fence{};
-        VkBuffer staging_buffer{};
-        VmaAllocation staging_alloc{};
-        VmaAllocator vma_alloc{};
-        u8* staging_ptr{};
-        VAddr guest_base{};
-        u32 img_width{};
-        u32 bpp{};
-        u32 min_x{};
-        u32 min_y{};
-        u32 max_x{};
-        u32 max_y{};
-    };
-    std::vector<PendingComputeDownload> pending_compute_downloads;
+    std::unique_ptr<class ComputeDownloadManager> compute_download;
 
     using RenderTargetInfo = std::pair<VideoCore::ImageId, VideoCore::TextureCache::ImageDesc>;
     std::array<RenderTargetInfo, AmdGpu::NUM_COLOR_BUFFERS> cb_descs;

--- a/src/video_core/texture_cache/image.cpp
+++ b/src/video_core/texture_cache/image.cpp
@@ -436,6 +436,72 @@ void Image::Download(std::span<const vk::BufferImageCopy> download_copies, vk::B
     });
 }
 
+void Image::DownloadToGuest(u32 min_x, u32 min_y, u32 max_x, u32 max_y) {
+    // Guard against invalid image or out-of-bounds rect.
+    if (info.guest_address == 0) return;
+    const u32 bpp = info.num_bits / 8u;
+    if (bpp == 0 || info.size.width == 0 || info.size.height == 0) return;
+    if (min_x >= max_x || min_y >= max_y) return;
+    if (max_x > info.size.width || max_y > info.size.height) return;
+
+    const u32 full_row_bytes = info.size.width * bpp;
+    const u32 rect_w = max_x - min_x;
+    const u32 rect_h = max_y - min_y;
+    const u32 partial_row_bytes = rect_w * bpp;
+    const u32 download_size = rect_h * full_row_bytes;
+    const VAddr guest_base = info.guest_address;
+
+    // Allocate staging buffer (full row width, rect_h rows).
+    const VkBufferCreateInfo buffer_ci = {
+        .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .size = download_size,
+        .usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+    };
+    VmaAllocationCreateInfo alloc_ci = {};
+    alloc_ci.flags =
+        VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT;
+    alloc_ci.usage = VMA_MEMORY_USAGE_AUTO;
+
+    VmaAllocator vma_alloc = backing->image.allocator;
+    VmaAllocation allocation = VK_NULL_HANDLE;
+    VmaAllocationInfo alloc_info{};
+    VkBuffer staging_vk = VK_NULL_HANDLE;
+    VkResult vk_res = vmaCreateBuffer(vma_alloc, &buffer_ci, &alloc_ci, &staging_vk,
+                                       &allocation, &alloc_info);
+    if (vk_res != VK_SUCCESS) return;
+    vk::Buffer staging_buffer{staging_vk};
+
+    // Download the rows covering the requested rectangle.
+    const vk::BufferImageCopy copy_region = {
+        .bufferOffset = 0,
+        .bufferRowLength = static_cast<u32>(info.size.width),
+        .bufferImageHeight = 0,
+        .imageSubresource =
+            {
+                .aspectMask = aspect_mask & ~vk::ImageAspectFlagBits::eStencil,
+                .mipLevel = 0,
+                .baseArrayLayer = 0,
+                .layerCount = 1,
+            },
+        .imageOffset = {0, static_cast<int32_t>(min_y), 0},
+        .imageExtent = {static_cast<u32>(info.size.width), rect_h, 1},
+    };
+    std::span copies{&copy_region, 1};
+    Download(copies, staging_buffer, 0, download_size);
+    scheduler->Finish();
+
+    // Per-row memcpy: only columns [min_x, max_x) to guest memory.
+    const u8* mapped = static_cast<const u8*>(alloc_info.pMappedData);
+    for (u32 row = 0; row < rect_h; ++row) {
+        const u32 src_off = row * full_row_bytes + min_x * bpp;
+        u8* dst = std::bit_cast<u8*>(guest_base + (min_y + row) * full_row_bytes + min_x * bpp);
+        std::memcpy(dst, mapped + src_off, partial_row_bytes);
+    }
+
+    vmaDestroyBuffer(vma_alloc, staging_vk, allocation);
+}
+
 static std::pair<u32, u32> SanitizeCopyLayers(const ImageInfo& src_info, const ImageInfo& dst_info,
                                               const u32 depth) {
     const auto vk_src_type = ConvertImageType(src_info.type);

--- a/src/video_core/texture_cache/image.h
+++ b/src/video_core/texture_cache/image.h
@@ -32,6 +32,7 @@ enum ImageFlagBits : u32 {
     GpuDirty = 1 << 2, ///< Contents have been modified from the GPU (valid data in buffer cache)
     Dirty = MaybeCpuDirty | CpuDirty | GpuDirty,
     GpuModified = 1 << 3, ///< Contents have been modified from the GPU
+    ComputeWritten = 1 << 4, ///< Written by compute dispatch (for GPU-side sync to textures)
     Registered = 1 << 6,  ///< True when the image is registered
     Picked = 1 << 7,      ///< Temporary flag to mark the image as picked
 };
@@ -134,6 +135,9 @@ struct Image {
     void Download(std::span<const vk::BufferImageCopy> download_copies, vk::Buffer buffer,
                   u64 offset, u64 download_size);
 
+    /// Download image content to guest memory for the pixel rectangle [min_x,min_y)-(max_x,max_y).
+    void DownloadToGuest(u32 min_x, u32 min_y, u32 max_x, u32 max_y);
+
     void CopyImage(Image& src_image);
     void CopyImageWithBuffer(Image& src_image, vk::Buffer buffer, u64 offset);
     void CopyMip(Image& src_image, u32 mip, u32 slice);
@@ -157,6 +161,13 @@ public:
     VAddr track_addr_end = 0;
     ImageId depth_id{};
     u64 depth_uid{};
+
+    // Pixel region written by last compute dispatch on this storage image.
+    struct {
+        u32 min_x = 0, min_y = 0;
+        u32 max_x = 0, max_y = 0; // exclusive
+        bool valid = false;
+    } compute_dirty_rect{};
 
     // Resource state tracking
     vk::ImageUsageFlags usage_flags;

--- a/src/video_core/texture_cache/image.h
+++ b/src/video_core/texture_cache/image.h
@@ -31,10 +31,10 @@ enum ImageFlagBits : u32 {
     CpuDirty = 1 << 1,      ///< Contents have been modified from the CPU
     GpuDirty = 1 << 2, ///< Contents have been modified from the GPU (valid data in buffer cache)
     Dirty = MaybeCpuDirty | CpuDirty | GpuDirty,
-    GpuModified = 1 << 3, ///< Contents have been modified from the GPU
+    GpuModified = 1 << 3,    ///< Contents have been modified from the GPU
     ComputeWritten = 1 << 4, ///< Written by compute dispatch (for GPU-side sync to textures)
-    Registered = 1 << 6,  ///< True when the image is registered
-    Picked = 1 << 7,      ///< Temporary flag to mark the image as picked
+    Registered = 1 << 6,     ///< True when the image is registered
+    Picked = 1 << 7,         ///< Temporary flag to mark the image as picked
 };
 DECLARE_ENUM_FLAG_OPERATORS(ImageFlagBits)
 

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -131,6 +131,16 @@ void TextureCache::DownloadImageMemory(ImageId image_id) {
         });
 }
 
+void TextureCache::InvalidateMemoryRange(VAddr addr, size_t size) {
+    ForEachImageInRegion(addr, size, [&](ImageId image_id, Image& image) {
+        if (True(image.flags & ImageFlagBits::ComputeWritten)) {
+            image.flags &= ~ImageFlagBits::ComputeWritten;
+        } else {
+            image.flags |= ImageFlagBits::GpuDirty;
+        }
+    });
+}
+
 void TextureCache::MarkAsMaybeDirty(ImageId image_id, Image& image) {
     if (image.hash == 0) {
         // Initialize hash

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -90,6 +90,11 @@ public:
     /// Marks an image as dirty if it exists at the provided address.
     void InvalidateMemoryFromGPU(VAddr address, size_t max_size);
 
+    /// After compute dispatch writes a storage image, marks overlapping non-compute images
+    /// GpuDirty (so they refresh from updated guest memory) and clears ComputeWritten from
+    /// storage images whose download has completed.
+    void InvalidateMemoryRange(VAddr addr, size_t size);
+
     /// Evicts any images that overlap the unmapped range.
     void UnmapMemory(VAddr cpu_addr, size_t size);
 


### PR DESCRIPTION
# Compute→Texture Data Sync for God of War III

## Problem

PS4 GCN unified memory allows a compute shader to write a storage image in
one format (R32G32B32A32Uint) and a graphics shader to read the same memory
as a texture in a different format (BC3/BC1). Vulkan prohibits cross-format
aliasing — the emulator creates separate VkImages. Compute writes go to the
storage VkImage (GPU-local), but texture Refresh reads guest memory which is
never updated with the compute output. BC3 textures sample stale data.

In God of War III Remastered, compute shader `ccdebd80f02a77aa` performs a
cascaded dispatch filling 4 MB R32 buffers. The game then creates BC3 textures
at overlapping addresses via an A/B double-buffer pattern, expecting the
compute output as their data source.

## Approach

After a direct compute dispatch, record `vkCmdCopyImageToBuffer` from the
storage VkImage to a staging buffer, then memcpy into guest memory. Subsequent
texture Refresh finds the updated data and uploads to the BC3 VkImage.

Copies from multiple dispatches are batched into the same command buffer
without flushing. At the start of the next graphics `BindResources`, a single
`scheduler.Wait(tick)` submits the batch and waits for GPU completion, then
memcpys and marks overlapping textures dirty via `InvalidateMemoryRange`.

Gated by game serial: CUSA01623 / CUSA01715 / CUSA01740. Other games incur
zero overhead.

## Limitations

- Simplified implementation based on assumptions about the known compute
  shader behavior. Completeness and performance not thoroughly tested.
- Opening battle scene looks correct. Some particles appear black in later
  scenes — may be caused by other compute shaders not yet handled.
- Only mip 0 / layer 0 is downloaded — the compute shader produces a single
  flat R32 surface and does not generate higher mips. Any higher mips of the
  overlapping BC3 texture would need a separate mipmap generation pass, which
  is outside the scope of this fix.

An ideal solution would keep the entire pipeline on the GPU — a compute
shader that directly reads the R32 storage image and writes BC3-encoded
blocks to the texture VkImage, eliminating the round-trip through guest
memory and CPU.

**For reference only.**

---

[Claude Code, deepseek-v4-pro]
