### PR TITLE
Fix shader cache invalidation caused by struct padding memcmp(Fixes #4645)

### DIFF
--- a/src/shader_recompiler/profile.h
+++ b/src/shader_recompiler/profile.h
@@ -52,6 +52,8 @@ struct Profile {
     bool needs_unorm_fixup{};
     bool needs_clip_distance_emulation{};
     bool supports_shader_stencil_export{};
+
+    bool operator==(const Profile&) const = default;
 };
 
 } // namespace Shader

--- a/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
@@ -313,8 +313,16 @@ void PipelineCache::WarmUp() {
                                            std::move(profile_data));
         return;
     }
+    if (profile_data.size() != sizeof(Shader::Profile)) {
+        LOG_WARNING(Render,
+                    "Pipeline cache profile has unexpected size ({} != {}). Ignoring the cache",
+                    profile_data.size(), sizeof(Shader::Profile));
+        Storage::DataBase::Instance().Close();
+        return;
+    }
+
     Shader::Profile cached_profile{};
-    std::memcpy(&cached_profile, profile_data.data(), sizeof(profile));
+    std::memcpy(&cached_profile, profile_data.data(), sizeof(cached_profile));
     if (cached_profile != profile) {
         LOG_WARNING(Render,
                     "Pipeline cache isn't compatible with current system. Ignoring the cache");

--- a/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
@@ -313,7 +313,9 @@ void PipelineCache::WarmUp() {
                                            std::move(profile_data));
         return;
     }
-    if (std::memcmp(profile_data.data(), &profile, sizeof(profile)) != 0) {
+    Shader::Profile cached_profile{};
+    std::memcpy(&cached_profile, profile_data.data(), sizeof(profile));
+    if (cached_profile != profile) {
         LOG_WARNING(Render,
                     "Pipeline cache isn't compatible with current system. Ignoring the cache");
         Storage::DataBase::Instance().Close();


### PR DESCRIPTION
### Description
This PR addresses issue #4645, where the shader cache (`profile.bin`) fails to load on subsequent game launches, preventing new shaders from compiling into the cache unless the cache file is manually deleted.
**Root Cause:**
When `PipelineCache::WarmUp()` evaluates the `profile.bin` compatibility on subsequent launches, it compares the loaded data against the currently active `Shader::Profile` using `std::memcmp`. However, because `Shader::Profile` contains a mix of `u64`, `u32`, and `bool` fields, the struct has several uninitialized padding bytes at the end of its memory layout. These uninitialized padding bytes contain random garbage depending on the compiler and execution, causing `std::memcmp` to fail even when the actual feature flags are completely identical. This failure closes the database and aborts cache usage.
**Fix:**
- Added `bool operator==(const Profile&) const = default;` to `Shader::Profile`. In C++20, this automatically generates a safe, member-wise comparison operator that explicitly ignores padding bytes.
- Updated `vk_pipeline_serialization.cpp` to load the profile data into a temporary `Profile` object and verify compatibility using `operator!=` instead of `std::memcmp`.
**Testing:**
- Verified that `profile.bin` is successfully recognized across multiple game launches.
- Shaders now correctly resume compiling and caching into the same folder without needing to clear the file.
Closes #4645.
