### PR TITLE
core: initialize NGS2 rack query output

### DIFF
--- a/src/core/libraries/ngs2/ngs2.cpp
+++ b/src/core/libraries/ngs2/ngs2.cpp
@@ -102,7 +102,7 @@ s32 PS4_SYSV_ABI sceNgs2RackLock(OrbisNgs2Handle rackHandle) {
 s32 PS4_SYSV_ABI sceNgs2RackQueryBufferSize(u32 rackId, const OrbisNgs2RackOption* option,
                                             OrbisNgs2ContextBufferInfo* outBufferInfo) {
     LOG_ERROR(Lib_Ngs2, "rackId = {}", rackId);
-    return ORBIS_OK;
+    return RackQueryBufferSize(option, outBufferInfo);
 }
 
 s32 PS4_SYSV_ABI sceNgs2RackSetUserData(OrbisNgs2Handle rackHandle, uintptr_t userData) {

--- a/src/core/libraries/ngs2/ngs2_impl.cpp
+++ b/src/core/libraries/ngs2/ngs2_impl.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "ngs2.h"
 #include "ngs2_error.h"
 #include "ngs2_impl.h"
 
@@ -182,6 +183,27 @@ s32 SystemSetup(const OrbisNgs2SystemOption* option, OrbisNgs2ContextBufferInfo*
     LOG_ERROR(Lib_Ngs2, "Invalid system buffer size ({}<{}[byte])", hostBufferInfo->hostBufferSize,
               requiredBufferSize);
     return ORBIS_NGS2_ERROR_INVALID_BUFFER_SIZE;
+}
+
+s32 RackQueryBufferSize(const OrbisNgs2RackOption* option,
+                        OrbisNgs2ContextBufferInfo* outBufferInfo) {
+    if (!outBufferInfo) {
+        return ORBIS_NGS2_ERROR_INVALID_BUFFER_ADDRESS;
+    }
+    if (option && option->size < sizeof(OrbisNgs2RackOption)) {
+        return ORBIS_NGS2_ERROR_INVALID_OPTION_SIZE;
+    }
+
+    StackBuffer stackBuffer;
+    size_t requiredBufferSize = 0;
+    const u8 optionFlags = option ? static_cast<u8>(option->flags >> 31) : 0;
+    StackBufferOpen(&stackBuffer, nullptr, 0, nullptr, optionFlags);
+    StackBufferClose(&stackBuffer, &requiredBufferSize);
+
+    outBufferInfo->hostBuffer = nullptr;
+    outBufferInfo->hostBufferSize = requiredBufferSize;
+    MemoryClear(outBufferInfo->reserved, sizeof(outBufferInfo->reserved));
+    return ORBIS_OK;
 }
 
 } // namespace Libraries::Ngs2

--- a/src/core/libraries/ngs2/ngs2_impl.h
+++ b/src/core/libraries/ngs2/ngs2_impl.h
@@ -7,6 +7,8 @@
 
 namespace Libraries::Ngs2 {
 
+struct OrbisNgs2RackOption;
+
 static const int ORBIS_NGS2_SYSTEM_NAME_LENGTH = 16;
 static const int ORBIS_NGS2_RACK_NAME_LENGTH = 16;
 
@@ -175,5 +177,7 @@ void* MemoryClear(void* buffer, size_t size);
 s32 SystemCleanup(OrbisNgs2Handle systemHandle, OrbisNgs2ContextBufferInfo* outInfo);
 s32 SystemSetup(const OrbisNgs2SystemOption* option, OrbisNgs2ContextBufferInfo* hostBufferInfo,
                 OrbisNgs2BufferFreeHandler hostFree, OrbisNgs2Handle* outHandle);
+s32 RackQueryBufferSize(const OrbisNgs2RackOption* option,
+                        OrbisNgs2ContextBufferInfo* outBufferInfo);
 
 } // namespace Libraries::Ngs2

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,11 @@ include(FetchContent)
 )
 FetchContent_MakeAvailable(googletest)
 
-set(TEST_TARGETS shadps4_settings_test shadps4_gcn_test)
+set(TEST_TARGETS
+    shadps4_settings_test
+    shadps4_ngs2_test
+    shadps4_gcn_test
+)
 
 set(SETTINGS_TEST_SOURCES
     # Under test
@@ -33,6 +37,29 @@ set(SETTINGS_TEST_SOURCES
     test_emulator_settings.cpp
 )
 
+set(NGS2_TEST_SOURCES
+    # Under test
+    ${CMAKE_SOURCE_DIR}/src/core/libraries/ngs2/ngs2_impl.cpp
+
+    # Minimal common and kernel support
+    ${CMAKE_SOURCE_DIR}/src/core/emulator_settings.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/emulator_state.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/libraries/kernel/sync/mutex.cpp
+    ${CMAKE_SOURCE_DIR}/src/common/path_util.cpp
+    ${CMAKE_SOURCE_DIR}/src/common/assert.cpp
+    ${CMAKE_SOURCE_DIR}/src/common/error.cpp
+    ${CMAKE_SOURCE_DIR}/src/common/string_util.cpp
+    ${CMAKE_SOURCE_DIR}/src/common/logging/log.cpp
+
+    # Stubs that replace dependencies
+    stubs/common_stub.cpp
+    stubs/core_stub.cpp
+    stubs/scm_rev_stub.cpp
+    stubs/sdl_stub.cpp
+
+    # Tests
+    test_ngs2.cpp
+)
 set(GCN_TEST_SOURCES
     # Under test
     ${CMAKE_SOURCE_DIR}/src/core/emulator_settings.cpp
@@ -129,6 +156,7 @@ set(GCN_TEST_SOURCES
 )
 
 add_executable(shadps4_settings_test ${SETTINGS_TEST_SOURCES})
+add_executable(shadps4_ngs2_test ${NGS2_TEST_SOURCES})
 add_executable(shadps4_gcn_test ${GCN_TEST_SOURCES})
 
 foreach(t ${TEST_TARGETS})
@@ -141,6 +169,14 @@ foreach(t ${TEST_TARGETS})
 endforeach()
 
 target_link_libraries(shadps4_settings_test PRIVATE
+    GTest::gtest_main
+    fmt::fmt
+    nlohmann_json::nlohmann_json
+    toml11::toml11
+    SDL3::SDL3
+    spdlog::spdlog
+)
+target_link_libraries(shadps4_ngs2_test PRIVATE
     GTest::gtest_main
     fmt::fmt
     nlohmann_json::nlohmann_json

--- a/tests/test_ngs2.cpp
+++ b/tests/test_ngs2.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <cstring>
+
+#include <gtest/gtest.h>
+
+#include "core/libraries/error_codes.h"
+#include "core/libraries/ngs2/ngs2.h"
+#include "core/libraries/ngs2/ngs2_error.h"
+
+namespace Libraries::Ngs2 {
+namespace {
+
+TEST(Ngs2Test, RackQueryBufferSizeInitializesSuccessfulOutput) {
+    OrbisNgs2ContextBufferInfo info;
+    std::memset(&info, 0xA5, sizeof(info));
+    const size_t poisoned_size = info.hostBufferSize;
+    const uintptr_t poisoned_user_data = info.userData;
+
+    EXPECT_EQ(RackQueryBufferSize(nullptr, &info), ORBIS_OK);
+    EXPECT_EQ(info.hostBuffer, nullptr);
+    EXPECT_GT(info.hostBufferSize, 0);
+    EXPECT_NE(info.hostBufferSize, poisoned_size);
+    for (const auto value : info.reserved) {
+        EXPECT_EQ(value, 0);
+    }
+    EXPECT_EQ(info.userData, poisoned_user_data);
+}
+
+TEST(Ngs2Test, RackQueryBufferSizeRejectsInvalidArguments) {
+    EXPECT_EQ(RackQueryBufferSize(nullptr, nullptr), ORBIS_NGS2_ERROR_INVALID_BUFFER_ADDRESS);
+
+    OrbisNgs2RackOption option{};
+    option.size = sizeof(option) - 1;
+    OrbisNgs2ContextBufferInfo info{};
+    EXPECT_EQ(RackQueryBufferSize(&option, &info), ORBIS_NGS2_ERROR_INVALID_OPTION_SIZE);
+}
+
+} // namespace
+} // namespace Libraries::Ngs2


### PR DESCRIPTION
## Summary

  Initialize the NGS2 rack query output before populating its implemented fields.

  This prevents callers from observing uninitialized host-stack data in fields that shadPS4 does not currently fill, while preserving the existing implemented values and ABI layout.

  ## Validation

  - Added focused NGS2 rack-query coverage
  - RelWithDebInfo build completed successfully with clang-cl
  - CTest: 411 passed, 1 HTTP-dependent test skipped, 0 failed
  
Game: Shadow of the Colossus