### PR TITLE
Fix stale guest memory when reusing GPU-written linear images through overlapping aliases

### DIFF
--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -86,17 +86,25 @@ ImageId TextureCache::GetNullImage(const vk::Format format) {
 }
 
 void TextureCache::ProcessDownloadImages() {
+    std::scoped_lock lock{mutex};
+    boost::container::small_vector<PendingImageDownload, 8> downloads;
+    downloads.reserve(download_images.size());
     for (const ImageId image_id : download_images) {
-        DownloadImageMemory(image_id, true);
+        if (auto download = ScheduleImageDownload(image_id)) {
+            downloads.push_back(*download);
+        }
     }
     download_images.clear();
+    CompleteImageDownloads(downloads);
 }
 
-void TextureCache::DownloadImageMemory(ImageId image_id, bool sync) {
+std::optional<TextureCache::PendingImageDownload> TextureCache::ScheduleImageDownload(
+    ImageId image_id) {
     Image& image = slot_images[image_id];
-    if (False(image.flags & ImageFlagBits::GpuModified)) {
-        return;
+    if (!image.SafeToDownload() || image.info.props.is_tiled || image.info.guest_address == 0) {
+        return {};
     }
+
     auto& download_buffer = buffer_cache.GetUtilityBuffer(MemoryUsage::Download);
     const u32 download_size = image.info.pitch * image.info.size.height * image.info.size.depth *
                               image.info.resources.layers * (image.info.num_bits / 8);
@@ -118,23 +126,73 @@ void TextureCache::DownloadImageMemory(ImageId image_id, bool sync) {
         .imageOffset = {0, 0, 0},
         .imageExtent = {image.info.size.width, image.info.size.height, image.info.size.depth},
     };
-    scheduler.EndRendering();
-    const auto cmdbuf = scheduler.CommandBuffer();
-    image.Transit(vk::ImageLayout::eTransferSrcOptimal, vk::AccessFlagBits2::eTransferRead, {});
-    cmdbuf.copyImageToBuffer(image.GetImage(), vk::ImageLayout::eTransferSrcOptimal,
-                             download_buffer.Handle(), image_download);
+    image.Download(std::span{&image_download, 1}, download_buffer.Handle(), offset, download_size);
 
-    if (sync) {
-        scheduler.Finish();
-        Core::Memory::Instance()->TryWriteBacking(std::bit_cast<u8*>(image.info.guest_address),
-                                                  download, download_size);
-    } else {
-        scheduler.DeferPriorityOperation(
-            [this, device_addr = image.info.guest_address, download, download_size] {
-                Core::Memory::Instance()->TryWriteBacking(std::bit_cast<u8*>(device_addr), download,
-                                                          download_size);
-            });
+    const u64 serial = ++image_download_serial;
+    latest_image_downloads[image.info.guest_address] = serial;
+    return PendingImageDownload{
+        .serial = serial,
+        .guest_address = image.info.guest_address,
+        .data = download,
+        .size = download_size,
+    };
+}
+
+void TextureCache::WritebackImageMemory(const PendingImageDownload& download) {
+    const auto it = latest_image_downloads.find(download.guest_address);
+    if (it == latest_image_downloads.end() || it->second != download.serial) {
+        return;
     }
+    if (!Core::Memory::Instance()->TryWriteBacking(std::bit_cast<u8*>(download.guest_address),
+                                                   download.data, download.size)) {
+        return;
+    }
+    latest_image_downloads.erase(it);
+}
+
+void TextureCache::CompleteImageDownloads(std::span<const PendingImageDownload> downloads) {
+    if (downloads.empty()) {
+        return;
+    }
+    scheduler.Finish();
+    for (const auto& download : downloads) {
+        WritebackImageMemory(download);
+    }
+}
+
+void TextureCache::DownloadImageMemory(ImageId image_id, bool sync) {
+    const auto download = ScheduleImageDownload(image_id);
+    if (!download) {
+        return;
+    }
+    if (sync) {
+        CompleteImageDownloads(std::span{&*download, size_t{1}});
+        return;
+    }
+    scheduler.DeferPriorityOperation([this, download = *download] {
+        std::scoped_lock lock{mutex};
+        WritebackImageMemory(download);
+    });
+}
+
+void TextureCache::SynchronizeGuestMemory(VAddr address, size_t size, const Image* excluded_image) {
+    if (!readback_linear_images) {
+        return;
+    }
+
+    boost::container::small_vector<PendingImageDownload, 8> downloads;
+    ForEachImageInRegion(address, size, [&](ImageId image_id, Image& image) {
+        if (&image == excluded_image) {
+            return;
+        }
+        if (auto download = ScheduleImageDownload(image_id)) {
+            downloads.push_back(*download);
+            download_images.erase(image_id);
+        }
+    });
+    // The requested alias may be uploaded from guest memory immediately after this call. Wait for
+    // overlapping linear images to reach the download buffer before exposing their contents.
+    CompleteImageDownloads(downloads);
 }
 
 void TextureCache::MarkAsMaybeDirty(ImageId image_id, Image& image) {
@@ -563,6 +621,13 @@ ImageId TextureCache::FindImage(ImageDesc& desc, bool exact_fmt) {
         image_id = cache_id;
     }
 
+    // A different representation may be uploaded from guest memory while an overlapping linear
+    // image still contains newer GPU-written data. Resolve pending writes before touching the
+    // overlap set.
+    if (!image_id) {
+        SynchronizeGuestMemory(info.guest_address, info.guest_size);
+    }
+
     // Try to resolve overlaps (if any)
     int view_mip{-1};
     int view_slice{-1};
@@ -726,6 +791,10 @@ void TextureCache::RefreshImage(Image& image) {
     if (False(image.flags & ImageFlagBits::Dirty) || image.info.num_samples > 1) {
         return;
     }
+
+    // RefreshImage reuploads from guest memory. Make overlapping GPU-written linear aliases
+    // visible before obtaining the upload source.
+    SynchronizeGuestMemory(image.info.guest_address, image.info.guest_size, &image);
 
     RENDERER_TRACE;
     TRACE_HINT(fmt::format("{:x}:{:x}", image.info.guest_address, image.info.guest_size));

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -5,6 +5,8 @@
 
 #include <condition_variable>
 #include <mutex>
+#include <optional>
+#include <span>
 #include <thread>
 #include <unordered_set>
 #include <boost/container/small_vector.hpp>
@@ -271,8 +273,27 @@ private:
     /// Gets or creates a null image for a particular format.
     ImageId GetNullImage(vk::Format format);
 
-    /// Copies image memory back to CPU.
+    struct PendingImageDownload {
+        u64 serial;
+        VAddr guest_address;
+        u8* data;
+        u32 size;
+    };
+
+    /// Schedules a copy of linear image memory into the download buffer.
+    [[nodiscard]] std::optional<PendingImageDownload> ScheduleImageDownload(ImageId image_id);
+
+    /// Copies a completed image download into guest memory unless a newer download superseded it.
+    void WritebackImageMemory(const PendingImageDownload& download);
+
+    /// Waits once for a batch of scheduled downloads and copies their newest results to the guest.
+    void CompleteImageDownloads(std::span<const PendingImageDownload> downloads);
+
+    /// Copies image memory back to CPU; synchronously when sync is set, deferred otherwise.
     void DownloadImageMemory(ImageId image_id, bool sync = false);
+
+    /// Makes GPU-written linear aliases visible before reuploading overlapping guest memory.
+    void SynchronizeGuestMemory(VAddr address, size_t size, const Image* excluded_image = nullptr);
 
     /// Thread function for copying downloaded images out to CPU memory.
     void DownloadedImagesThread(const std::stop_token& token);
@@ -323,6 +344,8 @@ private:
     tsl::robin_map<u64, Sampler> samplers;
     tsl::robin_map<vk::Format, ImageId> null_images;
     std::unordered_set<ImageId> download_images;
+    tsl::robin_map<VAddr, u64> latest_image_downloads;
+    u64 image_download_serial{};
     u64 total_used_memory = 0;
     u64 trigger_gc_memory = 0;
     u64 pressure_gc_memory = 0;


### PR DESCRIPTION
### Problem

Some games (namely GOW3) reuse the same guest memory range through different image representations. A linear image may be written by the GPU and later reinterpreted as a tiled or compressed texture.

With **Enable Readback Linear Images** enabled, shadPS4 already scheduled GPU-to-CPU readbacks for linear images. However, those readbacks were asynchronous. This left a timing window where an overlapping image could be recreated from guest memory before the pending linear-image writeback had completed.

In that case, the new texture was uploaded from stale guest-memory data even though the most recent contents already existed on the GPU. This could result in progressive texture corruption when the aliased representation was used later.

### Fix

Keep the existing linear-image readback path asynchronous in the common case, but synchronize it on demand when an overlapping alias actually depends on the updated guest-memory contents.

The updated flow is:

GPU writes a linear image
- schedule the existing asynchronous readback

Later, an overlapping image needs to be reconstructed from guest memory
- detect pending linear-image readbacks for the overlapping range
- wait once for the relevant batch
- commit the completed data to guest memory
- reconstruct the alias from coherent data

This preserves the existing readback infrastructure and only adds the missing dependency point before alias reconstruction. The existing path performs preventive asynchronous readbacks. This change adds the required demand-driven synchronization when another image representation needs those bytes immediately. This avoids the broader synchronization cost of forcing every linear-image readback to complete immediately while still guaranteeing correctness for dependent alias reuse.

Before:
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/a562f33f-16bf-4a02-8fbf-58470c41f98b" />

After:
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/f9c1c265-253a-4411-a6fd-5be7a02ec679" />