### PR TITLE
video_core: harden DMA fault tracking

### DIFF
--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -1153,6 +1153,7 @@ Id EmitContext::DefineGetBdaPointer() {
     const auto caching_pagebits{
         Constant(U64, static_cast<u64>(VideoCore::BufferCache::CACHING_PAGEBITS))};
     const auto caching_pagemask{Constant(U64, VideoCore::BufferCache::CACHING_PAGESIZE - 1)};
+    const auto caching_numpages{Constant(U64, VideoCore::BufferCache::CACHING_NUMPAGES)};
 
     const auto func_type{TypeFunction(U64, U64)};
     const auto func{OpFunction(U64, spv::FunctionControlMask::MaskNone, func_type)};
@@ -1162,27 +1163,37 @@ Id EmitContext::DefineGetBdaPointer() {
 
     const auto fault_label{OpLabel()};
     const auto available_label{OpLabel()};
+    const auto mark_fault_label{OpLabel()};
+    const auto fault_marked_label{OpLabel()};
     const auto merge_label{OpLabel()};
 
     // Get page BDA
     const auto page{OpShiftRightLogical(U64, address, caching_pagebits)};
     const auto page32{OpUConvert(U32[1], page)};
+    const auto is_valid_page{OpULessThan(U1[1], page, caching_numpages)};
+    const auto safe_page32{OpSelect(U32[1], is_valid_page, page32, u32_zero_value)};
     const auto& bda_buffer{buffers[bda_pagetable_index]};
     const auto [bda_buffer_id, bda_pointer_type] = bda_buffer.Alias(PointerType::U64);
-    const auto bda_ptr{OpAccessChain(bda_pointer_type, bda_buffer_id, u32_zero_value, page32)};
+    const auto bda_ptr{OpAccessChain(bda_pointer_type, bda_buffer_id, u32_zero_value, safe_page32)};
     const auto bda{OpLoad(U64, bda_ptr)};
 
     // Check if page is GPU cached
-    const auto is_fault{OpIEqual(U1[1], bda, u64_zero_value)};
+    const auto is_available{
+        OpLogicalAnd(U1[1], is_valid_page, OpINotEqual(U1[1], bda, u64_zero_value))};
     OpSelectionMerge(merge_label, spv::SelectionControlMask::MaskNone);
-    OpBranchConditional(is_fault, fault_label, available_label);
+    OpBranchConditional(is_available, available_label, fault_label);
 
-    // First time acces, mark as fault
+    // First time access, mark a fault only when the guest address is representable by the
+    // fixed-size BDA page table and fault bitmap.
     AddLabel(fault_label);
+    OpSelectionMerge(fault_marked_label, spv::SelectionControlMask::MaskNone);
+    OpBranchConditional(is_valid_page, mark_fault_label, fault_marked_label);
+
+    AddLabel(mark_fault_label);
     const auto& fault_buffer{buffers[fault_buffer_index]};
     const auto [fault_buffer_id, fault_pointer_type] = fault_buffer.Alias(PointerType::U32);
-    const auto page_div32{OpShiftRightLogical(U32[1], page32, ConstU32(5U))};
-    const auto page_mod32{OpBitwiseAnd(U32[1], page32, ConstU32(31U))};
+    const auto page_div32{OpShiftRightLogical(U32[1], safe_page32, ConstU32(5U))};
+    const auto page_mod32{OpBitwiseAnd(U32[1], safe_page32, ConstU32(31U))};
     const auto page_mask{OpShiftLeftLogical(U32[1], u32_one_value, page_mod32)};
     const auto fault_ptr{
         OpAccessChain(fault_pointer_type, fault_buffer_id, u32_zero_value, page_div32)};
@@ -1190,8 +1201,10 @@ Id EmitContext::DefineGetBdaPointer() {
     // sequence can lose one of those faults, so update the shared device buffer atomically.
     const auto device_scope{ConstU32(static_cast<u32>(spv::Scope::Device))};
     OpAtomicOr(U32[1], fault_ptr, device_scope, u32_zero_value, page_mask);
+    OpBranch(fault_marked_label);
 
     // Return null pointer
+    AddLabel(fault_marked_label);
     const auto fallback_result{u64_zero_value};
     OpBranch(merge_label);
 
@@ -1203,7 +1216,7 @@ Id EmitContext::DefineGetBdaPointer() {
 
     // Merge
     AddLabel(merge_label);
-    const auto result{OpPhi(U64, addr, available_label, fallback_result, fault_label)};
+    const auto result{OpPhi(U64, addr, available_label, fallback_result, fault_marked_label)};
     OpReturnValue(result);
     OpFunctionEnd();
     return func;

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -1186,9 +1186,10 @@ Id EmitContext::DefineGetBdaPointer() {
     const auto page_mask{OpShiftLeftLogical(U32[1], u32_one_value, page_mod32)};
     const auto fault_ptr{
         OpAccessChain(fault_pointer_type, fault_buffer_id, u32_zero_value, page_div32)};
-    const auto fault_value{OpLoad(U32[1], fault_ptr)};
-    const auto fault_value_masked{OpBitwiseOr(U32[1], fault_value, page_mask)};
-    OpStore(fault_ptr, fault_value_masked);
+    // Different invocations can fault pages covered by the same bitmap word. A load/OR/store
+    // sequence can lose one of those faults, so update the shared device buffer atomically.
+    const auto device_scope{ConstU32(static_cast<u32>(spv::Scope::Device))};
+    OpAtomicOr(U32[1], fault_ptr, device_scope, u32_zero_value, page_mask);
 
     // Return null pointer
     const auto fallback_result{u64_zero_value};

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -26,6 +26,10 @@ static const char* ccb_task_name{"CCB_TASK"};
 #define MAX_NAMES 56
 static_assert(Liverpool::NumComputeRings <= MAX_NAMES);
 
+bool Liverpool::IsMapped(VAddr addr, u64 size) const {
+    return rasterizer && rasterizer->IsMapped(addr, size);
+}
+
 #define NAME_NUM(z, n, name) BOOST_PP_STRINGIZE(name) BOOST_PP_STRINGIZE(n),
 #define NAME_ARRAY(name, num) {BOOST_PP_REPEAT(num, NAME_NUM, name)}
 

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -87,6 +87,8 @@ public:
         return num_submits == 0;
     }
 
+    bool IsMapped(VAddr addr, u64 size) const;
+
     void SetVoPort(Libraries::VideoOut::VideoOutPort* port) {
         vo_port = port;
     }

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -39,6 +39,11 @@ BufferCache::BufferCache(const Vulkan::Instance& instance_, Vulkan::Scheduler& s
     Vulkan::SetObjectName(instance.GetDevice(), bda_pagetable_buffer.Handle(),
                           "BDA Page Table Buffer");
 
+    // Unregistered pages must contain a null BDA. Device-local allocation contents are undefined,
+    // and treating arbitrary nonzero data as a physical storage-buffer pointer can cause a device
+    // loss before the DMA fault path can cache the guest page.
+    bda_pagetable_buffer.Fill(0, static_cast<u32>(BDA_PAGETABLE_SIZE), 0);
+
     memory_tracker = std::make_unique<MemoryTracker>(tracker);
 
     std::memset(gds_buffer.mapped_data.data(), 0, DataShareBufferSize);
@@ -421,6 +426,10 @@ std::pair<Buffer*, u32> BufferCache::ObtainBufferForImage(VAddr gpu_addr, u32 si
 bool BufferCache::IsRegionRegistered(VAddr addr, size_t size) {
     // Check if we are missing some edge case here
     return buffer_ranges.Intersects(addr, size);
+}
+
+bool BufferCache::IsRegionGpuMapped(VAddr addr, size_t size) const {
+    return liverpool->IsMapped(addr, size);
 }
 
 bool BufferCache::IsRegionCpuModified(VAddr addr, size_t size) {

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -134,6 +134,9 @@ public:
     /// Return true when a region is registered on the cache
     [[nodiscard]] bool IsRegionRegistered(VAddr addr, size_t size);
 
+    /// Return true when a region is mapped for GPU access.
+    [[nodiscard]] bool IsRegionGpuMapped(VAddr addr, size_t size) const;
+
     /// Return true when a CPU region is modified from the CPU
     [[nodiscard]] bool IsRegionCpuModified(VAddr addr, size_t size);
 

--- a/src/video_core/buffer_cache/fault_address.h
+++ b/src/video_core/buffer_cache/fault_address.h
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <algorithm>
+
+#include "common/types.h"
+
+namespace VideoCore {
+
+constexpr bool IsFaultAddressCacheable(VAddr fault_address, bool is_gpu_mapped) {
+    return fault_address != 0 && is_gpu_mapped;
+}
+
+constexpr u32 ClampFaultCount(u64 reported_count, u32 area_entries) {
+    const u64 max_faults = area_entries > 0 ? area_entries - 1 : 0;
+    return static_cast<u32>(std::min(reported_count, max_faults));
+}
+
+} // namespace VideoCore

--- a/src/video_core/buffer_cache/fault_manager.cpp
+++ b/src/video_core/buffer_cache/fault_manager.cpp
@@ -26,6 +26,9 @@ FaultManager::FaultManager(const Vulkan::Instance& instance, Vulkan::Scheduler& 
                       0,        AllFlags,  MaxPendingFaults * PageFaultAreaSize} {
     const auto device = instance.GetDevice();
     Vulkan::SetObjectName(device, fault_buffer.Handle(), "Fault Buffer");
+    // The guest shaders atomically set bits in this bitmap. Device-local allocation contents are
+    // undefined, so the initial state must be made explicitly empty.
+    fault_buffer.Fill(0, static_cast<u32>(fault_buffer_size), 0);
 
     const std::array<vk::DescriptorSetLayoutBinding, 2> bindings = {{
         {
@@ -100,7 +103,7 @@ void FaultManager::ProcessFaultBuffer() {
         .srcStageMask = vk::PipelineStageFlagBits2::eComputeShader,
         .srcAccessMask = vk::AccessFlagBits2::eShaderWrite,
         .dstStageMask = vk::PipelineStageFlagBits2::eAllCommands,
-        .dstAccessMask = vk::AccessFlagBits2::eShaderWrite,
+        .dstAccessMask = vk::AccessFlagBits2::eShaderRead | vk::AccessFlagBits2::eShaderWrite,
         .buffer = fault_buffer.Handle(),
         .offset = 0,
         .size = fault_buffer_size,
@@ -157,10 +160,16 @@ void FaultManager::ProcessFaultBuffer() {
     scheduler.DeferOperation([this, mapped, area = current_area] {
         fault_ranges.Clear();
         const u64* fault_buf = std::bit_cast<const u64*>(mapped);
-        const u32 fault_count = fault_buf[0];
+        const u32 fault_count = ClampFaultCount(fault_buf[0], MaxPageFaults);
         for (u32 i = 1; i <= fault_count; ++i) {
-            fault_ranges.Add(fault_buf[i], caching_pagesize);
-            LOG_INFO(Render_Vulkan, "Accessed non-GPU cached memory at {:#x}", fault_buf[i]);
+            const VAddr fault_address = fault_buf[i];
+            const bool is_gpu_mapped =
+                buffer_cache.IsRegionGpuMapped(fault_address, caching_pagesize);
+            if (!IsFaultAddressCacheable(fault_address, is_gpu_mapped)) {
+                continue;
+            }
+            fault_ranges.Add(fault_address, caching_pagesize);
+            LOG_INFO(Render_Vulkan, "Accessed non-GPU cached memory at {:#x}", fault_address);
         }
         fault_ranges.ForEach([&](VAddr start, VAddr end) {
             ASSERT_MSG((end - start) <= std::numeric_limits<u32>::max(),

--- a/src/video_core/buffer_cache/fault_manager.h
+++ b/src/video_core/buffer_cache/fault_manager.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "video_core/buffer_cache/buffer.h"
+#include "video_core/buffer_cache/fault_address.h"
 #include "video_core/buffer_cache/range_set.h"
 
 namespace VideoCore {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -125,6 +125,7 @@ set(GCN_TEST_SOURCES
     gcn/translator.cpp
 
     # Tests
+    gcn/test_dma_fault_bitmap.cpp
     gcn/test_gcn_instructions.cpp
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,11 @@ include(FetchContent)
 )
 FetchContent_MakeAvailable(googletest)
 
-set(TEST_TARGETS shadps4_settings_test shadps4_gcn_test)
+set(TEST_TARGETS
+    shadps4_settings_test
+    shadps4_buffer_cache_test
+    shadps4_gcn_test
+)
 
 set(SETTINGS_TEST_SOURCES
     # Under test
@@ -31,6 +35,10 @@ set(SETTINGS_TEST_SOURCES
 
     # Tests
     test_emulator_settings.cpp
+)
+
+set(BUFFER_CACHE_TEST_SOURCES
+    test_fault_address.cpp
 )
 
 set(GCN_TEST_SOURCES
@@ -130,6 +138,7 @@ set(GCN_TEST_SOURCES
 )
 
 add_executable(shadps4_settings_test ${SETTINGS_TEST_SOURCES})
+add_executable(shadps4_buffer_cache_test ${BUFFER_CACHE_TEST_SOURCES})
 add_executable(shadps4_gcn_test ${GCN_TEST_SOURCES})
 
 foreach(t ${TEST_TARGETS})
@@ -149,6 +158,7 @@ target_link_libraries(shadps4_settings_test PRIVATE
     SDL3::SDL3
     spdlog::spdlog
 )
+target_link_libraries(shadps4_buffer_cache_test PRIVATE GTest::gtest_main)
 target_link_libraries(shadps4_gcn_test PRIVATE
     GTest::gtest_main
     fmt::fmt

--- a/tests/gcn/test_dma_fault_bitmap.cpp
+++ b/tests/gcn/test_dma_fault_bitmap.cpp
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <limits>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <gtest/gtest.h>
+#include <spirv/unified1/spirv.hpp>
+
+#include "shader_recompiler/backend/spirv/emit_spirv.h"
+#include "shader_recompiler/ir/post_order.h"
+#include "shader_recompiler/recompiler.h"
+#include "shader_recompiler/runtime_info.h"
+#include "video_core/buffer_cache/buffer_cache.h"
+
+namespace {
+
+std::vector<u32> EmitDmaShader() {
+    Shader::Info info{};
+    info.stage = Shader::Stage::Compute;
+    info.l_stage = Shader::LogicalStage::Compute;
+    info.uses_dma = true;
+    info.buffers.push_back({
+        .used_types = Shader::IR::Type::U64,
+        .inline_cbuf = AmdGpu::Buffer::Placeholder(VideoCore::BufferCache::BDA_PAGETABLE_SIZE),
+        .buffer_type = Shader::BufferType::BdaPagetable,
+        .is_written = true,
+    });
+    info.buffers.push_back({
+        .used_types = Shader::IR::Type::U32,
+        .inline_cbuf = AmdGpu::Buffer::Placeholder(std::numeric_limits<u32>::max()),
+        .buffer_type = Shader::BufferType::FaultBuffer,
+        .is_written = true,
+    });
+
+    Shader::IR::Program program{info};
+    Shader::Pools pools{};
+    auto* const block = pools.block_pool.Create(pools.inst_pool);
+    program.blocks.push_back(block);
+    program.syntax_list.emplace_back();
+    program.syntax_list.back().type = Shader::IR::AbstractSyntaxNode::Type::Block;
+    program.syntax_list.back().data.block = block;
+    program.syntax_list.emplace_back();
+    program.syntax_list.back().type = Shader::IR::AbstractSyntaxNode::Type::Return;
+    program.post_order_blocks = Shader::IR::PostOrder(program.syntax_list.front());
+
+    Shader::Profile profile{};
+    profile.supported_spirv = 0x00010600;
+    profile.subgroup_size = 32;
+    Shader::RuntimeInfo runtime_info{};
+    runtime_info.Initialize(Shader::Stage::Compute);
+    runtime_info.cs_info.workgroup_size = {1, 1, 1};
+    Shader::Backend::Bindings bindings{};
+    return Shader::Backend::SPIRV::EmitSPIRV(profile, runtime_info, program, bindings);
+}
+
+TEST(DmaFaultBitmap, AtomicallyPreservesConcurrentPageFaults) {
+    const std::vector<u32> spirv = EmitDmaShader();
+    std::unordered_map<u32, u32> constants;
+    std::unordered_set<u32> access_chains;
+    std::unordered_set<u32> shift_results;
+    std::vector<u32> stored_pointers;
+
+    struct AtomicOr {
+        u32 pointer;
+        u32 scope;
+        u32 semantics;
+        u32 value;
+    };
+    std::vector<AtomicOr> atomic_ors;
+
+    for (size_t offset = 5; offset < spirv.size();) {
+        const u32 instruction = spirv[offset];
+        const u16 word_count = instruction >> 16;
+        ASSERT_NE(word_count, 0);
+        ASSERT_LE(offset + word_count, spirv.size());
+        const auto opcode = static_cast<spv::Op>(instruction & 0xffff);
+        switch (opcode) {
+        case spv::Op::OpConstant:
+            if (word_count == 4) {
+                constants.emplace(spirv[offset + 2], spirv[offset + 3]);
+            }
+            break;
+        case spv::Op::OpAccessChain:
+            ASSERT_GE(word_count, 4);
+            access_chains.emplace(spirv[offset + 2]);
+            break;
+        case spv::Op::OpShiftLeftLogical:
+            ASSERT_EQ(word_count, 5);
+            shift_results.emplace(spirv[offset + 2]);
+            break;
+        case spv::Op::OpAtomicOr:
+            ASSERT_EQ(word_count, 7);
+            atomic_ors.push_back({
+                .pointer = spirv[offset + 3],
+                .scope = spirv[offset + 4],
+                .semantics = spirv[offset + 5],
+                .value = spirv[offset + 6],
+            });
+            break;
+        case spv::Op::OpStore:
+            ASSERT_GE(word_count, 3);
+            stored_pointers.push_back(spirv[offset + 1]);
+            break;
+        default:
+            break;
+        }
+        offset += word_count;
+    }
+
+    ASSERT_EQ(atomic_ors.size(), 1);
+    const AtomicOr& atomic = atomic_ors.front();
+    EXPECT_TRUE(access_chains.contains(atomic.pointer));
+    EXPECT_TRUE(shift_results.contains(atomic.value));
+    ASSERT_TRUE(constants.contains(atomic.scope));
+    EXPECT_EQ(constants.at(atomic.scope), static_cast<u32>(spv::ScopeDevice));
+    ASSERT_TRUE(constants.contains(atomic.semantics));
+    EXPECT_EQ(constants.at(atomic.semantics), 0U);
+    EXPECT_FALSE(std::ranges::contains(stored_pointers, atomic.pointer));
+}
+
+} // namespace

--- a/tests/gcn/test_dma_fault_bitmap.cpp
+++ b/tests/gcn/test_dma_fault_bitmap.cpp
@@ -61,6 +61,8 @@ TEST(DmaFaultBitmap, AtomicallyPreservesConcurrentPageFaults) {
     std::unordered_set<u32> access_chains;
     std::unordered_set<u32> shift_results;
     std::vector<u32> stored_pointers;
+    bool has_page_bounds_check = false;
+    u32 conditional_branch_count = 0;
 
     struct AtomicOr {
         u32 pointer;
@@ -99,6 +101,12 @@ TEST(DmaFaultBitmap, AtomicallyPreservesConcurrentPageFaults) {
                 .value = spirv[offset + 6],
             });
             break;
+        case spv::Op::OpULessThan:
+            has_page_bounds_check = true;
+            break;
+        case spv::Op::OpBranchConditional:
+            ++conditional_branch_count;
+            break;
         case spv::Op::OpStore:
             ASSERT_GE(word_count, 3);
             stored_pointers.push_back(spirv[offset + 1]);
@@ -118,6 +126,8 @@ TEST(DmaFaultBitmap, AtomicallyPreservesConcurrentPageFaults) {
     ASSERT_TRUE(constants.contains(atomic.semantics));
     EXPECT_EQ(constants.at(atomic.semantics), 0U);
     EXPECT_FALSE(std::ranges::contains(stored_pointers, atomic.pointer));
+    EXPECT_TRUE(has_page_bounds_check);
+    EXPECT_GE(conditional_branch_count, 2U);
 }
 
 } // namespace

--- a/tests/test_fault_address.cpp
+++ b/tests/test_fault_address.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "video_core/buffer_cache/fault_address.h"
+
+namespace VideoCore {
+
+TEST(FaultAddress, RejectsNullAddressEvenWhenReportedMapped) {
+    EXPECT_FALSE(IsFaultAddressCacheable(0, true));
+}
+
+TEST(FaultAddress, RejectsUnmappedAddress) {
+    EXPECT_FALSE(IsFaultAddressCacheable(0x3F800000, false));
+}
+
+TEST(FaultAddress, AcceptsMappedGuestAddress) {
+    EXPECT_TRUE(IsFaultAddressCacheable(0x200000000, true));
+}
+
+TEST(FaultAddress, FaultCountUsesAvailablePayloadSlots) {
+    EXPECT_EQ(ClampFaultCount(7, 1024), 7);
+    EXPECT_EQ(ClampFaultCount(1024, 1024), 1023);
+    EXPECT_EQ(ClampFaultCount(std::numeric_limits<u64>::max(), 1024), 1023);
+}
+
+TEST(FaultAddress, FaultCountHandlesEmptyArea) {
+    EXPECT_EQ(ClampFaultCount(1, 0), 0);
+}
+
+} // namespace VideoCore


### PR DESCRIPTION
## Summary

  Harden the optional GPU DMA fault path at its concurrency, initialization, and bounds boundaries.

  - Record page-fault bitmap bits with a device-scope atomic OR so concurrent invocations cannot lose faults
  - Explicitly zero the device-local BDA page table and fault bitmap before first use
  - Guard generated page-table and fault-bitmap accesses against addresses outside the representable guest range
  - Clamp downloaded fault counts to the payload capacity and ignore null or currently unmapped guest addresses

  The changes are split into two commits so the atomic shader correction and host-side initialization/bounds hardening remain independently reviewable.

  ## Validation

  - Added SPIR-V coverage requiring the atomic update and page bounds check
  - Added focused fault-address and payload-count unit tests
  - RelWithDebInfo build completed successfully with clang-cl
  - CTest: 415 passed, 1 HTTP-dependent test skipped, 0 failed
  
Game: Shadow of the Colossus