### PR TITLE
UPNP Support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -148,3 +148,6 @@
 [submodule "externals/libressl"]
 	path = externals/libressl
 	url = https://github.com/shadexternals/libressl
+[submodule "externals/miniupnp"]
+	path = externals/miniupnp
+	url = https://github.com/miniupnp/miniupnp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,6 +384,8 @@ set(NETWORK_LIBS src/core/libraries/network/http.cpp
                  src/core/libraries/network/net_epoll.h
                  src/core/libraries/network/net_resolver.cpp
                  src/core/libraries/network/net_resolver.h
+                 src/core/libraries/network/net_upnp.cpp
+                 src/core/libraries/network/net_upnp.h
                  src/core/libraries/network/net_error.h
                  src/core/libraries/network/net.h
                  src/core/libraries/network/ssl.cpp
@@ -1186,7 +1188,7 @@ create_target_directory_groups(shadps4)
 target_link_libraries(shadps4 PRIVATE spdlog::spdlog)
 target_link_libraries(shadps4 PRIVATE magic_enum::magic_enum fmt::fmt toml11::toml11 tsl::robin_map xbyak::xbyak Tracy::TracyClient RenderDoc::API FFmpeg::ffmpeg Dear_ImGui ImGuiFileDialog gcn half::half ZLIB::ZLIB PNG::PNG minimp3)
 target_link_libraries(shadps4 PRIVATE Boost::headers GPUOpen::VulkanMemoryAllocator LibAtrac9 sirit Vulkan::Headers xxHash::xxhash Zydis::Zydis glslang::glslang SDL3::SDL3 pugixml::pugixml)
-target_link_libraries(shadps4 PRIVATE stb::headers lfreist-hwinfo::hwinfo nlohmann_json::nlohmann_json miniz::miniz fdk-aac CLI11::CLI11 OpenAL::OpenAL Cpp_Httplib)
+target_link_libraries(shadps4 PRIVATE stb::headers lfreist-hwinfo::hwinfo nlohmann_json::nlohmann_json miniz::miniz fdk-aac CLI11::CLI11 OpenAL::OpenAL Cpp_Httplib libminiupnpc-static)
 target_link_libraries(shadps4 PRIVATE Freetype::Freetype)
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -296,6 +296,14 @@ if (NOT TARGET CLI11::CLI11)
     add_subdirectory(CLI11)
 endif()
 
+# miniupnpc
+set(UPNPC_BUILD_STATIC ON CACHE BOOL "" FORCE)
+set(UPNPC_BUILD_SHARED OFF CACHE BOOL "" FORCE)
+set(UPNPC_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(UPNPC_BUILD_SAMPLE OFF CACHE BOOL "" FORCE)
+set(UPNPC_NO_INSTALL ON CACHE BOOL "" FORCE)
+add_subdirectory(miniupnp/miniupnpc)
+
 # minimp3
 add_library(minimp3 INTERFACE)
 target_include_directories(minimp3 INTERFACE minimp3)

--- a/src/core/emulator_settings.h
+++ b/src/core/emulator_settings.h
@@ -112,7 +112,7 @@ struct OverrideItem {
 };
 
 template <typename Struct, typename T>
-inline OverrideItem make_override(const char* key, Setting<T> Struct::* member) {
+inline OverrideItem make_override(const char* key, Setting<T> Struct::*member) {
     return OverrideItem{
         key,
         [member, key](void* base, const nlohmann::json& entry, std::vector<std::string>& changed) {
@@ -184,6 +184,9 @@ struct GeneralSettings {
     Setting<int> console_language{1};
     Setting<int> big_picture_scale{1000};
     Setting<std::string> shadnet_server{""};
+    Setting<std::string> signaling_addr{""};
+    Setting<u16> signaling_port{};
+    Setting<bool> enable_upnp{true};
 
     // return a vector of override descriptors (runtime, but tiny)
     std::vector<OverrideItem> GetOverrideableFields() const {
@@ -202,7 +205,9 @@ struct GeneralSettings {
             make_override<GeneralSettings>("trophy_notification_side",
                                            &GeneralSettings::trophy_notification_side),
             make_override<GeneralSettings>("connected_to_network",
-                                           &GeneralSettings::connected_to_network)};
+                                           &GeneralSettings::connected_to_network),
+            make_override<GeneralSettings>("signaling_addr", &GeneralSettings::signaling_addr),
+            make_override<GeneralSettings>("signaling_port", &GeneralSettings::signaling_port)};
     }
 };
 
@@ -212,7 +217,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(GeneralSettings, install_dirs, addon_install_
                                    trophy_notification_duration, show_splash,
                                    trophy_notification_side, connected_to_network,
                                    discord_rpc_enabled, show_fps_counter, console_language,
-                                   big_picture_scale, shadnet_server)
+                                   big_picture_scale, shadnet_server, signaling_addr,
+                                   signaling_port, enable_upnp)
 
 // -------------------------------
 // Log settings
@@ -596,6 +602,9 @@ public:
     SETTING_FORWARD(m_general, ConsoleLanguage, console_language)
     SETTING_FORWARD(m_general, BigPictureScale, big_picture_scale)
     SETTING_FORWARD(m_general, ShadNetServer, shadnet_server)
+    SETTING_FORWARD(m_general, SignalingAddr, signaling_addr)
+    SETTING_FORWARD(m_general, SignalingPort, signaling_port)
+    SETTING_FORWARD_BOOL(m_general, UPnPEnabled, enable_upnp)
 
     // Log settings
     SETTING_FORWARD_BOOL(m_log, LogAppend, append)

--- a/src/core/emulator_settings.h
+++ b/src/core/emulator_settings.h
@@ -112,7 +112,7 @@ struct OverrideItem {
 };
 
 template <typename Struct, typename T>
-inline OverrideItem make_override(const char* key, Setting<T> Struct::*member) {
+inline OverrideItem make_override(const char* key, Setting<T> Struct::* member) {
     return OverrideItem{
         key,
         [member, key](void* base, const nlohmann::json& entry, std::vector<std::string>& changed) {

--- a/src/core/emulator_settings.h
+++ b/src/core/emulator_settings.h
@@ -207,7 +207,8 @@ struct GeneralSettings {
             make_override<GeneralSettings>("connected_to_network",
                                            &GeneralSettings::connected_to_network),
             make_override<GeneralSettings>("signaling_addr", &GeneralSettings::signaling_addr),
-            make_override<GeneralSettings>("signaling_port", &GeneralSettings::signaling_port)};
+            make_override<GeneralSettings>("signaling_port", &GeneralSettings::signaling_port),
+            make_override<GeneralSettings>("enable_upnp", &GeneralSettings::enable_upnp)};
     }
 };
 

--- a/src/core/libraries/network/net_upnp.cpp
+++ b/src/core/libraries/network/net_upnp.cpp
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <chrono>
+#include <cstring>
+#include <upnperrors.h>
+#include "common/logging/log.h"
+#include "net_upnp.h"
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#endif
+
+namespace Libraries::Net {
+
+UPnPClient& UPnPClient::Instance() {
+    static UPnPClient instance;
+    return instance;
+}
+
+UPnPClient::~UPnPClient() {
+    if (m_thread.joinable())
+        m_thread.join();
+    if (m_available.load())
+        FreeUPNPUrls(&m_urls);
+}
+
+void UPnPClient::Start() {
+    bool expected = false;
+    if (!m_started.compare_exchange_strong(expected, true))
+        return;
+    LOG_INFO(Lib_Net, "UPNP: starting discovery thread");
+    m_thread = std::thread(&UPnPClient::DiscoverThread, this);
+}
+
+bool UPnPClient::WaitReady(int timeout_ms) {
+    std::unique_lock lock(m_mutex);
+    m_cv.wait_for(lock, std::chrono::milliseconds(timeout_ms), [this] { return m_done.load(); });
+    return m_available.load();
+}
+
+bool UPnPClient::IsAvailable() const {
+    return m_available.load();
+}
+
+u32 UPnPClient::GetExternalIp() const {
+    return m_external_ip_nbo.load();
+}
+
+std::string UPnPClient::GetExternalIpString() const {
+    return m_available.load() ? std::string(m_external_ip_str) : std::string{};
+}
+
+u16 UPnPClient::GetExternalPort() const {
+    return m_external_port.load();
+}
+
+void UPnPClient::DiscoverThread() {
+    int error = 0;
+    UPNPDev* devlist = upnpDiscover(2000, nullptr, nullptr, UPNP_LOCAL_PORT_ANY, 0, 2, &error);
+
+    if (!devlist) {
+        LOG_INFO(Lib_Net, "UPNP: no IGD found (error={})", error);
+        m_done = true;
+        m_cv.notify_all();
+        return;
+    }
+
+    char wan_addr[40]{};
+    const int ret = UPNP_GetValidIGD(devlist, &m_urls, &m_data, m_lan_addr, sizeof(m_lan_addr),
+                                     wan_addr, sizeof(wan_addr));
+    freeUPNPDevlist(devlist);
+
+    if (ret != 1) {
+        LOG_INFO(Lib_Net, "UPNP: no valid IGD (ret={})", ret);
+        m_done = true;
+        m_cv.notify_all();
+        return;
+    }
+
+    char external_ip[40]{};
+    if (UPNP_GetExternalIPAddress(m_urls.controlURL, m_data.first.servicetype, external_ip) !=
+        UPNPCOMMAND_SUCCESS) {
+        LOG_WARNING(Lib_Net, "UPNP: IGD found but failed to get external IP");
+        FreeUPNPUrls(&m_urls);
+        m_done = true;
+        m_cv.notify_all();
+        return;
+    }
+
+    u32 ip_nbo = 0;
+    inet_pton(AF_INET, external_ip, &ip_nbo);
+    m_external_ip_nbo.store(ip_nbo);
+    std::strncpy(m_external_ip_str, external_ip, sizeof(m_external_ip_str) - 1);
+    m_available = true;
+
+    LOG_INFO(Lib_Net, "UPNP: IGD found - external IP={} lan={} (port mapping available)",
+             external_ip, m_lan_addr);
+
+    m_done = true;
+    m_cv.notify_all();
+}
+
+void UPnPClient::AddMapping(u16 port) {
+    if (!m_available.load())
+        return;
+
+    const std::string port_str = std::to_string(port);
+    const int ret =
+        UPNP_AddPortMapping(m_urls.controlURL, m_data.first.servicetype, port_str.c_str(),
+                            port_str.c_str(), m_lan_addr, "shadPS4", "UDP", nullptr, "0");
+
+    if (ret == UPNPCOMMAND_SUCCESS) {
+        m_external_port.store(port);
+        LOG_INFO(Lib_Net, "UPNP: mapped UDP port {}", port);
+    } else {
+        // Store the requested port as best-guess even on failure so callers still get a value.
+        m_external_port.store(port);
+        LOG_WARNING(Lib_Net, "UPNP: failed to map port {} ({})", port, strupnperror(ret));
+    }
+}
+
+void UPnPClient::RemoveMapping(u16 port) {
+    if (!m_available.load())
+        return;
+
+    const std::string port_str = std::to_string(port);
+    UPNP_DeletePortMapping(m_urls.controlURL, m_data.first.servicetype, port_str.c_str(), "UDP",
+                           nullptr);
+
+    LOG_INFO(Lib_Net, "UPNP: removed UDP port mapping {}", port);
+}
+
+} // namespace Libraries::Net

--- a/src/core/libraries/network/net_upnp.h
+++ b/src/core/libraries/network/net_upnp.h
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <string>
+#include <thread>
+#include "common/types.h"
+
+#include <miniupnpc.h>
+#include <upnpcommands.h>
+
+namespace Libraries::Net {
+
+class UPnPClient {
+public:
+    static UPnPClient& Instance();
+
+    // Kick off async IGD discovery. Safe to call multiple times — only the first call has effect.
+    void Start();
+
+    // Block until discovery completes or timeout_ms elapses. Returns true if IGD was found.
+    bool WaitReady(int timeout_ms);
+
+    bool IsAvailable() const;
+
+    // External IP in network byte order as reported by the IGD. 0 if not yet known.
+    u32 GetExternalIp() const;
+
+    // External IP as a dotted-decimal string. Empty if not yet known.
+    std::string GetExternalIpString() const;
+
+    // External port the IGD mapped for us. Matches the internal port unless the router remapped it.
+    u16 GetExternalPort() const;
+
+    void AddMapping(u16 port);
+    void RemoveMapping(u16 port);
+
+private:
+    UPnPClient() = default;
+    ~UPnPClient();
+    UPnPClient(const UPnPClient&) = delete;
+    UPnPClient& operator=(const UPnPClient&) = delete;
+
+    void DiscoverThread();
+
+    std::atomic<bool> m_started{false};
+    std::atomic<bool> m_done{false};
+    std::atomic<bool> m_available{false};
+    std::atomic<u32> m_external_ip_nbo{0};
+    std::atomic<u16> m_external_port{0};
+    char m_external_ip_str[16]{};
+
+    char m_lan_addr[64]{};
+    UPNPUrls m_urls{};
+    IGDdatas m_data{};
+
+    std::mutex m_mutex;
+    std::condition_variable m_cv;
+    std::thread m_thread;
+};
+
+} // namespace Libraries::Net


### PR DESCRIPTION
Adds UPNP (currently not wired to anything) for NAT support utilizing the miniupnpc library.

Adds Settings:
enable_upnp
signaling_addr
signaling_port

If upnp is disabled, signaling will fall back to defined signaling_addr and signaling_port for signaling / matching2 activities, for those that have port forwarding and not upnp.