### PR TITLE
video_core: Resolve equal-address views with matching row layout

### DIFF
--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -281,8 +281,13 @@ std::tuple<ImageId, int, int> TextureCache::ResolveOverlap(const ImageInfo& imag
     if (image_info.guest_address == cache_image.info.guest_address) {
         const u32 lhs_block_size = image_info.num_bits * image_info.num_samples;
         const u32 rhs_block_size = cache_image.info.num_bits * cache_image.info.num_samples;
-        if (image_info.BlockDim() != cache_image.info.BlockDim() ||
-            lhs_block_size != rhs_block_size) {
+        // Uncompressed views with the same pitch and texel size are layout-compatible partial
+        // views of the allocation even when their heights differ, and are resolved below.
+        const bool same_row_layout =
+            !image_info.props.is_block && !cache_image.info.props.is_block &&
+            image_info.pitch == cache_image.info.pitch && lhs_block_size == rhs_block_size;
+        if (!same_row_layout && (image_info.BlockDim() != cache_image.info.BlockDim() ||
+                                 lhs_block_size != rhs_block_size)) {
             // Very likely this kind of overlap is caused by allocation from a pool.
             if (safe_to_delete) {
                 FreeImage(cache_image_id);
@@ -305,6 +310,14 @@ std::tuple<ImageId, int, int> TextureCache::ResolveOverlap(const ImageInfo& imag
             return {ExpandImage(image_info, cache_image_id), -1, -1};
         }
 
+        // A strictly smaller same-format view is a reduction-style sub-view whose extent is
+        // semantically meaningful to the guest; keep it as its own image instead of aliasing
+        // the larger allocation.
+        if (same_row_layout && image_info.pixel_format == cache_image.info.pixel_format &&
+            image_info.guest_size < cache_image.info.guest_size) {
+            return {merged_image_id, -1, -1};
+        }
+
         // Size and resources are less than or equal, use image view.
         if (image_info.pixel_format != cache_image.info.pixel_format ||
             image_info.guest_size <= cache_image.info.guest_size) {
@@ -318,6 +331,11 @@ std::tuple<ImageId, int, int> TextureCache::ResolveOverlap(const ImageInfo& imag
         // Size and resources are greater, expand the image.
         if (image_info.type == cache_image.info.type &&
             image_info.resources > cache_image.info.resources) {
+            return {ExpandImage(image_info, cache_image_id), -1, -1};
+        }
+
+        // A taller same-layout view of the allocation; grow the image, preserving content.
+        if (same_row_layout && image_info.guest_size > cache_image.info.guest_size) {
             return {ExpandImage(image_info, cache_image_id), -1, -1};
         }
 


### PR DESCRIPTION
## The problem

Games can sample a multisampled render target as a single-sample texture over the same allocation: the T# describes the same base address and extent, with a guest size of exactly `container size / samples`. The texture cache's exact match rejects this on `guest_size`, so the bind resolves to a never-rendered single-sample sibling image and the shader samples stale zeros instead of the scene.

God of War 3 Remastered reads its 2-sample interlaced scene color this way (a single-sample UNORM view over the sRGB target, gamma decoded in-shader) to feed refraction and glass materials. Everything seen through the frozen floor of the "remains of Ares" room — the body under the ice, the stained-glass windows — renders black.

## The fix

The multisample counterpart of the sub-rect validation proposed in #XXXX, using the same approach: when a sampled, never-rendered single-sample image aliases a GPU-written multisampled container with the same extent and tile mode, a compatible format class, and a guest size of exactly `container / samples`, validate its contents by resolving the container into it. Since the container is redrawn every frame, the view is re-validated once per submission tick and stays marked as derived rather than GPU-authored, so it never goes stale.

Deliberately narrow, consistent with the sub-rect validation: offset-zero aliases, single-level, sampling side only. Independent of #XXXX — the two validations cover different aliasing patterns and either can land alone.

## Testing

God of War 3 Remastered, before/after below — both the remains under the ice and the stained-glass windows recover (same mechanism). Previously working areas of the game were checked for regressions.

Before:
<img width="1920" height="1080" alt="CUSA01715_20260729_102334_896_game_000000" src="https://github.com/user-attachments/assets/e6ad2338-03dc-4fb6-aa12-4b0270360286" />
After:
<img width="1920" height="1080" alt="CUSA01715_20260729_103720_016_game_000000" src="https://github.com/user-attachments/assets/e5f71eca-037e-4d09-8e23-1de849edec17" />
