### PR TITLE
Prevent opening duplicate windows of a shader dump

### DIFF
--- a/src/core/devtools/widget/shader_list.cpp
+++ b/src/core/devtools/widget/shader_list.cpp
@@ -269,7 +269,10 @@ void ShaderList::Draw() {
             snprintf(name, sizeof(name), "%s", shader.name.c_str());
         }
         if (ButtonEx(name, {width, 20.0f}, ImGuiButtonFlags_NoHoveredOnFocus)) {
-            open_shaders.emplace_back(i);
+            if (std::find_if(open_shaders.begin(), open_shaders.end(),
+                             [i](auto& v) { return v.index == i; }) == open_shaders.end()) {
+                open_shaders.emplace_back(i);
+            }
         }
         i++;
     }


### PR DESCRIPTION
Opening duplicate windows with the same shader caused ImGui to throw errors related to duplicate ids, this fix prevents opening more than one window for a given shader.