### PR TITLE
Fix issue 4696

### DIFF
--- a/src/core/libraries/save_data/savedata.cpp
+++ b/src/core/libraries/save_data/savedata.cpp
@@ -1259,7 +1259,7 @@ Error PS4_SYSV_ABI sceSaveDataMount(const OrbisSaveDataMount* mount,
         LOG_INFO(Lib_SaveData, "called without initialize");
         return setNotInitializedError();
     }
-    if (mount == nullptr && mount->dirName != nullptr) {
+    if (mount == nullptr || mount->dirName == nullptr) {
         LOG_INFO(Lib_SaveData, "called with invalid parameter");
         return Error::PARAMETER;
     }
@@ -1280,7 +1280,7 @@ Error PS4_SYSV_ABI sceSaveDataMount2(const OrbisSaveDataMount2* mount,
         LOG_INFO(Lib_SaveData, "called without initialize");
         return setNotInitializedError();
     }
-    if (mount == nullptr && mount->dirName != nullptr) {
+    if (mount == nullptr || mount->dirName == nullptr) {
         LOG_INFO(Lib_SaveData, "called with invalid parameter");
         return Error::PARAMETER;
     }


### PR DESCRIPTION
Fixes #4696
This PR fixes a bug in `savedata.cpp` where `sceSaveDataMount` and `sceSaveDataMount2` would crash the emulator due to a null-pointer dereference when receiving invalid arguments.
Previously, the null-check was written as `if (mount == nullptr && mount->dirName != nullptr)`. This logic used `&&`, causing a short-circuit dereference of `mount->dirName` if `mount` was indeed null. It also failed to catch cases where `mount` was valid but `mount->dirName` was null, leading to a crash in the subsequent `LOG_DEBUG` macro.
By correcting the check to use `||` and `==` instead, invalid parameters now safely return `Error::PARAMETER` as intended without crashing the emulator.
# Changes
* Corrected null-check condition in `sceSaveDataMount` to `if (mount == nullptr || mount->dirName == nullptr)`.
* Corrected null-check condition in `sceSaveDataMount2` to `if (mount == nullptr || mount->dirName == nullptr)`.