### PR TITLE
Lib.Sysmodule: LLE libSceWkFontConfig.sprx

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The following firmware modules are supported and must be placed in shadPS4's `sy
 | libSceAudiodec.sprx      | libSceCesCs.sprx         | libSceFont.sprx          | libSceFontFt.sprx        |
 | libSceFreeTypeOt.sprx    | libSceJpegDec.sprx       | libSceJpegEnc.sprx       | libSceJson.sprx          |
 | libSceJson2.sprx         | libSceLibcInternal.sprx  | libSceNgs2.sprx          | libScePngEnc.sprx        |
-| libSceRtc.sprx           | libSceSystemGesture.sprx | libSceUlt.sprx           |                          |
+| libSceRtc.sprx           | libSceSystemGesture.sprx | libSceUlt.sprx           | libSceWkFontConfig.sprx  |
 </div>
 
 > [!Caution]

--- a/src/core/libraries/sysmodule/sysmodule_internal.cpp
+++ b/src/core/libraries/sysmodule/sysmodule_internal.cpp
@@ -225,6 +225,7 @@ s32 loadModuleInternal(s32 index, s32 argc, const void* argv, s32* res_out) {
              {"libSceFont.sprx", &Libraries::Font::RegisterlibSceFont},
              {"libSceFontFt.sprx", &Libraries::FontFt::RegisterlibSceFontFt},
              {"libSceFreeTypeOt.sprx", nullptr},
+             {"libSceWkFontConfig.sprx", nullptr},
              {"libSceSystemGesture.sprx", &Libraries::SystemGesture::RegisterLib}});
 
         // Iterate through the allowed array


### PR DESCRIPTION
This is a library that hardcodes valid firmware font paths. While it should be easy to HLE in the future, this library is entirely safe to LLE.

Fixes the current crash in WeatherNation

<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/6f2f9289-2bed-4b3b-8c1a-56d4d4c1046c" />
