### PR TITLE
shader_recompiler: implement V_MBCNT masked bit counts

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
@@ -463,6 +463,7 @@ Id EmitImageAtomicExchange32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id co
 Id EmitImageAtomicCmpSwap32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address, Id value,
                             Id cmp_value);
 Id EmitCubeFaceIndex(EmitContext& ctx, IR::Inst* inst, Id cube_coords);
+Id EmitGuestLaneId(EmitContext& ctx);
 Id EmitLaneId(EmitContext& ctx);
 Id EmitWarpId(EmitContext& ctx);
 Id EmitQuadShuffle(EmitContext& ctx, Id value, Id index);

--- a/src/shader_recompiler/backend/spirv/emit_spirv_warp.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_warp.cpp
@@ -6,6 +6,13 @@
 
 namespace Shader::Backend::SPIRV {
 
+Id EmitGuestLaneId(EmitContext& ctx) {
+    ASSERT(ctx.l_stage == LogicalStage::Compute);
+    constexpr u32 guest_wave_size = 64;
+    const Id invocation_index = ctx.OpLoad(ctx.U32[1], ctx.local_invocation_index);
+    return ctx.OpBitwiseAnd(ctx.U32[1], invocation_index, ctx.ConstU32(guest_wave_size - 1));
+}
+
 Id SubgroupScope(EmitContext& ctx) {
     return ctx.ConstU32(static_cast<u32>(spv::Scope::Subgroup));
 }

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -307,6 +307,12 @@ void EmitContext::DefineWorkgroupIndex() {
 }
 
 void EmitContext::DefineInputs() {
+    if (info.uses_guest_lane_id) {
+        ASSERT(l_stage == LogicalStage::Compute);
+        local_invocation_index =
+            DefineVariable(U32[1], spv::BuiltIn::LocalInvocationIndex, spv::StorageClass::Input);
+        Decorate(local_invocation_index, spv::Decoration::Flat);
+    }
     if (info.uses_lane_id) {
         subgroup_local_invocation_id = DefineVariable(
             U32[1], spv::BuiltIn::SubgroupLocalInvocationId, spv::StorageClass::Input);

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -272,6 +272,7 @@ public:
     Id num_workgroups_id{};
     Id workgroup_index_id{};
     Id local_invocation_id{};
+    Id local_invocation_index{};
     Id invocation_id{};
     Id subgroup_local_invocation_id{};
     Id image_u32{};

--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -707,35 +707,25 @@ void Translator::V_BCNT_U32_B32(const GcnInst& inst) {
 }
 
 void Translator::V_MBCNT_U32_B32(bool is_low, const GcnInst& inst) {
-    if (!is_low) {
-        // v_mbcnt_hi_u32_b32 vX, -1, 0
-        if (inst.src[0].field == OperandField::SignedConstIntNeg && inst.src[0].code == 193 &&
-            inst.src[1].field == OperandField::ConstZero) {
-            return;
-        }
-        // v_mbcnt_hi_u32_b32 vX, exec_hi, 0/vZ
-        if ((inst.src[0].field == OperandField::ExecHi ||
-             inst.src[0].field == OperandField::VccHi ||
-             inst.src[0].field == OperandField::ScalarGPR) &&
-            (inst.src[1].field == OperandField::ConstZero ||
-             inst.src[1].field == OperandField::VectorGPR)) {
-            return SetDst(inst.dst[0], GetSrc(inst.src[1]));
-        }
-        UNREACHABLE();
-    } else {
-        // v_mbcnt_lo_u32_b32 vY, -1, vX
-        // used combined with above to fetch lane id in non-compute stages
-        if (inst.src[0].field == OperandField::SignedConstIntNeg && inst.src[0].code == 193) {
-            return SetDst(inst.dst[0], ir.LaneId());
-        }
-        // v_mbcnt_lo_u32_b32 vY, exec_lo, vX
-        // used combined with above for append buffer indexing.
-        if (inst.src[0].field == OperandField::ExecLo || inst.src[0].field == OperandField::VccLo ||
-            inst.src[0].field == OperandField::ScalarGPR) {
-            return SetDst(inst.dst[0], GetSrc(inst.src[1]));
-        }
-        UNREACHABLE();
+    const IR::U32 src1 = GetSrc(inst.src[1]);
+    if (inst.src[0].field == OperandField::ExecLo || inst.src[0].field == OperandField::ExecHi) {
+        // The IR tracks EXEC per invocation rather than as a guest wave64 mask. Preserve the
+        // existing behavior until EXEC ballots can be reconstructed across host subgroups.
+        return SetDst(inst.dst[0], src1);
     }
+
+    const IR::U32 src0 = GetSrc(inst.src[0]);
+    const IR::U32 lane_id = info.l_stage == LogicalStage::Compute ? ir.GuestLaneId() : ir.LaneId();
+    const IR::U32 half_wave_size = ir.Imm32(32);
+    IR::U32 num_mask_bits;
+    if (is_low) {
+        num_mask_bits = ir.UMin(lane_id, half_wave_size);
+    } else {
+        num_mask_bits = ir.ISub(ir.UMax(lane_id, half_wave_size), half_wave_size);
+    }
+    const IR::U32 thread_mask = ir.BitFieldExtract(ir.Imm32(~0u), ir.Imm32(0), num_mask_bits);
+    const IR::U32 masked_value = ir.BitwiseAnd(src0, thread_mask);
+    SetDst(inst.dst[0], ir.IAdd(ir.BitCount(masked_value), src1));
 }
 
 void Translator::V_ADD_I32(const GcnInst& inst) {

--- a/src/shader_recompiler/info.h
+++ b/src/shader_recompiler/info.h
@@ -134,6 +134,7 @@ struct Info : InfoPersistent {
     bool has_image_query{};
     bool uses_buffer_atomic_float_min_max{};
     bool uses_image_atomic_float_min_max{};
+    bool uses_guest_lane_id{};
     bool uses_lane_id{};
     bool uses_group_quad{};
     bool uses_group_ballot{};

--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -647,6 +647,10 @@ U32 IREmitter::DataConsume(const U32& counter) {
     return Inst<U32>(Opcode::DataConsume, counter, Imm32(0));
 }
 
+U32 IREmitter::GuestLaneId() {
+    return Inst<U32>(Opcode::GuestLaneId);
+}
+
 U32 IREmitter::LaneId() {
     return Inst<U32>(Opcode::LaneId);
 }

--- a/src/shader_recompiler/ir/ir_emitter.h
+++ b/src/shader_recompiler/ir/ir_emitter.h
@@ -175,6 +175,7 @@ public:
 
     [[nodiscard]] U32 DataAppend(const U32& counter);
     [[nodiscard]] U32 DataConsume(const U32& counter);
+    [[nodiscard]] U32 GuestLaneId();
     [[nodiscard]] U32 LaneId();
     [[nodiscard]] U32 WarpId();
     [[nodiscard]] U32 QuadShuffle(const U32& value, const U32& index);

--- a/src/shader_recompiler/ir/opcodes.inc
+++ b/src/shader_recompiler/ir/opcodes.inc
@@ -446,6 +446,7 @@ OPCODE(ImageAtomicCmpSwap32,                                U32,            Opaq
 OPCODE(CubeFaceIndex,                                       F32,            F32x3,                                                                          )
 
 // Warp operations
+OPCODE(GuestLaneId,                                         U32,                                                                                            )
 OPCODE(LaneId,                                              U32,                                                                                            )
 OPCODE(WarpId,                                              U32,                                                                                            )
 OPCODE(QuadShuffle,                                         U32,            U32,            U32                                                             )

--- a/src/shader_recompiler/ir/passes/shader_info_collection_pass.cpp
+++ b/src/shader_recompiler/ir/passes/shader_info_collection_pass.cpp
@@ -123,6 +123,9 @@ void Visit(Info& info, const IR::Inst& inst) {
     case IR::Opcode::BufferAtomicUMin64:
         info.uses_buffer_int64_atomics = true;
         break;
+    case IR::Opcode::GuestLaneId:
+        info.uses_guest_lane_id = true;
+        break;
     case IR::Opcode::LaneId:
         info.uses_lane_id = true;
         break;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -152,7 +152,9 @@ set(GCN_TEST_SOURCES
     gcn/translator.cpp
 
     # Tests
+    gcn/test_guest_lane_id.cpp
     gcn/test_gcn_instructions.cpp
+    gcn/test_mbcnt.cpp
 )
 
 add_executable(shadps4_settings_test ${SETTINGS_TEST_SOURCES})

--- a/tests/gcn/test_guest_lane_id.cpp
+++ b/tests/gcn/test_guest_lane_id.cpp
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <algorithm>
+
+#include <gtest/gtest.h>
+
+#include "common/object_pool.h"
+#include "shader_recompiler/frontend/translate/translate.h"
+#include "shader_recompiler/info.h"
+#include "shader_recompiler/ir/passes/ir_passes.h"
+#include "shader_recompiler/profile.h"
+
+namespace Shader::Gcn {
+namespace {
+
+size_t CountOpcode(const IR::Block& block, IR::Opcode opcode) {
+    return std::ranges::count_if(block.Instructions(), [opcode](const IR::Inst& inst) {
+        return inst.GetOpcode() == opcode;
+    });
+}
+
+void EmitMbcntLaneId(Translator& translator, bool is_low = true) {
+    GcnInst inst{};
+    inst.src[0].field = OperandField::SignedConstIntNeg;
+    inst.src[0].code = 193;
+    inst.src[1].field = OperandField::VectorGPR;
+    inst.src[1].code = 0;
+    inst.dst[0].field = OperandField::VectorGPR;
+    inst.dst[0].code = 3;
+    translator.V_MBCNT_U32_B32(is_low, inst);
+}
+
+TEST(GuestLaneIdTest, ComputeMbcntUsesGuestLaneId) {
+    Info info{};
+    info.stage = Stage::Compute;
+    info.l_stage = LogicalStage::Compute;
+    RuntimeInfo runtime_info{};
+    runtime_info.Initialize(Stage::Compute);
+    Profile profile{};
+    Common::ObjectPool<IR::Inst> inst_pool{64};
+    IR::Block block{inst_pool};
+    Translator translator{info, runtime_info, profile};
+    translator.EmitPrologue(&block);
+
+    EmitMbcntLaneId(translator);
+
+    EXPECT_EQ(CountOpcode(block, IR::Opcode::GuestLaneId), 1);
+    EXPECT_EQ(CountOpcode(block, IR::Opcode::LaneId), 0);
+    EXPECT_EQ(CountOpcode(block, IR::Opcode::BitFieldUExtract), 1);
+    EXPECT_EQ(CountOpcode(block, IR::Opcode::BitwiseAnd32), 1);
+    EXPECT_EQ(CountOpcode(block, IR::Opcode::BitCount32), 1);
+    EXPECT_EQ(CountOpcode(block, IR::Opcode::GetVectorRegister), 1);
+}
+
+TEST(GuestLaneIdTest, ComputeMbcntHighUsesGuestLaneId) {
+    Info info{};
+    info.stage = Stage::Compute;
+    info.l_stage = LogicalStage::Compute;
+    RuntimeInfo runtime_info{};
+    runtime_info.Initialize(Stage::Compute);
+    Profile profile{};
+    Common::ObjectPool<IR::Inst> inst_pool{64};
+    IR::Block block{inst_pool};
+    Translator translator{info, runtime_info, profile};
+    translator.EmitPrologue(&block);
+
+    EmitMbcntLaneId(translator, false);
+
+    EXPECT_EQ(CountOpcode(block, IR::Opcode::GuestLaneId), 1);
+    EXPECT_EQ(CountOpcode(block, IR::Opcode::BitFieldUExtract), 1);
+    EXPECT_EQ(CountOpcode(block, IR::Opcode::BitwiseAnd32), 1);
+    EXPECT_EQ(CountOpcode(block, IR::Opcode::BitCount32), 1);
+    EXPECT_EQ(CountOpcode(block, IR::Opcode::GetVectorRegister), 1);
+}
+
+TEST(GuestLaneIdTest, NonComputeMbcntKeepsSubgroupLaneId) {
+    Info info{};
+    info.stage = Stage::Fragment;
+    info.l_stage = LogicalStage::Fragment;
+    RuntimeInfo runtime_info{};
+    runtime_info.Initialize(Stage::Fragment);
+    Profile profile{};
+    Common::ObjectPool<IR::Inst> inst_pool{64};
+    IR::Block block{inst_pool};
+    Translator translator{info, runtime_info, profile};
+    translator.EmitPrologue(&block);
+
+    EmitMbcntLaneId(translator);
+
+    EXPECT_EQ(CountOpcode(block, IR::Opcode::GuestLaneId), 0);
+    EXPECT_EQ(CountOpcode(block, IR::Opcode::LaneId), 1);
+}
+
+TEST(GuestLaneIdTest, ShaderInfoTracksGuestAndSubgroupLaneIdsSeparately) {
+    Info info{};
+    info.stage = Stage::Compute;
+    info.l_stage = LogicalStage::Compute;
+    Profile profile{};
+    Common::ObjectPool<IR::Inst> inst_pool{64};
+    IR::Block block{inst_pool};
+    IR::IREmitter ir{block};
+    ir.Reference(ir.GuestLaneId());
+    ir.Reference(ir.LaneId());
+    IR::Program program{info};
+    program.blocks = {&block};
+    program.post_order_blocks = {&block};
+
+    Optimization::CollectShaderInfoPass(program, profile);
+
+    EXPECT_TRUE(info.uses_guest_lane_id);
+    EXPECT_TRUE(info.uses_lane_id);
+}
+
+} // namespace
+} // namespace Shader::Gcn

--- a/tests/gcn/test_mbcnt.cpp
+++ b/tests/gcn/test_mbcnt.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <array>
+
+#include <gtest/gtest.h>
+
+#include "gcn_test_runner.hpp"
+#include "instructions.hpp"
+#include "translator.hpp"
+
+class MbcntGcnTest : public ::testing::Test {
+protected:
+    static void TearDownTestSuite() {
+        gcn_test::Runner::DestroyInstance();
+    }
+};
+
+TEST_F(MbcntGcnTest, PreservesAccumulator) {
+    auto runner = gcn_test::Runner::instance().value();
+    const auto instruction =
+        VOP2(OpcodeVOP2::V_MBCNT_LO_U32_B32, VOperand8::V0, SOperand9::ConstNeg1, VOperand8::V0)
+            .Get();
+    EXPECT_EQ(instruction, 0x460000c1u);
+
+    auto spirv = TranslateToSpirv(instruction);
+    auto result = runner->run<u32>(spirv, std::array{7u});
+
+    EXPECT_TRUE(result.has_value());
+    EXPECT_EQ(*result, 7u);
+}


### PR DESCRIPTION
## Summary

  This replaces the previous compute lane-ID post-pass with a proper implementation of `V_MBCNT_LO_U32_B32` and `V_MBCNT_HI_U32_B32`.

  shadPS4 previously lowered `v_mbcnt_lo_u32_b32 v0, -1, v0` directly to `LaneId`, which discarded the `v0` accumulator. This exact instruction (`0x460000c1`) appears in Shadow of the Colossus compute shader `0x91c6c95e`.

  Compute shaders now use a separate guest lane ID derived from `LocalInvocationIndex & 63`. The existing `LaneId` still represents the host subgroup lane, so real subgroup operations are not broadly rewritten.

  `EXEC`-backed masks retain their existing behavior for now, since reconstructing guest wave64 `EXEC` across multiple host subgroups needs a separate implementation.

  ## Validation

  - Rebased onto current `main` (`4c72de07`)
  - Full RelWithDebInfo executable and PDB build succeeded with clang-cl 22.1.3
  - Full GCN shader suite: 49 passed, 0 failed
  - Added a Vulkan regression test using the exact `0x460000c1` instruction
  - Added translation tests for LO/HI masked counts, compute guest lane IDs, non-compute subgroup lane IDs, and shader metadata tracking
  
Game: Shadow of the Colossus