### PR TITLE
Lib.Zlib: Use miniz instead of zlib-ng

### DIFF
--- a/src/core/libraries/zlib/zlib.cpp
+++ b/src/core/libraries/zlib/zlib.cpp
@@ -55,9 +55,9 @@ void ZlibTaskThread(const std::stop_token& stop) {
             task_queue.pop();
         }
 
-        uLongf decompressed_length = task.dst_length;
-        const auto ret = mz_uncompress(static_cast<Bytef*>(task.dst), &decompressed_length,
-                                       static_cast<const Bytef*>(task.src), task.src_length);
+        mz_ulong decompressed_length = task.dst_length;
+        const auto ret = mz_uncompress(static_cast<u8*>(task.dst), &decompressed_length,
+                                       static_cast<const u8*>(task.src), task.src_length);
 
         {
             // Lock, insert the new result, and push the finished request ID to the done queue.

--- a/src/core/libraries/zlib/zlib.cpp
+++ b/src/core/libraries/zlib/zlib.cpp
@@ -5,8 +5,8 @@
 #include <mutex>
 #include <stop_token>
 #include <unordered_map>
-#include <queue>
 #include <miniz.h>
+#include <queue>
 
 #include "common/logging/log.h"
 #include "common/thread.h"

--- a/src/core/libraries/zlib/zlib.cpp
+++ b/src/core/libraries/zlib/zlib.cpp
@@ -92,7 +92,7 @@ s32 PS4_SYSV_ABI sceZlibInitialize(const void* buffer, u32 length) {
 
 s32 PS4_SYSV_ABI sceZlibInflate(const void* src, u32 src_len, void* dst, u32 dst_len,
                                 u64* request_id) {
-    LOG_DEBUG(Lib_Zlib, "(STUBBED) called");
+    LOG_DEBUG(Lib_Zlib, "called");
     if (!task_thread.Joinable()) {
         return ORBIS_ZLIB_ERROR_NOT_INITIALIZED;
     }
@@ -117,7 +117,7 @@ s32 PS4_SYSV_ABI sceZlibInflate(const void* src, u32 src_len, void* dst, u32 dst
 }
 
 s32 PS4_SYSV_ABI sceZlibWaitForDone(u64* request_id, const u32* timeout) {
-    LOG_DEBUG(Lib_Zlib, "(STUBBED) called");
+    LOG_DEBUG(Lib_Zlib, "called");
     if (!task_thread.Joinable()) {
         return ORBIS_ZLIB_ERROR_NOT_INITIALIZED;
     }
@@ -143,7 +143,7 @@ s32 PS4_SYSV_ABI sceZlibWaitForDone(u64* request_id, const u32* timeout) {
 }
 
 s32 PS4_SYSV_ABI sceZlibGetResult(const u64 request_id, u32* dst_length, s32* status) {
-    LOG_DEBUG(Lib_Zlib, "(STUBBED) called");
+    LOG_DEBUG(Lib_Zlib, "called");
     if (!task_thread.Joinable()) {
         return ORBIS_ZLIB_ERROR_NOT_INITIALIZED;
     }

--- a/src/core/libraries/zlib/zlib.cpp
+++ b/src/core/libraries/zlib/zlib.cpp
@@ -6,7 +6,7 @@
 #include <stop_token>
 #include <unordered_map>
 #include <queue>
-#include <zlib.h>
+#include <miniz.h>
 
 #include "common/logging/log.h"
 #include "common/thread.h"

--- a/src/core/libraries/zlib/zlib.cpp
+++ b/src/core/libraries/zlib/zlib.cpp
@@ -56,7 +56,7 @@ void ZlibTaskThread(const std::stop_token& stop) {
         }
 
         uLongf decompressed_length = task.dst_length;
-        const auto ret = uncompress(static_cast<Bytef*>(task.dst), &decompressed_length,
+        const auto ret = mz_uncompress(static_cast<Bytef*>(task.dst), &decompressed_length,
                                     static_cast<const Bytef*>(task.src), task.src_length);
 
         {

--- a/src/core/libraries/zlib/zlib.cpp
+++ b/src/core/libraries/zlib/zlib.cpp
@@ -57,7 +57,7 @@ void ZlibTaskThread(const std::stop_token& stop) {
 
         uLongf decompressed_length = task.dst_length;
         const auto ret = mz_uncompress(static_cast<Bytef*>(task.dst), &decompressed_length,
-                                    static_cast<const Bytef*>(task.src), task.src_length);
+                                       static_cast<const Bytef*>(task.src), task.src_length);
 
         {
             // Lock, insert the new result, and push the finished request ID to the done queue.


### PR DESCRIPTION
This might fix the random, Windows-specific crashes on boot in Rise of the Tomb Raider v1.00.
I'm not entirely confident, so I'm marking this as a draft until multiple testers verify.

Fix was suggested by @liuk7071, I did my own testing and it seems to address the issue, but since this is a random issue, I can't be certain.