### PR TITLE
ajm: Prevent AT9 data overread crashes

### DIFF
--- a/src/core/libraries/ajm/ajm_at9.cpp
+++ b/src/core/libraries/ajm/ajm_at9.cpp
@@ -156,17 +156,19 @@ DecoderResult AjmAt9Decoder::ProcessData(std::span<u8>& in_buf, SparseOutputBuff
     int bytes_used = 0;
     switch (m_format) {
     case AjmFormatEncoding::S16:
-        ret = Atrac9Decode(m_handle, in_buf.data(), reinterpret_cast<s16*>(m_pcm_buffer.data()),
-                           &bytes_used, True(m_flags & AjmAt9CodecFlags::NonInterleavedOutput));
+        ret = Atrac9Decode(m_handle, in_buf.data(), static_cast<int>(in_buf.size()),
+                           reinterpret_cast<s16*>(m_pcm_buffer.data()), &bytes_used,
+                           True(m_flags & AjmAt9CodecFlags::NonInterleavedOutput));
         break;
     case AjmFormatEncoding::S32:
-        ret = Atrac9DecodeS32(m_handle, in_buf.data(), reinterpret_cast<s32*>(m_pcm_buffer.data()),
-                              &bytes_used, True(m_flags & AjmAt9CodecFlags::NonInterleavedOutput));
+        ret = Atrac9DecodeS32(m_handle, in_buf.data(), static_cast<int>(in_buf.size()),
+                              reinterpret_cast<s32*>(m_pcm_buffer.data()), &bytes_used,
+                              True(m_flags & AjmAt9CodecFlags::NonInterleavedOutput));
         break;
     case AjmFormatEncoding::Float:
-        ret =
-            Atrac9DecodeF32(m_handle, in_buf.data(), reinterpret_cast<float*>(m_pcm_buffer.data()),
-                            &bytes_used, True(m_flags & AjmAt9CodecFlags::NonInterleavedOutput));
+        ret = Atrac9DecodeF32(m_handle, in_buf.data(), static_cast<int>(in_buf.size()),
+                              reinterpret_cast<float*>(m_pcm_buffer.data()), &bytes_used,
+                              True(m_flags & AjmAt9CodecFlags::NonInterleavedOutput));
         break;
     default:
         UNREACHABLE();
@@ -225,8 +227,8 @@ DecoderResult AjmAt9Decoder::ProcessData(std::span<u8>& in_buf, SparseOutputBuff
         // Drain the remaining superframe
         std::vector<s16> buf(m_codec_info.frameSamples * m_codec_info.channels, 0);
         while ((m_num_frames % m_codec_info.framesInSuperframe) != 0) {
-            ret = Atrac9Decode(m_handle, in_buf.data(), buf.data(), &bytes_used,
-                               True(m_flags & AjmAt9CodecFlags::NonInterleavedOutput));
+            ret = Atrac9Decode(m_handle, in_buf.data(), static_cast<int>(in_buf.size()), buf.data(),
+                               &bytes_used, True(m_flags & AjmAt9CodecFlags::NonInterleavedOutput));
             in_buf = in_buf.subspan(bytes_used);
             m_superframe_bytes_remain -= bytes_used;
             result.frames_decoded += 1;


### PR DESCRIPTION
Updates LibAtrac9 with logic to prevent variable-length huffman code reads from over-reading the audio buffer and causing page fault crashes.

Should prevent some random crashes in games like Persona 4 Dancing.