### PR TITLE
Use CopySparseMemory for StreamBuffer::Copy on guest addresses

### DIFF
--- a/src/video_core/buffer_cache/buffer.h
+++ b/src/video_core/buffer_cache/buffer.h
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 #include "common/types.h"
+#include "core/memory.h"
 #include "video_core/amdgpu/resource.h"
 #include "video_core/renderer_vulkan/vk_common.h"
 
@@ -182,7 +183,13 @@ public:
     /// Maps and commits a memory region with user provided data
     u64 Copy(auto src, size_t size, size_t alignment = 0) {
         const auto [data, offset] = Map(size, alignment);
-        std::memcpy(data, reinterpret_cast<const void*>(src), size);
+        auto* memory = Core::Memory::Instance();
+        const VAddr src_vaddr = reinterpret_cast<const VAddr>(src);
+        if (memory->IsValidGpuMapping(src_vaddr, size)) {
+            memory->CopySparseMemory(src_vaddr, data, size);
+        } else {
+            std::memcpy(data, reinterpret_cast<const void*>(src), size);
+        }
         Commit();
         return offset;
     }


### PR DESCRIPTION
Helps significantly with stability issues in newer UE titles (and to some extent, Minecraft Bedrock), which are unmapping memory during submits. These unmaps during submits would cause the std::memcpy to trigger an access violation.

Since CopySparseMemory has it's own checks to ensure addresses are in the guest address space, while StreamBuffer copies are occasionally performed with host addresses, we need to ensure we only call CopySparseMemory on valid guest addresses, or it will assert.