### PR TITLE
video_core: preserve coherence across aliased images

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1122,6 +1122,8 @@ set(VIDEO_CORE src/video_core/amdgpu/cb_db_extent.h
                src/video_core/renderer_vulkan/host_passes/fsr_pass.h
                src/video_core/renderer_vulkan/host_passes/pp_pass.cpp
                src/video_core/renderer_vulkan/host_passes/pp_pass.h
+               src/video_core/texture_cache/aliasing.cpp
+               src/video_core/texture_cache/aliasing.h
                src/video_core/texture_cache/blit_helper.cpp
                src/video_core/texture_cache/blit_helper.h
                src/video_core/texture_cache/host_compatibility.cpp

--- a/src/video_core/buffer_cache/buffer.cpp
+++ b/src/video_core/buffer_cache/buffer.cpp
@@ -160,6 +160,13 @@ void Buffer::Fill(u64 offset, u32 num_bytes, u32 value) {
     });
 }
 
+void Buffer::Invalidate(u64 offset, u64 size) {
+    ASSERT(offset + size <= size_bytes);
+    if (!is_coherent && usage == MemoryUsage::Download) {
+        vmaInvalidateAllocation(instance->GetAllocator(), buffer.allocation, offset, size);
+    }
+}
+
 constexpr u64 WATCHES_INITIAL_RESERVE = 0x4000;
 constexpr u64 WATCHES_RESERVE_CHUNK = 0x1000;
 

--- a/src/video_core/buffer_cache/buffer.h
+++ b/src/video_core/buffer_cache/buffer.h
@@ -150,6 +150,9 @@ public:
 
     void Fill(u64 offset, u32 num_bytes, u32 value);
 
+    /// Makes a completed download range visible to the CPU.
+    void Invalidate(u64 offset, u64 size);
+
 public:
     VAddr cpu_addr = 0;
     bool is_picked{};

--- a/src/video_core/texture_cache/aliasing.cpp
+++ b/src/video_core/texture_cache/aliasing.cpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <algorithm>
+#include <optional>
+
+#include "video_core/texture_cache/aliasing.h"
+#include "video_core/texture_cache/host_compatibility.h"
+#include "video_core/texture_cache/image_info.h"
+#include "video_core/texture_cache/types.h"
+
+namespace VideoCore {
+
+std::optional<Extent3D> GetAliasCopyExtent(const ImageInfo& src, const ImageInfo& dst) {
+    const bool same_layout =
+        src.guest_address == dst.guest_address && src.num_bits == dst.num_bits &&
+        src.num_samples == dst.num_samples && !src.props.is_depth && !dst.props.is_depth &&
+        src.props.is_block == dst.props.is_block && src.props.is_pow2 == dst.props.is_pow2 &&
+        src.type == dst.type && src.pitch == dst.pitch && src.tile_mode == dst.tile_mode &&
+        src.array_mode == dst.array_mode && src.bank_swizzle == dst.bank_swizzle &&
+        src.alt_tile == dst.alt_tile;
+    if (!same_layout) {
+        return std::nullopt;
+    }
+
+    if (src.pixel_format == dst.pixel_format && src.resources.levels == 1 &&
+        dst.resources.levels == 1 && src.resources.layers >= dst.resources.layers &&
+        src.size.width >= dst.size.width && src.size.height >= dst.size.height &&
+        src.size.depth >= dst.size.depth) {
+        return dst.size;
+    }
+
+    const bool can_copy_intersection = !src.props.is_block && src.resources.levels == 1 &&
+                                       dst.resources.levels == 1 && src.resources.layers == 1 &&
+                                       dst.resources.layers == 1 && src.size.depth == 1 &&
+                                       dst.size.depth == 1 && src.size.width == dst.size.width &&
+                                       IsVulkanFormatCompatible(src.pixel_format, dst.pixel_format);
+    if (!can_copy_intersection) {
+        return std::nullopt;
+    }
+
+    return Extent3D{
+        .width = src.size.width,
+        .height = std::min(src.size.height, dst.size.height),
+        .depth = 1,
+    };
+}
+
+} // namespace VideoCore

--- a/src/video_core/texture_cache/aliasing.h
+++ b/src/video_core/texture_cache/aliasing.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <optional>
+
+#include "video_core/texture_cache/types.h"
+
+namespace VideoCore {
+
+struct ImageInfo;
+
+[[nodiscard]] std::optional<Extent3D> GetAliasCopyExtent(const ImageInfo& src,
+                                                         const ImageInfo& dst);
+
+} // namespace VideoCore

--- a/src/video_core/texture_cache/image.h
+++ b/src/video_core/texture_cache/image.h
@@ -32,6 +32,7 @@ enum ImageFlagBits : u32 {
     GpuDirty = 1 << 2, ///< Contents have been modified from the GPU (valid data in buffer cache)
     Dirty = MaybeCpuDirty | CpuDirty | GpuDirty,
     GpuModified = 1 << 3, ///< Contents have been modified from the GPU
+    Aliased = 1 << 4,     ///< Image shares its guest storage with another compatible image
     Registered = 1 << 6,  ///< True when the image is registered
     Picked = 1 << 7,      ///< Temporary flag to mark the image as picked
 };
@@ -176,6 +177,7 @@ public:
     BackingImage* backing{};
     boost::container::static_vector<u64, 16> mip_hashes{};
     u64 image_uid{};
+    u64 alias_generation{};
     u64 lru_id{};
     u64 tick_accessed_last{};
     u64 hash{};

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -1,8 +1,15 @@
 // SPDX-FileCopyrightText: Copyright 2024-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <algorithm>
+#include <atomic>
+#include <map>
+#include <memory>
+#include <optional>
+
 #include <xxhash.h>
 
+#include "common/alignment.h"
 #include "common/assert.h"
 #include "common/debug.h"
 #include "common/div_ceil.h"
@@ -10,9 +17,11 @@
 #include "core/emulator_settings.h"
 #include "core/memory.h"
 #include "video_core/buffer_cache/buffer_cache.h"
+#include "video_core/buffer_cache/region_definitions.h"
 #include "video_core/page_manager.h"
 #include "video_core/renderer_vulkan/vk_instance.h"
 #include "video_core/renderer_vulkan/vk_scheduler.h"
+#include "video_core/texture_cache/aliasing.h"
 #include "video_core/texture_cache/host_compatibility.h"
 #include "video_core/texture_cache/texture_cache.h"
 #include "video_core/texture_cache/tile_manager.h"
@@ -22,11 +31,190 @@ namespace VideoCore {
 static constexpr u64 PageShift = 12;
 static constexpr u64 NumFramesBeforeRemoval = 32;
 
+struct PendingImageDownload {
+    struct Page {
+        VAddr address;
+        u64 generation;
+    };
+
+    VAddr address;
+    u8* data;
+    Buffer* buffer;
+    u64 buffer_offset;
+    u64 size;
+    std::unique_ptr<Buffer> async_buffer;
+    boost::container::small_vector<Page, 4> pages;
+};
+
+class ReadbackTracker {
+public:
+    explicit ReadbackTracker(PageManager& page_manager_) : page_manager{&page_manager_} {}
+
+    void TrackAsync(PendingImageDownload& pending) {
+        active_downloads.fetch_add(1, std::memory_order_acq_rel);
+        std::scoped_lock lock{mutex};
+        if (canceled) {
+            return;
+        }
+        ForEachPage(pending.address, pending.size, [&](VAddr page) {
+            PageState& state = pages[page];
+            if (!state.watched) {
+                page_manager->UpdatePageWatchers<true>(page, PageSize(page));
+                state.watched = true;
+            }
+            ++state.readers;
+            pending.pages.push_back({page, state.generation});
+        });
+    }
+
+    void Invalidate(VAddr address, u64 size) {
+        if (size == 0 || active_downloads.load(std::memory_order_acquire) == 0) {
+            return;
+        }
+        std::scoped_lock lock{mutex};
+        if (canceled) {
+            return;
+        }
+        const VAddr begin = PageManager::GetPageAddr(address);
+        const VAddr end = PageManager::GetNextPageAddr(address + size - 1);
+        for (auto it = pages.lower_bound(begin); it != pages.end() && it->first < end; ++it) {
+            const VAddr page = it->first;
+            PageState& state = it->second;
+            ++state.generation;
+            if (state.watched) {
+                page_manager->UpdatePageWatchers<false>(page, PageSize(page));
+                state.watched = false;
+            }
+        }
+    }
+
+    void CompleteSync(const PendingImageDownload& pending) {
+        Invalidate(pending.address, pending.size);
+        pending.buffer->Invalidate(pending.buffer_offset, pending.size);
+        Core::Memory::Instance()->TryWriteBacking(std::bit_cast<u8*>(pending.address), pending.data,
+                                                  pending.size);
+    }
+
+    void CompleteAsync(const PendingImageDownload& pending) {
+        SCOPE_EXIT {
+            active_downloads.fetch_sub(1, std::memory_order_release);
+        };
+        std::scoped_lock lock{mutex};
+        if (canceled) {
+            return;
+        }
+        pending.buffer->Invalidate(pending.buffer_offset, pending.size);
+        for (const PendingImageDownload::Page& page : pending.pages) {
+            const auto it = pages.find(page.address);
+            if (it == pages.end() || it->second.generation != page.generation) {
+                continue;
+            }
+            const VAddr begin = std::max<VAddr>(pending.address, page.address);
+            const VAddr end = std::min<VAddr>(pending.address + pending.size,
+                                              page.address + PageSize(page.address));
+            Core::Memory::Instance()->TryWriteBacking(
+                std::bit_cast<u8*>(begin), pending.data + (begin - pending.address), end - begin);
+        }
+        Release(pending);
+    }
+
+    void Cancel() {
+        std::scoped_lock lock{mutex};
+        canceled = true;
+        for (const auto& [page, state] : pages) {
+            if (state.watched) {
+                page_manager->UpdatePageWatchers<false>(page, PageSize(page));
+            }
+        }
+        pages.clear();
+    }
+
+private:
+    struct PageState {
+        u64 generation{};
+        u32 readers{};
+        bool watched{};
+    };
+
+    static VAddr PageSize(VAddr page) {
+        return PageManager::GetNextPageAddr(page) - page;
+    }
+
+    template <typename Func>
+    static void ForEachPage(VAddr address, u64 size, Func&& func) {
+        const VAddr end = PageManager::GetNextPageAddr(address + size - 1);
+        for (VAddr page = PageManager::GetPageAddr(address); page < end; page += PageSize(page)) {
+            func(page);
+        }
+    }
+
+    void Release(const PendingImageDownload& pending) {
+        for (const PendingImageDownload::Page& page : pending.pages) {
+            const auto it = pages.find(page.address);
+            if (it == pages.end()) {
+                continue;
+            }
+            PageState& state = it->second;
+            ASSERT(state.readers > 0);
+            if (--state.readers != 0) {
+                continue;
+            }
+            if (state.watched) {
+                page_manager->UpdatePageWatchers<false>(page.address, PageSize(page.address));
+            }
+            pages.erase(it);
+        }
+    }
+
+    std::mutex mutex;
+    std::map<VAddr, PageState> pages;
+    PageManager* page_manager;
+    std::atomic<u32> active_downloads{};
+    bool canceled{};
+};
+
+[[nodiscard]] static u64 GetDownloadSize(const ImageInfo& info) {
+    return static_cast<u64>(info.pitch) * info.size.height * info.size.depth *
+           info.resources.layers * (info.num_bits / 8);
+}
+
+[[nodiscard]] static bool Covers(const Extent3D& extent, const ImageInfo& info) {
+    return extent.width == info.size.width && extent.height == info.size.height &&
+           extent.depth == info.size.depth;
+}
+
+[[nodiscard]] static bool CanAlias(const Image& lhs, const Image& rhs) {
+    return GetAliasCopyExtent(lhs.info, rhs.info) || GetAliasCopyExtent(rhs.info, lhs.info);
+}
+
+static void SetAliasIdentity(ImageId& dst_id, u64& dst_uid, ImageId src_id, u64 src_uid) {
+    dst_id = src_id;
+    dst_uid = src_uid;
+}
+
+template <typename Func>
+void TextureCache::ForEachAlias(const Image& image, Func&& func) {
+    const u64 page_index = image.info.guest_address >> Traits::PageBits;
+    const auto page = page_table.find(page_index);
+    if (page == nullptr) {
+        return;
+    }
+    for (const ImageId candidate_id : *page) {
+        Image& candidate = slot_images[candidate_id];
+        if (candidate.info.guest_address == image.info.guest_address &&
+            CanAlias(candidate, image)) {
+            func(candidate_id, candidate);
+        }
+    }
+}
+
 TextureCache::TextureCache(const Vulkan::Instance& instance_, Vulkan::Scheduler& scheduler_,
                            AmdGpu::Liverpool* liverpool_, BufferCache& buffer_cache_,
                            PageManager& tracker_)
     : instance{instance_}, scheduler{scheduler_}, liverpool{liverpool_},
-      buffer_cache{buffer_cache_}, tracker{tracker_}, blit_helper{instance, scheduler},
+      buffer_cache{buffer_cache_}, tracker{tracker_},
+      readback_tracker{std::make_shared<ReadbackTracker>(tracker)},
+      blit_helper{instance, scheduler},
       tile_manager{instance, scheduler, buffer_cache.GetUtilityBuffer(MemoryUsage::Stream)},
       readback_linear_images{EmulatorSettings.IsReadbackLinearImagesEnabled()} {
 
@@ -58,29 +246,277 @@ TextureCache::TextureCache(const Vulkan::Instance& instance_, Vulkan::Scheduler&
     trigger_gc_memory = static_cast<u64>((device_local_memory - mem_threshold) / 2);
 }
 
-TextureCache::~TextureCache() = default;
-
-void TextureCache::ProcessDownloadImages() {
-    std::unique_lock lk{download_images_mutex};
-    for (const ImageId image_id : download_images) {
-        DownloadImageMemory(image_id, true);
-    }
-    download_images.clear();
+TextureCache::~TextureCache() {
+    readback_tracker->Cancel();
 }
 
-void TextureCache::DownloadImageMemory(ImageId image_id, bool sync) {
+void TextureCache::UpdateImage(ImageId image_id) {
+    PrepareImageAccess(image_id, AliasAccess::Read);
+}
+
+void TextureCache::PrepareImageAccess(ImageId image_id, AliasAccess access, bool queue_download) {
+    std::scoped_lock lock{mutex};
+    UpdateImageImpl(image_id);
+    SynchronizeAlias(image_id);
+    if (access == AliasAccess::ReadWrite) {
+        PublishAliasWrite(image_id);
+    }
+    if (queue_download) {
+        download_images.emplace(image_id);
+    }
+}
+
+void TextureCache::UpdateImageImpl(ImageId image_id) {
     Image& image = slot_images[image_id];
-    if (False(image.flags & ImageFlagBits::GpuModified)) {
+    TrackImage(image_id);
+    TouchImage(image);
+    RefreshImage(image);
+}
+
+void TextureCache::ProcessDownloadImages() {
+    std::scoped_lock lock{mutex};
+    boost::container::small_vector<ImageId, 16> images;
+    images.reserve(download_images.size() + pending_alias_downloads.size());
+    const auto append = [this, &images](ImageId image_id) {
+        if (!image_id || !slot_images.is_allocated(image_id) ||
+            False(slot_images[image_id].flags & ImageFlagBits::GpuModified) ||
+            std::ranges::find(images, image_id) != images.end()) {
+            return;
+        }
+        images.push_back(image_id);
+    };
+    for (const ImageId image_id : download_images) {
+        append(image_id);
+    }
+    for (const VAddr address : pending_alias_downloads) {
+        auto state_it = alias_states.find(address);
+        if (state_it == alias_states.end()) {
+            continue;
+        }
+        AliasState& state = state_it.value();
+        if (!state.download) {
+            continue;
+        }
+        const ImageId download_id = state.download;
+        const u64 download_uid = state.download_uid;
+        SetAliasIdentity(state.download, state.download_uid, {}, 0);
+        if (!download_id || !slot_images.is_allocated(download_id)) {
+            continue;
+        }
+        const Image& image = slot_images[download_id];
+        if (image.image_uid == download_uid && image.info.guest_address == address &&
+            True(image.flags & ImageFlagBits::GpuModified)) {
+            append(download_id);
+        }
+    }
+    pending_alias_downloads.clear();
+    download_images.clear();
+
+    auto& download_buffer = buffer_cache.GetUtilityBuffer(MemoryUsage::Download);
+    const u64 buffer_size = download_buffer.SizeBytes();
+    size_t batch_begin = 0;
+    while (batch_begin < images.size()) {
+        u64 batch_size{};
+        size_t batch_end = batch_begin;
+        for (; batch_end < images.size(); ++batch_end) {
+            const u64 size = GetDownloadSize(slot_images[images[batch_end]].info);
+            ASSERT_MSG(size <= buffer_size, "Image download ({:#x}) exceeds stream buffer ({:#x})",
+                       size, buffer_size);
+            if (size > buffer_size ||
+                (batch_size != 0 && Common::AlignUp(batch_size, 16) + size > buffer_size)) {
+                break;
+            }
+            batch_size = Common::AlignUp(batch_size, 16) + size;
+        }
+        if (batch_end == batch_begin) {
+            ++batch_begin;
+            continue;
+        }
+
+        const auto [data, offset] = download_buffer.Map(batch_size, 16);
+        ASSERT(data != nullptr);
+        download_buffer.Commit();
+        boost::container::small_vector<PendingImageDownload, 16> pending;
+        pending.reserve(batch_end - batch_begin);
+        u64 subrange{};
+        for (size_t index = batch_begin; index < batch_end; ++index) {
+            subrange = Common::AlignUp(subrange, 16);
+            pending.push_back(ScheduleImageDownload(slot_images[images[index]], download_buffer,
+                                                    data + subrange, offset + subrange));
+            subrange += pending.back().size;
+        }
+        scheduler.Finish();
+        for (const PendingImageDownload& download : pending) {
+            readback_tracker->CompleteSync(download);
+        }
+        batch_begin = batch_end;
+    }
+}
+
+void TextureCache::SynchronizeAlias(ImageId image_id) {
+    Image& dst = slot_images[image_id];
+    if (False(dst.flags & ImageFlagBits::Aliased)) {
         return;
     }
-    auto& download_buffer = buffer_cache.GetUtilityBuffer(MemoryUsage::Download);
-    const u32 download_size = image.info.pitch * image.info.size.height * image.info.size.depth *
-                              image.info.resources.layers * (image.info.num_bits / 8);
+    auto state_it = alias_states.find(dst.info.guest_address);
+    if (state_it == alias_states.end()) {
+        return;
+    }
+    AliasState& state = state_it.value();
+    if (!IsLiveImage(state.backing, state.backing_uid)) {
+        if (!IsLiveImage(state.writer, state.writer_uid)) {
+            state.ResetAuthority();
+            return;
+        }
+        SetAliasIdentity(state.backing, state.backing_uid, state.writer, state.writer_uid);
+        SetAliasIdentity(state.writer, state.writer_uid, {}, 0);
+    }
+
+    if (state.writer == image_id && state.writer_uid == dst.image_uid) {
+        return;
+    }
+
+    if (!CommitAliasWriter(state)) {
+        state.ResetAuthority();
+        return;
+    }
+    Image& current = slot_images[state.backing];
+    const bool same_image = state.backing == image_id;
+    const bool up_to_date = current.alias_generation <= dst.alias_generation;
+    const std::optional copy_extent = GetAliasCopyExtent(current.info, dst.info);
+    if (same_image || up_to_date || !copy_extent) {
+        return;
+    }
+
+    CopyAlias(state.backing, image_id, *copy_extent);
+    dst.alias_generation = current.alias_generation;
+    dst.flags |= ImageFlagBits::GpuModified;
+    dst.flags &= ~ImageFlagBits::Dirty;
+    const std::optional reverse_extent = GetAliasCopyExtent(dst.info, current.info);
+    if (reverse_extent && Covers(*reverse_extent, current.info) &&
+        !Covers(*copy_extent, dst.info)) {
+        SetAliasIdentity(state.backing, state.backing_uid, image_id, dst.image_uid);
+    }
+}
+
+bool TextureCache::CommitAliasWriter(AliasState& state) {
+    if (!state.writer) {
+        return true;
+    }
+    if (!IsLiveImage(state.writer, state.writer_uid)) {
+        return false;
+    }
+    if (!IsLiveImage(state.backing, state.backing_uid)) {
+        return false;
+    }
+
+    Image& writer = slot_images[state.writer];
+    Image& backing = slot_images[state.backing];
+    if (state.writer != state.backing && writer.alias_generation > backing.alias_generation) {
+        const std::optional extent = GetAliasCopyExtent(writer.info, backing.info);
+        if (!extent) {
+            return false;
+        }
+        // Writable aliases are materialized from the backing before use, so copying their
+        // complete logical extent preserves backing contents outside the written region.
+        CopyAlias(state.writer, state.backing, *extent);
+        backing.alias_generation = writer.alias_generation;
+        backing.flags |= ImageFlagBits::GpuModified;
+        backing.flags &= ~ImageFlagBits::Dirty;
+    }
+    SetAliasIdentity(state.writer, state.writer_uid, {}, 0);
+    return true;
+}
+
+void TextureCache::CopyAlias(ImageId src_id, ImageId dst_id, const Extent3D& extent) {
+    Image& src = slot_images[src_id];
+    Image& dst = slot_images[dst_id];
+    scheduler.EndRendering();
+    auto barriers =
+        src.GetBarriers(vk::ImageLayout::eTransferSrcOptimal, vk::AccessFlagBits2::eTransferRead,
+                        vk::PipelineStageFlagBits2::eCopy, {});
+    const auto dst_barriers =
+        dst.GetBarriers(vk::ImageLayout::eTransferDstOptimal, vk::AccessFlagBits2::eTransferWrite,
+                        vk::PipelineStageFlagBits2::eCopy, {});
+    barriers.insert(barriers.end(), dst_barriers.begin(), dst_barriers.end());
+    const auto cmdbuf = scheduler.CommandBuffer();
+    if (!barriers.empty()) {
+        cmdbuf.pipelineBarrier2(vk::DependencyInfo{
+            .imageMemoryBarrierCount = static_cast<u32>(barriers.size()),
+            .pImageMemoryBarriers = barriers.data(),
+        });
+    }
+
+    const vk::ImageCopy region = {
+        .srcSubresource =
+            {
+                .aspectMask = vk::ImageAspectFlagBits::eColor,
+                .mipLevel = 0,
+                .baseArrayLayer = 0,
+                .layerCount = std::min(src.info.resources.layers, dst.info.resources.layers),
+            },
+        .srcOffset = {0, 0, 0},
+        .dstSubresource =
+            {
+                .aspectMask = vk::ImageAspectFlagBits::eColor,
+                .mipLevel = 0,
+                .baseArrayLayer = 0,
+                .layerCount = std::min(src.info.resources.layers, dst.info.resources.layers),
+            },
+        .dstOffset = {0, 0, 0},
+        .extent = {extent.width, extent.height, extent.depth},
+    };
+    cmdbuf.copyImage(src.GetImage(), vk::ImageLayout::eTransferSrcOptimal, dst.GetImage(),
+                     vk::ImageLayout::eTransferDstOptimal, region);
+}
+
+void TextureCache::PublishAliasWrite(ImageId image_id) {
+    Image& image = slot_images[image_id];
+    image.flags |= ImageFlagBits::GpuModified;
+    readback_tracker->Invalidate(image.info.guest_address, image.info.guest_size);
+    image.alias_generation = ++alias_generation;
+    if (False(image.flags & ImageFlagBits::Aliased)) {
+        return;
+    }
+
+    AliasState& state = alias_states[image.info.guest_address];
+    if (IsLiveImage(state.backing, state.backing_uid)) {
+        const Image& backing = slot_images[state.backing];
+        if (!CanAlias(image, backing)) {
+            state.ResetAuthority();
+        }
+    }
+    state.members = std::max(state.members, 2u);
+    const bool continuing_write = state.writer == image_id && state.writer_uid == image.image_uid;
+    if (!state.backing) {
+        SetAliasIdentity(state.backing, state.backing_uid, image_id, image.image_uid);
+    } else if (!continuing_write && IsLiveImage(state.backing, state.backing_uid)) {
+        const Image& backing = slot_images[state.backing];
+        const std::optional extent = GetAliasCopyExtent(image.info, backing.info);
+        if (extent && Covers(*extent, backing.info)) {
+            SetAliasIdentity(state.backing, state.backing_uid, image_id, image.image_uid);
+        } else {
+            SetAliasIdentity(state.writer, state.writer_uid, image_id, image.image_uid);
+        }
+    } else if (!continuing_write) {
+        SetAliasIdentity(state.backing, state.backing_uid, image_id, image.image_uid);
+    }
+
+    const u64 download_size = GetDownloadSize(image.info);
+    const bool needs_download = state.members > 1 && download_size <= TRACKER_BYTES_PER_PAGE;
+    if (needs_download && !state.download) {
+        pending_alias_downloads.push_back(image.info.guest_address);
+    }
+    SetAliasIdentity(state.download, state.download_uid, needs_download ? image_id : ImageId{},
+                     needs_download ? image.image_uid : 0);
+}
+
+PendingImageDownload TextureCache::ScheduleImageDownload(Image& image, Buffer& buffer, u8* data,
+                                                         u64 buffer_offset) {
+    const u64 download_size = GetDownloadSize(image.info);
     ASSERT(download_size <= image.info.guest_size);
-    const auto [download, offset] = download_buffer.Map(download_size);
-    download_buffer.Commit();
     const vk::BufferImageCopy image_download = {
-        .bufferOffset = offset,
+        .bufferOffset = buffer_offset,
         .bufferRowLength = image.info.pitch,
         .bufferImageHeight = image.info.size.height,
         .imageSubresource =
@@ -95,22 +531,33 @@ void TextureCache::DownloadImageMemory(ImageId image_id, bool sync) {
         .imageExtent = {image.info.size.width, image.info.size.height, image.info.size.depth},
     };
     scheduler.EndRendering();
-    const auto cmdbuf = scheduler.CommandBuffer();
     image.Transit(vk::ImageLayout::eTransferSrcOptimal, vk::AccessFlagBits2::eTransferRead, {});
-    cmdbuf.copyImageToBuffer(image.GetImage(), vk::ImageLayout::eTransferSrcOptimal,
-                             download_buffer.Handle(), image_download);
+    scheduler.CommandBuffer().copyImageToBuffer(
+        image.GetImage(), vk::ImageLayout::eTransferSrcOptimal, buffer.Handle(), image_download);
+    return {
+        .address = image.info.guest_address,
+        .data = data,
+        .buffer = &buffer,
+        .buffer_offset = buffer_offset,
+        .size = download_size,
+    };
+}
 
-    if (sync) {
-        scheduler.Finish();
-        Core::Memory::Instance()->TryWriteBacking(std::bit_cast<u8*>(image.info.guest_address),
-                                                  download, download_size);
-    } else {
-        scheduler.DeferPriorityOperation(
-            [this, device_addr = image.info.guest_address, download, download_size] {
-                Core::Memory::Instance()->TryWriteBacking(std::bit_cast<u8*>(device_addr), download,
-                                                          download_size);
-            });
+void TextureCache::DownloadImageMemory(ImageId image_id) {
+    Image& image = slot_images[image_id];
+    if (False(image.flags & ImageFlagBits::GpuModified)) {
+        return;
     }
+    const u64 download_size = GetDownloadSize(image.info);
+    auto buffer = std::make_unique<Buffer>(instance, scheduler, MemoryUsage::Download, 0, AllFlags,
+                                           download_size);
+    PendingImageDownload pending =
+        ScheduleImageDownload(image, *buffer, buffer->mapped_data.data(), 0);
+    pending.async_buffer = std::move(buffer);
+    readback_tracker->TrackAsync(pending);
+    scheduler.DeferPriorityOperation([tracker = readback_tracker, pending = std::move(pending)] {
+        tracker->CompleteAsync(pending);
+    });
 }
 
 void TextureCache::MarkAsMaybeDirty(ImageId image_id, Image& image) {
@@ -123,8 +570,21 @@ void TextureCache::MarkAsMaybeDirty(ImageId image_id, Image& image) {
     UntrackImage(image_id);
 }
 
+void TextureCache::InvalidateAlias(Image& image) {
+    if (False(image.flags & ImageFlagBits::Aliased)) {
+        image.alias_generation = 0;
+        return;
+    }
+    if (auto state_it = alias_states.find(image.info.guest_address);
+        state_it != alias_states.end()) {
+        state_it.value().ResetAuthority();
+    }
+    image.alias_generation = 0;
+}
+
 void TextureCache::InvalidateMemory(VAddr addr, size_t size) {
     std::scoped_lock lock{mutex};
+    readback_tracker->Invalidate(addr, size);
     const auto pages_start = PageManager::GetPageAddr(addr);
     const auto pages_end = PageManager::GetNextPageAddr(addr + size - 1);
     ForEachImageInRegion(pages_start, pages_end - pages_start, [&](ImageId image_id, Image& image) {
@@ -133,6 +593,7 @@ void TextureCache::InvalidateMemory(VAddr addr, size_t size) {
         if (image.Overlaps(addr, size)) {
             // Modified region overlaps image, so the image was definitely accessed by this fault.
             // Untrack the image, so that the range is unprotected and the guest can write freely.
+            InvalidateAlias(image);
             image.flags |= ImageFlagBits::CpuDirty;
             UntrackImage(image_id);
         } else if (pages_end < image_end) {
@@ -156,6 +617,7 @@ void TextureCache::InvalidateMemory(VAddr addr, size_t size) {
 
 void TextureCache::InvalidateMemoryFromGPU(VAddr address, size_t max_size) {
     std::scoped_lock lock{mutex};
+    readback_tracker->Invalidate(address, max_size);
     ForEachImageInRegion(address, max_size, [&](ImageId image_id, Image& image) {
         // Only consider images that match base address.
         // TODO: Maybe also consider subresources
@@ -163,12 +625,14 @@ void TextureCache::InvalidateMemoryFromGPU(VAddr address, size_t max_size) {
             return;
         }
         // Ensure image is reuploaded when accessed again.
+        InvalidateAlias(image);
         image.flags |= ImageFlagBits::GpuDirty;
     });
 }
 
 void TextureCache::UnmapMemory(VAddr cpu_addr, size_t size) {
     std::scoped_lock lk{mutex};
+    readback_tracker->Invalidate(cpu_addr, size);
 
     ImageIds deleted_images;
     ForEachImageInRegion(cpu_addr, size, [&](ImageId id, Image&) { deleted_images.push_back(id); });
@@ -620,27 +1084,21 @@ ImageId TextureCache::FindImageFromRange(VAddr address, size_t size, bool ensure
 
 ImageView& TextureCache::FindTexture(ImageId image_id, const ImageDesc& desc) {
     Image& image = slot_images[image_id];
-    if (desc.type == BindingType::Storage) {
-        image.flags |= ImageFlagBits::GpuModified;
-        if (readback_linear_images && (!image.info.props.is_tiled || image.info.size.width <= 8) &&
-            image.info.guest_address != 0) {
-            std::unique_lock lk{download_images_mutex};
-            download_images.emplace(image_id);
-        }
-    }
-    UpdateImage(image_id);
+    const bool is_storage = desc.type == BindingType::Storage;
+    const bool queue_download = is_storage && readback_linear_images &&
+                                (!image.info.props.is_tiled || image.info.size.width <= 8) &&
+                                image.info.guest_address != 0;
+    PrepareImageAccess(image_id, is_storage ? AliasAccess::ReadWrite : AliasAccess::Read,
+                       queue_download);
     return image.FindView(desc.view_info);
 }
 
 ImageView& TextureCache::FindRenderTarget(ImageId image_id, const ImageDesc& desc) {
     Image& image = slot_images[image_id];
-    image.flags |= ImageFlagBits::GpuModified;
-    if (readback_linear_images && (!image.info.props.is_tiled || image.info.size.width <= 8)) {
-        std::unique_lock lk{download_images_mutex};
-        download_images.emplace(image_id);
-    }
+    const bool queue_download =
+        readback_linear_images && (!image.info.props.is_tiled || image.info.size.width <= 8);
     image.usage.render_target = 1u;
-    UpdateImage(image_id);
+    PrepareImageAccess(image_id, AliasAccess::ReadWrite, queue_download);
 
     // Register meta data for this color buffer
     if (desc.info.meta_info.cmask_addr) {
@@ -660,9 +1118,10 @@ ImageView& TextureCache::FindRenderTarget(ImageId image_id, const ImageDesc& des
 
 ImageView& TextureCache::FindDepthTarget(ImageId image_id, const ImageDesc& desc) {
     Image& image = slot_images[image_id];
-    image.flags |= ImageFlagBits::GpuModified;
     image.usage.depth_target = 1u;
     UpdateImage(image_id);
+    readback_tracker->Invalidate(image.info.guest_address, image.info.guest_size);
+    image.flags |= ImageFlagBits::GpuModified;
 
     // Register meta data for this depth buffer
     if (desc.info.meta_info.htile_addr) {
@@ -815,6 +1274,28 @@ void TextureCache::RegisterImage(ImageId image_id) {
     image.flags |= ImageFlagBits::Registered;
     total_used_memory += Common::AlignUp(image.info.guest_size, 1024);
     image.lru_id = lru_cache.Insert(image_id, gc_tick);
+
+    AliasState* state{};
+    bool inserted{};
+    u32 aliases{};
+    ForEachAlias(image, [&](ImageId candidate_id, Image& candidate) {
+        if (!state) {
+            auto result = alias_states.try_emplace(image.info.guest_address);
+            state = std::addressof(result.first.value());
+            inserted = result.second;
+        }
+        ++aliases;
+        candidate.flags |= ImageFlagBits::Aliased;
+        if (!IsLiveImage(state->backing, state->backing_uid) ||
+            slot_images[state->backing].alias_generation < candidate.alias_generation) {
+            SetAliasIdentity(state->backing, state->backing_uid, candidate_id, candidate.image_uid);
+        }
+    });
+    if (state) {
+        image.flags |= ImageFlagBits::Aliased;
+        state->members = inserted ? aliases + 1 : state->members + 1;
+    }
+
     ForEachPage(image.info.guest_address, image.info.guest_size,
                 [this, image_id](u64 page) { page_table[page].push_back(image_id); });
 }
@@ -1072,6 +1553,62 @@ void TextureCache::DeleteImage(ImageId image_id) {
     ASSERT_MSG(!image.IsTracked(), "Image was not untracked");
     ASSERT_MSG(False(image.flags & ImageFlagBits::Registered), "Image was not unregistered");
 
+    const auto alias_it = True(image.flags & ImageFlagBits::Aliased)
+                              ? alias_states.find(image.info.guest_address)
+                              : alias_states.end();
+    if (alias_it != alias_states.end()) {
+        AliasState& state = alias_it.value();
+        bool state_valid = true;
+        if (state.download == image_id && state.download_uid == image.image_uid) {
+            SetAliasIdentity(state.download, state.download_uid, {}, 0);
+        }
+
+        const bool owns_authority =
+            (state.writer == image_id && state.writer_uid == image.image_uid) ||
+            (state.backing == image_id && state.backing_uid == image.image_uid);
+        if (owns_authority) {
+            state_valid = CommitAliasWriter(state);
+        }
+        if (!state_valid) {
+            state.ResetAuthority();
+        } else if (state.backing == image_id && state.backing_uid == image.image_uid) {
+            ImageId replacement{};
+            ForEachAlias(image, [&](ImageId candidate_id, Image& candidate) {
+                if (replacement) {
+                    return;
+                }
+                const std::optional to_backing = GetAliasCopyExtent(candidate.info, image.info);
+                const std::optional to_candidate = GetAliasCopyExtent(image.info, candidate.info);
+                if (to_backing && to_candidate && Covers(*to_backing, image.info) &&
+                    Covers(*to_candidate, candidate.info)) {
+                    replacement = candidate_id;
+                }
+            });
+            if (replacement) {
+                Image& candidate = slot_images[replacement];
+                if (candidate.alias_generation < image.alias_generation) {
+                    CopyAlias(image_id, replacement, candidate.info.size);
+                    candidate.alias_generation = image.alias_generation;
+                    candidate.flags |= ImageFlagBits::GpuModified;
+                    candidate.flags &= ~ImageFlagBits::Dirty;
+                }
+                SetAliasIdentity(state.backing, state.backing_uid, replacement,
+                                 candidate.image_uid);
+            } else {
+                state.ResetAuthority();
+            }
+        } else if (!IsLiveImage(state.backing, state.backing_uid)) {
+            state.ResetAuthority();
+        }
+        ASSERT(state.members > 1);
+        if (--state.members == 1) {
+            ForEachAlias(image, [](ImageId, Image& candidate) {
+                candidate.flags &= ~ImageFlagBits::Aliased;
+            });
+            alias_states.erase(alias_it);
+        }
+    }
+
     // Remove any registered meta areas.
     const auto& meta_info = image.info.meta_info;
     if (meta_info.cmask_addr) {
@@ -1084,12 +1621,7 @@ void TextureCache::DeleteImage(ImageId image_id) {
         surface_metas.erase(meta_info.htile_addr);
     }
 
-    {
-        std::unique_lock lk{download_images_mutex};
-        if (download_images.contains(image_id)) {
-            download_images.erase(image_id);
-        }
-    }
+    download_images.erase(image_id);
 
     // Reclaim image and any image views it references.
     scheduler.DeferOperation([this, image_id] {

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -3,12 +3,10 @@
 
 #pragma once
 
-#include <condition_variable>
+#include <memory>
 #include <mutex>
-#include <thread>
 #include <unordered_set>
 #include <boost/container/small_vector.hpp>
-#include <queue>
 #include <tsl/robin_map.h>
 
 #include "common/lru_cache.h"
@@ -28,7 +26,10 @@ struct Liverpool;
 namespace VideoCore {
 
 class BufferCache;
+class Buffer;
 class PageManager;
+class ReadbackTracker;
+struct PendingImageDownload;
 
 class TextureCache {
     // Default values for garbage collection
@@ -112,13 +113,7 @@ public:
     [[nodiscard]] ImageView& FindDepthTarget(ImageId image_id, const ImageDesc& desc);
 
     /// Updates image contents if it was modified by CPU.
-    void UpdateImage(ImageId image_id) {
-        std::scoped_lock lock{mutex};
-        Image& image = slot_images[image_id];
-        TrackImage(image_id);
-        TouchImage(image);
-        RefreshImage(image);
-    }
+    void UpdateImage(ImageId image_id);
 
     /// Resolves overlap between existing cache image and pending merged image
     [[nodiscard]] std::tuple<ImageId, int, int> ResolveOverlap(const ImageInfo& info,
@@ -252,6 +247,15 @@ public:
     }
 
 private:
+    struct AliasState;
+    enum class AliasAccess {
+        Read,
+        ReadWrite,
+    };
+
+    void PrepareImageAccess(ImageId image_id, AliasAccess access, bool queue_download = false);
+    void UpdateImageImpl(ImageId image_id);
+
     /// Iterate over all page indices in a range
     template <typename Func>
     static void ForEachPage(PAddr addr, size_t size, Func&& func) {
@@ -268,11 +272,9 @@ private:
         }
     }
 
-    /// Copies image memory back to CPU.
-    void DownloadImageMemory(ImageId image_id, bool sync = false);
-
-    /// Thread function for copying downloaded images out to CPU memory.
-    void DownloadedImagesThread(const std::stop_token& token);
+    [[nodiscard]] PendingImageDownload ScheduleImageDownload(Image& image, Buffer& buffer, u8* data,
+                                                             u64 buffer_offset);
+    void DownloadImageMemory(ImageId image_id);
 
     /// Create an image from the given parameters
     [[nodiscard]] ImageId InsertImage(const ImageInfo& info, VAddr cpu_addr);
@@ -295,6 +297,24 @@ private:
 
     void MarkAsMaybeDirty(ImageId image_id, Image& image);
 
+    void InvalidateAlias(Image& image);
+
+    void SynchronizeAlias(ImageId image_id);
+
+    [[nodiscard]] bool CommitAliasWriter(AliasState& state);
+
+    void CopyAlias(ImageId src_id, ImageId dst_id, const Extent3D& extent);
+
+    void PublishAliasWrite(ImageId image_id);
+
+    template <typename Func>
+    void ForEachAlias(const Image& image, Func&& func);
+
+    [[nodiscard]] bool IsLiveImage(ImageId image_id, u64 image_uid) const {
+        return image_id && slot_images.is_allocated(image_id) &&
+               slot_images[image_id].image_uid == image_uid;
+    }
+
     /// Removes the image and any views/surface metas that reference it.
     void DeleteImage(ImageId image_id);
 
@@ -316,12 +336,32 @@ private:
     AmdGpu::Liverpool* liverpool;
     BufferCache& buffer_cache;
     PageManager& tracker;
+    std::shared_ptr<ReadbackTracker> readback_tracker;
     BlitHelper blit_helper;
     TileManager tile_manager;
     Common::SlotVector<Image> slot_images;
     Common::SlotVector<ImageView> slot_image_views;
     tsl::robin_map<u64, Sampler> samplers;
     std::unordered_set<ImageId> download_images;
+    struct AliasState {
+        // Backing contains the complete shared-memory view; writer is an uncommitted write.
+        u64 backing_uid{};
+        u64 writer_uid{};
+        u64 download_uid{};
+        ImageId backing{};
+        ImageId writer{};
+        ImageId download{};
+        u32 members{};
+
+        void ResetAuthority() {
+            const u32 member_count = members;
+            *this = {};
+            members = member_count;
+        }
+    };
+    tsl::robin_map<VAddr, AliasState> alias_states;
+    boost::container::small_vector<VAddr, 4> pending_alias_downloads;
+    u64 alias_generation{};
     u64 total_used_memory = 0;
     u64 trigger_gc_memory = 0;
     u64 pressure_gc_memory = 0;
@@ -337,7 +377,6 @@ private:
     PageTable page_table;
     std::mutex mutex;
     std::mutex samplers_mutex;
-    std::mutex download_images_mutex;
     struct MetaDataInfo {
         enum class Type {
             CMask,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TEST_TARGETS
     shadps4_settings_test
     shadps4_ngs2_test
     shadps4_gcn_test
+    shadps4_aliasing_test
 )
 
 set(SETTINGS_TEST_SOURCES
@@ -59,6 +60,11 @@ set(NGS2_TEST_SOURCES
 
     # Tests
     test_ngs2.cpp
+)
+set(ALIASING_TEST_SOURCES
+    ${CMAKE_SOURCE_DIR}/src/video_core/texture_cache/aliasing.cpp
+    ${CMAKE_SOURCE_DIR}/src/video_core/texture_cache/host_compatibility.cpp
+    test_aliasing.cpp
 )
 set(GCN_TEST_SOURCES
     # Under test
@@ -158,6 +164,7 @@ set(GCN_TEST_SOURCES
 add_executable(shadps4_settings_test ${SETTINGS_TEST_SOURCES})
 add_executable(shadps4_ngs2_test ${NGS2_TEST_SOURCES})
 add_executable(shadps4_gcn_test ${GCN_TEST_SOURCES})
+add_executable(shadps4_aliasing_test ${ALIASING_TEST_SOURCES})
 
 foreach(t ${TEST_TARGETS})
     target_include_directories(${t} PRIVATE
@@ -196,6 +203,11 @@ target_link_libraries(shadps4_gcn_test PRIVATE
     SDL3::SDL3
     spdlog::spdlog
     half::half
+)
+target_link_libraries(shadps4_aliasing_test PRIVATE
+    GTest::gtest_main
+    Vulkan::Headers
+    spdlog::spdlog
 )
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR

--- a/tests/test_aliasing.cpp
+++ b/tests/test_aliasing.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <gtest/gtest.h>
+#include <vulkan/vulkan.hpp>
+
+#include "video_core/amdgpu/resource.h"
+#include "video_core/texture_cache/aliasing.h"
+#include "video_core/texture_cache/image_info.h"
+#include "video_core/texture_cache/types.h"
+
+namespace VideoCore {
+namespace {
+
+ImageInfo MakeImageInfo(Extent3D size, vk::Format format = vk::Format::eR8G8B8A8Unorm) {
+    ImageInfo info{};
+    info.guest_address = 0x100000;
+    info.num_bits = 32;
+    info.pixel_format = format;
+    info.type = AmdGpu::ImageType::Color2D;
+    info.pitch = size.width;
+    info.size = size;
+    return info;
+}
+
+TEST(AliasingTest, CopiesCoveredImageWithIdenticalFormat) {
+    const ImageInfo src = MakeImageInfo({1920, 1088, 1});
+    const ImageInfo dst = MakeImageInfo({1920, 1080, 1});
+
+    EXPECT_EQ(GetAliasCopyExtent(src, dst), dst.size);
+    EXPECT_EQ(GetAliasCopyExtent(dst, src), dst.size);
+}
+
+TEST(AliasingTest, CopiesIntersectionBetweenCompatibleViews) {
+    const ImageInfo src = MakeImageInfo({1920, 1088, 1}, vk::Format::eR8G8B8A8Uint);
+    const ImageInfo dst = MakeImageInfo({1920, 1080, 1}, vk::Format::eR8G8B8A8Unorm);
+
+    const Extent3D intersection{1920, 1080, 1};
+    EXPECT_EQ(GetAliasCopyExtent(src, dst), intersection);
+    EXPECT_EQ(GetAliasCopyExtent(dst, src), intersection);
+}
+
+TEST(AliasingTest, RejectsDifferentMemoryLayouts) {
+    const ImageInfo src = MakeImageInfo({1920, 1088, 1});
+    ImageInfo dst = MakeImageInfo({1920, 1080, 1});
+
+    dst.guest_address += 0x1000;
+    EXPECT_FALSE(GetAliasCopyExtent(src, dst).has_value());
+
+    dst = MakeImageInfo({1920, 1080, 1});
+    ++dst.pitch;
+    EXPECT_FALSE(GetAliasCopyExtent(src, dst).has_value());
+
+    dst = MakeImageInfo({1920, 1080, 1});
+    dst.props.is_depth = true;
+    EXPECT_FALSE(GetAliasCopyExtent(src, dst).has_value());
+}
+
+TEST(AliasingTest, RejectsIncompatibleIntersectionCopies) {
+    const ImageInfo src = MakeImageInfo({1920, 1088, 1}, vk::Format::eR8G8B8A8Uint);
+    ImageInfo dst = MakeImageInfo({1280, 1080, 1}, vk::Format::eR8G8B8A8Unorm);
+    EXPECT_FALSE(GetAliasCopyExtent(src, dst).has_value());
+
+    dst = MakeImageInfo({1920, 1080, 1}, vk::Format::eR16G16B16A16Sfloat);
+    EXPECT_FALSE(GetAliasCopyExtent(src, dst).has_value());
+
+    dst = MakeImageInfo({1920, 1080, 1}, vk::Format::eR8G8B8A8Unorm);
+    dst.resources.levels = 2;
+    EXPECT_FALSE(GetAliasCopyExtent(src, dst).has_value());
+}
+
+} // namespace
+} // namespace VideoCore


### PR DESCRIPTION
## Problem

PS4 applications can bind the same guest surface memory through image descriptions with different extents or Vulkan-compatible formats. The texture cache represented these bindings as independent host images, so writes performed through one alias were not consistently visible through the others. Asynchronous readbacks could also overwrite newer guest writes with stale GPU data. This caused missing post-processing effects, stale render-target contents, and incorrect composition in titles such as God of War III Remastered.

## Fix

Track compatible images sharing the same guest address as a coherent alias group with an authoritative backing image, pending writer, and generation counters. Synchronize contents through explicit Vulkan image copies and barriers, supporting both complete coverage and compatible partial intersections. Track asynchronous readback pages by generation so invalidated guest pages are not overwritten, and invalidate non-coherent download allocations before host reads. Alias copy compatibility is isolated as a pure operation shared by the runtime and offline tests.

## Testing

Fixes God of War III Remastered's hidden chest effects and hyper-exposure bug.

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/2f11a96c-b6c9-4728-a2cd-e97f15cb0434" />
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/ca7ce135-d661-4c20-bd9d-d8a8a467f819" />
<img width="1919" height="1079" alt="before3" src="https://github.com/user-attachments/assets/93d7b492-0be8-41ea-9d9b-8ca643e23bd1" />
<img width="1919" height="1079" alt="after3" src="https://github.com/user-attachments/assets/e5c2c405-e862-4da1-859d-00d37afd5326" />

