### PR TITLE
Fix Vulkan validation errors in image descriptors and auxiliary tessellation interfaces

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_quad_rect.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_quad_rect.cpp
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <array>
+#include <vector>
+
 #include <sirit/sirit.h>
 #include "shader_recompiler/backend/spirv/emit_spirv_quad_rect.h"
 #include "shader_recompiler/runtime_info.h"
@@ -12,8 +15,16 @@ using Sirit::Id;
 constexpr u32 SPIRV_VERSION_1_5 = 0x00010500;
 
 struct QuadRectListEmitter : public Sirit::Module {
-    explicit QuadRectListEmitter(const FragmentRuntimeInfo& fs_info_)
-        : Sirit::Module{SPIRV_VERSION_1_5}, fs_info{fs_info_} {
+    struct AuxParam {
+        Id input{};
+        Id output{};
+        u32 location{};
+    };
+
+    explicit QuadRectListEmitter(const FragmentRuntimeInfo& fs_info_,
+                                 u64 previous_stage_output_mask_)
+        : Sirit::Module{SPIRV_VERSION_1_5}, fs_info{fs_info_},
+          previous_stage_output_mask{previous_stage_output_mask_} {
         void_id = TypeVoid();
         bool_id = TypeBool();
         float_id = TypeFloat(32);
@@ -24,9 +35,11 @@ struct QuadRectListEmitter : public Sirit::Module {
         vec3_id = TypeVector(float_id, 3);
         vec4_id = TypeVector(float_id, 4);
 
+        const Id float_zero{Constant(float_id, 0.0f)};
         float_one = Constant(float_id, 1.0f);
         float_min_one = Constant(float_id, -1.0f);
         int_zero = Constant(int_id, 0);
+        vec4_zero = ConstantComposite(vec4_id, float_zero, float_zero, float_zero, float_zero);
 
         const Id float_arr{TypeArray(float_id, Constant(uint_id, 1U))};
         gl_per_vertex_type = TypeStruct(vec4_id, float_id, float_arr, float_arr);
@@ -115,17 +128,18 @@ struct QuadRectListEmitter : public Sirit::Module {
         const Id position{OpSelect(vec4_id, invocation_3, pos3, OpLoad(vec4_id, in_ptr))};
         OpStore(OpAccessChain(output_vec4, gl_out, invocation_id, Int(0)), position);
 
-        // Set attributes
-        for (int i = 0; i < inputs.size(); i++) {
-            // vec4 in_paramN3 = interpolate(bary_coord, in_paramN[0], in_paramN[1], in_paramN[2]);
-            const Id v0{OpLoad(vec4_id, OpAccessChain(input_vec4, inputs[i], Int(0)))};
-            const Id v1{OpLoad(vec4_id, OpAccessChain(input_vec4, inputs[i], Int(1)))};
-            const Id v2{OpLoad(vec4_id, OpAccessChain(input_vec4, inputs[i], Int(2)))};
-            const Id in_param3{interpolate(v0, v1, v2)};
-            // out_paramN[gl_InvocationID] = gl_InvocationID == 3 ? in_paramN3 : in_paramN[index];
-            const Id in_param{OpLoad(vec4_id, OpAccessChain(input_vec4, inputs[i], index))};
-            const Id out_param{OpSelect(vec4_id, invocation_3, in_param3, in_param)};
-            OpStore(OpAccessChain(output_vec4, outputs[i], invocation_id), out_param);
+        // Preserve the downstream interface, zero-filling locations absent from the VS.
+        for (const auto& param : params) {
+            Id out_param = vec4_zero;
+            if (Sirit::ValidId(param.input)) {
+                const Id v0{OpLoad(vec4_id, OpAccessChain(input_vec4, param.input, Int(0)))};
+                const Id v1{OpLoad(vec4_id, OpAccessChain(input_vec4, param.input, Int(1)))};
+                const Id v2{OpLoad(vec4_id, OpAccessChain(input_vec4, param.input, Int(2)))};
+                const Id in_param3{interpolate(v0, v1, v2)};
+                const Id in_param{OpLoad(vec4_id, OpAccessChain(input_vec4, param.input, index))};
+                out_param = OpSelect(vec4_id, invocation_3, in_param3, in_param);
+            }
+            OpStore(OpAccessChain(output_vec4, param.output, invocation_id), out_param);
         }
 
         OpReturn();
@@ -161,10 +175,12 @@ struct QuadRectListEmitter : public Sirit::Module {
         const Id in_position{OpLoad(vec4_id, OpAccessChain(input_vec4, gl_in, index, Int(0)))};
         OpStore(OpAccessChain(output_vec4, gl_out, invocation_id, Int(0)), in_position);
 
-        for (int i = 0; i < inputs.size(); i++) {
-            // out_paramN[gl_InvocationID] = in_paramN[gl_InvocationID];
-            const Id in_param{OpLoad(vec4_id, OpAccessChain(input_vec4, inputs[i], index))};
-            OpStore(OpAccessChain(output_vec4, outputs[i], invocation_id), in_param);
+        for (const auto& param : params) {
+            Id in_param = vec4_zero;
+            if (Sirit::ValidId(param.input)) {
+                in_param = OpLoad(vec4_id, OpAccessChain(input_vec4, param.input, index));
+            }
+            OpStore(OpAccessChain(output_vec4, param.output, invocation_id), in_param);
         }
 
         OpReturn();
@@ -189,9 +205,9 @@ struct QuadRectListEmitter : public Sirit::Module {
         OpStore(OpAccessChain(output_vec4, gl_per_vertex, Int(0)), position);
 
         // out_paramN = in_paramN[index];
-        for (int i = 0; i < inputs.size(); i++) {
-            const Id param{OpLoad(vec4_id, OpAccessChain(input_vec4, inputs[i], index))};
-            OpStore(outputs[i], param);
+        for (const auto& param : params) {
+            const Id value{OpLoad(vec4_id, OpAccessChain(input_vec4, param.input, index))};
+            OpStore(param.output, value);
         }
 
         OpReturn();
@@ -235,6 +251,20 @@ private:
         AddLabel(OpLabel());
     }
 
+    bool IsPreviousStageOutputAvailable(u32 location) const {
+        return (previous_stage_output_mask & (1ull << location)) != 0;
+    }
+
+    void AddParam(spv::ExecutionModel model, Id input_type, u32 location) {
+        AuxParam& param = params.emplace_back();
+        param.location = location;
+        if (model == spv::ExecutionModel::TessellationEvaluation ||
+            IsPreviousStageOutputAvailable(location)) {
+            param.input = AddInput(input_type);
+            Decorate(param.input, spv::Decoration::Location, location);
+        }
+    }
+
     void DefineOutputs(spv::ExecutionModel model) {
         if (model == spv::ExecutionModel::TessellationControl) {
             const Id gl_per_vertex_array{TypeArray(gl_per_vertex_type, Constant(uint_id, 4U))};
@@ -252,16 +282,12 @@ private:
         } else {
             gl_per_vertex = AddOutput(gl_per_vertex_type);
         }
-        outputs.reserve(fs_info.num_inputs);
-        for (int i = 0; i < fs_info.num_inputs; i++) {
-            const auto& input = fs_info.inputs[i];
-            if (input.IsDefault()) {
-                continue;
-            }
-            outputs.emplace_back(AddOutput(model == spv::ExecutionModel::TessellationControl
-                                               ? TypeArray(vec4_id, Int(4))
-                                               : vec4_id));
-            Decorate(outputs.back(), spv::Decoration::Location, input.param_index);
+
+        for (auto& param : params) {
+            param.output = AddOutput(model == spv::ExecutionModel::TessellationControl
+                                         ? TypeArray(vec4_id, Int(4))
+                                         : vec4_id);
+            Decorate(param.output, spv::Decoration::Location, param.location);
         }
     }
 
@@ -275,20 +301,27 @@ private:
         }
         const Id gl_per_vertex_array{TypeArray(gl_per_vertex_type, Constant(uint_id, 32U))};
         gl_in = AddInput(gl_per_vertex_array);
-        const Id float_arr{TypeArray(vec4_id, Int(32))};
-        inputs.reserve(fs_info.num_inputs);
-        for (int i = 0; i < fs_info.num_inputs; i++) {
+
+        params.reserve(fs_info.num_inputs);
+        const Id input_type{TypeArray(vec4_id, Int(32))};
+        if (fs_info.clip_distance_emulation) {
+            AddParam(model, input_type, 0);
+        }
+        const u32 num_inputs =
+            fs_info.num_inputs - static_cast<u32>(fs_info.clip_distance_emulation);
+        for (u32 i = 0; i < num_inputs; i++) {
             const auto& input = fs_info.inputs[i];
             if (input.IsDefault()) {
                 continue;
             }
-            inputs.emplace_back(AddInput(float_arr));
-            Decorate(inputs.back(), spv::Decoration::Location, input.param_index);
+            AddParam(model, input_type,
+                     AuxTessAttributeLocation(input.param_index, fs_info.clip_distance_emulation));
         }
     }
 
 private:
-    FragmentRuntimeInfo fs_info;
+    const FragmentRuntimeInfo& fs_info;
+    const u64 previous_stage_output_mask;
     Id main;
     Id void_id;
     Id bool_id;
@@ -302,6 +335,7 @@ private:
     Id float_one;
     Id float_min_one;
     Id int_zero;
+    Id vec4_zero;
     Id gl_per_vertex_type;
     Id gl_in;
     union {
@@ -314,13 +348,13 @@ private:
         Id gl_tess_coord;
         Id gl_invocation_id;
     };
-    std::vector<Id> inputs;
-    std::vector<Id> outputs;
+    std::vector<AuxParam> params;
     std::vector<Id> interfaces;
 };
 
-std::vector<u32> EmitAuxilaryTessShader(AuxShaderType type, const FragmentRuntimeInfo& fs_info) {
-    QuadRectListEmitter ctx{fs_info};
+std::vector<u32> EmitAuxilaryTessShader(AuxShaderType type, const FragmentRuntimeInfo& fs_info,
+                                        u64 previous_stage_output_mask) {
+    QuadRectListEmitter ctx{fs_info, previous_stage_output_mask};
     switch (type) {
     case AuxShaderType::RectListTCS:
         ctx.EmitRectListTCS();

--- a/src/shader_recompiler/backend/spirv/emit_spirv_quad_rect.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_quad_rect.h
@@ -18,7 +18,13 @@ enum class AuxShaderType : u32 {
     PassthroughTES,
 };
 
+[[nodiscard]] constexpr u32 AuxTessAttributeLocation(u32 param_index,
+                                                     bool clip_distance_emulation) noexcept {
+    return param_index + (clip_distance_emulation ? 1u : 0u);
+}
+
 [[nodiscard]] std::vector<u32> EmitAuxilaryTessShader(AuxShaderType type,
-                                                      const FragmentRuntimeInfo& fs_info);
+                                                      const FragmentRuntimeInfo& fs_info,
+                                                      u64 previous_stage_output_mask = ~0ull);
 
 } // namespace Shader::Backend::SPIRV

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -8,6 +8,8 @@
 #include "common/assert.h"
 #include "shader_recompiler/backend/spirv/emit_spirv_discard_frag.h"
 #include "shader_recompiler/backend/spirv/emit_spirv_quad_rect.h"
+#include "shader_recompiler/info.h"
+#include "shader_recompiler/ir/attribute.h"
 #include "video_core/renderer_vulkan/liverpool_to_vk.h"
 #include "video_core/renderer_vulkan/vk_graphics_pipeline.h"
 #include "video_core/renderer_vulkan/vk_instance.h"
@@ -17,6 +19,34 @@
 namespace Vulkan {
 
 using Shader::Backend::SPIRV::AuxShaderType;
+
+namespace {
+
+u64 BuildAuxTessPreviousStageOutputMask(const Shader::Info* vs_info,
+                                        const Shader::FragmentRuntimeInfo& fs_info) {
+    if (!vs_info) {
+        return 0;
+    }
+
+    u64 mask = 0;
+    if (fs_info.clip_distance_emulation &&
+        vs_info->stores.GetAny(Shader::IR::Attribute::ClipDistance)) {
+        mask |= 1ull;
+    }
+
+    for (u32 i = 0; i < Shader::IR::NumParams; ++i) {
+        const auto param = Shader::IR::Attribute::Param0 + static_cast<int>(i);
+        if (!vs_info->stores.GetAny(param)) {
+            continue;
+        }
+        const u32 location =
+            Shader::Backend::SPIRV::AuxTessAttributeLocation(i, fs_info.clip_distance_emulation);
+        mask |= 1ull << location;
+    }
+    return mask;
+}
+
+} // Anonymous namespace
 
 static constexpr std::array LogicalStageToStageBit = {
     vk::ShaderStageFlagBits::eFragment,
@@ -195,7 +225,11 @@ GraphicsPipeline::GraphicsPipeline(
         const auto type = is_quad_list ? AuxShaderType::QuadListTCS : AuxShaderType::RectListTCS;
         if (!preloading) {
             const auto& fs_info = runtime_infos[u32(Shader::LogicalStage::Fragment)].fs_info;
-            sdata.tcs = Shader::Backend::SPIRV::EmitAuxilaryTessShader(type, fs_info);
+            const auto* vs_info = infos[u32(Shader::LogicalStage::Vertex)];
+            const u64 previous_stage_output_mask =
+                BuildAuxTessPreviousStageOutputMask(vs_info, fs_info);
+            sdata.tcs = Shader::Backend::SPIRV::EmitAuxilaryTessShader(type, fs_info,
+                                                                       previous_stage_output_mask);
         }
         shader_stages.emplace_back(vk::PipelineShaderStageCreateInfo{
             .stage = vk::ShaderStageFlagBits::eTessellationControl,

--- a/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
@@ -14,7 +14,7 @@ namespace Serialization {
 /* You should increment versions below once corresponding serialization scheme is changed. */
 static constexpr u32 ShaderBinaryVersion = 2u;
 static constexpr u32 ShaderMetaVersion = 2u;
-static constexpr u32 PipelineKeyVersion = 2u;
+static constexpr u32 PipelineKeyVersion = 3u;
 } // namespace Serialization
 
 namespace Vulkan {


### PR DESCRIPTION
Fixes invalid VS-to-TCS interfaces in auxiliary tessellation shaders used for rect and quad lists.

The generated TCS now declares inputs only for locations actually exported by the vertex shader, while preserving the outputs required by later stages. Missing inputs are synthesized as zero without adding invalid interface declarations. Clip-distance emulation is handled as a separate shifted location, and the pipeline cache version is bumped to discard stale auxiliary shaders.

The image descriptor portion of the original implementation has been removed. The new implementation is now based on the recent robustness2 changes.

Validated with sparse vertex exports, clip-distance emulation, SPIR-V validation, and the GCN test suite.