### PR TITLE
Nix: Abseil-Cpp for protobuff.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "abseilCppSource": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750171688,
+        "narHash": "sha256-eB7OqTO9Vwts9nYQ/Mdq0Ds4T1KgmmpYdzU09VPWOhk=",
+        "owner": "abseil",
+        "repo": "abseil-cpp",
+        "rev": "76bb24329e8bf5f39704eb10d21b9a80befa7c81",
+        "type": "github"
+      },
+      "original": {
+        "owner": "abseil",
+        "ref": "20250512.1",
+        "repo": "abseil-cpp",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1779560665,
@@ -18,6 +35,7 @@
     },
     "root": {
       "inputs": {
+        "abseilCppSource": "abseilCppSource",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -6,10 +6,15 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    
+    abseilCppSource = {
+      url = "github:abseil/abseil-cpp?ref=20250512.1";
+      flake = false;
+    };
   };
 
   outputs =
-    { self, nixpkgs }:
+    { self, nixpkgs, abseilCppSource }:
     let
       pkgsLinux = nixpkgs.legacyPackages.x86_64-linux;
 
@@ -21,6 +26,7 @@
         let
           shell =
             { self
+            , lib
             , mkShell
             , clangStdenv
             , clang-tools
@@ -87,7 +93,7 @@
                   clang-tools
                   cmake
                   pkg-config
-                ] ++ sdlConfigureDeps ++ pkgsLinux.lib.optionals enableDebugTooling [ renderdoc gef strace perf vulkan-tools ];
+                ] ++ sdlConfigureDeps ++ lib.optionals enableDebugTooling [ renderdoc gef strace perf vulkan-tools ];
 
               shellHook = ''
                 echo "Entering shadPS4 development shell!"
@@ -112,6 +118,7 @@
 
           build =
             { clangStdenv
+            , lib
             , cmake
             , ninja
             , pkg-config
@@ -151,6 +158,7 @@
             , libuuid
             , systemdMinimal
             , libx11
+            , abseilCppSource
             , releaseMode ? "debug"
             , enableDiscordRpc ? false
             ,
@@ -201,9 +209,10 @@
 
               cmakeFlags = [
                 (getBuildSettings releaseMode).flag
-                (pkgsLinux.lib.cmakeBool "ENABLE_DISCORD_RPC" enableDiscordRpc)
-                (pkgsLinux.lib.cmakeBool "ENABLE_TESTS" false)
-                (pkgsLinux.lib.cmakeBool "ENABLE_SYSTEM_LIBRARIES" true)
+                (lib.cmakeBool "ENABLE_DISCORD_RPC" enableDiscordRpc)
+                (lib.cmakeBool "ENABLE_TESTS" false)
+                (lib.cmakeBool "ENABLE_SYSTEM_LIBRARIES" true)
+                "-DFETCHCONTENT_SOURCE_DIR_ABSL=${abseilCppSource}"
               ];
               dontStrip = (getBuildSettings releaseMode).symbols;
 
@@ -219,10 +228,10 @@
             });
         in
         {
-          debug = pkgsLinux.callPackage build { releaseMode = "debug"; };
-          release = pkgsLinux.callPackage build { releaseMode = "release"; };
-          releaseWithDebInfo = pkgsLinux.callPackage build { releaseMode = "relWithDebInfo"; };
-          default = pkgsLinux.callPackage build { releaseMode = "relWithDebInfo"; };
+          debug = pkgsLinux.callPackage build { releaseMode = "debug"; inherit abseilCppSource; };
+          release = pkgsLinux.callPackage build { releaseMode = "release"; inherit abseilCppSource; };
+          releaseWithDebInfo = pkgsLinux.callPackage build { releaseMode = "relWithDebInfo"; inherit abseilCppSource; };
+          default = pkgsLinux.callPackage build { releaseMode = "relWithDebInfo"; inherit abseilCppSource; };
         };
     };
 }


### PR DESCRIPTION
Pulls the required abseil-cpp source into the Nix sandbox for the protobuf library to compile correctly. 