### PR TITLE
kernel: fix recursive read-lock deadlock on PthreadRwlock

### DIFF
--- a/src/common/shared_first_mutex.h
+++ b/src/common/shared_first_mutex.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <condition_variable>
 #include <mutex>
 
@@ -26,6 +27,16 @@ public:
         return true;
     }
 
+    template <typename Clock, typename Duration>
+    bool try_lock_until(const std::chrono::time_point<Clock, Duration>& abs_time) {
+        std::unique_lock<std::mutex> lock(mtx);
+        if (!cv.wait_until(lock, abs_time, [this]() { return !writer_active && readers == 0; })) {
+            return false;
+        }
+        writer_active = true;
+        return true;
+    }
+
     void unlock() {
         std::lock_guard<std::mutex> lock(mtx);
         writer_active = false;
@@ -36,6 +47,25 @@ public:
         std::unique_lock<std::mutex> lock(mtx);
         cv.wait(lock, [this]() { return !writer_active; });
         ++readers;
+    }
+
+    bool try_lock_shared() {
+        std::lock_guard<std::mutex> lock(mtx);
+        if (writer_active) {
+            return false;
+        }
+        ++readers;
+        return true;
+    }
+
+    template <typename Clock, typename Duration>
+    bool try_lock_shared_until(const std::chrono::time_point<Clock, Duration>& abs_time) {
+        std::unique_lock<std::mutex> lock(mtx);
+        if (!cv.wait_until(lock, abs_time, [this]() { return !writer_active; })) {
+            return false;
+        }
+        ++readers;
+        return true;
     }
 
     void unlock_shared() {

--- a/src/core/libraries/kernel/threads/pthread.h
+++ b/src/core/libraries/kernel/threads/pthread.h
@@ -10,6 +10,7 @@
 #include <shared_mutex>
 
 #include "common/enum.h"
+#include "common/shared_first_mutex.h"
 #include "core/libraries/kernel/sync/mutex.h"
 #include "core/libraries/kernel/sync/semaphore.h"
 #include "core/libraries/kernel/time.h"
@@ -202,7 +203,7 @@ struct PthreadRwlockAttr {
 using PthreadRwlockAttrT = PthreadRwlockAttr*;
 
 struct PthreadRwlock {
-    std::shared_timed_mutex lock;
+    Common::SharedFirstMutex lock;
     Pthread* owner;
 
     int Wrlock(const OrbisKernelTimespec* abstime);


### PR DESCRIPTION
Rewrote my fix in PR #4468 by amending SharedFirstMutex to allow timed-locking. The fix is now completely out of rwlock.cpp. I have tested and confirmed that the deadlock is fixed as in my previous PR 