### PR TITLE
video_core: Validate sampled sub-rect images from containing image

### DIFF
--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -573,6 +573,60 @@ ImageId TextureCache::FindImage(ImageDesc& desc, bool exact_fmt) {
         RegisterImage(image_id);
     }
 
+    // Reduction chains sample never-rendered sub-views of a GPU-written container through
+    // the same base address and pitch. Their extent is semantically meaningful, so validate
+    // their texels from the container's top-left region before each use. This has to happen
+    // on the lookup path: once the sub-view exists, its binds resolve by exact match and no
+    // longer reach overlap resolution.
+    if (desc.type == BindingType::Texture) {
+        Image& view_image = slot_images[image_id];
+        if (False(view_image.flags & ImageFlagBits::GpuModified) &&
+            view_image.info.resources.levels == 1 && !view_image.info.props.is_block) {
+            ImageId container_id{};
+            ForEachImageInRegion(info.guest_address, 1, [&](ImageId cid, Image& cimg) {
+                if (cid == image_id || cimg.info.guest_address != info.guest_address ||
+                    False(cimg.flags & ImageFlagBits::GpuModified) ||
+                    cimg.info.pixel_format != view_image.info.pixel_format ||
+                    cimg.info.pitch != view_image.info.pitch ||
+                    cimg.info.num_samples != view_image.info.num_samples ||
+                    cimg.info.size.width < view_image.info.size.width ||
+                    cimg.info.size.height < view_image.info.size.height) {
+                    return;
+                }
+                container_id = cid;
+            });
+            if (container_id) {
+                Image& container = slot_images[container_id];
+                scheduler.EndRendering();
+                container.Transit(vk::ImageLayout::eTransferSrcOptimal,
+                                  vk::AccessFlagBits2::eTransferRead, {});
+                view_image.Transit(vk::ImageLayout::eTransferDstOptimal,
+                                   vk::AccessFlagBits2::eTransferWrite, {});
+                const vk::ImageCopy region = {
+                    .srcSubresource = {.aspectMask = vk::ImageAspectFlagBits::eColor,
+                                       .mipLevel = 0,
+                                       .baseArrayLayer = 0,
+                                       .layerCount = 1},
+                    .srcOffset = {0, 0, 0},
+                    .dstSubresource = {.aspectMask = vk::ImageAspectFlagBits::eColor,
+                                       .mipLevel = 0,
+                                       .baseArrayLayer = 0,
+                                       .layerCount = 1},
+                    .dstOffset = {0, 0, 0},
+                    .extent = {view_image.info.size.width, view_image.info.size.height, 1},
+                };
+                scheduler.CommandBuffer().copyImage(
+                    container.GetImage(), vk::ImageLayout::eTransferSrcOptimal,
+                    view_image.GetImage(), vk::ImageLayout::eTransferDstOptimal, region);
+                view_image.flags &= ~ImageFlagBits::Dirty;
+                LOG_DEBUG(Render_Vulkan, "validated sub-view {}x{} from container {}x{} at {:#x}",
+                          view_image.info.size.width, view_image.info.size.height,
+                          container.info.size.width, container.info.size.height,
+                          info.guest_address);
+            }
+        }
+    }
+
     Image& image = slot_images[image_id];
     image.tick_accessed_last = scheduler.CurrentTick();
     TouchImage(image);


### PR DESCRIPTION
## The problem

Games reuse one scratch allocation for GPU reduction chains (auto-exposure and similar), sampling each stage through a smaller descriptor over the same base address and pitch. The texture cache resolves those descriptors to never-rendered sibling images instead of the GPU-written container, so the luminance shader reads stale zeros — in God of War 3 Remastered the measured exposure collapses and bloom floods the entire frame white.

## The fix

A first conservative step toward proper sub-rect validation, following review feedback on [#4768](https://github.com/shadps4-emu/shadPS4/pull/4768#issuecomment-5111691734): when a sampled texture resolves to a never-rendered image whose base address, pitch and format match a GPU-written image of larger extent, validate its contents from that image with a GPU-side copy before sampling. Deliberately narrow — offset-zero, sampling side only — with the generalization (tracked validation, arbitrary offsets, render-side handling) planned as a follow-up.

## Testing

God of War 3 Remastered, before/after below. Tested with "Enable readback linear images" on and readbacks mode at its default (Disabled).

## Before and After
Before 1:
<img width="1920" height="1080" alt="BEFORE1" src="https://github.com/user-attachments/assets/91c8835c-da5c-41a3-9a73-0c2a8c9fa904" />
After 1:
<img width="1920" height="1080" alt="AFTER1" src="https://github.com/user-attachments/assets/601c34bf-fee3-406b-a8f5-7f0076469b32" />

Before 2:
<img width="1920" height="1080" alt="BEFORE2" src="https://github.com/user-attachments/assets/3ce4f330-3acd-4784-80f9-536f3e1af344" />
After 2:
<img width="1920" height="1080" alt="AFTER2" src="https://github.com/user-attachments/assets/7482c5eb-15db-4656-8d4d-38b9275380e1" />