### PR TITLE
Use IsValidMapping for StreamBuffer::Copy check instead of IsValidGpuMapping

### DIFF
--- a/src/video_core/buffer_cache/buffer.h
+++ b/src/video_core/buffer_cache/buffer.h
@@ -185,7 +185,7 @@ public:
         const auto [data, offset] = Map(size, alignment);
         auto* memory = Core::Memory::Instance();
         const VAddr src_vaddr = reinterpret_cast<const VAddr>(src);
-        if (memory->IsValidGpuMapping(src_vaddr, size)) {
+        if (memory->IsValidMapping(src_vaddr)) {
             memory->CopySparseMemory(src_vaddr, data, size);
         } else {
             std::memcpy(data, reinterpret_cast<const void*>(src), size);


### PR DESCRIPTION
Was hoping to get away with lower overhead, but we need to have a lower-bounded check too, or Windows with it's somewhat sparse address space will have issues with host mappings going through CopySparseMemory and asserting.

Intentionally not checking size, as the more robust mapping check would be a huge performance loss for a hot code path like this.

This should fix Windows-specific regressions after #4744 