### PR TITLE
documents: Minor updates to macOS build instructions

### DIFF
--- a/documents/building-macos.md
+++ b/documents/building-macos.md
@@ -11,16 +11,17 @@ First, make sure you have **Xcode 16.0 or newer** installed.
 
 For installing other tools and library dependencies we will be using [Homebrew](https://brew.sh/).
 
-On an ARM system, we will need the native ARM Homebrew to install tools and x86_64 Homebrew to install libraries.
-
-First, install native Homebrew and tools:
+First, install Homebrew:
 ```
-# Installs native Homebrew to /opt/homebrew
+# Installs Homebrew to /opt/homebrew
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 # Adds Homebrew to your path
 echo 'eval $(/opt/homebrew/bin/brew shellenv)' >> ~/.zprofile
 eval $(/opt/homebrew/bin/brew shellenv)
-# Installs tools.
+```
+
+Then, use Homebrew to install the required build tools:
+```
 brew install clang-format cmake
 ```
 
@@ -42,13 +43,12 @@ Enter the directory:
 cd build/
 ```
 
-Use make to build the project:
+Use cmake to build the project:
 ```
 cmake --build . --parallel$(sysctl -n hw.ncpu)
 ```
 
 Now run the emulator:
-
 ```
 ./shadps4 /"PATH"/"TO"/"GAME"/"FOLDER"/eboot.bin
 ```


### PR DESCRIPTION
Mainly removing some old wording about ARM vs x86_64 brew, as we don't install any x86_64 libraries from brew anymore.