### PR TITLE
Render.Vulkan: Avoid storing texture_cache image download lambda as a local variable

### DIFF
--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -124,16 +124,16 @@ void TextureCache::DownloadImageMemory(ImageId image_id, bool sync) {
     cmdbuf.copyImageToBuffer(image.GetImage(), vk::ImageLayout::eTransferSrcOptimal,
                              download_buffer.Handle(), image_download);
 
-    const auto write_data = [this, device_addr = image.info.guest_address, download,
-                             download_size] {
-        Core::Memory::Instance()->TryWriteBacking(std::bit_cast<u8*>(device_addr), download,
-                                                  download_size);
-    };
     if (sync) {
         scheduler.Finish();
-        write_data();
+        Core::Memory::Instance()->TryWriteBacking(std::bit_cast<u8*>(image.info.guest_address),
+                                                  download, download_size);
     } else {
-        scheduler.DeferPriorityOperation(write_data);
+        scheduler.DeferPriorityOperation(
+            [this, device_addr = image.info.guest_address, download, download_size] {
+                Core::Memory::Instance()->TryWriteBacking(std::bit_cast<u8*>(device_addr), download,
+                                                          download_size);
+            });
     }
 }
 


### PR DESCRIPTION
Parameters to the TryWriteBacking call were getting corrupted during async texture downloads after #4593

Reported by Discord user Andersson799 in the official Discord server.