### PR TITLE
fix: zlib-ng on GH runner using native instructions instead of the global config

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -51,7 +51,8 @@ if (NOT TARGET ZLIB::ZLIB)
     set(ZLIB_ENABLE_TESTS OFF)
     set(WITH_GTEST OFF)
     set(WITH_NEW_STRATEGIES ON)
-    set(WITH_NATIVE_INSTRUCTIONS ON)
+    # Will mess with gh actions
+    set(WITH_NATIVE_INSTRUCTIONS OFF)
     set(ZLIB_COMPAT ON CACHE BOOL "" FORCE)
     include(FetchContent)
     FetchContent_Declare(


### PR DESCRIPTION
If the user oh so desires, `CMAKE_CXX_FLAGS="-mtune=native -march=naitve"` should satisfy this, otherwise this seems to cause issues with gh runners