### PR TITLE
Core: Fix libSceNpPartner module name

### DIFF
--- a/src/core/libraries/libs.cpp
+++ b/src/core/libraries/libs.cpp
@@ -134,7 +134,7 @@ void InitHLELibs(Core::Loader::SymbolsResolver* sym) {
             {"libSceNpSnsFacebookDialog.sprx", Libraries::Np::NpSnsFacebookDialog::RegisterLib},
             {"libSceNpAuth.sprx", Libraries::Np::NpAuth::RegisterLib},
             {"libSceNpParty.sprx", Libraries::Np::NpParty::RegisterLib},
-            {"libSceNpPartner.sprx", Libraries::Np::NpPartner::RegisterLib},
+            {"libSceNpPartner001.sprx", Libraries::Np::NpPartner::RegisterLib},
             {"libSceNpTus.sprx", Libraries::Np::NpTus::RegisterLib},
             {"libSceScreenShot.sprx", Libraries::ScreenShot::RegisterLib},
             {"libSceAppContent.sprx", Libraries::AppContent::RegisterLib},


### PR DESCRIPTION
A quick and completely useless fix for a bug introduced by #4710.