### PR TITLE
Clamp scissor extent to zero for inverted rects

### DIFF
--- a/src/video_core/amdgpu/regs_primitive.h
+++ b/src/video_core/amdgpu/regs_primitive.h
@@ -150,11 +150,11 @@ struct Scissor {
     }
 
     u32 GetWidth() const {
-        return static_cast<u32>(Clamp(bottom_right_x) - Clamp(top_left_x));
+        return static_cast<u32>(std::max(0, Clamp(bottom_right_x) - Clamp(top_left_x)));
     }
 
     u32 GetHeight() const {
-        return static_cast<u32>(Clamp(bottom_right_y) - Clamp(top_left_y));
+        return static_cast<u32>(std::max(0, Clamp(bottom_right_y) - Clamp(top_left_y)));
     }
 };
 


### PR DESCRIPTION
Fixup for 
```
[Render.Vulkan] <Error> (shadPS4:GpuCommandProcessor) vk_platform.cpp:57 DebugUtilsCallback: VUID-vkCmdSetScissorWithCount-offset-03400: vkCmdSetScissorWithCount(): pScissors[0] offset.x (30042) + extent.width (4294939174) is 4294969216 which will overflow int32_t.
The Vulkan spec states: Evaluation of (offset.x + extent.width) must not cause a signed integer addition overflow for any element of pScissors (https://docs.vulkan.org/spec/latest/chapters/vertexpostproc.html#VUID-vkCmdSetScissorWithCount-offset-03400)
[Render.Vulkan] <Error> (shadPS4:GpuCommandProcessor) vk_platform.cpp:57 DebugUtilsCallback: VUID-vkCmdSetScissorWithCount-offset-03401: vkCmdSetScissorWithCount(): pScissors[0] offset.y (32415) + extent.height (4294935961) is 4294968376 which will overflow int32_t.
The Vulkan spec states: Evaluation of (offset.y + extent.height) must not cause a signed integer addition overflow for any element of pScissors (https://docs.vulkan.org/spec/latest/chapters/vertexpostproc.html#VUID-vkCmdSetScissorWithCount-offset-03401)
```