### PR TITLE
Kernel.Pthreads: Restructure PthreadMutex struct

### DIFF
--- a/src/core/libraries/kernel/threads/pthread.h
+++ b/src/core/libraries/kernel/threads/pthread.h
@@ -61,14 +61,15 @@ enum class PthreadMutexProt : u32 {
 };
 
 struct PthreadMutex {
-    std::string name;
-    PthreadMutexFlags m_flags;
-    int m_count;
-    TimedMutex m_lock;
     Pthread* m_owner;
+    int m_count;
     int m_spinloops;
     int m_yieldloops;
     PthreadMutexProt m_protocol;
+    u64 : 64;
+    PthreadMutexFlags m_flags;
+    TimedMutex m_lock;
+    std::string name;
 
     [[nodiscard]] PthreadMutexType Type() const noexcept {
         return static_cast<PthreadMutexType>(m_flags & PthreadMutexFlags::TypeMask);
@@ -99,6 +100,9 @@ struct PthreadMutex {
     int IsOwned(Pthread* curthread) const;
 };
 using PthreadMutexT = PthreadMutex*;
+
+// libc and libSceLibcInternal modify the m_flags of a mutex, make sure it's in the right spot.
+static_assert(offsetof(PthreadMutex, m_flags) == 0x20, "Incorrect offset for mutex flags");
 
 struct PthreadMutexAttr {
     PthreadMutexType m_type;

--- a/src/core/libraries/kernel/threads/pthread.h
+++ b/src/core/libraries/kernel/threads/pthread.h
@@ -41,6 +41,7 @@ struct Pthread;
 
 enum class PthreadMutexFlags : u32 {
     TypeMask = 0xff,
+    Private = 0x100,
     Deferred = 0x200,
 };
 DECLARE_ENUM_FLAG_OPERATORS(PthreadMutexFlags)
@@ -60,14 +61,14 @@ enum class PthreadMutexProt : u32 {
 };
 
 struct PthreadMutex {
-    TimedMutex m_lock;
+    std::string name;
     PthreadMutexFlags m_flags;
-    Pthread* m_owner;
     int m_count;
+    TimedMutex m_lock;
+    Pthread* m_owner;
     int m_spinloops;
     int m_yieldloops;
     PthreadMutexProt m_protocol;
-    std::string name;
 
     [[nodiscard]] PthreadMutexType Type() const noexcept {
         return static_cast<PthreadMutexType>(m_flags & PthreadMutexFlags::TypeMask);


### PR DESCRIPTION
As part of libc's mspace functions, when creating pthread mutexes for internal use, they modify the internal data of these mutexes to add the Private flag to m_flags. Previously, on Linux, this would modify internal data of our TimedMutex, and on Windows this would modify the m_yieldloops variable.

This PR reorganizes the struct to place m_flags at a accurate offset so these modifications work.

I would like to know if std::string is size 0x20 on Mac. It's size 0x20 on Windows and Linux, but I don't have a Mac, and I know their types tend to differ. If it is a different size, then I'll need to add filler to the PthreadMutex instead.

Credit to @liuk7071 for bringing this to my attention. As far as I've seen, this appears to be the only place and way libc does this.