### PR TITLE
avplayer: fixes for frame dimensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -612,7 +612,9 @@ set(FIBER_LIB src/core/libraries/fiber/fiber_context.cpp
               src/core/libraries/fiber/fiber_error.h
 )
 
-set(VDEC_LIB src/core/libraries/videodec/videodec2_impl.cpp
+set(VDEC_LIB src/core/libraries/videodec/video_utils.cpp
+             src/core/libraries/videodec/video_utils.h
+             src/core/libraries/videodec/videodec2_impl.cpp
              src/core/libraries/videodec/videodec2_impl.h
              src/core/libraries/videodec/videodec2.cpp
              src/core/libraries/videodec/videodec2.h

--- a/src/core/libraries/avplayer/avplayer.h
+++ b/src/core/libraries/avplayer/avplayer.h
@@ -52,7 +52,7 @@ struct AvPlayerAudio {
     u8 reserved1[2];
     u32 sample_rate;
     u32 size;
-    u8 language_code[4];
+    char language_code[4];
 };
 
 struct AvPlayerVideo {
@@ -70,7 +70,7 @@ struct AvPlayerTextPosition {
 };
 
 struct AvPlayerTimedText {
-    u8 language_code[4];
+    char language_code[4];
     u16 text_size;
     u16 font_size;
     AvPlayerTextPosition position;

--- a/src/core/libraries/avplayer/avplayer_source.cpp
+++ b/src/core/libraries/avplayer/avplayer_source.cpp
@@ -25,8 +25,7 @@ extern "C" {
 
 namespace Libraries::AvPlayer {
 
-AvPlayerSource::AvPlayerSource(AvPlayerStateCallback& state, bool use_vdec2)
-    : m_state(state), m_use_vdec2(use_vdec2) {}
+AvPlayerSource::AvPlayerSource(AvPlayerStateCallback& state) : m_state(state) {}
 
 AvPlayerSource::~AvPlayerSource() {
     Stop();
@@ -135,12 +134,8 @@ bool AvPlayerSource::GetStreamInfo(u32 stream_index, AvPlayerStreamInfo& info) {
         LOG_INFO(Lib_AvPlayer, "Stream {} is a video stream.", stream_index);
         info.details.video.aspect_ratio =
             f32(p_stream->codecpar->width) / p_stream->codecpar->height;
-        auto width = u32(p_stream->codecpar->width);
-        auto height = u32(p_stream->codecpar->height);
-        if (!m_use_vdec2) {
-            width = Common::AlignUp(width, 16);
-            height = Common::AlignUp(height, 16);
-        }
+        const auto width = Common::AlignUp<u32>(p_stream->codecpar->width, 16);
+        const auto height = Common::AlignUp<u32>(p_stream->codecpar->height, 16);
         info.details.video.width = width;
         info.details.video.height = height;
         if (p_lang_node != nullptr) {
@@ -238,12 +233,8 @@ bool AvPlayerSource::Start() {
                       m_video_stream_index.value());
             return false;
         }
-        auto width = u32(m_video_codec_context->width);
-        auto height = u32(m_video_codec_context->height);
-        if (!m_use_vdec2) {
-            width = Common::AlignUp(width, 16);
-            height = Common::AlignUp(height, 16);
-        }
+        const auto width = Common::AlignUp<u32>(m_video_codec_context->width, 16);
+        const auto height = Common::AlignUp<u32>(m_video_codec_context->height, 16);
         const auto size = (width * height * 3) / 2;
         for (u64 index = 0; index < m_max_num_video_framebuffers; ++index) {
             m_video_buffers.Push(GuestBuffer(m_memory_replacement, 0x100, size, true));
@@ -269,11 +260,11 @@ bool AvPlayerSource::Start() {
                       m_audio_stream_index.value());
             return false;
         }
-        const auto num_channels = m_audio_codec_context->ch_layout.nb_channels;
-        const auto align = num_channels * sizeof(u16);
-        const auto size = num_channels * sizeof(u16) * 1024;
-        for (u64 index = 0; index < 8; ++index) {
-            m_audio_buffers.Push(GuestBuffer(m_memory_replacement, 0x100, size, false));
+        constexpr u8 max_channels = 8;
+        constexpr size_t max_sample_size = sizeof(s32);
+        const auto size = max_channels * max_sample_size * 1024;
+        for (u64 index = 0; index < 4; ++index) {
+            m_audio_buffers.Push(GuestBuffer(m_memory_replacement, 0x10, size, false));
         }
     }
     m_demuxer_thread.Run([this](std::stop_token stop) { this->DemuxerThread(stop); });
@@ -633,23 +624,18 @@ static u64 FrameTimestampMillis(const AVFrame& frame, AVRational time_base) {
     return millis > 0 ? u64(millis) : 0;
 }
 
-static void CopyNV12Data(u8* dst, const AVFrame& src, bool use_vdec2) {
-    auto dst_width = u32(src.width);
-    auto dst_height = u32(src.height);
-    if (!use_vdec2) {
-        dst_width = Common::AlignUp(dst_width, 16);
-        dst_height = Common::AlignUp(dst_height, 16);
-    }
+static void CopyNV12Data(u8* dst, const AVFrame& src) {
+    const auto dst_width = Common::AlignUp<u32>(src.width, 16);
+    const auto dst_height = Common::AlignUp<u32>(src.height, 16);
 
     const auto src_width = u32(src.width);
     const auto src_height = u32(src.height);
     const auto dst_size = (dst_width * dst_height * 3) / 2;
-    std::memset(dst, 0, dst_size);
 
-    ASSERT(src.data[0] != nullptr);
-    ASSERT(src.data[1] != nullptr);
-    ASSERT(src.linesize[0] >= s32(src_width));
-    ASSERT(src.linesize[1] >= s32(src_width));
+    DEBUG_ASSERT(src.data[0] != nullptr);
+    DEBUG_ASSERT(src.data[1] != nullptr);
+    DEBUG_ASSERT(src.linesize[0] >= s32(src_width));
+    DEBUG_ASSERT(src.linesize[1] >= s32(src_width));
 
     const auto luma_dst = dst;
     for (u32 y = 0; y < src_height; ++y) {
@@ -666,17 +652,13 @@ Frame AvPlayerSource::PrepareVideoFrame(GuestBuffer buffer, const AVFrame& frame
     ASSERT(frame.format == AV_PIX_FMT_NV12);
 
     auto p_buffer = buffer.GetBuffer();
-    CopyNV12Data(p_buffer, frame, m_use_vdec2);
+    CopyNV12Data(p_buffer, frame);
 
     const auto stream = m_avformat_context->streams[m_video_stream_index.value()];
     const auto timestamp = FrameTimestampMillis(frame, stream->time_base);
 
-    auto width = u32(frame.width);
-    auto height = u32(frame.height);
-    if (!m_use_vdec2) {
-        width = Common::AlignUp(width, 16);
-        height = Common::AlignUp(height, 16);
-    }
+    const auto width = Common::AlignUp<u32>(frame.width, 16);
+    const auto height = Common::AlignUp<u32>(frame.height, 16);
     Core::Memory::Instance()->InvalidateMemory(reinterpret_cast<VAddr>(p_buffer),
                                                (width * height * 3) / 2);
 

--- a/src/core/libraries/avplayer/avplayer_source.cpp
+++ b/src/core/libraries/avplayer/avplayer_source.cpp
@@ -631,6 +631,11 @@ static void CopyNV12Data(u8* dst, const AVFrame& src) {
     const auto luma_dst = dst;
     const auto chroma_dst = dst + dst_pitch * dst_height;
 
+    if (dst_height != src.height) {
+        std::memset(luma_dst + src.height * dst_pitch, 0x10, dst_pitch * (dst_height - src.height));
+        std::memset(chroma_dst + (src.height * dst_pitch) / 2, 0x80,
+                    dst_pitch * (dst_height - src.height) / 2);
+    }
     if (src.width == dst_pitch) {
         std::memcpy(luma_dst, src.data[0], src.width * src.height);
         std::memcpy(chroma_dst, src.data[1], (src.width * src.height) / 2);

--- a/src/core/libraries/avplayer/avplayer_source.cpp
+++ b/src/core/libraries/avplayer/avplayer_source.cpp
@@ -1,9 +1,10 @@
-// SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2024-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "common/alignment.h"
 #include "common/singleton.h"
 #include "common/thread.h"
+#include "core/libraries/videodec/video_utils.h"
 #include "core/file_sys/fs.h"
 #include "core/libraries/avplayer/avplayer_error.h"
 #include "core/libraries/avplayer/avplayer_file_streamer.h"
@@ -624,38 +625,11 @@ static u64 FrameTimestampMillis(const AVFrame& frame, AVRational time_base) {
     return millis > 0 ? u64(millis) : 0;
 }
 
-static void CopyNV12Data(u8* dst, const AVFrame& src) {
-    const auto dst_pitch = Common::AlignUp<u32>(src.width, 64);
-    const auto dst_height = Common::AlignUp<u32>(src.height, 16);
-
-    const auto luma_dst = dst;
-    const auto chroma_dst = dst + dst_pitch * dst_height;
-
-    if (dst_height != src.height) {
-        std::memset(luma_dst + src.height * dst_pitch, 0x10, dst_pitch * (dst_height - src.height));
-        std::memset(chroma_dst + (src.height * dst_pitch) / 2, 0x80,
-                    dst_pitch * (dst_height - src.height) / 2);
-    }
-    if (src.width == dst_pitch) {
-        std::memcpy(luma_dst, src.data[0], src.width * src.height);
-        std::memcpy(chroma_dst, src.data[1], (src.width * src.height) / 2);
-        return;
-    }
-
-    for (u32 y = 0; y < src.height; ++y) {
-        std::memcpy(luma_dst + y * dst_pitch, src.data[0] + y * src.linesize[0], src.width);
-    }
-
-    for (u32 y = 0; y < src.height / 2; ++y) {
-        std::memcpy(chroma_dst + y * dst_pitch, src.data[1] + y * src.linesize[1], src.width);
-    }
-}
-
 Frame AvPlayerSource::PrepareVideoFrame(GuestBuffer buffer, const AVFrame& frame) {
     ASSERT(frame.format == AV_PIX_FMT_NV12);
 
     auto p_buffer = buffer.GetBuffer();
-    CopyNV12Data(p_buffer, frame);
+    Videodec::CopyNV12Data(p_buffer, frame);
 
     const auto stream = m_avformat_context->streams[m_video_stream_index.value()];
     const auto timestamp = FrameTimestampMillis(frame, stream->time_base);

--- a/src/core/libraries/avplayer/avplayer_source.cpp
+++ b/src/core/libraries/avplayer/avplayer_source.cpp
@@ -4,11 +4,11 @@
 #include "common/alignment.h"
 #include "common/singleton.h"
 #include "common/thread.h"
-#include "core/libraries/videodec/video_utils.h"
 #include "core/file_sys/fs.h"
 #include "core/libraries/avplayer/avplayer_error.h"
 #include "core/libraries/avplayer/avplayer_file_streamer.h"
 #include "core/libraries/avplayer/avplayer_source.h"
+#include "core/libraries/videodec/video_utils.h"
 #include "core/memory.h"
 
 #include <magic_enum/magic_enum.hpp>

--- a/src/core/libraries/avplayer/avplayer_source.cpp
+++ b/src/core/libraries/avplayer/avplayer_source.cpp
@@ -233,9 +233,9 @@ bool AvPlayerSource::Start() {
                       m_video_stream_index.value());
             return false;
         }
-        const auto width = Common::AlignUp<u32>(m_video_codec_context->width, 16);
+        const auto pitch = Common::AlignUp<u32>(m_video_codec_context->width, 64);
         const auto height = Common::AlignUp<u32>(m_video_codec_context->height, 16);
-        const auto size = (width * height * 3) / 2;
+        const auto size = (pitch * height * 3) / 2;
         for (u64 index = 0; index < m_max_num_video_framebuffers; ++index) {
             m_video_buffers.Push(GuestBuffer(m_memory_replacement, 0x100, size, true));
         }
@@ -263,7 +263,7 @@ bool AvPlayerSource::Start() {
         constexpr u8 max_channels = 8;
         constexpr size_t max_sample_size = sizeof(s32);
         const auto size = max_channels * max_sample_size * 1024;
-        for (u64 index = 0; index < 4; ++index) {
+        for (u64 index = 0; index < (m_max_num_video_framebuffers * 2); ++index) {
             m_audio_buffers.Push(GuestBuffer(m_memory_replacement, 0x10, size, false));
         }
     }
@@ -625,26 +625,24 @@ static u64 FrameTimestampMillis(const AVFrame& frame, AVRational time_base) {
 }
 
 static void CopyNV12Data(u8* dst, const AVFrame& src) {
-    const auto dst_width = Common::AlignUp<u32>(src.width, 16);
+    const auto dst_pitch = Common::AlignUp<u32>(src.width, 64);
     const auto dst_height = Common::AlignUp<u32>(src.height, 16);
 
-    const auto src_width = u32(src.width);
-    const auto src_height = u32(src.height);
-    const auto dst_size = (dst_width * dst_height * 3) / 2;
-
-    DEBUG_ASSERT(src.data[0] != nullptr);
-    DEBUG_ASSERT(src.data[1] != nullptr);
-    DEBUG_ASSERT(src.linesize[0] >= s32(src_width));
-    DEBUG_ASSERT(src.linesize[1] >= s32(src_width));
-
     const auto luma_dst = dst;
-    for (u32 y = 0; y < src_height; ++y) {
-        std::memcpy(luma_dst + y * dst_width, src.data[0] + y * src.linesize[0], src_width);
+    const auto chroma_dst = dst + dst_pitch * dst_height;
+
+    if (src.width == dst_pitch) {
+        std::memcpy(luma_dst, src.data[0], src.width * src.height);
+        std::memcpy(chroma_dst, src.data[1], (src.width * src.height) / 2);
+        return;
     }
 
-    const auto chroma_dst = dst + dst_width * dst_height;
-    for (u32 y = 0; y < src_height / 2; ++y) {
-        std::memcpy(chroma_dst + y * dst_width, src.data[1] + y * src.linesize[1], src_width);
+    for (u32 y = 0; y < src.height; ++y) {
+        std::memcpy(luma_dst + y * dst_pitch, src.data[0] + y * src.linesize[0], src.width);
+    }
+
+    for (u32 y = 0; y < src.height / 2; ++y) {
+        std::memcpy(chroma_dst + y * dst_pitch, src.data[1] + y * src.linesize[1], src.width);
     }
 }
 
@@ -658,6 +656,7 @@ Frame AvPlayerSource::PrepareVideoFrame(GuestBuffer buffer, const AVFrame& frame
     const auto timestamp = FrameTimestampMillis(frame, stream->time_base);
 
     const auto width = Common::AlignUp<u32>(frame.width, 16);
+    const auto pitch = Common::AlignUp<u32>(frame.width, 64);
     const auto height = Common::AlignUp<u32>(frame.height, 16);
     Core::Memory::Instance()->InvalidateMemory(reinterpret_cast<VAddr>(p_buffer),
                                                (width * height * 3) / 2);
@@ -676,11 +675,11 @@ Frame AvPlayerSource::PrepareVideoFrame(GuestBuffer buffer, const AVFrame& frame
                                 .height = height,
                                 .aspect_ratio = (float)av_q2d(frame.sample_aspect_ratio),
                                 .crop_left_offset = u32(frame.crop_left),
-                                .crop_right_offset = u32(frame.crop_right + (width - frame.width)),
+                                .crop_right_offset = u32(frame.crop_right + (pitch - frame.width)),
                                 .crop_top_offset = u32(frame.crop_top),
                                 .crop_bottom_offset =
                                     u32(frame.crop_bottom + (height - frame.height)),
-                                .pitch = width,
+                                .pitch = pitch,
                                 .luma_bit_depth = 8,
                                 .chroma_bit_depth = 8,
                             },

--- a/src/core/libraries/avplayer/avplayer_source.h
+++ b/src/core/libraries/avplayer/avplayer_source.h
@@ -142,7 +142,7 @@ private:
 
 class AvPlayerSource {
 public:
-    AvPlayerSource(AvPlayerStateCallback& state, bool use_vdec2);
+    AvPlayerSource(AvPlayerStateCallback& state);
     ~AvPlayerSource();
 
     bool Init(const AvPlayerInitData& init_data, std::string_view path);
@@ -192,7 +192,6 @@ private:
     Frame PrepareVideoFrame(GuestBuffer buffer, const AVFrame& frame);
 
     AvPlayerStateCallback& m_state;
-    bool m_use_vdec2 = false;
 
     AvPlayerMemAllocator m_memory_replacement{};
     u32 m_max_num_video_framebuffers{};

--- a/src/core/libraries/avplayer/avplayer_state.cpp
+++ b/src/core/libraries/avplayer/avplayer_state.cpp
@@ -52,16 +52,16 @@ void PS4_SYSV_ABI AvPlayerState::AutoPlayEventCallback(void* opaque, AvPlayerEve
                     audio_stream_index = stream_index;
                 }
                 if (!default_language.empty() &&
-                    default_language == info.details.video.language_code) {
+                    default_language == info.details.audio.language_code) {
                     audio_stream_index = stream_index;
                 }
                 break;
             case AvPlayerStreamType::TimedText:
-                if (default_language.empty()) {
+                if (timedtext_stream_index == -1) {
                     timedtext_stream_index = stream_index;
-                    break;
                 }
-                if (default_language == info.details.video.language_code) {
+                if (!default_language.empty() &&
+                    default_language == info.details.subs.language_code) {
                     timedtext_stream_index = stream_index;
                 }
                 break;
@@ -142,10 +142,7 @@ bool AvPlayerState::AddSource(std::string_view path, AvPlayerSourceType source_t
 
         s32 sdk_ver{};
         Libraries::Kernel::sceKernelGetCompiledSdkVersion(&sdk_ver);
-        bool uses_vdec2 = m_post_init_data.video_decoder_init.decoder_type.video_type ==
-                              AvPlayerVideoDecoderType::Software2 ||
-                          sdk_ver >= Common::ElfInfo::FW_550;
-        m_up_source = std::make_unique<AvPlayerSource>(*this, uses_vdec2);
+        m_up_source = std::make_unique<AvPlayerSource>(*this);
         if (!m_up_source->Init(m_init_data, path)) {
             SetState(AvState::Error);
             m_up_source.reset();

--- a/src/core/libraries/videodec/video_utils.cpp
+++ b/src/core/libraries/videodec/video_utils.cpp
@@ -7,6 +7,8 @@
 
 #include <libavutil/frame.h>
 
+#include <cstring>
+
 namespace Libraries::Videodec {
 
 void CopyNV12Data(u8* dst, const AVFrame& src) {

--- a/src/core/libraries/videodec/video_utils.cpp
+++ b/src/core/libraries/videodec/video_utils.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "video_utils.h"
+
+#include "common/alignment.h"
+
+#include <libavutil/frame.h>
+
+namespace Libraries::Videodec {
+
+void CopyNV12Data(u8* dst, const AVFrame& src) {
+    const auto dst_pitch = Common::AlignUp<u32>(src.width, 64);
+    const auto dst_height = Common::AlignUp<u32>(src.height, 16);
+
+    const auto luma_dst = dst;
+    const auto chroma_dst = dst + dst_pitch * dst_height;
+
+    if (src.width != dst_pitch) {
+        for (u32 y = 0; y < src.height; ++y) {
+            std::memcpy(luma_dst + y * dst_pitch, src.data[0] + y * src.linesize[0], src.width);
+        }
+        for (u32 y = 0; y < src.height / 2; ++y) {
+            std::memcpy(chroma_dst + y * dst_pitch, src.data[1] + y * src.linesize[1], src.width);
+        }
+    } else {
+        std::memcpy(luma_dst, src.data[0], src.width * src.height);
+        std::memcpy(chroma_dst, src.data[1], (src.width * src.height) / 2);
+    }
+
+    if (src.height != dst_height) {
+        // Extend the data vertically to the crop space
+        const auto ly = src.height - 1;
+        for (u32 y = src.height; y < dst_height; ++y) {
+            std::memcpy(luma_dst + y * dst_pitch, src.data[0] + ly * src.linesize[0], src.width);
+        }
+        const auto cy = (src.height / 2) - 1;
+        for (u32 y = src.height / 2; y < dst_height / 2; ++y) {
+            std::memcpy(chroma_dst + y * dst_pitch, src.data[1] + cy * src.linesize[1], src.width);
+        }
+    }
+}
+
+} // namespace Libraries::Videodec

--- a/src/core/libraries/videodec/video_utils.h
+++ b/src/core/libraries/videodec/video_utils.h
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "common/types.h"
+
+struct AVFrame;
+
+namespace Libraries::Videodec {
+
+void CopyNV12Data(u8* dst, const AVFrame& src);
+
+}

--- a/src/core/libraries/videodec/videodec2_impl.cpp
+++ b/src/core/libraries/videodec/videodec2_impl.cpp
@@ -3,34 +3,17 @@
 
 #include "videodec2_impl.h"
 
+#include "common/alignment.h"
 #include "common/assert.h"
 #include "common/logging/log.h"
-#include "core/libraries/videodec/videodec_error.h"
+#include "video_utils.h"
+#include "videodec_error.h"
 
 #include "common/support/avdec.h"
 
 namespace Libraries::Videodec2 {
 
 std::vector<OrbisVideodec2AvcPictureInfo> gPictureInfos;
-
-static inline void CopyNV12Data(u8* dst, const AVFrame& src) {
-    if (src.width == src.linesize[0]) {
-        std::memcpy(dst, src.data[0], src.width * src.height);
-        std::memcpy(dst + (src.width * src.height), src.data[1], (src.width * src.height) / 2);
-        return;
-    }
-
-    for (u16 row = 0; row < src.height; row++) {
-        u64 dst_offset = row * src.width;
-        std::memcpy(dst + dst_offset, src.data[0] + (row * src.linesize[0]), src.width);
-    }
-
-    u64 dst_base = src.width * src.height;
-    for (u16 row = 0; row < src.height / 2; row++) {
-        u64 dst_offset = row * src.width;
-        std::memcpy(dst + dst_base + dst_offset, src.data[1] + (row * src.linesize[1]), src.width);
-    }
-}
 
 VdecDecoder::VdecDecoder(const OrbisVideodec2DecoderConfigInfo& configInfo,
                          const OrbisVideodec2DecoderMemoryInfo& memoryInfo) {
@@ -99,61 +82,62 @@ s32 VdecDecoder::Decode(const OrbisVideodec2InputData& inputData,
         return ORBIS_VIDEODEC2_ERROR_API_FAIL;
     }
 
-    while (true) {
-        ret = avcodec_receive_frame(mCodecContext, frame);
-        if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
-            break;
-        } else if (ret < 0) {
-            LOG_ERROR(Lib_Vdec2, "Error receiving frame from decoder: {}", ret);
-            av_packet_free(&packet);
-            av_frame_free(&frame);
-            return ORBIS_VIDEODEC2_ERROR_API_FAIL;
-        }
-
-        if (frame->format != AV_PIX_FMT_NV12) {
-            AVFrame* nv12_frame = ConvertNV12Frame(*frame);
-            ASSERT(nv12_frame);
-            av_frame_free(&frame);
-            frame = nv12_frame;
-        }
-
-        CopyNV12Data((u8*)frameBuffer.frameBuffer, *frame);
-        frameBuffer.isAccepted = true;
-
-        outputInfo.codecType = 1; // FIXME: Hardcoded to AVC
-        outputInfo.frameWidth = frame->width;
-        outputInfo.frameHeight = frame->height;
-        outputInfo.framePitch = frame->width;
-        outputInfo.frameBufferSize = frameBuffer.frameBufferSize;
-        outputInfo.frameBuffer = frameBuffer.frameBuffer;
-
-        outputInfo.isValid = true;
-        outputInfo.isErrorFrame = false;
-        outputInfo.pictureCount = 1; // TODO: 2 pictures for interlaced video
-
-        // Only set framePitchInBytes if the game uses the newer struct version.
-        if (outputInfo.thisSize == sizeof(OrbisVideodec2OutputInfo)) {
-            outputInfo.framePitchInBytes = frame->width;
-        }
-
-        if (outputInfo.isValid) {
-            OrbisVideodec2AvcPictureInfo pictureInfo = {};
-
-            pictureInfo.thisSize = sizeof(OrbisVideodec2AvcPictureInfo);
-            pictureInfo.isValid = true;
-
-            pictureInfo.ptsData = inputData.ptsData;
-            pictureInfo.dtsData = inputData.dtsData;
-            pictureInfo.attachedData = inputData.attachedData;
-
-            pictureInfo.frameCropLeftOffset = frame->crop_left;
-            pictureInfo.frameCropRightOffset = frame->crop_right;
-            pictureInfo.frameCropTopOffset = frame->crop_top;
-            pictureInfo.frameCropBottomOffset = frame->crop_bottom;
-
-            gPictureInfos.push_back(pictureInfo);
-        }
+    ret = avcodec_receive_frame(mCodecContext, frame);
+    if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
+        av_frame_free(&frame);
+        return ORBIS_OK;
+    } else if (ret < 0) {
+        LOG_ERROR(Lib_Vdec2, "Error receiving frame from decoder: {}", ret);
+        av_packet_free(&packet);
+        av_frame_free(&frame);
+        return ORBIS_VIDEODEC2_ERROR_API_FAIL;
     }
+
+    if (frame->format != AV_PIX_FMT_NV12) {
+        AVFrame* nv12_frame = ConvertNV12Frame(*frame);
+        ASSERT(nv12_frame);
+        av_frame_free(&frame);
+        frame = nv12_frame;
+    }
+
+    Videodec::CopyNV12Data((u8*)frameBuffer.frameBuffer, *frame);
+    frameBuffer.isAccepted = true;
+
+    const auto width = Common::AlignUp<u32>(frame->width, 16);
+    const auto pitch = Common::AlignUp<u32>(frame->width, 64);
+    const auto height = Common::AlignUp<u32>(frame->height, 16);
+
+    outputInfo.codecType = 1; // FIXME: Hardcoded to AVC
+    outputInfo.frameWidth = width;
+    outputInfo.framePitch = pitch;
+    outputInfo.frameHeight = height;
+    outputInfo.frameBuffer = frameBuffer.frameBuffer;
+    outputInfo.frameBufferSize = (pitch * height * 3) / 2;
+
+    outputInfo.isValid = true;
+    outputInfo.isErrorFrame = false;
+    outputInfo.pictureCount = 1; // TODO: 2 pictures for interlaced video
+
+    // Only set framePitchInBytes if the game uses the newer struct version.
+    if (outputInfo.thisSize == sizeof(OrbisVideodec2OutputInfo)) {
+        outputInfo.framePitchInBytes = pitch;
+    }
+
+    OrbisVideodec2AvcPictureInfo pictureInfo = {};
+
+    pictureInfo.thisSize = sizeof(OrbisVideodec2AvcPictureInfo);
+    pictureInfo.isValid = true;
+
+    pictureInfo.ptsData = inputData.ptsData;
+    pictureInfo.dtsData = inputData.dtsData;
+    pictureInfo.attachedData = inputData.attachedData;
+
+    pictureInfo.frameCropTopOffset = 0;
+    pictureInfo.frameCropLeftOffset = 0;
+    pictureInfo.frameCropRightOffset = pitch - frame->width;
+    pictureInfo.frameCropBottomOffset = height - frame->height;
+
+    gPictureInfos.push_back(pictureInfo);
 
     av_packet_free(&packet);
     av_frame_free(&frame);
@@ -178,44 +162,62 @@ s32 VdecDecoder::Flush(OrbisVideodec2FrameBuffer& frameBuffer,
         return ORBIS_VIDEODEC2_ERROR_API_FAIL;
     }
 
-    while (true) {
-        int ret = avcodec_receive_frame(mCodecContext, frame);
-        if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
-            break;
-        } else if (ret < 0) {
-            LOG_ERROR(Lib_Vdec2, "Error receiving frame from decoder: {}", ret);
-            av_frame_free(&frame);
-            return ORBIS_VIDEODEC2_ERROR_API_FAIL;
-        }
-
-        if (frame->format != AV_PIX_FMT_NV12) {
-            AVFrame* nv12_frame = ConvertNV12Frame(*frame);
-            ASSERT(nv12_frame);
-            av_frame_free(&frame);
-            frame = nv12_frame;
-        }
-
-        CopyNV12Data((u8*)frameBuffer.frameBuffer, *frame);
-        frameBuffer.isAccepted = true;
-
-        outputInfo.codecType = 1; // FIXME: Hardcoded to AVC
-        outputInfo.frameWidth = frame->width;
-        outputInfo.frameHeight = frame->height;
-        outputInfo.framePitch = frame->width;
-        outputInfo.frameBufferSize = frameBuffer.frameBufferSize;
-        outputInfo.frameBuffer = frameBuffer.frameBuffer;
-
-        outputInfo.isValid = true;
-        outputInfo.isErrorFrame = false;
-        outputInfo.pictureCount = 1; // TODO: 2 pictures for interlaced video
-
-        // Only set framePitchInBytes if the game uses the newer struct version.
-        if (outputInfo.thisSize == sizeof(OrbisVideodec2OutputInfo)) {
-            outputInfo.framePitchInBytes = frame->width;
-        }
-
-        // FIXME: Should we add picture info here too?
+    avcodec_send_packet(mCodecContext, nullptr);
+    int ret = avcodec_receive_frame(mCodecContext, frame);
+    if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
+        av_frame_free(&frame);
+        return ORBIS_OK;
+    } else if (ret < 0) {
+        LOG_ERROR(Lib_Vdec2, "Error receiving frame from decoder: {}", ret);
+        av_frame_free(&frame);
+        return ORBIS_VIDEODEC2_ERROR_API_FAIL;
     }
+
+    if (frame->format != AV_PIX_FMT_NV12) {
+        AVFrame* nv12_frame = ConvertNV12Frame(*frame);
+        ASSERT(nv12_frame);
+        av_frame_free(&frame);
+        frame = nv12_frame;
+    }
+
+    Videodec::CopyNV12Data((u8*)frameBuffer.frameBuffer, *frame);
+    frameBuffer.isAccepted = true;
+
+    const auto width = Common::AlignUp<u32>(frame->width, 16);
+    const auto pitch = Common::AlignUp<u32>(frame->width, 64);
+    const auto height = Common::AlignUp<u32>(frame->height, 16);
+
+    outputInfo.codecType = 1; // FIXME: Hardcoded to AVC
+    outputInfo.frameWidth = width;
+    outputInfo.framePitch = pitch;
+    outputInfo.frameHeight = height;
+    outputInfo.frameBuffer = frameBuffer.frameBuffer;
+    outputInfo.frameBufferSize = (pitch * height * 3) / 2;
+
+    outputInfo.isValid = true;
+    outputInfo.isErrorFrame = false;
+    outputInfo.pictureCount = 1; // TODO: 2 pictures for interlaced video
+
+    // Only set framePitchInBytes if the game uses the newer struct version.
+    if (outputInfo.thisSize == sizeof(OrbisVideodec2OutputInfo)) {
+        outputInfo.framePitchInBytes = pitch;
+    }
+
+    OrbisVideodec2AvcPictureInfo pictureInfo = {};
+
+    pictureInfo.thisSize = sizeof(OrbisVideodec2AvcPictureInfo);
+    pictureInfo.isValid = true;
+
+    pictureInfo.ptsData = frame->pts;
+    pictureInfo.dtsData = frame->pkt_dts;
+    pictureInfo.attachedData = 0;
+
+    pictureInfo.frameCropTopOffset = 0;
+    pictureInfo.frameCropLeftOffset = 0;
+    pictureInfo.frameCropRightOffset = pitch - frame->width;
+    pictureInfo.frameCropBottomOffset = height - frame->height;
+
+    gPictureInfos.push_back(pictureInfo);
 
     av_frame_free(&frame);
     return ORBIS_OK;

--- a/src/core/libraries/videodec/videodec_impl.cpp
+++ b/src/core/libraries/videodec/videodec_impl.cpp
@@ -6,18 +6,12 @@
 #include "common/alignment.h"
 #include "common/assert.h"
 #include "common/logging/log.h"
-#include "core/libraries/videodec/videodec_error.h"
+#include "video_utils.h"
+#include "videodec_error.h"
 
 #include "common/support/avdec.h"
 
 namespace Libraries::Videodec {
-
-static inline void CopyNV12Data(u8* dst, const AVFrame& src) {
-    u32 width = Common::AlignUp((u32)src.width, 16);
-    u32 height = Common::AlignUp((u32)src.height, 16);
-    std::memcpy(dst, src.data[0], src.width * src.height);
-    std::memcpy(dst + src.width * height, src.data[1], (src.width * src.height) / 2);
-}
 
 VdecDecoder::VdecDecoder(const OrbisVideodecConfigInfo& pCfgInfoIn,
                          const OrbisVideodecResourceInfo& pRsrcInfoIn) {
@@ -96,13 +90,22 @@ s32 VdecDecoder::Decode(const OrbisVideodecInputData& pInputDataIn,
 
     CopyNV12Data((u8*)pFrameBufferInOut.pFrameBuffer, *frame);
 
+    const auto width = Common::AlignUp<u32>(frame->width, 16);
+    const auto pitch = Common::AlignUp<u32>(frame->width, 64);
+    const auto height = Common::AlignUp<u32>(frame->height, 16);
+
     pPictureInfoOut.codecType = 0;
-    pPictureInfoOut.frameWidth = Common::AlignUp((u32)frame->width, 16);
-    pPictureInfoOut.frameHeight = Common::AlignUp((u32)frame->height, 16);
-    pPictureInfoOut.framePitch = frame->linesize[0];
+    pPictureInfoOut.frameWidth = width;
+    pPictureInfoOut.framePitch = pitch;
+    pPictureInfoOut.frameHeight = height;
 
     pPictureInfoOut.isValid = true;
     pPictureInfoOut.isErrorPic = false;
+
+    pPictureInfoOut.codec.avc.frameCropTopOffset = 0;
+    pPictureInfoOut.codec.avc.frameCropLeftOffset = 0;
+    pPictureInfoOut.codec.avc.frameCropRightOffset = pitch - frame->width;
+    pPictureInfoOut.codec.avc.frameCropBottomOffset = height - frame->height;
     pPictureInfoOut.attachedData = pInputDataIn.attachedData;
 
     av_packet_free(&packet);
@@ -146,22 +149,22 @@ s32 VdecDecoder::Flush(OrbisVideodecFrameBuffer& pFrameBufferInOut,
 
     CopyNV12Data((u8*)pFrameBufferInOut.pFrameBuffer, *frame);
 
+    const auto width = Common::AlignUp<u32>(frame->width, 16);
+    const auto pitch = Common::AlignUp<u32>(frame->width, 64);
+    const auto height = Common::AlignUp<u32>(frame->height, 16);
+
     pPictureInfoOut.codecType = 0;
-    pPictureInfoOut.frameWidth = Common::AlignUp((u32)frame->width, 16);
-    pPictureInfoOut.frameHeight = Common::AlignUp((u32)frame->height, 16);
-    pPictureInfoOut.framePitch = frame->linesize[0];
+    pPictureInfoOut.frameWidth = width;
+    pPictureInfoOut.framePitch = pitch;
+    pPictureInfoOut.frameHeight = height;
 
     pPictureInfoOut.isValid = true;
     pPictureInfoOut.isErrorPic = false;
 
-    u32 width = Common::AlignUp((u32)frame->width, 16);
-    u32 height = Common::AlignUp((u32)frame->height, 16);
-    pPictureInfoOut.codec.avc.frameCropLeftOffset = u32(frame->crop_left);
-    pPictureInfoOut.codec.avc.frameCropRightOffset =
-        u32(frame->crop_right + (width - frame->width));
-    pPictureInfoOut.codec.avc.frameCropTopOffset = u32(frame->crop_top);
-    pPictureInfoOut.codec.avc.frameCropBottomOffset =
-        u32(frame->crop_bottom + (height - frame->height));
+    pPictureInfoOut.codec.avc.frameCropTopOffset = 0;
+    pPictureInfoOut.codec.avc.frameCropLeftOffset = 0;
+    pPictureInfoOut.codec.avc.frameCropRightOffset = pitch - frame->width;
+    pPictureInfoOut.codec.avc.frameCropBottomOffset = height - frame->height;
 
     av_frame_free(&frame);
     return ORBIS_OK;


### PR DESCRIPTION
During the extensive testing on PS4 using the homebrew I have yet to find a case where these are not aligned for AVC videos. Let me know if it breaks videos in any games.

Also:
* Extended video data to the cropped part of the video as observed on the PS4 (only vertical for now)
* Synced vdec implementation to avplayer and vdec2 implementation to vdec improvements in flush function.
* Removed excessive memset from frame data fill
* Aligned pitch to 64 after testing videos with width 720 on PS4
* Fixed stream tracks selection by language
* Changed the number of audio buffers to `max_frame_buffers * 2` as observed on the PS4. Each audio buffer is now 32KB in size and aligned to 16 as it is on PS4.