### PR TITLE
Kernel.Fs: Use intermediate buffer for storing file read data before copying to host memory

### DIFF
--- a/src/common/io_file.h
+++ b/src/common/io_file.h
@@ -185,6 +185,7 @@ public:
         u64 written = std::fwrite(data.data(), sizeof(T), data.size(), file);
         ASSERT_MSG(std::ferror(file) == 0, "Failed to write to file, error = {}",
                    std::strerror(errno));
+        std::fflush(file);
         return written;
     }
 
@@ -222,6 +223,7 @@ public:
 
         u64 bytes = std::fwrite(&object, sizeof(T), 1, file) == 1;
         ASSERT_MSG(std::ferror(file) == 0, "Failed to read file, error = {}", std::strerror(errno));
+        std::fflush(file);
         return bytes;
     }
 

--- a/src/common/io_file.h
+++ b/src/common/io_file.h
@@ -169,22 +169,12 @@ public:
 
     template <typename T>
     size_t ReadRaw(void* data, size_t size) const {
-        if (std::ferror(file)) {
-            LOG_ERROR(Core, "file {} in error state?", file_path.string().data());
-            std::clearerr(file);
-        }
         u64 read = std::fread(data, sizeof(T), size, file);
         if (std::ferror(file)) {
             LOG_ERROR(
                 Core,
                 "file read errored, file = {}, data = {}, offset = {:#x}, size = {:#x}, errno = {}",
                 file_path.string().data(), fmt::ptr(data), Tell(), size, std::strerror(errno));
-            std::clearerr(file);
-        }
-        if (std::feof(file)) {
-            LOG_ERROR(Core,
-                      "end of file reached, file = {}, data = {}, offset = {:#x}, size = {:#x}",
-                      file_path.string().data(), fmt::ptr(data), Tell(), size);
             std::clearerr(file);
         }
         return read;

--- a/src/common/io_file.h
+++ b/src/common/io_file.h
@@ -9,6 +9,7 @@
 #include <type_traits>
 
 #include "common/concepts.h"
+#include "common/logging/log.h"
 #include "common/types.h"
 #include "enum.h"
 
@@ -168,7 +169,25 @@ public:
 
     template <typename T>
     size_t ReadRaw(void* data, size_t size) const {
-        return std::fread(data, sizeof(T), size, file);
+        if (std::ferror(file)) {
+            LOG_ERROR(Core, "file {} in error state?", file_path.string().data());
+            std::clearerr(file);
+        }
+        u64 read = std::fread(data, sizeof(T), size, file);
+        if (std::ferror(file)) {
+            LOG_ERROR(
+                Core,
+                "file read errored, file = {}, data = {}, offset = {:#x}, size = {:#x}, errno = {}",
+                file_path.string().data(), fmt::ptr(data), Tell(), size, std::strerror(errno));
+            std::clearerr(file);
+        }
+        if (std::feof(file)) {
+            LOG_ERROR(Core,
+                      "end of file reached, file = {}, data = {}, offset = {:#x}, size = {:#x}",
+                      file_path.string().data(), fmt::ptr(data), Tell(), size);
+            std::clearerr(file);
+        }
+        return read;
     }
 
     template <typename T>

--- a/src/common/io_file.h
+++ b/src/common/io_file.h
@@ -8,8 +8,8 @@
 #include <span>
 #include <type_traits>
 
+#include "common/assert.h"
 #include "common/concepts.h"
-#include "common/logging/log.h"
 #include "common/types.h"
 #include "enum.h"
 
@@ -170,13 +170,7 @@ public:
     template <typename T>
     size_t ReadRaw(void* data, size_t size) const {
         u64 read = std::fread(data, sizeof(T), size, file);
-        if (std::ferror(file)) {
-            LOG_ERROR(
-                Core,
-                "file read errored, file = {}, data = {}, offset = {:#x}, size = {:#x}, errno = {}",
-                file_path.string().data(), fmt::ptr(data), Tell(), size, std::strerror(errno));
-            std::clearerr(file);
-        }
+        ASSERT_MSG(std::ferror(file) == 0, "Failed to read file, error = {}", std::strerror(errno));
         return read;
     }
 
@@ -188,7 +182,10 @@ public:
             return 0;
         }
 
-        return std::fwrite(data.data(), sizeof(T), data.size(), file);
+        u64 written = std::fwrite(data.data(), sizeof(T), data.size(), file);
+        ASSERT_MSG(std::ferror(file) == 0, "Failed to write to file, error = {}",
+                   std::strerror(errno));
+        return written;
     }
 
     template <typename T>
@@ -200,12 +197,16 @@ public:
             return false;
         }
 
-        return std::fread(&object, sizeof(T), 1, file) == 1;
+        bool success = std::fread(&object, sizeof(T), 1, file) == 1;
+        ASSERT_MSG(std::ferror(file) == 0, "Failed to read file, error = {}", std::strerror(errno));
+        return success;
     }
 
     template <typename T>
     size_t WriteRaw(const void* data, size_t size) const {
-        auto bytes = std::fwrite(data, sizeof(T), size, file);
+        u64 bytes = std::fwrite(data, sizeof(T), size, file);
+        ASSERT_MSG(std::ferror(file) == 0, "Failed to write to file, error = {}",
+                   std::strerror(errno));
         std::fflush(file);
         return bytes;
     }
@@ -219,7 +220,9 @@ public:
             return false;
         }
 
-        return std::fwrite(&object, sizeof(T), 1, file) == 1;
+        u64 bytes = std::fwrite(&object, sizeof(T), 1, file) == 1;
+        ASSERT_MSG(std::ferror(file) == 0, "Failed to read file, error = {}", std::strerror(errno));
+        return bytes;
     }
 
     std::string ReadString(size_t length) const;

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -358,6 +358,7 @@ s64 ReadFile(Common::FS::IOFile& file, void* buf, u64 nbytes) {
     const auto remaining = file.GetSize() - file.Tell();
     memory->InvalidateMemory(reinterpret_cast<VAddr>(buf), std::min<u64>(nbytes, remaining));
     void* file_buf = std::malloc(nbytes);
+    ASSERT_MSG(file_buf != nullptr, "malloc failed on size {:#x}", nbytes);
     u64 bytes = file.ReadRaw<u8>(file_buf, nbytes);
     std::memcpy(buf, file_buf, bytes);
     std::free(file_buf);

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -352,16 +352,18 @@ s64 PS4_SYSV_ABI sceKernelWrite(s32 fd, const void* buf, u64 nbytes) {
     return result;
 }
 
+static std::vector<u8> file_buf{};
+
 s64 ReadFile(Common::FS::IOFile& file, void* buf, u64 nbytes) {
     const auto* memory = Core::Memory::Instance();
     // Invalidate up to the actual number of bytes that could be read.
     const auto remaining = file.GetSize() - file.Tell();
     memory->InvalidateMemory(reinterpret_cast<VAddr>(buf), std::min<u64>(nbytes, remaining));
-    void* file_buf = std::malloc(nbytes);
-    ASSERT_MSG(file_buf != nullptr, "malloc failed on size {:#x}", nbytes);
-    u64 bytes = file.ReadRaw<u8>(file_buf, nbytes);
-    std::memcpy(buf, file_buf, bytes);
-    std::free(file_buf);
+    if (file_buf.capacity() < nbytes) {
+        file_buf.reserve(nbytes);
+    }
+    u64 bytes = file.ReadRaw<u8>(file_buf.data(), nbytes);
+    std::memcpy(buf, file_buf.data(), bytes);
     return bytes;
 }
 

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -352,7 +352,7 @@ s64 PS4_SYSV_ABI sceKernelWrite(s32 fd, const void* buf, u64 nbytes) {
     return result;
 }
 
-static std::vector<u8> file_buf{};
+static thread_local std::vector<u8> file_buf{};
 
 s64 ReadFile(Common::FS::IOFile& file, void* buf, u64 nbytes) {
     const auto* memory = Core::Memory::Instance();

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -357,8 +357,11 @@ s64 ReadFile(Common::FS::IOFile& file, void* buf, u64 nbytes) {
     // Invalidate up to the actual number of bytes that could be read.
     const auto remaining = file.GetSize() - file.Tell();
     memory->InvalidateMemory(reinterpret_cast<VAddr>(buf), std::min<u64>(nbytes, remaining));
-
-    return file.ReadRaw<u8>(buf, nbytes);
+    void* file_buf = std::malloc(nbytes);
+    u64 bytes = file.ReadRaw<u8>(file_buf, nbytes);
+    std::memcpy(buf, file_buf, bytes);
+    std::free(file_buf);
+    return bytes;
 }
 
 s64 PS4_SYSV_ABI readv(s32 fd, const OrbisKernelIovec* iov, s32 iovcnt) {


### PR DESCRIPTION
In a variety of titles, our io_file ReadRaw would fail silently in the std::fread call. These failing calls would return 0 bytes read, set the stream's error flag for std::ferror to detect, and set errno to einval.

For some reason, std::fread does not error if we read into a host buffer, then copy that data to the guest. While I feel this might be too hacky to actually merge, I think it's useful as a test to get more information about affected titles.

The issues this caused depended on the title, but it's responsible for old UE4 titles attempting to map more memory than the PS4 contains, the InvalidFileFourCC errors in Shadow of the Colossus, and probably is responsible for issues in other titles too.

Credits to @Kravickas for (indirectly) giving me the idea to try this.