### PR TITLE
fix: null dereference in internal__Foprep on file exhaustion

### DIFF
--- a/src/core/libraries/libc_internal/libc_internal_io.cpp
+++ b/src/core/libraries/libc_internal/libc_internal_io.cpp
@@ -73,6 +73,7 @@ OrbisFILE* PS4_SYSV_ABI internal__Foprep(const char* path, const char* mode, Orb
                                          s32 fd, s32 s_mode, s32 flag) {
     if (file == nullptr) {
         *Kernel::__Error() = POSIX_ENOMEM;
+        return nullptr;
     }
 
     // Preserve mode and index


### PR DESCRIPTION
Closes #4698
This PR fixes a bug in `libc_internal_io.cpp` where the emulator would crash upon exhausting the `FILE` table. 
Previously, `internal__Foprep` checked if the `file` argument was `nullptr` and set the `POSIX_ENOMEM` error, but it was missing an explicit `return` statement. This caused the function to fall through and immediately dereference the null `file` pointer on the subsequent lines. 
By adding the missing `return nullptr;`, this function now cleanly propagates the error back to the guest application instead of crashing the emulator. 
# Changes
* Added `return nullptr;` after setting `*Kernel::__Error() = POSIX_ENOMEM;` inside `internal__Foprep`.