### PR TITLE
voice: Return ORBIS_FAIL in sceVoiceReadFromOPort to fix BO3 hang

### DIFF
--- a/src/core/libraries/voice/voice.cpp
+++ b/src/core/libraries/voice/voice.cpp
@@ -93,7 +93,7 @@ s32 PS4_SYSV_ABI sceVoicePausePortAll() {
 
 s32 PS4_SYSV_ABI sceVoiceReadFromOPort() {
     LOG_ERROR(Lib_Voice, "(STUBBED) called");
-    return ORBIS_OK;
+    return ORBIS_FAIL;
 }
 
 s32 PS4_SYSV_ABI sceVoiceResetPort() {


### PR DESCRIPTION
Fixes a startup hang in BO3 where the game gets stuck polling for microphone input. Returning ORBIS_FAIL bypasses the loop. 

With this fix, BO3 successfully reaches in-game (tested via null gpu).