### PR TITLE
avplayer: fixes to stack usage

### DIFF
--- a/src/core/libraries/avplayer/avplayer_source.cpp
+++ b/src/core/libraries/avplayer/avplayer_source.cpp
@@ -77,6 +77,10 @@ bool AvPlayerSource::Init(const AvPlayerInitData& init_data, std::string_view pa
     }
     m_avformat_context = AVFormatContextPtr(context, &ReleaseAVFormatContext);
 
+    return true;
+}
+
+bool AvPlayerSource::FindStreams() {
     if (avformat_find_stream_info(m_avformat_context.get(), nullptr) >= 0) {
         m_streams.reserve(m_avformat_context->nb_streams);
         for (u32 idx = 0; idx < m_avformat_context->nb_streams; ++idx) {
@@ -86,10 +90,7 @@ bool AvPlayerSource::Init(const AvPlayerInitData& init_data, std::string_view pa
             m_streams.push_back({idx, CreateStreamInfo(idx)});
         }
     }
-    return true;
-}
-
-bool AvPlayerSource::HasStreams() {
+    m_duration = DurationMillis();
     return m_streams.size() >= 0;
 }
 
@@ -418,8 +419,11 @@ u64 AvPlayerSource::DurationMillis() const {
         if (!stream_index.has_value()) {
             return;
         }
+        if (stream_index.value() < 0) {
+            return;
+        }
         const auto index = m_streams[stream_index.value()].ffmpeg_index;
-        if (index < 0 || u32(index) >= m_avformat_context->nb_streams) {
+        if (index >= m_streams.size()) {
             return;
         }
         const auto stream = m_avformat_context->streams[index];
@@ -449,9 +453,8 @@ u64 AvPlayerSource::CurrentTime() {
         return 0;
     }
 
-    const auto duration = DurationMillis();
     if (m_is_eof && !IsActive()) {
-        return duration;
+        return m_duration;
     }
     if (!IsActive()) {
         return 0;
@@ -465,7 +468,7 @@ u64 AvPlayerSource::CurrentTime() {
         return 0;
     }
     const auto current_time = u64(elapsed);
-    return duration != 0 && current_time > duration ? duration : current_time;
+    return m_duration != 0 && current_time > m_duration ? m_duration : current_time;
 }
 
 bool AvPlayerSource::IsActive() {

--- a/src/core/libraries/avplayer/avplayer_source.h
+++ b/src/core/libraries/avplayer/avplayer_source.h
@@ -146,7 +146,7 @@ public:
     ~AvPlayerSource();
 
     bool Init(const AvPlayerInitData& init_data, std::string_view path);
-    bool HasStreams();
+    bool FindStreams();
     s32 GetStreamCount();
     bool GetStreamInfo(u32 stream_index, AvPlayerStreamInfo& info);
     bool EnableStream(u32 stream_index);
@@ -200,6 +200,7 @@ private:
     };
 
     std::vector<Stream> m_streams;
+    u64 m_duration = 0;
 
     AvPlayerMemAllocator m_memory_replacement{};
     u32 m_max_num_video_framebuffers{};

--- a/src/core/libraries/avplayer/avplayer_state.cpp
+++ b/src/core/libraries/avplayer/avplayer_state.cpp
@@ -459,7 +459,7 @@ void AvPlayerState::ProcessEvent() {
     }
     case AvEventType::AddSource: {
         std::shared_lock lock(m_source_mutex);
-        if (m_up_source->HasStreams()) {
+        if (m_up_source->FindStreams()) {
             SetState(AvState::Ready);
             OnPlaybackStateChanged(AvState::Ready);
         } else {


### PR DESCRIPTION
* Moved stream iteration back to the av controller thread to save stack space
* Duration is now calculated only once