### PR TITLE
Lib.NpWebApi: Logging fixups

### DIFF
--- a/src/core/libraries/np/np_web_api/np_web_api.cpp
+++ b/src/core/libraries/np/np_web_api/np_web_api.cpp
@@ -170,8 +170,8 @@ s32 PS4_SYSV_ABI sceNpWebApiAbortRequest(s64 requestId) {
 
 s32 PS4_SYSV_ABI sceNpWebApiAddHttpRequestHeader(s64 requestId, const char* pFieldName,
                                                  const char* pValue) {
-    LOG_INFO(Lib_NpWebApi, "called, requestId = {:#x}, pFieldName = '{}', pValue = '{}'",
-             requestId, (pFieldName ? pFieldName : "null"), (pValue ? pValue : "null"));
+    LOG_INFO(Lib_NpWebApi, "called, requestId = {:#x}, pFieldName = '{}', pValue = '{}'", requestId,
+             (pFieldName ? pFieldName : "null"), (pValue ? pValue : "null"));
     if (pFieldName == nullptr || pValue == nullptr)
         return ORBIS_NP_WEBAPI_ERROR_INVALID_ARGUMENT;
     return addHttpRequestHeaderInternal(requestId, pFieldName, pValue);

--- a/src/core/libraries/np/np_web_api/np_web_api.cpp
+++ b/src/core/libraries/np/np_web_api/np_web_api.cpp
@@ -159,18 +159,18 @@ s32 PS4_SYSV_ABI sceNpWebApiUnregisterServicePushEventCallback(s32 titleUserCtxI
 }
 
 s32 PS4_SYSV_ABI sceNpWebApiAbortHandle(s32 libCtxId, s32 handleId) {
-    LOG_INFO(Lib_NpWebApi, "called libCtxId = {:#x}, handleId = {:#x}", libCtxId, handleId);
+    LOG_INFO(Lib_NpWebApi, "called, libCtxId = {:#x}, handleId = {:#x}", libCtxId, handleId);
     return abortHandle(libCtxId, handleId);
 }
 
 s32 PS4_SYSV_ABI sceNpWebApiAbortRequest(s64 requestId) {
-    LOG_INFO(Lib_NpWebApi, "called requestId = {:#x}", requestId);
+    LOG_INFO(Lib_NpWebApi, "called, requestId = {:#x}", requestId);
     return abortRequest(requestId);
 }
 
 s32 PS4_SYSV_ABI sceNpWebApiAddHttpRequestHeader(s64 requestId, const char* pFieldName,
                                                  const char* pValue) {
-    LOG_INFO(Lib_NpWebApi, "called : requestId = {:#x}, pFieldName = '{}', pValue = '{}'",
+    LOG_INFO(Lib_NpWebApi, "called, requestId = {:#x}, pFieldName = '{}', pValue = '{}'",
              requestId, (pFieldName ? pFieldName : "null"), (pValue ? pValue : "null"));
     if (pFieldName == nullptr || pValue == nullptr)
         return ORBIS_NP_WEBAPI_ERROR_INVALID_ARGUMENT;
@@ -180,7 +180,7 @@ s32 PS4_SYSV_ABI sceNpWebApiAddHttpRequestHeader(s64 requestId, const char* pFie
 s32 PS4_SYSV_ABI sceNpWebApiAddMultipartPart(s64 requestId,
                                              const OrbisNpWebApiMultipartPartParameter* pParam,
                                              s32* pIndex) {
-    LOG_INFO(Lib_NpWebApi, "called : requestId = {:#x}, headerNum = {}, contentLength = {}",
+    LOG_INFO(Lib_NpWebApi, "called, requestId = {:#x}, headerNum = {}, contentLength = {}",
              requestId, (pParam ? pParam->headerNum : 0), (pParam ? pParam->contentLength : 0));
     return addMultipartPart(requestId, pParam, pIndex);
 }
@@ -196,7 +196,7 @@ void PS4_SYSV_ABI sceNpWebApiCheckTimeout() {
 s32 PS4_SYSV_ABI sceNpWebApiClearAllUnusedConnection(s32 userCtxId,
                                                      bool bRemainKeepAliveConnection) {
     LOG_ERROR(Lib_NpWebApi,
-              "called (STUBBED) : userCtxId = {:#x}, "
+              "called (STUBBED), userCtxId = {:#x}, "
               "bRemainKeepAliveConnection = {}",
               userCtxId, bRemainKeepAliveConnection);
     return ORBIS_OK;
@@ -205,7 +205,7 @@ s32 PS4_SYSV_ABI sceNpWebApiClearAllUnusedConnection(s32 userCtxId,
 s32 PS4_SYSV_ABI sceNpWebApiClearUnusedConnection(s32 userCtxId, const char* pApiGroup,
                                                   bool bRemainKeepAliveConnection) {
     LOG_ERROR(Lib_NpWebApi,
-              "called (STUBBED) : userCtxId = {:#x}, "
+              "called (STUBBED), userCtxId = {:#x}, "
               "pApiGroup = '{}', bRemainKeepAliveConnection = {}",
               userCtxId, (pApiGroup ? pApiGroup : "null"), bRemainKeepAliveConnection);
     return ORBIS_OK;
@@ -256,7 +256,7 @@ s32 PS4_SYSV_ABI sceNpWebApiCreateMultipartRequest(s32 titleUserCtxId, const cha
     }
 
     LOG_INFO(Lib_NpWebApi,
-             "called titleUserCtxId = {:#x}, pApiGroup = '{}', pPath = '{}', method = {}",
+             "called, titleUserCtxId = {:#x}, pApiGroup = '{}', pPath = '{}', method = {}",
              titleUserCtxId, pApiGroup, pPath, magic_enum::enum_name(method));
 
     return createRequest(titleUserCtxId, pApiGroup, pPath, method, nullptr, nullptr, pRequestId,
@@ -282,7 +282,7 @@ s32 PS4_SYSV_ABI sceNpWebApiCreateRequest(s32 titleUserCtxId, const char* pApiGr
     }
 
     LOG_INFO(Lib_NpWebApi,
-             "called titleUserCtxId = {:#x}, pApiGroup = '{}', pPath = '{}', method = {}",
+             "called, titleUserCtxId = {:#x}, pApiGroup = '{}', pPath = '{}', method = {}",
              titleUserCtxId, pApiGroup, pPath, magic_enum::enum_name(method));
 
     return createRequest(titleUserCtxId, pApiGroup, pPath, method, pContentParameter, nullptr,
@@ -312,7 +312,7 @@ s32 PS4_SYSV_ABI sceNpWebApiDeleteRequest(s64 requestId) {
 s32 PS4_SYSV_ABI sceNpWebApiGetConnectionStats(s32 userCtxId, const char* pApiGroup,
                                                OrbisNpWebApiConnectionStats* pStats) {
     LOG_ERROR(Lib_NpWebApi,
-              "called (STUBBED) : userCtxId = {:#x}, "
+              "called (STUBBED), userCtxId = {:#x}, "
               "pApiGroup = '{}', pStats = {}",
               userCtxId, (pApiGroup ? pApiGroup : "null"), fmt::ptr(pStats));
     return ORBIS_OK;
@@ -320,13 +320,13 @@ s32 PS4_SYSV_ABI sceNpWebApiGetConnectionStats(s32 userCtxId, const char* pApiGr
 
 s32 PS4_SYSV_ABI sceNpWebApiGetErrorCode() {
     const s32 code = getLastWebApiError();
-    LOG_INFO(Lib_NpWebApi, "called : lastErrorCode = {:#x}", code);
+    LOG_INFO(Lib_NpWebApi, "called, lastErrorCode = {:#x}", code);
     return code;
 }
 
 s32 PS4_SYSV_ABI sceNpWebApiGetHttpResponseHeaderValue(s64 requestId, const char* pFieldName,
                                                        char* pValue, u64 valueSize) {
-    LOG_INFO(Lib_NpWebApi, "called : requestId = {:#x}, pFieldName = '{}', valueSize = {}",
+    LOG_INFO(Lib_NpWebApi, "called, requestId = {:#x}, pFieldName = '{}', valueSize = {}",
              requestId, (pFieldName ? pFieldName : "null"), valueSize);
     if (pFieldName == nullptr || pValue == nullptr || valueSize == 0)
         return ORBIS_NP_WEBAPI_ERROR_INVALID_ARGUMENT;
@@ -335,7 +335,7 @@ s32 PS4_SYSV_ABI sceNpWebApiGetHttpResponseHeaderValue(s64 requestId, const char
 
 s32 PS4_SYSV_ABI sceNpWebApiGetHttpResponseHeaderValueLength(s64 requestId, const char* pFieldName,
                                                              u64* pValueLength) {
-    LOG_INFO(Lib_NpWebApi, "called : requestId = {:#x}, pFieldName = '{}'", requestId,
+    LOG_INFO(Lib_NpWebApi, "called, requestId = {:#x}, pFieldName = '{}'", requestId,
              (pFieldName ? pFieldName : "null"));
     if (pFieldName == nullptr || pValueLength == nullptr)
         return ORBIS_NP_WEBAPI_ERROR_INVALID_ARGUMENT;
@@ -343,7 +343,7 @@ s32 PS4_SYSV_ABI sceNpWebApiGetHttpResponseHeaderValueLength(s64 requestId, cons
 }
 
 s32 PS4_SYSV_ABI sceNpWebApiGetHttpStatusCode(s64 requestId, s32* out_status_code) {
-    LOG_INFO(Lib_NpWebApi, "called : requestId = {:#x}", requestId);
+    LOG_INFO(Lib_NpWebApi, "called, requestId = {:#x}", requestId);
     // On newer SDKs, NULL output pointer is invalid
     if (getCompiledSdkVersion() > Common::ElfInfo::FW_100 && out_status_code == nullptr)
         return ORBIS_NP_WEBAPI_ERROR_INVALID_ARGUMENT;
@@ -353,13 +353,13 @@ s32 PS4_SYSV_ABI sceNpWebApiGetHttpStatusCode(s64 requestId, s32* out_status_cod
 
 s32 PS4_SYSV_ABI sceNpWebApiGetMemoryPoolStats(s32 libCtxId,
                                                OrbisNpWebApiMemoryPoolStats* pCurrentStat) {
-    LOG_ERROR(Lib_NpWebApi, "called (STUBBED) : libCtxId = {:#x}, pCurrentStat = {}", libCtxId,
+    LOG_ERROR(Lib_NpWebApi, "called (STUBBED), libCtxId = {:#x}, pCurrentStat = {}", libCtxId,
               fmt::ptr(pCurrentStat));
     return ORBIS_OK;
 }
 
 s32 PS4_SYSV_ABI sceNpWebApiInitialize(s32 libHttpCtxId, u64 poolSize) {
-    LOG_INFO(Lib_NpWebApi, "called libHttpCtxId = {:#x}, poolSize = {:#x} bytes", libHttpCtxId,
+    LOG_INFO(Lib_NpWebApi, "called, libHttpCtxId = {:#x}, poolSize = {:#x} bytes", libHttpCtxId,
              poolSize);
     if (!g_is_initialized) {
         g_is_initialized = true;
@@ -377,7 +377,7 @@ s32 PS4_SYSV_ABI sceNpWebApiInitialize(s32 libHttpCtxId, u64 poolSize) {
 }
 
 s32 PS4_SYSV_ABI sceNpWebApiInitializeForPresence(s32 libHttpCtxId, u64 poolSize) {
-    LOG_INFO(Lib_NpWebApi, "called libHttpCtxId = {:#x}, poolSize = {:#x} bytes", libHttpCtxId,
+    LOG_INFO(Lib_NpWebApi, "called, libHttpCtxId = {:#x}, poolSize = {:#x} bytes", libHttpCtxId,
              poolSize);
     if (!g_is_initialized) {
         g_is_initialized = true;
@@ -423,7 +423,7 @@ s32 PS4_SYSV_ABI sceNpWebApiIntCreateRequest(
     }
 
     LOG_INFO(Lib_NpWebApi,
-             "called titleUserCtxId = {:#x}, pApiGroup = '{}', pPath = '{}', method = {}",
+             "called, titleUserCtxId = {:#x}, pApiGroup = '{}', pPath = '{}', method = {}",
              titleUserCtxId, pApiGroup, pPath, magic_enum::enum_name(method));
 
     return createRequest(titleUserCtxId, pApiGroup, pPath, method, pContentParameter, pInternalArgs,
@@ -490,7 +490,7 @@ s32 PS4_SYSV_ABI sceNpWebApiIntRegisterServicePushEventCallbackA(
 }
 
 s32 PS4_SYSV_ABI sceNpWebApiReadData(s64 requestId, void* pData, u64 size) {
-    LOG_INFO(Lib_NpWebApi, "called : requestId = {:#x}, pData = {}, size = {:#x}", requestId,
+    LOG_INFO(Lib_NpWebApi, "called, requestId = {:#x}, pData = {}, size = {:#x}", requestId,
              fmt::ptr(pData), size);
     if (pData == nullptr || size == 0)
         return ORBIS_NP_WEBAPI_ERROR_INVALID_ARGUMENT;
@@ -557,25 +557,25 @@ s32 PS4_SYSV_ABI sceNpWebApiSetHandleTimeout(s32 libCtxId, s32 handleId, u32 tim
 }
 
 s32 PS4_SYSV_ABI sceNpWebApiSetMaxConnection(s32 libCtxId, s32 maxConnection) {
-    LOG_ERROR(Lib_NpWebApi, "called (STUBBED) : libCtxId = {:#x}, maxConnection = {}", libCtxId,
+    LOG_ERROR(Lib_NpWebApi, "called (STUBBED), libCtxId = {:#x}, maxConnection = {}", libCtxId,
               maxConnection);
     return ORBIS_OK;
 }
 
 s32 PS4_SYSV_ABI sceNpWebApiSetMultipartContentType(s64 requestId, const char* pTypeName,
                                                     const char* pBoundary) {
-    LOG_INFO(Lib_NpWebApi, "called : requestId = {:#x}, pTypeName = '{}', pBoundary = '{}'",
+    LOG_INFO(Lib_NpWebApi, "called, requestId = {:#x}, pTypeName = '{}', pBoundary = '{}'",
              requestId, (pTypeName ? pTypeName : "null"), (pBoundary ? pBoundary : "null"));
     return setMultipartContentType(requestId, pTypeName, pBoundary);
 }
 
 s32 PS4_SYSV_ABI sceNpWebApiSetRequestTimeout(s64 requestId, u32 timeout) {
-    LOG_INFO(Lib_NpWebApi, "called requestId = {:#x}, timeout = {} ms", requestId, timeout);
+    LOG_INFO(Lib_NpWebApi, "called, requestId = {:#x}, timeout = {} ms", requestId, timeout);
     return setRequestTimeout(requestId, timeout);
 }
 
 s32 PS4_SYSV_ABI sceNpWebApiTerminate(s32 libCtxId) {
-    LOG_INFO(Lib_NpWebApi, "called libCtxId = {:#x}", libCtxId);
+    LOG_INFO(Lib_NpWebApi, "called, libCtxId = {:#x}", libCtxId);
     s32 result = terminateContext(libCtxId);
     if (result != ORBIS_OK) {
         return result;
@@ -629,7 +629,7 @@ s32 PS4_SYSV_ABI sceNpWebApiUtilityParseNpId(const char* pJsonNpId,
 }
 
 s32 PS4_SYSV_ABI sceNpWebApiVshInitialize(s32 libHttpCtxId, u64 poolSize) {
-    LOG_INFO(Lib_NpWebApi, "called libHttpCtxId = {:#x}, poolSize = {:#x} bytes", libHttpCtxId,
+    LOG_INFO(Lib_NpWebApi, "called, libHttpCtxId = {:#x}, poolSize = {:#x} bytes", libHttpCtxId,
              poolSize);
     if (!g_is_initialized) {
         g_is_initialized = true;

--- a/src/core/libraries/np/np_web_api/np_web_api_internal.cpp
+++ b/src/core/libraries/np/np_web_api/np_web_api_internal.cpp
@@ -1254,8 +1254,7 @@ s32 createPushEventFilterInternal(OrbisNpWebApiContext* context,
     filter->parentContext = context;
     filter->filterId = filterId;
 
-    LOG_INFO(Lib_NpWebApi, "createPushEventFilter: filterId={} dataTypeParams={}", filterId,
-             filterParamNum);
+    LOG_INFO(Lib_NpWebApi, "filterId={} dataTypeParams={}", filterId, filterParamNum);
     if (pFilterParam != nullptr && filterParamNum != 0) {
         for (u64 param_idx = 0; param_idx < filterParamNum; param_idx++) {
             OrbisNpWebApiPushEventFilterParameter copy = OrbisNpWebApiPushEventFilterParameter{};
@@ -1384,7 +1383,7 @@ s32 createServicePushEventFilterInternal(
 
     if (pNpServiceName != nullptr && !EmulatorSettings.IsShadNetEnabled()) {
         // Seems sceNpManagerIntGetUserList fails?
-        LOG_DEBUG(Lib_NpWebApi, "Cannot create service push event while PSN is disabled");
+        LOG_DEBUG(Lib_NpWebApi, "Cannot create service push event while shadNet is disabled");
         handle->userCount--;
         return ORBIS_NP_WEBAPI_ERROR_SIGNED_IN_USER_NOT_FOUND;
     }
@@ -1403,19 +1402,19 @@ s32 createServicePushEventFilterInternal(
     if (pNpServiceName == nullptr) {
         filter->internal = true;
     } else {
-        // TODO: if pNpServiceName is non-null, create an np request for this filter.
-        LOG_ERROR(Lib_NpWebApi, "Np behavior not handled");
         filter->npServiceName = std::string(pNpServiceName);
     }
 
     filter->npServiceLabel = npServiceLabel;
-
+    LOG_INFO(Lib_NpWebApi, "filterId={} dataTypeParams={}", filterId, filterParamNum);
     if (pFilterParam != nullptr && filterParamNum != 0) {
         for (u64 param_idx = 0; param_idx < filterParamNum; param_idx++) {
             OrbisNpWebApiServicePushEventFilterParameter copy =
                 OrbisNpWebApiServicePushEventFilterParameter{};
             memcpy(&copy, &pFilterParam[param_idx],
                    sizeof(OrbisNpWebApiServicePushEventFilterParameter));
+            LOG_INFO(Lib_NpWebApi, "  filterParam[{}] data_type='{}'", param_idx,
+                     copy.dataType.val);
             filter->filterParams.emplace_back(copy);
         }
     }
@@ -1561,7 +1560,7 @@ s32 createExtendedPushEventFilterInternal(
 
     if (pNpServiceName != nullptr && !EmulatorSettings.IsShadNetEnabled()) {
         // Seems sceNpManagerIntGetUserList fails?
-        LOG_DEBUG(Lib_NpWebApi, "Cannot create extended push event while PSN is disabled");
+        LOG_DEBUG(Lib_NpWebApi, "Cannot create extended push event while shadNet is disabled");
         handle->userCount--;
         return ORBIS_NP_WEBAPI_ERROR_SIGNED_IN_USER_NOT_FOUND;
     }
@@ -1581,16 +1580,13 @@ s32 createExtendedPushEventFilterInternal(
     if (pNpServiceName == nullptr) {
         npServiceLabel = ORBIS_NP_INVALID_SERVICE_LABEL;
     } else {
-        // TODO: if pNpServiceName is non-null, create an np request for this filter.
-        LOG_ERROR(Lib_NpWebApi, "Np behavior not handled");
         filter->npServiceName = std::string(pNpServiceName);
     }
 
     filter->npServiceLabel = npServiceLabel;
 
-    LOG_INFO(Lib_NpWebApi,
-             "createExtdPushEventFilter: filterId={} service='{}' label={:#x} dataTypeParams={}",
-             filterId, pNpServiceName ? pNpServiceName : "null", npServiceLabel, filterParamNum);
+    LOG_INFO(Lib_NpWebApi, "filterId={} service='{}' label={:#x} dataTypeParams={}", filterId,
+             pNpServiceName ? pNpServiceName : "null", npServiceLabel, filterParamNum);
     if (pFilterParam != nullptr && filterParamNum != 0) {
         for (u64 param_idx = 0; param_idx < filterParamNum; param_idx++) {
             OrbisNpWebApiExtdPushEventFilterParameter copy =

--- a/src/core/libraries/np/np_web_api/np_web_api_internal.cpp
+++ b/src/core/libraries/np/np_web_api/np_web_api_internal.cpp
@@ -784,7 +784,7 @@ s32 sendRequest(s64 requestId, s32 partIndex, const void* pData, u64 dataSize, s
         const s32 tmpl_id = Libraries::Http::sceHttpCreateTemplate(
             context->libHttpCtxId, "libhttp", /*httpVer=*/2, /*isAutoProxyConf=*/0);
         if (tmpl_id < 0) {
-            LOG_ERROR(Lib_NpWebApi, "sendRequest: sceHttpCreateTemplate failed: {:#x}", tmpl_id);
+            LOG_ERROR(Lib_NpWebApi, "sceHttpCreateTemplate failed: {:#x}", tmpl_id);
             releaseRequest(request);
             releaseUserContext(user_context);
             releaseContext(context);
@@ -794,8 +794,7 @@ s32 sendRequest(s64 requestId, s32 partIndex, const void* pData, u64 dataSize, s
         const int conn_id = Libraries::Http::sceHttpCreateConnectionWithURL(
             tmpl_id, base_url.c_str(), /*enableKeepalive=*/true);
         if (conn_id < 0) {
-            LOG_ERROR(Lib_NpWebApi, "sendRequest: sceHttpCreateConnectionWithURL failed: {:#x}",
-                      conn_id);
+            LOG_ERROR(Lib_NpWebApi, "sceHttpCreateConnectionWithURL failed: {:#x}", conn_id);
             Libraries::Http::sceHttpDeleteTemplate(tmpl_id);
             request->http_template_id = 0;
             releaseRequest(request);
@@ -829,7 +828,7 @@ s32 sendRequest(s64 requestId, s32 partIndex, const void* pData, u64 dataSize, s
             sceMethod = 8; // out-of-band PATCH marker recognised by libhttp
             break;
         default:
-            LOG_ERROR(Lib_NpWebApi, "sendRequest: unknown method enum value {}",
+            LOG_ERROR(Lib_NpWebApi, "unknown method enum value {}",
                       static_cast<int>(request->userMethod));
             releaseRequest(request);
             releaseUserContext(user_context);
@@ -840,8 +839,7 @@ s32 sendRequest(s64 requestId, s32 partIndex, const void* pData, u64 dataSize, s
         const int req_id = Libraries::Http::sceHttpCreateRequestWithURL(
             conn_id, sceMethod, full_url.c_str(), request->userContentLength);
         if (req_id < 0) {
-            LOG_ERROR(Lib_NpWebApi, "sendRequest: sceHttpCreateRequestWithURL failed: {:#x}",
-                      req_id);
+            LOG_ERROR(Lib_NpWebApi, "sceHttpCreateRequestWithURL failed: {:#x}", req_id);
             Libraries::Http::sceHttpDeleteConnection(conn_id);
             request->http_connection_id = 0;
             Libraries::Http::sceHttpDeleteTemplate(tmpl_id);
@@ -868,7 +866,7 @@ s32 sendRequest(s64 requestId, s32 partIndex, const void* pData, u64 dataSize, s
                                                      /*mode=*/0);
         } else {
             LOG_WARNING(Lib_NpWebApi,
-                        "sendRequest: no bearer token for user_id={}; request to '{}' will "
+                        "no bearer token for user_id={}; request to '{}' will "
                         "be unauthenticated (expect 401 from server)",
                         user_context->userId, request->userPath);
         }
@@ -907,15 +905,14 @@ s32 sendRequest(s64 requestId, s32 partIndex, const void* pData, u64 dataSize, s
     const s32 send_err =
         Libraries::Http::sceHttpSendRequest(request->http_request_id, sendData, sendSize);
     if (send_err < 0) {
-        LOG_ERROR(Lib_NpWebApi, "sendRequest: sceHttpSendRequest failed: {:#x}", send_err);
+        LOG_ERROR(Lib_NpWebApi, "sceHttpSendRequest failed: {:#x}", send_err);
         releaseRequest(request);
         releaseUserContext(user_context);
         releaseContext(context);
         return send_err;
     }
 
-    LOG_INFO(Lib_NpWebApi,
-             "sendRequest OK requestId={:#x} apiGroup='{}' path='{}' method={} httpReqId={}",
+    LOG_INFO(Lib_NpWebApi, "requestId={:#x} apiGroup='{}' path='{}' method={} httpReqId={}",
              requestId, request->userApiGroup, request->userPath,
              magic_enum::enum_name(request->userMethod), request->http_request_id);
 
@@ -2045,7 +2042,7 @@ s32 PS4_SYSV_ABI readDataInternal(s64 requestId, void* pData, u64 size) {
     }
 
     if (result > 0) {
-        LOG_INFO(Lib_NpWebApi, "readData reqId={:#x} -> {} bytes: {:.256s}", requestId, result,
+        LOG_INFO(Lib_NpWebApi, "reqId={:#x} -> {} bytes: {:.256s}", requestId, result,
                  std::string(reinterpret_cast<const char*>(pData),
                              std::min<u64>(result, 256))); // debug to be removed
     }
@@ -2182,8 +2179,7 @@ void DrainPushEvents() {
                         exarr.empty() ? nullptr : exarr.data();
 
                     LOG_INFO(
-                        Lib_NpWebApi,
-                        "DrainPushEvents: invoking extd cb ctx={:#x} cbId={} dataType='{}'",
+                        Lib_NpWebApi, "invoking extd cb ctx={:#x} cbId={} dataType='{}'",
                         title_user_ctx_id, cbId,
                         ev.dataType); // debug confirm the listener callback fires. to be removed
                     reinterpret_cast<ExtdCbA>(raw)(
@@ -2234,7 +2230,7 @@ void DrainPushEvents() {
                             continue;
                         }
                         LOG_INFO(Lib_NpWebApi,
-                                 "DrainPushEvents: invoking basic cb ctx={:#x} cbId={} "
+                                 "invoking basic cb ctx={:#x} cbId={} "
                                  "dataType='{}'",
                                  title_user_ctx_id, cbId,
                                  ev.dataType); // debug confirm the listener callback fires. to be


### PR DESCRIPTION
Updates logs for sceNpWebApiCreateServicePushEventFilter and sceNpWebApiCreateExtdPushEventFilter to remove references to PSN, remove outdated error messages, and log filter parameters. Also touched up other log messages to make them more consistent with code I wrote.