### PR TITLE
Render.Recompiler: V_LOG_CLAMP_F32

### DIFF
--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -166,6 +166,8 @@ void Translator::EmitVectorAlu(const GcnInst& inst) {
         return V_FLOOR_F32(inst);
     case Opcode::V_EXP_F32:
         return V_EXP_F32(inst);
+    case Opcode::V_LOG_CLAMP_F32:
+        return V_LOG_F32(inst);
     case Opcode::V_LOG_F32:
         return V_LOG_F32(inst);
     case Opcode::V_RCP_F32:


### PR DESCRIPTION
Like the other clamp ops we've already got, I'm just ignoring the clamp here and using our V_LOG_F32 for this. Let me know if that's not fine.

Should fix a bug in F1® 2021 that @UltraDaCat reported