### PR TITLE
imgui: only redraw for visible content to fix external fps counters

### DIFF
--- a/src/core/devtools/layer.cpp
+++ b/src/core/devtools/layer.cpp
@@ -373,6 +373,10 @@ void L::SetupSettings() {
     DockBuilderFinish(dock_id);
 }
 
+bool L::ShouldKeepDrawing() {
+    return DebugState.IsShowingDebugMenuBar();
+}
+
 void L::Draw() {
     const auto io = GetIO();
     PushID("DevtoolsLayer");

--- a/src/core/devtools/layer.h
+++ b/src/core/devtools/layer.h
@@ -13,6 +13,7 @@ public:
     static void SetupSettings();
 
     void Draw() override;
+    bool ShouldKeepDrawing() override;
 
     // Must be inside a window
     static void DrawNullGpuNotice();

--- a/src/imgui/friends_layer.cpp
+++ b/src/imgui/friends_layer.cpp
@@ -22,6 +22,9 @@ char g_add_buf[64] = {};
 class FriendsLayer final : public ImGui::Layer {
 public:
     void Draw() override;
+    bool ShouldKeepDrawing() override {
+        return g_open;
+    }
 };
 
 FriendsLayer g_layer;

--- a/src/imgui/imgui_layer.h
+++ b/src/imgui/imgui_layer.h
@@ -12,6 +12,9 @@ public:
     static void RemoveLayer(Layer* layer);
 
     virtual void Draw() = 0;
+    virtual bool ShouldKeepDrawing() {
+        return true;
+    }
 };
 
 } // namespace ImGui

--- a/src/imgui/invitation_prompt_layer.cpp
+++ b/src/imgui/invitation_prompt_layer.cpp
@@ -47,6 +47,10 @@ float g_back_held_secs = 0.0f;
 class InvitationPromptUI final : public ImGui::Layer {
 public:
     void Draw() override;
+    bool ShouldKeepDrawing() override {
+        std::lock_guard lock(g_mutex);
+        return !g_prompts.empty();
+    }
 };
 
 InvitationPromptUI g_layer;

--- a/src/imgui/renderer/imgui_core.cpp
+++ b/src/imgui/renderer/imgui_core.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2024-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <algorithm>
 #include <atomic>
 #include <cstdint>
 #include <SDL3/SDL_events.h>
@@ -284,7 +285,8 @@ void Render(const vk::CommandBuffer& cmdbuf, const vk::ImageView& image_view,
 }
 
 bool MustKeepDrawing() {
-    return layers.size() > 1 || change_layers.size() > 1 || DebugState.IsShowingDebugMenuBar();
+    return std::ranges::any_of(layers, [](Layer* layer) { return layer->ShouldKeepDrawing(); }) ||
+           change_layers.size() > 1;
 }
 
 } // namespace Core

--- a/src/imgui/shadnet_notifications_layer.cpp
+++ b/src/imgui/shadnet_notifications_layer.cpp
@@ -52,6 +52,10 @@ std::string NowHMS() {
 class ShadNetNotificationsUI final : public ImGui::Layer {
 public:
     void Draw() override;
+    bool ShouldKeepDrawing() override {
+        std::lock_guard lock(g_mutex);
+        return !g_toasts.empty();
+    }
 };
 
 ShadNetNotificationsUI g_layer;


### PR DESCRIPTION
Fixes external fps counters showing inflated fps numbers due to broken visibility checks for the three new layers added in PR #4607. Basically the three new always-registered layers lacked side clauses unlike the Devtool layer, resulting in no visibility checks so registration == permanent visibility. Added ShouldKeepDrawing() overrides to fix this. Credit to DuskyRed for pointing out these three lines were causing the issue:
```
ImGui::Friends::Register();
ImGui::ShadNetNotify::Register();
ImGui::InvitationPrompt::Register();
```
Anyway, I just found it annoying to press f10 every time and close rivatuner