### PR TITLE
Lib.AvPlayer: Fixes to decoder loops

### DIFF
--- a/src/core/libraries/avplayer/avplayer_source.cpp
+++ b/src/core/libraries/avplayer/avplayer_source.cpp
@@ -361,7 +361,8 @@ bool AvPlayerSource::GetVideoData(AvPlayerFrameInfoEx& video_info) {
 
     const auto& new_frame = m_video_frames.Front();
     if (m_state.GetSyncMode() == AvPlayerAvSyncMode::Default) {
-        if (m_audio_stream_index) {
+        if (m_audio_stream_index && m_audio_decoder_thread.Joinable()) {
+            // Audio is available, sync video with it.
             if (new_frame.info.timestamp > m_last_audio_ts.value_or(0)) {
                 return false;
             }
@@ -573,12 +574,15 @@ void AvPlayerSource::DemuxerThread(std::stop_token stop) {
     m_audio_packets_cv.Notify();
     m_video_frames_cv.Notify();
     m_audio_frames_cv.Notify();
+    m_video_buffers_cv.Notify();
+    m_audio_buffers_cv.Notify();
 
     m_video_decoder_thread.Join();
     m_audio_decoder_thread.Join();
     m_state.OnEOF();
 
     LOG_INFO(Lib_AvPlayer, "Demuxer Thread exited normally");
+    m_demuxer_thread.Join();
 }
 
 AvPlayerSource::AVFramePtr AvPlayerSource::ConvertVideoFrame(const AVFrame& frame) {
@@ -709,8 +713,8 @@ void AvPlayerSource::VideoDecoderThread(std::stop_token stop) {
 
     LOG_INFO(Lib_AvPlayer, "Video Decoder Thread started");
     while ((!m_is_eof || m_video_packets.Size() != 0) && !stop.stop_requested()) {
-        if (!m_video_packets_cv.Wait(stop,
-                                     [this] { return m_video_packets.Size() != 0 || m_is_eof; })) {
+        if (m_video_packets.Size() == 0 &&
+            !m_video_packets_cv.Wait(stop, [this] { return m_video_packets.Size() != 0; })) {
             continue;
         }
         const auto packet = m_video_packets.Pop();
@@ -726,11 +730,9 @@ void AvPlayerSource::VideoDecoderThread(std::stop_token stop) {
             return;
         }
         while (res >= 0) {
-            if (!m_video_buffers_cv.Wait(stop, [this] { return m_video_buffers.Size() != 0; })) {
+            if (m_video_buffers.Size() == 0 &&
+                !m_video_buffers_cv.Wait(stop, [this] { return m_video_buffers.Size() != 0; })) {
                 break;
-            }
-            if (m_video_buffers.Size() == 0) {
-                continue;
             }
             auto up_frame = AVFramePtr(av_frame_alloc(), &ReleaseAVFrame);
             res = avcodec_receive_frame(m_video_codec_context.get(), up_frame.get());
@@ -767,6 +769,7 @@ void AvPlayerSource::VideoDecoderThread(std::stop_token stop) {
     }
 
     LOG_INFO(Lib_AvPlayer, "Video Decoder Thread exited normally");
+    m_video_decoder_thread.Join();
 }
 
 AvPlayerSource::AVFramePtr AvPlayerSource::ConvertAudioFrame(const AVFrame& frame) {
@@ -832,8 +835,8 @@ void AvPlayerSource::AudioDecoderThread(std::stop_token stop) {
 
     LOG_INFO(Lib_AvPlayer, "Audio Decoder Thread started");
     while ((!m_is_eof || m_audio_packets.Size() != 0) && !stop.stop_requested()) {
-        if (!m_audio_packets_cv.Wait(stop,
-                                     [this] { return m_audio_packets.Size() != 0 || m_is_eof; })) {
+        if (m_audio_packets.Size() == 0 &&
+            !m_audio_packets_cv.Wait(stop, [this] { return m_audio_packets.Size() != 0; })) {
             continue;
         }
         const auto packet = m_audio_packets.Pop();
@@ -848,11 +851,9 @@ void AvPlayerSource::AudioDecoderThread(std::stop_token stop) {
             return;
         }
         while (res >= 0) {
-            if (!m_audio_buffers_cv.Wait(stop, [this] { return m_audio_buffers.Size() != 0; })) {
+            if (m_audio_buffers.Size() == 0 &&
+                !m_audio_buffers_cv.Wait(stop, [this] { return m_audio_buffers.Size() != 0; })) {
                 break;
-            }
-            if (m_audio_buffers.Size() == 0) {
-                continue;
             }
 
             auto up_frame = AVFramePtr(av_frame_alloc(), &ReleaseAVFrame);
@@ -886,6 +887,7 @@ void AvPlayerSource::AudioDecoderThread(std::stop_token stop) {
     }
 
     LOG_INFO(Lib_AvPlayer, "Audio Decoder Thread exited normally");
+    m_audio_decoder_thread.Join();
 }
 
 bool AvPlayerSource::HasRunningThreads() const {


### PR DESCRIPTION
This PR fixes some deadlock issues I've noticed while looking through our AvPlayer code.

Firstly, I've adjusted the sync logic to actually check if the audio decoder thread is active. In games where video would sync to audio, if the audio decoder stopped producing frames, threads calling sceAvPlayerGetVideoData would no longer pop frames and push buffers, and the video decoder would deadlock. On real hardware, such videos continue to completion.

Secondly, I've stopped the decoders from waiting when there are still valid packets or buffers to decode. I don't think this should happen, but I don't know our AvPlayer code well enough to know for certain.

Finally, if the decoder or demuxer threads were to exit on their own, their Kernel::Thread object would still be marked as Joinable. This means that if the AvPlayer decoding and demuxer threads all exit, sceAvPlayerIsActive would still return true. To fix this, I've made the threads attempt to join with themselves, which sets the actual pthread object to null and resolves the issue.

There's still more deadlock potential in these decoders, but this does partially fix the regression in Batman - Return to Arkham games, where they would hang part-way through videos since the audio decoder exited naturally. Unfortunately, they're still prone to hanging when trying to exit AvPlayer, due to some internal race involving their code for exiting AvPlayer playback.

This PR needs a proper review before merging. I haven't spotted any regressions on my end, but I would like some testers to check other games (perhaps some of the recently regressed ones too?). It would also be a good idea to have a reviewer take a look since this is mostly based on game behavior, not actual decompilation.