### PR TITLE
Lib.Kernel: Check to ensure heap_api is valid before running heap mallocs in TlsGetAddr

### DIFF
--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -459,7 +459,12 @@ void* Linker::TlsGetAddr(u64 module_index, u64 offset) {
     if (!addr) {
         // Module was just loaded by above code. Allocate TLS block for it.
         const u32 init_image_size = module->tls.init_image_size;
-        u8* dest = reinterpret_cast<u8*>(heap_api->heap_malloc(module->tls.image_size));
+        u8* dest{}; 
+        if (heap_api && heap_api->heap_malloc) {
+            dest = reinterpret_cast<u8*>(heap_api->heap_malloc(module->tls.image_size));
+        } else {
+            dest = std::malloc(module->tls.image_size);
+        }
         const u8* src = reinterpret_cast<const u8*>(module->tls.image_virtual_addr);
         std::memcpy(dest, src, init_image_size);
         std::memset(dest + init_image_size, 0, module->tls.image_size - init_image_size);

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -463,7 +463,7 @@ void* Linker::TlsGetAddr(u64 module_index, u64 offset) {
         if (heap_api && heap_api->heap_malloc) {
             dest = reinterpret_cast<u8*>(heap_api->heap_malloc(module->tls.image_size));
         } else {
-            dest = std::malloc(module->tls.image_size);
+            dest = reinterpret_cast<u8*>(std::malloc(module->tls.image_size));
         }
         const u8* src = reinterpret_cast<const u8*>(module->tls.image_virtual_addr);
         std::memcpy(dest, src, init_image_size);

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -459,7 +459,7 @@ void* Linker::TlsGetAddr(u64 module_index, u64 offset) {
     if (!addr) {
         // Module was just loaded by above code. Allocate TLS block for it.
         const u32 init_image_size = module->tls.init_image_size;
-        u8* dest{}; 
+        u8* dest{};
         if (heap_api && heap_api->heap_malloc) {
             dest = reinterpret_cast<u8*>(heap_api->heap_malloc(module->tls.image_size));
         } else {


### PR DESCRIPTION
Technically libkernel uses libSceLibcInternal's malloc, but we're already doing this host malloc workaround in several other places, so this should be fine.