### PR TITLE
shader_recompiler: Initialize GS vertex offsets from the input primitive type

### DIFF
--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -226,11 +226,28 @@ void Translator::EmitPrologue(IR::Block* first_block) {
         }
         break;
     case LogicalStage::Geometry:
-        switch (runtime_info.gs_info.out_primitive[0]) {
-        case AmdGpu::GsOutputPrimitiveType::TriangleStrip:
+        // The GS wave receives one ES vertex offset per input primitive vertex in V0-V6, with
+        // the primitive id in V2. The offset count is a property of the input primitive type;
+        // adjacency primitives carry up to 6 vertices.
+        switch (runtime_info.gs_info.in_primitive) {
+        case AmdGpu::PrimitiveType::AdjTriangleList:
+        case AmdGpu::PrimitiveType::AdjTriangleStrip:
+            ir.SetVectorReg(IR::VectorReg::V6, ir.Imm32(5u)); // vertex 5
+            ir.SetVectorReg(IR::VectorReg::V5, ir.Imm32(4u)); // vertex 4
+            [[fallthrough]];
+        case AmdGpu::PrimitiveType::AdjLineList:
+        case AmdGpu::PrimitiveType::AdjLineStrip:
+            ir.SetVectorReg(IR::VectorReg::V4, ir.Imm32(3u)); // vertex 3
+            [[fallthrough]];
+        case AmdGpu::PrimitiveType::TriangleList:
+        case AmdGpu::PrimitiveType::TriangleStrip:
+        case AmdGpu::PrimitiveType::RectList:
             ir.SetVectorReg(IR::VectorReg::V3, ir.Imm32(2u)); // vertex 2
-        case AmdGpu::GsOutputPrimitiveType::LineStrip:
+            [[fallthrough]];
+        case AmdGpu::PrimitiveType::LineList:
+        case AmdGpu::PrimitiveType::LineStrip:
             ir.SetVectorReg(IR::VectorReg::V1, ir.Imm32(1u)); // vertex 1
+            [[fallthrough]];
         default:
             ir.SetVectorReg(IR::VectorReg::V0, ir.Imm32(0u)); // vertex 0
             break;


### PR DESCRIPTION
Restores rendering of the contour cel shader outline in Gravity Rush 2 by fixing a bug in which GS input vertex-offset registers were initialized from output primitive type, leaving adjacency vertices undefined. 
Unlike most shaders in Gravity Rush 2, cel shader outlines utilize triangles with adjacency (6 vertices). Currently, the GS prologue initializes ES-vertex-offset registers by switching on output primitive type, which limits the number of vertices that can be set up for input to 3, causing vertices 3-5 to be folded into garbage. The fix is to switch on input primitive type, intializing every provided offset (6) V0-V1, V3-V6. 

Before (switching on output primitive type)
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/cfa3c2c4-400c-48b7-8f70-7f9a9959e364" />


After (switching on input primitive type)
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/fc304501-ba97-420a-a8c2-cc9ab8787544" />
