### PR TITLE
amdgpu: Reassemble fragmented ASC PM4 packets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -421,7 +421,3 @@ cmake-build-*
 
 # Nix Result symlink
 result
-
-# Local AI development guidance
-/AGENTS.md
-/documents/georgemoralis_style_reference.md

--- a/.gitignore
+++ b/.gitignore
@@ -421,3 +421,7 @@ cmake-build-*
 
 # Nix Result symlink
 result
+
+# Local AI development guidance
+/AGENTS.md
+/documents/georgemoralis_style_reference.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1050,6 +1050,8 @@ set(VIDEO_CORE src/video_core/amdgpu/cb_db_extent.h
                src/video_core/amdgpu/liverpool.h
                src/video_core/amdgpu/pixel_format.cpp
                src/video_core/amdgpu/pixel_format.h
+               src/video_core/amdgpu/pm4_packet_assembler.cpp
+               src/video_core/amdgpu/pm4_packet_assembler.h
                src/video_core/amdgpu/pm4_cmds.h
                src/video_core/amdgpu/pm4_opcodes.h
                src/video_core/amdgpu/regs_color.h

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -920,44 +920,16 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
     while (!acb.empty()) {
         ProcessCommands();
 
-        auto* header = reinterpret_cast<const PM4Header*>(acb.data());
-        size_t next_dw_off = header->type == 2 ? 1 : header->type3.NumWords() + 1;
-        const bool has_pending_packet = !queue.pending_packet.empty();
-
-        if (has_pending_packet) [[unlikely]] {
-            header = reinterpret_cast<const PM4Header*>(queue.pending_packet.data());
-            const size_t packet_dwords = header->type3.NumWords() + 1;
-            ASSERT_MSG(queue.pending_packet.size() < packet_dwords,
-                       "Buffered PM4 packet is already complete");
-
-            const size_t remaining_dwords = packet_dwords - queue.pending_packet.size();
-            next_dw_off = std::min(remaining_dwords, acb.size());
-            queue.pending_packet.insert(queue.pending_packet.end(), acb.begin(),
-                                        acb.begin() + next_dw_off);
-
-            // DingDong can expose one large PM4 packet through several ring fragments. Keep the
-            // packet buffered until it is complete; parsing a partial body would read past the
-            // current submission and corrupt the ASC queue state.
-            if (next_dw_off < remaining_dwords) {
-                if constexpr (!is_indirect) {
-                    *queue.read_addr += next_dw_off;
-                    *queue.read_addr %= queue.ring_size_dw;
-                }
-                break;
-            }
-            header = reinterpret_cast<const PM4Header*>(queue.pending_packet.data());
-        } else if (next_dw_off > acb.size()) [[unlikely]] {
-            queue.pending_packet.assign(acb.begin(), acb.end());
-            if constexpr (!is_indirect) {
-                *queue.read_addr += acb.size();
-                *queue.read_addr %= queue.ring_size_dw;
-            }
-            break;
-        }
+        const bool has_pending_packet = !is_indirect && queue.packet_assembler.HasPendingPacket();
+        const std::span<const u32> pending_packet =
+            has_pending_packet ? queue.packet_assembler.PendingPacket() : std::span<const u32>{};
+        auto* header = reinterpret_cast<const PM4Header*>(has_pending_packet ? pending_packet.data()
+                                                                             : acb.data());
 
         if (header->type == 2) {
+            ASSERT_MSG(!has_pending_packet, "Buffered ASC PM4 packet has invalid type 2");
             // Type-2 packet are used for padding purposes
-            next_dw_off = 1;
+            constexpr size_t next_dw_off = 1;
             acb = NextPacket(acb, next_dw_off);
             if constexpr (!is_indirect) {
                 *queue.read_addr += next_dw_off;
@@ -969,6 +941,40 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
         if (header->type != 3) {
             // No other types of packets were spotted so far
             UNREACHABLE_MSG("Invalid PM4 type {}", header->type.Value());
+        }
+
+        const size_t packet_dwords = header->type3.NumWords() + 1;
+        size_t next_dw_off = packet_dwords;
+        std::vector<u32> completed_packet;
+
+        if constexpr (!is_indirect) {
+            auto assembly_result = queue.packet_assembler.Consume(acb, packet_dwords);
+            ASSERT_MSG(assembly_result.status != Pm4PacketAssembler::Status::Invalid,
+                       "ASC PM4 packet assembler rejected queue state");
+
+            next_dw_off = assembly_result.consumed_dwords;
+
+            if (assembly_result.status == Pm4PacketAssembler::Status::Incomplete) [[unlikely]] {
+                *queue.read_addr += next_dw_off;
+                *queue.read_addr %= queue.ring_size_dw;
+                break;
+            }
+
+            // Consume() transfers a reconstructed packet out of the queue before dispatch. The
+            // local vector remains alive across coroutine yields, while recursive indirect-buffer
+            // processing observes an empty queue assembler instead of the completed outer packet.
+            completed_packet = std::move(assembly_result.completed_packet);
+            if (!completed_packet.empty()) [[unlikely]] {
+                header = reinterpret_cast<const PM4Header*>(completed_packet.data());
+            }
+        } else if (packet_dwords > acb.size()) [[unlikely]] {
+            // Indirect buffers describe one contiguous command range and have no later DingDong
+            // fragment. Never leak a truncated indirect packet into the direct queue assembler.
+            LOG_ERROR(
+                Lib_GnmDriver,
+                "Indirect PM4 packet exceeds its buffer. Packet dwords={}, remaining dwords={}",
+                packet_dwords, acb.size());
+            break;
         }
 
         const PM4ItOpcode opcode = header->type3.opcode;
@@ -1183,10 +1189,6 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
         if constexpr (!is_indirect) {
             *queue.read_addr += next_dw_off;
             *queue.read_addr %= queue.ring_size_dw;
-        }
-
-        if (has_pending_packet) [[unlikely]] {
-            queue.pending_packet.clear();
         }
     }
 

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright 2024-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <algorithm>
+
 #include <boost/preprocessor/stringize.hpp>
 
 #include "common/assert.h"
@@ -919,21 +921,33 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
         ProcessCommands();
 
         auto* header = reinterpret_cast<const PM4Header*>(acb.data());
-        u32 next_dw_off = header->type3.NumWords() + 1;
+        size_t next_dw_off = header->type == 2 ? 1 : header->type3.NumWords() + 1;
+        const bool has_pending_packet = !queue.pending_packet.empty();
 
-        // If we have a buffered packet, use it.
-        if (queue.tmp_dwords > 0) [[unlikely]] {
-            header = reinterpret_cast<const PM4Header*>(queue.tmp_packet.data());
-            next_dw_off = header->type3.NumWords() + 1 - queue.tmp_dwords;
-            std::memcpy(queue.tmp_packet.data() + queue.tmp_dwords, acb.data(),
-                        next_dw_off * sizeof(u32));
-            queue.tmp_dwords = 0;
-        }
+        if (has_pending_packet) [[unlikely]] {
+            header = reinterpret_cast<const PM4Header*>(queue.pending_packet.data());
+            const size_t packet_dwords = header->type3.NumWords() + 1;
+            ASSERT_MSG(queue.pending_packet.size() < packet_dwords,
+                       "Buffered PM4 packet is already complete");
 
-        // If the packet is split across ring boundary, buffer until next submission
-        if (next_dw_off > acb.size()) [[unlikely]] {
-            std::memcpy(queue.tmp_packet.data(), acb.data(), acb.size_bytes());
-            queue.tmp_dwords = acb.size();
+            const size_t remaining_dwords = packet_dwords - queue.pending_packet.size();
+            next_dw_off = std::min(remaining_dwords, acb.size());
+            queue.pending_packet.insert(queue.pending_packet.end(), acb.begin(),
+                                        acb.begin() + next_dw_off);
+
+            // DingDong can expose one large PM4 packet through several ring fragments. Keep the
+            // packet buffered until it is complete; parsing a partial body would read past the
+            // current submission and corrupt the ASC queue state.
+            if (next_dw_off < remaining_dwords) {
+                if constexpr (!is_indirect) {
+                    *queue.read_addr += next_dw_off;
+                    *queue.read_addr %= queue.ring_size_dw;
+                }
+                break;
+            }
+            header = reinterpret_cast<const PM4Header*>(queue.pending_packet.data());
+        } else if (next_dw_off > acb.size()) [[unlikely]] {
+            queue.pending_packet.assign(acb.begin(), acb.end());
             if constexpr (!is_indirect) {
                 *queue.read_addr += acb.size();
                 *queue.read_addr %= queue.ring_size_dw;
@@ -1169,6 +1183,10 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
         if constexpr (!is_indirect) {
             *queue.read_addr += next_dw_off;
             *queue.read_addr %= queue.ring_size_dw;
+        }
+
+        if (has_pending_packet) [[unlikely]] {
+            queue.pending_packet.clear();
         }
     }
 

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -18,6 +18,7 @@
 #include "common/types.h"
 #include "common/unique_function.h"
 #include "video_core/amdgpu/cb_db_extent.h"
+#include "video_core/amdgpu/pm4_packet_assembler.h"
 #include "video_core/amdgpu/regs.h"
 
 namespace Vulkan {
@@ -137,7 +138,7 @@ public:
         u32* read_addr;
         u32 ring_size_dw;
         u32 pipe_id;
-        std::vector<u32> pending_packet;
+        Pm4PacketAssembler packet_assembler;
     };
     Common::SlotVector<AscQueueInfo> asc_queues{};
 

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -133,13 +133,11 @@ public:
     }
 
     struct AscQueueInfo {
-        static constexpr size_t Pm4BufferSize = 1024;
         VAddr map_addr;
         u32* read_addr;
         u32 ring_size_dw;
         u32 pipe_id;
-        std::array<u32, Pm4BufferSize> tmp_packet;
-        u32 tmp_dwords;
+        std::vector<u32> pending_packet;
     };
     Common::SlotVector<AscQueueInfo> asc_queues{};
 

--- a/src/video_core/amdgpu/pm4_packet_assembler.cpp
+++ b/src/video_core/amdgpu/pm4_packet_assembler.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "video_core/amdgpu/pm4_packet_assembler.h"
+
+#include <algorithm>
+#include <utility>
+
+namespace AmdGpu {
+
+Pm4PacketAssembler::Result Pm4PacketAssembler::Consume(std::span<const u32> fragment,
+                                                       size_t packet_dwords) {
+    if (packet_dwords == 0 || fragment.empty()) {
+        return {Status::Invalid, 0, {}};
+    }
+
+    if (pending_packet.empty()) {
+        if (packet_dwords <= fragment.size()) {
+            return {Status::Complete, packet_dwords, {}};
+        }
+
+        // The PM4 header provides the final packet size up front. Reserving it avoids repeatedly
+        // reallocating when DingDong exposes a large packet through several small ring fragments.
+        pending_packet.reserve(packet_dwords);
+        pending_packet.assign(fragment.begin(), fragment.end());
+        return {Status::Incomplete, fragment.size(), {}};
+    }
+
+    if (pending_packet.size() >= packet_dwords) {
+        return {Status::Invalid, 0, {}};
+    }
+
+    const size_t remaining_dwords = packet_dwords - pending_packet.size();
+    const size_t consumed_dwords = std::min(remaining_dwords, fragment.size());
+    pending_packet.insert(pending_packet.end(), fragment.begin(),
+                          fragment.begin() + consumed_dwords);
+
+    if (consumed_dwords < remaining_dwords) {
+        return {Status::Incomplete, consumed_dwords, {}};
+    }
+
+    // Transfer ownership before the caller executes the packet. Queue-owned pending state must be
+    // empty if the packet recursively enters an indirect buffer on the same virtual queue.
+    return {Status::Complete, consumed_dwords, std::exchange(pending_packet, std::vector<u32>{})};
+}
+
+bool Pm4PacketAssembler::HasPendingPacket() const noexcept {
+    return !pending_packet.empty();
+}
+
+std::span<const u32> Pm4PacketAssembler::PendingPacket() const noexcept {
+    return pending_packet;
+}
+
+} // namespace AmdGpu

--- a/src/video_core/amdgpu/pm4_packet_assembler.h
+++ b/src/video_core/amdgpu/pm4_packet_assembler.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <cstddef>
+#include <span>
+#include <vector>
+
+#include "common/types.h"
+
+namespace AmdGpu {
+
+/// Reassembles direct ASC PM4 packets exposed through multiple DingDong ring fragments.
+/// The state belongs to one virtual queue and must not be reused for indirect buffers.
+class Pm4PacketAssembler {
+public:
+    enum class Status {
+        Complete,
+        Incomplete,
+        Invalid,
+    };
+
+    struct Result {
+        Status status{Status::Invalid};
+        size_t consumed_dwords{};
+        std::vector<u32> completed_packet;
+    };
+
+    [[nodiscard]] Result Consume(std::span<const u32> fragment, size_t packet_dwords);
+    [[nodiscard]] bool HasPendingPacket() const noexcept;
+    [[nodiscard]] std::span<const u32> PendingPacket() const noexcept;
+
+private:
+    std::vector<u32> pending_packet;
+};
+
+} // namespace AmdGpu

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ include(FetchContent)
 )
 FetchContent_MakeAvailable(googletest)
 
-set(TEST_TARGETS shadps4_settings_test shadps4_gcn_test)
+set(TEST_TARGETS shadps4_settings_test shadps4_gcn_test shadps4_video_core_test)
 
 set(SETTINGS_TEST_SOURCES
     # Under test
@@ -128,8 +128,17 @@ set(GCN_TEST_SOURCES
     gcn/test_gcn_instructions.cpp
 )
 
+set(VIDEO_CORE_TEST_SOURCES
+    # Under test
+    ${CMAKE_SOURCE_DIR}/src/video_core/amdgpu/pm4_packet_assembler.cpp
+
+    # Tests
+    video_core/test_pm4_packet_assembler.cpp
+)
+
 add_executable(shadps4_settings_test ${SETTINGS_TEST_SOURCES})
 add_executable(shadps4_gcn_test ${GCN_TEST_SOURCES})
+add_executable(shadps4_video_core_test ${VIDEO_CORE_TEST_SOURCES})
 
 foreach(t ${TEST_TARGETS})
     target_include_directories(${t} PRIVATE
@@ -161,6 +170,7 @@ target_link_libraries(shadps4_gcn_test PRIVATE
     spdlog::spdlog
     half::half
 )
+target_link_libraries(shadps4_video_core_test PRIVATE GTest::gtest_main)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
     CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")

--- a/tests/video_core/test_pm4_packet_assembler.cpp
+++ b/tests/video_core/test_pm4_packet_assembler.cpp
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <algorithm>
+#include <array>
+#include <numeric>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "video_core/amdgpu/pm4_packet_assembler.h"
+
+namespace AmdGpu {
+namespace {
+
+using Status = Pm4PacketAssembler::Status;
+
+TEST(Pm4PacketAssemblerTest, CompletesPacketWithoutBuffering) {
+    Pm4PacketAssembler assembler;
+    const std::array<u32, 5> input{1, 2, 3, 4, 99};
+
+    const auto result = assembler.Consume(input, 4);
+
+    EXPECT_EQ(result.status, Status::Complete);
+    EXPECT_EQ(result.consumed_dwords, 4u);
+    EXPECT_TRUE(result.completed_packet.empty());
+    EXPECT_FALSE(assembler.HasPendingPacket());
+}
+
+TEST(Pm4PacketAssemblerTest, CompletesAcrossThreeFragmentsAndLeavesTrailingData) {
+    Pm4PacketAssembler assembler;
+    const std::vector<u32> packet{10, 11, 12, 13, 14, 15};
+    const std::array<u32, 2> first{10, 11};
+    const std::array<u32, 1> second{12};
+    const std::array<u32, 5> last_with_trailing{13, 14, 15, 90, 91};
+
+    const auto first_result = assembler.Consume(first, packet.size());
+    ASSERT_EQ(first_result.status, Status::Incomplete);
+    EXPECT_EQ(first_result.consumed_dwords, first.size());
+
+    const auto second_result = assembler.Consume(second, packet.size());
+    ASSERT_EQ(second_result.status, Status::Incomplete);
+    EXPECT_EQ(second_result.consumed_dwords, second.size());
+
+    const auto final_result = assembler.Consume(last_with_trailing, packet.size());
+    EXPECT_EQ(final_result.status, Status::Complete);
+    EXPECT_EQ(final_result.consumed_dwords, 3u);
+    EXPECT_EQ(final_result.completed_packet, packet);
+    EXPECT_FALSE(assembler.HasPendingPacket());
+}
+
+TEST(Pm4PacketAssemblerTest, HandlesPacketLargerThanLegacyScratchBuffer) {
+    constexpr size_t PacketDwords = 2048;
+    Pm4PacketAssembler assembler;
+    std::vector<u32> packet(PacketDwords);
+    std::iota(packet.begin(), packet.end(), 0u);
+
+    const auto first_result = assembler.Consume(std::span{packet}.first(700), packet.size());
+    ASSERT_EQ(first_result.status, Status::Incomplete);
+
+    const auto second_result =
+        assembler.Consume(std::span{packet}.subspan(700, 700), packet.size());
+    ASSERT_EQ(second_result.status, Status::Incomplete);
+
+    const auto final_result = assembler.Consume(std::span{packet}.subspan(1400), packet.size());
+    EXPECT_EQ(final_result.status, Status::Complete);
+    EXPECT_EQ(final_result.completed_packet, packet);
+    EXPECT_FALSE(assembler.HasPendingPacket());
+}
+
+TEST(Pm4PacketAssemblerTest, ReleasesCompletedPacketBeforeNestedDispatch) {
+    Pm4PacketAssembler assembler;
+    const std::array<u32, 2> outer_start{20, 21};
+    const std::array<u32, 2> outer_end{22, 23};
+    const std::array<u32, 2> nested_packet{30, 31};
+
+    ASSERT_EQ(assembler.Consume(outer_start, 4).status, Status::Incomplete);
+    const auto outer_result = assembler.Consume(outer_end, 4);
+    ASSERT_EQ(outer_result.status, Status::Complete);
+    ASSERT_FALSE(assembler.HasPendingPacket());
+
+    const auto nested_result = assembler.Consume(nested_packet, nested_packet.size());
+    EXPECT_EQ(nested_result.status, Status::Complete);
+    EXPECT_EQ(nested_result.consumed_dwords, nested_packet.size());
+    EXPECT_FALSE(assembler.HasPendingPacket());
+}
+
+TEST(Pm4PacketAssemblerTest, KeepsPendingDataIsolatedPerQueue) {
+    Pm4PacketAssembler first_queue;
+    Pm4PacketAssembler second_queue;
+    const std::array<u32, 2> first_fragment{1, 2};
+    const std::array<u32, 3> second_fragment{7, 8, 9};
+
+    ASSERT_EQ(first_queue.Consume(first_fragment, 4).status, Status::Incomplete);
+    ASSERT_EQ(second_queue.Consume(second_fragment, 5).status, Status::Incomplete);
+
+    EXPECT_TRUE(std::ranges::equal(first_queue.PendingPacket(), first_fragment));
+    EXPECT_TRUE(std::ranges::equal(second_queue.PendingPacket(), second_fragment));
+}
+
+TEST(Pm4PacketAssemblerTest, CompletesSingleDwordPacketWithoutPendingState) {
+    Pm4PacketAssembler assembler;
+    const std::array<u32, 1> type_two_padding{0x80000000u};
+
+    const auto result = assembler.Consume(type_two_padding, 1);
+
+    EXPECT_EQ(result.status, Status::Complete);
+    EXPECT_EQ(result.consumed_dwords, 1u);
+    EXPECT_FALSE(assembler.HasPendingPacket());
+}
+
+} // namespace
+} // namespace AmdGpu


### PR DESCRIPTION
## Summary

Rework ASC PM4 packet reassembly so direct DingDong submissions can safely contain packets split
across any number of ring fragments, including packets larger than the previous 1024-dword
temporary buffer.

## Problem

Direct ASC submissions are not guaranteed to end on a PM4 packet boundary.

The existing path assumes that the next submission contains the complete remainder of a split
Type-3 packet. It may therefore read beyond the supplied span when a packet remains incomplete,
while the fixed temporary buffer also limits reconstructed packets to 1024 dwords.

This can corrupt ASC queue progress and eventually stall guest GPU command processing.

## Changes

- Add a PM4 packet assembler owned by each ASC virtual queue.
- Accumulate incomplete packets across multiple DingDong fragments.
- Advance the guest read pointer only by dwords consumed from the current fragment.
- Remove the fixed 1024-dword packet-size limitation.
- Transfer completed packet storage out of queue state before dispatch.
- Keep indirect-buffer processing isolated from direct ASC packet assembly.
- Preserve the zero-allocation path for packets already complete in the current fragment.

This generalizes the split-packet handling introduced by #2476.

## Tests

Added focused tests covering:

- Complete packets without buffering.
- A 6-dword packet reconstructed from 2, 1 and 3-dword fragments.
- Preservation of trailing commands in the final fragment.
- A 2048-dword packet reconstructed from 700, 700 and 648-dword fragments.
- Queue-local pending state.
- Nested dispatch after completed-packet ownership transfer.
- Single-dword packet handling.

Verification results:

```text
x64-Clang-Debug build: PASS
Pm4PacketAssemblerTest: 6/6 PASS
CTest excluding GcnTest: 491/491 PASS (1 existing conditional skip)
clang-format --dry-run --Werror: PASS
git diff --check: PASS
```

## Runtime validation

Tested with:

```text
Title: GUNDAM VERSUS
Serial: CUSA08379
GPU: NVIDIA GeForce RTX 4070
Driver: NVIDIA 596.36.0.0
Vulkan: 1.4.329
```

Before this change, normal 3D gameplay stopped making frame and input progress after approximately
one minute while background audio continued.

With this change, the same installation, user data, configuration and gameplay path remained
responsive beyond the previous failure interval. One validation run continued for more than four
minutes, and a second run also started and progressed normally.

No ASC PM4 assertion, truncated indirect-packet error, unhandled exception or crash was observed.

AMD hardware was not available for local runtime testing. The implementation is vendor-independent
and operates only on guest ASC ring and PM4 packet state.
