### PR TITLE
feat(macOS): add Vulkan host diagnostics command

### DIFF
--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -1,10 +1,13 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <optional>
+
 #include <boost/container/static_vector.hpp>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
+#include "common/arch.h"
 #include "common/assert.h"
 #include "common/debug.h"
 #include "common/types.h"
@@ -15,6 +18,10 @@
 #include "video_core/renderer_vulkan/vk_platform.h"
 
 #include <vk_mem_alloc.h>
+
+#ifdef __APPLE__
+#include <sys/sysctl.h>
+#endif
 
 namespace Vulkan {
 
@@ -85,6 +92,71 @@ std::string GetReadableVersion(u32 version) {
     return fmt::format("{}.{}.{}", VK_VERSION_MAJOR(version), VK_VERSION_MINOR(version),
                        VK_VERSION_PATCH(version));
 }
+
+#ifdef __APPLE__
+std::string ProcessArchitecture() {
+#if defined(ARCH_ARM64)
+    return "arm64";
+#elif defined(ARCH_X86_64)
+    return "x86_64";
+#else
+    return "unknown";
+#endif
+}
+
+std::optional<std::string> GetSysctlString(const char* name) {
+    size_t size = 0;
+    if (sysctlbyname(name, nullptr, &size, nullptr, 0) != 0 || size == 0) {
+        return std::nullopt;
+    }
+
+    std::string value(size, '\0');
+    if (sysctlbyname(name, value.data(), &size, nullptr, 0) != 0) {
+        return std::nullopt;
+    }
+
+    if (!value.empty() && value.back() == '\0') {
+        value.pop_back();
+    }
+    return value;
+}
+
+std::optional<int> GetSysctlInt(const char* name) {
+    int value = 0;
+    size_t size = sizeof(value);
+    if (sysctlbyname(name, &value, &size, nullptr, 0) != 0) {
+        return std::nullopt;
+    }
+    return value;
+}
+
+std::string HostArchitecture() {
+    if (const auto arm64 = GetSysctlInt("hw.optional.arm64"); arm64.value_or(0) == 1) {
+        return "arm64";
+    }
+    return GetSysctlString("hw.machine").value_or("unknown");
+}
+
+std::string OperatingSystemVersion() {
+    const auto product_version = GetSysctlString("kern.osproductversion");
+    const auto build_version = GetSysctlString("kern.osversion");
+
+    if (product_version && build_version) {
+        return fmt::format("macOS {} ({})", *product_version, *build_version);
+    }
+    if (product_version) {
+        return fmt::format("macOS {}", *product_version);
+    }
+    return "macOS";
+}
+
+std::string RosettaTranslated() {
+    if (const auto translated = GetSysctlInt("sysctl.proc_translated")) {
+        return *translated == 1 ? "Yes" : "No";
+    }
+    return "Unknown";
+}
+#endif
 
 } // Anonymous namespace
 
@@ -636,6 +708,12 @@ void Instance::CollectDeviceParameters() {
     const std::string api_version = GetReadableVersion(properties.apiVersion);
     const std::string extensions = fmt::format("{}", fmt::join(available_extensions, ", "));
 
+#ifdef __APPLE__
+    LOG_INFO(Render_Vulkan, "Host_OS: {}", OperatingSystemVersion());
+    LOG_INFO(Render_Vulkan, "Host_Arch: {}", HostArchitecture());
+    LOG_INFO(Render_Vulkan, "Process_Arch: {}", ProcessArchitecture());
+    LOG_INFO(Render_Vulkan, "Rosetta_Translated: {}", RosettaTranslated());
+#endif
     LOG_INFO(Render_Vulkan, "GPU_Vendor: {}", vendor_name);
     LOG_INFO(Render_Vulkan, "GPU_Model: {}", model_name);
     LOG_INFO(Render_Vulkan, "GPU_Integrated: {}", IsIntegrated() ? "Yes" : "No");


### PR DESCRIPTION
## Summary

Adds a CLI command that prints Vulkan host/device diagnostics without launching a game:

```sh
shadps4 --dump-vulkan-info
```

This creates a headless Vulkan instance, enumerates host physical devices, prints macOS/process
architecture info, reports Rosetta status, and dumps Vulkan device properties, memory info,
selected portability-related extensions, and shadPS4-relevant feature support.

This is intended to support Apple Silicon / future native Metal work by making host GPU capability
reports reproducible before larger renderer-backend changes. It complements the renderer backend
abstraction RFC/PR work in
[#4149](https://github.com/shadps4-emu/shadPS4/pull/4149) and
[#4160](https://github.com/shadps4-emu/shadPS4/pull/4160) by giving contributors a convenient way
to compare host Vulkan/KosmicKrisp/MoltenVK data across Apple Silicon machines.

I’m also interested in contributing more Apple Silicon / Metal-related work. My background is in low-level systems work, and I’ve seen firsthand how much better a native Metal renderer can perform on macOS compared with Vulkan translation layers in projects like PCSX2.

## Example output

Captured on native arm64 macOS with KosmicKrisp:

```text
$ ./shadps4 --dump-vulkan-info
shadPS4 Vulkan host diagnostics
Host:
  os: macOS 26.1 (25B78)
  host_arch: arm64
  process_arch: arm64
  rosetta_translated: false
Vulkan:
  device_count: 1
  selected_device_index: 0
  device[0]:
    selected: true
    device_name: Apple M3 Pro
    vendor_name: KosmicKrisp
    vendor_id: 0x106b
    device_id: 0x64
    device_type: IntegratedGpu
    driver_id: MesaKosmickrisp
    driver_version: 26.1.99
    api_version: 1.3.353
    subgroup_size: 32
    max_compute_shared_memory_size: 32768
    max_sampler_anisotropy: 16
    portability_extensions:
      VK_EXT_memory_budget: true
      VK_KHR_swapchain: true
      VK_KHR_push_descriptor: true
      VK_EXT_depth_clip_control: true
      VK_EXT_shader_atomic_float: true
      VK_EXT_image_2d_view_of_3d: true
      VK_EXT_attachment_feedback_loop_layout: true
    feature_support:
      geometryShader: false
      tessellationShader: true
      samplerAnisotropy: true
      shaderInt64: true
      shaderFloat16: true
      subgroupSizeControl: true
      synchronization2: true
      dynamicRendering: true
      timelineSemaphore: true
```

Captured under Rosetta/x86_64 on the same Apple Silicon host:

```text
Host:
  os: macOS 26.1 (25B78)
  host_arch: arm64
  process_arch: x86_64
  rosetta_translated: true
Vulkan:
  device_count: 1
  selected_device_index: 0
  device[0]:
    device_name: Apple M3 Pro
    vendor_name: KosmicKrisp
    driver_id: MesaKosmickrisp
    api_version: 1.3.353
```

## Validation

- Built native arm64 Release on macOS.
- Built x86_64/Rosetta Release on macOS.
- Ran `shadps4 --dump-vulkan-info` for both architectures.
- Confirmed both runs exit successfully without game files.
- Confirmed output includes host architecture, process architecture, Rosetta status, Vulkan device
  count, selected device index, device properties, portability-related extensions, and feature
  support.