### PR TITLE
shader_recompiler: propagate V_ADD_I32 carry-out

### DIFF
--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -739,13 +739,14 @@ void Translator::V_MBCNT_U32_B32(bool is_low, const GcnInst& inst) {
 }
 
 void Translator::V_ADD_I32(const GcnInst& inst) {
-    // Signed or unsigned components
+    // The sum is identical for signed and unsigned components. VCC (or the VOP3 scalar
+    // destination) receives the unsigned carry-out, despite the legacy _I32 mnemonic.
     const IR::U32 src0{GetSrc(inst.src[0])};
     const IR::U32 src1{GetSrc(inst.src[1])};
     const IR::U32 result{ir.IAdd(src0, src1)};
     SetDst(inst.dst[0], result);
 
-    // TODO: Carry-out with signed or unsigned components
+    SetCarryOut(inst, ir.ILessThan(result, src0, false));
 }
 
 void Translator::V_SUB_I32(const GcnInst& inst) {

--- a/tests/gcn/test_gcn_instructions.cpp
+++ b/tests/gcn/test_gcn_instructions.cpp
@@ -54,6 +54,23 @@ TEST_F(GcnTest, add_f32) {
     EXPECT_EQ(*result, 7.5f);
 }
 
+TEST_F(GcnTest, add_i32_carry_feeds_addc_u32) {
+    auto runner = gcn_test::Runner::instance().value();
+    const std::array<u64, 2> instructions{
+        VOP2(OpcodeVOP2::V_ADD_I32, VOperand8::V1, SOperand9::S0, VOperand8::V1).Get(),
+        VOP2(OpcodeVOP2::V_ADDC_U32, VOperand8::V0, SOperand9::S2, VOperand8::V3).Get(),
+    };
+    const auto spirv = TranslateToSpirv(instructions);
+
+    const auto overflow = runner->run<u32>(spirv, std::array{0xffffffffU, 1U, 7U, 0U});
+    ASSERT_TRUE(overflow.has_value());
+    EXPECT_EQ(*overflow, 8U);
+
+    const auto no_overflow = runner->run<u32>(spirv, std::array{2U, 1U, 7U, 0U});
+    ASSERT_TRUE(no_overflow.has_value());
+    EXPECT_EQ(*no_overflow, 7U);
+}
+
 TEST_F(GcnTest, add_nan) {
     auto runner = gcn_test::Runner::instance().value();
 

--- a/tests/gcn/translator.cpp
+++ b/tests/gcn/translator.cpp
@@ -24,17 +24,25 @@ void ResourceTrackingPassStub(IR::Program& program, const Profile& profile);
 }
 
 std::vector<u32> TranslateToSpirv(u64 raw_gcn_inst) {
-    std::array<u32, 2> provided_inst{static_cast<u32>(raw_gcn_inst & 0xFFFFFFFFU),
-                                     static_cast<u32>(raw_gcn_inst >> 32)};
+    return TranslateToSpirv(std::span<const u64>{&raw_gcn_inst, 1});
+}
+
+std::vector<u32> TranslateToSpirv(std::span<const u64> raw_gcn_insts) {
     std::array<u32, 2> store{
         0xe0700000,
         0x80000000 // buffer_store_dword v0, v0, s[0:3], 0
     };
-    Gcn::GcnCodeSlice first(provided_inst.data(), provided_inst.data() + provided_inst.size());
     Gcn::GcnCodeSlice second(store.data(), store.data() + store.size());
 
     Gcn::GcnDecodeContext decoder;
-    Gcn::GcnInst inst = decoder.decodeInstruction(first);
+    std::vector<Gcn::GcnInst> instructions;
+    instructions.reserve(raw_gcn_insts.size());
+    for (const u64 raw_gcn_inst : raw_gcn_insts) {
+        std::array<u32, 2> provided_inst{static_cast<u32>(raw_gcn_inst & 0xFFFFFFFFU),
+                                         static_cast<u32>(raw_gcn_inst >> 32)};
+        Gcn::GcnCodeSlice slice(provided_inst.data(), provided_inst.data() + provided_inst.size());
+        instructions.push_back(decoder.decodeInstruction(slice));
+    }
     Gcn::GcnInst store_inst = decoder.decodeInstruction(second);
 
     Shader::Info info{};
@@ -79,7 +87,9 @@ std::vector<u32> TranslateToSpirv(u64 raw_gcn_inst) {
         mov.dst[0].code = i;
         translator.S_MOV(mov);
     }
-    translator.TranslateInstruction(inst);
+    for (const Gcn::GcnInst& inst : instructions) {
+        translator.TranslateInstruction(inst);
+    }
     translator.TranslateInstruction(store_inst);
 
     Shader::Optimization::SsaRewritePass(program.post_order_blocks);

--- a/tests/gcn/translator.hpp
+++ b/tests/gcn/translator.hpp
@@ -3,8 +3,10 @@
 
 #pragma once
 
+#include <span>
 #include <vector>
 
 #include "common/types.h"
 
 std::vector<u32> TranslateToSpirv(u64 raw_gcn_inst);
+std::vector<u32> TranslateToSpirv(std::span<const u64> raw_gcn_insts);


### PR DESCRIPTION
## Summary

  Propagate the unsigned carry-out produced by `V_ADD_I32` to VCC, or to the VOP3 scalar destination.

  The 32-bit sum is identical for signed and unsigned inputs, but the instruction’s legacy `_I32` mnemonic does not mean its carry output should be discarded. This also makes chained `V_ADD_I32` → `V_ADDC_U32` sequences behave correctly.

  ## Validation

  - Added an executable GCN regression covering both carry and no-carry chains
  - RelWithDebInfo build completed successfully with clang-cl
  - CTest: 410 passed, 1 HTTP-dependent test skipped, 0 failed
  
Game: Shadow of the Colossus