### PR TITLE
video_core: Respect depth write state for register clears

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -895,8 +895,10 @@ RenderState Rasterizer::BeginRendering(const GraphicsPipeline* pipeline) {
         auto& image = texture_cache.GetImage(image_id);
 
         const auto slice = image_view.info.range.base.layer;
-        const bool is_depth_clear = regs.depth_render_control.depth_clear_enable ||
-                                    texture_cache.IsMetaCleared(htile_address, slice);
+        const bool is_depth_clear =
+            (regs.depth_render_control.depth_clear_enable && regs.depth_control.depth_enable &&
+             regs.depth_control.depth_write_enable) ||
+            texture_cache.IsMetaCleared(htile_address, slice);
         const bool is_stencil_clear = regs.depth_render_control.stencil_clear_enable;
         texture_cache.TouchMeta(htile_address, slice, false);
         ASSERT(desc.view_info.range.extent.levels == 1 && !image.binding.needs_rebind);


### PR DESCRIPTION
## Problem

`DB_RENDER_CONTROL.DEPTH_CLEAR_ENABLE` controls how depth writes are processed, but the Vulkan backend treated the bit as an unconditional depth attachment clear. Games can leave it enabled during color-only draws with depth writes disabled, which erased existing scene depth and caused particles such as fire to render through occluding geometry.

## Fix

Gate register-driven depth attachment clears on an enabled depth test, enabled guest Z-write, and a valid depth buffer. HTILE metadata clears remain unchanged, preserving legitimate depth clears while preventing color-only draws from destroying previously rendered depth.

## Testing

God of War III Remastered no longer renders particle effects over occluding geometry. Testing is welcomed.

Before:
<img width="1919" height="1079" alt="before" src="https://github.com/user-attachments/assets/b11ed524-5e6a-474c-990f-7990a6b3b77d" />

After:
<img width="1919" height="1079" alt="after" src="https://github.com/user-attachments/assets/5a2a2fc5-b1da-4eb5-b14e-5fe00945d5a5" />
