### PR TITLE
libraries: add three missing semicolons

### DIFF
--- a/src/core/libraries/kernel/kernel.cpp
+++ b/src/core/libraries/kernel/kernel.cpp
@@ -463,8 +463,8 @@ void RegisterLib(Core::Loader::SymbolsResolver* sym) {
     Libraries::Kernel::RegisterCoredump(sym);
 
     LIB_OBJ("f7uOxY9mM1U", "libkernel", 1, "libkernel", &g_stack_chk_guard);
-    LIB_OBJ("+2thxYZ4syk", "libkernel", 1, "libkernel", &g_environ)
-    LIB_OBJ("djxxOmW6-aw", "libkernel", 1, "libkernel", &g_progname)
+    LIB_OBJ("+2thxYZ4syk", "libkernel", 1, "libkernel", &g_environ);
+    LIB_OBJ("djxxOmW6-aw", "libkernel", 1, "libkernel", &g_progname);
     LIB_FUNCTION("D4yla3vx4tY", "libkernel", 1, "libkernel", sceKernelError);
     LIB_FUNCTION("YeU23Szo3BM", "libkernel", 1, "libkernel", sceKernelGetAllowedSdkVersionOnSystem);
     LIB_FUNCTION("Mv1zUObHvXI", "libkernel", 1, "libkernel", sceKernelGetSystemSwVersion);

--- a/src/core/libraries/libs.h
+++ b/src/core/libraries/libs.h
@@ -8,7 +8,7 @@
 #include "core/tls.h"
 
 #define LIB_FUNCTION(nid, lib, libversion, mod, function)                                          \
-    {                                                                                              \
+    do {                                                                                           \
         Core::Loader::SymbolResolver sr{};                                                         \
         sr.name = nid;                                                                             \
         sr.library = lib;                                                                          \
@@ -17,10 +17,10 @@
         sr.type = Core::Loader::SymbolType::Function;                                              \
         auto func = reinterpret_cast<u64>(HOST_CALL(function));                                    \
         sym->AddSymbol(sr, func);                                                                  \
-    }
+    } while (0)
 
 #define LIB_OBJ(nid, lib, libversion, mod, obj)                                                    \
-    {                                                                                              \
+    do {                                                                                           \
         Core::Loader::SymbolResolver sr{};                                                         \
         sr.name = nid;                                                                             \
         sr.library = lib;                                                                          \
@@ -28,7 +28,7 @@
         sr.module = mod;                                                                           \
         sr.type = Core::Loader::SymbolType::Object;                                                \
         sym->AddSymbol(sr, reinterpret_cast<u64>(obj));                                            \
-    }
+    } while (0)
 
 namespace Libraries {
 

--- a/src/core/libraries/ngs2/ngs2.cpp
+++ b/src/core/libraries/ngs2/ngs2.cpp
@@ -562,7 +562,7 @@ void RegisterLib(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("4lFaRxd-aLs", "libSceNgs2", 1, "libSceNgs2", sceNgs2SystemGetUserData);
     LIB_FUNCTION("gThZqM5PYlQ", "libSceNgs2", 1, "libSceNgs2", sceNgs2SystemLock);
     LIB_FUNCTION("pgFAiLR5qT4", "libSceNgs2", 1, "libSceNgs2", sceNgs2SystemQueryBufferSize);
-    LIB_FUNCTION("3oIK7y7O4k0", "libSceNgs2", 1, "libSceNgs2", sceNgs2SystemQueryInfo)
+    LIB_FUNCTION("3oIK7y7O4k0", "libSceNgs2", 1, "libSceNgs2", sceNgs2SystemQueryInfo);
     LIB_FUNCTION("i0VnXM-C9fc", "libSceNgs2", 1, "libSceNgs2", sceNgs2SystemRender);
     LIB_FUNCTION("AQkj7C0f3PY", "libSceNgs2", 1, "libSceNgs2", sceNgs2SystemResetOption);
     LIB_FUNCTION("gXiormHoZZ4", "libSceNgs2", 1, "libSceNgs2", sceNgs2SystemRunCommands);


### PR DESCRIPTION
As funny as this sounds, yes, the shadPS4 codebase was indeed either missing three semicolons, or had 5072 extraneous ones, I chose to go with the former.