### PR TITLE
Add log text area to the Application Bug Report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/app-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/app-bug-report.yaml
@@ -74,3 +74,10 @@ body:
       placeholder: "Example: 16 GB"
     validations:
       required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: "Log File"
+      description: Drag and drop the log file here. It can be found by right clicking on a game name -> Open Folder... -> Open Log Folder. Make sure that the log `sync` option is ticked.
+    validations:
+      required: false


### PR DESCRIPTION
Add a log text area to the Application Bug Report template since a lot of people use it instead of using the Game Emulation Bug Report, requirement is set to false in case it's used properly.