### PR TITLE
Windows pass MS_VC_EXCEPTION to handler

### DIFF
--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -11,6 +11,7 @@
 
 #ifdef _WIN32
 #include <windows.h>
+static constexpr DWORD MS_VC_EXCEPTION = 0x406D1388;
 #else
 #include <csignal>
 #include <pthread.h>

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -53,6 +53,9 @@ static LONG WINAPI SignalHandler(EXCEPTION_POINTERS* pExp) noexcept {
     case DBG_PRINTEXCEPTION_WIDE_C:
         // Used by OutputDebugString functions.
         return EXCEPTION_CONTINUE_EXECUTION;
+    case MS_VC_EXCEPTION:
+        LOG_DEBUG(Debug, "Pass MS_VC_EXCEPTION at {} to handler", address);
+        return EXCEPTION_EXECUTE_HANDLER;
     default:
         break;
     }


### PR DESCRIPTION
I noticed in https://github.com/shadps4-emu/shadPS4/issues/4525#issuecomment-4646462574 that OpenAL was throwing MS_VC_EXCEPTION
https://github.com/shadexternals/openal-soft/blob/83ea7236c6f23fc98e2b62eb9c5b3abfd4b2be86/common/althrd_setname.cpp#L31
This will remove the 2 false-alarm Critical log lines.