### PR TITLE
Fix grammatical and factual mistakes

### DIFF
--- a/.github/ISSUE_TEMPLATE/game-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/game-bug-report.yaml
@@ -31,7 +31,7 @@ body:
 
         When there are several "Critical" lines, the last one is the most important one.
         
-        Don't run inside or attached to a debugger or extension tool, such as: Renderdoc, Vulkan Validation Layers, Reshade
+        Don't run inside or attached to a debugger or external tool, such as: Renderdoc, Vulkan Validation Layers, Reshade
   - type: checkboxes
     id: checklist
     attributes:

--- a/.github/ISSUE_TEMPLATE/game-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/game-bug-report.yaml
@@ -27,11 +27,11 @@ body:
 
         Don't edit log.
         
-        Don't force kill the application (or precise it in your issue if you had to.)
+        Don't force kill the application (or mention it in your issue if you had to).
 
-        When there are several "Critical" lines, the first one is the most important one.
+        When there are several "Critical" lines, the last one is the most important one.
         
-        Don't run inside or attached to a debugger or extension tool.
+        Don't run inside or attached to a debugger or extension tool, such as: Renderdoc, Vulkan Validation Layers, Reshade
   - type: checkboxes
     id: checklist
     attributes:


### PR DESCRIPTION
#4459 had a few mistakes that this PR aims to fix. After my PR about not logging asserts and unreachables twice, the last Critical log once again became the relevant one. Also, the previous wording assumed Windows as the platform, when on other OSes, that wasn't true anyway.