### PR TITLE
Fix flaky GCN tests

### DIFF
--- a/tests/gcn/gcn_test_runner.cpp
+++ b/tests/gcn/gcn_test_runner.cpp
@@ -136,6 +136,11 @@ std::expected<Runner*, ErrorInfo> Runner::instance() {
     return g_runner.get();
 }
 
+void Runner::DestroyInstance() {
+    std::lock_guard lock{g_runner_mutex};
+    g_runner.reset();
+}
+
 std::expected<void, ErrorInfo> Runner::initialize() {
     VULKAN_HPP_DEFAULT_DISPATCHER.init();
 
@@ -223,6 +228,7 @@ std::expected<void, ErrorInfo> Runner::initialize() {
     vk::PhysicalDeviceVulkan12Features v12_feat{
         .pNext = &v11_feat,
         .uniformAndStorageBuffer8BitAccess = VK_TRUE,
+        .shaderFloat16 = VK_TRUE,
         .shaderInt8 = VK_TRUE,
     };
     vk::PhysicalDeviceFeatures phys_feat{

--- a/tests/gcn/gcn_test_runner.hpp
+++ b/tests/gcn/gcn_test_runner.hpp
@@ -42,6 +42,7 @@ struct ErrorInfo {
 class Runner {
 public:
     static std::expected<Runner*, ErrorInfo> instance();
+    static void DestroyInstance();
 
     std::expected<void, ErrorInfo> run_raw(
         std::span<const std::uint32_t> spirv,

--- a/tests/gcn/instructions.hpp
+++ b/tests/gcn/instructions.hpp
@@ -1266,7 +1266,7 @@ private:
         u64 src2 : 9;
         u64 omod : 2;
         u64 neg : 3;
-    } i;
+    } i{};
 
     static_assert(sizeof(VOP3Internal) == sizeof(u64));
 };
@@ -1345,7 +1345,7 @@ private:
         u64 src2 : 9;
         u64 op_sel_hi01 : 2;
         u64 neg : 3;
-    } i;
+    } i{};
 
     static_assert(sizeof(VOP3PInternal) == sizeof(u64));
 };

--- a/tests/gcn/test_gcn_instructions.cpp
+++ b/tests/gcn/test_gcn_instructions.cpp
@@ -15,6 +15,10 @@ protected:
     void SetUp() override {}
 
     void TearDown() override {}
+
+    static void TearDownTestSuite() {
+        gcn_test::Runner::DestroyInstance();
+    }
 };
 
 struct F32x2 {


### PR DESCRIPTION
The GCN tests would sometimes pass on Windows with Visual Studio 2022 but consistently failed on Linux.

On Linux, a segfault during teardown caused CTest to report every GCN test as failed. After fixing the segfault, some tests were still flaky because the generated instructions depended on uninitialized values in memory.

This PR explicitly destroys the GCN test runner during test suite teardown and initializes the instruction fields so the generated encodings are deterministic everywhere.

Tested on:
- Ubuntu 25.10, NVIDIA GTX 1650 / driver 595.71.05
- Ubuntu 25.10 with llvmpipe
- Windows 11 with Visual Studio 2022