### PR TITLE
[Core] Add configurable PS4 HDD timing for /app0 reads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -867,6 +867,8 @@ set(CORE src/core/aerolib/stubs.cpp
          src/core/file_sys/directories/normal_directory.h
          src/core/file_sys/directories/pfs_directory.cpp
          src/core/file_sys/directories/pfs_directory.h
+         src/core/file_sys/storage_scheduler.cpp
+         src/core/file_sys/storage_scheduler.h
          src/core/file_format/pfs.h
          src/core/file_format/psf.cpp
          src/core/file_format/psf.h

--- a/src/core/emulator_settings.h
+++ b/src/core/emulator_settings.h
@@ -188,6 +188,8 @@ struct GeneralSettings {
     Setting<bool> neo_mode{false};
     Setting<bool> dev_kit_mode{false};
     Setting<int> extra_dmem_in_mbytes{0};
+    Setting<u32> app0_read_bandwidth_mibps{0};
+    Setting<bool> app0_read_disable_time_stretching{false};
     Setting<bool> shad_net_enabled{false};
     Setting<bool> trophy_popup_disabled{false};
     Setting<double> trophy_notification_duration{6.0};
@@ -211,6 +213,10 @@ struct GeneralSettings {
             make_override<GeneralSettings>("dev_kit_mode", &GeneralSettings::dev_kit_mode),
             make_override<GeneralSettings>("extra_dmem_in_mbytes",
                                            &GeneralSettings::extra_dmem_in_mbytes),
+            make_override<GeneralSettings>("app0_read_bandwidth_mibps",
+                                           &GeneralSettings::app0_read_bandwidth_mibps),
+            make_override<GeneralSettings>("app0_read_disable_time_stretching",
+                                           &GeneralSettings::app0_read_disable_time_stretching),
             make_override<GeneralSettings>("shad_net_enabled", &GeneralSettings::shad_net_enabled),
             make_override<GeneralSettings>("trophy_popup_disabled",
                                            &GeneralSettings::trophy_popup_disabled),
@@ -231,8 +237,9 @@ struct GeneralSettings {
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(GeneralSettings, install_dirs, addon_install_dir, home_dir,
                                    sys_modules_dir, font_dir, volume_slider, neo_mode, dev_kit_mode,
-                                   extra_dmem_in_mbytes, shad_net_enabled, trophy_popup_disabled,
-                                   trophy_notification_duration, show_splash,
+                                   extra_dmem_in_mbytes, app0_read_bandwidth_mibps,
+                                   app0_read_disable_time_stretching, shad_net_enabled,
+                                   trophy_popup_disabled, trophy_notification_duration, show_splash,
                                    trophy_notification_side, connected_to_network,
                                    discord_rpc_enabled, show_fps_counter, console_language,
                                    big_picture_scale, shadnet_server, shadnet_webapi_server,
@@ -622,6 +629,9 @@ public:
     SETTING_FORWARD_BOOL(m_general, Neo, neo_mode)
     SETTING_FORWARD_BOOL(m_general, DevKit, dev_kit_mode)
     SETTING_FORWARD(m_general, ExtraDmemInMBytes, extra_dmem_in_mbytes)
+    SETTING_FORWARD(m_general, App0ReadBandwidthMiBps, app0_read_bandwidth_mibps)
+    SETTING_FORWARD_BOOL(m_general, App0ReadDisableTimeStretching,
+                         app0_read_disable_time_stretching)
     bool IsShadNetEnabled() const {
         return m_general.shad_net_enabled.get(m_configMode) &&
                !m_shadnet_session_disabled.load(std::memory_order_relaxed);

--- a/src/core/file_sys/fs.cpp
+++ b/src/core/file_sys/fs.cpp
@@ -536,7 +536,7 @@ std::optional<std::vector<u8>> MntPoints::ReadFile(std::string_view guest_path) 
 int HandleTable::CreateHandle() {
     std::scoped_lock lock{m_mutex};
 
-    auto* file = new File{};
+    auto file = std::make_shared<File>();
     file->is_opened = false;
 
     int existingFilesNum = m_files.size();
@@ -552,64 +552,74 @@ int HandleTable::CreateHandle() {
     return m_files.size() - 1;
 }
 
-void HandleTable::DeleteHandle(int d) {
+s64 File::PRead(void* buffer, u64 nbytes, u64 offset) {
     std::scoped_lock lock{m_mutex};
-    delete m_files.at(d);
-    m_files[d] = nullptr;
+    if (!IsBackendOpen()) {
+        return -1;
+    }
+    const s64 original_position = Tell();
+    if (original_position < 0 || !Seek(static_cast<s64>(offset))) {
+        return -1;
+    }
+    const s64 result = Read(buffer, nbytes);
+    Seek(original_position);
+    return result;
+}
+
+s64 File::PWrite(const void* buffer, u64 nbytes, u64 offset) {
+    std::scoped_lock lock{m_mutex};
+    if (!IsBackendOpen()) {
+        return -1;
+    }
+    const s64 original_position = Tell();
+    if (original_position < 0 || !Seek(static_cast<s64>(offset))) {
+        return -1;
+    }
+    const s64 result = Write(buffer, nbytes);
+    Seek(original_position);
+    return result;
+}
+
+std::shared_ptr<File> HandleTable::DeleteHandle(int d) {
+    std::scoped_lock lock{m_mutex};
+    if (d < 0 || d >= m_files.size()) {
+        return {};
+    }
+    return std::move(m_files[d]);
+}
+
+std::shared_ptr<File> HandleTable::GetFileShared(int d) {
+    std::scoped_lock lock{m_mutex};
+    if (d < 0 || d >= m_files.size()) {
+        return {};
+    }
+    return m_files[d];
 }
 
 File* HandleTable::GetFile(int d) {
-    std::scoped_lock lock{m_mutex};
-    if (d < 0 || d >= m_files.size()) {
-        return nullptr;
-    }
-    return m_files.at(d);
+    return GetFileShared(d).get();
 }
 
 File* HandleTable::GetSocket(int d) {
-    std::scoped_lock lock{m_mutex};
-    if (d < 0 || d >= m_files.size()) {
-        return nullptr;
-    }
-    auto file = m_files.at(d);
-    if (!file) {
-        return nullptr;
-    }
-    if (file->type != Core::FileSys::FileType::Socket) {
-        return nullptr;
-    }
-    return file;
+    auto* file = GetFile(d);
+    return file && file->type == FileType::Socket ? file : nullptr;
 }
 
 File* HandleTable::GetEpoll(int d) {
-    std::scoped_lock lock{m_mutex};
-    if (d < 0 || d >= m_files.size()) {
-        return nullptr;
-    }
-    auto file = m_files.at(d);
-    if (file->type != Core::FileSys::FileType::Epoll) {
-        return nullptr;
-    }
-    return file;
+    auto* file = GetFile(d);
+    return file && file->type == FileType::Epoll ? file : nullptr;
 }
 
 File* HandleTable::GetResolver(int d) {
-    std::scoped_lock lock{m_mutex};
-    if (d < 0 || d >= m_files.size()) {
-        return nullptr;
-    }
-    auto file = m_files.at(d);
-    if (file->type != Core::FileSys::FileType::Resolver) {
-        return nullptr;
-    }
-    return file;
+    auto* file = GetFile(d);
+    return file && file->type == FileType::Resolver ? file : nullptr;
 }
 
 File* HandleTable::GetFile(const std::filesystem::path& host_name) {
     std::scoped_lock lock{m_mutex};
-    for (auto* file : m_files) {
+    for (const auto& file : m_files) {
         if (file != nullptr && file->m_host_name == host_name) {
-            return file;
+            return file.get();
         }
     }
     return nullptr;
@@ -633,10 +643,11 @@ void HandleTable::CreateStdHandles() {
 
 int HandleTable::GetFileDescriptor(File* file) {
     std::scoped_lock lock{m_mutex};
-    auto it = std::find(m_files.begin(), m_files.end(), file);
+    const auto raw_it =
+        std::ranges::find_if(m_files, [file](const auto& entry) { return entry.get() == file; });
 
-    if (it != m_files.end()) {
-        return std::distance(m_files.begin(), it);
+    if (raw_it != m_files.end()) {
+        return std::distance(m_files.begin(), raw_it);
     }
     return 0;
 }

--- a/src/core/file_sys/fs.h
+++ b/src/core/file_sys/fs.h
@@ -182,6 +182,10 @@ struct File {
     Common::FS::IOFile* GetHostFile() const {
         return handle ? handle->GetHostFile() : nullptr;
     }
+
+    // Positional I/O preserving the current file offset; locks m_mutex internally.
+    s64 PRead(void* buffer, u64 nbytes, u64 offset);
+    s64 PWrite(const void* buffer, u64 nbytes, u64 offset);
 };
 
 class HandleTable {
@@ -190,7 +194,10 @@ public:
     virtual ~HandleTable() = default;
 
     int CreateHandle();
-    void DeleteHandle(int d);
+    std::shared_ptr<File> DeleteHandle(int d);
+    std::shared_ptr<File> GetFileShared(int d);
+    // Raw access does not extend the file's lifetime. New asynchronous callers must use
+    // GetFileShared instead.
     File* GetFile(int d);
     File* GetSocket(int d);
     File* GetEpoll(int d);
@@ -201,7 +208,7 @@ public:
     void CreateStdHandles();
 
 private:
-    std::vector<File*> m_files;
+    std::vector<std::shared_ptr<File>> m_files;
     std::mutex m_mutex;
 };
 

--- a/src/core/file_sys/storage_scheduler.cpp
+++ b/src/core/file_sys/storage_scheduler.cpp
@@ -1,0 +1,264 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <algorithm>
+#include <chrono>
+#include <condition_variable>
+#include <cstring>
+#include <deque>
+#include <mutex>
+#include <semaphore>
+#include <thread>
+#include <utility>
+
+#include "common/logging/log.h"
+#include "common/thread.h"
+#include "core/file_sys/fs.h"
+#include "core/file_sys/storage_scheduler.h"
+#include "core/memory.h"
+
+namespace Core::FileSys {
+namespace {
+
+using Clock = std::chrono::steady_clock;
+using Nanoseconds = std::chrono::nanoseconds;
+
+Nanoseconds TransferDuration(StorageSchedulerConfig config, u64 bytes, u32 slowdown_percent) {
+    if (!config.IsEnabled() || bytes == 0) {
+        return {};
+    }
+    const u64 bytes_per_second = static_cast<u64>(config.bandwidth_mibps) * 1024ULL * 1024ULL;
+    const auto duration =
+        std::chrono::seconds{bytes / bytes_per_second} +
+        Nanoseconds{bytes % bytes_per_second * 1'000'000'000ULL / bytes_per_second};
+    return duration * slowdown_percent / 100;
+}
+
+} // namespace
+
+struct StorageScheduler::Impl {
+    struct Pending final : StorageRequest {
+        std::shared_ptr<File> file;
+        StorageReadSpans spans;
+        u64 offset{};
+        u64 requested{};
+        StorageCompletion completion;
+    };
+
+    ~Impl() {
+        worker.request_stop();
+        cv.notify_all();
+    }
+
+    Clock::time_point ScheduleTransfer(u64 bytes, StorageSchedulerConfig current_config) {
+        const auto now = Clock::now();
+        const u32 slowdown = current_config.disable_time_stretching
+                                 ? 100
+                                 : slowdown_percent.load(std::memory_order_relaxed);
+        transfer_cursor = std::max(transfer_cursor, now - BurstDuration);
+        transfer_cursor += TransferDuration(current_config, bytes, slowdown);
+        return transfer_cursor;
+    }
+
+    static void Publish(const Pending& pending, std::span<const u8> data) {
+        u64 source_offset{};
+        for (const auto& span : pending.spans) {
+            const u64 copy_size = std::min<u64>(span.size, data.size() - source_offset);
+            if (copy_size == 0) {
+                break;
+            }
+            Core::Memory::Instance()->InvalidateMemory(reinterpret_cast<VAddr>(span.data),
+                                                       copy_size);
+            std::memcpy(span.data, data.data() + source_offset, copy_size);
+            source_offset += copy_size;
+        }
+    }
+
+    static void Complete(Pending& pending, s64 result, bool canceled) {
+        if (auto completion = std::move(pending.completion)) {
+            completion(result, canceled);
+        }
+    }
+
+    void Run(std::stop_token stop_token) {
+        Common::SetCurrentThreadName("shadPS4:Hdd");
+        std::vector<u8> staging;
+        while (!stop_token.stop_requested()) {
+            std::shared_ptr<Pending> pending;
+            {
+                std::unique_lock lock{mutex};
+                cv.wait(lock, [&] { return stop_token.stop_requested() || !queue.empty(); });
+                if (stop_token.stop_requested()) {
+                    break;
+                }
+                // FIOS2 already scheduled its chunks; preserve that submission order.
+                pending = std::move(queue.front());
+                queue.pop_front();
+            }
+
+            if (!pending->Start()) {
+                Complete(*pending, -1, true);
+                continue;
+            }
+
+            Clock::time_point deadline;
+            {
+                std::scoped_lock lock{mutex};
+                const auto current_config = config.load(std::memory_order_acquire);
+                deadline = ScheduleTransfer(pending->requested, current_config);
+            }
+
+            staging.resize(pending->requested);
+            const s64 result =
+                pending->file->PRead(staging.data(), staging.size(), pending->offset);
+            const size_t read = result > 0 ? static_cast<size_t>(result) : 0;
+            {
+                std::unique_lock lock{mutex};
+                cv.wait_until(lock, deadline, [&] { return stop_token.stop_requested(); });
+            }
+            if (stop_token.stop_requested()) {
+                Complete(*pending, -1, true);
+                break;
+            }
+
+            if (result >= 0) {
+                Publish(*pending, std::span<const u8>{staging.data(), read});
+            }
+            Complete(*pending, result, false);
+        }
+
+        std::deque<std::shared_ptr<Pending>> canceled;
+        {
+            std::scoped_lock lock{mutex};
+            canceled.swap(queue);
+        }
+        for (auto& pending : canceled) {
+            Complete(*pending, -1, true);
+        }
+    }
+
+    void ReportGuestFlip(Nanoseconds expected_period) {
+        const auto now = Clock::now();
+        if (expected_period <= Nanoseconds::zero()) {
+            return;
+        }
+        if (last_flip_time == Clock::time_point{} ||
+            now - last_flip_time > std::chrono::seconds{2}) {
+            last_flip_time = now;
+            flip_period_ema = Nanoseconds::zero();
+            slowdown_percent.store(100, std::memory_order_relaxed);
+            return;
+        }
+
+        const auto period = std::chrono::duration_cast<Nanoseconds>(now - last_flip_time);
+        last_flip_time = now;
+        flip_period_ema =
+            flip_period_ema == Nanoseconds::zero() ? period : (flip_period_ema * 9 + period) / 10;
+        const u64 percent = std::clamp<u64>(static_cast<u64>(flip_period_ema.count()) * 100 /
+                                                static_cast<u64>(expected_period.count()),
+                                            100, 400);
+        slowdown_percent.store(static_cast<u32>((percent + 12) / 25 * 25),
+                               std::memory_order_relaxed);
+    }
+
+    std::atomic<StorageSchedulerConfig> config{};
+    std::atomic<u32> slowdown_percent{100};
+    static constexpr auto BurstDuration = std::chrono::milliseconds{5};
+    std::mutex mutex;
+    std::condition_variable cv;
+    std::deque<std::shared_ptr<Pending>> queue;
+    Clock::time_point transfer_cursor{};
+    Clock::time_point last_flip_time{};
+    Nanoseconds flip_period_ema{};
+    std::jthread worker;
+};
+
+StorageScheduler::StorageScheduler() : impl{std::make_unique<Impl>()} {}
+
+StorageScheduler::~StorageScheduler() = default;
+
+StorageSchedulerConfig StorageScheduler::Configure(StorageSchedulerConfig config) {
+    const u32 requested_bandwidth = config.bandwidth_mibps;
+    config.bandwidth_mibps = NormalizeReadBandwidth(requested_bandwidth);
+    if (config.bandwidth_mibps != requested_bandwidth) {
+        LOG_WARNING(Config, "App0 HDD bandwidth {} MiB/s normalized to {} MiB/s",
+                    requested_bandwidth, config.bandwidth_mibps);
+    }
+    impl->config.store(config, std::memory_order_release);
+    std::scoped_lock lock{impl->mutex};
+    if (config.IsEnabled() && !impl->worker.joinable()) {
+        impl->worker =
+            std::jthread{[scheduler = impl.get()](std::stop_token stop) { scheduler->Run(stop); }};
+    }
+    impl->transfer_cursor = {};
+    impl->slowdown_percent.store(100, std::memory_order_relaxed);
+    impl->last_flip_time = {};
+    impl->flip_period_ema = Nanoseconds::zero();
+    return config;
+}
+
+bool StorageScheduler::IsEnabled() const {
+    return impl->config.load(std::memory_order_acquire).IsEnabled();
+}
+
+StorageRequestHandle StorageScheduler::SubmitRead(std::shared_ptr<File> file,
+                                                  StorageReadSpans spans, u64 offset,
+                                                  StorageCompletion completion) {
+    auto pending = std::make_shared<Impl::Pending>();
+    pending->file = std::move(file);
+    pending->spans = std::move(spans);
+    pending->offset = offset;
+    pending->completion = std::move(completion);
+    for (const auto& span : pending->spans) {
+        pending->requested += span.size;
+    }
+
+    if (pending->requested == 0) {
+        static_cast<void>(pending->Start());
+        Impl::Complete(*pending, 0, false);
+        return pending;
+    }
+
+    {
+        std::scoped_lock lock{impl->mutex};
+        impl->queue.push_back(pending);
+    }
+    impl->cv.notify_one();
+    return pending;
+}
+
+s64 StorageScheduler::ReadBlocking(std::shared_ptr<File> file,
+                                   std::span<const StorageReadSpan> spans, u64 offset) {
+    std::binary_semaphore complete{0};
+    s64 result{-1};
+    SubmitRead(std::move(file), {spans.begin(), spans.end()}, offset, [&](s64 read, bool canceled) {
+        result = canceled ? -1 : read;
+        complete.release();
+    });
+    complete.acquire();
+    return result;
+}
+
+void StorageScheduler::Cancel(const StorageRequestHandle& request) {
+    if (request) {
+        request->Cancel();
+    }
+}
+
+void StorageScheduler::ReportGuestFlip(std::chrono::nanoseconds expected_flip_period) {
+    if (IsEnabled()) {
+        impl->ReportGuestFlip(expected_flip_period);
+    }
+}
+
+StorageScheduler& GetApp0StorageScheduler() {
+    static StorageScheduler scheduler;
+    return scheduler;
+}
+
+bool ShouldScheduleAppRead(const File& file) {
+    return (file.m_guest_name == "/app0" || file.m_guest_name.starts_with("/app0/")) &&
+           GetApp0StorageScheduler().IsEnabled();
+}
+
+} // namespace Core::FileSys

--- a/src/core/file_sys/storage_scheduler.h
+++ b/src/core/file_sys/storage_scheduler.h
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <span>
+
+#include <boost/container/small_vector.hpp>
+
+#include "common/types.h"
+
+namespace Core::FileSys {
+
+struct File;
+
+// Zero and values above 200 select native/unlimited speed. Small non-zero values are clamped to
+// 50 MiB/s so a typo cannot make games appear broken. Every value in [50, 200] is accepted.
+[[nodiscard]] constexpr u32 NormalizeReadBandwidth(u32 bandwidth_mibps) {
+    if (bandwidth_mibps == 0 || bandwidth_mibps > 200) {
+        return 0;
+    }
+    return std::max(bandwidth_mibps, 50u);
+}
+
+struct StorageSchedulerConfig {
+    u32 bandwidth_mibps{};
+    bool disable_time_stretching{};
+
+    [[nodiscard]] constexpr bool IsEnabled() const {
+        return bandwidth_mibps != 0;
+    }
+};
+
+struct StorageReadSpan {
+    void* data{};
+    u64 size{};
+};
+
+using StorageReadSpans = boost::container::small_vector<StorageReadSpan, 4>;
+
+class StorageRequest {
+private:
+    friend class StorageScheduler;
+    [[nodiscard]] bool Start() {
+        return !started_or_canceled.test_and_set(std::memory_order_acq_rel);
+    }
+    void Cancel() {
+        started_or_canceled.test_and_set(std::memory_order_acq_rel);
+    }
+    std::atomic_flag started_or_canceled;
+};
+
+using StorageRequestHandle = std::shared_ptr<StorageRequest>;
+using StorageCompletion = std::function<void(s64 result, bool canceled)>;
+
+class StorageScheduler {
+public:
+    StorageScheduler();
+    ~StorageScheduler();
+
+    StorageScheduler(const StorageScheduler&) = delete;
+    StorageScheduler& operator=(const StorageScheduler&) = delete;
+
+    [[nodiscard]] StorageSchedulerConfig Configure(StorageSchedulerConfig config);
+    [[nodiscard]] bool IsEnabled() const;
+
+    StorageRequestHandle SubmitRead(std::shared_ptr<File> file, StorageReadSpans spans, u64 offset,
+                                    StorageCompletion completion);
+    s64 ReadBlocking(std::shared_ptr<File> file, std::span<const StorageReadSpan> spans,
+                     u64 offset);
+    void Cancel(const StorageRequestHandle& request);
+
+    // Called from the present thread on every real guest flip. When the emulator runs slower
+    // than the game's target flip cadence, modeled I/O time is stretched by the same ratio so
+    // the guest-perceived delivery rate per frame stays close to a real PS4 under load.
+    void ReportGuestFlip(std::chrono::nanoseconds expected_flip_period);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl;
+};
+
+StorageScheduler& GetApp0StorageScheduler();
+
+// True when reads from this file must be routed through the app0 storage scheduler.
+[[nodiscard]] bool ShouldScheduleAppRead(const File& file);
+
+} // namespace Core::FileSys

--- a/src/core/libraries/kernel/aio.cpp
+++ b/src/core/libraries/kernel/aio.cpp
@@ -1,305 +1,537 @@
-// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2024-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <ranges>
 #include <thread>
+#include <utility>
+
+#include <boost/container/small_vector.hpp>
 
 #include "aio.h"
-#include "common/assert.h"
-#include "common/debug.h"
 #include "common/logging/log.h"
-#include "core/libraries/kernel/equeue.h"
+#include "common/singleton.h"
+#include "common/thread.h"
+#include "core/file_sys/fs.h"
+#include "core/file_sys/storage_scheduler.h"
 #include "core/libraries/kernel/orbis_error.h"
 #include "core/libraries/libs.h"
-#include "file_system.h"
+#include "core/memory.h"
 
 namespace Libraries::Kernel {
+namespace {
 
-#define MAX_QUEUE 512
+constexpr u32 MaxRequests = 512;
+constexpr u32 SlotBits = 9;
+constexpr u32 SlotMask = (1u << SlotBits) - 1;
 
-static s32* id_state;
-static s32 id_index;
+void PublishResult(OrbisKernelAioResult* result, s64 return_value, AioState state) {
+    result->returnValue = return_value;
+    std::atomic_ref{result->state}.store(state, std::memory_order_release);
+}
 
-s32 PS4_SYSV_ABI sceKernelAioInitializeImpl(void* p, s32 size) {
+struct AioRecord {
+    AioRecord(OrbisKernelAioSubmitId id, u32 command_count, bool abort_on_error)
+        : id{id}, remaining{command_count}, abort_on_error{abort_on_error} {}
 
-    return 0;
+    [[nodiscard]] bool IsComplete() const {
+        return state.load(std::memory_order_acquire) >= ORBIS_KERNEL_AIO_STATE_COMPLETED;
+    }
+
+    const OrbisKernelAioSubmitId id;
+    std::atomic<s32> state{ORBIS_KERNEL_AIO_STATE_PROCESSING};
+    std::atomic<u32> remaining;
+    std::atomic_bool cancel_requested{};
+    const bool abort_on_error;
+    std::mutex mutex;
+    boost::container::small_vector<Core::FileSys::StorageRequestHandle, 4> storage_requests;
+};
+
+using AioRecords = boost::container::small_vector<std::shared_ptr<AioRecord>, 4>;
+
+struct SubmittedCommand {
+    OrbisKernelAioRWRequest request;
+    std::shared_ptr<Core::FileSys::File> file;
+};
+
+struct NativeCommand {
+    std::shared_ptr<AioRecord> record;
+    SubmittedCommand command;
+    bool write;
+};
+
+s64 ReadNative(const std::shared_ptr<Core::FileSys::File>& file, void* buffer, u64 size,
+               u64 offset);
+s64 WriteNative(const std::shared_ptr<Core::FileSys::File>& file, const void* buffer, u64 size,
+                u64 offset);
+
+class AioManager {
+public:
+    ~AioManager() {
+        worker.request_stop();
+        native_cv.notify_all();
+    }
+
+    std::shared_ptr<AioRecord> Allocate(u32 command_count, bool abort_on_error) {
+        std::scoped_lock lock{records_mutex};
+        for (u32 attempt = 0; attempt < MaxRequests - 1; ++attempt) {
+            const u32 slot = next_slot;
+            next_slot = next_slot == MaxRequests - 1 ? 1 : next_slot + 1;
+            const auto& existing = records[slot];
+            if (existing && !existing->IsComplete()) {
+                continue;
+            }
+
+            u32 generation = ++generations[slot];
+            if (generation == 0 || generation >= (1u << (31 - SlotBits))) {
+                generation = generations[slot] = 1;
+            }
+            const auto id = static_cast<s32>((generation << SlotBits) | slot);
+            auto record = std::make_shared<AioRecord>(id, command_count, abort_on_error);
+            records[slot] = record;
+            return record;
+        }
+        return {};
+    }
+
+    std::shared_ptr<AioRecord> Lookup(OrbisKernelAioSubmitId id) const {
+        std::scoped_lock lock{records_mutex};
+        const auto slot = FindSlot(id);
+        return slot ? records[*slot] : nullptr;
+    }
+
+    std::shared_ptr<AioRecord> Remove(OrbisKernelAioSubmitId id) {
+        std::scoped_lock lock{records_mutex};
+        const auto slot = FindSlot(id);
+        return slot ? std::exchange(records[*slot], nullptr) : nullptr;
+    }
+
+    // Mirrors the PS4 kernel: an in-flight request cannot be deleted (EBUSY). This also
+    // guarantees no completion can publish into guest memory after a successful delete.
+    s32 Delete(OrbisKernelAioSubmitId id) {
+        std::scoped_lock lock{records_mutex};
+        const auto slot = FindSlot(id);
+        if (!slot) {
+            return ORBIS_KERNEL_ERROR_EINVAL;
+        }
+        if (!records[*slot]->IsComplete()) {
+            return ORBIS_KERNEL_ERROR_EBUSY;
+        }
+        records[*slot] = nullptr;
+        return ORBIS_OK;
+    }
+
+    void Enqueue(NativeCommand command) {
+        {
+            std::scoped_lock lock{native_mutex};
+            if (!worker.joinable()) {
+                worker = std::jthread{[this](std::stop_token stop_token) { Run(stop_token); }};
+            }
+            native_queue.push_back(std::move(command));
+        }
+        native_cv.notify_one();
+    }
+
+    void AttachStorageRequest(const std::shared_ptr<AioRecord>& record,
+                              Core::FileSys::StorageRequestHandle request) {
+        std::scoped_lock lock{record->mutex};
+        if (record->cancel_requested.load(std::memory_order_acquire)) {
+            Core::FileSys::GetApp0StorageScheduler().Cancel(request);
+        } else if (!record->IsComplete()) {
+            record->storage_requests.push_back(std::move(request));
+        }
+    }
+
+    void Complete(const std::shared_ptr<AioRecord>& record, OrbisKernelAioResult* result,
+                  s64 return_value, bool canceled) {
+        const bool cancellation =
+            canceled || record->cancel_requested.load(std::memory_order_acquire);
+        const bool failed = return_value < 0;
+        PublishResult(result,
+                      cancellation ? static_cast<s64>(ORBIS_KERNEL_ERROR_ECANCELED) : return_value,
+                      cancellation || failed ? ORBIS_KERNEL_AIO_STATE_ABORTED
+                                             : ORBIS_KERNEL_AIO_STATE_COMPLETED);
+
+        if (record->remaining.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+            const bool abort_record = cancellation || (failed && record->abort_on_error);
+            {
+                std::scoped_lock lock{record->mutex};
+                record->storage_requests.clear();
+                record->state.store(abort_record ? ORBIS_KERNEL_AIO_STATE_ABORTED
+                                                 : ORBIS_KERNEL_AIO_STATE_COMPLETED,
+                                    std::memory_order_release);
+            }
+            wait_cv.notify_all();
+        }
+    }
+
+    s32 Cancel(const std::shared_ptr<AioRecord>& record) {
+        if (record->IsComplete()) {
+            return record->state.load(std::memory_order_acquire);
+        }
+        record->cancel_requested.store(true, std::memory_order_release);
+        std::scoped_lock lock{record->mutex};
+        for (const auto& request : record->storage_requests) {
+            Core::FileSys::GetApp0StorageScheduler().Cancel(request);
+        }
+        return record->state.load(std::memory_order_acquire);
+    }
+
+    s32 Wait(const AioRecords& records_to_wait, bool wait_any, u32* usec) {
+        const auto predicate = [&] {
+            if (wait_any) {
+                return std::ranges::any_of(records_to_wait,
+                                           [](const auto& record) { return record->IsComplete(); });
+            }
+            return std::ranges::all_of(records_to_wait,
+                                       [](const auto& record) { return record->IsComplete(); });
+        };
+
+        std::unique_lock lock{wait_mutex};
+        if (usec == nullptr || *usec == 0) {
+            wait_cv.wait(lock, predicate);
+            return ORBIS_OK;
+        }
+        const auto timeout = std::chrono::microseconds{*usec};
+        const auto begin = std::chrono::steady_clock::now();
+        if (!wait_cv.wait_for(lock, timeout, predicate)) {
+            *usec = 0;
+            return ORBIS_KERNEL_ERROR_ETIMEDOUT;
+        }
+        const auto elapsed = std::chrono::steady_clock::now() - begin;
+        *usec = elapsed < timeout
+                    ? static_cast<u32>(
+                          std::chrono::duration_cast<std::chrono::microseconds>(timeout - elapsed)
+                              .count())
+                    : 0;
+        return ORBIS_OK;
+    }
+
+private:
+    // Validates an id and resolves it to its slot. Requires records_mutex to be held.
+    std::optional<u32> FindSlot(OrbisKernelAioSubmitId id) const {
+        if (id <= 0) {
+            return std::nullopt;
+        }
+        const u32 slot = static_cast<u32>(id) & SlotMask;
+        if (slot == 0 || slot >= MaxRequests || !records[slot] || records[slot]->id != id) {
+            return std::nullopt;
+        }
+        return slot;
+    }
+
+    void Run(std::stop_token stop_token) {
+        Common::SetCurrentThreadName("shadPS4:AioWork");
+        while (!stop_token.stop_requested()) {
+            NativeCommand native;
+            {
+                std::unique_lock lock{native_mutex};
+                native_cv.wait(
+                    lock, [&] { return stop_token.stop_requested() || !native_queue.empty(); });
+                if (stop_token.stop_requested()) {
+                    break;
+                }
+                native = std::move(native_queue.front());
+                native_queue.pop_front();
+            }
+
+            const auto& request = native.command.request;
+            if (native.record->cancel_requested.load(std::memory_order_acquire)) {
+                Complete(native.record, request.result, -1, true);
+                continue;
+            }
+            const s64 result =
+                native.write
+                    ? WriteNative(native.command.file, request.buf, request.nbyte, request.offset)
+                    : ReadNative(native.command.file, request.buf, request.nbyte, request.offset);
+            Complete(native.record, request.result, result, false);
+        }
+    }
+
+    mutable std::mutex records_mutex;
+    std::array<std::shared_ptr<AioRecord>, MaxRequests> records;
+    std::array<u32, MaxRequests> generations{};
+    u32 next_slot{1};
+
+    std::mutex native_mutex;
+    std::condition_variable native_cv;
+    std::deque<NativeCommand> native_queue;
+
+    std::mutex wait_mutex;
+    std::condition_variable wait_cv;
+    // Joined before the synchronization primitives and queues it accesses are destroyed.
+    std::jthread worker;
+};
+
+AioManager& GetAioManager() {
+    static AioManager manager;
+    return manager;
+}
+
+s64 ReadNative(const std::shared_ptr<Core::FileSys::File>& file, void* buffer, u64 size,
+               u64 offset) {
+    if (!file || file->type != Core::FileSys::FileType::Regular || file->IsWriteOnly()) {
+        return ORBIS_KERNEL_ERROR_EBADF;
+    }
+    const u64 file_size = file->GetSize();
+    const u64 readable = offset < file_size ? std::min(size, file_size - offset) : 0;
+    Core::Memory::Instance()->InvalidateMemory(reinterpret_cast<VAddr>(buffer), readable);
+    const s64 result = file->PRead(buffer, readable, offset);
+    return result < 0 ? ORBIS_KERNEL_ERROR_EIO : result;
+}
+
+s64 WriteNative(const std::shared_ptr<Core::FileSys::File>& file, const void* buffer, u64 size,
+                u64 offset) {
+    if (!file || file->type != Core::FileSys::FileType::Regular) {
+        return ORBIS_KERNEL_ERROR_EBADF;
+    }
+    const s64 result = file->PWrite(buffer, size, offset);
+    return result < 0 ? ORBIS_KERNEL_ERROR_EIO : result;
+}
+
+s32 SubmitCommands(OrbisKernelAioRWRequest requests[], s32 size, s32, OrbisKernelAioSubmitId ids[],
+                   bool multiple, bool write) {
+    if (requests == nullptr || ids == nullptr) {
+        return ORBIS_KERNEL_ERROR_EFAULT;
+    }
+    if (size <= 0) {
+        return ORBIS_KERNEL_ERROR_EINVAL;
+    }
+    auto* handles = Common::Singleton<Core::FileSys::HandleTable>::Instance();
+    boost::container::small_vector<SubmittedCommand, 4> commands;
+    commands.reserve(size);
+    for (s32 index = 0; index < size; ++index) {
+        if (requests[index].result == nullptr ||
+            (requests[index].buf == nullptr && requests[index].nbyte != 0)) {
+            return ORBIS_KERNEL_ERROR_EFAULT;
+        }
+        if (requests[index].nbyte < 0 || requests[index].offset < 0) {
+            return ORBIS_KERNEL_ERROR_EINVAL;
+        }
+        auto file = handles->GetFileShared(requests[index].fd);
+        if (!file) {
+            return ORBIS_KERNEL_ERROR_EBADF;
+        }
+        commands.push_back({requests[index], std::move(file)});
+    }
+
+    for (const auto& command : commands) {
+        PublishResult(command.request.result, 0, ORBIS_KERNEL_AIO_STATE_SUBMITTED);
+    }
+
+    auto& manager = GetAioManager();
+    AioRecords records;
+    if (multiple) {
+        records.reserve(size);
+        for (s32 index = 0; index < size; ++index) {
+            auto record = manager.Allocate(1, true);
+            if (!record) {
+                for (const auto& allocated : records) {
+                    manager.Remove(allocated->id);
+                }
+                for (const auto& command : commands) {
+                    PublishResult(command.request.result, ORBIS_KERNEL_ERROR_EAGAIN,
+                                  ORBIS_KERNEL_AIO_STATE_ABORTED);
+                }
+                return ORBIS_KERNEL_ERROR_EAGAIN;
+            }
+            ids[index] = record->id;
+            records.push_back(std::move(record));
+        }
+    } else {
+        auto record = manager.Allocate(static_cast<u32>(size), false);
+        if (!record) {
+            for (const auto& command : commands) {
+                PublishResult(command.request.result, ORBIS_KERNEL_ERROR_EAGAIN,
+                              ORBIS_KERNEL_AIO_STATE_ABORTED);
+            }
+            return ORBIS_KERNEL_ERROR_EAGAIN;
+        }
+        ids[0] = record->id;
+        records.assign(size, record);
+    }
+
+    for (s32 index = 0; index < size; ++index) {
+        auto record = records[index];
+        auto command = std::move(commands[index]);
+        std::atomic_ref{command.request.result->state}.store(ORBIS_KERNEL_AIO_STATE_PROCESSING,
+                                                             std::memory_order_release);
+
+        if (!write && Core::FileSys::ShouldScheduleAppRead(*command.file)) {
+            if (command.file->type != Core::FileSys::FileType::Regular ||
+                command.file->IsWriteOnly()) {
+                manager.Complete(record, command.request.result, ORBIS_KERNEL_ERROR_EBADF, false);
+                continue;
+            }
+            const u64 offset = static_cast<u64>(command.request.offset);
+            const u64 file_size = command.file->GetSize();
+            const u64 readable =
+                offset < file_size ? std::min<u64>(command.request.nbyte, file_size - offset) : 0;
+            Core::FileSys::StorageReadSpans spans{{command.request.buf, readable}};
+            auto request = Core::FileSys::GetApp0StorageScheduler().SubmitRead(
+                command.file, std::move(spans), offset,
+                [record, result = command.request.result](s64 value, bool canceled) {
+                    GetAioManager().Complete(record, result,
+                                             value < 0 ? ORBIS_KERNEL_ERROR_EIO : value, canceled);
+                });
+            manager.AttachStorageRequest(record, std::move(request));
+            continue;
+        }
+
+        manager.Enqueue({record, std::move(command), write});
+    }
+    return ORBIS_OK;
+}
+
+AioRecords LookupRecords(const OrbisKernelAioSubmitId ids[], s32 num) {
+    AioRecords records;
+    records.reserve(num);
+    for (s32 index = 0; index < num; ++index) {
+        auto record = GetAioManager().Lookup(ids[index]);
+        if (!record) {
+            return {};
+        }
+        records.push_back(std::move(record));
+    }
+    return records;
+}
+
+} // namespace
+
+s32 PS4_SYSV_ABI sceKernelAioInitializeImpl(void*, s32) {
+    GetAioManager();
+    return ORBIS_OK;
 }
 
 s32 PS4_SYSV_ABI sceKernelAioDeleteRequest(OrbisKernelAioSubmitId id, s32* ret) {
     if (ret == nullptr) {
         return ORBIS_KERNEL_ERROR_EFAULT;
     }
-    id_state[id] = ORBIS_KERNEL_AIO_STATE_ABORTED;
-    *ret = 0;
-    return 0;
+    const s32 result = GetAioManager().Delete(id);
+    if (result != ORBIS_OK) {
+        return result;
+    }
+    *ret = ORBIS_OK;
+    return ORBIS_OK;
 }
 
-s32 PS4_SYSV_ABI sceKernelAioDeleteRequests(OrbisKernelAioSubmitId id[], s32 num, s32 ret[]) {
-    if (ret == nullptr) {
+s32 PS4_SYSV_ABI sceKernelAioDeleteRequests(OrbisKernelAioSubmitId ids[], s32 num, s32 ret[]) {
+    if (ids == nullptr || ret == nullptr) {
         return ORBIS_KERNEL_ERROR_EFAULT;
     }
-    for (s32 i = 0; i < num; i++) {
-        id_state[id[i]] = ORBIS_KERNEL_AIO_STATE_ABORTED;
-        ret[i] = 0;
+    for (s32 index = 0; index < num; ++index) {
+        ret[index] = GetAioManager().Delete(ids[index]);
     }
-
-    return 0;
+    return ORBIS_OK;
 }
+
 s32 PS4_SYSV_ABI sceKernelAioPollRequest(OrbisKernelAioSubmitId id, s32* state) {
     if (state == nullptr) {
         return ORBIS_KERNEL_ERROR_EFAULT;
     }
-    *state = id_state[id];
-    return 0;
+    auto record = GetAioManager().Lookup(id);
+    if (!record) {
+        return ORBIS_KERNEL_ERROR_EINVAL;
+    }
+    *state = record->state.load(std::memory_order_acquire);
+    return ORBIS_OK;
 }
 
-s32 PS4_SYSV_ABI sceKernelAioPollRequests(OrbisKernelAioSubmitId id[], s32 num, s32 state[]) {
-    if (state == nullptr) {
+s32 PS4_SYSV_ABI sceKernelAioPollRequests(OrbisKernelAioSubmitId ids[], s32 num, s32 state[]) {
+    if (ids == nullptr || state == nullptr) {
         return ORBIS_KERNEL_ERROR_EFAULT;
     }
-    for (s32 i = 0; i < num; i++) {
-        state[i] = id_state[id[i]];
+    for (s32 index = 0; index < num; ++index) {
+        const s32 error = sceKernelAioPollRequest(ids[index], &state[index]);
+        if (error != ORBIS_OK) {
+            return error;
+        }
     }
-
-    return 0;
+    return ORBIS_OK;
 }
 
 s32 PS4_SYSV_ABI sceKernelAioCancelRequest(OrbisKernelAioSubmitId id, s32* state) {
     if (state == nullptr) {
         return ORBIS_KERNEL_ERROR_EFAULT;
     }
-    if (id) {
-        id_state[id] = ORBIS_KERNEL_AIO_STATE_ABORTED;
-        *state = ORBIS_KERNEL_AIO_STATE_ABORTED;
-    } else {
-        *state = ORBIS_KERNEL_AIO_STATE_PROCESSING;
+    auto record = GetAioManager().Lookup(id);
+    if (!record) {
+        return ORBIS_KERNEL_ERROR_EINVAL;
     }
-    return 0;
+    *state = GetAioManager().Cancel(record);
+    return ORBIS_OK;
 }
 
-s32 PS4_SYSV_ABI sceKernelAioCancelRequests(OrbisKernelAioSubmitId id[], s32 num, s32 state[]) {
-    if (state == nullptr) {
+s32 PS4_SYSV_ABI sceKernelAioCancelRequests(OrbisKernelAioSubmitId ids[], s32 num, s32 state[]) {
+    if (ids == nullptr || state == nullptr) {
         return ORBIS_KERNEL_ERROR_EFAULT;
     }
-    for (s32 i = 0; i < num; i++) {
-        if (id[i]) {
-            id_state[id[i]] = ORBIS_KERNEL_AIO_STATE_ABORTED;
-            state[i] = ORBIS_KERNEL_AIO_STATE_ABORTED;
-        } else {
-            state[i] = ORBIS_KERNEL_AIO_STATE_PROCESSING;
+    for (s32 index = 0; index < num; ++index) {
+        const s32 error = sceKernelAioCancelRequest(ids[index], &state[index]);
+        if (error != ORBIS_OK) {
+            return error;
         }
     }
-
-    return 0;
+    return ORBIS_OK;
 }
 
 s32 PS4_SYSV_ABI sceKernelAioWaitRequest(OrbisKernelAioSubmitId id, s32* state, u32* usec) {
     if (state == nullptr) {
         return ORBIS_KERNEL_ERROR_EFAULT;
     }
-    u32 timer = 0;
-
-    s32 timeout = 0;
-
-    while (id_state[id] == ORBIS_KERNEL_AIO_STATE_PROCESSING) {
-        sceKernelUsleep(10);
-
-        timer += 10;
-        if (*usec) {
-            if (timer > *usec) {
-                timeout = 1;
-                break;
-            }
-        }
+    auto record = GetAioManager().Lookup(id);
+    if (!record) {
+        return ORBIS_KERNEL_ERROR_EINVAL;
     }
-
-    *state = id_state[id];
-
-    if (timeout)
-        return ORBIS_KERNEL_ERROR_ETIMEDOUT;
-    return 0;
+    const s32 result = GetAioManager().Wait({record}, false, usec);
+    *state = record->state.load(std::memory_order_acquire);
+    return result;
 }
 
-s32 PS4_SYSV_ABI sceKernelAioWaitRequests(OrbisKernelAioSubmitId id[], s32 num, s32 state[],
+s32 PS4_SYSV_ABI sceKernelAioWaitRequests(OrbisKernelAioSubmitId ids[], s32 num, s32 state[],
                                           u32 mode, u32* usec) {
-    if (state == nullptr) {
+    if (ids == nullptr || state == nullptr || num <= 0) {
         return ORBIS_KERNEL_ERROR_EFAULT;
     }
-    u32 timer = 0;
-    s32 timeout = 0;
-    s32 completion = 0;
-
-    for (s32 i = 0; i < num; i++) {
-        if (!completion && !timeout) {
-            while (id_state[id[i]] == ORBIS_KERNEL_AIO_STATE_PROCESSING) {
-                sceKernelUsleep(10);
-                timer += 10;
-
-                if (*usec) {
-                    if (timer > *usec) {
-                        timeout = 1;
-                        break;
-                    }
-                }
-            }
-        }
-
-        if (mode == 0x02) {
-            if (id_state[id[i]] == ORBIS_KERNEL_AIO_STATE_COMPLETED)
-                completion = 1;
-        }
-
-        state[i] = id_state[id[i]];
+    auto records = LookupRecords(ids, num);
+    if (records.size() != static_cast<size_t>(num)) {
+        return ORBIS_KERNEL_ERROR_EINVAL;
     }
-
-    if (timeout)
-        return ORBIS_KERNEL_ERROR_ETIMEDOUT;
-
-    return 0;
+    const s32 result = GetAioManager().Wait(records, mode == 0x02, usec);
+    for (s32 index = 0; index < num; ++index) {
+        state[index] = records[index]->state.load(std::memory_order_acquire);
+    }
+    return result;
 }
 
-s32 PS4_SYSV_ABI sceKernelAioSubmitReadCommands(OrbisKernelAioRWRequest req[], s32 size, s32 prio,
-                                                OrbisKernelAioSubmitId* id) {
-    if (req == nullptr) {
-        return ORBIS_KERNEL_ERROR_EFAULT;
-    }
-    if (id == nullptr) {
-        return ORBIS_KERNEL_ERROR_EFAULT;
-    }
-    id_state[id_index] = ORBIS_KERNEL_AIO_STATE_PROCESSING;
-
-    for (s32 i = 0; i < size; i++) {
-
-        s64 ret = sceKernelPread(req[i].fd, req[i].buf, req[i].nbyte, req[i].offset);
-
-        if (ret < 0) {
-            req[i].result->state = ORBIS_KERNEL_AIO_STATE_ABORTED;
-            req[i].result->returnValue = ret;
-
-        } else {
-            req[i].result->state = ORBIS_KERNEL_AIO_STATE_COMPLETED;
-            req[i].result->returnValue = ret;
-        }
-    }
-
-    id_state[id_index] = ORBIS_KERNEL_AIO_STATE_COMPLETED;
-
-    *id = id_index;
-
-    id_index = (id_index + 1) % MAX_QUEUE;
-
-    if (!id_index)
-        id_index++;
-
-    return 0;
+s32 PS4_SYSV_ABI sceKernelAioSubmitReadCommands(OrbisKernelAioRWRequest requests[], s32 size,
+                                                s32 priority, OrbisKernelAioSubmitId* id) {
+    return SubmitCommands(requests, size, priority, id, false, false);
 }
 
-s32 PS4_SYSV_ABI sceKernelAioSubmitReadCommandsMultiple(OrbisKernelAioRWRequest req[], s32 size,
-                                                        s32 prio, OrbisKernelAioSubmitId id[]) {
-    if (req == nullptr) {
-        return ORBIS_KERNEL_ERROR_EFAULT;
-    }
-    if (id == nullptr) {
-        return ORBIS_KERNEL_ERROR_EFAULT;
-    }
-    for (s32 i = 0; i < size; i++) {
-        id_state[id_index] = ORBIS_KERNEL_AIO_STATE_PROCESSING;
-
-        s64 ret = sceKernelPread(req[i].fd, req[i].buf, req[i].nbyte, req[i].offset);
-
-        if (ret < 0) {
-            req[i].result->state = ORBIS_KERNEL_AIO_STATE_ABORTED;
-            req[i].result->returnValue = ret;
-
-            id_state[id_index] = ORBIS_KERNEL_AIO_STATE_ABORTED;
-
-        } else {
-            req[i].result->state = ORBIS_KERNEL_AIO_STATE_COMPLETED;
-            req[i].result->returnValue = ret;
-
-            id_state[id_index] = ORBIS_KERNEL_AIO_STATE_COMPLETED;
-        }
-
-        id[i] = id_index;
-
-        id_index = (id_index + 1) % MAX_QUEUE;
-
-        if (!id_index)
-            id_index++;
-    }
-
-    return 0;
+s32 PS4_SYSV_ABI sceKernelAioSubmitReadCommandsMultiple(OrbisKernelAioRWRequest requests[],
+                                                        s32 size, s32 priority,
+                                                        OrbisKernelAioSubmitId ids[]) {
+    return SubmitCommands(requests, size, priority, ids, true, false);
 }
 
-s32 PS4_SYSV_ABI sceKernelAioSubmitWriteCommands(OrbisKernelAioRWRequest req[], s32 size, s32 prio,
-                                                 OrbisKernelAioSubmitId* id) {
-    if (req == nullptr) {
-        return ORBIS_KERNEL_ERROR_EFAULT;
-    }
-    if (id == nullptr) {
-        return ORBIS_KERNEL_ERROR_EFAULT;
-    }
-    for (s32 i = 0; i < size; i++) {
-        id_state[id_index] = ORBIS_KERNEL_AIO_STATE_PROCESSING;
-
-        s64 ret = sceKernelPwrite(req[i].fd, req[i].buf, req[i].nbyte, req[i].offset);
-
-        if (ret < 0) {
-            req[i].result->state = ORBIS_KERNEL_AIO_STATE_ABORTED;
-            req[i].result->returnValue = ret;
-
-            id_state[id_index] = ORBIS_KERNEL_AIO_STATE_ABORTED;
-
-        } else {
-            req[i].result->state = ORBIS_KERNEL_AIO_STATE_COMPLETED;
-            req[i].result->returnValue = ret;
-
-            id_state[id_index] = ORBIS_KERNEL_AIO_STATE_COMPLETED;
-        }
-    }
-
-    *id = id_index;
-
-    id_index = (id_index + 1) % MAX_QUEUE;
-
-    // skip id_index equals 0 , because sceKernelAioCancelRequest will submit id
-    // equal to 0
-    if (!id_index)
-        id_index++;
-
-    return 0;
+s32 PS4_SYSV_ABI sceKernelAioSubmitWriteCommands(OrbisKernelAioRWRequest requests[], s32 size,
+                                                 s32 priority, OrbisKernelAioSubmitId* id) {
+    return SubmitCommands(requests, size, priority, id, false, true);
 }
 
-s32 PS4_SYSV_ABI sceKernelAioSubmitWriteCommandsMultiple(OrbisKernelAioRWRequest req[], s32 size,
-                                                         s32 prio, OrbisKernelAioSubmitId id[]) {
-    if (req == nullptr) {
-        return ORBIS_KERNEL_ERROR_EFAULT;
-    }
-    if (id == nullptr) {
-        return ORBIS_KERNEL_ERROR_EFAULT;
-    }
-    for (s32 i = 0; i < size; i++) {
-        id_state[id_index] = ORBIS_KERNEL_AIO_STATE_PROCESSING;
-        s64 ret = sceKernelPwrite(req[i].fd, req[i].buf, req[i].nbyte, req[i].offset);
-
-        if (ret < 0) {
-            req[i].result->state = ORBIS_KERNEL_AIO_STATE_ABORTED;
-            req[i].result->returnValue = ret;
-
-            id_state[id_index] = ORBIS_KERNEL_AIO_STATE_ABORTED;
-
-        } else {
-            req[i].result->state = ORBIS_KERNEL_AIO_STATE_COMPLETED;
-            req[i].result->returnValue = ret;
-            id_state[id_index] = ORBIS_KERNEL_AIO_STATE_COMPLETED;
-        }
-
-        id[i] = id_index;
-        id_index = (id_index + 1) % MAX_QUEUE;
-
-        if (!id_index)
-            id_index++;
-    }
-    return 0;
+s32 PS4_SYSV_ABI sceKernelAioSubmitWriteCommandsMultiple(OrbisKernelAioRWRequest requests[],
+                                                         s32 size, s32 priority,
+                                                         OrbisKernelAioSubmitId ids[]) {
+    return SubmitCommands(requests, size, priority, ids, true, true);
 }
 
 s32 PS4_SYSV_ABI sceKernelAioSetParam() {
@@ -313,10 +545,7 @@ s32 PS4_SYSV_ABI sceKernelAioInitializeParam() {
 }
 
 void RegisterAio(Core::Loader::SymbolsResolver* sym) {
-    id_index = 1;
-    id_state = (int*)malloc(sizeof(int) * MAX_QUEUE);
-    memset(id_state, 0, sizeof(sizeof(int) * MAX_QUEUE));
-
+    GetAioManager();
     LIB_FUNCTION("fR521KIGgb8", "libkernel", 1, "libkernel", sceKernelAioCancelRequest);
     LIB_FUNCTION("3Lca1XBrQdY", "libkernel", 1, "libkernel", sceKernelAioCancelRequests);
     LIB_FUNCTION("5TgME6AYty4", "libkernel", 1, "libkernel", sceKernelAioDeleteRequest);

--- a/src/core/libraries/kernel/aio.h
+++ b/src/core/libraries/kernel/aio.h
@@ -3,12 +3,6 @@
 
 #pragma once
 
-#include <condition_variable>
-#include <mutex>
-#include <string>
-#include <vector>
-#include <boost/asio/steady_timer.hpp>
-
 #include "common/types.h"
 
 namespace Core::Loader {
@@ -29,7 +23,7 @@ struct OrbisKernelAioResult {
     u32 state;
 };
 
-typedef s32 OrbisKernelAioSubmitId;
+using OrbisKernelAioSubmitId = s32;
 
 struct OrbisKernelAioRWRequest {
     s64 offset;

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -1,8 +1,13 @@
 // SPDX-FileCopyrightText: Copyright 2025-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <limits>
 #include <map>
+#include <mutex>
+#include <optional>
 #include <ranges>
+#include <string_view>
+#include <vector>
 #include <magic_enum/magic_enum.hpp>
 
 #include "common/assert.h"
@@ -21,6 +26,7 @@
 #include "core/file_sys/directories/normal_directory.h"
 #include "core/file_sys/directories/pfs_directory.h"
 #include "core/file_sys/fs.h"
+#include "core/file_sys/storage_scheduler.h"
 #include "core/libraries/kernel/file_system.h"
 #include "core/libraries/kernel/orbis_error.h"
 #include "core/libraries/kernel/posix_error.h"
@@ -264,8 +270,7 @@ s32 PS4_SYSV_ABI sceKernelOpen(const char* path, s32 flags, /* SceKernelMode*/ u
 
 s32 PS4_SYSV_ABI close(s32 fd) {
     auto* h = Common::Singleton<Core::FileSys::HandleTable>::Instance();
-    auto* file = h->GetFile(fd);
-    if (file == nullptr) {
+    if (fd < 0) {
         *__Error() = POSIX_EBADF;
         return -1;
     }
@@ -273,15 +278,16 @@ s32 PS4_SYSV_ABI close(s32 fd) {
         *__Error() = POSIX_EPERM;
         return -1;
     }
-    if (file->type == Core::FileSys::FileType::Regular) {
-        file->handle.reset();
-    } else if (file->type == Core::FileSys::FileType::Socket) {
+    auto file = h->DeleteHandle(fd);
+    if (file == nullptr) {
+        *__Error() = POSIX_EBADF;
+        return -1;
+    }
+    if (file->type == Core::FileSys::FileType::Socket) {
         file->socket->Close();
     }
     file->is_opened = false;
     LOG_INFO(Kernel_Fs, "Closing {}", file->m_guest_name);
-    // FIXME: Lock file mutex before deleting it?
-    h->DeleteHandle(fd);
     return ORBIS_OK;
 }
 
@@ -356,15 +362,88 @@ s64 ReadFile(Core::FileSys::File* file, void* buf, u64 nbytes) {
     return bytes;
 }
 
+// Returns the errno for an invalid iovec array, or 0 when it is acceptable.
+s32 IovecError(const OrbisKernelIovec* iov, s32 iovcnt) {
+    if (iovcnt < 0) {
+        return POSIX_EINVAL;
+    }
+    if (iov == nullptr && iovcnt != 0) {
+        return POSIX_EFAULT;
+    }
+    return 0;
+}
+
+s64 ReadRegularScheduled(const std::shared_ptr<Core::FileSys::File>& file,
+                         const OrbisKernelIovec* iov, s32 iovcnt, std::optional<u64> offset) {
+    auto& scheduler = Core::FileSys::GetApp0StorageScheduler();
+    Core::FileSys::StorageReadSpans spans;
+    spans.reserve(iovcnt);
+    u64 read_offset{};
+    u64 readable{};
+    {
+        std::scoped_lock lock{file->m_mutex};
+        const s64 current = offset ? static_cast<s64>(*offset) : file->Tell();
+        if (current < 0) {
+            *__Error() = POSIX_EIO;
+            return -1;
+        }
+        read_offset = static_cast<u64>(current);
+        const u64 file_size = file->GetSize();
+        u64 requested{};
+        for (s32 index = 0; index < iovcnt; ++index) {
+            if (iov[index].iov_base == nullptr && iov[index].iov_len != 0) {
+                *__Error() = POSIX_EFAULT;
+                return -1;
+            }
+            if (iov[index].iov_len > std::numeric_limits<u64>::max() - requested) {
+                *__Error() = POSIX_EINVAL;
+                return -1;
+            }
+            requested += iov[index].iov_len;
+            spans.push_back({iov[index].iov_base, iov[index].iov_len});
+        }
+        readable = read_offset < file_size ? std::min(requested, file_size - read_offset) : 0;
+        // Reserve the range before releasing the file lock so concurrent reads cannot claim it.
+        if (!offset && !file->Seek(static_cast<s64>(read_offset + readable))) {
+            *__Error() = POSIX_EIO;
+            return -1;
+        }
+    }
+
+    u64 remaining = readable;
+    for (auto& span : spans) {
+        span.size = std::min(span.size, remaining);
+        remaining -= span.size;
+    }
+    const s64 result = scheduler.ReadBlocking(file, spans, read_offset);
+    if (!offset && result != static_cast<s64>(readable)) {
+        std::scoped_lock lock{file->m_mutex};
+        const auto reserved_end = static_cast<s64>(read_offset + readable);
+        // Do not overwrite a position changed by another operation while this read was pending.
+        if (file->Tell() == reserved_end) {
+            file->Seek(static_cast<s64>(read_offset + std::max<s64>(result, 0)));
+        }
+    }
+    if (result < 0) {
+        *__Error() = POSIX_EIO;
+        return -1;
+    }
+    return result;
+}
+
 s64 PS4_SYSV_ABI readv(s32 fd, const OrbisKernelIovec* iov, s32 iovcnt) {
+    if (const s32 error = IovecError(iov, iovcnt); error != 0) {
+        *__Error() = error;
+        return -1;
+    }
     auto* h = Common::Singleton<Core::FileSys::HandleTable>::Instance();
-    auto* file = h->GetFile(fd);
+    auto file = h->GetFileShared(fd);
     if (file == nullptr) {
         *__Error() = POSIX_EBADF;
         return -1;
     }
 
-    std::scoped_lock lk{file->m_mutex};
+    std::unique_lock lk{file->m_mutex};
     if (file->type == Core::FileSys::FileType::Device) {
         s64 result = file->device->readv(iov, iovcnt);
         if (result < 0) {
@@ -386,9 +465,14 @@ s64 PS4_SYSV_ABI readv(s32 fd, const OrbisKernelIovec* iov, s32 iovcnt) {
         return -1;
     }
 
+    if (Core::FileSys::ShouldScheduleAppRead(*file)) {
+        lk.unlock();
+        return ReadRegularScheduled(file, iov, iovcnt, std::nullopt);
+    }
+
     s64 total_read = 0;
     for (s32 i = 0; i < iovcnt; i++) {
-        total_read += ReadFile(file, iov[i].iov_base, iov[i].iov_len);
+        total_read += ReadFile(file.get(), iov[i].iov_base, iov[i].iov_len);
     }
     return total_read;
 }
@@ -520,13 +604,13 @@ s64 PS4_SYSV_ABI sceKernelLseek(s32 fd, s64 offset, s32 whence) {
 
 s64 PS4_SYSV_ABI read(s32 fd, void* buf, u64 nbytes) {
     auto* h = Common::Singleton<Core::FileSys::HandleTable>::Instance();
-    auto* file = h->GetFile(fd);
+    auto file = h->GetFileShared(fd);
     if (file == nullptr) {
         *__Error() = POSIX_EBADF;
         return -1;
     }
 
-    std::scoped_lock lk{file->m_mutex};
+    std::unique_lock lk{file->m_mutex};
     if (file->type == Core::FileSys::FileType::Device) {
         s64 result = file->device->read(buf, nbytes);
         if (result < 0) {
@@ -550,8 +634,13 @@ s64 PS4_SYSV_ABI read(s32 fd, void* buf, u64 nbytes) {
         *__Error() = POSIX_EBADF;
         return -1;
     }
+    if (Core::FileSys::ShouldScheduleAppRead(*file)) {
+        lk.unlock();
+        const OrbisKernelIovec iov{buf, nbytes};
+        return ReadRegularScheduled(file, &iov, 1, std::nullopt);
+    }
 
-    return ReadFile(file, buf, nbytes);
+    return ReadFile(file.get(), buf, nbytes);
 }
 
 s64 PS4_SYSV_ABI posix_read(s32 fd, void* buf, u64 nbytes) {
@@ -919,7 +1008,7 @@ s32 PS4_SYSV_ABI posix_rename(const char* from, const char* to) {
     fs::copy(src_path, dst_path,
              fs::copy_options::overwrite_existing | fs::copy_options::recursive);
     auto* h = Common::Singleton<Core::FileSys::HandleTable>::Instance();
-    auto file = h->GetFile(src_path);
+    auto* file = h->GetFile(src_path);
     if (file) {
         Common::FS::FileAccessMode access_mode = Common::FS::FileAccessMode::ReadWrite;
         if (auto* host = file->GetHostFile()) {
@@ -951,15 +1040,19 @@ s64 PS4_SYSV_ABI posix_preadv(s32 fd, OrbisKernelIovec* iov, s32 iovcnt, s64 off
         *__Error() = POSIX_EINVAL;
         return -1;
     }
+    if (const s32 error = IovecError(iov, iovcnt); error != 0) {
+        *__Error() = error;
+        return -1;
+    }
 
     auto* h = Common::Singleton<Core::FileSys::HandleTable>::Instance();
-    auto* file = h->GetFile(fd);
+    auto file = h->GetFileShared(fd);
     if (file == nullptr) {
         *__Error() = POSIX_EBADF;
         return -1;
     }
 
-    std::scoped_lock lk{file->m_mutex};
+    std::unique_lock lk{file->m_mutex};
     if (file->type == Core::FileSys::FileType::Device) {
         s64 result = file->device->preadv(iov, iovcnt, offset);
         if (result < 0) {
@@ -981,6 +1074,11 @@ s64 PS4_SYSV_ABI posix_preadv(s32 fd, OrbisKernelIovec* iov, s32 iovcnt, s64 off
         return -1;
     }
 
+    if (Core::FileSys::ShouldScheduleAppRead(*file)) {
+        lk.unlock();
+        return ReadRegularScheduled(file, iov, iovcnt, static_cast<u64>(offset));
+    }
+
     const s64 pos = file->Tell();
     SCOPE_EXIT {
         file->Seek(pos);
@@ -991,7 +1089,7 @@ s64 PS4_SYSV_ABI posix_preadv(s32 fd, OrbisKernelIovec* iov, s32 iovcnt, s64 off
     }
     s64 total_read = 0;
     for (s32 i = 0; i < iovcnt; i++) {
-        total_read += ReadFile(file, iov[i].iov_base, iov[i].iov_len);
+        total_read += ReadFile(file.get(), iov[i].iov_base, iov[i].iov_len);
     }
     return total_read;
 }

--- a/src/core/libraries/videoout/driver.cpp
+++ b/src/core/libraries/videoout/driver.cpp
@@ -6,6 +6,7 @@
 #include "common/thread.h"
 #include "core/debug_state.h"
 #include "core/emulator_settings.h"
+#include "core/file_sys/storage_scheduler.h"
 #include "core/libraries/kernel/time.h"
 #include "core/libraries/videoout/driver.h"
 #include "core/libraries/videoout/videoout_error.h"
@@ -275,6 +276,16 @@ void VideoOutDriver::Flip(const Request& req) {
     }
     // save to prev buf index
     port->prev_index = req.index;
+
+    // Real guest flips (never DrawLastFrame re-presents) feed the app0 storage scheduler so
+    // modeled I/O stretches when the emulator runs below the game's target flip cadence.
+    auto& storage = Core::FileSys::GetApp0StorageScheduler();
+    const u32 vblank_frequency = EmulatorSettings.GetVblankFrequency();
+    if (storage.IsEnabled() && vblank_frequency != 0) {
+        const auto expected_period =
+            std::chrono::nanoseconds{1'000'000'000 / vblank_frequency} * (port->flip_rate + 1);
+        storage.ReportGuestFlip(expected_period);
+    }
 }
 
 void VideoOutDriver::DrawBlankFrame() {

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -33,6 +33,7 @@
 #include "core/file_format/psf.h"
 #include "core/file_format/trp.h"
 #include "core/file_sys/fs.h"
+#include "core/file_sys/storage_scheduler.h"
 #include "core/libraries/kernel/kernel.h"
 #include "core/libraries/libs.h"
 #include "core/libraries/np/np_trophy.h"
@@ -421,6 +422,10 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
     }
 
     EmulatorSettings.Load(id);
+    const auto storage_config = Core::FileSys::GetApp0StorageScheduler().Configure({
+        .bandwidth_mibps = EmulatorSettings.GetApp0ReadBandwidthMiBps(),
+        .disable_time_stretching = EmulatorSettings.IsApp0ReadDisableTimeStretching(),
+    });
     // Switch to configured log
     Common::Log::Switch((!id.empty() && EmulatorSettings.IsLogSeparate()) ? id + ".log"
                                                                           : "shad_log.txt");
@@ -463,6 +468,9 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
     LOG_INFO(Config, "General isDevKit: {}", EmulatorSettings.IsDevKit());
     LOG_INFO(Config, "General isConnectedToNetwork: {}", EmulatorSettings.IsConnectedToNetwork());
     LOG_INFO(Config, "General isShadNetEnabled: {}", EmulatorSettings.IsShadNetEnabled());
+    LOG_INFO(Config, "Storage app0ReadBandwidthMiBps: {}", storage_config.bandwidth_mibps);
+    LOG_INFO(Config, "Storage app0ReadDisableTimeStretching: {}",
+             storage_config.disable_time_stretching);
     LOG_INFO(Config, "Log sync: {}", EmulatorSettings.IsLogSync());
     LOG_INFO(Config, "Log skipDuplicate: {}", EmulatorSettings.IsLogSkipDuplicate());
 #ifdef _WIN32

--- a/src/imgui/big_picture/settings_dialog_imgui.cpp
+++ b/src/imgui/big_picture/settings_dialog_imgui.cpp
@@ -11,6 +11,7 @@
 #include "common/logging/log.h"
 #include "common/path_util.h"
 #include "core/devtools/layer.h"
+#include "core/file_sys/storage_scheduler.h"
 #include "imgui/imgui_std.h"
 #include "settings_dialog_imgui.h"
 
@@ -20,6 +21,15 @@ constexpr float gameImageSize = 200.f;
 constexpr float settingsIconSize = 125.f;
 
 namespace ImGuiEmuSettings {
+
+namespace {
+
+int NormalizeHddReadBandwidth(int bandwidthMibps) {
+    return static_cast<int>(
+        Core::FileSys::NormalizeReadBandwidth(static_cast<u32>(bandwidthMibps)));
+}
+
+} // namespace
 
 int SettingsWindow::GetComboIndex(std::string selection, std::vector<std::string> options) {
     for (int i = 0; i < options.size(); i++) {
@@ -88,6 +98,9 @@ void SettingsWindow::LoadSettings(std::string profile) {
         pipelineCacheEnabledSetting = EmulatorSettings.IsPipelineCacheEnabled();
         pipelineCacheArchiveSetting = EmulatorSettings.IsPipelineCacheArchived();
         extraDmemSetting = EmulatorSettings.GetExtraDmemInMBytes();
+        app0ReadBandwidthSetting = NormalizeHddReadBandwidth(
+            static_cast<int>(EmulatorSettings.GetApp0ReadBandwidthMiBps()));
+        app0ReadDisableTimeStretchingSetting = EmulatorSettings.IsApp0ReadDisableTimeStretching();
         vblankFrequencySetting = EmulatorSettings.GetVblankFrequency();
     }
 }
@@ -143,6 +156,11 @@ void SettingsWindow::SaveSettings(std::string profile) {
         EmulatorSettings.SetPipelineCacheEnabled(pipelineCacheEnabledSetting, true);
         EmulatorSettings.SetPipelineCacheArchived(pipelineCacheArchiveSetting, true);
         EmulatorSettings.SetExtraDmemInMBytes(extraDmemSetting, true);
+        app0ReadBandwidthSetting = NormalizeHddReadBandwidth(app0ReadBandwidthSetting);
+        EmulatorSettings.SetApp0ReadBandwidthMiBps(static_cast<u32>(app0ReadBandwidthSetting),
+                                                   true);
+        EmulatorSettings.SetApp0ReadDisableTimeStretching(app0ReadDisableTimeStretchingSetting,
+                                                          true);
         EmulatorSettings.SetVblankFrequency(vblankFrequencySetting, true);
     }
 
@@ -740,6 +758,23 @@ void SettingsWindow::DrawSettingsTable(SettingsCategory category) {
             ImGui::TableSetupColumn("Value");
 
             AddSettingSliderInt("Additional DMem Allocation", extraDmemSetting, 0, 20000);
+            ImGui::TableNextRow();
+            ImGui::TableNextColumn();
+            ImGui::TextWrapped(
+                "HDD Read Bandwidth\n0 or above 200: Unlimited; 1-49: 50 MiB/s minimum");
+            ImGui::TableNextColumn();
+            ImGui::SetNextItemWidth(180.0f * uiScale);
+            ImGui::InputInt("##HDD Read Bandwidth", &app0ReadBandwidthSetting, 1, 10);
+            ImGui::SameLine();
+            ImGui::TextUnformatted("MiB/s");
+            const bool storageScheduleEnabled =
+                NormalizeHddReadBandwidth(app0ReadBandwidthSetting) != 0;
+            ImGui::BeginDisabled(!storageScheduleEnabled);
+            AddSettingCheckbox(
+                "Disable Time Stretching\nUse fixed HDD timing without frame-rate scaling. "
+                "Warning: this might break some games.",
+                app0ReadDisableTimeStretchingSetting);
+            ImGui::EndDisabled();
             AddSettingSliderInt("Vblank Frequency", vblankFrequencySetting, 30, 360);
             AddSettingCombo("Readbacks Mode", readbacksModeSetting, readbacksModeOptions);
             AddSettingCheckbox("Enable Readback Linear Images", readbackLinearImagesSetting);

--- a/src/imgui/big_picture/settings_dialog_imgui.h
+++ b/src/imgui/big_picture/settings_dialog_imgui.h
@@ -164,6 +164,8 @@ private:
     bool pipelineCacheEnabledSetting;
     bool pipelineCacheArchiveSetting;
     int extraDmemSetting;
+    int app0ReadBandwidthSetting;
+    bool app0ReadDisableTimeStretchingSetting;
     int vblankFrequencySetting;
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(SETTINGS_TEST_SOURCES
 
     # Tests
     test_emulator_settings.cpp
+    test_storage_config.cpp
 )
 
 set(NGS2_TEST_SOURCES
@@ -173,6 +174,7 @@ target_link_libraries(shadps4_settings_test PRIVATE
     fmt::fmt
     nlohmann_json::nlohmann_json
     toml11::toml11
+    Boost::headers
     SDL3::SDL3
     spdlog::spdlog
 )

--- a/tests/test_storage_config.cpp
+++ b/tests/test_storage_config.cpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <algorithm>
+#include <string_view>
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp> // NOLINT(misc-include-cleaner)
+#include <nlohmann/json_fwd.hpp>
+
+#include "core/emulator_settings.h"
+#include "core/file_sys/storage_scheduler.h"
+
+TEST(StorageConfigTest, NormalizesBandwidth) {
+    using Core::FileSys::NormalizeReadBandwidth;
+
+    EXPECT_EQ(NormalizeReadBandwidth(0), 0u);
+    EXPECT_EQ(NormalizeReadBandwidth(1), 50u);
+    EXPECT_EQ(NormalizeReadBandwidth(50), 50u);
+    EXPECT_EQ(NormalizeReadBandwidth(137), 137u);
+    EXPECT_EQ(NormalizeReadBandwidth(200), 200u);
+    EXPECT_EQ(NormalizeReadBandwidth(201), 0u);
+}
+
+TEST(StorageConfigTest, SettingsAreSerializedAndOverrideable) {
+    const GeneralSettings settings;
+    const nlohmann::json json = settings;
+
+    EXPECT_EQ(json.at("app0_read_bandwidth_mibps"), 0u);
+    EXPECT_FALSE(json.at("app0_read_disable_time_stretching"));
+
+    const auto overrides = settings.GetOverrideableFields();
+    const auto has_override = [&](std::string_view key) {
+        return std::ranges::any_of(overrides,
+                                   [=](const OverrideItem& item) { return item.key == key; });
+    };
+    EXPECT_TRUE(has_override("app0_read_bandwidth_mibps"));
+    EXPECT_TRUE(has_override("app0_read_disable_time_stretching"));
+}


### PR DESCRIPTION
## The problem

After two fucking months of debugging, finally: God of War 3 Remastered has multiple texture corruption problems during normal gameplay on shadPS4. This PR addresses one of them. After investigating a giant multi-frame RenderDoc capture, I isolated the problem to the CPU production side. After a painfully long analysis using CDB, I tracked the bug to a fucking use-after-free.

The problem? It's in the game's logic, not shadPS4's. The game uses a compactor running on the main thread that was tuned, terribly one might say, around the PS4's original asset-streaming and HDD speeds. When under memory pressure due to the increased I/O speed possible on shadPS4, or even a warm cache on the PS4 as documented in some user reports, the allocator fails to allocate memory for high-resolution textures and correctly returns `RAX = 0`, BUT THE GAME IGNORES IT.

The game then proceeds to use the memory slot in the texture descriptor despite not actually having ownership over it. In most cases, this causes garbage data to be uploaded to the GPU and therefore corrupt textures. Other times, it causes crashes. It's technically possible to create a per-game patch that circumvents this, but it would take a lot of work that I'm now too burned out to do after this incredible experience.

## The fix

Implement a completion-rate limiter that preserves the resulting FIOS2 FIFO order - it is disabled by default and gated by a setting. The limiter uses a token-bucket virtual-time cursor. Each read advances the cursor by `bytes / configured bandwidth`, while accumulated credit is clamped to a 5 ms burst window. The host `PRead` starts immediately into a reusable staging buffer. The storage worker waits only for any modeled time remaining after the host read completes. Data is then copied to the guest spans, and the operation is completed. This avoids large completion bursts on SSDs and faster HDDs.

Add a time-dilation factor derived from the guest's presentation cadence. Real guest flips feed an exponential moving average of the observed flip period. It scales future token charges from 1× to 4× in 25% increments. This prevents the game from receiving too much throughput during slower moments. Time dilation can be disabled independently. Both synchronous reads and AIO read commands respect this limiter.

Configured bandwidths between 50 and 200 MiB/s enable the limiter. Anything below 50 MiB/s is clamped to 50 MiB/s to avoid issues. Setting it to 0 or anything above 200 MiB/s disables the limiter.

The launcher options are already implemented. I will open a PR for them when this one is approved.

## Testing

Manually tested in the Gaia scene. The fread PR helps with general texture corruption, but this limiter remained necessary to fix the scene in the screenshots.

## Before and After

<img width="1919" height="1079" alt="BEFORE" src="https://github.com/user-attachments/assets/b910cc96-31dd-4906-8ee3-8d0980a71e00" />
<img width="1919" height="1079" alt="AFTER" src="https://github.com/user-attachments/assets/037868da-20f5-4b22-a1ba-4669889abec0" />
