### PR TITLE
Log option for flushing

### DIFF
--- a/documents/Debugging/Debugging.md
+++ b/documents/Debugging/Debugging.md
@@ -71,6 +71,7 @@ You can configure the emulator by editing the `config.json` file found in the `u
     - Examples:
       - If the log is being spammed with messages coming from Lib.Pad, you can use `Lib.Pad:Critical` to only log critical-level messages.
       - If you'd like to mute everything, but still want to receive messages from Vulkan rendering: `*:Off Render.Vulkan:Info` (if you want critical at least `*:Critical Render.Vulkan:Info`)
+  - `flush_level`: Sets the log level for which logs at or above will be flushed.
   - `skip_duplicate`: Skip same lines with a `Skipped N duplicate messages..` message (`true`/`false`)
     - By default, the emulator will skip same lines for `maxSkipDuration` milliseconds.
   - `append`: Append log to the existing file (`true`/`false`)

--- a/src/common/logging/log.cpp
+++ b/src/common/logging/log.cpp
@@ -218,6 +218,7 @@ void Setup(std::string_view shadps4_filename) {
 void Switch(std::string_view game_filename) {
     UpdateSinks();
     UpdateLogLevels(EmulatorSettings.GetLogFilter());
+    UpdateLogFlushLevel(EmulatorSettings.GetLogFlushLevel());
 
     g_shad_file_sink->_size_limit = EmulatorSettings.GetLogSizeLimit();
     g_shad_file_sink->session_file_helper_.open(
@@ -314,6 +315,14 @@ void UpdateLogLevels(std::string_view log_filter) {
                                                                     : default_log_level);
         } else {
             logger->set_level(spdlog::level::off);
+        }
+    }
+}
+
+void UpdateLogFlushLevel(std::string_view log_flush_level) {
+    if (!log_flush_level.empty()) {
+        for (auto& [name, logger] : ALL_LOGGERS) {
+            logger->flush_on(spdlog::level_from_str(log_flush_level.data()));
         }
     }
 }

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -40,6 +40,7 @@ void Terminate();
 void UpdateSinks();
 
 void UpdateLogLevels(std::string_view log_filter);
+void UpdateLogFlushLevel(std::string_view log_flush_level);
 
 static constexpr std::array level_string_views{"Trace", "Debug",    "Info", "Warning",
                                                "Error", "Critical", "Off"};

--- a/src/core/emulator_settings.h
+++ b/src/core/emulator_settings.h
@@ -245,6 +245,7 @@ struct LogSettings {
     Setting<bool> append{false}; // specific
     Setting<bool> enable{true};  // specific
     Setting<std::string> filter{""};
+    Setting<std::string> flush_level{""};
     Setting<u32> max_skip_duration{5'000};
     Setting<bool> separate{false}; // specific
     Setting<unsigned long long> size_limit{100_MB};
@@ -260,6 +261,7 @@ struct LogSettings {
             make_override<LogSettings>("append", &LogSettings::append),
             make_override<LogSettings>("enable", &LogSettings::enable),
             make_override<LogSettings>("filter", &LogSettings::filter),
+            make_override<LogSettings>("flush_level", &LogSettings::flush_level),
             make_override<LogSettings>("max_skip_duration", &LogSettings::max_skip_duration),
             make_override<LogSettings>("separate", &LogSettings::separate),
             make_override<LogSettings>("size_limit", &LogSettings::size_limit),
@@ -272,11 +274,12 @@ struct LogSettings {
     }
 };
 #ifdef _WIN32
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(LogSettings, append, enable, filter, max_skip_duration, separate,
-                                   size_limit, skip_duplicate, sync, type)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(LogSettings, append, enable, filter, flush_level,
+                                   max_skip_duration, separate, size_limit, skip_duplicate, sync,
+                                   type)
 #else
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(LogSettings, append, enable, filter, max_skip_duration, separate,
-                                   size_limit, skip_duplicate, sync)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(LogSettings, append, enable, filter, flush_level,
+                                   max_skip_duration, separate, size_limit, skip_duplicate, sync)
 #endif
 
 // -------------------------------
@@ -653,6 +656,7 @@ public:
     SETTING_FORWARD_BOOL(m_log, LogAppend, append)
     SETTING_FORWARD_BOOL(m_log, LogEnable, enable)
     SETTING_FORWARD(m_log, LogFilter, filter)
+    SETTING_FORWARD(m_log, LogFlushLevel, flush_level)
     SETTING_FORWARD(m_log, LogMaxSkipDuration, max_skip_duration)
     SETTING_FORWARD_BOOL(m_log, LogSeparate, separate)
     SETTING_FORWARD(m_log, LogSizeLimit, size_limit)


### PR DESCRIPTION
By default, dont flush because we already have order with `sync` and flush on exit.
The valid log levels are the same as for `filter` (case insensitive)