### PR TITLE
video_core: Close shader cache if ignored

### DIFF
--- a/src/video_core/cache_storage.cpp
+++ b/src/video_core/cache_storage.cpp
@@ -133,6 +133,7 @@ void DataBase::Close() {
         mz_zip_writer_end(&zip_ar);
     }
 
+    opened = false;
     LOG_INFO(Render, "Cache dumped");
 }
 

--- a/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
@@ -316,6 +316,7 @@ void PipelineCache::WarmUp() {
     if (std::memcmp(profile_data.data(), &profile, sizeof(profile)) != 0) {
         LOG_WARNING(Render,
                     "Pipeline cache isn't compatible with current system. Ignoring the cache");
+        Storage::DataBase::Instance().Close();
         return;
     }
 


### PR DESCRIPTION
Call `Close` on shader cache if it is ignored due to incompatibility. Otherwise it is left open and in the read-only preload state, and any later write attempt will crash asserting that it is no longer read-only.