### PR TITLE
Lib.Mouse: Fix sceMouseOpen checks

### DIFF
--- a/src/core/libraries/mouse/mouse.cpp
+++ b/src/core/libraries/mouse/mouse.cpp
@@ -81,15 +81,15 @@ int PS4_SYSV_ABI sceMouseOpen(Libraries::UserService::OrbisUserServiceUserId use
                               s32 index, OrbisMouseOpenParam* pParam) {
     LOG_WARNING(Lib_Mouse, "(DUMMY) called, uid: {}, type: {}, index: {}", userId, type, index);
     auto u = UserManagement.GetUserByID(userId);
-    if (!u || !pParam || (u8)pParam->flag > 1 || index < 0 || index > 1) {
+    if (!u || type != 0 || index < 0 || index > 1) {
         LOG_ERROR(Lib_Mouse, "invalid argument");
         return ORBIS_MOUSE_ERROR_INVALID_ARG;
     }
-    if (pParam->flag == MouseOpenBehaviour::Merged && index != 0) {
+    if (pParam && True(pParam->flag & MouseOpenBehaviour::Merged) && index != 0) {
         LOG_ERROR(Lib_Mouse, "Only one mouse can be opened in merged mode!");
         return ORBIS_MOUSE_ERROR_ALREADY_OPENED;
     }
-    g_is_merged_mode = pParam->flag == MouseOpenBehaviour::Merged;
+    g_is_merged_mode = pParam && True(pParam->flag & MouseOpenBehaviour::Merged);
     if (mouse_handles[index] != -1) {
         LOG_ERROR(Lib_Mouse, "already opened");
         return ORBIS_MOUSE_ERROR_ALREADY_OPENED;

--- a/src/core/libraries/mouse/mouse.cpp
+++ b/src/core/libraries/mouse/mouse.cpp
@@ -85,7 +85,8 @@ int PS4_SYSV_ABI sceMouseOpen(Libraries::UserService::OrbisUserServiceUserId use
         LOG_ERROR(Lib_Mouse, "invalid argument");
         return ORBIS_MOUSE_ERROR_INVALID_ARG;
     }
-    bool merged_mode = pParam && True(pParam->flag & MouseOpenBehaviour::Merged);
+    MouseOpenBehaviour mouse_mode = pParam ? pParam->flag : MouseOpenBehaviour::Normal;
+    bool merged_mode = True(mouse_mode & MouseOpenBehaviour::Merged);
     if (merged_mode && index != 0) {
         LOG_ERROR(Lib_Mouse, "Only one mouse can be opened in merged mode!");
         return ORBIS_MOUSE_ERROR_ALREADY_OPENED;

--- a/src/core/libraries/mouse/mouse.cpp
+++ b/src/core/libraries/mouse/mouse.cpp
@@ -85,11 +85,12 @@ int PS4_SYSV_ABI sceMouseOpen(Libraries::UserService::OrbisUserServiceUserId use
         LOG_ERROR(Lib_Mouse, "invalid argument");
         return ORBIS_MOUSE_ERROR_INVALID_ARG;
     }
-    if (pParam && True(pParam->flag & MouseOpenBehaviour::Merged) && index != 0) {
+    bool merged_mode = pParam && True(pParam->flag & MouseOpenBehaviour::Merged);
+    if (merged_mode && index != 0) {
         LOG_ERROR(Lib_Mouse, "Only one mouse can be opened in merged mode!");
         return ORBIS_MOUSE_ERROR_ALREADY_OPENED;
     }
-    g_is_merged_mode = pParam && True(pParam->flag & MouseOpenBehaviour::Merged);
+    g_is_merged_mode = merged_mode;
     if (mouse_handles[index] != -1) {
         LOG_ERROR(Lib_Mouse, "already opened");
         return ORBIS_MOUSE_ERROR_ALREADY_OPENED;

--- a/src/core/libraries/mouse/mouse.h
+++ b/src/core/libraries/mouse/mouse.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "common/enum.h"
 #include "common/ring_buffer_queue.h"
 #include "core/libraries/system/userservice.h"
 
@@ -27,6 +28,7 @@ enum class MouseOpenBehaviour : u8 {
     Normal = 0,
     Merged = 1,
 };
+DECLARE_ENUM_FLAG_OPERATORS(MouseOpenBehaviour);
 
 struct OrbisMouseOpenParam {
     MouseOpenBehaviour flag;


### PR DESCRIPTION
Looking closer at decompilation, null parameters is allowed. If pParam is null, or if the game has SDK ver < FW 2.00, it will just follow the code path for non-merged mode. If param is non-null, SDK is greater than FW 2.00, and the first bit of the flag is true, then it follows the code for merged mode.

For simplicity, this PR ignores the FW 2.00 check. If it comes up in the future, we can handle it.