### PR TITLE
Remove image ids from download_images on TextureCache::DeleteImage calls

### DIFF
--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -61,6 +61,7 @@ TextureCache::TextureCache(const Vulkan::Instance& instance_, Vulkan::Scheduler&
 TextureCache::~TextureCache() = default;
 
 void TextureCache::ProcessDownloadImages() {
+    std::unique_lock lk{download_images_mutex};
     for (const ImageId image_id : download_images) {
         DownloadImageMemory(image_id, true);
     }
@@ -622,6 +623,7 @@ ImageView& TextureCache::FindTexture(ImageId image_id, const ImageDesc& desc) {
     if (desc.type == BindingType::Storage) {
         image.flags |= ImageFlagBits::GpuModified;
         if (readback_linear_images && !image.info.props.is_tiled && image.info.guest_address != 0) {
+            std::unique_lock lk{download_images_mutex};
             download_images.emplace(image_id);
         }
     }
@@ -633,6 +635,7 @@ ImageView& TextureCache::FindRenderTarget(ImageId image_id, const ImageDesc& des
     Image& image = slot_images[image_id];
     image.flags |= ImageFlagBits::GpuModified;
     if (readback_linear_images && !image.info.props.is_tiled) {
+        std::unique_lock lk{download_images_mutex};
         download_images.emplace(image_id);
     }
     image.usage.render_target = 1u;
@@ -1078,6 +1081,13 @@ void TextureCache::DeleteImage(ImageId image_id) {
     }
     if (meta_info.htile_addr) {
         surface_metas.erase(meta_info.htile_addr);
+    }
+
+    {
+        std::unique_lock lk{download_images_mutex};
+        if (download_images.contains(image_id)) {
+            download_images.erase(image_id);
+        }
     }
 
     // Reclaim image and any image views it references.

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -337,6 +337,7 @@ private:
     PageTable page_table;
     std::mutex mutex;
     std::mutex samplers_mutex;
+    std::mutex download_images_mutex;
     struct MetaDataInfo {
         enum class Type {
             CMask,


### PR DESCRIPTION
If we delete images while they're queued for download, then ProcessDownloadImages will attempt to retrieve a deleted image and trigger debug asserts (and probably more issues outside of debug builds).

This became more apparent after #4593, which both enabled image deletions during ProcessDownloadImages (through `scheduler.Finish()` running deferred operations), and added more images to `download_images`.

This PR adds a mutex to operations involving the `download_images` set, and removes images from `download_images` on DeleteImage calls, preventing these issues.

This fixes a regression in Assassin's Creed Unity with ReadbackLinearImages after #4593. This doesn't appear to break Marvel's Spider-Man, but will need testing in UFC titles (and needs a proper review). 