### PR TITLE
Miscellaneous renderer fixes

### DIFF
--- a/src/shader_recompiler/ir/passes/flatten_extended_userdata_pass.cpp
+++ b/src/shader_recompiler/ir/passes/flatten_extended_userdata_pass.cpp
@@ -113,7 +113,7 @@ static bool SrtWalkerSignalHandler(void* context, void* fault_address) {
     // Fill nops
     memset(code_patch + patch_size, 0x90, len - patch_size);
 
-    LOG_DEBUG(Render_Recompiler, "Patched SRT walker at {}", code);
+    LOG_DEBUG(Render_Recompiler, "Patched SRT walker at {}, fault address {}", code, fault_address);
 
     return true;
 }

--- a/src/shader_recompiler/ir/passes/flatten_extended_userdata_pass.cpp
+++ b/src/shader_recompiler/ir/passes/flatten_extended_userdata_pass.cpp
@@ -113,7 +113,8 @@ static bool SrtWalkerSignalHandler(void* context, void* fault_address) {
     // Fill nops
     memset(code_patch + patch_size, 0x90, len - patch_size);
 
-    LOG_DEBUG(Render_Recompiler, "Patched SRT walker at {}, fault address {}", code, fault_address);
+    LOG_WARNING(Render_Recompiler, "Patched SRT walker at {}, fault address {}", code,
+                fault_address);
 
     return true;
 }

--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -13,8 +13,8 @@ namespace AmdGpu {
 
 // Table 8.5 Buffer Resource Descriptor [Sea Islands Series Instruction Set Architecture]
 struct Buffer {
-    u64 base_address : 44;
-    u64 _padding0 : 4;
+    u64 base_address : 40;
+    u64 _padding0 : 8;
     u64 stride : 14;
     u64 cache_swizzle : 1;
     u64 swizzle_enable : 1;

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -173,7 +173,7 @@ void BufferCache::BindVertexBuffers(
     // Build list of ranges covering the requested buffers
     Vulkan::VertexInputs<BufferRange> ranges{};
     for (const auto& buffer : guest_buffers) {
-        if (buffer.GetSize() > 0) {
+        if (buffer.base_address != 0 && buffer.GetSize() > 0) {
             ranges.emplace_back(buffer.base_address, buffer.base_address + buffer.GetSize());
         }
     }
@@ -216,7 +216,7 @@ void BufferCache::BindVertexBuffers(
     Vulkan::VertexInputs<vk::DeviceSize> host_sizes;
     Vulkan::VertexInputs<vk::DeviceSize> host_strides;
     for (const auto& buffer : guest_buffers) {
-        if (buffer.GetSize() > 0) {
+        if (buffer.base_address != 0 && buffer.GetSize() > 0) {
             const auto host_buffer_info =
                 std::ranges::find_if(ranges_merged, [&](const BufferRange& range) {
                     return buffer.base_address >= range.base_address &&

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -382,8 +382,7 @@ void BufferCache::CopyBuffer(VAddr dst, VAddr src, u32 num_bytes, bool dst_gds, 
 std::pair<Buffer*, u32> BufferCache::ObtainBuffer(VAddr device_addr, u32 size, bool is_written,
                                                   bool is_texel_buffer, BufferId buffer_id) {
     // For read-only buffers use device local stream buffer to reduce renderpass breaks.
-    if (!is_written && size <= CACHING_PAGESIZE && !IsRegionGpuModified(device_addr, size) &&
-        IsRegionCpuModified(device_addr, size)) {
+    if (!is_written && size <= CACHING_PAGESIZE && !IsRegionGpuModified(device_addr, size)) {
         const u64 offset = stream_buffer.Copy(device_addr, size, instance.UniformMinAlignment());
         return {&stream_buffer, offset};
     }


### PR DESCRIPTION
- Add fault address logging to the SRT walker patchs and bump log severity to warning.
- Ignore 4 most-significant bits of Buffer base_address to match hardware observations.
- Do not allow binding vertex buffers with a base_address of 0.
- Revert an optimization to BufferCache::ObtainBuffer that caused graphical regressions in some Unreal Engine titles.

The last change fixes severe graphical flickering in Dragon Ball Z Kakarot, other changes were made while debugging Persona 3 Reload issues (though don't improve the game at all).