### PR TITLE
video_core: synchronize independently backed aliased images

### DIFF
--- a/src/video_core/buffer_cache/buffer.cpp
+++ b/src/video_core/buffer_cache/buffer.cpp
@@ -160,6 +160,13 @@ void Buffer::Fill(u64 offset, u32 num_bytes, u32 value) {
     });
 }
 
+void Buffer::Invalidate(u64 offset, u64 size) {
+    ASSERT(offset + size <= size_bytes);
+    if (!is_coherent && usage == MemoryUsage::Download) {
+        vmaInvalidateAllocation(instance->GetAllocator(), buffer.allocation, offset, size);
+    }
+}
+
 constexpr u64 WATCHES_INITIAL_RESERVE = 0x4000;
 constexpr u64 WATCHES_RESERVE_CHUNK = 0x1000;
 

--- a/src/video_core/buffer_cache/buffer.h
+++ b/src/video_core/buffer_cache/buffer.h
@@ -150,6 +150,9 @@ public:
 
     void Fill(u64 offset, u32 num_bytes, u32 value);
 
+    /// Makes a completed download range visible to the CPU.
+    void Invalidate(u64 offset, u64 size);
+
 public:
     VAddr cpu_addr = 0;
     bool is_picked{};

--- a/src/video_core/texture_cache/image.h
+++ b/src/video_core/texture_cache/image.h
@@ -176,6 +176,7 @@ public:
     BackingImage* backing{};
     boost::container::static_vector<u64, 16> mip_hashes{};
     u64 image_uid{};
+    u64 alias_generation{};
     u64 lru_id{};
     u64 tick_accessed_last{};
     u64 hash{};

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -1,8 +1,13 @@
 // SPDX-FileCopyrightText: Copyright 2024-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <algorithm>
+#include <map>
+#include <memory>
+
 #include <xxhash.h>
 
+#include "common/alignment.h"
 #include "common/assert.h"
 #include "common/debug.h"
 #include "common/div_ceil.h"
@@ -22,11 +27,165 @@ namespace VideoCore {
 static constexpr u64 PageShift = 12;
 static constexpr u64 NumFramesBeforeRemoval = 32;
 
+struct PendingImageDownload {
+    struct Page {
+        VAddr address;
+        u64 generation;
+    };
+
+    VAddr address;
+    u8* data;
+    Buffer* buffer;
+    u64 buffer_offset;
+    u64 size;
+    std::unique_ptr<Buffer> async_buffer;
+    boost::container::small_vector<Page, 4> pages;
+};
+
+class ReadbackTracker {
+public:
+    explicit ReadbackTracker(PageManager& page_manager_) : page_manager{&page_manager_} {}
+
+    void TrackAsync(PendingImageDownload& pending) {
+        std::scoped_lock lock{mutex};
+        if (canceled) {
+            return;
+        }
+        ForEachPage(pending.address, pending.size, [&](VAddr page) {
+            PageState& state = pages[page];
+            if (!state.watched) {
+                page_manager->UpdatePageWatchers<true>(page, PageSize(page));
+                state.watched = true;
+            }
+            ++state.readers;
+            pending.pages.push_back({page, state.generation});
+        });
+    }
+
+    void Invalidate(VAddr address, u64 size) {
+        std::scoped_lock lock{mutex};
+        if (canceled || size == 0) {
+            return;
+        }
+        const VAddr begin = PageManager::GetPageAddr(address);
+        const VAddr end = PageManager::GetNextPageAddr(address + size - 1);
+        for (auto it = pages.lower_bound(begin); it != pages.end() && it->first < end; ++it) {
+            const VAddr page = it->first;
+            PageState& state = it->second;
+            ++state.generation;
+            if (state.watched) {
+                page_manager->UpdatePageWatchers<false>(page, PageSize(page));
+                state.watched = false;
+            }
+        }
+    }
+
+    void CompleteSync(const PendingImageDownload& pending) {
+        Invalidate(pending.address, pending.size);
+        pending.buffer->Invalidate(pending.buffer_offset, pending.size);
+        Core::Memory::Instance()->TryWriteBacking(std::bit_cast<u8*>(pending.address), pending.data,
+                                                  pending.size);
+    }
+
+    void CompleteAsync(const PendingImageDownload& pending) {
+        std::scoped_lock lock{mutex};
+        if (canceled) {
+            return;
+        }
+        pending.buffer->Invalidate(pending.buffer_offset, pending.size);
+        for (const PendingImageDownload::Page& page : pending.pages) {
+            const auto it = pages.find(page.address);
+            if (it == pages.end() || it->second.generation != page.generation) {
+                continue;
+            }
+            const VAddr begin = std::max<VAddr>(pending.address, page.address);
+            const VAddr end = std::min<VAddr>(pending.address + pending.size,
+                                              page.address + PageSize(page.address));
+            Core::Memory::Instance()->TryWriteBacking(
+                std::bit_cast<u8*>(begin), pending.data + (begin - pending.address), end - begin);
+        }
+        Release(pending);
+    }
+
+    void Cancel() {
+        std::scoped_lock lock{mutex};
+        canceled = true;
+        for (const auto& [page, state] : pages) {
+            if (state.watched) {
+                page_manager->UpdatePageWatchers<false>(page, PageSize(page));
+            }
+        }
+        pages.clear();
+        page_manager = nullptr;
+    }
+
+private:
+    struct PageState {
+        u64 generation{};
+        u32 readers{};
+        bool watched{};
+    };
+
+    static VAddr PageSize(VAddr page) {
+        return PageManager::GetNextPageAddr(page) - page;
+    }
+
+    template <typename Func>
+    static void ForEachPage(VAddr address, u64 size, Func&& func) {
+        const VAddr end = PageManager::GetNextPageAddr(address + size - 1);
+        for (VAddr page = PageManager::GetPageAddr(address); page < end; page += PageSize(page)) {
+            func(page);
+        }
+    }
+
+    void Release(const PendingImageDownload& pending) {
+        for (const PendingImageDownload::Page& page : pending.pages) {
+            const auto it = pages.find(page.address);
+            if (it == pages.end()) {
+                continue;
+            }
+            PageState& state = it->second;
+            ASSERT(state.readers > 0);
+            if (--state.readers == 0) {
+                if (state.watched) {
+                    page_manager->UpdatePageWatchers<false>(page.address, PageSize(page.address));
+                }
+                pages.erase(it);
+            }
+        }
+    }
+
+    std::mutex mutex;
+    std::map<VAddr, PageState> pages;
+    PageManager* page_manager;
+    bool canceled{};
+};
+
+[[nodiscard]] static u64 GetDownloadSize(const ImageInfo& info) {
+    return static_cast<u64>(info.pitch) * info.size.height * info.size.depth *
+           info.resources.layers * (info.num_bits / 8);
+}
+
+[[nodiscard]] static bool IsAliasCopyCompatible(const Image& src, const Image& dst) {
+    return src.info.guest_address == dst.info.guest_address &&
+           src.info.pixel_format == dst.info.pixel_format &&
+           src.info.num_bits == dst.info.num_bits && src.info.num_samples == dst.info.num_samples &&
+           !src.info.props.is_depth && !dst.info.props.is_depth &&
+           src.info.props.is_block == dst.info.props.is_block &&
+           src.info.tile_mode == dst.info.tile_mode && src.info.array_mode == dst.info.array_mode &&
+           src.info.bank_swizzle == dst.info.bank_swizzle &&
+           src.info.alt_tile == dst.info.alt_tile && src.info.size.width >= dst.info.size.width &&
+           src.info.size.height >= dst.info.size.height &&
+           src.info.size.depth >= dst.info.size.depth;
+}
+
 TextureCache::TextureCache(const Vulkan::Instance& instance_, Vulkan::Scheduler& scheduler_,
                            AmdGpu::Liverpool* liverpool_, BufferCache& buffer_cache_,
                            PageManager& tracker_)
     : instance{instance_}, scheduler{scheduler_}, liverpool{liverpool_},
-      buffer_cache{buffer_cache_}, tracker{tracker_}, blit_helper{instance, scheduler},
+      buffer_cache{buffer_cache_}, tracker{tracker_},
+      readback_tracker{std::make_shared<ReadbackTracker>(tracker)},
+      blit_helper{instance, scheduler},
       tile_manager{instance, scheduler, buffer_cache.GetUtilityBuffer(MemoryUsage::Stream)},
       readback_linear_images{EmulatorSettings.IsReadbackLinearImagesEnabled()} {
 
@@ -58,29 +217,192 @@ TextureCache::TextureCache(const Vulkan::Instance& instance_, Vulkan::Scheduler&
     trigger_gc_memory = static_cast<u64>((device_local_memory - mem_threshold) / 2);
 }
 
-TextureCache::~TextureCache() = default;
-
-void TextureCache::ProcessDownloadImages() {
-    std::unique_lock lk{download_images_mutex};
-    for (const ImageId image_id : download_images) {
-        DownloadImageMemory(image_id, true);
-    }
-    download_images.clear();
+TextureCache::~TextureCache() {
+    readback_tracker->Cancel();
 }
 
-void TextureCache::DownloadImageMemory(ImageId image_id, bool sync) {
+void TextureCache::UpdateImage(ImageId image_id) {
+    std::scoped_lock lock{mutex};
+    UpdateImageImpl(image_id);
+}
+
+void TextureCache::UpdateImageForTexture(ImageId image_id) {
+    std::scoped_lock lock{mutex};
+    UpdateImageImpl(image_id);
+    SynchronizeAlias(image_id);
+}
+
+void TextureCache::UpdateImageImpl(ImageId image_id) {
     Image& image = slot_images[image_id];
-    if (False(image.flags & ImageFlagBits::GpuModified)) {
+    TrackImage(image_id);
+    TouchImage(image);
+    RefreshImage(image);
+}
+
+void TextureCache::ProcessDownloadImages() {
+    std::scoped_lock lock{mutex};
+    boost::container::small_vector<ImageId, 16> images;
+    images.reserve(download_images.size() + pending_alias_downloads.size());
+    const auto append = [this, &images](ImageId image_id) {
+        if (!image_id || !slot_images.is_allocated(image_id) ||
+            False(slot_images[image_id].flags & ImageFlagBits::GpuModified) ||
+            std::ranges::find(images, image_id) != images.end()) {
+            return;
+        }
+        images.push_back(image_id);
+    };
+    for (const ImageId image_id : download_images) {
+        append(image_id);
+    }
+    for (const VAddr address : pending_alias_downloads) {
+        auto state_it = alias_states.find(address);
+        if (state_it == alias_states.end()) {
+            continue;
+        }
+        AliasState& state = state_it.value();
+        if (!state.download_pending) {
+            continue;
+        }
+        state.download_pending = false;
+        if (!state.writer || !slot_images.is_allocated(state.writer)) {
+            continue;
+        }
+        const Image& image = slot_images[state.writer];
+        if (image.image_uid == state.writer_uid && image.info.guest_address == address &&
+            True(image.flags & ImageFlagBits::GpuModified)) {
+            append(state.writer);
+        }
+    }
+    pending_alias_downloads.clear();
+    download_images.clear();
+
+    auto& download_buffer = buffer_cache.GetUtilityBuffer(MemoryUsage::Download);
+    const u64 buffer_size = download_buffer.SizeBytes();
+    size_t batch_begin = 0;
+    while (batch_begin < images.size()) {
+        u64 batch_size{};
+        size_t batch_end = batch_begin;
+        for (; batch_end < images.size(); ++batch_end) {
+            const u64 size = GetDownloadSize(slot_images[images[batch_end]].info);
+            ASSERT_MSG(size <= buffer_size, "Image download ({:#x}) exceeds stream buffer ({:#x})",
+                       size, buffer_size);
+            if (size > buffer_size ||
+                (batch_size != 0 && Common::AlignUp(batch_size, 16) + size > buffer_size)) {
+                break;
+            }
+            batch_size = Common::AlignUp(batch_size, 16) + size;
+        }
+        if (batch_end == batch_begin) {
+            ++batch_begin;
+            continue;
+        }
+
+        const auto [data, offset] = download_buffer.Map(batch_size, 16);
+        ASSERT(data != nullptr);
+        download_buffer.Commit();
+        boost::container::small_vector<PendingImageDownload, 16> pending;
+        pending.reserve(batch_end - batch_begin);
+        u64 subrange{};
+        for (size_t index = batch_begin; index < batch_end; ++index) {
+            subrange = Common::AlignUp(subrange, 16);
+            pending.push_back(ScheduleImageDownload(slot_images[images[index]], download_buffer,
+                                                    data + subrange, offset + subrange));
+            subrange += pending.back().size;
+        }
+        scheduler.Finish();
+        for (const PendingImageDownload& download : pending) {
+            readback_tracker->CompleteSync(download);
+        }
+        batch_begin = batch_end;
+    }
+}
+
+void TextureCache::SynchronizeAlias(ImageId image_id) {
+    Image& dst = slot_images[image_id];
+    auto state_it = alias_states.find(dst.info.guest_address);
+    if (state_it == alias_states.end()) {
         return;
     }
-    auto& download_buffer = buffer_cache.GetUtilityBuffer(MemoryUsage::Download);
-    const u32 download_size = image.info.pitch * image.info.size.height * image.info.size.depth *
-                              image.info.resources.layers * (image.info.num_bits / 8);
+    AliasState& state = state_it.value();
+    if (!state.writer || !slot_images.is_allocated(state.writer)) {
+        alias_states.erase(dst.info.guest_address);
+        return;
+    }
+    Image& src = slot_images[state.writer];
+    if (src.image_uid != state.writer_uid) {
+        alias_states.erase(dst.info.guest_address);
+        return;
+    }
+    if (state.writer == image_id || src.alias_generation <= dst.alias_generation ||
+        !IsAliasCopyCompatible(src, dst)) {
+        return;
+    }
+
+    scheduler.EndRendering();
+    src.Transit(vk::ImageLayout::eTransferSrcOptimal, vk::AccessFlagBits2::eTransferRead, {});
+    dst.Transit(vk::ImageLayout::eTransferDstOptimal, vk::AccessFlagBits2::eTransferWrite, {});
+
+    const vk::ImageCopy region = {
+        .srcSubresource =
+            {
+                .aspectMask = vk::ImageAspectFlagBits::eColor,
+                .mipLevel = 0,
+                .baseArrayLayer = 0,
+                .layerCount = std::min(src.info.resources.layers, dst.info.resources.layers),
+            },
+        .srcOffset = {0, 0, 0},
+        .dstSubresource =
+            {
+                .aspectMask = vk::ImageAspectFlagBits::eColor,
+                .mipLevel = 0,
+                .baseArrayLayer = 0,
+                .layerCount = std::min(src.info.resources.layers, dst.info.resources.layers),
+            },
+        .dstOffset = {0, 0, 0},
+        .extent = {dst.info.size.width, dst.info.size.height, dst.info.size.depth},
+    };
+    scheduler.CommandBuffer().copyImage(src.GetImage(), vk::ImageLayout::eTransferSrcOptimal,
+                                        dst.GetImage(), vk::ImageLayout::eTransferDstOptimal,
+                                        region);
+    dst.alias_generation = src.alias_generation;
+    dst.flags |= ImageFlagBits::GpuModified;
+    dst.flags &= ~ImageFlagBits::Dirty;
+    state.has_alias = true;
+}
+
+void TextureCache::MarkGpuWrite(ImageId image_id) {
+    std::scoped_lock lock{mutex};
+    Image& image = slot_images[image_id];
+    readback_tracker->Invalidate(image.info.guest_address, image.info.guest_size);
+    image.alias_generation = ++alias_generation;
+
+    AliasState& state = alias_states[image.info.guest_address];
+    if (state.writer) {
+        if (slot_images.is_allocated(state.writer) &&
+            slot_images[state.writer].image_uid == state.writer_uid) {
+            state.has_alias |= state.writer != image_id;
+        } else {
+            state = {};
+        }
+    }
+    state.writer = image_id;
+    state.writer_uid = image.image_uid;
+
+    constexpr u64 SmallAliasReadbackLimit = 4_KB;
+    const u64 download_size = GetDownloadSize(image.info);
+    const bool needs_download = state.has_alias && download_size <= SmallAliasReadbackLimit;
+    if (needs_download && !state.download_pending) {
+        pending_alias_downloads.push_back(image.info.guest_address);
+    }
+    state.download_pending = needs_download;
+}
+
+PendingImageDownload TextureCache::ScheduleImageDownload(Image& image, Buffer& buffer, u8* data,
+                                                         u64 buffer_offset) {
+    const u64 download_size = GetDownloadSize(image.info);
     ASSERT(download_size <= image.info.guest_size);
-    const auto [download, offset] = download_buffer.Map(download_size);
-    download_buffer.Commit();
     const vk::BufferImageCopy image_download = {
-        .bufferOffset = offset,
+        .bufferOffset = buffer_offset,
         .bufferRowLength = image.info.pitch,
         .bufferImageHeight = image.info.size.height,
         .imageSubresource =
@@ -95,22 +417,33 @@ void TextureCache::DownloadImageMemory(ImageId image_id, bool sync) {
         .imageExtent = {image.info.size.width, image.info.size.height, image.info.size.depth},
     };
     scheduler.EndRendering();
-    const auto cmdbuf = scheduler.CommandBuffer();
     image.Transit(vk::ImageLayout::eTransferSrcOptimal, vk::AccessFlagBits2::eTransferRead, {});
-    cmdbuf.copyImageToBuffer(image.GetImage(), vk::ImageLayout::eTransferSrcOptimal,
-                             download_buffer.Handle(), image_download);
+    scheduler.CommandBuffer().copyImageToBuffer(
+        image.GetImage(), vk::ImageLayout::eTransferSrcOptimal, buffer.Handle(), image_download);
+    return {
+        .address = image.info.guest_address,
+        .data = data,
+        .buffer = &buffer,
+        .buffer_offset = buffer_offset,
+        .size = download_size,
+    };
+}
 
-    if (sync) {
-        scheduler.Finish();
-        Core::Memory::Instance()->TryWriteBacking(std::bit_cast<u8*>(image.info.guest_address),
-                                                  download, download_size);
-    } else {
-        scheduler.DeferPriorityOperation(
-            [this, device_addr = image.info.guest_address, download, download_size] {
-                Core::Memory::Instance()->TryWriteBacking(std::bit_cast<u8*>(device_addr), download,
-                                                          download_size);
-            });
+void TextureCache::DownloadImageMemory(ImageId image_id) {
+    Image& image = slot_images[image_id];
+    if (False(image.flags & ImageFlagBits::GpuModified)) {
+        return;
     }
+    const u64 download_size = GetDownloadSize(image.info);
+    auto buffer = std::make_unique<Buffer>(instance, scheduler, MemoryUsage::Download, 0, AllFlags,
+                                           download_size);
+    PendingImageDownload pending =
+        ScheduleImageDownload(image, *buffer, buffer->mapped_data.data(), 0);
+    pending.async_buffer = std::move(buffer);
+    readback_tracker->TrackAsync(pending);
+    scheduler.DeferPriorityOperation([tracker = readback_tracker, pending = std::move(pending)] {
+        tracker->CompleteAsync(pending);
+    });
 }
 
 void TextureCache::MarkAsMaybeDirty(ImageId image_id, Image& image) {
@@ -123,8 +456,14 @@ void TextureCache::MarkAsMaybeDirty(ImageId image_id, Image& image) {
     UntrackImage(image_id);
 }
 
+void TextureCache::InvalidateAlias(Image& image) {
+    alias_states.erase(image.info.guest_address);
+    image.alias_generation = 0;
+}
+
 void TextureCache::InvalidateMemory(VAddr addr, size_t size) {
     std::scoped_lock lock{mutex};
+    readback_tracker->Invalidate(addr, size);
     const auto pages_start = PageManager::GetPageAddr(addr);
     const auto pages_end = PageManager::GetNextPageAddr(addr + size - 1);
     ForEachImageInRegion(pages_start, pages_end - pages_start, [&](ImageId image_id, Image& image) {
@@ -133,6 +472,7 @@ void TextureCache::InvalidateMemory(VAddr addr, size_t size) {
         if (image.Overlaps(addr, size)) {
             // Modified region overlaps image, so the image was definitely accessed by this fault.
             // Untrack the image, so that the range is unprotected and the guest can write freely.
+            InvalidateAlias(image);
             image.flags |= ImageFlagBits::CpuDirty;
             UntrackImage(image_id);
         } else if (pages_end < image_end) {
@@ -156,6 +496,7 @@ void TextureCache::InvalidateMemory(VAddr addr, size_t size) {
 
 void TextureCache::InvalidateMemoryFromGPU(VAddr address, size_t max_size) {
     std::scoped_lock lock{mutex};
+    readback_tracker->Invalidate(address, max_size);
     ForEachImageInRegion(address, max_size, [&](ImageId image_id, Image& image) {
         // Only consider images that match base address.
         // TODO: Maybe also consider subresources
@@ -163,12 +504,14 @@ void TextureCache::InvalidateMemoryFromGPU(VAddr address, size_t max_size) {
             return;
         }
         // Ensure image is reuploaded when accessed again.
+        InvalidateAlias(image);
         image.flags |= ImageFlagBits::GpuDirty;
     });
 }
 
 void TextureCache::UnmapMemory(VAddr cpu_addr, size_t size) {
     std::scoped_lock lk{mutex};
+    readback_tracker->Invalidate(cpu_addr, size);
 
     ImageIds deleted_images;
     ForEachImageInRegion(cpu_addr, size, [&](ImageId id, Image&) { deleted_images.push_back(id); });
@@ -620,15 +963,15 @@ ImageId TextureCache::FindImageFromRange(VAddr address, size_t size, bool ensure
 
 ImageView& TextureCache::FindTexture(ImageId image_id, const ImageDesc& desc) {
     Image& image = slot_images[image_id];
+    UpdateImageForTexture(image_id);
     if (desc.type == BindingType::Storage) {
         image.flags |= ImageFlagBits::GpuModified;
+        MarkGpuWrite(image_id);
         if (readback_linear_images && (!image.info.props.is_tiled || image.info.size.width <= 8) &&
             image.info.guest_address != 0) {
-            std::unique_lock lk{download_images_mutex};
             download_images.emplace(image_id);
         }
     }
-    UpdateImage(image_id);
     return image.FindView(desc.view_info);
 }
 
@@ -641,6 +984,7 @@ ImageView& TextureCache::FindRenderTarget(ImageId image_id, const ImageDesc& des
     }
     image.usage.render_target = 1u;
     UpdateImage(image_id);
+    MarkGpuWrite(image_id);
 
     // Register meta data for this color buffer
     if (desc.info.meta_info.cmask_addr) {
@@ -660,9 +1004,10 @@ ImageView& TextureCache::FindRenderTarget(ImageId image_id, const ImageDesc& des
 
 ImageView& TextureCache::FindDepthTarget(ImageId image_id, const ImageDesc& desc) {
     Image& image = slot_images[image_id];
-    image.flags |= ImageFlagBits::GpuModified;
     image.usage.depth_target = 1u;
     UpdateImage(image_id);
+    readback_tracker->Invalidate(image.info.guest_address, image.info.guest_size);
+    image.flags |= ImageFlagBits::GpuModified;
 
     // Register meta data for this depth buffer
     if (desc.info.meta_info.htile_addr) {
@@ -1071,6 +1416,14 @@ void TextureCache::DeleteImage(ImageId image_id) {
     Image& image = slot_images[image_id];
     ASSERT_MSG(!image.IsTracked(), "Image was not untracked");
     ASSERT_MSG(False(image.flags & ImageFlagBits::Registered), "Image was not unregistered");
+
+    const auto alias_it = alias_states.find(image.info.guest_address);
+    if (alias_it != alias_states.end()) {
+        const AliasState& state = alias_it->second;
+        if (state.writer == image_id && state.writer_uid == image.image_uid) {
+            alias_states.erase(image.info.guest_address);
+        }
+    }
 
     // Remove any registered meta areas.
     const auto& meta_info = image.info.meta_info;

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -3,12 +3,10 @@
 
 #pragma once
 
-#include <condition_variable>
+#include <memory>
 #include <mutex>
-#include <thread>
 #include <unordered_set>
 #include <boost/container/small_vector.hpp>
-#include <queue>
 #include <tsl/robin_map.h>
 
 #include "common/lru_cache.h"
@@ -28,7 +26,10 @@ struct Liverpool;
 namespace VideoCore {
 
 class BufferCache;
+class Buffer;
 class PageManager;
+class ReadbackTracker;
+struct PendingImageDownload;
 
 class TextureCache {
     // Default values for garbage collection
@@ -112,13 +113,7 @@ public:
     [[nodiscard]] ImageView& FindDepthTarget(ImageId image_id, const ImageDesc& desc);
 
     /// Updates image contents if it was modified by CPU.
-    void UpdateImage(ImageId image_id) {
-        std::scoped_lock lock{mutex};
-        Image& image = slot_images[image_id];
-        TrackImage(image_id);
-        TouchImage(image);
-        RefreshImage(image);
-    }
+    void UpdateImage(ImageId image_id);
 
     /// Resolves overlap between existing cache image and pending merged image
     [[nodiscard]] std::tuple<ImageId, int, int> ResolveOverlap(const ImageInfo& info,
@@ -252,6 +247,9 @@ public:
     }
 
 private:
+    void UpdateImageForTexture(ImageId image_id);
+    void UpdateImageImpl(ImageId image_id);
+
     /// Iterate over all page indices in a range
     template <typename Func>
     static void ForEachPage(PAddr addr, size_t size, Func&& func) {
@@ -268,11 +266,9 @@ private:
         }
     }
 
-    /// Copies image memory back to CPU.
-    void DownloadImageMemory(ImageId image_id, bool sync = false);
-
-    /// Thread function for copying downloaded images out to CPU memory.
-    void DownloadedImagesThread(const std::stop_token& token);
+    [[nodiscard]] PendingImageDownload ScheduleImageDownload(Image& image, Buffer& buffer, u8* data,
+                                                             u64 buffer_offset);
+    void DownloadImageMemory(ImageId image_id);
 
     /// Create an image from the given parameters
     [[nodiscard]] ImageId InsertImage(const ImageInfo& info, VAddr cpu_addr);
@@ -295,6 +291,12 @@ private:
 
     void MarkAsMaybeDirty(ImageId image_id, Image& image);
 
+    void InvalidateAlias(Image& image);
+
+    void SynchronizeAlias(ImageId image_id);
+
+    void MarkGpuWrite(ImageId image_id);
+
     /// Removes the image and any views/surface metas that reference it.
     void DeleteImage(ImageId image_id);
 
@@ -316,12 +318,22 @@ private:
     AmdGpu::Liverpool* liverpool;
     BufferCache& buffer_cache;
     PageManager& tracker;
+    std::shared_ptr<ReadbackTracker> readback_tracker;
     BlitHelper blit_helper;
     TileManager tile_manager;
     Common::SlotVector<Image> slot_images;
     Common::SlotVector<ImageView> slot_image_views;
     tsl::robin_map<u64, Sampler> samplers;
     std::unordered_set<ImageId> download_images;
+    struct AliasState {
+        ImageId writer{};
+        u64 writer_uid{};
+        bool has_alias{};
+        bool download_pending{};
+    };
+    tsl::robin_map<VAddr, AliasState> alias_states;
+    boost::container::small_vector<VAddr, 4> pending_alias_downloads;
+    u64 alias_generation{};
     u64 total_used_memory = 0;
     u64 trigger_gc_memory = 0;
     u64 pressure_gc_memory = 0;


### PR DESCRIPTION
## Problem
TextureCache allocates distinct image slots when descriptors differ, even if sharing guest_address. Storage writes (`ImageFlagBits::GpuModified`) update only the writer's Vulkan image, causing aliased sampler reads in FindTexture (e.g., GOW3 luminance reduction chains) to consume stale allocations.

## Solution
Introduce generation-based alias tracking via alias_states in TextureCache. SynchronizeAlias checks writer `alias_generation` during UpdateImageForTexture to copy overlapping subresources via ScheduleImageDownload, while an asynchronous ReadbackTracker handles CPU backing writebacks (`TryWriteBacking`) and invalidates stale aliases on CPU/GPU writes and unmaps.

## Testing
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/7ee42e39-b22c-423b-a89b-425dd78dfbbd" />
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/47ac32a3-3e80-4d00-8cd6-12c8c68a0178" />

