### PR TITLE
Lock priority pending ops mutex in PopPendingOperations

### DIFF
--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -119,6 +119,7 @@ void Scheduler::Wait(u64 tick) {
 }
 
 void Scheduler::PopPendingOperations() {
+    std::unique_lock lk(priority_pending_ops_mutex);
     master_semaphore.Refresh();
     while (!pending_ops.empty() && master_semaphore.IsFree(pending_ops.front().gpu_tick)) {
         pending_ops.front().callback();


### PR DESCRIPTION
Thanks to recent changes to readbackLinearImages, we get a lot more of these pending ops, and a lot more of these PopPendingOperations calls. This exposed a race condition where calls to PopPendingOperations would run simultaneously with our PriorityPendingOpsRunner threads, and potentially call a callback while a runner pops it off the pending ops queue.

This helps with more stability issues Unreal Engine titles face.