### PR TITLE
Do not auto-stub unresolved objects

### DIFF
--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -382,6 +382,11 @@ bool Linker::Resolve(const std::string& name, Loader::SymbolType sym_type, Modul
         LOG_WARNING(Core_Linker, "Linker: Stub resolved {} as {} (lib: {}, mod: {})", sr.name,
                     return_info->name, library->name, module->name);
     }
+    if (!record && sym_type == Loader::SymbolType::Object) {
+        LOG_WARNING(Core_Linker, "Patching object stub with unresolve indicator");
+        return_info->virtual_address = 0x7c00000000ull;
+        return false;
+    }
     return false;
 }
 

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -371,7 +371,10 @@ bool Linker::Resolve(const std::string& name, Loader::SymbolType sym_type, Modul
     }
 
     const auto aeronid = AeroLib::FindByNid(sr.name.c_str());
-    if (aeronid) {
+    if (sym_type == Loader::SymbolType::Object) {
+        return_info->name = aeronid ? aeronid->name : "Unknown object";
+        return_info->virtual_address = 0;
+    } else if (aeronid) {
         return_info->name = aeronid->name;
         return_info->virtual_address = AeroLib::GetStub(aeronid->nid);
     } else {
@@ -381,11 +384,6 @@ bool Linker::Resolve(const std::string& name, Loader::SymbolType sym_type, Modul
     if (library->name != "libc" && library->name != "libSceFios2") {
         LOG_WARNING(Core_Linker, "Linker: Stub resolved {} as {} (lib: {}, mod: {})", sr.name,
                     return_info->name, library->name, module->name);
-    }
-    if (!record && sym_type == Loader::SymbolType::Object) {
-        LOG_WARNING(Core_Linker, "Patching object stub with unresolve indicator");
-        return_info->virtual_address = 0x7c00000000ull;
-        return false;
     }
     return false;
 }


### PR DESCRIPTION
With this fix, @StevenMiller123's lle_malloc_stuff branch, and adding libSceFreeTypeOl.sprx to the list of LLE modules, my OpenOrbis homebrew apps finally load libSceFreeType correctly (which previously saw the automatically stubbed objects have a valid address, and tried to use them), and display text.