### PR TITLE
Lib.Sysmodule: More safe LLE modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,12 +151,15 @@ The following firmware modules are supported and must be placed in shadPS4's `sy
 
 <div align="center">
 
-| Modules                  | Modules                  | Modules                  | Modules                  |
-|--------------------------|--------------------------|--------------------------|--------------------------|
-| libSceAudiodec.sprx      | libSceCesCs.sprx         | libSceFont.sprx          | libSceFontFt.sprx        |
-| libSceFreeTypeOt.sprx    | libSceJpegDec.sprx       | libSceJpegEnc.sprx       | libSceJson.sprx          |
-| libSceJson2.sprx         | libSceLibcInternal.sprx  | libSceNgs2.sprx          | libScePngEnc.sprx        |
-| libSceRtc.sprx           | libSceSystemGesture.sprx | libSceUlt.sprx           | libSceWkFontConfig.sprx  |
+| Modules                        | Modules                        | Modules                        | Modules                        |
+|--------------------------------|--------------------------------|--------------------------------|--------------------------------|
+| libSceAudiodec.sprx            | libSceAudiodecCpu.sprx         | libSceAudiodecCpuDdp.sprx      | libSceAudiodecCpuDtsHdLbr.sprx |
+| libSceAudiodecCpuHevag.sprx    | libSceAudiodecCpuM4aac.sprx    | libSceCesCs.sprx               | libSceFont.sprx                |
+| libSceFontFt.sprx              | libSceFreeTypeOl.sprx          | libSceFreeTypeOptOl.sprx       | libSceFreeTypeOt.sprx          |
+| libSceJpegDec.sprx             | libSceJpegEnc.sprx             | libSceJson.sprx                | libSceJson2.sprx               |
+| libSceLibcInternal.sprx        | libSceNgs2.sprx                | libScePngEnc.sprx              | libSceRtc.sprx                 |
+| libSceRudp.sprx                | libSceSystemGesture.sprx       | libSceUlt.sprx                 | libSceWkFontConfig.sprx        |
+| libSceXml.sprx                 |
 </div>
 
 > [!Caution]

--- a/src/core/libraries/font/font.cpp
+++ b/src/core/libraries/font/font.cpp
@@ -7360,7 +7360,7 @@ s32 PS4_SYSV_ABI Func_FE7E5AE95D3058F5() {
     return ORBIS_OK;
 }
 
-void RegisterlibSceFont(Core::Loader::SymbolsResolver* sym) {
+void RegisterLib(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("CUKn5pX-NVY", "libSceFont", 1, "libSceFont", sceFontAttachDeviceCacheBuffer);
     LIB_FUNCTION("3OdRkSjOcog", "libSceFont", 1, "libSceFont", sceFontBindRenderer);
     LIB_FUNCTION("6DFUkCwQLa8", "libSceFont", 1, "libSceFont", sceFontCharacterGetBidiLevel);

--- a/src/core/libraries/font/font.h
+++ b/src/core/libraries/font/font.h
@@ -767,5 +767,5 @@ s32 PS4_SYSV_ABI Func_EAC96B2186B71E14();
 s32 PS4_SYSV_ABI Func_FE4788A96EF46256();
 s32 PS4_SYSV_ABI Func_FE7E5AE95D3058F5();
 
-void RegisterlibSceFont(Core::Loader::SymbolsResolver* sym);
+void RegisterLib(Core::Loader::SymbolsResolver* sym);
 } // namespace Libraries::Font

--- a/src/core/libraries/font/fontft.cpp
+++ b/src/core/libraries/font/fontft.cpp
@@ -124,7 +124,7 @@ const OrbisFontRendererSelection* PS4_SYSV_ABI sceFontSelectRendererFt(int value
     return nullptr;
 }
 
-void RegisterlibSceFontFt(Core::Loader::SymbolsResolver* sym) {
+void RegisterLib(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("e60aorDdpB8", "libSceFontFt", 1, "libSceFontFt", sceFontFtInitAliases);
     LIB_FUNCTION("BxcmiMc3UaA", "libSceFontFt", 1, "libSceFontFt", sceFontFtSetAliasFont);
     LIB_FUNCTION("MEWjebIzDEI", "libSceFontFt", 1, "libSceFontFt", sceFontFtSetAliasPath);

--- a/src/core/libraries/font/fontft.h
+++ b/src/core/libraries/font/fontft.h
@@ -51,5 +51,5 @@ s32 PS4_SYSV_ABI sceFontSelectGlyphsFt();
 const OrbisFontLibrarySelection* PS4_SYSV_ABI sceFontSelectLibraryFt(int value);
 const OrbisFontRendererSelection* PS4_SYSV_ABI sceFontSelectRendererFt(int value);
 
-void RegisterlibSceFontFt(Core::Loader::SymbolsResolver* sym);
+void RegisterLib(Core::Loader::SymbolsResolver* sym);
 } // namespace Libraries::FontFt

--- a/src/core/libraries/libs.cpp
+++ b/src/core/libraries/libs.cpp
@@ -155,7 +155,6 @@ void InitHLELibs(Core::Loader::SymbolsResolver* sym) {
     Libraries::CompanionHttpd::RegisterLib(sym);
     Libraries::CompanionUtil::RegisterLib(sym);
     Libraries::Voice::RegisterLib(sym);
-    Libraries::Rudp::RegisterLib(sym);
     Libraries::VrTracker::RegisterLib(sym);
     Libraries::ContentExport::RegisterLib(sym);
     Libraries::VideoRecording::RegisterLib(sym);

--- a/src/core/libraries/sysmodule/sysmodule_internal.cpp
+++ b/src/core/libraries/sysmodule/sysmodule_internal.cpp
@@ -17,6 +17,7 @@
 #include "core/libraries/libs.h"
 #include "core/libraries/ngs2/ngs2.h"
 #include "core/libraries/rtc/rtc.h"
+#include "core/libraries/rudp/rudp.h"
 #include "core/libraries/sysmodule/sysmodule_error.h"
 #include "core/libraries/sysmodule/sysmodule_internal.h"
 #include "core/libraries/sysmodule/sysmodule_table.h"
@@ -224,11 +225,20 @@ s32 loadModuleInternal(s32 index, s32 argc, const void* argv, s32* res_out) {
              {"libSceLibcInternal.sprx", &Libraries::LibcInternal::RegisterLib},
              {"libSceCesCs.sprx", nullptr},
              {"libSceAudiodec.sprx", nullptr},
-             {"libSceFont.sprx", &Libraries::Font::RegisterlibSceFont},
-             {"libSceFontFt.sprx", &Libraries::FontFt::RegisterlibSceFontFt},
+             {"libSceAudiodecCpu.sprx", nullptr},
+             {"libSceAudiodecCpuDdp.sprx", nullptr},
+             {"libSceAudiodecCpuM4aac.sprx", nullptr},
+             {"libSceAudiodecCpuDtsHdLbr.sprx", nullptr},
+             {"libSceAudiodecCpuHevag.sprx", nullptr},
+             {"libSceFont.sprx", &Libraries::Font::RegisterLib},
+             {"libSceFontFt.sprx", &Libraries::FontFt::RegisterLib},
              {"libSceFreeTypeOt.sprx", nullptr},
+             {"libSceFreeTypeOl.sprx", nullptr},
+             {"libSceFreeTypeOptOl.sprx", nullptr},
+             {"libSceRudp.sprx", &Libraries::Rudp::RegisterLib},
              {"libSceWkFontConfig.sprx", nullptr},
-             {"libSceSystemGesture.sprx", &Libraries::SystemGesture::RegisterLib}});
+             {"libSceSystemGesture.sprx", &Libraries::SystemGesture::RegisterLib},
+             {"libSceXml.sprx", nullptr}});
 
         // Iterate through the allowed array
         const auto it = std::ranges::find_if(


### PR DESCRIPTION
This PR enables loading more of our unimplemented libraries as LLE.
Specifically:
- libSceAudiodecCpu.sprx
- libSceAudiodecCpuDdp.sprx
- libSceAudiodecCpuDtsHdLbr.sprx
- libSceAudiodecCpuHevag.sprx
- libSceAudiodecCpuM4aac.sprx
- libSceFreeTypeOl.sprx
- libSceFreeTypeOptOl.sprx
- libSceRudp.sprx
- libSceXml.sprx

libSceRudp has been safe to LLE for a while now thanks to the initial sockets implementation, the rest of these are only safe now that LLE mallocs work.

libSceAudiodecCpu and it's various codec libraries are used by old versions of YouTube for audio playback. libSceFreeTypeOl is frequently used by OpenOrbis homebrews for rendering fonts. libSceXml and libSceRudp are used by a variety of games, but I haven't run into any that completely broke without them.