### PR TITLE
camera: fix regression in low firmware games

### DIFF
--- a/src/core/libraries/camera/camera.cpp
+++ b/src/core/libraries/camera/camera.cpp
@@ -461,9 +461,14 @@ s32 PS4_SYSV_ABI sceCameraGetFrameData(s32 handle, OrbisCameraFrameData* frame_d
     }
     frame_data->meta.format[0][0] = output_config0.format.formatLevel0;
     frame_data->meta.format[1][0] = output_config1.format.formatLevel0;
-    // not fully correct, but good enough
-    frame_data->pFramePointerListGarlic[0][0] = frame_data->pFramePointerList[0][0];
-    frame_data->pFramePointerListGarlic[1][0] = frame_data->pFramePointerList[1][0];
+
+    // on older firmwares, this wasn't present, and the original library also checks struct size
+    // instead of the SDK version, and without this check, we'd smash the stack in those games
+    if (frame_data->sizeThis == 584) {
+        // not fully correct, but good enough
+        frame_data->pFramePointerListGarlic[0][0] = frame_data->pFramePointerList[0][0];
+        frame_data->pFramePointerListGarlic[1][0] = frame_data->pFramePointerList[1][0];
+    }
     return ORBIS_OK;
 }
 


### PR DESCRIPTION
I was accidentally smashing the stack in Tearaway Unfolded with my last camera PR, due to Sony changing struct layouts in later SDKs.