### PR TITLE
Add error logging for unsupported file descriptors

### DIFF
--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -1454,7 +1454,7 @@ s32 PS4_SYSV_ABI posix_select(s32 nfds, fd_set* readfds, fd_set* writefds, fd_se
                 }
             }();
             if (native_fd == -1) {
-                LOG_ERROR(Kernel_Fs, "Unsupported fd %d", i);
+                LOG_ERROR(Kernel_Fs, "Unsupported fd {}", i);
                 continue;
             }
             host_to_guest.emplace(native_fd, i);

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -1323,6 +1323,7 @@ s32 PS4_SYSV_ABI posix_select(s32 nfds, fd_set_posix* readfds, fd_set_posix* wri
         }
 
         if (native_fd == -1) {
+            LOG_WARNING(Kernel_Fs, "Unsupported fd {}", i);
             continue;
         }
 
@@ -1454,7 +1455,7 @@ s32 PS4_SYSV_ABI posix_select(s32 nfds, fd_set* readfds, fd_set* writefds, fd_se
                 }
             }();
             if (native_fd == -1) {
-                LOG_ERROR(Kernel_Fs, "Unsupported fd {}", i);
+                LOG_WARNING(Kernel_Fs, "Unsupported fd {}", i);
                 continue;
             }
             host_to_guest.emplace(native_fd, i);

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -1456,7 +1456,7 @@ s32 PS4_SYSV_ABI posix_select(s32 nfds, fd_set* readfds, fd_set* writefds, fd_se
             if (native_fd == -1) {
                 LOG_ERROR(Kernel_Fs,
                           "Unsupported fd %d",
-                          fd);
+                          i);
                 continue;
             }
             host_to_guest.emplace(native_fd, i);

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -1454,9 +1454,7 @@ s32 PS4_SYSV_ABI posix_select(s32 nfds, fd_set* readfds, fd_set* writefds, fd_se
                 }
             }();
             if (native_fd == -1) {
-                LOG_ERROR(Kernel_Fs,
-                          "Unsupported fd %d",
-                          i);
+                LOG_ERROR(Kernel_Fs, "Unsupported fd %d", i);
                 continue;
             }
             host_to_guest.emplace(native_fd, i);

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -1454,6 +1454,9 @@ s32 PS4_SYSV_ABI posix_select(s32 nfds, fd_set* readfds, fd_set* writefds, fd_se
                 }
             }();
             if (native_fd == -1) {
+                LOG_ERROR(Kernel_Fs,
+                          "Unsupported fd %d",
+                          fd);
                 continue;
             }
             host_to_guest.emplace(native_fd, i);


### PR DESCRIPTION
Log an error when an unsupported file descriptor is encountered.
