### PR TITLE
macOS: Enable stack-switching thread helper compilation on ARM64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,9 +363,9 @@ set(KERNEL_LIB src/core/libraries/kernel/coredump/coredump.cpp
                src/core/libraries/kernel/aio.h
 )
 
-if (ARCHITECTURE STREQUAL "x86_64")
+if (ARCHITECTURE STREQUAL "x86_64" OR ARCHITECTURE STREQUAL "arm64")
     list(APPEND KERNEL_LIB src/core/libraries/kernel/threads/stack.S)
-    set_source_files_properties(src/core/libraries/kernel/threads/stack.s PROPERTIES COMPILE_OPTIONS -Wno-unused-command-line-argument)
+    set_source_files_properties(src/core/libraries/kernel/threads/stack.S PROPERTIES COMPILE_OPTIONS -Wno-unused-command-line-argument)
 endif()
 
 set(NETWORK_LIBS src/core/libraries/network/http.cpp

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -12,7 +12,7 @@
 #include "core/libraries/libs.h"
 #include "core/memory.h"
 
-#ifdef ARCH_X86_64
+#if defined(ARCH_X86_64) || defined(__arm64__) || defined(__aarch64__)
 extern "C" void* PS4_SYSV_ABI _runOnAnotherStack(void* arg, void* func,
                                                  void* stackb) asm("_runOnAnotherStack");
 #else

--- a/src/core/libraries/kernel/threads/stack.S
+++ b/src/core/libraries/kernel/threads/stack.S
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+#if defined(__x86_64__)
+
 .global _runOnAnotherStack
 _runOnAnotherStack:
   pushq %r12
@@ -35,3 +37,41 @@ _runOnAnotherStack:
   popq %r13
   popq %r12
   ret
+
+#elif defined(__arm64__) || defined(__aarch64__)
+
+.global _runOnAnotherStack
+_runOnAnotherStack:
+  // Save frame pointer (x29), link register (x30), and callee-saved registers x19, x20
+  stp x29, x30, [sp, #-32]!
+  mov x29, sp
+  stp x19, x20, [sp, #16]
+
+  // Save the current stack pointer into x19 (callee-saved)
+  mov x19, sp
+  // Save the current frame pointer into x20 (callee-saved)
+  mov x20, x29
+
+  // Align the target stack pointer (x2) to 16 bytes (ARM64 constraint)
+  and x2, x2, #-16
+
+  // Switch stack pointer to the new stack (x2)
+  mov sp, x2
+  // Switch frame pointer to the new stack (x2)
+  mov x29, x2
+
+  // Call the function (target address is in x1)
+  // Note: the argument is already in x0!
+  blr x1
+
+  // Restore the old stack pointer and frame pointer
+  mov sp, x19
+  mov x29, x20
+
+  // Restore saved registers and return
+  ldp x19, x20, [sp, #16]
+  ldp x29, x30, [sp], #32
+  ret
+
+#endif
+


### PR DESCRIPTION
### Summary
This PR enables compiling the emulator's native stack-switching assembly thread helper (`stack.S`) on ARM64 architectures (such as Apple Silicon macOS).

### Details
1. **CMake Configuration (`CMakeLists.txt`):**
   * **Problem:** Compiling the emulator on ARM64 macOS would fail because the stack-switching assembly file (`stack.S`) was omitted from the build compilation list (which was hardcoded to `x86_64` architecture only).
   * **Fix:** Updated the architecture check in `CMakeLists.txt` to include `arm64` and append `stack.S` for compilation.

2. **Assembly and Thread Helpers (`pthread.cpp` and `stack.S`):**
   * **Problem:** `pthread.cpp` declares `_runOnAnotherStack` only for `ARCH_X86_64`, which fails to link on ARM64.
   * **Fix:** Added compiler checks for `__arm64__` / `__aarch64__` in `pthread.cpp` and implemented the corresponding ARM64 assembly routine for `_runOnAnotherStack` in `stack.S`.