### PR TITLE
shader_recompiler: restore LDS bounds semantics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -981,6 +981,7 @@ set(SHADER_RECOMPILER src/shader_recompiler/profile.h
                       src/shader_recompiler/backend/spirv/emit_spirv_quad_rect.h
                       src/shader_recompiler/backend/spirv/emit_spirv_select.cpp
                       src/shader_recompiler/backend/spirv/emit_spirv_shared_memory.cpp
+                      src/shader_recompiler/backend/spirv/emit_spirv_shared_memory_bounds.h
                       src/shader_recompiler/backend/spirv/emit_spirv_special.cpp
                       src/shader_recompiler/backend/spirv/emit_spirv_undefined.cpp
                       src/shader_recompiler/backend/spirv/emit_spirv_warp.cpp

--- a/src/shader_recompiler/backend/spirv/emit_spirv_atomic.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_atomic.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "shader_recompiler/backend/spirv/emit_spirv_instructions.h"
+#include "shader_recompiler/backend/spirv/emit_spirv_shared_memory_bounds.h"
 #include "shader_recompiler/backend/spirv/spirv_emit_context.h"
 
 namespace Shader::Backend::SPIRV {
@@ -20,36 +21,56 @@ Id SharedAtomicU32(EmitContext& ctx, Id offset, Id value,
                    Id (Sirit::Module::*atomic_func)(Id, Id, Id, Id, Id)) {
     const Id shift_id{ctx.ConstU32(2U)};
     const Id index{ctx.OpShiftRightLogical(ctx.U32[1], offset, shift_id)};
-    const Id pointer{ctx.EmitSharedMemoryAccess(ctx.shared_u32, ctx.shared_memory_u32, index)};
-    const auto [scope, semantics]{AtomicArgs(ctx)};
-    return (ctx.*atomic_func)(ctx.U32[1], pointer, scope, semantics, value);
+    return EmitCheckedSharedResult(
+        ctx, offset, ctx.runtime_info.cs_info.shared_memory_size, 4u, ctx.U32[1],
+        ctx.u32_zero_value, [&] {
+            const Id pointer{
+                ctx.EmitSharedMemoryAccess(ctx.shared_u32, ctx.shared_memory_u32, index)};
+            const auto [scope, semantics]{AtomicArgs(ctx)};
+            return (ctx.*atomic_func)(ctx.U32[1], pointer, scope, semantics, value);
+        });
 }
 
 Id SharedAtomicU32IncDec(EmitContext& ctx, Id offset,
                          Id (Sirit::Module::*atomic_func)(Id, Id, Id, Id)) {
     const Id shift_id{ctx.ConstU32(2U)};
     const Id index{ctx.OpShiftRightLogical(ctx.U32[1], offset, shift_id)};
-    const Id pointer{ctx.EmitSharedMemoryAccess(ctx.shared_u32, ctx.shared_memory_u32, index)};
-    const auto [scope, semantics]{AtomicArgs(ctx)};
-    return (ctx.*atomic_func)(ctx.U32[1], pointer, scope, semantics);
+    return EmitCheckedSharedResult(
+        ctx, offset, ctx.runtime_info.cs_info.shared_memory_size, 4u, ctx.U32[1],
+        ctx.u32_zero_value, [&] {
+            const Id pointer{
+                ctx.EmitSharedMemoryAccess(ctx.shared_u32, ctx.shared_memory_u32, index)};
+            const auto [scope, semantics]{AtomicArgs(ctx)};
+            return (ctx.*atomic_func)(ctx.U32[1], pointer, scope, semantics);
+        });
 }
 
 Id SharedAtomicU64(EmitContext& ctx, Id offset, Id value,
                    Id (Sirit::Module::*atomic_func)(Id, Id, Id, Id, Id)) {
     const Id shift_id{ctx.ConstU32(3U)};
     const Id index{ctx.OpShiftRightLogical(ctx.U32[1], offset, shift_id)};
-    const Id pointer{ctx.EmitSharedMemoryAccess(ctx.shared_u64, ctx.shared_memory_u64, index)};
-    const auto [scope, semantics]{AtomicArgs(ctx)};
-    return (ctx.*atomic_func)(ctx.U64, pointer, scope, semantics, value);
+    return EmitCheckedSharedResult(
+        ctx, offset, ctx.runtime_info.cs_info.shared_memory_size, 8u, ctx.U64, ctx.u64_zero_value,
+        [&] {
+            const Id pointer{
+                ctx.EmitSharedMemoryAccess(ctx.shared_u64, ctx.shared_memory_u64, index)};
+            const auto [scope, semantics]{AtomicArgs(ctx)};
+            return (ctx.*atomic_func)(ctx.U64, pointer, scope, semantics, value);
+        });
 }
 
 Id SharedAtomicU64IncDec(EmitContext& ctx, Id offset,
                          Id (Sirit::Module::*atomic_func)(Id, Id, Id, Id)) {
     const Id shift_id{ctx.ConstU32(3U)};
     const Id index{ctx.OpShiftRightLogical(ctx.U32[1], offset, shift_id)};
-    const Id pointer{ctx.EmitSharedMemoryAccess(ctx.shared_u64, ctx.shared_memory_u64, index)};
-    const auto [scope, semantics]{AtomicArgs(ctx)};
-    return (ctx.*atomic_func)(ctx.U64, pointer, scope, semantics);
+    return EmitCheckedSharedResult(
+        ctx, offset, ctx.runtime_info.cs_info.shared_memory_size, 8u, ctx.U64, ctx.u64_zero_value,
+        [&] {
+            const Id pointer{
+                ctx.EmitSharedMemoryAccess(ctx.shared_u64, ctx.shared_memory_u64, index)};
+            const auto [scope, semantics]{AtomicArgs(ctx)};
+            return (ctx.*atomic_func)(ctx.U64, pointer, scope, semantics);
+        });
 }
 
 template <bool is_float = false>

--- a/src/shader_recompiler/backend/spirv/emit_spirv_shared_memory.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_shared_memory.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "shader_recompiler/backend/spirv/emit_spirv_instructions.h"
+#include "shader_recompiler/backend/spirv/emit_spirv_shared_memory_bounds.h"
 #include "shader_recompiler/backend/spirv/spirv_emit_context.h"
 
 namespace Shader::Backend::SPIRV {
@@ -9,43 +10,61 @@ namespace Shader::Backend::SPIRV {
 Id EmitLoadSharedU16(EmitContext& ctx, Id offset) {
     const Id shift_id{ctx.ConstU32(1U)};
     const Id index{ctx.OpShiftRightLogical(ctx.U32[1], offset, shift_id)};
-    const Id pointer = ctx.EmitSharedMemoryAccess(ctx.shared_u16, ctx.shared_memory_u16, index);
-    return ctx.OpLoad(ctx.U16, pointer);
+    return EmitCheckedSharedResult(ctx, offset, ctx.runtime_info.cs_info.shared_memory_size, 2u,
+                                   ctx.U16, ctx.u16_zero_value, [&] {
+                                       const Id pointer = ctx.EmitSharedMemoryAccess(
+                                           ctx.shared_u16, ctx.shared_memory_u16, index);
+                                       return ctx.OpLoad(ctx.U16, pointer);
+                                   });
 }
 
 Id EmitLoadSharedU32(EmitContext& ctx, Id offset) {
     const Id shift_id{ctx.ConstU32(2U)};
     const Id index{ctx.OpShiftRightLogical(ctx.U32[1], offset, shift_id)};
-    const Id pointer = ctx.EmitSharedMemoryAccess(ctx.shared_u32, ctx.shared_memory_u32, index);
-    return ctx.OpLoad(ctx.U32[1], pointer);
+    return EmitCheckedSharedResult(ctx, offset, ctx.runtime_info.cs_info.shared_memory_size, 4u,
+                                   ctx.U32[1], ctx.u32_zero_value, [&] {
+                                       const Id pointer = ctx.EmitSharedMemoryAccess(
+                                           ctx.shared_u32, ctx.shared_memory_u32, index);
+                                       return ctx.OpLoad(ctx.U32[1], pointer);
+                                   });
 }
 
 Id EmitLoadSharedU64(EmitContext& ctx, Id offset) {
     const Id shift_id{ctx.ConstU32(3U)};
     const Id index{ctx.OpShiftRightLogical(ctx.U32[1], offset, shift_id)};
-    const Id pointer = ctx.EmitSharedMemoryAccess(ctx.shared_u64, ctx.shared_memory_u64, index);
-    return ctx.OpLoad(ctx.U64, pointer);
+    return EmitCheckedSharedResult(ctx, offset, ctx.runtime_info.cs_info.shared_memory_size, 8u,
+                                   ctx.U64, ctx.u64_zero_value, [&] {
+                                       const Id pointer = ctx.EmitSharedMemoryAccess(
+                                           ctx.shared_u64, ctx.shared_memory_u64, index);
+                                       return ctx.OpLoad(ctx.U64, pointer);
+                                   });
 }
 
 void EmitWriteSharedU16(EmitContext& ctx, Id offset, Id value) {
     const Id shift{ctx.ConstU32(1U)};
     const Id index{ctx.OpShiftRightLogical(ctx.U32[1], offset, shift)};
-    const Id pointer = ctx.EmitSharedMemoryAccess(ctx.shared_u16, ctx.shared_memory_u16, index);
-    ctx.OpStore(pointer, value);
+    EmitCheckedSharedWrite(ctx, offset, ctx.runtime_info.cs_info.shared_memory_size, 2u, [&] {
+        const Id pointer = ctx.EmitSharedMemoryAccess(ctx.shared_u16, ctx.shared_memory_u16, index);
+        ctx.OpStore(pointer, value);
+    });
 }
 
 void EmitWriteSharedU32(EmitContext& ctx, Id offset, Id value) {
     const Id shift{ctx.ConstU32(2U)};
     const Id index{ctx.OpShiftRightLogical(ctx.U32[1], offset, shift)};
-    const Id pointer = ctx.EmitSharedMemoryAccess(ctx.shared_u32, ctx.shared_memory_u32, index);
-    ctx.OpStore(pointer, value);
+    EmitCheckedSharedWrite(ctx, offset, ctx.runtime_info.cs_info.shared_memory_size, 4u, [&] {
+        const Id pointer = ctx.EmitSharedMemoryAccess(ctx.shared_u32, ctx.shared_memory_u32, index);
+        ctx.OpStore(pointer, value);
+    });
 }
 
 void EmitWriteSharedU64(EmitContext& ctx, Id offset, Id value) {
     const Id shift{ctx.ConstU32(3U)};
     const Id index{ctx.OpShiftRightLogical(ctx.U32[1], offset, shift)};
-    const Id pointer = ctx.EmitSharedMemoryAccess(ctx.shared_u64, ctx.shared_memory_u64, index);
-    ctx.OpStore(pointer, value);
+    EmitCheckedSharedWrite(ctx, offset, ctx.runtime_info.cs_info.shared_memory_size, 8u, [&] {
+        const Id pointer = ctx.EmitSharedMemoryAccess(ctx.shared_u64, ctx.shared_memory_u64, index);
+        ctx.OpStore(pointer, value);
+    });
 }
 
 } // namespace Shader::Backend::SPIRV

--- a/src/shader_recompiler/backend/spirv/emit_spirv_shared_memory_bounds.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_shared_memory_bounds.h
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <utility>
+
+#include "shader_recompiler/backend/spirv/spirv_emit_context.h"
+
+namespace Shader::Backend::SPIRV {
+
+inline Id SharedMemoryAccessInBounds(EmitContext& ctx, Id byte_offset, u32 allocation_size,
+                                     u32 access_size) {
+    ASSERT(access_size > 0);
+    // Express the complete-access check as offset < valid_start_count. This avoids overflowing a
+    // dynamic offset while still requiring the final byte of a multi-byte access to fit.
+    const u32 valid_start_count =
+        allocation_size >= access_size ? allocation_size - access_size + 1 : 0;
+    return ctx.OpULessThan(ctx.U1[1], byte_offset, ctx.ConstU32(valid_start_count));
+}
+
+template <typename Emit>
+Id EmitCheckedSharedResult(EmitContext& ctx, Id byte_offset, u32 allocation_size, u32 access_size,
+                           Id result_type, Id zero_value, Emit&& emit) {
+    const Id in_bounds = SharedMemoryAccessInBounds(ctx, byte_offset, allocation_size, access_size);
+    const Id access_label = ctx.OpLabel();
+    const Id merge_label = ctx.OpLabel();
+    const Id out_of_bounds_predecessor = ctx.last_label;
+
+    ctx.OpSelectionMerge(merge_label, spv::SelectionControlMask::MaskNone);
+    ctx.OpBranchConditional(in_bounds, access_label, merge_label);
+
+    ctx.AddLabel(access_label);
+    // The callback constructs the Workgroup pointer as well as performing the access. Keeping it
+    // in this block avoids an out-of-range OpAccessChain on the rejected path.
+    const Id result = std::forward<Emit>(emit)();
+    ctx.OpBranch(merge_label);
+
+    ctx.AddLabel(merge_label);
+    return ctx.OpPhi(result_type, result, access_label, zero_value, out_of_bounds_predecessor);
+}
+
+template <typename Emit>
+void EmitCheckedSharedWrite(EmitContext& ctx, Id byte_offset, u32 allocation_size, u32 access_size,
+                            Emit&& emit) {
+    const Id in_bounds = SharedMemoryAccessInBounds(ctx, byte_offset, allocation_size, access_size);
+    const Id access_label = ctx.OpLabel();
+    const Id merge_label = ctx.OpLabel();
+
+    ctx.OpSelectionMerge(merge_label, spv::SelectionControlMask::MaskNone);
+    ctx.OpBranchConditional(in_bounds, access_label, merge_label);
+
+    ctx.AddLabel(access_label);
+    // As above, do not construct the Workgroup pointer until the legal branch is active.
+    std::forward<Emit>(emit)();
+    ctx.OpBranch(merge_label);
+
+    ctx.AddLabel(merge_label);
+}
+
+} // namespace Shader::Backend::SPIRV

--- a/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
@@ -12,7 +12,7 @@
 
 namespace Serialization {
 /* You should increment versions below once corresponding serialization scheme is changed. */
-static constexpr u32 ShaderBinaryVersion = 2u;
+static constexpr u32 ShaderBinaryVersion = 3u;
 static constexpr u32 ShaderMetaVersion = 2u;
 static constexpr u32 PipelineKeyVersion = 2u;
 } // namespace Serialization

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,7 @@ set(GCN_TEST_SOURCES
     ${CMAKE_SOURCE_DIR}/src/shader_recompiler/backend/spirv/emit_spirv_logical.cpp
     ${CMAKE_SOURCE_DIR}/src/shader_recompiler/backend/spirv/emit_spirv_select.cpp
     ${CMAKE_SOURCE_DIR}/src/shader_recompiler/backend/spirv/emit_spirv_shared_memory.cpp
+    ${CMAKE_SOURCE_DIR}/src/shader_recompiler/backend/spirv/emit_spirv_shared_memory_bounds.h
     ${CMAKE_SOURCE_DIR}/src/shader_recompiler/backend/spirv/emit_spirv_special.cpp
     ${CMAKE_SOURCE_DIR}/src/shader_recompiler/backend/spirv/emit_spirv_undefined.cpp
     ${CMAKE_SOURCE_DIR}/src/shader_recompiler/backend/spirv/emit_spirv_warp.cpp
@@ -152,6 +153,7 @@ set(GCN_TEST_SOURCES
     gcn/translator.cpp
 
     # Tests
+    gcn/test_lds_bounds.cpp
     gcn/test_gcn_instructions.cpp
 )
 

--- a/tests/gcn/test_lds_bounds.cpp
+++ b/tests/gcn/test_lds_bounds.cpp
@@ -1,0 +1,263 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <algorithm>
+#include <array>
+#include <ranges>
+#include <span>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <spirv/unified1/spirv.hpp11>
+
+#include "gcn_test_runner.hpp"
+#include "shader_recompiler/frontend/opcodes.h"
+#include "translator.hpp"
+
+namespace {
+
+using Shader::Gcn::InstEncoding;
+using Shader::Gcn::OpcodeDS;
+
+constexpr u64 EncodeDs(OpcodeDS opcode, u8 address, u8 data0 = 0, u8 data1 = 0, u8 dest = 0,
+                       u8 offset0 = 0, u8 offset1 = 0) {
+    return u64{offset0} | (u64{offset1} << 8) | (u64{std::to_underlying(opcode)} << 18) |
+           (u64{std::to_underlying(InstEncoding::DS)} << 0) | (u64{address} << 32) |
+           (u64{data0} << 40) | (u64{data1} << 48) | (u64{dest} << 56);
+}
+
+struct SpirvInstruction {
+    spv::Op opcode;
+    std::span<const u32> operands;
+};
+
+std::vector<SpirvInstruction> DecodeSpirv(std::span<const u32> spirv) {
+    constexpr size_t HeaderWords = 5;
+    EXPECT_GE(spirv.size(), HeaderWords);
+    std::vector<SpirvInstruction> instructions;
+    for (size_t offset = HeaderWords; offset < spirv.size();) {
+        const u32 word_count = spirv[offset] >> 16;
+        const auto opcode = static_cast<spv::Op>(spirv[offset] & 0xffff);
+        EXPECT_GT(word_count, 0u);
+        EXPECT_LE(offset + word_count, spirv.size());
+        if (word_count == 0 || offset + word_count > spirv.size()) {
+            break;
+        }
+        instructions.push_back({opcode, spirv.subspan(offset + 1, word_count - 1)});
+        offset += word_count;
+    }
+    return instructions;
+}
+
+void ExpectGuardedWorkgroupAccess(std::span<const u32> spirv, spv::Op memory_opcode,
+                                  bool returns_zero) {
+    const auto instructions = DecodeSpirv(spirv);
+
+    std::unordered_set<u32> workgroup_variables;
+    std::unordered_set<u32> zero_constants;
+    std::unordered_set<u32> bounds_conditions;
+    for (const auto& inst : instructions) {
+        if (inst.opcode == spv::Op::OpVariable && inst.operands.size() >= 3 &&
+            inst.operands[2] == std::to_underlying(spv::StorageClass::Workgroup)) {
+            workgroup_variables.insert(inst.operands[1]);
+        } else if (inst.opcode == spv::Op::OpConstant && inst.operands.size() >= 3 &&
+                   std::ranges::all_of(inst.operands.subspan(2),
+                                       [](u32 word) { return word == 0; })) {
+            zero_constants.insert(inst.operands[1]);
+        } else if (inst.opcode == spv::Op::OpULessThan && inst.operands.size() >= 4) {
+            bounds_conditions.insert(inst.operands[1]);
+        }
+    }
+    ASSERT_FALSE(workgroup_variables.empty());
+    ASSERT_FALSE(bounds_conditions.empty());
+
+    std::unordered_set<u32> guarded_blocks;
+    std::unordered_set<u32> merge_blocks;
+    for (const auto& inst : instructions) {
+        if (inst.opcode == spv::Op::OpBranchConditional && inst.operands.size() >= 3 &&
+            bounds_conditions.contains(inst.operands[0])) {
+            guarded_blocks.insert(inst.operands[1]);
+            merge_blocks.insert(inst.operands[2]);
+        }
+    }
+    ASSERT_FALSE(guarded_blocks.empty());
+
+    u32 current_block{};
+    std::unordered_set<u32> guarded_pointers;
+    bool found_memory_operation = false;
+    bool found_zero_phi = false;
+    for (const auto& inst : instructions) {
+        if (inst.opcode == spv::Op::OpLabel && !inst.operands.empty()) {
+            current_block = inst.operands[0];
+            continue;
+        }
+        if (inst.opcode == spv::Op::OpAccessChain && inst.operands.size() >= 3 &&
+            workgroup_variables.contains(inst.operands[2])) {
+            EXPECT_TRUE(guarded_blocks.contains(current_block))
+                << "Workgroup OpAccessChain was emitted outside the in-bounds block";
+            guarded_pointers.insert(inst.operands[1]);
+            continue;
+        }
+
+        const auto uses_guarded_pointer = [&] {
+            if (memory_opcode == spv::Op::OpStore) {
+                return inst.opcode == memory_opcode && !inst.operands.empty() &&
+                       guarded_pointers.contains(inst.operands[0]);
+            }
+            return inst.opcode == memory_opcode && inst.operands.size() >= 3 &&
+                   guarded_pointers.contains(inst.operands[2]);
+        }();
+        if (uses_guarded_pointer) {
+            EXPECT_TRUE(guarded_blocks.contains(current_block));
+            found_memory_operation = true;
+        }
+
+        if (returns_zero && inst.opcode == spv::Op::OpPhi && merge_blocks.contains(current_block) &&
+            inst.operands.size() >= 6) {
+            for (size_t operand = 2; operand + 1 < inst.operands.size(); operand += 2) {
+                if (zero_constants.contains(inst.operands[operand]) &&
+                    !guarded_blocks.contains(inst.operands[operand + 1])) {
+                    found_zero_phi = true;
+                }
+            }
+        }
+    }
+
+    EXPECT_FALSE(guarded_pointers.empty());
+    EXPECT_TRUE(found_memory_operation);
+    EXPECT_EQ(found_zero_phi, returns_zero);
+}
+
+void ExpectBoundsLimit(std::span<const u32> spirv, u32 expected_limit) {
+    const auto instructions = DecodeSpirv(spirv);
+    std::unordered_map<u32, u32> constants;
+    for (const auto& inst : instructions) {
+        if (inst.opcode == spv::Op::OpConstant && inst.operands.size() == 3) {
+            constants.emplace(inst.operands[1], inst.operands[2]);
+        }
+    }
+    const auto comparison = std::ranges::find_if(instructions, [](const auto& inst) {
+        return inst.opcode == spv::Op::OpULessThan && inst.operands.size() >= 4;
+    });
+    ASSERT_NE(comparison, instructions.end());
+    ASSERT_TRUE(constants.contains(comparison->operands[3]));
+    EXPECT_EQ(constants.at(comparison->operands[3]), expected_limit);
+}
+
+TEST(LdsBoundsCodegen, LoadB32ReturnsZeroWithoutCreatingAnOutOfBoundsPointer) {
+    constexpr u32 LdsSize = 16;
+    const auto spirv = TranslateToSpirv(EncodeDs(OpcodeDS::DS_READ_B32, 0, 0, 0, 0), LdsSize);
+    ExpectGuardedWorkgroupAccess(spirv, spv::Op::OpLoad, true);
+    ExpectBoundsLimit(spirv, LdsSize - sizeof(u32) + 1);
+}
+
+TEST(LdsBoundsCodegen, LoadB64ReturnsZeroWithoutCreatingAnOutOfBoundsPointer) {
+    constexpr u32 LdsSize = 16;
+    const auto spirv = TranslateToSpirv(EncodeDs(OpcodeDS::DS_READ_B64, 0, 0, 0, 0), LdsSize);
+    ExpectGuardedWorkgroupAccess(spirv, spv::Op::OpLoad, true);
+    ExpectBoundsLimit(spirv, LdsSize - sizeof(u64) + 1);
+}
+
+TEST(LdsBoundsCodegen, WriteB32IsDiscardedWithoutCreatingAnOutOfBoundsPointer) {
+    constexpr u32 LdsSize = 16;
+    const auto spirv = TranslateToSpirv(EncodeDs(OpcodeDS::DS_WRITE_B32, 0, 1), LdsSize);
+    ExpectGuardedWorkgroupAccess(spirv, spv::Op::OpStore, false);
+}
+
+TEST(LdsBoundsCodegen, ReturningAtomicIsDiscardedAndReturnsZero) {
+    constexpr u32 LdsSize = 16;
+    const auto spirv = TranslateToSpirv(EncodeDs(OpcodeDS::DS_ADD_RTN_U32, 0, 1, 0, 0), LdsSize);
+    ExpectGuardedWorkgroupAccess(spirv, spv::Op::OpAtomicIAdd, true);
+}
+
+TEST(LdsBoundsRuntime, ReadB32AtAllocationEndReturnsZero) {
+#ifdef __APPLE__
+    GTEST_SKIP() << "The Vulkan GCN runner is unavailable under this checkout's MoltenVK setup";
+#endif
+    constexpr u32 LdsSize = 16;
+    const auto runner = gcn_test::Runner::instance();
+    if (!runner) {
+        GTEST_SKIP() << runner.error().message;
+    }
+    const auto spirv = TranslateToSpirv(EncodeDs(OpcodeDS::DS_READ_B32, 0, 0, 0, 0), LdsSize);
+    const auto result = (*runner)->run<u32>(spirv, LdsSize);
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    EXPECT_EQ(*result, 0u);
+}
+
+TEST(LdsBoundsRuntime, ReadB64CrossingAllocationEndReturnsZero) {
+#ifdef __APPLE__
+    GTEST_SKIP() << "The Vulkan GCN runner is unavailable under this checkout's MoltenVK setup";
+#endif
+    constexpr u32 LdsSize = 16;
+    const auto runner = gcn_test::Runner::instance();
+    if (!runner) {
+        GTEST_SKIP() << runner.error().message;
+    }
+    const auto spirv = TranslateToSpirv(EncodeDs(OpcodeDS::DS_READ_B64, 0, 0, 0, 0), LdsSize);
+    const auto result = (*runner)->run<u32>(spirv, LdsSize - sizeof(u32));
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    EXPECT_EQ(*result, 0u);
+}
+
+TEST(LdsBoundsRuntime, OutOfRangeWriteDoesNotChangeValidLds) {
+#ifdef __APPLE__
+    GTEST_SKIP() << "The Vulkan GCN runner is unavailable under this checkout's MoltenVK setup";
+#endif
+    constexpr u32 LdsSize = 16;
+    constexpr u32 Sentinel = 0x12345678;
+    const auto runner = gcn_test::Runner::instance();
+    if (!runner) {
+        GTEST_SKIP() << runner.error().message;
+    }
+    const std::array instructions{
+        EncodeDs(OpcodeDS::DS_WRITE_B32, 0, 1),
+        EncodeDs(OpcodeDS::DS_WRITE_B32, 2, 3),
+        EncodeDs(OpcodeDS::DS_READ_B32, 0, 0, 0, 0),
+    };
+    const auto spirv = TranslateToSpirv(instructions, LdsSize);
+    const auto result = (*runner)->run<u32>(spirv, std::array{0u, Sentinel, LdsSize, 0xdeadbeefu});
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    EXPECT_EQ(*result, Sentinel);
+}
+
+TEST(LdsBoundsRuntime, OutOfRangeAtomicDoesNotChangeValidLds) {
+#ifdef __APPLE__
+    GTEST_SKIP() << "The Vulkan GCN runner is unavailable under this checkout's MoltenVK setup";
+#endif
+    constexpr u32 LdsSize = 16;
+    constexpr u32 Sentinel = 7;
+    const auto runner = gcn_test::Runner::instance();
+    if (!runner) {
+        GTEST_SKIP() << runner.error().message;
+    }
+    const std::array instructions{
+        EncodeDs(OpcodeDS::DS_WRITE_B32, 0, 1),
+        EncodeDs(OpcodeDS::DS_ADD_U32, 2, 3),
+        EncodeDs(OpcodeDS::DS_READ_B32, 0, 0, 0, 0),
+    };
+    const auto spirv = TranslateToSpirv(instructions, LdsSize);
+    const auto result = (*runner)->run<u32>(spirv, std::array{0u, Sentinel, LdsSize, 5u});
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    EXPECT_EQ(*result, Sentinel);
+}
+
+TEST(LdsBoundsRuntime, ReturningOutOfRangeAtomicReturnsZero) {
+#ifdef __APPLE__
+    GTEST_SKIP() << "The Vulkan GCN runner is unavailable under this checkout's MoltenVK setup";
+#endif
+    constexpr u32 LdsSize = 16;
+    const auto runner = gcn_test::Runner::instance();
+    if (!runner) {
+        GTEST_SKIP() << runner.error().message;
+    }
+    const auto spirv = TranslateToSpirv(EncodeDs(OpcodeDS::DS_ADD_RTN_U32, 0, 1, 0, 0), LdsSize);
+    const auto result = (*runner)->run<u32>(spirv, std::array{LdsSize, 5u});
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    EXPECT_EQ(*result, 0u);
+}
+
+} // namespace

--- a/tests/gcn/translator.cpp
+++ b/tests/gcn/translator.cpp
@@ -27,7 +27,11 @@ std::vector<u32> TranslateToSpirv(u64 raw_gcn_inst) {
     return TranslateToSpirv(std::span<const u64>{&raw_gcn_inst, 1});
 }
 
-std::vector<u32> TranslateToSpirv(std::span<const u64> raw_gcn_insts) {
+std::vector<u32> TranslateToSpirv(u64 raw_gcn_inst, u32 shared_memory_size) {
+    return TranslateToSpirv(std::span<const u64>{&raw_gcn_inst, 1}, shared_memory_size);
+}
+
+std::vector<u32> TranslateToSpirv(std::span<const u64> raw_gcn_insts, u32 shared_memory_size) {
     std::array<u32, 2> store{
         0xe0700000,
         0x80000000 // buffer_store_dword v0, v0, s[0:3], 0
@@ -73,6 +77,7 @@ std::vector<u32> TranslateToSpirv(std::span<const u64> raw_gcn_insts) {
     runtime_info.Initialize(Stage::Compute);
     runtime_info.num_user_data = 4;
     runtime_info.cs_info.workgroup_size = {1, 1, 1};
+    runtime_info.cs_info.shared_memory_size = shared_memory_size;
 
     Gcn::Translator translator(program.info, runtime_info, profile);
     translator.EmitPrologue(block);

--- a/tests/gcn/translator.hpp
+++ b/tests/gcn/translator.hpp
@@ -9,4 +9,5 @@
 #include "common/types.h"
 
 std::vector<u32> TranslateToSpirv(u64 raw_gcn_inst);
-std::vector<u32> TranslateToSpirv(std::span<const u64> raw_gcn_insts);
+std::vector<u32> TranslateToSpirv(u64 raw_gcn_inst, u32 shared_memory_size);
+std::vector<u32> TranslateToSpirv(std::span<const u64> raw_gcn_insts, u32 shared_memory_size = 0);


### PR DESCRIPTION
## Summary

Fixes #4659.

Restore deterministic PS4 LDS/workgroup-memory behavior for accesses outside the compute shader's allocated shared-memory range:

- out-of-range 16/32/64-bit loads return zero;
- out-of-range 16/32/64-bit writes have no side effect;
- out-of-range 32/64-bit shared atomics have no side effect and return zero;
- the SPIR-V `Workgroup` pointer is constructed only inside the in-bounds control-flow block; and
- the shader-binary cache version is incremented so existing SPIR-V generated without these checks cannot bypass the fix.

This is a general shader-recompiler correction and contains no Driveclub- or driver-specific matching.

## Problem

Issue #4659 reports a regression introduced between shadPS4 0.15 and 0.16: Driveclub renders a regular lattice of transparent square artifacts in the color-selection screen and during races on Linux with RADV. Reports cover multiple AMD GPUs and Mesa versions, while the same artifact is not reported on Windows.

PR #4385 removed shared-memory bounds checks from LDS loads, stores, and atomics. That changed a deterministic guest operation into undefined host behavior:

- the guest GPU returns zero for an out-of-range LDS read and discards out-of-range LDS writes;
- an out-of-range SPIR-V `OpAccessChain` into `Workgroup` storage is undefined, and Vulkan descriptor robustness does not make workgroup memory safe.

Tiled compute shaders can use LDS for tile data and border/halo lanes. Undefined values at a tile boundary can therefore become a repeated screen-space lattice, matching the artifact in #4659. Driver-dependent undefined behavior also explains why the regression is especially visible on Linux/RADV.

## Implementation

The new shared-memory helper checks the original unsigned byte offset against the last valid starting position for the complete access:

```text
offset < allocation_size - access_size + 1
```

The limit becomes zero when the allocation is smaller than the access. This form avoids overflowing a dynamic `offset + access_size` calculation.

For value-producing operations, the legal branch performs the access and the merge block selects either that result or typed zero with `OpPhi`. Writes branch around the store entirely. Crucially, the callback creates the `OpAccessChain` only after entering the legal branch; the rejected path never constructs an invalid workgroup pointer.

The checks cover the common shared atomic helpers used by add/subtract, signed and unsigned min/max, bitwise operations, increment, and decrement in their 32- and 64-bit forms. Buffer and image operations are unchanged.

`ShaderBinaryVersion` is advanced from 2 to 3 because this changes generated SPIR-V. Without invalidation, a title can preload the old unchecked shader binary and appear unaffected by the fix.

## Validation

### Driveclub on RADV

Validated with Driveclub CUSA00093 v1.28 on Linux x86_64 Batocera using Mesa RADV on an AMD Radeon 780M:

1. The title cache was removed and the patched build generated fresh shaders: the square lattice was absent.
2. The immediately preceding build without LDS restoration was selected and the title cache was removed again: the square lattice returned.
3. The patched build has been restored with another empty title cache.


### Automated checks

- `cmake --build build --target shadps4`
- `shadps4_gcn_test`
- Four structural SPIR-V tests verify the conditional branch, pointer placement, complete-access bound, zero-valued load/atomic merge, and discarded write behavior.
- Five Vulkan execution tests cover out-of-range reads, crossing accesses, writes, and atomics. They run when the GCN Vulkan runner is available and skip under the current macOS/MoltenVK setup.

