### PR TITLE
Recompiler: Log missing fields for Translator::SetDst

### DIFF
--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -935,7 +935,7 @@ void Translator::SetDst(const InstOperand& operand, const IR::U32F32& value) {
     case OperandField::M0:
         return ir.SetM0(result);
     default:
-        UNREACHABLE();
+        UNREACHABLE_MSG("Unknown field {}", u32(operand.field));
     }
 }
 


### PR DESCRIPTION
This unreachable is hit by Like a Dragon: Pirate Yakuza in Hawaii, best to log more detail so we can actually fix the issue without having it.