### PR TITLE
Fix patchInfo to own its strings

### DIFF
--- a/src/common/memory_patcher.h
+++ b/src/common/memory_patcher.h
@@ -26,12 +26,12 @@ enum PatchMask : uint8_t {
 };
 
 struct patchInfo {
-    const std::string& gameSerial;
-    const std::string& modNameStr;
-    const std::string& offsetStr;
-    const std::string& valueStr;
-    const std::string& targetStr;
-    const std::string& sizeStr;
+    std::string gameSerial;
+    std::string modNameStr;
+    std::string offsetStr;
+    std::string valueStr;
+    std::string targetStr;
+    std::string sizeStr;
     bool isOffset;
     bool littleEndian;
     PatchMask patchMask;


### PR DESCRIPTION
PR [#4627](https://github.com/shadps4-emu/shadPS4/pull/4627) changed `patchInfo`  struct members from owning `std::string` values to `const std::string&` references 
([memory_patcher.h L28–39](https://github.com/notanenergydrinkaddict/shadPS4/blob/e2368ad20c71fbf4896d2a2fd21948662d96199c/src/common/memory_patcher.h#L28-L39)):

```diff
 struct patchInfo {
-    std::string gameSerial;
-    std::string modNameStr;
-    std::string offsetStr;
-    std::string valueStr;
-    std::string targetStr;
-    std::string sizeStr;
+    const std::string& gameSerial;
+    const std::string& modNameStr;
+    const std::string& offsetStr;
+    const std::string& valueStr;
+    const std::string& targetStr;
+    const std::string& sizeStr;
```

The struct is only valid while the original string variables are alive. In `ipc.cpp`, those strings are temporaries from 
`next_str()` and they go out of scope immediately after construction, leaving the queued `patchInfo` with dangling references which leads to undefined behavior or a crash.

See also: [`ipc.cpp` ](https://github.com/shadps4-emu/shadPS4/pull/4627/files#diff-3b27d500a721c85ac2abb9d22273b71219acc2a97cc088ac90f41b2f8987a075)
```cpp
const MemoryPatcher::patchInfo entry = {
    .gameSerial = "*",
    .modNameStr = next_str(),  // temporary, all strings die at the end of the block
    .offsetStr  = next_str(),
     .valueStr = next_str(),
     .targetStr = next_str(),
     .sizeStr = next_str(),
     .isOffset = next_u64() != 0,
     .littleEndian = next_u64() != 0,
     .patchMask = static_cast<MemoryPatcher::PatchMask>(next_u64()),
     .maskOffset = static_cast<int>(next_u64()),
 };
    ...
};
MemoryPatcher::AddPatchToQueue(entry); // entry queued, but all strings are already dead
```

This leads to IpcClient::sendMemoryPatches not working and therefore cheats that modify memory during runtime don't work either.

To fix this I kept the fields as owning `std::string` (not references) so the struct stores its own copies of the data safely.