### PR TITLE
Lib.NpWebApi: Swap global mutex to recursive

### DIFF
--- a/src/core/libraries/np/np_web_api/np_web_api_internal.cpp
+++ b/src/core/libraries/np/np_web_api/np_web_api_internal.cpp
@@ -12,7 +12,7 @@
 
 namespace Libraries::Np::NpWebApi {
 
-static std::mutex g_global_mutex;
+static std::recursive_mutex g_global_mutex;
 static std::map<s32, OrbisNpWebApiContext*> g_contexts;
 static s32 g_library_context_count = 0;
 static s32 g_user_context_count = 0;


### PR DESCRIPTION
It's recursive in the actual library, and since our implementation is based on the actual library, this is needed for our code to function appropriately.

Comes up in Gran Turismo Sport when the shadNet/network emulation settings are enabled.