### PR TITLE
video_core: Require robustness2 and remove null buffer/image workarounds

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -43,13 +43,6 @@ BufferCache::BufferCache(const Vulkan::Instance& instance_, Vulkan::Scheduler& s
 
     std::memset(gds_buffer.mapped_data.data(), 0, DataShareBufferSize);
 
-    // Ensure the first slot is used for the null buffer
-    const auto null_id =
-        slot_buffers.insert(instance, scheduler, MemoryUsage::DeviceLocal, 0, AllFlags, 16);
-    ASSERT(null_id.index == 0);
-    const vk::Buffer& null_buffer = slot_buffers[null_id].buffer;
-    Vulkan::SetObjectName(instance.GetDevice(), null_buffer, "Null Buffer");
-
     // Set up garbage collection parameters
     if (!instance.CanReportMemoryUsage()) {
         trigger_gc_memory = DEFAULT_TRIGGER_GC_MEMORY;
@@ -222,8 +215,6 @@ void BufferCache::BindVertexBuffers(
     Vulkan::VertexInputs<vk::DeviceSize> host_offsets;
     Vulkan::VertexInputs<vk::DeviceSize> host_sizes;
     Vulkan::VertexInputs<vk::DeviceSize> host_strides;
-    const auto null_buffer =
-        instance.IsNullDescriptorSupported() ? VK_NULL_HANDLE : GetBuffer(NULL_BUFFER_ID).Handle();
     for (const auto& buffer : guest_buffers) {
         if (buffer.GetSize() > 0) {
             const auto host_buffer_info =
@@ -236,7 +227,7 @@ void BufferCache::BindVertexBuffers(
             host_offsets.push_back(host_buffer_info->offset + buffer.base_address -
                                    host_buffer_info->base_address);
         } else {
-            host_buffers.emplace_back(null_buffer);
+            host_buffers.emplace_back(VK_NULL_HANDLE);
             host_offsets.push_back(0);
         }
         host_sizes.push_back(buffer.GetSize());
@@ -441,9 +432,7 @@ bool BufferCache::IsRegionGpuModified(VAddr addr, size_t size) {
 }
 
 BufferId BufferCache::FindBuffer(VAddr device_addr, u32 size) {
-    if (device_addr == 0) {
-        return NULL_BUFFER_ID;
-    }
+    ASSERT(device_addr != 0);
     const u64 page = device_addr >> CACHING_PAGEBITS;
     const BufferId buffer_id = page_table[page].buffer_id;
     if (!buffer_id) {

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -28,8 +28,6 @@ namespace VideoCore {
 
 using BufferId = Common::SlotId;
 
-static constexpr BufferId NULL_BUFFER_ID{0};
-
 class TextureCache;
 class MemoryTracker;
 class PageManager;

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -245,6 +245,16 @@ bool Instance::CreateDevice() {
     ASSERT_MSG(add_extension(VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME),
                "Required Vulkan extension unavailable: {}",
                VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME);
+    ASSERT_MSG(add_extension(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME),
+               "Required Vulkan extension unavailable: {}", VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
+
+    const auto robustness2_features = feature_chain.get<vk::PhysicalDeviceRobustness2FeaturesEXT>();
+    ASSERT_MSG(robustness2_features.robustBufferAccess2,
+               "Required Vulkan feature unavailable: robustBufferAccess2");
+    ASSERT_MSG(robustness2_features.robustImageAccess2,
+               "Required Vulkan feature unavailable: robustImageAccess2");
+    ASSERT_MSG(robustness2_features.nullDescriptor,
+               "Required Vulkan feature unavailable: nullDescriptor");
 
     // Optional
     maintenance_8 = add_extension(VK_KHR_MAINTENANCE_8_EXTENSION_NAME);
@@ -264,15 +274,6 @@ bool Instance::CreateDevice() {
             feature_chain.get<vk::PhysicalDeviceExtendedDynamicState3FeaturesEXT>();
         LOG_INFO(Render_Vulkan, "- extendedDynamicState3ColorWriteMask: {}",
                  dynamic_state_3_features.extendedDynamicState3ColorWriteMask);
-    }
-    robustness2 = add_extension(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
-    if (robustness2) {
-        robustness2_features = feature_chain.get<vk::PhysicalDeviceRobustness2FeaturesEXT>();
-        LOG_INFO(Render_Vulkan, "- robustBufferAccess2: {}",
-                 robustness2_features.robustBufferAccess2);
-        LOG_INFO(Render_Vulkan, "- robustImageAccess2: {}",
-                 robustness2_features.robustImageAccess2);
-        LOG_INFO(Render_Vulkan, "- nullDescriptor: {}", robustness2_features.nullDescriptor);
     }
     custom_border_color = add_extension(VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
     depth_clip_control = add_extension(VK_EXT_DEPTH_CLIP_CONTROL_EXTENSION_NAME);
@@ -450,9 +451,9 @@ bool Instance::CreateDevice() {
             .depthClipEnable = true,
         },
         vk::PhysicalDeviceRobustness2FeaturesEXT{
-            .robustBufferAccess2 = robustness2_features.robustBufferAccess2,
-            .robustImageAccess2 = robustness2_features.robustImageAccess2,
-            .nullDescriptor = robustness2_features.nullDescriptor,
+            .robustBufferAccess2 = true,
+            .robustImageAccess2 = true,
+            .nullDescriptor = true,
         },
         vk::PhysicalDeviceVertexInputDynamicStateFeaturesEXT{
             .vertexInputDynamicState = true,
@@ -515,9 +516,6 @@ bool Instance::CreateDevice() {
     }
     if (!depth_clip_enable) {
         device_chain.unlink<vk::PhysicalDeviceDepthClipEnableFeaturesEXT>();
-    }
-    if (!robustness2) {
-        device_chain.unlink<vk::PhysicalDeviceRobustness2FeaturesEXT>();
     }
     if (!vertex_input_dynamic_state) {
         device_chain.unlink<vk::PhysicalDeviceVertexInputDynamicStateFeaturesEXT>();

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -165,11 +165,6 @@ public:
         return vertex_input_dynamic_state;
     }
 
-    /// Returns true when the nullDescriptor feature of VK_EXT_robustness2 is supported.
-    bool IsNullDescriptorSupported() const {
-        return robustness2 && robustness2_features.nullDescriptor;
-    }
-
     /// Returns true when VK_KHR_fragment_shader_barycentric is supported.
     bool IsFragmentShaderBarycentricSupported() const {
         return fragment_shader_barycentric;
@@ -474,7 +469,6 @@ private:
     vk::PhysicalDeviceVulkan12Features vk12_features;
     vk::PhysicalDeviceVulkan13Features vk13_features;
     vk::PhysicalDeviceExtendedDynamicState3FeaturesEXT dynamic_state_3_features;
-    vk::PhysicalDeviceRobustness2FeaturesEXT robustness2_features;
     vk::PhysicalDeviceShaderAtomicFloat2FeaturesEXT shader_atomic_float2_features;
     vk::PhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR
         workgroup_memory_explicit_layout_features;
@@ -499,7 +493,6 @@ private:
     bool dynamic_state_3{};
     bool depth_range_unrestricted{};
     bool vertex_input_dynamic_state{};
-    bool robustness2{};
     bool list_restart{};
     bool legacy_vertex_attributes{};
     bool provoking_vertex{};

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -641,11 +641,8 @@ void Rasterizer::BindBuffers(const Shader::Info& stage, Shader::Backend::Binding
                 const auto [data, offset] = lds_buffer.Map(lds_size, alignment);
                 std::memset(data, 0, lds_size);
                 buffer_infos.emplace_back(lds_buffer.Handle(), offset, lds_size);
-            } else if (instance.IsNullDescriptorSupported()) {
-                buffer_infos.emplace_back(VK_NULL_HANDLE, 0, VK_WHOLE_SIZE);
             } else {
-                auto& null_buffer = buffer_cache.GetBuffer(VideoCore::NULL_BUFFER_ID);
-                buffer_infos.emplace_back(null_buffer.Handle(), 0, VK_WHOLE_SIZE);
+                buffer_infos.emplace_back(VK_NULL_HANDLE, 0, VK_WHOLE_SIZE);
             }
         } else {
             const auto [vk_buffer, offset] = buffer_cache.ObtainBuffer(
@@ -694,7 +691,7 @@ void Rasterizer::BindTextures(const Shader::Info& stage, Shader::Backend::Bindin
             LOG_WARNING(Render_Vulkan, "Unexpected metadata read by a shader (texture)");
         }
 
-        if (tsharp.GetDataFmt() == AmdGpu::DataFormat::FormatInvalid) {
+        if (tsharp.Address() == 0 || tsharp.GetDataFmt() == AmdGpu::DataFormat::FormatInvalid) {
             image_bindings.emplace_back(std::piecewise_construct, std::tuple{}, std::tuple{});
             image_descriptor_array_sizes.push_back(1);
             continue;
@@ -739,13 +736,7 @@ void Rasterizer::BindTextures(const Shader::Info& stage, Shader::Backend::Bindin
     for (auto& [image_id, desc] : image_bindings) {
         bool is_storage = desc.type == VideoCore::TextureCache::BindingType::Storage;
         if (!image_id) {
-            if (instance.IsNullDescriptorSupported()) {
-                image_infos.emplace_back(VK_NULL_HANDLE, VK_NULL_HANDLE, vk::ImageLayout::eGeneral);
-            } else {
-                auto& null_image_view = texture_cache.FindTexture(VideoCore::NULL_IMAGE_ID, desc);
-                image_infos.emplace_back(VK_NULL_HANDLE, *null_image_view.image_view,
-                                         vk::ImageLayout::eGeneral);
-            }
+            image_infos.emplace_back(VK_NULL_HANDLE, VK_NULL_HANDLE, vk::ImageLayout::eGeneral);
         } else {
             if (auto& old_image = texture_cache.GetImage(image_id);
                 old_image.binding.needs_rebind) {

--- a/src/video_core/texture_cache/image.h
+++ b/src/video_core/texture_cache/image.h
@@ -78,8 +78,6 @@ public:
     vk::ImageCreateInfo image_ci{};
 };
 
-constexpr Common::SlotId NULL_IMAGE_ID{0};
-
 class BlitHelper;
 
 struct Image {

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -29,9 +29,6 @@ TextureCache::TextureCache(const Vulkan::Instance& instance_, Vulkan::Scheduler&
       buffer_cache{buffer_cache_}, tracker{tracker_}, blit_helper{instance, scheduler},
       tile_manager{instance, scheduler, buffer_cache.GetUtilityBuffer(MemoryUsage::Stream)},
       readback_linear_images{EmulatorSettings.IsReadbackLinearImagesEnabled()} {
-    // Create basic null image at fixed image ID.
-    const auto null_id = GetNullImage(vk::Format::eR8G8B8A8Unorm);
-    ASSERT(null_id.index == NULL_IMAGE_ID.index);
 
     // Set up garbage collection parameters.
     if (!instance.CanReportMemoryUsage()) {
@@ -57,33 +54,6 @@ TextureCache::TextureCache(const Vulkan::Instance& instance_, Vulkan::Scheduler&
 }
 
 TextureCache::~TextureCache() = default;
-
-ImageId TextureCache::GetNullImage(const vk::Format format) {
-    const auto existing_image = null_images.find(format);
-    if (existing_image != null_images.end()) {
-        return existing_image->second;
-    }
-
-    ImageInfo info{};
-    info.pixel_format = format;
-    info.type = AmdGpu::ImageType::Color2D;
-    info.tile_mode = AmdGpu::TileMode::Thin1DThin;
-    info.num_bits = 32;
-    info.UpdateSize();
-
-    const ImageId null_id =
-        slot_images.insert(instance, scheduler, blit_helper, slot_image_views, info);
-    auto& image = slot_images[null_id];
-    Vulkan::SetObjectName(instance.GetDevice(), image.GetImage(),
-                          fmt::format("Null Image ({})", vk::to_string(format)));
-
-    image.flags = ImageFlagBits::Empty;
-    image.track_addr = image.info.guest_address;
-    image.track_addr_end = image.info.guest_address + image.info.guest_size;
-
-    null_images.emplace(format, null_id);
-    return null_id;
-}
 
 void TextureCache::ProcessDownloadImages() {
     for (const ImageId image_id : download_images) {
@@ -529,10 +499,7 @@ ImageId TextureCache::ExpandImage(const ImageInfo& info, ImageId image_id) {
 
 ImageId TextureCache::FindImage(ImageDesc& desc, bool exact_fmt) {
     const auto& info = desc.info;
-
-    if (info.guest_address == 0) [[unlikely]] {
-        return GetNullImage(info.pixel_format);
-    }
+    ASSERT(info.guest_address != 0);
 
     std::scoped_lock lock{mutex};
     ImageIds image_ids;

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -268,9 +268,6 @@ private:
         }
     }
 
-    /// Gets or creates a null image for a particular format.
-    ImageId GetNullImage(vk::Format format);
-
     /// Copies image memory back to CPU.
     void DownloadImageMemory(ImageId image_id, bool sync = false);
 
@@ -321,7 +318,6 @@ private:
     Common::SlotVector<Image> slot_images;
     Common::SlotVector<ImageView> slot_image_views;
     tsl::robin_map<u64, Sampler> samplers;
-    tsl::robin_map<vk::Format, ImageId> null_images;
     std::unordered_set<ImageId> download_images;
     u64 total_used_memory = 0;
     u64 trigger_gc_memory = 0;


### PR DESCRIPTION
The current null image workarounds are not always reliable. For example, if depth null image is attempted it currently creates an incorrect image and can crash from bad Vulkan usage.

These workarounds were only originally added for MoltenVK which lacked anything from `robustness2` except image robustness. Now that we are using KosmicKrisp for macOS with full `robustness2` support, we can just drop these and require it, simplifying things a lot.

`robustness2` is widely supported on desktop GPUs, and all of its features are required by the Vulkan 2026 roadmap milestone as well.

This fixes some validation issues in Ratchet & Clank (2016), which would lead to a crash using mesa builds with asserts enabled.