### PR TITLE
avplayer: lock state while starting

### DIFF
--- a/src/core/libraries/avplayer/avplayer_state.cpp
+++ b/src/core/libraries/avplayer/avplayer_state.cpp
@@ -175,7 +175,7 @@ bool AvPlayerState::GetStreamInfo(u32 stream_index, AvPlayerStreamInfo& info) {
 
 // Called inside GAME thread
 bool AvPlayerState::Start() {
-    std::shared_lock lock(m_source_mutex);
+    std::unique_lock lock(m_source_mutex);
     if (m_current_state == AvState::Ready || m_current_state == AvState::Stop || Stop()) {
         m_eof_stop_event_sent = false;
         SetState(AvState::Starting);


### PR DESCRIPTION
Fixes a regression in GRIS. That game sets the video on pause when `IsActive` returns `true` for the first time. If we don't make this state transition atomic the game can attempt to `Pause` in `Starting` state which is an invalid operation. This was unearthed by the Abstract Filesystem PR because apparently it makes the starting slower.