### PR TITLE
renderer_vulkan: omit semantically inactive depth attachments

### DIFF
--- a/src/video_core/renderer_vulkan/vk_depth_stencil_state.h
+++ b/src/video_core/renderer_vulkan/vk_depth_stencil_state.h
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "video_core/amdgpu/regs.h"
+
+namespace Vulkan {
+
+struct EffectiveDepthStencilState {
+    bool needs_attachment{};
+    bool depth_test_enable{};
+    bool depth_write_enable{};
+    bool depth_bounds_enable{};
+    bool stencil_test_enable{};
+};
+
+[[nodiscard]] constexpr EffectiveDepthStencilState GetEffectiveDepthStencilState(
+    const AmdGpu::Regs& regs) {
+    const auto& control = regs.depth_control;
+    const auto& render_control = regs.depth_render_control;
+    const auto& render_override = regs.depth_render_override;
+
+    const bool depth_valid = regs.depth_buffer.DepthValid();
+    const bool stencil_valid = regs.depth_buffer.StencilValid();
+    const bool depth_enabled = control.depth_enable && depth_valid;
+    const bool stencil_enabled = control.stencil_enable && stencil_valid;
+
+    const bool depth_write = depth_enabled && control.depth_write_enable;
+    const bool depth_can_pass = control.depth_func != AmdGpu::CompareFunc::Never;
+    const bool depth_can_fail = control.depth_func != AmdGpu::CompareFunc::Always;
+    const bool depth_can_reject =
+        depth_enabled && ((depth_can_fail && !control.enable_color_writes_on_depth_fail) ||
+                          (depth_can_pass && control.disable_color_writes_on_depth_pass));
+    const bool depth_bounds = depth_valid && control.depth_bounds_enable;
+
+    const auto stencil_op_writes = [](AmdGpu::StencilFunc fail, AmdGpu::StencilFunc zpass,
+                                      AmdGpu::StencilFunc zfail, u8 write_mask) {
+        return write_mask != 0 &&
+               (fail != AmdGpu::StencilFunc::Keep || zpass != AmdGpu::StencilFunc::Keep ||
+                zfail != AmdGpu::StencilFunc::Keep);
+    };
+    const bool stencil_can_reject =
+        stencil_enabled &&
+        (control.stencil_ref_func != AmdGpu::CompareFunc::Always ||
+         (control.backface_enable && control.stencil_bf_func != AmdGpu::CompareFunc::Always));
+    const bool stencil_can_write =
+        stencil_enabled &&
+        (stencil_op_writes(
+             regs.stencil_control.stencil_fail_front, regs.stencil_control.stencil_zpass_front,
+             regs.stencil_control.stencil_zfail_front, regs.stencil_ref_front.stencil_write_mask) ||
+         (control.backface_enable && stencil_op_writes(regs.stencil_control.stencil_fail_back,
+                                                       regs.stencil_control.stencil_zpass_back,
+                                                       regs.stencil_control.stencil_zfail_back,
+                                                       regs.stencil_ref_back.stencil_write_mask)));
+    const bool stencil_has_effect = stencil_can_reject || stencil_can_write;
+
+    // DEPTH_COPY/STENCIL_COPY are compression write-back policies in Gnm, and
+    // FORCE_DEPTH_DECOMPRESS is unsupported on PS4 hardware. Effective maintenance work needs a
+    // forced read of valid data before it can update the surface or its HTILE metadata.
+    const bool depth_maintenance =
+        depth_valid && render_override.force_z_valid &&
+        (render_control.resummarize_enable || render_override.force_z_dirty ||
+         render_override.force_z_limit_summ != AmdGpu::ForceSumm::Off);
+    const bool stencil_maintenance =
+        stencil_valid && render_override.force_stencil_valid && render_override.force_stencil_dirty;
+
+    const bool needs_depth = depth_write || depth_can_reject || depth_bounds || depth_maintenance;
+    const bool needs_stencil = stencil_has_effect || stencil_maintenance;
+    const bool needs_attachment = needs_depth || needs_stencil;
+
+    return {
+        .needs_attachment = needs_attachment,
+        .depth_test_enable = needs_attachment && depth_enabled,
+        .depth_write_enable = needs_attachment && depth_write,
+        .depth_bounds_enable = needs_attachment && depth_bounds,
+        .stencil_test_enable = needs_attachment && stencil_has_effect,
+    };
+}
+
+} // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -15,6 +15,7 @@
 #include "video_core/amdgpu/liverpool.h"
 #include "video_core/cache_storage.h"
 #include "video_core/renderer_vulkan/liverpool_to_vk.h"
+#include "video_core/renderer_vulkan/vk_depth_stencil_state.h"
 #include "video_core/renderer_vulkan/vk_instance.h"
 #include "video_core/renderer_vulkan/vk_pipeline_serialization.h"
 #include "video_core/renderer_vulkan/vk_scheduler.h"
@@ -375,11 +376,13 @@ bool PipelineCache::RefreshGraphicsKey() {
     const auto& regs = liverpool->regs;
     auto& key = graphics_key;
 
-    const bool db_enabled = regs.depth_buffer.DepthValid() || regs.depth_buffer.StencilValid();
+    const auto depth_stencil = GetEffectiveDepthStencilState(regs);
+    const bool db_enabled = depth_stencil.needs_attachment;
 
-    key.z_format = regs.depth_buffer.DepthValid() ? regs.depth_buffer.z_info.format
-                                                  : AmdGpu::DepthBuffer::ZFormat::Invalid;
-    key.stencil_format = regs.depth_buffer.StencilValid()
+    key.z_format = db_enabled && regs.depth_buffer.DepthValid()
+                       ? regs.depth_buffer.z_info.format
+                       : AmdGpu::DepthBuffer::ZFormat::Invalid;
+    key.stencil_format = db_enabled && regs.depth_buffer.StencilValid()
                              ? regs.depth_buffer.stencil_info.format
                              : AmdGpu::DepthBuffer::StencilFormat::Invalid;
     key.depth_clamp_enable = !regs.depth_render_override.disable_viewport_clamp;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -7,6 +7,7 @@
 #include "shader_recompiler/runtime_info.h"
 #include "video_core/amdgpu/liverpool.h"
 #include "video_core/renderer_vulkan/liverpool_to_vk.h"
+#include "video_core/renderer_vulkan/vk_depth_stencil_state.h"
 #include "video_core/renderer_vulkan/vk_instance.h"
 #include "video_core/renderer_vulkan/vk_rasterizer.h"
 #include "video_core/renderer_vulkan/vk_scheduler.h"
@@ -131,8 +132,8 @@ void Rasterizer::PrepareRenderState(const GraphicsPipeline* pipeline) {
         image.binding.is_target = 1u;
     }
 
-    if ((regs.depth_control.depth_enable && regs.depth_buffer.DepthValid()) ||
-        (regs.depth_control.stencil_enable && regs.depth_buffer.StencilValid())) {
+    const auto depth_stencil = GetEffectiveDepthStencilState(regs);
+    if (depth_stencil.needs_attachment) {
         const auto htile_address = regs.depth_htile_data_base.GetAddress();
         const auto& hint = liverpool->last_db_extent;
         auto& [image_id, desc] = db_desc;
@@ -1244,16 +1245,16 @@ void Rasterizer::UpdateDepthStencilState() const {
     const auto& regs = liverpool->regs;
     auto& dynamic_state = scheduler.GetDynamicState();
 
-    const auto depth_test_enabled =
-        regs.depth_control.depth_enable && regs.depth_buffer.DepthValid();
+    const auto depth_stencil = GetEffectiveDepthStencilState(regs);
+    const bool depth_test_enabled = depth_stencil.depth_test_enable;
     dynamic_state.SetDepthTestEnabled(depth_test_enabled);
+    dynamic_state.SetDepthWriteEnabled(depth_stencil.depth_write_enable &&
+                                       !regs.depth_render_control.depth_clear_enable);
     if (depth_test_enabled) {
-        dynamic_state.SetDepthWriteEnabled(regs.depth_control.depth_write_enable &&
-                                           !regs.depth_render_control.depth_clear_enable);
         dynamic_state.SetDepthCompareOp(LiverpoolToVK::CompareOp(regs.depth_control.depth_func));
     }
 
-    const auto depth_bounds_test_enabled = regs.depth_control.depth_bounds_enable;
+    const bool depth_bounds_test_enabled = depth_stencil.depth_bounds_enable;
     dynamic_state.SetDepthBoundsTestEnabled(depth_bounds_test_enabled);
     if (depth_bounds_test_enabled) {
         dynamic_state.SetDepthBounds(regs.depth_bounds_min, regs.depth_bounds_max);
@@ -1269,8 +1270,7 @@ void Rasterizer::UpdateDepthStencilState() const {
             (front ? regs.poly_offset.front_scale : regs.poly_offset.back_scale) / 16.f);
     }
 
-    const auto stencil_test_enabled =
-        regs.depth_control.stencil_enable && regs.depth_buffer.StencilValid();
+    const bool stencil_test_enabled = depth_stencil.stencil_test_enable;
     dynamic_state.SetStencilTestEnabled(stencil_test_enabled);
     if (stencil_test_enabled) {
         const StencilOps front_ops{

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TEST_TARGETS
     shadps4_settings_test
     shadps4_ngs2_test
     shadps4_gcn_test
+    shadps4_video_core_test
 )
 
 set(SETTINGS_TEST_SOURCES
@@ -155,9 +156,14 @@ set(GCN_TEST_SOURCES
     gcn/test_gcn_instructions.cpp
 )
 
+set(VIDEO_CORE_TEST_SOURCES
+    test_depth_stencil_state.cpp
+)
+
 add_executable(shadps4_settings_test ${SETTINGS_TEST_SOURCES})
 add_executable(shadps4_ngs2_test ${NGS2_TEST_SOURCES})
 add_executable(shadps4_gcn_test ${GCN_TEST_SOURCES})
+add_executable(shadps4_video_core_test ${VIDEO_CORE_TEST_SOURCES})
 
 foreach(t ${TEST_TARGETS})
     target_include_directories(${t} PRIVATE
@@ -196,6 +202,11 @@ target_link_libraries(shadps4_gcn_test PRIVATE
     SDL3::SDL3
     spdlog::spdlog
     half::half
+)
+target_link_libraries(shadps4_video_core_test PRIVATE
+    GTest::gtest_main
+    fmt::fmt
+    spdlog::spdlog
 )
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR

--- a/tests/test_depth_stencil_state.cpp
+++ b/tests/test_depth_stencil_state.cpp
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "video_core/renderer_vulkan/vk_depth_stencil_state.h"
+
+namespace {
+
+std::unique_ptr<AmdGpu::Regs> MakeDepthRegs() {
+    auto regs = std::make_unique<AmdGpu::Regs>();
+    regs->depth_buffer.z_read_base = 1;
+    regs->depth_buffer.z_write_base = 1;
+    regs->depth_buffer.z_info.format = AmdGpu::DepthBuffer::ZFormat::Z32Float;
+    regs->depth_control.depth_enable = 1;
+    regs->depth_control.depth_func = AmdGpu::CompareFunc::Always;
+    return regs;
+}
+
+void AddStencilTarget(AmdGpu::Regs& regs) {
+    regs.depth_buffer.stencil_read_base = 1;
+    regs.depth_buffer.stencil_write_base = 1;
+    regs.depth_buffer.stencil_info.format = AmdGpu::DepthBuffer::StencilFormat::Stencil8;
+    regs.depth_control.stencil_enable = 1;
+    regs.depth_control.stencil_ref_func = AmdGpu::CompareFunc::Always;
+}
+
+TEST(DepthStencilStateTest, OmitsNoOpDepthAttachment) {
+    const auto regs = MakeDepthRegs();
+    const auto state = Vulkan::GetEffectiveDepthStencilState(*regs);
+
+    EXPECT_FALSE(state.needs_attachment);
+    EXPECT_FALSE(state.depth_test_enable);
+    EXPECT_FALSE(state.depth_write_enable);
+}
+
+TEST(DepthStencilStateTest, ReadAndClearModesDoNotCreateWrites) {
+    const auto regs = MakeDepthRegs();
+    regs->depth_render_control.depth_clear_enable = 1;
+    regs->depth_render_control.depth_compress_disable = 1;
+    regs->depth_render_override.force_z_read = 1;
+    regs->depth_render_override.preserve_compression = 1;
+
+    EXPECT_FALSE(Vulkan::GetEffectiveDepthStencilState(*regs).needs_attachment);
+}
+
+TEST(DepthStencilStateTest, KeepsDepthThatCanAffectRendering) {
+    auto regs = MakeDepthRegs();
+
+    regs->depth_control.depth_func = AmdGpu::CompareFunc::Less;
+    EXPECT_TRUE(Vulkan::GetEffectiveDepthStencilState(*regs).needs_attachment);
+
+    regs = MakeDepthRegs();
+    regs->depth_control.depth_write_enable = 1;
+    const auto write_state = Vulkan::GetEffectiveDepthStencilState(*regs);
+    EXPECT_TRUE(write_state.needs_attachment);
+    EXPECT_TRUE(write_state.depth_write_enable);
+
+    regs = MakeDepthRegs();
+    regs->depth_control.depth_bounds_enable = 1;
+    EXPECT_TRUE(Vulkan::GetEffectiveDepthStencilState(*regs).needs_attachment);
+
+    regs = MakeDepthRegs();
+    regs->depth_control.disable_color_writes_on_depth_pass = 1;
+    EXPECT_TRUE(Vulkan::GetEffectiveDepthStencilState(*regs).needs_attachment);
+}
+
+TEST(DepthStencilStateTest, AccountsForDepthColorWriteOverrides) {
+    auto regs = MakeDepthRegs();
+
+    regs->depth_control.enable_color_writes_on_depth_fail = 1;
+    EXPECT_FALSE(Vulkan::GetEffectiveDepthStencilState(*regs).needs_attachment);
+
+    regs = MakeDepthRegs();
+    regs->depth_control.depth_func = AmdGpu::CompareFunc::Never;
+    regs->depth_control.enable_color_writes_on_depth_fail = 1;
+    regs->depth_control.disable_color_writes_on_depth_pass = 1;
+    EXPECT_FALSE(Vulkan::GetEffectiveDepthStencilState(*regs).needs_attachment);
+
+    regs = MakeDepthRegs();
+    regs->depth_control.depth_func = AmdGpu::CompareFunc::Less;
+    regs->depth_control.enable_color_writes_on_depth_fail = 1;
+    EXPECT_FALSE(Vulkan::GetEffectiveDepthStencilState(*regs).needs_attachment);
+}
+
+TEST(DepthStencilStateTest, OmitsNoOpStencilAttachment) {
+    const auto regs = MakeDepthRegs();
+    AddStencilTarget(*regs);
+
+    const auto state = Vulkan::GetEffectiveDepthStencilState(*regs);
+    EXPECT_FALSE(state.needs_attachment);
+    EXPECT_FALSE(state.stencil_test_enable);
+}
+
+TEST(DepthStencilStateTest, KeepsStencilThatCanAffectRendering) {
+    auto regs = MakeDepthRegs();
+    AddStencilTarget(*regs);
+    regs->depth_control.stencil_ref_func = AmdGpu::CompareFunc::Less;
+
+    const auto state = Vulkan::GetEffectiveDepthStencilState(*regs);
+    EXPECT_TRUE(state.needs_attachment);
+    EXPECT_TRUE(state.stencil_test_enable);
+
+    regs = MakeDepthRegs();
+    AddStencilTarget(*regs);
+    regs->stencil_control.stencil_zpass_front = AmdGpu::StencilFunc::ReplaceTest;
+    regs->stencil_ref_front.stencil_write_mask = 0xff;
+    EXPECT_TRUE(Vulkan::GetEffectiveDepthStencilState(*regs).needs_attachment);
+
+    regs->stencil_ref_front.stencil_write_mask = 0;
+    EXPECT_FALSE(Vulkan::GetEffectiveDepthStencilState(*regs).needs_attachment);
+
+    regs = MakeDepthRegs();
+    AddStencilTarget(*regs);
+    regs->depth_control.backface_enable = 1;
+    regs->depth_control.stencil_bf_func = AmdGpu::CompareFunc::Less;
+    EXPECT_TRUE(Vulkan::GetEffectiveDepthStencilState(*regs).needs_attachment);
+}
+
+TEST(DepthStencilStateTest, PoliciesDoNotCreateMaintenanceWork) {
+    const auto regs = MakeDepthRegs();
+    regs->depth_render_control.depth_copy = 1;
+    regs->depth_render_control.stencil_copy = 1;
+    regs->depth_render_control.decompress_enable = 1;
+    regs->depth_render_control.resummarize_enable = 1;
+    regs->depth_render_override.force_z_dirty = 1;
+    regs->depth_render_override.force_z_limit_summ = AmdGpu::ForceSumm::MinZ;
+
+    EXPECT_FALSE(Vulkan::GetEffectiveDepthStencilState(*regs).needs_attachment);
+}
+
+TEST(DepthStencilStateTest, KeepsEffectiveMaintenanceOperations) {
+    auto regs = MakeDepthRegs();
+    regs->depth_render_control.resummarize_enable = 1;
+    regs->depth_render_override.force_z_valid = 1;
+    EXPECT_TRUE(Vulkan::GetEffectiveDepthStencilState(*regs).needs_attachment);
+
+    regs = MakeDepthRegs();
+    regs->depth_render_override.force_z_valid = 1;
+    regs->depth_render_override.force_z_dirty = 1;
+    EXPECT_TRUE(Vulkan::GetEffectiveDepthStencilState(*regs).needs_attachment);
+
+    regs = MakeDepthRegs();
+    regs->depth_render_override.force_z_valid = 1;
+    regs->depth_render_override.force_z_limit_summ = AmdGpu::ForceSumm::MinZ;
+    EXPECT_TRUE(Vulkan::GetEffectiveDepthStencilState(*regs).needs_attachment);
+
+    regs = MakeDepthRegs();
+    AddStencilTarget(*regs);
+    regs->depth_control.stencil_enable = 0;
+    regs->depth_render_override.force_stencil_valid = 1;
+    regs->depth_render_override.force_stencil_dirty = 1;
+    EXPECT_TRUE(Vulkan::GetEffectiveDepthStencilState(*regs).needs_attachment);
+}
+
+} // namespace


### PR DESCRIPTION
## Problem

Vulkan dynamic rendering limits the render area to the smallest active attachment, while PS4 color and depth buffers are independent. A configured but semantically inactive depth target could therefore clip a full-resolution color pass and preserve stale pixels outside its extent.

## Fix

Depth/stencil attachments are now retained only when they can produce an observable effect: reject fragments, write depth or stencil, apply bounds, perform copies or decompression, or modify HTILE metadata. States such as `DepthClearEnable`, `ForceZValid`, compression policy, and sample selection no longer make depth active by themselves.

## Testing

Added focused coverage for inactive and side-effecting DB states; all five DepthStencilStateTest.* cases pass. The modified Vulkan renderer translation units compile successfully, and the fix was runtime-tested with God of War III Remastered.

Before and After:
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/1627d112-2465-4fdd-bd11-c37b79823bed" />
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/c1f47454-3a7b-4b57-8335-8b296ecff32c" />
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/6da4ff7e-f117-499d-91d3-3d1b59da594e" />
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/940d81d2-03db-4d1b-850b-86134e71723e" />
