### PR TITLE
videodec: Flush codec buffers on packet EOF

### DIFF
--- a/src/core/libraries/videodec/videodec2_impl.cpp
+++ b/src/core/libraries/videodec/videodec2_impl.cpp
@@ -70,9 +70,16 @@ s32 VdecDecoder::Decode(const OrbisVideodec2InputData& inputData,
 
     int ret = avcodec_send_packet(mCodecContext, packet);
     if (ret < 0) {
-        LOG_ERROR(Lib_Vdec2, "Error sending packet to decoder: {}", ret);
-        av_packet_free(&packet);
-        return ORBIS_VIDEODEC2_ERROR_API_FAIL;
+        if (ret == AVERROR_EOF) {
+            // Attempt to flush buffers and try again.
+            avcodec_flush_buffers(mCodecContext);
+            ret = avcodec_send_packet(mCodecContext, packet);
+        }
+        if (ret < 0) {
+            LOG_ERROR(Lib_Vdec2, "Error sending packet to decoder: {}", ret);
+            av_packet_free(&packet);
+            return ORBIS_VIDEODEC2_ERROR_API_FAIL;
+        }
     }
 
     AVFrame* frame = av_frame_alloc();

--- a/src/core/libraries/videodec/videodec_impl.cpp
+++ b/src/core/libraries/videodec/videodec_impl.cpp
@@ -57,9 +57,16 @@ s32 VdecDecoder::Decode(const OrbisVideodecInputData& pInputDataIn,
 
     int ret = avcodec_send_packet(mCodecContext, packet);
     if (ret < 0) {
-        LOG_ERROR(Lib_Videodec, "Error sending packet to decoder: {}", ret);
-        av_packet_free(&packet);
-        return ORBIS_VIDEODEC_ERROR_API_FAIL;
+        if (ret == AVERROR_EOF) {
+            // Attempt to flush buffers and try again.
+            avcodec_flush_buffers(mCodecContext);
+            ret = avcodec_send_packet(mCodecContext, packet);
+        }
+        if (ret < 0) {
+            LOG_ERROR(Lib_Videodec, "Error sending packet to decoder: {}", ret);
+            av_packet_free(&packet);
+            return ORBIS_VIDEODEC_ERROR_API_FAIL;
+        }
     }
 
     AVFrame* frame = av_frame_alloc();


### PR DESCRIPTION
After sending a null packet to flush the codec, FFmpeg will return an EOF error until buffers are flushed. Handle subsequent decode calls by the game by flushing and retrying packet send on EOF.

Fixes video playback in Hatsune Miku: Project Diva X.

Thanks @roamic for helping debug this.