### PR TITLE
shader_recompiler: Always specialize vertex attributes on number class

### DIFF
--- a/src/shader_recompiler/profile.h
+++ b/src/shader_recompiler/profile.h
@@ -33,7 +33,6 @@ struct Profile {
     bool support_fp16_signed_zero_inf_nan_preserve{};
     bool support_fp32_signed_zero_inf_nan_preserve{};
     bool support_fp64_signed_zero_inf_nan_preserve{};
-    bool support_legacy_vertex_attributes{};
     bool supports_image_load_store_lod{};
     bool supports_native_cube_calc{};
     bool supports_trinary_minmax{};

--- a/src/shader_recompiler/specialization.h
+++ b/src/shader_recompiler/specialization.h
@@ -100,7 +100,7 @@ struct StageSpecialization {
         if (info_.stage == Stage::Vertex && fetch_shader_data) {
             // Specialize shader on VS input number types to follow spec.
             ForEachSharp(vs_attribs, fetch_shader_data->attributes,
-                         [&profile_, this](auto& spec, const auto& desc, AmdGpu::Buffer sharp) {
+                         [this](auto& spec, const auto& desc, AmdGpu::Buffer sharp) {
                              using InstanceIdType = Shader::Gcn::VertexAttribute::InstanceIdType;
                              if (const auto step_rate = desc.GetStepRate();
                                  step_rate != InstanceIdType::None) {
@@ -110,9 +110,7 @@ struct StageSpecialization {
                                                            ? runtime_info.vs_info.step_rate_1
                                                            : 1);
                              }
-                             spec.num_class = profile_.support_legacy_vertex_attributes
-                                                  ? AmdGpu::NumberClass{}
-                                                  : AmdGpu::GetNumberClass(sharp.GetNumberFmt());
+                             spec.num_class = AmdGpu::GetNumberClass(sharp.GetNumberFmt());
                              spec.dst_select = sharp.DstSelect();
                          });
         }

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -294,7 +294,6 @@ bool Instance::CreateDevice() {
         fragment_shader_barycentric =
             add_extension(VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME);
     }
-    legacy_vertex_attributes = add_extension(VK_EXT_LEGACY_VERTEX_ATTRIBUTES_EXTENSION_NAME);
     provoking_vertex = add_extension(VK_EXT_PROVOKING_VERTEX_EXTENSION_NAME);
     shader_stencil_export = add_extension(VK_EXT_SHADER_STENCIL_EXPORT_EXTENSION_NAME);
     image_load_store_lod = add_extension(VK_AMD_SHADER_IMAGE_LOAD_STORE_LOD_EXTENSION_NAME);
@@ -466,9 +465,6 @@ bool Instance::CreateDevice() {
         vk::PhysicalDeviceFragmentShaderBarycentricFeaturesKHR{
             .fragmentShaderBarycentric = true,
         },
-        vk::PhysicalDeviceLegacyVertexAttributesFeaturesEXT{
-            .legacyVertexAttributes = true,
-        },
         vk::PhysicalDeviceProvokingVertexFeaturesEXT{
             .provokingVertexLast = true,
         },
@@ -525,9 +521,6 @@ bool Instance::CreateDevice() {
     }
     if (!fragment_shader_barycentric) {
         device_chain.unlink<vk::PhysicalDeviceFragmentShaderBarycentricFeaturesKHR>();
-    }
-    if (!legacy_vertex_attributes) {
-        device_chain.unlink<vk::PhysicalDeviceLegacyVertexAttributesFeaturesEXT>();
     }
     if (!provoking_vertex) {
         device_chain.unlink<vk::PhysicalDeviceProvokingVertexFeaturesEXT>();

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -500,7 +500,6 @@ private:
     bool depth_range_unrestricted{};
     bool vertex_input_dynamic_state{};
     bool list_restart{};
-    bool legacy_vertex_attributes{};
     bool provoking_vertex{};
     bool shader_stencil_export{};
     bool image_load_store_lod{};

--- a/src/video_core/renderer_vulkan/vk_instance.h
+++ b/src/video_core/renderer_vulkan/vk_instance.h
@@ -185,11 +185,6 @@ public:
         return list_restart && list_restart_features.primitiveTopologyPatchListRestart;
     }
 
-    /// Returns true when VK_EXT_legacy_vertex_attributes is supported.
-    bool IsLegacyVertexAttributesSupported() const {
-        return legacy_vertex_attributes;
-    }
-
     /// Returns true when VK_EXT_provoking_vertex is supported.
     bool IsProvokingVertexSupported() const {
         return provoking_vertex;

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -284,7 +284,6 @@ PipelineCache::PipelineCache(const Instance& instance_, Scheduler& scheduler_,
             bool(vk12_props.shaderSignedZeroInfNanPreserveFloat32),
         .support_fp64_signed_zero_inf_nan_preserve =
             bool(vk12_props.shaderSignedZeroInfNanPreserveFloat64),
-        .support_legacy_vertex_attributes = instance_.IsLegacyVertexAttributesSupported(),
         .supports_image_load_store_lod = instance_.IsImageLoadStoreLodSupported(),
         .supports_native_cube_calc = instance_.IsAmdGcnShaderSupported(),
         .supports_trinary_minmax = instance_.IsAmdShaderTrinaryMinMaxSupported(),


### PR DESCRIPTION
With VK_EXT_legacy_vertex_attributes present, the same vertex shader did not get separate variants for different attribute number classes (e.g. sint vs float) whichever variant was compiled first served all of them, reading the attribute through the wrong type.
In practice this corrupted vertex fetch for the mismatched draws, causing vertex explosions and missing UI elements.

Should I do the cleanup? What's the plan for now unused code?