### PR TITLE
Do not log out user on pad disconnect

### DIFF
--- a/src/core/libraries/pad/pad.cpp
+++ b/src/core/libraries/pad/pad.cpp
@@ -735,7 +735,6 @@ int PS4_SYSV_ABI scePadSetVibration(s32 handle, const OrbisPadVibrationParam* pP
     if (pParam != nullptr) {
         LOG_DEBUG(Lib_Pad, "scePadSetVibration called handle = {} data = {} , {}", handle,
                   pParam->smallMotor, pParam->largeMotor);
-        auto& controllers = *Common::Singleton<GameControllers>::Instance();
         controller.SetVibration(pParam->smallMotor, pParam->largeMotor);
         return ORBIS_OK;
     }

--- a/src/input/controller.cpp
+++ b/src/input/controller.cpp
@@ -260,10 +260,11 @@ void GameControllers::TryOpenSDLControllers() {
             }
             if (!still_connected) {
                 auto u = UserManagement.GetUserByID(controllers[i]->user_id);
-                UserManagement.LogoutUser(u);
                 SDL_CloseGamepad(pad);
                 controllers[i]->m_sdl_gamepad = nullptr;
                 controllers[i]->user_id = -1;
+                controllers[i]->m_connected = false;
+                controllers[i]->m_connected_count = 0;
                 slot_taken[i] = false;
             }
         }
@@ -294,6 +295,8 @@ void GameControllers::TryOpenSDLControllers() {
                 c->user_id = u->user_id;
                 slot_taken[i] = true;
                 UserManagement.LoginUser(u, i + 1);
+                c->m_connected = true;
+                c->m_connected_count = 1;
                 if (EmulatorSettings.IsMotionControlsEnabled()) {
                     if (SDL_SetGamepadSensorEnabled(c->m_sdl_gamepad, SDL_SENSOR_GYRO, true)) {
                         c->gyro_poll_rate =

--- a/src/input/controller.cpp
+++ b/src/input/controller.cpp
@@ -232,6 +232,17 @@ void GameControllers::CalculateOrientation(Libraries::Pad::OrbisFVector3& accele
               orientation.y, orientation.z, orientation.w);
 }
 
+void GameController::ConnectController(SDL_Gamepad* pad) {
+    m_sdl_gamepad = pad;
+    m_connected_count = 1;
+    m_connected = true;
+}
+void GameController::DisconnectController() {
+    m_sdl_gamepad = nullptr;
+    m_connected_count = 0;
+    m_connected = false;
+}
+
 bool is_first_check = true;
 
 void GameControllers::TryOpenSDLControllers() {
@@ -261,10 +272,8 @@ void GameControllers::TryOpenSDLControllers() {
             if (!still_connected) {
                 auto u = UserManagement.GetUserByID(controllers[i]->user_id);
                 SDL_CloseGamepad(pad);
-                controllers[i]->m_sdl_gamepad = nullptr;
+                controllers[i]->DisconnectController();
                 controllers[i]->user_id = -1;
-                controllers[i]->m_connected = false;
-                controllers[i]->m_connected_count = 0;
                 slot_taken[i] = false;
             }
         }
@@ -289,14 +298,12 @@ void GameControllers::TryOpenSDLControllers() {
                               // Player N won't be registered at all
                 }
                 auto* c = controllers[i];
-                c->m_sdl_gamepad = pad;
                 LOG_INFO(Input, "Gamepad registered for slot {}! Handle: {}", i,
                          SDL_GetGamepadID(pad));
-                c->user_id = u->user_id;
                 slot_taken[i] = true;
+                c->user_id = u->user_id;
                 UserManagement.LoginUser(u, i + 1);
-                c->m_connected = true;
-                c->m_connected_count = 1;
+                c->ConnectController(pad);
                 if (EmulatorSettings.IsMotionControlsEnabled()) {
                     if (SDL_SetGamepadSensorEnabled(c->m_sdl_gamepad, SDL_SENSOR_GYRO, true)) {
                         c->gyro_poll_rate =
@@ -324,6 +331,7 @@ void GameControllers::TryOpenSDLControllers() {
         if (controller_count - move_count == 0) {
             auto u = UserManagement.GetUserByPlayerIndex(1);
             controllers[0]->user_id = u->user_id;
+            controllers[0]->ConnectController(nullptr);
             UserManagement.LoginUser(u, 1);
         }
     }

--- a/src/input/controller.h
+++ b/src/input/controller.h
@@ -114,6 +114,8 @@ class GameController {
 public:
     GameController();
     virtual ~GameController() = default;
+    void ConnectController(SDL_Gamepad* pad);
+    void DisconnectController();
 
     void ReadState(State* state, bool* isConnected, int* connectedCount);
     int ReadStates(State* states, int states_num, bool* isConnected, int* connectedCount);
@@ -155,8 +157,8 @@ public:
 private:
     void PushState();
 
-    bool m_connected = true;
-    int m_connected_count = 1;
+    bool m_connected = false;
+    int m_connected_count = 0;
     u8 m_touch_count = 0;
     u8 m_secondary_touch_count = 0;
     u8 m_previous_touchnum = 0;
@@ -178,10 +180,7 @@ class GameControllers {
 public:
     GameControllers()
         : controllers({new GameController(), new GameController(), new GameController(),
-                       new GameController(), new GameController()}) {
-        controllers[4]->m_connected = false;
-        controllers[4]->m_connected_count = 0;
-    };
+                       new GameController(), new GameController()}) {};
     virtual ~GameControllers() = default;
     GameController* operator[](const size_t& i) const {
         if (i > 4) {

--- a/src/sdl_window.cpp
+++ b/src/sdl_window.cpp
@@ -269,6 +269,7 @@ void WindowSDL::WaitEvent() {
                     break;
                 }
                 controllers[i]->user_id = u->user_id;
+                controllers[i]->ConnectController(controllers[i]->m_sdl_gamepad);
                 UserManagement.LoginUser(u, i + 1);
                 break;
             }
@@ -279,6 +280,7 @@ void WindowSDL::WaitEvent() {
         for (int i = 3; i >= 0; i--) {
             if (controllers[i]->user_id != -1) {
                 UserManagement.LogoutUser(UserManagement.GetUserByID(controllers[i]->user_id));
+                controllers[i]->DisconnectController();
                 controllers[i]->user_id = -1;
                 break;
             }


### PR DESCRIPTION
Fixes a hang in one of the UFC games as reported by @Missake212. Since this only concerns disconnecting a gamepad at runtime, it shouldn't cause any major regressions, but still, some testing would be appreciated nonetheless.