### PR TITLE
texture_cache: Fix MipOf and SliceOf checks

### DIFF
--- a/src/video_core/texture_cache/image.cpp
+++ b/src/video_core/texture_cache/image.cpp
@@ -672,12 +672,15 @@ void Image::CopyImageWithBuffer(Image& src_image, vk::Buffer buffer, u64 offset)
 void Image::CopyMip(Image& src_image, u32 mip, u32 slice) {
     const auto& src_info = src_image.info;
 
-    const auto src_block_dim = src_info.BlockDim();
-    const auto dst_block_dim = info.BlockDim();
-    const auto mip_block_w = std::max(dst_block_dim.width >> mip, 1u);
-    const auto mip_block_h = std::max(dst_block_dim.height >> mip, 1u);
-    ASSERT(mip_block_w == src_block_dim.width);
-    ASSERT(mip_block_h == src_block_dim.height);
+    const auto dst_dim = info.props.is_block ? 2 : 0;
+    const auto mip_block_w = std::max(info.size.width >> (mip + dst_dim), 1u);
+    const auto mip_block_h = std::max(info.size.height >> (mip + dst_dim), 1u);
+    const auto mip_block_p = std::max(info.mips_layout[mip].pitch >> dst_dim, 1u);
+
+    const auto src_dim = src_info.props.is_block ? 2 : 0;
+    ASSERT(mip_block_w == (src_info.size.width >> src_dim));
+    ASSERT(mip_block_h == (src_info.size.height >> src_dim));
+    ASSERT(mip_block_p == (src_info.pitch >> src_dim));
 
     const auto [src_layers, dst_layers] = SanitizeCopyLayers(src_info, info, src_info.size.depth);
 

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -247,7 +247,7 @@ s32 ImageInfo::MipOf(const ImageInfo& info) const {
     if (mip < 0) {
         return -1;
     }
-    
+
     // 2D block dimensions of both images should be the same.
     const auto mip_w = std::max(info.size.width >> (mip + info_dim), 1u);
     const auto mip_h = std::max(info.size.height >> (mip + info_dim), 1u);

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -221,10 +221,13 @@ s32 ImageInfo::MipOf(const ImageInfo& info) const {
         return -1;
     }
 
-    // Currently we expect only on level to be copied.
+    // Currently we expect only one level to be copied.
     if (resources.levels != 1) {
         return -1;
     }
+
+    const auto info_dim = info.props.is_block ? 2 : 0;
+    const auto this_dim = props.is_block ? 2 : 0;
 
     // Find mip
     auto mip = -1;
@@ -234,7 +237,8 @@ s32 ImageInfo::MipOf(const ImageInfo& info) const {
         const VAddr mip_end = mip_base + mip_size;
         const u32 slice_size = mip_size / info.resources.layers;
         if (guest_address >= mip_base && guest_address < mip_end &&
-            (guest_address - mip_base) % slice_size == 0) {
+            (guest_address - mip_base) % slice_size == 0 &&
+            (pitch >> this_dim) == (mip_pitch >> info_dim)) {
             mip = m;
             break;
         }
@@ -243,18 +247,13 @@ s32 ImageInfo::MipOf(const ImageInfo& info) const {
     if (mip < 0) {
         return -1;
     }
-
-    const auto curr_block_dim = BlockDim();
-    const auto info_block_dim = info.MipBlockDim(mip);
-
+    
     // 2D block dimensions of both images should be the same.
-    const auto mip_w = std::max(info_block_dim.width, 1u);
-    const auto mip_h = std::max(info_block_dim.height, 1u);
-
-    // Current dimensions need to be padded to a tile.
-    const auto cur_w = std::max(curr_block_dim.width, 8u);
-    const auto cur_h = std::max(curr_block_dim.height, 8u);
-    if ((cur_w != mip_w) || (cur_h != mip_h)) {
+    const auto mip_w = std::max(info.size.width >> (mip + info_dim), 1u);
+    const auto mip_h = std::max(info.size.height >> (mip + info_dim), 1u);
+    const auto this_w = std::max(size.width >> this_dim, 1u);
+    const auto this_h = std::max(size.height >> this_dim, 1u);
+    if ((this_w != mip_w) || (this_h != mip_h)) {
         return -1;
     }
 
@@ -283,17 +282,15 @@ s32 ImageInfo::SliceOf(const ImageInfo& info, s32 mip) const {
         return -1;
     }
 
-    const auto curr_block_dim = BlockDim();
-    const auto info_block_dim = info.MipBlockDim(mip);
-
     // 2D block dimensions of both images should be the same.
-    const auto mip_w = std::max(info_block_dim.width, 1u);
-    const auto mip_h = std::max(info_block_dim.height, 1u);
+    const auto info_dim = info.props.is_block ? 2 : 0;
+    const auto mip_w = std::max(info.size.width >> (mip + info_dim), 1u);
+    const auto mip_h = std::max(info.size.height >> (mip + info_dim), 1u);
 
-    // Current dimensions need to be padded to a tile.
-    const auto cur_w = std::max(curr_block_dim.width, 8u);
-    const auto cur_h = std::max(curr_block_dim.height, 8u);
-    if ((cur_w != mip_w) || (cur_h != mip_h)) {
+    const auto this_dim = props.is_block ? 2 : 0;
+    const auto this_w = std::max(size.width >> this_dim, 1u);
+    const auto this_h = std::max(size.height >> this_dim, 1u);
+    if ((this_w != mip_w) || (this_h != mip_h)) {
         return -1;
     }
 

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -245,12 +245,16 @@ s32 ImageInfo::MipOf(const ImageInfo& info) const {
     }
 
     const auto curr_block_dim = BlockDim();
-    const auto info_block_dim = info.BlockDim();
+    const auto info_block_dim = info.MipBlockDim(mip);
 
     // 2D block dimensions of both images should be the same.
-    const auto mip_w = std::max(info_block_dim.width >> mip, 1u);
-    const auto mip_h = std::max(info_block_dim.height >> mip, 1u);
-    if ((curr_block_dim.width != mip_w) || (curr_block_dim.height != mip_h)) {
+    const auto mip_w = std::max(info_block_dim.width, 1u);
+    const auto mip_h = std::max(info_block_dim.height, 1u);
+
+    // Current dimensions need to be padded to a tile.
+    const auto cur_w = std::max(curr_block_dim.width, 8u);
+    const auto cur_h = std::max(curr_block_dim.height, 8u);
+    if ((cur_w != mip_w) || (cur_h != mip_h)) {
         return -1;
     }
 
@@ -280,12 +284,16 @@ s32 ImageInfo::SliceOf(const ImageInfo& info, s32 mip) const {
     }
 
     const auto curr_block_dim = BlockDim();
-    const auto info_block_dim = info.BlockDim();
+    const auto info_block_dim = info.MipBlockDim(mip);
 
     // 2D block dimensions of both images should be the same.
-    const auto mip_w = std::max(info_block_dim.width >> mip, 1u);
-    const auto mip_h = std::max(info_block_dim.height >> mip, 1u);
-    if ((curr_block_dim.width != mip_w) || (curr_block_dim.height != mip_h)) {
+    const auto mip_w = std::max(info_block_dim.width, 1u);
+    const auto mip_h = std::max(info_block_dim.height, 1u);
+
+    // Current dimensions need to be padded to a tile.
+    const auto cur_w = std::max(curr_block_dim.width, 8u);
+    const auto cur_h = std::max(curr_block_dim.height, 8u);
+    if ((cur_w != mip_w) || (cur_h != mip_h)) {
         return -1;
     }
 

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "common/assert.h"

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2024-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "common/assert.h"

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -286,11 +286,13 @@ s32 ImageInfo::SliceOf(const ImageInfo& info, s32 mip) const {
     const auto info_dim = info.props.is_block ? 2 : 0;
     const auto mip_w = std::max(info.size.width >> (mip + info_dim), 1u);
     const auto mip_h = std::max(info.size.height >> (mip + info_dim), 1u);
+    const auto mip_p = std::max(info.pitch >> (mip + info_dim), 1u);
 
     const auto this_dim = props.is_block ? 2 : 0;
     const auto this_w = std::max(size.width >> this_dim, 1u);
     const auto this_h = std::max(size.height >> this_dim, 1u);
-    if ((this_w != mip_w) || (this_h != mip_h)) {
+    const auto this_p = std::max(pitch >> this_dim, 1u);
+    if ((this_w != mip_w) || (this_h != mip_h) || (this_p != mip_p)) {
         return -1;
     }
 

--- a/src/video_core/texture_cache/image_info.cpp
+++ b/src/video_core/texture_cache/image_info.cpp
@@ -286,7 +286,7 @@ s32 ImageInfo::SliceOf(const ImageInfo& info, s32 mip) const {
     const auto info_dim = info.props.is_block ? 2 : 0;
     const auto mip_w = std::max(info.size.width >> (mip + info_dim), 1u);
     const auto mip_h = std::max(info.size.height >> (mip + info_dim), 1u);
-    const auto mip_p = std::max(info.pitch >> (mip + info_dim), 1u);
+    const auto mip_p = std::max(info.mips_layout[mip].pitch >> info_dim, 1u);
 
     const auto this_dim = props.is_block ? 2 : 0;
     const auto this_w = std::max(size.width >> this_dim, 1u);

--- a/src/video_core/texture_cache/image_info.h
+++ b/src/video_core/texture_cache/image_info.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once

--- a/src/video_core/texture_cache/image_info.h
+++ b/src/video_core/texture_cache/image_info.h
@@ -46,9 +46,15 @@ struct ImageInfo {
     bool IsTiled() const {
         return tile_mode != AmdGpu::TileMode::DisplayLinearAligned;
     }
+
     Extent2D BlockDim() const {
         const auto dim = props.is_block ? 2 : 0;
         return Extent2D{pitch >> dim, size.height >> dim};
+    }
+
+    Extent2D MipBlockDim(s32 mip) const {
+        const auto dim = props.is_block ? 2 : 0;
+        return Extent2D{mips_layout[mip].pitch >> dim, mips_layout[mip].height >> dim};
     }
 
     s32 MipOf(const ImageInfo& info) const;

--- a/src/video_core/texture_cache/image_info.h
+++ b/src/video_core/texture_cache/image_info.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2024-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once

--- a/src/video_core/texture_cache/image_info.h
+++ b/src/video_core/texture_cache/image_info.h
@@ -52,11 +52,6 @@ struct ImageInfo {
         return Extent2D{pitch >> dim, size.height >> dim};
     }
 
-    Extent2D MipBlockDim(s32 mip) const {
-        const auto dim = props.is_block ? 2 : 0;
-        return Extent2D{mips_layout[mip].pitch >> dim, mips_layout[mip].height >> dim};
-    }
-
     s32 MipOf(const ImageInfo& info) const;
     s32 SliceOf(const ImageInfo& info, s32 mip) const;
 


### PR DESCRIPTION
After #4553 modified these checks, UE games started exhibiting a green glow. The issue was that the BlockDim width was coming from image pitch. The mip's pitch value is padded, while the pitch calculated from the parent image was not. As a result, the width validity check was failing, and actual image mips were not getting recognized correctly.

This PR changes the check back to using the actual width and height, and manually shifting values to appropriately account for block images. I've also added a separate check for the actual pitch, accounting for the padding by checking through mips_layout instead of calculating based on mip index.

These changes were suggested by @raphaelthegreat, and fixes the UE green glow.