### PR TITLE
Kernel.Vmm: Properly handle search_end restrictions in sceKernelAllocateDirectMemory

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -256,7 +256,7 @@ PAddr MemoryManager::Allocate(PAddr search_start, PAddr search_end, u64 size, u6
         mapping_end = mapping_start + size;
     }
 
-    if (dmem_area == dmem_map.end()) {
+    if (dmem_area == dmem_map.end() || mapping_end > search_end) {
         // There are no suitable mappings in this range
         LOG_ERROR(Kernel_Vmm, "Unable to find free direct memory area: size = {:#x}", size);
         return -1;


### PR DESCRIPTION
We weren't properly ensuring allocated areas fell within the requested range. In Skyrim, this caused a bug where the game would succeed an allocation that should fail, then fail a direct memory mapping because the game attempts to use a physical address that isn't mapped.

This brings Skyrim to menus, where it crashes on the PM4 races seen in most games. Might go further if I tested a release build instead.
<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/634aa69e-2bd6-4f55-badf-cc2141957986" />
