### PR TITLE
Move asm to unit file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,8 +364,7 @@ set(KERNEL_LIB src/core/libraries/kernel/coredump/coredump.cpp
 )
 
 if (ARCHITECTURE STREQUAL "x86_64" OR ARCHITECTURE STREQUAL "arm64")
-    list(APPEND KERNEL_LIB src/core/libraries/kernel/threads/stack.S)
-    set_source_files_properties(src/core/libraries/kernel/threads/stack.S PROPERTIES COMPILE_OPTIONS -Wno-unused-command-line-argument)
+    list(APPEND KERNEL_LIB src/core/libraries/kernel/threads/stack_asm.cpp)
 endif()
 
 set(NETWORK_LIBS src/core/libraries/network/http.cpp
@@ -609,13 +608,11 @@ set(USBD_LIB src/core/libraries/usbd/usbd.cpp
              src/core/libraries/usbd/emulated/skylander.h
 )
 
-set(FIBER_LIB src/core/libraries/fiber/fiber_context.s
+set(FIBER_LIB src/core/libraries/fiber/fiber_context.cpp
               src/core/libraries/fiber/fiber.cpp
               src/core/libraries/fiber/fiber.h
               src/core/libraries/fiber/fiber_error.h
 )
-
-set_source_files_properties(src/core/libraries/fiber/fiber_context.s PROPERTIES COMPILE_OPTIONS -Wno-unused-command-line-argument)
 
 set(VDEC_LIB src/core/libraries/videodec/videodec2_impl.cpp
              src/core/libraries/videodec/videodec2_impl.h

--- a/src/core/libraries/fiber/fiber.cpp
+++ b/src/core/libraries/fiber/fiber.cpp
@@ -29,7 +29,7 @@ extern "C" void PS4_SYSV_ABI _sceFiberSwitchEntry(OrbisFiberData* data,
                                                   bool set_fpu) asm("_sceFiberSwitchEntry");
 extern "C" void PS4_SYSV_ABI _sceFiberForceQuit(u64 ret) asm("_sceFiberForceQuit");
 
-extern "C" void PS4_SYSV_ABI _sceFiberForceQuit(u64 ret) {
+extern "C" void __attribute__((used)) PS4_SYSV_ABI _sceFiberForceQuit(u64 ret) {
     OrbisFiberContext* g_ctx = GetFiberContext();
     g_ctx->return_val = ret;
     _sceFiberLongJmp(g_ctx);

--- a/src/core/libraries/fiber/fiber_context.cpp
+++ b/src/core/libraries/fiber/fiber_context.cpp
@@ -1,6 +1,13 @@
-# SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
-# SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/types.h"
+
+#if defined(__x86_64__)
+asm(".att_syntax prefix");
+#endif
+
+asm(R"(
 .global _sceFiberSetJmp
 _sceFiberSetJmp:
     movq %rax, 0x0(%rdi)
@@ -119,3 +126,4 @@ _sceFiberSwitchEntry:
     movl $1, %edi
     call _sceFiberForceQuit
     ret
+)");

--- a/src/core/libraries/kernel/threads/stack_asm.cpp
+++ b/src/core/libraries/kernel/threads/stack_asm.cpp
@@ -1,13 +1,22 @@
-# SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
-# SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#if defined(__x86_64__)
+asm(".att_syntax prefix");
+#endif
 
 #if defined(__x86_64__)
 
+asm(R"(
 .global _runOnAnotherStack
 _runOnAnotherStack:
   pushq %r12
   pushq %r13
+)");
+
 #ifdef _WIN32
+
+asm(R"(
   pushq %r14
   pushq %r15
 
@@ -19,7 +28,11 @@ _runOnAnotherStack:
   xorq %rcx, %rcx
   movq %rcx, %gs:0x08 # teb->stack_bottom = 0
   movq %rcx, %gs:0x10 # teb->stack_top = 0
+)");
+
 #endif
+
+asm(R"(
   movq %rsp, %r12
   movq %rbp, %r13
   movq %rdx, %rsp
@@ -27,19 +40,29 @@ _runOnAnotherStack:
   callq *%rsi
   movq %r13, %rbp
   movq %r12, %rsp
+)");
+
 #ifdef _WIN32
+
+asm(R"(
   # restore stack check registers
   movq %r14, %gs:0x08 # teb->stack_bottom
   movq %r15, %gs:0x10 # teb->stack_top
   popq %r15
   popq %r14
+)");
+
 #endif
+
+asm(R"(
   popq %r13
   popq %r12
   ret
+)");
 
 #elif defined(__arm64__) || defined(__aarch64__)
 
+asm(R"(
 .global _runOnAnotherStack
 _runOnAnotherStack:
   // Save frame pointer (x29), link register (x30), and callee-saved registers x19, x20
@@ -73,5 +96,6 @@ _runOnAnotherStack:
   ldp x29, x30, [sp], #32
   ret
 
-#endif
+)");
 
+#endif


### PR DESCRIPTION
`__attribute__((used))` is needed to prevent lto from vanishing `_sceFiberForceQuit` symbol into orbit.

All generators are checked with CI and seems to work fine, did this so I can debug in visual studio without the headache fighting with launch.vs.json randomly resetting and cmake regenerating projects for no reason on visual studio launches.