### PR TITLE
fix: FBSD 15 libc++ quirks with includes

### DIFF
--- a/src/common/cstring.h
+++ b/src/common/cstring.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <algorithm>
+#include <ranges>
 #include <string_view>
 
 #include "assert.h"

--- a/src/core/file_format/psf.cpp
+++ b/src/core/file_format/psf.cpp
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <algorithm>
 #include <cstring>
+#include <ranges>
 
 #include "common/assert.h"
 #include "common/io_file.h"

--- a/src/core/libraries/network/net_epoll.cpp
+++ b/src/core/libraries/network/net_epoll.cpp
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <algorithm>
+#include <ranges>
+
 #include "common/assert.h"
 #include "common/types.h"
 #include "net_epoll.h"

--- a/src/core/libraries/network/net_upnp.cpp
+++ b/src/core/libraries/network/net_upnp.cpp
@@ -12,6 +12,7 @@
 #include <ws2tcpip.h>
 #else
 #include <arpa/inet.h>
+#include <net/if.h>
 #endif
 
 namespace Libraries::Net {

--- a/src/core/libraries/np/object_manager.h
+++ b/src/core/libraries/np/object_manager.h
@@ -1,8 +1,10 @@
 // SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <algorithm>
 #include <array>
 #include <mutex>
+#include <ranges>
 
 template <typename T, size_t N, int INVALID_OBJECT_ID_ERROR, int OBJECT_NOT_FOUND_ERROR,
           int MAX_OBJECTS_ERROR>

--- a/src/core/libraries/save_data/save_backup.cpp
+++ b/src/core/libraries/save_data/save_backup.cpp
@@ -1,8 +1,10 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <algorithm>
 #include <deque>
 #include <mutex>
+#include <ranges>
 #include <semaphore>
 
 #include <magic_enum/magic_enum.hpp>

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <algorithm>
+#include <ranges>
 #include <span>
 #include "common/types.h"
 #include "shader_recompiler/frontend/tessellation.h"

--- a/src/video_core/renderer_vulkan/vk_presenter.cpp
+++ b/src/video_core/renderer_vulkan/vk_presenter.cpp
@@ -34,6 +34,7 @@
 #include <ctime>
 #include <filesystem>
 #include <iomanip>
+#include <fstream>
 #include <limits>
 #include <memory>
 #include <span>

--- a/src/video_core/renderer_vulkan/vk_presenter.cpp
+++ b/src/video_core/renderer_vulkan/vk_presenter.cpp
@@ -33,8 +33,8 @@
 #include <cstring>
 #include <ctime>
 #include <filesystem>
-#include <iomanip>
 #include <fstream>
+#include <iomanip>
 #include <limits>
 #include <memory>
 #include <span>


### PR DESCRIPTION
generally using `std::ranges` without either `<ranges>` and `<algorithm>` ought to trip up atleast one libc++...
such libc++ is called FBSD15 default clang libc++.