### PR TITLE
devtools: draw calls and dispatch frame info

### DIFF
--- a/src/core/debug_state.h
+++ b/src/core/debug_state.h
@@ -144,6 +144,12 @@ class DebugStateImpl {
 
     std::atomic_int32_t flip_frame_count = 0;
     std::atomic_int32_t gnm_frame_count = 0;
+    // Counted during the frame, then folded into a running average when the frame flips. The raw
+    // per frame count changes too fast to read while playing, so only the average is shown.
+    std::atomic_int32_t draw_call_count = 0;
+    std::atomic<float> draw_call_count_avg = 0.0f;
+    std::atomic_int32_t dispatch_count = 0;
+    std::atomic<float> dispatch_count_avg = 0.0f;
 
     s32 gnm_frame_dump_request_count = -1;
     std::unordered_map<size_t, FrameDump*> waiting_reg_dumps;
@@ -188,7 +194,34 @@ public:
     }
 
     void IncFlipFrameNum() {
+        // Low weight on the newest frame, so the average settles instead of jumping around.
+        static constexpr float smoothing = 0.05f;
+        const auto draws = draw_call_count.exchange(0, std::memory_order_relaxed);
+        const auto draws_avg = draw_call_count_avg.load(std::memory_order_relaxed);
+        draw_call_count_avg.store(draws_avg + (float(draws) - draws_avg) * smoothing,
+                                  std::memory_order_relaxed);
+
+        const auto dispatches = dispatch_count.exchange(0, std::memory_order_relaxed);
+        const auto dispatches_avg = dispatch_count_avg.load(std::memory_order_relaxed);
+        dispatch_count_avg.store(dispatches_avg + (float(dispatches) - dispatches_avg) * smoothing,
+                                 std::memory_order_relaxed);
         ++flip_frame_count;
+    }
+
+    void IncDrawCall() noexcept {
+        draw_call_count.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    void IncDispatch() noexcept {
+        dispatch_count.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    [[nodiscard]] float GetDrawCallsAvg() const noexcept {
+        return draw_call_count_avg.load(std::memory_order_relaxed);
+    }
+
+    [[nodiscard]] float GetDispatchesAvg() const noexcept {
+        return dispatch_count_avg.load(std::memory_order_relaxed);
     }
 
     void IncGnmFrameNum() {

--- a/src/core/devtools/widget/frame_graph.cpp
+++ b/src/core/devtools/widget/frame_graph.cpp
@@ -96,6 +96,8 @@ void FrameGraph::Draw() {
         Text("Presenter time: %.3f ms (%.1f FPS)", io.DeltaTime * 1000.0f, 1.0f / io.DeltaTime);
         Text("Flip frame: %d Gnm submit frame: %d", DebugState.flip_frame_count.load(),
              DebugState.gnm_frame_count.load());
+        Text("Draw calls: %.0f   Dispatches: %.0f", DebugState.GetDrawCallsAvg(),
+             DebugState.GetDispatchesAvg());
         Text("Game Res: %dx%d", DebugState.game_resolution.first,
              DebugState.game_resolution.second);
         Text("Output Res: %dx%d", DebugState.output_resolution.first,

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "common/debug.h"
+#include "core/debug_state.h"
 #include "core/emulator_settings.h"
 #include "core/memory.h"
 #include "shader_recompiler/runtime_info.h"
@@ -229,6 +230,7 @@ void Rasterizer::Draw(bool is_indexed, u32 index_offset) {
         cmdbuf.draw(regs.num_indices, regs.num_instances.NumInstances(), vertex_offset,
                     instance_offset);
     }
+    DebugState.IncDrawCall();
 
     ResetBindings();
 }
@@ -298,6 +300,7 @@ void Rasterizer::DrawIndirect(bool is_indexed, VAddr arg_address, u32 offset, u3
         } else {
             cmdbuf.drawIndexedIndirect(buffer->Handle(), base, max_count, stride);
         }
+        DebugState.IncDrawCall();
     } else {
         ASSERT(sizeof(VkDrawIndirectCommand) == stride);
 
@@ -307,6 +310,7 @@ void Rasterizer::DrawIndirect(bool is_indexed, VAddr arg_address, u32 offset, u3
         } else {
             cmdbuf.drawIndirect(buffer->Handle(), base, max_count, stride);
         }
+        DebugState.IncDrawCall();
     }
 
     ResetBindings();
@@ -338,6 +342,7 @@ void Rasterizer::DispatchDirect() {
     const auto cmdbuf = scheduler.CommandBuffer();
     cmdbuf.bindPipeline(vk::PipelineBindPoint::eCompute, pipeline->Handle());
     cmdbuf.dispatch(cs_program.dim_x, cs_program.dim_y, cs_program.dim_z);
+    DebugState.IncDispatch();
 
     ResetBindings();
 }
@@ -370,6 +375,7 @@ void Rasterizer::DispatchIndirect(VAddr address, u32 offset, u32 size) {
     const auto cmdbuf = scheduler.CommandBuffer();
     cmdbuf.bindPipeline(vk::PipelineBindPoint::eCompute, pipeline->Handle());
     cmdbuf.dispatchIndirect(buffer->Handle(), base);
+    DebugState.IncDispatch();
 
     ResetBindings();
 }


### PR DESCRIPTION
adds per-frame draw calls and dispatch counts to the video debug info under GPU tools.
<img width="352" height="219" alt="image" src="https://github.com/user-attachments/assets/cb89e40f-e010-4093-b2e1-1f9c235cc6e2" />

