### PR TITLE
Core: Only initialize logging once

### DIFF
--- a/src/common/key_manager.cpp
+++ b/src/common/key_manager.cpp
@@ -78,13 +78,12 @@ bool KeyManager::LoadFromFile() {
             SetDefaultKeys();
             TransferTrophyKey();
             SaveToFile();
-            LOG_DEBUG(KeyManager, "Created default key file: {}", keysPath.string());
             return true;
         }
 
         std::ifstream file(keysPath);
         if (!file.is_open()) {
-            LOG_ERROR(KeyManager, "Could not open key file: {}", keysPath.string());
+            fmt::println("Could not open key file: {}", keysPath.string());
             return false;
         }
 
@@ -104,12 +103,10 @@ bool KeyManager::LoadFromFile() {
                 SaveToFile();
             }
         }
-
-        LOG_DEBUG(KeyManager, "Successfully loaded keys from: {}", keysPath.string());
         return true;
 
     } catch (const std::exception& e) {
-        LOG_ERROR(KeyManager, "Error loading keys, using defaults: {}", e.what());
+        fmt::println("Error loading keys, using defaults: {}", e.what());
         SetDefaultKeys();
         return false;
     }
@@ -125,7 +122,7 @@ bool KeyManager::SaveToFile() {
 
         std::ofstream file(keysPath);
         if (!file.is_open()) {
-            LOG_ERROR(KeyManager, "Could not open key file for writing: {}", keysPath.string());
+            fmt::println("Could not open key file for writing: {}", keysPath.string());
             return false;
         }
 
@@ -133,15 +130,13 @@ bool KeyManager::SaveToFile() {
         file.flush();
 
         if (file.fail()) {
-            LOG_ERROR(KeyManager, "Failed to write keys to: {}", keysPath.string());
+            fmt::println("Failed to write keys to: {}", keysPath.string());
             return false;
         }
-
-        LOG_DEBUG(KeyManager, "Successfully saved keys to: {}", keysPath.string());
         return true;
 
     } catch (const std::exception& e) {
-        LOG_ERROR(KeyManager, "Error saving keys: {}", e.what());
+        fmt::println("Error saving keys: {}", e.what());
         return false;
     }
 }

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -55,10 +55,7 @@ static constexpr std::array level_string_views{"Trace", "Debug",    "Info", "War
                         spdlog::source_loc::basename(__FILE__), __LINE__,                          \
                         std::string_view(__func__) == "operator()" ? "lambda" : __func__,          \
                         ##__VA_ARGS__);                                                            \
-        } else {                                                                                   \
-            std::cerr << "Attempting to log before logger is initialized!" << std::endl;           \
-            std::quick_exit(1);                                                                    \
-        }                                                                                          \
+        }                                                                                          \                                                                                      \
     } while (false)
 
 #ifdef _DEBUG

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -55,7 +55,7 @@ static constexpr std::array level_string_views{"Trace", "Debug",    "Info", "War
                         spdlog::source_loc::basename(__FILE__), __LINE__,                          \
                         std::string_view(__func__) == "operator()" ? "lambda" : __func__,          \
                         ##__VA_ARGS__);                                                            \
-        }                                                                                          \                                                                                      \
+        }                                                                                          \
     } while (false)
 
 #ifdef _DEBUG

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <iostream>
 #include <unordered_map>
 #include <vector>
 #include <spdlog/details/fmt_helper.h>
@@ -54,6 +55,9 @@ static constexpr std::array level_string_views{"Trace", "Debug",    "Info", "War
                         spdlog::source_loc::basename(__FILE__), __LINE__,                          \
                         std::string_view(__func__) == "operator()" ? "lambda" : __func__,          \
                         ##__VA_ARGS__);                                                            \
+        } else {                                                                                   \
+            std::cerr << "Attempting to log before logger is initialized!" << std::endl;           \
+            std::quick_exit(1);                                                                    \
         }                                                                                          \
     } while (false)
 

--- a/src/core/emulator_settings.cpp
+++ b/src/core/emulator_settings.cpp
@@ -89,12 +89,11 @@ std::optional<T> get_optional(const toml::value& v, const std::string& key) {
 
 void EmulatorSettingsImpl::PrintChangedSummary(const std::vector<std::string>& changed) {
     if (changed.empty()) {
-        LOG_DEBUG(Config, "No game-specific overrides applied");
         return;
     }
-    LOG_DEBUG(Config, "Game-specific overrides applied:");
+    fmt::println("Game-specific overrides applied:");
     for (const auto& k : changed)
-        LOG_DEBUG(Config, "    * {}", k);
+        fmt::println("    * {}", k);
 }
 
 // ── Singleton ────────────────────────────────────────────────────────
@@ -232,7 +231,6 @@ void EmulatorSettingsImpl::ClearGameSpecificOverrides() {
     ClearGroupOverrides(m_audio);
     ClearGroupOverrides(m_gpu);
     ClearGroupOverrides(m_vulkan);
-    LOG_DEBUG(Config, "All game-specific overrides cleared");
 }
 
 void EmulatorSettingsImpl::ResetGameSpecificValue(const std::string& key) {
@@ -260,7 +258,7 @@ void EmulatorSettingsImpl::ResetGameSpecificValue(const std::string& key) {
         return;
     if (tryGroup(m_vulkan))
         return;
-    LOG_WARNING(Config, "ResetGameSpecificValue: key '{}' not found", key);
+    fmt::println("ResetGameSpecificValue: key '{}' not found", key);
 }
 
 bool EmulatorSettingsImpl::Save(const std::string& serial) {
@@ -302,7 +300,7 @@ bool EmulatorSettingsImpl::Save(const std::string& serial) {
 
             std::ofstream out(path);
             if (!out) {
-                LOG_ERROR(Config, "Failed to open game config for writing: {}", path.string());
+                fmt::println("Failed to open game config for writing: {}", path.string());
                 return false;
             }
             out << std::setw(2) << j;
@@ -344,14 +342,14 @@ bool EmulatorSettingsImpl::Save(const std::string& serial) {
 
             std::ofstream out(path);
             if (!out) {
-                LOG_ERROR(Config, "Failed to open config for writing: {}", path.string());
+                fmt::println("Failed to open config for writing: {}", path.string());
                 return false;
             }
             out << std::setw(2) << existing;
             return !out.fail();
         }
     } catch (const std::exception& e) {
-        LOG_ERROR(Config, "Error saving settings: {}", e.what());
+        fmt::println("Error saving settings: {}", e.what());
         return false;
     }
 }
@@ -364,7 +362,6 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
             // ── Global config ──────────────────────────────────────────
             const auto userDir = Common::FS::GetUserPath(Common::FS::PathType::UserDir);
             const auto configPath = userDir / "config.json";
-            LOG_DEBUG(Config, "Loading global config from: {}", configPath.string());
 
             if (std::ifstream in{configPath}; in.good()) {
                 json gj;
@@ -385,8 +382,6 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
                 mergeGroup(m_audio, "Audio");
                 mergeGroup(m_gpu, "GPU");
                 mergeGroup(m_vulkan, "Vulkan");
-
-                LOG_DEBUG(Config, "Global config loaded successfully");
             } else {
                 if (std::filesystem::exists(Common::FS::GetUserPath(Common::FS::PathType::UserDir) /
                                             "config.toml")) {
@@ -420,7 +415,6 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
                         }
                     }
                 }
-                LOG_DEBUG(Config, "Global config not found - using defaults");
                 SetDefaultValues();
                 Save();
             }
@@ -436,16 +430,13 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
             // base configuration.
             const auto gamePath =
                 Common::FS::GetUserPath(Common::FS::PathType::CustomConfigs) / (serial + ".json");
-            LOG_DEBUG(Config, "Applying game config: {}", gamePath.string());
 
             if (!std::filesystem::exists(gamePath)) {
-                LOG_DEBUG(Config, "No game-specific config found for {}", serial);
                 return false;
             }
 
             std::ifstream in(gamePath);
             if (!in) {
-                LOG_ERROR(Config, "Failed to open game config: {}", gamePath.string());
                 return false;
             }
 
@@ -478,7 +469,7 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
             return true;
         }
     } catch (const std::exception& e) {
-        LOG_ERROR(Config, "Error loading settings: {}", e.what());
+        fmt::println("Error loading settings: {}", e.what());
         return false;
     }
 }
@@ -678,7 +669,7 @@ bool EmulatorSettingsImpl::TransferSettings() {
             }
             s.install_dirs.value = settings_install_dirs;
         } catch (const std::exception& e) {
-            LOG_WARNING(Config, "Failed to transfer install directories: {}", e.what());
+            fmt::println("Failed to transfer install directories: {}", e.what());
         }
 
         // Transfer addon install directory
@@ -694,7 +685,7 @@ bool EmulatorSettingsImpl::TransferSettings() {
                 }
             }
         } catch (const std::exception& e) {
-            LOG_WARNING(Config, "Failed to transfer addon install directory: {}", e.what());
+            fmt::println("Failed to transfer addon install directory: {}", e.what());
         }
     }
     if (og_data.contains("General")) {
@@ -713,7 +704,7 @@ bool EmulatorSettingsImpl::TransferSettings() {
                 }
             }
         } catch (const std::exception& e) {
-            LOG_WARNING(Config, "Failed to transfer sysmodules install directory: {}", e.what());
+            fmt::println("Failed to transfer sysmodules install directory: {}", e.what());
         }
 
         // Transfer font install directory
@@ -729,7 +720,7 @@ bool EmulatorSettingsImpl::TransferSettings() {
                 }
             }
         } catch (const std::exception& e) {
-            LOG_WARNING(Config, "Failed to transfer font install directory: {}", e.what());
+            fmt::println("Failed to transfer font install directory: {}", e.what());
         }
     }
 

--- a/src/core/emulator_settings.cpp
+++ b/src/core/emulator_settings.cpp
@@ -89,12 +89,11 @@ std::optional<T> get_optional(const toml::value& v, const std::string& key) {
 
 void EmulatorSettingsImpl::PrintChangedSummary(const std::vector<std::string>& changed) {
     if (changed.empty()) {
-        LOG_DEBUG(Config, "No game-specific overrides applied");
         return;
     }
-    LOG_DEBUG(Config, "Game-specific overrides applied:");
+    std::cout << "Game-specific overrides applied:" << std::endl;
     for (const auto& k : changed)
-        LOG_DEBUG(Config, "    * {}", k);
+        std::cout << "    * " << k << std::endl;
 }
 
 // ── Singleton ────────────────────────────────────────────────────────
@@ -232,7 +231,6 @@ void EmulatorSettingsImpl::ClearGameSpecificOverrides() {
     ClearGroupOverrides(m_audio);
     ClearGroupOverrides(m_gpu);
     ClearGroupOverrides(m_vulkan);
-    LOG_DEBUG(Config, "All game-specific overrides cleared");
 }
 
 void EmulatorSettingsImpl::ResetGameSpecificValue(const std::string& key) {
@@ -260,7 +258,7 @@ void EmulatorSettingsImpl::ResetGameSpecificValue(const std::string& key) {
         return;
     if (tryGroup(m_vulkan))
         return;
-    LOG_WARNING(Config, "ResetGameSpecificValue: key '{}' not found", key);
+    std::cerr << "ResetGameSpecificValue: key '" << key << "' not found" << std::endl;
 }
 
 bool EmulatorSettingsImpl::Save(const std::string& serial) {
@@ -302,7 +300,8 @@ bool EmulatorSettingsImpl::Save(const std::string& serial) {
 
             std::ofstream out(path);
             if (!out) {
-                LOG_ERROR(Config, "Failed to open game config for writing: {}", path.string());
+                std::cerr << "Failed to open game config for writing: " << path.string()
+                          << std::endl;
                 return false;
             }
             out << std::setw(2) << j;
@@ -344,14 +343,14 @@ bool EmulatorSettingsImpl::Save(const std::string& serial) {
 
             std::ofstream out(path);
             if (!out) {
-                LOG_ERROR(Config, "Failed to open config for writing: {}", path.string());
+                std::cerr << "Failed to open config for writing: " << path.string() << std::endl;
                 return false;
             }
             out << std::setw(2) << existing;
             return !out.fail();
         }
     } catch (const std::exception& e) {
-        LOG_ERROR(Config, "Error saving settings: {}", e.what());
+        std::cerr << "Error saving settings: " << e.what() << std::endl;
         return false;
     }
 }
@@ -364,7 +363,6 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
             // ── Global config ──────────────────────────────────────────
             const auto userDir = Common::FS::GetUserPath(Common::FS::PathType::UserDir);
             const auto configPath = userDir / "config.json";
-            LOG_DEBUG(Config, "Loading global config from: {}", configPath.string());
 
             if (std::ifstream in{configPath}; in.good()) {
                 json gj;
@@ -385,8 +383,6 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
                 mergeGroup(m_audio, "Audio");
                 mergeGroup(m_gpu, "GPU");
                 mergeGroup(m_vulkan, "Vulkan");
-
-                LOG_DEBUG(Config, "Global config loaded successfully");
             } else {
                 if (std::filesystem::exists(Common::FS::GetUserPath(Common::FS::PathType::UserDir) /
                                             "config.toml")) {
@@ -420,7 +416,6 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
                         }
                     }
                 }
-                LOG_DEBUG(Config, "Global config not found - using defaults");
                 SetDefaultValues();
                 Save();
             }
@@ -436,16 +431,14 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
             // base configuration.
             const auto gamePath =
                 Common::FS::GetUserPath(Common::FS::PathType::CustomConfigs) / (serial + ".json");
-            LOG_DEBUG(Config, "Applying game config: {}", gamePath.string());
 
             if (!std::filesystem::exists(gamePath)) {
-                LOG_DEBUG(Config, "No game-specific config found for {}", serial);
                 return false;
             }
 
             std::ifstream in(gamePath);
             if (!in) {
-                LOG_ERROR(Config, "Failed to open game config: {}", gamePath.string());
+                std::cerr << "Failed to open game config: " << gamePath.string() << std::endl;
                 return false;
             }
 
@@ -478,7 +471,7 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
             return true;
         }
     } catch (const std::exception& e) {
-        LOG_ERROR(Config, "Error loading settings: {}", e.what());
+        std::cerr << "Error loading settings: " << e.what() << std::endl;
         return false;
     }
 }
@@ -678,7 +671,7 @@ bool EmulatorSettingsImpl::TransferSettings() {
             }
             s.install_dirs.value = settings_install_dirs;
         } catch (const std::exception& e) {
-            LOG_WARNING(Config, "Failed to transfer install directories: {}", e.what());
+            std::cerr << "Failed to transfer install directories: " << e.what() << std::endl;
         }
 
         // Transfer addon install directory
@@ -694,7 +687,7 @@ bool EmulatorSettingsImpl::TransferSettings() {
                 }
             }
         } catch (const std::exception& e) {
-            LOG_WARNING(Config, "Failed to transfer addon install directory: {}", e.what());
+            std::cerr << "Failed to transfer addon install directory: " << e.what() << std::endl;
         }
     }
     if (og_data.contains("General")) {
@@ -713,7 +706,8 @@ bool EmulatorSettingsImpl::TransferSettings() {
                 }
             }
         } catch (const std::exception& e) {
-            LOG_WARNING(Config, "Failed to transfer sysmodules install directory: {}", e.what());
+            std::cerr << "Failed to transfer sysmodules install directory: " << e.what()
+                      << std::endl;
         }
 
         // Transfer font install directory
@@ -729,7 +723,7 @@ bool EmulatorSettingsImpl::TransferSettings() {
                 }
             }
         } catch (const std::exception& e) {
-            LOG_WARNING(Config, "Failed to transfer font install directory: {}", e.what());
+            std::cerr << "Failed to transfer font install directory: " << e.what() << std::endl;
         }
     }
 

--- a/src/core/emulator_settings.cpp
+++ b/src/core/emulator_settings.cpp
@@ -89,11 +89,12 @@ std::optional<T> get_optional(const toml::value& v, const std::string& key) {
 
 void EmulatorSettingsImpl::PrintChangedSummary(const std::vector<std::string>& changed) {
     if (changed.empty()) {
+        LOG_DEBUG(Config, "No game-specific overrides applied");
         return;
     }
-    std::cout << "Game-specific overrides applied:" << std::endl;
+    LOG_DEBUG(Config, "Game-specific overrides applied:");
     for (const auto& k : changed)
-        std::cout << "    * " << k << std::endl;
+        LOG_DEBUG(Config, "    * {}", k);
 }
 
 // ── Singleton ────────────────────────────────────────────────────────
@@ -231,6 +232,7 @@ void EmulatorSettingsImpl::ClearGameSpecificOverrides() {
     ClearGroupOverrides(m_audio);
     ClearGroupOverrides(m_gpu);
     ClearGroupOverrides(m_vulkan);
+    LOG_DEBUG(Config, "All game-specific overrides cleared");
 }
 
 void EmulatorSettingsImpl::ResetGameSpecificValue(const std::string& key) {
@@ -258,7 +260,7 @@ void EmulatorSettingsImpl::ResetGameSpecificValue(const std::string& key) {
         return;
     if (tryGroup(m_vulkan))
         return;
-    std::cerr << "ResetGameSpecificValue: key '" << key << "' not found" << std::endl;
+    LOG_WARNING(Config, "ResetGameSpecificValue: key '{}' not found", key);
 }
 
 bool EmulatorSettingsImpl::Save(const std::string& serial) {
@@ -300,8 +302,7 @@ bool EmulatorSettingsImpl::Save(const std::string& serial) {
 
             std::ofstream out(path);
             if (!out) {
-                std::cerr << "Failed to open game config for writing: " << path.string()
-                          << std::endl;
+                LOG_ERROR(Config, "Failed to open game config for writing: {}", path.string());
                 return false;
             }
             out << std::setw(2) << j;
@@ -343,14 +344,14 @@ bool EmulatorSettingsImpl::Save(const std::string& serial) {
 
             std::ofstream out(path);
             if (!out) {
-                std::cerr << "Failed to open config for writing: " << path.string() << std::endl;
+                LOG_ERROR(Config, "Failed to open config for writing: {}", path.string());
                 return false;
             }
             out << std::setw(2) << existing;
             return !out.fail();
         }
     } catch (const std::exception& e) {
-        std::cerr << "Error saving settings: " << e.what() << std::endl;
+        LOG_ERROR(Config, "Error saving settings: {}", e.what());
         return false;
     }
 }
@@ -363,6 +364,7 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
             // ── Global config ──────────────────────────────────────────
             const auto userDir = Common::FS::GetUserPath(Common::FS::PathType::UserDir);
             const auto configPath = userDir / "config.json";
+            LOG_DEBUG(Config, "Loading global config from: {}", configPath.string());
 
             if (std::ifstream in{configPath}; in.good()) {
                 json gj;
@@ -383,6 +385,8 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
                 mergeGroup(m_audio, "Audio");
                 mergeGroup(m_gpu, "GPU");
                 mergeGroup(m_vulkan, "Vulkan");
+
+                LOG_DEBUG(Config, "Global config loaded successfully");
             } else {
                 if (std::filesystem::exists(Common::FS::GetUserPath(Common::FS::PathType::UserDir) /
                                             "config.toml")) {
@@ -416,6 +420,7 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
                         }
                     }
                 }
+                LOG_DEBUG(Config, "Global config not found - using defaults");
                 SetDefaultValues();
                 Save();
             }
@@ -431,14 +436,16 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
             // base configuration.
             const auto gamePath =
                 Common::FS::GetUserPath(Common::FS::PathType::CustomConfigs) / (serial + ".json");
+            LOG_DEBUG(Config, "Applying game config: {}", gamePath.string());
 
             if (!std::filesystem::exists(gamePath)) {
+                LOG_DEBUG(Config, "No game-specific config found for {}", serial);
                 return false;
             }
 
             std::ifstream in(gamePath);
             if (!in) {
-                std::cerr << "Failed to open game config: " << gamePath.string() << std::endl;
+                LOG_ERROR(Config, "Failed to open game config: {}", gamePath.string());
                 return false;
             }
 
@@ -471,7 +478,7 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
             return true;
         }
     } catch (const std::exception& e) {
-        std::cerr << "Error loading settings: " << e.what() << std::endl;
+        LOG_ERROR(Config, "Error loading settings: {}", e.what());
         return false;
     }
 }
@@ -671,7 +678,7 @@ bool EmulatorSettingsImpl::TransferSettings() {
             }
             s.install_dirs.value = settings_install_dirs;
         } catch (const std::exception& e) {
-            std::cerr << "Failed to transfer install directories: " << e.what() << std::endl;
+            LOG_WARNING(Config, "Failed to transfer install directories: {}", e.what());
         }
 
         // Transfer addon install directory
@@ -687,7 +694,7 @@ bool EmulatorSettingsImpl::TransferSettings() {
                 }
             }
         } catch (const std::exception& e) {
-            std::cerr << "Failed to transfer addon install directory: " << e.what() << std::endl;
+            LOG_WARNING(Config, "Failed to transfer addon install directory: {}", e.what());
         }
     }
     if (og_data.contains("General")) {
@@ -706,8 +713,7 @@ bool EmulatorSettingsImpl::TransferSettings() {
                 }
             }
         } catch (const std::exception& e) {
-            std::cerr << "Failed to transfer sysmodules install directory: " << e.what()
-                      << std::endl;
+            LOG_WARNING(Config, "Failed to transfer sysmodules install directory: {}", e.what());
         }
 
         // Transfer font install directory
@@ -723,7 +729,7 @@ bool EmulatorSettingsImpl::TransferSettings() {
                 }
             }
         } catch (const std::exception& e) {
-            std::cerr << "Failed to transfer font install directory: " << e.what() << std::endl;
+            LOG_WARNING(Config, "Failed to transfer font install directory: {}", e.what());
         }
     }
 

--- a/src/core/emulator_settings.h
+++ b/src/core/emulator_settings.h
@@ -116,26 +116,20 @@ inline OverrideItem make_override(const char* key, Setting<T> Struct::* member) 
     return OverrideItem{
         key,
         [member, key](void* base, const nlohmann::json& entry, std::vector<std::string>& changed) {
-            LOG_DEBUG(Config, "[make_override] Processing key: {}", key);
-            LOG_DEBUG(Config, "[make_override] Entry JSON: {}", entry.dump());
             Struct* obj = reinterpret_cast<Struct*>(base);
             Setting<T>& dst = obj->*member;
             try {
                 T newValue = entry.get<T>();
-                LOG_DEBUG(Config, "[make_override] Parsed value: {}", newValue);
-                LOG_DEBUG(Config, "[make_override] Current value: {}", dst.value);
                 if (dst.value != newValue) {
                     std::ostringstream oss;
-                    oss << key << " ( " << dst.value << " → " << newValue << " )";
+                    oss << key << " ( " << dst.value << " -> " << newValue << " )";
                     changed.push_back(oss.str());
-                    LOG_DEBUG(Config, "[make_override] Recorded change: {}", oss.str());
                 }
                 dst.game_specific_value = newValue;
-                LOG_DEBUG(Config, "[make_override] Successfully updated {}", key);
             } catch (const std::exception& e) {
-                LOG_ERROR(Config, "[make_override] ERROR parsing {}: {}", key, e.what());
-                LOG_ERROR(Config, "[make_override] Entry was: {}", entry.dump());
-                LOG_ERROR(Config, "[make_override] Type name: {}", entry.type_name());
+                fmt::println("[make_override] error parsing {}: {}", key, e.what());
+                fmt::println("[make_override] Entry was: {}", entry.dump());
+                fmt::println("[make_override] Type name: {}", entry.type_name());
             }
         },
 

--- a/src/core/emulator_settings.h
+++ b/src/core/emulator_settings.h
@@ -5,6 +5,7 @@
 
 #include <filesystem>
 #include <functional>
+#include <iostream>
 #include <memory>
 #include <mutex>
 #include <sstream>
@@ -116,26 +117,19 @@ inline OverrideItem make_override(const char* key, Setting<T> Struct::* member) 
     return OverrideItem{
         key,
         [member, key](void* base, const nlohmann::json& entry, std::vector<std::string>& changed) {
-            LOG_DEBUG(Config, "[make_override] Processing key: {}", key);
-            LOG_DEBUG(Config, "[make_override] Entry JSON: {}", entry.dump());
             Struct* obj = reinterpret_cast<Struct*>(base);
             Setting<T>& dst = obj->*member;
             try {
                 T newValue = entry.get<T>();
-                LOG_DEBUG(Config, "[make_override] Parsed value: {}", newValue);
-                LOG_DEBUG(Config, "[make_override] Current value: {}", dst.value);
                 if (dst.value != newValue) {
                     std::ostringstream oss;
-                    oss << key << " ( " << dst.value << " → " << newValue << " )";
+                    oss << key << " ( " << dst.value << " -> " << newValue << " )";
                     changed.push_back(oss.str());
-                    LOG_DEBUG(Config, "[make_override] Recorded change: {}", oss.str());
                 }
                 dst.game_specific_value = newValue;
-                LOG_DEBUG(Config, "[make_override] Successfully updated {}", key);
             } catch (const std::exception& e) {
-                LOG_ERROR(Config, "[make_override] ERROR parsing {}: {}", key, e.what());
-                LOG_ERROR(Config, "[make_override] Entry was: {}", entry.dump());
-                LOG_ERROR(Config, "[make_override] Type name: {}", entry.type_name());
+                std::cerr << "make_override: failed to parse " << key << ": " << e.what()
+                          << std::endl;
             }
         },
 

--- a/src/core/emulator_settings.h
+++ b/src/core/emulator_settings.h
@@ -5,7 +5,6 @@
 
 #include <filesystem>
 #include <functional>
-#include <iostream>
 #include <memory>
 #include <mutex>
 #include <sstream>
@@ -117,19 +116,26 @@ inline OverrideItem make_override(const char* key, Setting<T> Struct::* member) 
     return OverrideItem{
         key,
         [member, key](void* base, const nlohmann::json& entry, std::vector<std::string>& changed) {
+            LOG_DEBUG(Config, "[make_override] Processing key: {}", key);
+            LOG_DEBUG(Config, "[make_override] Entry JSON: {}", entry.dump());
             Struct* obj = reinterpret_cast<Struct*>(base);
             Setting<T>& dst = obj->*member;
             try {
                 T newValue = entry.get<T>();
+                LOG_DEBUG(Config, "[make_override] Parsed value: {}", newValue);
+                LOG_DEBUG(Config, "[make_override] Current value: {}", dst.value);
                 if (dst.value != newValue) {
                     std::ostringstream oss;
-                    oss << key << " ( " << dst.value << " -> " << newValue << " )";
+                    oss << key << " ( " << dst.value << " → " << newValue << " )";
                     changed.push_back(oss.str());
+                    LOG_DEBUG(Config, "[make_override] Recorded change: {}", oss.str());
                 }
                 dst.game_specific_value = newValue;
+                LOG_DEBUG(Config, "[make_override] Successfully updated {}", key);
             } catch (const std::exception& e) {
-                std::cerr << "make_override: failed to parse " << key << ": " << e.what()
-                          << std::endl;
+                LOG_ERROR(Config, "[make_override] ERROR parsing {}: {}", key, e.what());
+                LOG_ERROR(Config, "[make_override] Entry was: {}", entry.dump());
+                LOG_ERROR(Config, "[make_override] Type name: {}", entry.type_name());
             }
         },
 

--- a/src/core/user_settings.cpp
+++ b/src/core/user_settings.cpp
@@ -59,13 +59,13 @@ bool UserSettingsImpl::Save() const {
 
         std::ofstream out(path);
         if (!out) {
-            LOG_ERROR(Config, "Failed to open user settings for writing: {}", path.string());
+            fmt::println("Failed to open user settings for writing: {}", path.string());
             return false;
         }
         out << std::setw(2) << existing;
         return !out.fail();
     } catch (const std::exception& e) {
-        LOG_ERROR(Config, "Error saving user settings: {}", e.what());
+        fmt::println("Error saving user settings: {}", e.what());
         return false;
     }
 }
@@ -74,7 +74,6 @@ bool UserSettingsImpl::Load() {
     const auto path = Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "users.json";
     try {
         if (!std::filesystem::exists(path)) {
-            LOG_DEBUG(Config, "User settings file not found: {}", path.string());
             if (m_userManager.GetUsers().user.empty())
                 m_userManager.GetUsers() = m_userManager.CreateDefaultUsers();
             m_loaded = true;
@@ -84,7 +83,7 @@ bool UserSettingsImpl::Load() {
 
         std::ifstream in(path);
         if (!in) {
-            LOG_ERROR(Config, "Failed to open user settings: {}", path.string());
+            fmt::println("Failed to open user settings: {}", path.string());
             return false;
         }
 
@@ -103,15 +102,13 @@ bool UserSettingsImpl::Load() {
             m_userManager.GetUsers() = default_users;
         }
 
-        LOG_DEBUG(Config, "User settings loaded successfully");
-
         m_loaded = true;
         if (m_userManager.GetUsers().commit_hash != Common::g_scm_rev)
             Save();
 
         return true;
     } catch (const std::exception& e) {
-        LOG_ERROR(Config, "Error loading user settings: {}", e.what());
+        fmt::println("Error loading user settings: {}", e.what());
         if (m_userManager.GetUsers().user.empty())
             m_userManager.GetUsers() = m_userManager.CreateDefaultUsers();
         return false;

--- a/src/core/user_settings.cpp
+++ b/src/core/user_settings.cpp
@@ -4,7 +4,6 @@
 #include <algorithm>
 #include <fstream>
 #include <iomanip>
-#include <iostream>
 #include <map>
 #include <common/path_util.h>
 #include <common/scm_rev.h>
@@ -60,13 +59,13 @@ bool UserSettingsImpl::Save() const {
 
         std::ofstream out(path);
         if (!out) {
-            std::cerr << "Failed to open user settings for writing: " << path.string() << std::endl;
+            LOG_ERROR(Config, "Failed to open user settings for writing: {}", path.string());
             return false;
         }
         out << std::setw(2) << existing;
         return !out.fail();
     } catch (const std::exception& e) {
-        std::cerr << "Error saving user settings: " << e.what() << std::endl;
+        LOG_ERROR(Config, "Error saving user settings: {}", e.what());
         return false;
     }
 }
@@ -75,6 +74,7 @@ bool UserSettingsImpl::Load() {
     const auto path = Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "users.json";
     try {
         if (!std::filesystem::exists(path)) {
+            LOG_DEBUG(Config, "User settings file not found: {}", path.string());
             if (m_userManager.GetUsers().user.empty())
                 m_userManager.GetUsers() = m_userManager.CreateDefaultUsers();
             m_loaded = true;
@@ -84,7 +84,7 @@ bool UserSettingsImpl::Load() {
 
         std::ifstream in(path);
         if (!in) {
-            std::cerr << "Failed to open user settings: " << path.string() << std::endl;
+            LOG_ERROR(Config, "Failed to open user settings: {}", path.string());
             return false;
         }
 
@@ -103,13 +103,15 @@ bool UserSettingsImpl::Load() {
             m_userManager.GetUsers() = default_users;
         }
 
+        LOG_DEBUG(Config, "User settings loaded successfully");
+
         m_loaded = true;
         if (m_userManager.GetUsers().commit_hash != Common::g_scm_rev)
             Save();
 
         return true;
     } catch (const std::exception& e) {
-        std::cerr << "Error loading user settings: " << e.what() << std::endl;
+        LOG_ERROR(Config, "Error loading user settings: {}", e.what());
         if (m_userManager.GetUsers().user.empty())
             m_userManager.GetUsers() = m_userManager.CreateDefaultUsers();
         return false;

--- a/src/core/user_settings.cpp
+++ b/src/core/user_settings.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <fstream>
 #include <iomanip>
+#include <iostream>
 #include <map>
 #include <common/path_util.h>
 #include <common/scm_rev.h>
@@ -59,13 +60,13 @@ bool UserSettingsImpl::Save() const {
 
         std::ofstream out(path);
         if (!out) {
-            LOG_ERROR(Config, "Failed to open user settings for writing: {}", path.string());
+            std::cerr << "Failed to open user settings for writing: " << path.string() << std::endl;
             return false;
         }
         out << std::setw(2) << existing;
         return !out.fail();
     } catch (const std::exception& e) {
-        LOG_ERROR(Config, "Error saving user settings: {}", e.what());
+        std::cerr << "Error saving user settings: " << e.what() << std::endl;
         return false;
     }
 }
@@ -74,7 +75,6 @@ bool UserSettingsImpl::Load() {
     const auto path = Common::FS::GetUserPath(Common::FS::PathType::UserDir) / "users.json";
     try {
         if (!std::filesystem::exists(path)) {
-            LOG_DEBUG(Config, "User settings file not found: {}", path.string());
             if (m_userManager.GetUsers().user.empty())
                 m_userManager.GetUsers() = m_userManager.CreateDefaultUsers();
             m_loaded = true;
@@ -84,7 +84,7 @@ bool UserSettingsImpl::Load() {
 
         std::ifstream in(path);
         if (!in) {
-            LOG_ERROR(Config, "Failed to open user settings: {}", path.string());
+            std::cerr << "Failed to open user settings: " << path.string() << std::endl;
             return false;
         }
 
@@ -103,15 +103,13 @@ bool UserSettingsImpl::Load() {
             m_userManager.GetUsers() = default_users;
         }
 
-        LOG_DEBUG(Config, "User settings loaded successfully");
-
         m_loaded = true;
         if (m_userManager.GetUsers().commit_hash != Common::g_scm_rev)
             Save();
 
         return true;
     } catch (const std::exception& e) {
-        LOG_ERROR(Config, "Error loading user settings: {}", e.what());
+        std::cerr << "Error loading user settings: " << e.what() << std::endl;
         if (m_userManager.GetUsers().user.empty())
             m_userManager.GetUsers() = m_userManager.CreateDefaultUsers();
         return false;

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -271,10 +271,9 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
     }
 
     game_info.game_folder = game_folder;
-    EmulatorSettings.Load(id);
-
-    Common::Log::Shutdown();
+    
     // Initialize logging as soon as possible
+    EmulatorSettings.Load(id);
     Common::Log::Setup((!id.empty() && EmulatorSettings.IsLogSeparate()) ? id + ".log"
                                                                          : "shad_log.txt");
 

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -252,6 +252,11 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
         }
     }
 
+    // Initialize logging as soon as possible
+    EmulatorSettings.Load(id);
+    Common::Log::Setup((!id.empty() && EmulatorSettings.IsLogSeparate()) ? id + ".log"
+                                                                         : "shad_log.txt");
+
     auto guest_eboot_path = "/app0/" + eboot_name.generic_string();
     const auto eboot_path = mnt->GetHostPath(guest_eboot_path);
 
@@ -271,11 +276,6 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
     }
 
     game_info.game_folder = game_folder;
-    
-    // Initialize logging as soon as possible
-    EmulatorSettings.Load(id);
-    Common::Log::Setup((!id.empty() && EmulatorSettings.IsLogSeparate()) ? id + ".log"
-                                                                         : "shad_log.txt");
 
     if (!std::filesystem::exists(file)) {
         LOG_CRITICAL(Loader, "eboot.bin does not exist: {}",

--- a/src/imgui/big_picture/big_picture.cpp
+++ b/src/imgui/big_picture/big_picture.cpp
@@ -115,18 +115,18 @@ SDL_Texture* LoadSdlTextureData(std::vector<u8> data) {
     unsigned char* image_data = stbi_load_from_memory(
         (const unsigned char*)data.data(), (int)data.size(), &image_width, &image_height, NULL, 4);
     if (image_data == nullptr) {
-        LOG_ERROR(ImGui, "Failed to load image: {}", stbi_failure_reason());
+        fmt::println("Failed to load image: {}", stbi_failure_reason());
     }
 
     SDL_Surface* surface = SDL_CreateSurfaceFrom(image_width, image_height, SDL_PIXELFORMAT_RGBA32,
                                                  (void*)image_data, channels * image_width);
     if (surface == nullptr) {
-        LOG_ERROR(ImGui, "Unable to create SDL surface: {}", SDL_GetError());
+        fmt::println("Unable to create SDL surface: {}", SDL_GetError());
     }
 
     SDL_Texture* texture = SDL_CreateTextureFromSurface(renderer, surface);
     if (texture == nullptr) {
-        LOG_ERROR(ImGui, "Unable to create SDL texture: {}", SDL_GetError());
+        fmt::println("Unable to create SDL texture: {}", SDL_GetError());
     }
 
     SDL_DestroySurface(surface);
@@ -190,13 +190,13 @@ void GetGameIconInfo(std::vector<IconInfo>& icons) {
 
 void Launch(char* executableName) {
     if (!SDL_Init(SDL_INIT_VIDEO)) {
-        LOG_ERROR(ImGui, "SDL_INIT_VIDEO Error: {}", SDL_GetError());
+        fmt::println("SDL_INIT_VIDEO Error: {}", SDL_GetError());
         SDL_Quit();
         return;
     }
 
     if (!SDL_Init(SDL_INIT_GAMEPAD)) {
-        LOG_ERROR(ImGui, "SDL_INIT_GAMEPAD Error: {}", SDL_GetError());
+        fmt::println("SDL_INIT_GAMEPAD Error: {}", SDL_GetError());
     }
 
     SDL_Window* window =
@@ -204,7 +204,7 @@ void Launch(char* executableName) {
     renderer = SDL_CreateRenderer(window, nullptr);
 
     if (window == nullptr) {
-        LOG_ERROR(ImGui, "SDL Window Creation Error: {}", SDL_GetError());
+        fmt::println("SDL Window Creation Error: {}", SDL_GetError());
         SDL_DestroyRenderer(renderer);
         SDL_Quit();
         return;

--- a/src/imgui/big_picture/big_picture.cpp
+++ b/src/imgui/big_picture/big_picture.cpp
@@ -190,13 +190,14 @@ void GetGameIconInfo(std::vector<IconInfo>& icons) {
 
 void Launch(char* executableName) {
     if (!SDL_Init(SDL_INIT_VIDEO)) {
-        LOG_ERROR(ImGui, "SDL_INIT_VIDEO Error: {}", SDL_GetError());
+        std::cout << "BigPictureMode Launch: SDL_INIT_VIDEO Error: " << SDL_GetError() << std::endl;
         SDL_Quit();
         return;
     }
 
     if (!SDL_Init(SDL_INIT_GAMEPAD)) {
-        LOG_ERROR(ImGui, "SDL_INIT_GAMEPAD Error: {}", SDL_GetError());
+        std::cout << "BigPictureMode Launch: SDL_INIT_GAMEPAD Error: " << SDL_GetError()
+                  << std::endl;
     }
 
     SDL_Window* window =
@@ -204,7 +205,8 @@ void Launch(char* executableName) {
     renderer = SDL_CreateRenderer(window, nullptr);
 
     if (window == nullptr) {
-        LOG_ERROR(ImGui, "SDL Window Creation Error: {}", SDL_GetError());
+        std::cout << "BigPictureMode Launch: SDL Window Creation Error: " << SDL_GetError()
+                  << std::endl;
         SDL_DestroyRenderer(renderer);
         SDL_Quit();
         return;

--- a/src/imgui/big_picture/big_picture.cpp
+++ b/src/imgui/big_picture/big_picture.cpp
@@ -190,14 +190,13 @@ void GetGameIconInfo(std::vector<IconInfo>& icons) {
 
 void Launch(char* executableName) {
     if (!SDL_Init(SDL_INIT_VIDEO)) {
-        std::cout << "BigPictureMode Launch: SDL_INIT_VIDEO Error: " << SDL_GetError() << std::endl;
+        LOG_ERROR(ImGui, "SDL_INIT_VIDEO Error: {}", SDL_GetError());
         SDL_Quit();
         return;
     }
 
     if (!SDL_Init(SDL_INIT_GAMEPAD)) {
-        std::cout << "BigPictureMode Launch: SDL_INIT_GAMEPAD Error: " << SDL_GetError()
-                  << std::endl;
+        LOG_ERROR(ImGui, "SDL_INIT_GAMEPAD Error: {}", SDL_GetError());
     }
 
     SDL_Window* window =
@@ -205,8 +204,7 @@ void Launch(char* executableName) {
     renderer = SDL_CreateRenderer(window, nullptr);
 
     if (window == nullptr) {
-        std::cout << "BigPictureMode Launch: SDL Window Creation Error: " << SDL_GetError()
-                  << std::endl;
+        LOG_ERROR(ImGui, "SDL Window Creation Error: {}", SDL_GetError());
         SDL_DestroyRenderer(renderer);
         SDL_Quit();
         return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,9 +103,6 @@ int main(int argc, char* argv[]) {
     if (waitPid)
         Core::Debugger::WaitForPid(*waitPid);
 
-    // Start default log
-    Common::Log::Setup("shad_log.txt");
-
     IPC::Instance().Init();
 
     auto emu_state = std::make_shared<EmulatorState>();
@@ -121,10 +118,8 @@ int main(int argc, char* argv[]) {
     EmulatorSettingsImpl::SetInstance(emu_settings);
     emu_settings->Load();
 
-    Common::Log::Shutdown();
-    // Start configured log
+    // Configure logger appropriately
     Common::Log::g_should_append |= EmulatorSettings.IsLogAppend();
-    Common::Log::Setup("shad_log.txt");
 
     if (bigPicture) {
         BigPictureMode::Launch(argv[0]);


### PR DESCRIPTION
Somewhere during the mess of config swap and logger backend swap, we settled on initializing our logger multiple times to get around some annoyances with the new config code. While I think the expectation was that we'd retain all logs from prior inits, things would only behave as expected if users enabled the log_append config setting (which is impractical for most users).

This PR restores our old behavior, initializing loggers after we read the game id from the param.sfo (at which point we know what to name our log). Error and warning logs that could fire before logger initialization now use fmt::println instead, and I've removed the debug logs since there's not a good way to handle those properly (since these components need to initialize well before we even try to load a game).

While there's not a whole lot of benefit to this now that the trophy-related warnings all fire after logger's done initializing, this does prevent the creation of shad_log.txt for users with separated logging enabled. This also means that log append will now function properly for users with separated logging disabled, as before the first init would forcibly truncate the log.