### PR TITLE
Issues observed in The Order: 1886 intro sequence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1019,6 +1019,7 @@ set(SHADER_RECOMPILER src/shader_recompiler/profile.h
                       src/shader_recompiler/ir/passes/hull_shader_transform.cpp
                       src/shader_recompiler/ir/passes/identity_removal_pass.cpp
                       src/shader_recompiler/ir/passes/inject_clip_distance_attributes.cpp
+                      src/shader_recompiler/ir/passes/insert_ssbo_store_load_barrier.cpp
                       src/shader_recompiler/ir/passes/ir_passes.h
                       src/shader_recompiler/ir/passes/lower_buffer_format_to_raw.cpp
                       src/shader_recompiler/ir/passes/lower_fp64_to_fp32.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -978,6 +978,8 @@ set(SHADER_RECOMPILER src/shader_recompiler/profile.h
                       src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
                       src/shader_recompiler/backend/spirv/emit_spirv_integer.cpp
                       src/shader_recompiler/backend/spirv/emit_spirv_logical.cpp
+                      src/shader_recompiler/backend/spirv/emit_spirv_per_vertex.cpp
+                      src/shader_recompiler/backend/spirv/emit_spirv_per_vertex.h
                       src/shader_recompiler/backend/spirv/emit_spirv_quad_rect.cpp
                       src/shader_recompiler/backend/spirv/emit_spirv_quad_rect.h
                       src/shader_recompiler/backend/spirv/emit_spirv_select.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -828,6 +828,7 @@ set(COMMON src/common/logging/classes.h
            src/common/number_utils.cpp
            src/common/memory_patcher.h
            src/common/memory_patcher.cpp
+           src/common/hack_features.cpp
            ${CMAKE_CURRENT_BINARY_DIR}/src/common/scm_rev.cpp
            src/common/scm_rev.h
            src/common/key_manager.cpp

--- a/src/common/bit_array.h
+++ b/src/common/bit_array.h
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <type_traits>
 #include "common/types.h"
 
 #ifdef __AVX2__
@@ -22,6 +23,12 @@ class BitArray {
     static constexpr size_t WORD_COUNT = N / BITS_PER_WORD;
     static constexpr size_t WORDS_PER_AVX = 4;
     static constexpr size_t AVX_WORD_COUNT = WORD_COUNT / WORDS_PER_AVX;
+
+    // summary: one bit per data word. Type picks the smallest that fits.
+    static_assert(WORD_COUNT <= 64, "BitArray summary requires WORD_COUNT <= 64 (N <= 4096)");
+    using SummaryType = std::conditional_t<(WORD_COUNT <= 8), u8,
+                        std::conditional_t<(WORD_COUNT <= 16), u16,
+                        std::conditional_t<(WORD_COUNT <= 32), u32, u64>>>;
 
 public:
     using Range = std::pair<size_t, size_t>;
@@ -66,6 +73,36 @@ public:
     using reference = const Range&;
 
     BitArray() = default;
+
+    /// O(1) check if any bit is set. Relies on summary word for fast path.
+    inline constexpr bool None() const {
+        return summary == 0;
+    }
+
+    inline constexpr bool Any() const {
+        return summary != 0;
+    }
+
+private:
+    static constexpr SummaryType SummaryBit(size_t word_idx) {
+        return static_cast<SummaryType>(1ULL << word_idx);
+    }
+
+    /// Call after modifying data[word_idx] to keep summary in sync.
+    void UpdateSummary(size_t word_idx) {
+        if (data[word_idx] == 0) {
+            summary &= ~SummaryBit(word_idx);
+        } else {
+            summary |= SummaryBit(word_idx);
+        }
+    }
+
+    /// Call after setting a bit — the word is guaranteed non-zero.
+    void SetSummaryBit(size_t word_idx) {
+        summary |= SummaryBit(word_idx);
+    }
+
+public:
     BitArray(const BitArray& other) = default;
     BitArray& operator=(const BitArray& other) = default;
     BitArray(BitArray&& other) noexcept = default;
@@ -84,8 +121,10 @@ public:
         const u64 end_mask = end_bit == BITS_PER_WORD - 1 ? ~0ULL : (1ULL << (end_bit + 1)) - 1;
         if (first_word == last_word) {
             data[first_word] = other.data[first_word] & (start_mask & end_mask);
+            UpdateSummary(first_word);
         } else {
             data[first_word] = other.data[first_word] & start_mask;
+            UpdateSummary(first_word);
             size_t i = first_word + 1;
 #ifdef BIT_ARRAY_USE_AVX
             for (; i + WORDS_PER_AVX <= last_word; i += WORDS_PER_AVX) {
@@ -97,7 +136,11 @@ public:
             for (; i < last_word; ++i) {
                 data[i] = other.data[i];
             }
+            for (size_t w = first_word + 1; w < last_word; ++w) {
+                UpdateSummary(w);
+            }
             data[last_word] = other.data[last_word] & end_mask;
+            UpdateSummary(last_word);
         }
     }
 
@@ -112,11 +155,15 @@ public:
     }
 
     inline constexpr void Set(size_t idx) {
-        data[idx / BITS_PER_WORD] |= (1ULL << (idx % BITS_PER_WORD));
+        const size_t w = idx / BITS_PER_WORD;
+        data[w] |= (1ULL << (idx % BITS_PER_WORD));
+        SetSummaryBit(w);
     }
 
     inline constexpr void Unset(size_t idx) {
-        data[idx / BITS_PER_WORD] &= ~(1ULL << (idx % BITS_PER_WORD));
+        const size_t w = idx / BITS_PER_WORD;
+        data[w] &= ~(1ULL << (idx % BITS_PER_WORD));
+        UpdateSummary(w);
     }
 
     inline constexpr bool Get(size_t idx) const {
@@ -135,8 +182,10 @@ public:
         const u64 end_mask = end_bit == BITS_PER_WORD - 1 ? ~0ULL : (1ULL << (end_bit + 1)) - 1;
         if (first_word == last_word) {
             data[first_word] |= start_mask & end_mask;
+            UpdateSummary(first_word);
         } else {
             data[first_word] |= start_mask;
+            UpdateSummary(first_word);
             size_t i = first_word + 1;
 #ifdef BIT_ARRAY_USE_AVX
             const __m256i value = _mm256_set1_epi64x(-1);
@@ -147,7 +196,12 @@ public:
             for (; i < last_word; ++i) {
                 data[i] = ~0ULL;
             }
+            // Full words between first and last become all-ones
+            for (size_t w = first_word + 1; w < last_word; ++w) {
+                SetSummaryBit(w);
+            }
             data[last_word] |= end_mask;
+            UpdateSummary(last_word);
         }
     }
 
@@ -163,8 +217,10 @@ public:
         const u64 end_mask = end_bit == BITS_PER_WORD - 1 ? 0ULL : ~((1ULL << (end_bit + 1)) - 1);
         if (first_word == last_word) {
             data[first_word] &= start_mask | end_mask;
+            UpdateSummary(first_word);
         } else {
             data[first_word] &= start_mask;
+            UpdateSummary(first_word);
             size_t i = first_word + 1;
 #ifdef BIT_ARRAY_USE_AVX
             const __m256i value = _mm256_setzero_si256();
@@ -175,7 +231,11 @@ public:
             for (; i < last_word; ++i) {
                 data[i] = 0ULL;
             }
+            // Full words between first and last become zero
+            summary &= static_cast<SummaryType>(
+                ~(((1ULL << last_word) - 1) ^ ((1ULL << (first_word + 1)) - 1)));
             data[last_word] &= end_mask;
+            UpdateSummary(last_word);
         }
     }
 
@@ -189,22 +249,13 @@ public:
 
     inline constexpr void Clear() {
         data.fill(0);
+        summary = 0;
     }
 
     inline constexpr void Fill() {
         data.fill(~0ULL);
-    }
-
-    inline constexpr bool None() const {
-        u64 result = 0;
-        for (const auto& word : data) {
-            result |= word;
-        }
-        return result == 0;
-    }
-
-    inline constexpr bool Any() const {
-        return !None();
+        summary = (WORD_COUNT == 64) ? static_cast<SummaryType>(~SummaryType{0})
+                                     : static_cast<SummaryType>((1ULL << WORD_COUNT) - 1);
     }
 
     Range FirstRangeFrom(size_t start) const {
@@ -343,6 +394,7 @@ public:
     inline constexpr BitArray& operator|=(const BitArray& other) {
         for (size_t i = 0; i < WORD_COUNT; ++i) {
             data[i] |= other.data[i];
+            if (data[i]) SetSummaryBit(i);
         }
         return *this;
     }
@@ -350,6 +402,7 @@ public:
     inline constexpr BitArray& operator&=(const BitArray& other) {
         for (size_t i = 0; i < WORD_COUNT; ++i) {
             data[i] &= other.data[i];
+            UpdateSummary(i);
         }
         return *this;
     }
@@ -357,6 +410,7 @@ public:
     inline constexpr BitArray& operator^=(const BitArray& other) {
         for (size_t i = 0; i < WORD_COUNT; ++i) {
             data[i] ^= other.data[i];
+            UpdateSummary(i);
         }
         return *this;
     }
@@ -383,6 +437,7 @@ public:
         BitArray result = *this;
         for (size_t i = 0; i < WORD_COUNT; ++i) {
             result.data[i] = ~result.data[i];
+            result.UpdateSummary(i);
         }
         return result;
     }
@@ -401,6 +456,7 @@ public:
 
 private:
     std::array<u64, WORD_COUNT> data{};
+    SummaryType summary{0}; // bit i = (data[i] != 0), enables O(1) None()/Any()
 };
 
 } // namespace Common

--- a/src/common/hack_features.cpp
+++ b/src/common/hack_features.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "common/assert.h"
+#include "common/hack_features.h"
+
+namespace Common {
+
+bool HackFeatures::isTheOrder1886 = false;
+bool HackFeatures::initialized = false;
+
+void HackFeatures::Init(std::string_view game_serial) {
+    ASSERT_MSG(!initialized, "HackFeatures::Init called more than once");
+    initialized = true;
+
+    // CUSA00035 / CUSA00076 / CUSA00100 are different regional/language
+    // releases of The Order: 1886.
+    if (game_serial == "CUSA00035" || game_serial == "CUSA00076" ||
+        game_serial == "CUSA00100") {
+        isTheOrder1886 = true;
+    }
+}
+
+} // namespace Common

--- a/src/common/hack_features.h
+++ b/src/common/hack_features.h
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <string_view>
+
+namespace Common {
+
+/// Temporary per-game hack flags.
+/// Initialize once with the game serial; query statically thereafter.
+class HackFeatures {
+public:
+    static bool isTheOrder1886;
+
+    /// Must be called exactly once during emulator startup, after param.sfo is parsed.
+    static void Init(std::string_view game_serial);
+
+private:
+    static bool initialized;
+};
+
+} // namespace Common

--- a/src/core/address_space.cpp
+++ b/src/core/address_space.cpp
@@ -99,8 +99,11 @@ struct MemoryRegion {
     PAddr phys_base;
     u64 size;
     u32 prot;
-    s32 fd;
+    u32 real_prot; // Actual protection used when mapping (guest == prot, mirror == PAGE_READONLY)
+    uintptr_t fd; // File/section HANDLE; uintptr_t avoids truncating a 64-bit handle
     bool is_mapped;
+    bool is_mirror;
+    bool is_anon_section; // File read-only converted to an anonymous section (fd is the section)
 };
 
 struct AddressSpace::Impl {
@@ -165,8 +168,9 @@ struct AddressSpace::Impl {
             // Restrict region size to avoid overly fragmenting the virtual memory space.
             if (info.State == MEM_FREE && info.RegionSize > 0x1000000) {
                 VAddr addr = Common::AlignUp(reinterpret_cast<VAddr>(info.BaseAddress), alignment);
-                regions.emplace(addr,
-                                MemoryRegion{addr, PAddr(-1), size, PAGE_NOACCESS, -1, false});
+                regions.emplace(addr, MemoryRegion{addr, PAddr(-1), size, PAGE_NOACCESS,
+                                                   PAGE_NOACCESS, uintptr_t(-1), false, false,
+                                                   false});
             }
         }
 
@@ -235,20 +239,31 @@ struct AddressSpace::Impl {
         PAddr phys_addr = region->phys_base;
         u64 size = region->size;
         ULONG prot = region->prot;
-        s32 fd = region->fd;
+        ULONG real_prot = region->real_prot;
+        uintptr_t fd = region->fd;
 
         void* ptr = nullptr;
-        if (phys_addr != -1) {
+        if (region->is_mirror) {
+            // Mirror: second view of the same section (zero-copy), always read-only.
             HANDLE backing = fd != -1 ? reinterpret_cast<HANDLE>(fd) : backing_handle;
-            if (fd != -1 && prot == PAGE_READONLY) {
-                // Allocate the memory for the mapping
+            ptr = MapViewOfFile3(backing, process, reinterpret_cast<PVOID>(virtual_addr), phys_addr,
+                                 size, MEM_REPLACE_PLACEHOLDER, real_prot, nullptr, 0);
+            ASSERT_MSG(ptr, "MapViewOfFile3 failed. {}", Common::GetLastErrorMsg());
+        } else if (phys_addr != -1) {
+            HANDLE backing = fd != -1 ? reinterpret_cast<HANDLE>(fd) : backing_handle;
+            if (fd != -1 && prot == PAGE_READONLY && !region->is_anon_section) {
+                // File read-only: create an anonymous section so the mapping can have a second
+                // (mirror) view, read the file into it, then drop to the requested protection.
                 DWORD resultvar;
-                ptr = VirtualAlloc2(process, reinterpret_cast<PVOID>(virtual_addr), size,
-                                    MEM_RESERVE | MEM_COMMIT | MEM_REPLACE_PLACEHOLDER,
-                                    PAGE_READWRITE, nullptr, 0);
+                HANDLE section = CreateFileMapping2(INVALID_HANDLE_VALUE, nullptr,
+                                                    FILE_MAP_ALL_ACCESS, PAGE_READWRITE,
+                                                    SEC_COMMIT, size, nullptr, nullptr, 0);
+                ASSERT_MSG(section, "CreateFileMapping2 failed. {}", Common::GetLastErrorMsg());
+                ptr = MapViewOfFile3(section, process, reinterpret_cast<PVOID>(virtual_addr), 0,
+                                     size, MEM_REPLACE_PLACEHOLDER, PAGE_READWRITE, nullptr, 0);
+                ASSERT_MSG(ptr, "MapViewOfFile3 failed. {}", Common::GetLastErrorMsg());
 
-                // Use ReadFile to read file contents into the memory area.
-                // Create an OVERLAPPED with the file offset, then supply that to ReadFile
+                // Read the file contents into the mapped section.
                 OVERLAPPED param{};
                 // Offset is the least-significant 32 bits, OffsetHigh is the most-significant.
                 param.Offset = phys_addr & 0xffffffffull;
@@ -263,8 +278,14 @@ struct AddressSpace::Impl {
                 ret = SetFilePointer(backing, size_low, &size_high, FILE_CURRENT);
 
                 // Protect the memory area appropriately
-                ret = VirtualProtect(ptr, size, prot, &resultvar);
+                ret = VirtualProtect(ptr, size, real_prot, &resultvar);
                 ASSERT_MSG(ret, "VirtualProtect failed. {}", Common::GetLastErrorMsg());
+
+                // Store the anonymous section so the mirror can map a second view of it. phys_base
+                // now holds the in-section offset (0) rather than the file offset.
+                region->fd = reinterpret_cast<uintptr_t>(section);
+                region->phys_base = 0;
+                region->is_anon_section = true;
             } else {
                 if (prot == PAGE_NOACCESS) {
                     DWORD resultvar;
@@ -272,19 +293,21 @@ struct AddressSpace::Impl {
                                          phys_addr, size, MEM_REPLACE_PLACEHOLDER, PAGE_READWRITE,
                                          nullptr, 0);
                     ASSERT_MSG(ptr, "MapViewOfFile3 failed. {}", Common::GetLastErrorMsg());
-                    bool ret = VirtualProtect(ptr, size, prot, &resultvar);
+                    bool ret = VirtualProtect(ptr, size, real_prot, &resultvar);
                     ASSERT_MSG(ret, "VirtualProtect failed. {}", Common::GetLastErrorMsg());
                 } else {
                     ptr =
                         MapViewOfFile3(backing, process, reinterpret_cast<PVOID>(virtual_addr),
-                                       phys_addr, size, MEM_REPLACE_PLACEHOLDER, prot, nullptr, 0);
+                                       phys_addr, size, MEM_REPLACE_PLACEHOLDER, real_prot,
+                                       nullptr, 0);
                     ASSERT_MSG(ptr, "MapViewOfFile3 failed. {}", Common::GetLastErrorMsg());
                 }
             }
         } else {
             ptr =
                 VirtualAlloc2(process, reinterpret_cast<PVOID>(virtual_addr), size,
-                              MEM_RESERVE | MEM_COMMIT | MEM_REPLACE_PLACEHOLDER, prot, nullptr, 0);
+                              MEM_RESERVE | MEM_COMMIT | MEM_REPLACE_PLACEHOLDER, real_prot,
+                              nullptr, 0);
         }
         ASSERT_MSG(ptr, "{}", Common::GetLastErrorMsg());
         return ptr;
@@ -294,11 +317,9 @@ struct AddressSpace::Impl {
         VAddr virtual_addr = region->base;
         PAddr phys_base = region->phys_base;
         u64 size = region->size;
-        ULONG prot = region->prot;
-        s32 fd = region->fd;
 
         bool ret = false;
-        if ((fd != -1 && prot != PAGE_READONLY) || (fd == -1 && phys_base != -1)) {
+        if (phys_base != -1) {
             ret = UnmapViewOfFile2(process, reinterpret_cast<PVOID>(virtual_addr),
                                    MEM_PRESERVE_PLACEHOLDER);
         } else {
@@ -352,8 +373,9 @@ struct AddressSpace::Impl {
             // Store a new region matching the removed area.
             it = regions.emplace_hint(std::next(it), virtual_addr,
                                       MemoryRegion(virtual_addr, next_region_phys_base,
-                                                   next_region_size, region.prot, region.fd,
-                                                   region.is_mapped));
+                                                   next_region_size, region.prot, region.real_prot,
+                                                   region.fd, region.is_mapped, region.is_mirror,
+                                                   region.is_anon_section));
         }
 
         // At this point, the region's base will match virtual_addr.
@@ -374,8 +396,9 @@ struct AddressSpace::Impl {
             // Store the new region matching the remaining space
             regions.emplace_hint(std::next(it), next_region_addr,
                                  MemoryRegion(next_region_addr, next_region_phys_base,
-                                              next_region_size, region.prot, region.fd,
-                                              region.is_mapped));
+                                              next_region_size, region.prot, region.real_prot,
+                                              region.fd, region.is_mapped, region.is_mirror,
+                                              region.is_anon_section));
 
             // Use VirtualFreeEx to create the split.
             if (!VirtualFreeEx(process, LPVOID(region.base), region.size,
@@ -395,8 +418,8 @@ struct AddressSpace::Impl {
         }
     }
 
-    void* Map(VAddr virtual_addr, PAddr phys_addr, u64 size, ULONG prot, s32 fd = -1) {
-        std::scoped_lock lk{mutex};
+    void* MapInternal(VAddr virtual_addr, PAddr phys_addr, u64 size, ULONG prot, ULONG real_prot,
+                      uintptr_t fd, bool is_mirror) {
         // Get a pointer to the region containing virtual_addr
         auto it = std::prev(regions.upper_bound(virtual_addr));
 
@@ -414,8 +437,24 @@ struct AddressSpace::Impl {
         region.is_mapped = true;
         region.phys_base = phys_addr;
         region.prot = prot;
+        region.real_prot = real_prot;
         region.fd = fd;
+        region.is_mirror = is_mirror;
         return MapRegion(&region);
+    }
+
+    void* Map(VAddr virtual_addr, PAddr phys_addr, u64 size, ULONG prot, uintptr_t fd = -1) {
+        std::scoped_lock lk{mutex};
+        void* ptr = MapInternal(virtual_addr, phys_addr, size, prot, prot, fd, false);
+        if (phys_addr != -1) {
+            // Map the read-only mirror view. A File read-only mapping was converted to an
+            // anonymous section above, so re-read the guest region's (possibly updated) fd and
+            // in-section offset and map the mirror from those.
+            auto it = std::prev(regions.upper_bound(virtual_addr));
+            MapInternal(virtual_addr + MIRROR_OFFSET, it->second.phys_base, size, prot,
+                        PAGE_READONLY, it->second.fd, true);
+        }
+        return ptr;
     }
 
     void CoalesceFreeRegions(VAddr virtual_addr) {
@@ -464,8 +503,7 @@ struct AddressSpace::Impl {
         }
     }
 
-    void Unmap(VAddr virtual_addr, u64 size) {
-        std::scoped_lock lk{mutex};
+    void UnmapInternal(VAddr virtual_addr, u64 size) {
         // Loop through all regions in the requested range
         u64 remaining_size = size;
         VAddr current_addr = virtual_addr;
@@ -488,6 +526,11 @@ struct AddressSpace::Impl {
             // Unmap the region if it was previously mapped
             if (region.is_mapped) {
                 UnmapRegion(&region);
+                // File read-only mappings own their anonymous section handle. Release it on the
+                // guest unmap; the mirror shares the same handle and must not close it again.
+                if (!region.is_mirror && region.fd != -1 && region.prot == PAGE_READONLY) {
+                    CloseHandle(reinterpret_cast<HANDLE>(region.fd));
+                }
             }
 
             // Update region data
@@ -495,6 +538,9 @@ struct AddressSpace::Impl {
             region.fd = -1;
             region.phys_base = -1;
             region.prot = PAGE_NOACCESS;
+            region.real_prot = PAGE_NOACCESS;
+            region.is_mirror = false;
+            region.is_anon_section = false;
 
             // Update loop variables
             remaining_size -= size_to_unmap;
@@ -503,6 +549,14 @@ struct AddressSpace::Impl {
 
         // Coalesce any free space produced from these unmaps.
         CoalesceFreeRegions(virtual_addr);
+    }
+
+    void Unmap(VAddr virtual_addr, u64 size) {
+        std::scoped_lock lk{mutex};
+        UnmapInternal(virtual_addr, size);
+        // Unmap the mirror view too. Every phys-backed mapping has one; anonymous mappings do not,
+        // and for them the mirror address is free space so UnmapInternal is a no-op there.
+        UnmapInternal(virtual_addr + MIRROR_OFFSET, size);
     }
 
     void Protect(VAddr virtual_addr, u64 size, bool read, bool write, bool execute) {

--- a/src/core/address_space.h
+++ b/src/core/address_space.h
@@ -21,6 +21,13 @@ enum class MemoryPermission : u32 {
 };
 DECLARE_ENUM_FLAG_OPERATORS(MemoryPermission)
 
+// Offset added to a guest virtual address to form its read-only mirror view (see
+// mirror-mapping-design.md). The mirror maps the same physical pages without page protection, so
+// reading it never triggers readback. Windows-only for now.
+#ifdef _WIN32
+constexpr VAddr MIRROR_OFFSET = 0x1000000000ULL;
+#endif
+
 /**
  * Represents the user virtual address space backed by a dmem memory block
  */

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -20,6 +20,7 @@
 #include "common/discord_rpc_handler.h"
 #endif
 #include "common/elf_info.h"
+#include "common/hack_features.h"
 #include "common/memory_patcher.h"
 #include "common/ntapi.h"
 #include "common/path_util.h"
@@ -430,6 +431,7 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
     auto& game_info = Common::ElfInfo::Instance();
     game_info.initialized = true;
     game_info.game_serial = id;
+    Common::HackFeatures::Init(id);
     game_info.title = title;
     game_info.app_ver = app_version;
     game_info.firmware_ver = fw_version & 0xFFF00000;

--- a/src/shader_recompiler/backend/spirv/emit_spirv_atomic.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_atomic.cpp
@@ -127,6 +127,41 @@ Id ImageAtomicU32CmpSwap(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords
     const auto [scope, semantics]{AtomicArgs(ctx)};
     return (ctx.*atomic_func)(ctx.U32[1], pointer, scope, semantics, semantics, value, cmp_value);
 }
+
+// Emulates a 32-bit float atomic min/max with integer atomics, for devices lacking
+// VK_EXT_shader_atomic_float2. IEEE-754 bit patterns preserve float ordering when compared as
+// signed integers for non-negative values, and reverse it (so min/max swap) when compared as
+// unsigned integers for negative ones, hence the two variants.
+// The two atomics MUST sit in mutually exclusive branches: OpSelect evaluates both of its
+// operands, so using it here applies both atomics to memory. As one is a min and the other a max
+// of the same value at the same address, the second undoes the first and the location ends up
+// holding the incoming value unconditionally, degrading the reduction to "last writer wins".
+template <typename NegFn, typename NonNegFn>
+Id AtomicF32MinMaxFallback(EmitContext& ctx, Id value, NegFn&& emit_neg, NonNegFn&& emit_non_neg) {
+    const Id u32_value = ctx.OpBitcast(ctx.U32[1], value);
+    const Id sign_bit_set = ctx.OpINotEqual(
+        ctx.U1[1],
+        ctx.OpBitFieldUExtract(ctx.U32[1], u32_value, ctx.ConstU32(31u), ctx.ConstU32(1u)),
+        ctx.u32_zero_value);
+
+    const Id neg_label = ctx.OpLabel();
+    const Id non_neg_label = ctx.OpLabel();
+    const Id merge_label = ctx.OpLabel();
+
+    ctx.OpSelectionMerge(merge_label, spv::SelectionControlMask::MaskNone);
+    ctx.OpBranchConditional(sign_bit_set, neg_label, non_neg_label);
+
+    ctx.AddLabel(neg_label);
+    const Id neg_result = EmitBitCastF32U32(ctx, emit_neg(u32_value));
+    ctx.OpBranch(merge_label);
+
+    ctx.AddLabel(non_neg_label);
+    const Id non_neg_result = EmitBitCastF32U32(ctx, emit_non_neg(u32_value));
+    ctx.OpBranch(merge_label);
+
+    ctx.AddLabel(merge_label);
+    return ctx.OpPhi(ctx.F32[1], neg_result, neg_label, non_neg_result, non_neg_label);
+}
 } // Anonymous namespace
 
 Id EmitSharedAtomicIAdd32(EmitContext& ctx, Id offset, Id value) {
@@ -251,20 +286,10 @@ Id EmitBufferAtomicFMin32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id addre
                                      &Sirit::Module::OpAtomicFMin);
     }
 
-    const auto u32_value = ctx.OpBitcast(ctx.U32[1], value);
-    // OpSelect requires a bool condition; produce one by comparing the sign bit to 0.
-    const auto sign_bit_set = ctx.OpINotEqual(
-        ctx.U1[1],
-        ctx.OpBitFieldUExtract(ctx.U32[1], u32_value, ctx.ConstU32(31u), ctx.ConstU32(1u)),
-        ctx.u32_zero_value);
-
-    // FIXME this needs control flow because it currently executes both atomics
-    const auto result = ctx.OpSelect(
-        ctx.F32[1], sign_bit_set,
-        EmitBitCastF32U32(ctx, EmitBufferAtomicUMax32(ctx, inst, handle, address, u32_value)),
-        EmitBitCastF32U32(ctx, EmitBufferAtomicSMin32(ctx, inst, handle, address, u32_value)));
-
-    return result;
+    return AtomicF32MinMaxFallback(
+        ctx, value,
+        [&](Id v) { return EmitBufferAtomicUMax32(ctx, inst, handle, address, v); },
+        [&](Id v) { return EmitBufferAtomicSMin32(ctx, inst, handle, address, v); });
 }
 
 Id EmitBufferAtomicSMax32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address, Id value) {
@@ -289,20 +314,10 @@ Id EmitBufferAtomicFMax32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id addre
                                      &Sirit::Module::OpAtomicFMax);
     }
 
-    const auto u32_value = ctx.OpBitcast(ctx.U32[1], value);
-    // OpSelect requires a bool condition; produce one by comparing the sign bit to 0.
-    const auto sign_bit_set = ctx.OpINotEqual(
-        ctx.U1[1],
-        ctx.OpBitFieldUExtract(ctx.U32[1], u32_value, ctx.ConstU32(31u), ctx.ConstU32(1u)),
-        ctx.u32_zero_value);
-
-    // FIXME this needs control flow because it currently executes both atomics
-    const auto result = ctx.OpSelect(
-        ctx.F32[1], sign_bit_set,
-        EmitBitCastF32U32(ctx, EmitBufferAtomicUMin32(ctx, inst, handle, address, u32_value)),
-        EmitBitCastF32U32(ctx, EmitBufferAtomicSMax32(ctx, inst, handle, address, u32_value)));
-
-    return result;
+    return AtomicF32MinMaxFallback(
+        ctx, value,
+        [&](Id v) { return EmitBufferAtomicUMin32(ctx, inst, handle, address, v); },
+        [&](Id v) { return EmitBufferAtomicSMax32(ctx, inst, handle, address, v); });
 }
 
 Id EmitBufferAtomicInc32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address) {
@@ -369,19 +384,9 @@ Id EmitImageAtomicFMax32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords
         return ImageAtomicF32(ctx, inst, handle, coords, value, &Sirit::Module::OpAtomicFMax);
     }
 
-    const auto u32_value = ctx.OpBitcast(ctx.U32[1], value);
-    // OpSelect requires a bool condition; produce one by comparing the sign bit to 0.
-    const auto sign_bit_set = ctx.OpINotEqual(
-        ctx.U1[1],
-        ctx.OpBitFieldUExtract(ctx.U32[1], u32_value, ctx.ConstU32(31u), ctx.ConstU32(1u)),
-        ctx.u32_zero_value);
-
-    const auto result = ctx.OpSelect(
-        ctx.F32[1], sign_bit_set,
-        EmitBitCastF32U32(ctx, EmitImageAtomicUMin32(ctx, inst, handle, coords, u32_value)),
-        EmitBitCastF32U32(ctx, EmitImageAtomicSMax32(ctx, inst, handle, coords, u32_value)));
-
-    return result;
+    return AtomicF32MinMaxFallback(
+        ctx, value, [&](Id v) { return EmitImageAtomicUMin32(ctx, inst, handle, coords, v); },
+        [&](Id v) { return EmitImageAtomicSMax32(ctx, inst, handle, coords, v); });
 }
 
 Id EmitImageAtomicFMin32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id value) {
@@ -389,19 +394,9 @@ Id EmitImageAtomicFMin32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords
         return ImageAtomicF32(ctx, inst, handle, coords, value, &Sirit::Module::OpAtomicFMin);
     }
 
-    const auto u32_value = ctx.OpBitcast(ctx.U32[1], value);
-    // OpSelect requires a bool condition; produce one by comparing the sign bit to 0.
-    const auto sign_bit_set = ctx.OpINotEqual(
-        ctx.U1[1],
-        ctx.OpBitFieldUExtract(ctx.U32[1], u32_value, ctx.ConstU32(31u), ctx.ConstU32(1u)),
-        ctx.u32_zero_value);
-
-    const auto result = ctx.OpSelect(
-        ctx.F32[1], sign_bit_set,
-        EmitBitCastF32U32(ctx, EmitImageAtomicUMax32(ctx, inst, handle, coords, u32_value)),
-        EmitBitCastF32U32(ctx, EmitImageAtomicSMin32(ctx, inst, handle, coords, u32_value)));
-
-    return result;
+    return AtomicF32MinMaxFallback(
+        ctx, value, [&](Id v) { return EmitImageAtomicUMax32(ctx, inst, handle, coords, v); },
+        [&](Id v) { return EmitImageAtomicSMin32(ctx, inst, handle, coords, v); });
 }
 
 Id EmitImageAtomicInc32(EmitContext&, IR::Inst*, u32, Id, Id) {

--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -72,6 +72,26 @@ Id EmitReadConst(EmitContext& ctx, IR::Inst* inst, Id addr, Id offset) {
 
 Id EmitReadConstBuffer(EmitContext& ctx, u32 handle, Id index) {
     const auto& buffer = ctx.buffers[handle];
+    const auto& desc = ctx.info.buffers[handle];
+    const auto vsharp = desc.GetSharp(ctx.info);
+    if (vsharp.GetElementSize() == 2) {
+        // Buffer has 2-byte elements. Guest address may be only 2-byte aligned,
+        // causing adjust % 4 == 2. Dword indexing (>>2) would lose the sub-4 precision.
+        // Use word indexing instead: dword_index*2 + word_offset, then assemble U32.
+        const Id word_index = ctx.OpIAdd(ctx.U32[1],
+            ctx.OpShiftLeftLogical(ctx.U32[1], index, ctx.ConstU32(1U)),
+            buffer.Offset(PointerSize::B16));
+        const auto [id, ptr_type] = buffer.Alias(PointerType::U16);
+        const Id lo = ctx.OpLoad(ctx.U16, ctx.OpAccessChain(ptr_type, id,
+                               ctx.u32_zero_value, word_index));
+        const Id hi = ctx.OpLoad(ctx.U16, ctx.OpAccessChain(ptr_type, id,
+                               ctx.u32_zero_value,
+                               ctx.OpIAdd(ctx.U32[1], word_index, ctx.ConstU32(1U))));
+        const Id hi32 = ctx.OpShiftLeftLogical(ctx.U32[1],
+                         ctx.OpUConvert(ctx.U32[1], hi), ctx.ConstU32(16U));
+        return ctx.OpBitwiseOr(ctx.U32[1], ctx.OpUConvert(ctx.U32[1], lo), hi32);
+    }
+    // Existing U32 path (element_size != 2)
     if (const Id offset = buffer.Offset(PointerSize::B32); Sirit::ValidId(offset)) {
         index = ctx.OpIAdd(ctx.U32[1], index, offset);
     }

--- a/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
@@ -222,15 +222,24 @@ Id EmitImageRead(EmitContext& ctx, IR::Inst* inst, u32 handle, Id coords, Id lod
     const auto& texture = ctx.images[handle & 0xFFFF];
     const Id color_type = texture.data_types->Get(4);
     ImageOperands operands;
-    operands.Add(spv::ImageOperandsMask::Sample, ms);
     Id texel;
     if (!texture.is_storage) {
         const Id image = ctx.OpLoad(texture.image_type, texture.id);
-        if (texture.view_type != AmdGpu::ImageType::Color2DMsaa) {
+        if (texture.view_type == AmdGpu::ImageType::Color2DMsaa) {
+            // GCN hardware wraps out-of-range MSAA sample indices (e.g., index 2→0, 3→1 on 2x).
+            // Vulkan requires valid sample indices and returns undefined values otherwise.
+            // Replicate GCN behavior: compute ms %= actual_sample_count via OpImageQuerySamples.
+            if (Sirit::ValidId(ms)) {
+                const Id sample_count = ctx.OpImageQuerySamples(ctx.U32[1], image);
+                const Id wrapped_ms = ctx.OpUMod(ctx.U32[1], ms, sample_count);
+                operands.Add(spv::ImageOperandsMask::Sample, wrapped_ms);
+            }
+        } else {
             if (Sirit::ValidId(ms)) {
                 LOG_ERROR(Render_Recompiler, "image is not MS but ms operand is provided");
             }
             operands.Add(spv::ImageOperandsMask::Lod, lod);
+            operands.Add(spv::ImageOperandsMask::Sample, ms);
         }
         texel = ctx.OpImageFetch(color_type, image, coords, operands.mask, operands.operands);
     } else {

--- a/src/shader_recompiler/backend/spirv/emit_spirv_per_vertex.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_per_vertex.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <sirit/sirit.h>
+#include "common/hash.h"
 #include "shader_recompiler/backend/spirv/emit_spirv_per_vertex.h"
 #include "shader_recompiler/info.h"
 #include "shader_recompiler/profile.h"
@@ -93,6 +94,30 @@ PerVertexLocations ComputePerVertexLocations(const Profile& profile, const Info&
     }
     locs.bary_coord_loc = loc;
     return locs;
+}
+
+u64 ComputePerVertexAuxGSSignature(const Info& info, const RuntimeInfo& runtime_info) {
+    const auto& fs_info = runtime_info.fs_info;
+    const bool has_clip = fs_info.clip_distance_emulation;
+    const u32 num_inputs = fs_info.num_inputs - (has_clip ? 1 : 0);
+    // Non-zero seed so 0 can be the "no aux GS" sentinel (HashCombine's constant already keeps
+    // the result non-zero, but seed explicitly). Covers the FS input interface the aux GS binds
+    // to: clip offset (defensive, always 0 here), the persp-center barycentric flag, and the
+    // ordered (param_index, is-per-vertex) list of non-default inputs — which jointly determine
+    // the GS input locations (param_index) and the output counter layout (order + per-vertex).
+    u64 signature = 0x9e3779b97f4a7c15ULL;
+    signature = HashCombine(signature, u64(has_clip));
+    signature = HashCombine(signature, u64(fs_info.addr_flags.persp_center_ena));
+    for (u32 i = 0; i < num_inputs; i++) {
+        const auto& input = fs_info.inputs[i];
+        if (input.IsDefault()) {
+            continue;
+        }
+        signature = HashCombine(signature, u64(input.param_index));
+        signature = HashCombine(signature,
+                                u64(info.fs_interpolation[i].primary == Qualifier::PerVertex));
+    }
+    return signature;
 }
 
 namespace {

--- a/src/shader_recompiler/backend/spirv/emit_spirv_per_vertex.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_per_vertex.cpp
@@ -1,0 +1,307 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <sirit/sirit.h>
+#include "shader_recompiler/backend/spirv/emit_spirv_per_vertex.h"
+#include "shader_recompiler/info.h"
+#include "shader_recompiler/profile.h"
+#include "shader_recompiler/runtime_info.h"
+
+namespace Shader::Backend::SPIRV {
+
+using Sirit::Id;
+
+constexpr u32 SPIRV_VERSION_1_5 = 0x00010500;
+
+u32 UnsupportedBarycentricMask(const RuntimeInfo& runtime_info) {
+    const auto& af = runtime_info.fs_info.addr_flags;
+    u32 mask = 0;
+    if (af.persp_sample_ena) {
+        mask |= 1u << 0;
+    }
+    if (af.persp_centroid_ena) {
+        mask |= 1u << 1;
+    }
+    if (af.persp_pull_model_ena) {
+        mask |= 1u << 2;
+    }
+    if (af.linear_sample_ena) {
+        mask |= 1u << 3;
+    }
+    if (af.linear_center_ena) {
+        mask |= 1u << 4;
+    }
+    if (af.linear_centroid_ena) {
+        mask |= 1u << 5;
+    }
+    return mask;
+}
+
+bool HasUnsupportedBarycentricVariant(const RuntimeInfo& runtime_info) {
+    return UnsupportedBarycentricMask(runtime_info) != 0;
+}
+
+bool CanPerVertexInterp(const Profile& profile, const RuntimeInfo& runtime_info) {
+    const auto& fs_info = runtime_info.fs_info;
+    // Only GPUs without per-vertex interpolation support (neither AMD explicit vertex parameter
+    // nor KHR barycentric) on a
+    // direct VS->FS triangle pipeline with no unsupported barycentric variant and no clip-distance
+    // emulation can use the per-vertex expansion fallback. All other barycentric variants
+    // (sample/centroid/nopersp/pull) are not covered by the fallback and degrade to the existing
+    // flat path. Clip-distance emulation occupies input location 0, which the auxiliary GS does not
+    // pass through, so such pipelines must also keep the legacy flat path.
+    return fs_info.is_vs_direct && fs_info.prim_type == AmdGpu::PrimitiveType::TriangleList &&
+           !profile.supports_amd_shader_explicit_vertex_parameter &&
+           !profile.supports_fragment_shader_barycentric &&
+           !HasUnsupportedBarycentricVariant(runtime_info) && !fs_info.clip_distance_emulation;
+}
+
+bool NeedsPerVertexAuxGS(const Profile& profile, const Info& info, const RuntimeInfo& runtime_info) {
+    if (!CanPerVertexInterp(profile, runtime_info)) {
+        return false;
+    }
+    const auto& fs_info = runtime_info.fs_info;
+    // The aux GS is needed if the FS reads the persp-center barycentric, or any per-vertex
+    // attribute (restored to PerVertex during translation).
+    if (fs_info.addr_flags.persp_center_ena) {
+        return true;
+    }
+    for (u32 i = 0; i < fs_info.num_inputs; i++) {
+        if (info.fs_interpolation[i].primary == Qualifier::PerVertex) {
+            return true;
+        }
+    }
+    return false;
+}
+
+PerVertexLocations ComputePerVertexLocations(const Profile& profile, const Info& info,
+                                             const RuntimeInfo& runtime_info) {
+    const auto& fs_info = runtime_info.fs_info;
+    const bool can_expand = CanPerVertexInterp(profile, runtime_info);
+    PerVertexLocations locs;
+    const bool has_clip = fs_info.clip_distance_emulation;
+    const u32 num_inputs = fs_info.num_inputs - (has_clip ? 1 : 0);
+    u32 loc = has_clip ? 1 : 0;
+    for (u32 i = 0; i < num_inputs; i++) {
+        const auto& input = fs_info.inputs[i];
+        if (input.IsDefault()) {
+            continue;
+        }
+        locs.slot_loc[i] = loc;
+        const bool per_vertex = info.fs_interpolation[i].primary == Qualifier::PerVertex;
+        loc += (per_vertex && can_expand) ? 3 : 1;
+    }
+    locs.bary_coord_loc = loc;
+    return locs;
+}
+
+namespace {
+
+class PerVertexAuxGSEmitter : public Sirit::Module {
+public:
+    PerVertexAuxGSEmitter(const Profile& profile_, const Info& info_,
+                         const RuntimeInfo& runtime_info_)
+        : Sirit::Module{SPIRV_VERSION_1_5}, info{info_}, fs_info{runtime_info_.fs_info} {
+        void_id = TypeVoid();
+        float_id = TypeFloat(32);
+        uint_id = TypeUInt(32U);
+        int_id = TypeInt(32U, true);
+        vec2_id = TypeVector(float_id, 2);
+        vec4_id = TypeVector(float_id, 4);
+
+        const Id float_arr{TypeArray(float_id, Constant(uint_id, 1U))};
+        gl_per_vertex_type = TypeStruct(vec4_id, float_id, float_arr, float_arr);
+        Decorate(gl_per_vertex_type, spv::Decoration::Block);
+        MemberDecorate(gl_per_vertex_type, 0U, spv::Decoration::BuiltIn,
+                       static_cast<u32>(spv::BuiltIn::Position));
+        MemberDecorate(gl_per_vertex_type, 1U, spv::Decoration::BuiltIn,
+                       static_cast<u32>(spv::BuiltIn::PointSize));
+        MemberDecorate(gl_per_vertex_type, 2U, spv::Decoration::BuiltIn,
+                       static_cast<u32>(spv::BuiltIn::ClipDistance));
+        MemberDecorate(gl_per_vertex_type, 3U, spv::Decoration::BuiltIn,
+                       static_cast<u32>(spv::BuiltIn::CullDistance));
+
+        has_clip = fs_info.clip_distance_emulation;
+        num_inputs = fs_info.num_inputs - (has_clip ? 1 : 0);
+        locs = ComputePerVertexLocations(profile_, info_, runtime_info_);
+        for (u32 i = 0; i < num_inputs; i++) {
+            if (!fs_info.inputs[i].IsDefault()) {
+                input_slots.push_back(i);
+                per_vertex[i] = info.fs_interpolation[i].primary == Qualifier::PerVertex;
+            }
+        }
+        has_bary_coord = fs_info.addr_flags.persp_center_ena != 0;
+    }
+
+    void Emit() {
+        DefineEntry();
+        DefineInputs();
+        DefineOutputs();
+        AddEntryPoint(spv::ExecutionModel::Geometry, main, "main", interfaces);
+        AddLabel(OpLabel());
+        EmitMain();
+    }
+
+private:
+    Id Int(s32 value) {
+        return Constant(int_id, value);
+    }
+
+    Id AddInput(Id type) {
+        const Id input{AddGlobalVariable(TypePointer(spv::StorageClass::Input, type),
+                                         spv::StorageClass::Input)};
+        interfaces.push_back(input);
+        return input;
+    }
+
+    Id AddOutput(Id type) {
+        const Id output{AddGlobalVariable(TypePointer(spv::StorageClass::Output, type),
+                                          spv::StorageClass::Output)};
+        interfaces.push_back(output);
+        return output;
+    }
+
+    void DefineEntry() {
+        AddCapability(spv::Capability::Shader);
+        AddCapability(spv::Capability::Geometry);
+        const Id void_function{TypeFunction(void_id)};
+        main = OpFunction(void_id, spv::FunctionControlMask::MaskNone, void_function);
+        AddExecutionMode(main, spv::ExecutionMode::Triangles);
+        AddExecutionMode(main, spv::ExecutionMode::OutputTriangleStrip);
+        AddExecutionMode(main, spv::ExecutionMode::OutputVertices, 3U);
+        AddExecutionMode(main, spv::ExecutionMode::Invocations, 1U);
+    }
+
+    void DefineInputs() {
+        // gl_in: per-vertex input array carrying gl_Position (3 vertices for a triangle).
+        gl_in = AddInput(TypeArray(gl_per_vertex_type, Constant(uint_id, 3U)));
+        // Attribute inputs come from the vertex shader, laid out at param_index + clip offset.
+        const Id input_arr{TypeArray(vec4_id, Constant(uint_id, 3U))};
+        input_ids.reserve(input_slots.size());
+        for (u32 i : input_slots) {
+            const Id id{AddInput(input_arr)};
+            Decorate(id, spv::Decoration::Location,
+                     fs_info.inputs[i].param_index + (has_clip ? 1 : 0));
+            input_ids.push_back(id);
+        }
+    }
+
+    void DefineOutputs() {
+        gl_out = AddOutput(gl_per_vertex_type);
+        output_ids.resize(input_slots.size());
+        pv_output_ids.resize(input_slots.size());
+        for (size_t k = 0; k < input_slots.size(); k++) {
+            const u32 i = input_slots[k];
+            const u32 loc = locs.slot_loc[i];
+            if (per_vertex[i]) {
+                // Expanded per-vertex attribute: 3 flat outputs carrying P0/P10/P20. Flat so the
+                // hardware never interpolates the packed 32-bit bit pattern (e.g. f16 pairs).
+                for (u32 j = 0; j < 3; j++) {
+                    const Id id{AddOutput(vec4_id)};
+                    Decorate(id, spv::Decoration::Location, loc + j);
+                    Decorate(id, spv::Decoration::Flat);
+                    pv_output_ids[k][j] = id;
+                }
+            } else {
+                // Non-per-vertex attribute passes through; interpolation is decided by the FS input.
+                const Id id{AddOutput(vec4_id)};
+                Decorate(id, spv::Decoration::Location, loc);
+                output_ids[k] = id;
+            }
+        }
+        if (has_bary_coord) {
+            bary_coord = AddOutput(vec2_id);
+            Decorate(bary_coord, spv::Decoration::Location, locs.bary_coord_loc);
+        }
+    }
+
+    void EmitMain() {
+        const Id input_vec4{TypePointer(spv::StorageClass::Input, vec4_id)};
+        const Id output_vec4{TypePointer(spv::StorageClass::Output, vec4_id)};
+
+        // Load gl_Position of the 3 input vertices.
+        std::array<Id, 3> pos;
+        for (int v = 0; v < 3; v++) {
+            pos[v] = OpLoad(vec4_id, OpAccessChain(input_vec4, gl_in, Int(v), Int(0)));
+        }
+
+        // Load the 3 per-vertex values of every non-default input attribute.
+        std::vector<std::array<Id, 3>> attr_vals(input_slots.size());
+        for (size_t k = 0; k < input_slots.size(); k++) {
+            for (int v = 0; v < 3; v++) {
+                attr_vals[k][v] = OpLoad(vec4_id, OpAccessChain(input_vec4, input_ids[k], Int(v)));
+            }
+        }
+
+        // Barycentric coordinate constants: vertex 0 -> (0,0), 1 -> (1,0), 2 -> (0,1).
+        std::array<Id, 3> bary_value;
+        if (has_bary_coord) {
+            bary_value[0] =
+                ConstantComposite(vec2_id, Constant(float_id, 0.0f), Constant(float_id, 0.0f));
+            bary_value[1] =
+                ConstantComposite(vec2_id, Constant(float_id, 1.0f), Constant(float_id, 0.0f));
+            bary_value[2] =
+                ConstantComposite(vec2_id, Constant(float_id, 0.0f), Constant(float_id, 1.0f));
+        }
+
+        // Emit 3 vertices. Expanded attributes write the same P0/P10/P20 to every output vertex
+        // (flat, independent of provoking vertex); passthrough attributes copy the current vertex.
+        for (int v = 0; v < 3; v++) {
+            OpStore(OpAccessChain(output_vec4, gl_out, Int(0)), pos[v]);
+            for (size_t k = 0; k < input_slots.size(); k++) {
+                if (per_vertex[input_slots[k]]) {
+                    for (int j = 0; j < 3; j++) {
+                        OpStore(pv_output_ids[k][j], attr_vals[k][j]);
+                    }
+                } else {
+                    OpStore(output_ids[k], attr_vals[k][v]);
+                }
+            }
+            if (has_bary_coord) {
+                OpStore(bary_coord, bary_value[v]);
+            }
+            OpEmitVertex();
+        }
+        OpEndPrimitive();
+        OpReturn();
+        OpFunctionEnd();
+    }
+
+private:
+    const Info& info;
+    const FragmentRuntimeInfo& fs_info;
+    PerVertexLocations locs;
+
+    bool has_clip{};
+    u32 num_inputs{};
+    bool has_bary_coord{};
+    std::vector<u32> input_slots;
+    std::array<bool, 32> per_vertex{};
+    std::vector<Id> input_ids;
+    std::vector<Id> output_ids;
+    std::vector<std::array<Id, 3>> pv_output_ids;
+
+    Id main;
+    Id void_id;
+    Id float_id;
+    Id uint_id;
+    Id int_id;
+    Id vec2_id;
+    Id vec4_id;
+    Id gl_per_vertex_type;
+    Id gl_in;
+    Id gl_out;
+    Id bary_coord;
+    std::vector<Id> interfaces;
+};
+
+} // namespace
+
+std::vector<u32> EmitPerVertexAuxGS(const Profile& profile, const Info& info,
+                                    const RuntimeInfo& runtime_info) {
+    PerVertexAuxGSEmitter ctx{profile, info, runtime_info};
+    ctx.Emit();
+    return ctx.Assemble();
+}
+
+} // namespace Shader::Backend::SPIRV

--- a/src/shader_recompiler/backend/spirv/emit_spirv_per_vertex.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_per_vertex.h
@@ -58,6 +58,14 @@ struct PerVertexLocations {
                                                            const Shader::Info& info,
                                                            const Shader::RuntimeInfo& runtime_info);
 
+// Interface-format signature of the auxiliary geometry shader: identifies the exact set of
+// FS inputs the aux GS binds to, independent of the FS body. Two fragment shaders whose input
+// interface format matches produce byte-identical aux GS SPIR-V and share one cached module.
+// Signature is non-zero (non-zero seed) so 0 can serve as the "no aux GS" sentinel. It is
+// computed at FS compile time (where fs_interpolation is still fresh) and stored per-variant.
+[[nodiscard]] u64 ComputePerVertexAuxGSSignature(const Shader::Info& info,
+                                                 const Shader::RuntimeInfo& runtime_info);
+
 // Emits an auxiliary geometry shader that expands per-vertex attributes into three flat
 // attributes (one per vertex, P0/P10/P20) and injects a smooth barycentric-coordinate
 // attribute assigned (0,0)/(1,0)/(0,1) across the triangle, for GPUs that

--- a/src/shader_recompiler/backend/spirv/emit_spirv_per_vertex.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_per_vertex.h
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <array>
+#include <vector>
+#include "common/types.h"
+
+namespace Shader {
+struct Info;
+struct Profile;
+struct RuntimeInfo;
+} // namespace Shader
+
+namespace Shader::Backend::SPIRV {
+
+// Output location layout shared by the auxiliary geometry shader (output side) and the
+// fragment shader input declaration (input side). Locations are assigned by a single
+// running counter rather than anchoring on param_index: per-vertex attributes have
+// contiguous param_index (spacing 1), so anchoring each expanded attribute onto
+// [param_index, param_index+2] would overlap.
+struct PerVertexLocations {
+    // Output location for each non-default input slot. For per-vertex attributes this is
+    // the start of 3 consecutive locations; for others it is a single location.
+    std::array<u32, 32> slot_loc{};
+    // Location of the injected smooth barycentric-coordinate attribute (vec2, I/J).
+    u32 bary_coord_loc = 0;
+};
+
+// Whether the per-vertex interpolation fallback is eligible for this fragment shader:
+// direct VS->FS triangle pipeline, no AMD explicit vertex parameter nor KHR barycentric, and no
+// unsupported barycentric variant (only persp_center is covered). Shared by the translation side
+// (restoring per-vertex instead of degrading to flat) and the FS compile side (aux GS generation).
+[[nodiscard]] bool CanPerVertexInterp(const Shader::Profile& profile,
+                                      const Shader::RuntimeInfo& runtime_info);
+
+// Whether the fragment shader requests a barycentric variant the fallback cannot reproduce
+// (anything other than persp_center: sample/centroid/pull-model/linear). Shared by the translation
+// side (boundary warning) and the FS compile side (CanPerVertexInterp gate).
+[[nodiscard]] bool HasUnsupportedBarycentricVariant(const Shader::RuntimeInfo& runtime_info);
+
+// Bitmask of the unsupported barycentric variants the shader requests, so the fallback warning can
+// report which variant (rather than a single bool): bit0=persp_sample, bit1=persp_centroid,
+// bit2=persp_pull_model, bit3=linear_sample, bit4=linear_center, bit5=linear_centroid.
+[[nodiscard]] u32 UnsupportedBarycentricMask(const Shader::RuntimeInfo& runtime_info);
+
+// Whether an auxiliary geometry shader must be generated for this fragment shader: the fallback
+// is eligible and the shader either reads a per-vertex attribute or the persp-center barycentric.
+[[nodiscard]] bool NeedsPerVertexAuxGS(const Shader::Profile& profile, const Shader::Info& info,
+                                       const Shader::RuntimeInfo& runtime_info);
+
+// Computes the output location layout for the fragment shader's non-default inputs.
+// Per-vertex attributes occupy 3 consecutive locations only when the fallback applies
+// (CanPerVertexInterp); otherwise they occupy 1, matching the AMD/barycentric single-location paths.
+// The optional clip-distance emulation input occupies location 0 and is skipped by the counter.
+[[nodiscard]] PerVertexLocations ComputePerVertexLocations(const Shader::Profile& profile,
+                                                           const Shader::Info& info,
+                                                           const Shader::RuntimeInfo& runtime_info);
+
+// Emits an auxiliary geometry shader that expands per-vertex attributes into three flat
+// attributes (one per vertex, P0/P10/P20) and injects a smooth barycentric-coordinate
+// attribute assigned (0,0)/(1,0)/(0,1) across the triangle, for GPUs that
+// lack both AMD explicit vertex parameter and KHR fragment shader barycentric.
+[[nodiscard]] std::vector<u32> EmitPerVertexAuxGS(const Shader::Profile& profile,
+                                                  const Shader::Info& info,
+                                                  const Shader::RuntimeInfo& runtime_info);
+
+} // namespace Shader::Backend::SPIRV

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -231,14 +231,16 @@ Id EmitContext::GetBufferSize(const u32 sharp_idx) {
 }
 
 void EmitContext::DefineBufferProperties() {
-    if (!profile.needs_buffer_offsets) {
-        return;
-    }
     for (u32 i = 0; i < buffers.size(); i++) {
         auto& buffer = buffers[i];
         const auto& desc = info.buffers[i];
         const u32 binding = buffer.binding;
         if (buffer.buffer_type != BufferType::Guest) {
+            continue;
+        }
+        // Bypass needs_buffer_offsets gate for element_size==2 buffers:
+        // they need B16 word offset even when the platform's StorageMinAlignment <= 4.
+        if (!profile.needs_buffer_offsets && !True(desc.used_types & IR::Type::U16)) {
             continue;
         }
 

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -3,6 +3,7 @@
 
 #include "common/assert.h"
 #include "common/div_ceil.h"
+#include "shader_recompiler/backend/spirv/emit_spirv_per_vertex.h"
 #include "shader_recompiler/backend/spirv/spirv_emit_context.h"
 #include "shader_recompiler/frontend/fetch_shader.h"
 #include "shader_recompiler/runtime_info.h"
@@ -339,6 +340,8 @@ void EmitContext::DefineInputs() {
         break;
     }
     case LogicalStage::Fragment: {
+        const bool can_expand = CanPerVertexInterp(profile, runtime_info);
+        const auto per_vertex_locs = ComputePerVertexLocations(profile, info, runtime_info);
         if (info.loads.GetAny(IR::Attribute::FragCoord)) {
             frag_coord = DefineVariable(F32[4], spv::BuiltIn::FragCoord, spv::StorageClass::Input);
         }
@@ -361,6 +364,9 @@ void EmitContext::DefineInputs() {
             } else if (profile.supports_fragment_shader_barycentric) {
                 bary_coord_smooth =
                     DefineVariable(F32[3], spv::BuiltIn::BaryCoordKHR, spv::StorageClass::Input);
+            } else {
+                // No-barycentric: injected smooth vec2 (I/J) from the auxiliary geometry shader.
+                bary_coord_smooth = DefineInput(F32[2], per_vertex_locs.bary_coord_loc);
             }
         }
         if (info.loads.GetAny(IR::Attribute::BaryCoordSmoothCentroid)) {
@@ -418,18 +424,27 @@ void EmitContext::DefineInputs() {
             const auto [primary, auxiliary] = info.fs_interpolation[i];
             const Id type = F32[num_components];
             const Id attr_id = [&] {
-                const auto bind_location = input.param_index + (has_clip_distance_inputs ? 1 : 0);
+                const u32 loc = can_expand
+                                    ? per_vertex_locs.slot_loc[i]
+                                    : input.param_index + (has_clip_distance_inputs ? 1 : 0);
                 if (primary == Qualifier::PerVertex &&
-                    profile.supports_fragment_shader_barycentric) {
-                    return Name(DefineInput(TypeArray(type, ConstU32(3U)), bind_location),
+                    !profile.supports_amd_shader_explicit_vertex_parameter) {
+                    // Barycentric (PerVertexKHR) and no-barycentric (flat array from the aux GS) both use a
+                    // 3-element array; AMD reads per-vertex values directly via ExplicitInterpAMD.
+                    return Name(DefineInput(TypeArray(type, ConstU32(3U)), loc),
                                 fmt::format("fs_in_attr{}_p", i));
                 }
-                return Name(DefineInput(type, bind_location), fmt::format("fs_in_attr{}", i));
+                return Name(DefineInput(type, loc), fmt::format("fs_in_attr{}", i));
             }();
             if (primary == Qualifier::PerVertex) {
-                Decorate(attr_id, profile.supports_amd_shader_explicit_vertex_parameter
-                                      ? spv::Decoration::ExplicitInterpAMD
-                                      : spv::Decoration::PerVertexKHR);
+                if (profile.supports_amd_shader_explicit_vertex_parameter) {
+                    Decorate(attr_id, spv::Decoration::ExplicitInterpAMD);
+                } else if (profile.supports_fragment_shader_barycentric) {
+                    Decorate(attr_id, spv::Decoration::PerVertexKHR);
+                } else {
+                    // No-barycentric: plain flat 3-element array supplied by the auxiliary geometry shader.
+                    Decorate(attr_id, spv::Decoration::Flat);
+                }
             } else if (primary != Qualifier::Smooth) {
                 Decorate(attr_id, primary == Qualifier::Flat ? spv::Decoration::Flat
                                                              : spv::Decoration::NoPerspective);

--- a/src/shader_recompiler/frontend/instruction.h
+++ b/src/shader_recompiler/frontend/instruction.h
@@ -177,7 +177,7 @@ struct InstControlMUBUF {
     u64 offen : 1;
     u64 idxen : 1;
     u64 glc : 1;
-    u64 : 1;
+    u64 addr64 : 1;
     u64 lds : 1;
     u64 : 37;
     u64 slc : 1;

--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "common/io_file.h"
+#include "common/logging/log.h"
 #include "common/path_util.h"
 #include "core/emulator_settings.h"
 #include "core/libraries/kernel/process.h"
+#include "shader_recompiler/backend/spirv/emit_spirv_per_vertex.h"
 #include "shader_recompiler/frontend/decode.h"
 #include "shader_recompiler/frontend/fetch_shader.h"
 #include "shader_recompiler/frontend/translate/translate.h"
@@ -131,8 +133,18 @@ void Translator::EmitPrologue(IR::Block* first_block) {
         dst_vreg =
             IterateBarycentrics(runtime_info, [this](u32 vreg, IR::Attribute attrib, u32 comp) {
                 if (profile.supports_amd_shader_explicit_vertex_parameter ||
-                    profile.supports_fragment_shader_barycentric) {
+                    profile.supports_fragment_shader_barycentric ||
+                    Shader::Backend::SPIRV::CanPerVertexInterp(profile, runtime_info)) {
                     ir.SetVectorReg(IR::VectorReg(vreg), ir.GetAttribute(attrib, comp));
+                } else if (runtime_info.fs_info.is_vs_direct && !per_vertex_fallback_warned) {
+                    LOG_WARNING(Render_Recompiler,
+                                "[FSInterp] barycentric fallback for FS {:#x}: per-vertex "
+                                "expansion unavailable (prim_type={}, unsupported_barycentric={:#x}, "
+                                "clip_distance_emulation={})",
+                                info.pgm_hash, u32(runtime_info.fs_info.prim_type),
+                                Shader::Backend::SPIRV::UnsupportedBarycentricMask(runtime_info),
+                                runtime_info.fs_info.clip_distance_emulation);
+                    per_vertex_fallback_warned = true;
                 }
             });
         if (runtime_info.fs_info.addr_flags.pos_x_float_ena) {

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -389,6 +389,7 @@ private:
     std::unordered_map<u32, IR::VectorReg> vgpr_map;
     std::array<IR::Attribute, MaxInterpVgpr> vgpr_to_interp{};
     bool opcode_missing = false;
+    bool per_vertex_fallback_warned = false;
     u32 pc{};
 };
 

--- a/src/shader_recompiler/frontend/translate/vector_interpolation.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_interpolation.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/logging/log.h"
+#include "shader_recompiler/backend/spirv/emit_spirv_per_vertex.h"
 #include "shader_recompiler/frontend/translate/translate.h"
 #include "shader_recompiler/profile.h"
 
@@ -100,12 +102,27 @@ void Translator::V_INTERP_MOV_F32(const GcnInst& inst) {
     auto& interp = info.fs_interpolation[attr_index];
     ASSERT(attr.is_flat || inst.src[0].code == 2);
     if (profile.supports_amd_shader_explicit_vertex_parameter ||
-        profile.supports_fragment_shader_barycentric) {
+        profile.supports_fragment_shader_barycentric ||
+        Shader::Backend::SPIRV::CanPerVertexInterp(profile, runtime_info)) {
         // VSRC 0=P10, 1=P20, 2=P0
         interp.primary = Qualifier::PerVertex;
         SetDst(inst.dst[0],
                ir.GetAttribute(attrib, inst.control.vintrp.chan, (inst.src[0].code + 1) % 3));
     } else {
+        // No-barycentric fallback boundary: a direct VS->FS pipeline that hit an unsupported barycentric
+        // variant, a non-triangle primitive, or clip-distance emulation degrades to flat (only the
+        // provoking vertex value is readable) and must be exposed; non-VS pipelines keep the legacy
+        // degradation silently.
+        if (runtime_info.fs_info.is_vs_direct && !per_vertex_fallback_warned) {
+            LOG_WARNING(Render_Recompiler,
+                        "[FSInterp] MOV fallback for FS {:#x}: per-vertex expansion unavailable "
+                        "(prim_type={}, unsupported_barycentric={:#x}, "
+                        "clip_distance_emulation={})",
+                        info.pgm_hash, u32(runtime_info.fs_info.prim_type),
+                        Shader::Backend::SPIRV::UnsupportedBarycentricMask(runtime_info),
+                        runtime_info.fs_info.clip_distance_emulation);
+            per_vertex_fallback_warned = true;
+        }
         interp.primary = Qualifier::Flat;
         SetDst(inst.dst[0], ir.GetAttribute(attrib, inst.control.vintrp.chan));
     }

--- a/src/shader_recompiler/frontend/translate/vector_memory.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_memory.cpp
@@ -209,15 +209,26 @@ void Translator::BUFFER_LOAD(u32 num_dwords, bool is_inst_typed, bool is_buffer_
     const IR::VectorReg vaddr{inst.src[0].code};
     const IR::ScalarReg sharp{inst.src[2].code * 4};
 
-    const IR::U32 index = mubuf.idxen ? ir.GetVectorReg(vaddr) : ir.Imm32(0);
-    const IR::VectorReg voffset_vgpr = mubuf.idxen ? vaddr + 1 : vaddr;
-    const IR::U32 voffset = mubuf.offen ? ir.GetVectorReg(voffset_vgpr) : ir.Imm32(0);
-    const IR::U32 soffset{GetSrc(inst.src[3])};
-    const IR::Value address = ir.CompositeConstruct(index, voffset, soffset);
+    IR::Value address;
+    if (mubuf.addr64) {
+        // addr64: VGPR pair provides a 64-bit byte offset from buffer base.
+        // idxen/offen are ignored in this mode (GCN3 ISA §8.1.5).
+        const IR::U32 addr_lo = ir.GetVectorReg(vaddr);
+        const IR::U32 addr_hi = ir.GetVectorReg(vaddr + 1);
+        const IR::U32 soffset{GetSrc(inst.src[3])};
+        address = ir.CompositeConstruct(addr_lo, addr_hi, soffset);
+    } else {
+        const IR::U32 index = mubuf.idxen ? ir.GetVectorReg(vaddr) : ir.Imm32(0);
+        const IR::VectorReg voffset_vgpr = mubuf.idxen ? vaddr + 1 : vaddr;
+        const IR::U32 voffset = mubuf.offen ? ir.GetVectorReg(voffset_vgpr) : ir.Imm32(0);
+        const IR::U32 soffset{GetSrc(inst.src[3])};
+        address = ir.CompositeConstruct(index, voffset, soffset);
+    }
 
     IR::BufferInstInfo buffer_info{};
     buffer_info.index_enable.Assign(mubuf.idxen);
     buffer_info.voffset_enable.Assign(mubuf.offen);
+    buffer_info.addr64.Assign(mubuf.addr64);
     buffer_info.inst_offset.Assign(mubuf.offset);
     buffer_info.globally_coherent.Assign(mubuf.glc);
     buffer_info.system_coherent.Assign(mubuf.slc);
@@ -277,15 +288,24 @@ void Translator::BUFFER_STORE(u32 num_dwords, bool is_inst_typed, bool is_buffer
     const IR::VectorReg vaddr{inst.src[0].code};
     const IR::ScalarReg sharp{inst.src[2].code * 4};
 
-    const IR::U32 index = mubuf.idxen ? ir.GetVectorReg(vaddr) : ir.Imm32(0);
-    const IR::VectorReg voffset_vgpr = mubuf.idxen ? vaddr + 1 : vaddr;
-    const IR::U32 voffset = mubuf.offen ? ir.GetVectorReg(voffset_vgpr) : ir.Imm32(0);
-    const IR::U32 soffset{GetSrc(inst.src[3])};
-    const IR::Value address = ir.CompositeConstruct(index, voffset, soffset);
+    IR::Value address;
+    if (mubuf.addr64) {
+        const IR::U32 addr_lo = ir.GetVectorReg(vaddr);
+        const IR::U32 addr_hi = ir.GetVectorReg(vaddr + 1);
+        const IR::U32 soffset{GetSrc(inst.src[3])};
+        address = ir.CompositeConstruct(addr_lo, addr_hi, soffset);
+    } else {
+        const IR::U32 index = mubuf.idxen ? ir.GetVectorReg(vaddr) : ir.Imm32(0);
+        const IR::VectorReg voffset_vgpr = mubuf.idxen ? vaddr + 1 : vaddr;
+        const IR::U32 voffset = mubuf.offen ? ir.GetVectorReg(voffset_vgpr) : ir.Imm32(0);
+        const IR::U32 soffset{GetSrc(inst.src[3])};
+        address = ir.CompositeConstruct(index, voffset, soffset);
+    }
 
     IR::BufferInstInfo buffer_info{};
     buffer_info.index_enable.Assign(mubuf.idxen);
     buffer_info.voffset_enable.Assign(mubuf.offen);
+    buffer_info.addr64.Assign(mubuf.addr64);
     buffer_info.inst_offset.Assign(mubuf.offset);
     buffer_info.globally_coherent.Assign(mubuf.glc);
     buffer_info.system_coherent.Assign(mubuf.slc);
@@ -345,15 +365,25 @@ void Translator::BUFFER_ATOMIC(AtomicOp op, const GcnInst& inst) {
     const IR::VectorReg vaddr{inst.src[0].code};
     const IR::VectorReg vdata{inst.src[1].code};
     const IR::ScalarReg srsrc{inst.src[2].code * 4};
-    const IR::U32 index = mubuf.idxen ? ir.GetVectorReg(vaddr) : ir.Imm32(0);
-    const IR::VectorReg voffset_vgpr = mubuf.idxen ? vaddr + 1 : vaddr;
-    const IR::U32 voffset = mubuf.offen ? ir.GetVectorReg(voffset_vgpr) : ir.Imm32(0);
-    const IR::U32 soffset{GetSrc(inst.src[3])};
-    const IR::Value address = ir.CompositeConstruct(index, voffset, soffset);
+
+    IR::Value address;
+    if (mubuf.addr64) {
+        const IR::U32 addr_lo = ir.GetVectorReg(vaddr);
+        const IR::U32 addr_hi = ir.GetVectorReg(vaddr + 1);
+        const IR::U32 soffset{GetSrc(inst.src[3])};
+        address = ir.CompositeConstruct(addr_lo, addr_hi, soffset);
+    } else {
+        const IR::U32 index = mubuf.idxen ? ir.GetVectorReg(vaddr) : ir.Imm32(0);
+        const IR::VectorReg voffset_vgpr = mubuf.idxen ? vaddr + 1 : vaddr;
+        const IR::U32 voffset = mubuf.offen ? ir.GetVectorReg(voffset_vgpr) : ir.Imm32(0);
+        const IR::U32 soffset{GetSrc(inst.src[3])};
+        address = ir.CompositeConstruct(index, voffset, soffset);
+    }
 
     IR::BufferInstInfo buffer_info{};
     buffer_info.index_enable.Assign(mubuf.idxen);
     buffer_info.voffset_enable.Assign(mubuf.offen);
+    buffer_info.addr64.Assign(mubuf.addr64);
     buffer_info.inst_offset.Assign(mubuf.offset);
     buffer_info.globally_coherent.Assign(mubuf.glc);
     buffer_info.system_coherent.Assign(mubuf.slc);

--- a/src/shader_recompiler/ir/passes/flatten_extended_userdata_pass.cpp
+++ b/src/shader_recompiler/ir/passes/flatten_extended_userdata_pass.cpp
@@ -3,6 +3,7 @@
 
 #include <unordered_map>
 #include <boost/container/flat_map.hpp>
+#include <boost/container/small_vector.hpp>
 #include <xbyak/xbyak.h>
 #include <xbyak/xbyak_util.h>
 #include "common/arch.h"
@@ -123,7 +124,8 @@ using namespace Shader;
 
 struct PassInfo {
     // map offset to inst
-    using PtrUserList = boost::container::flat_map<u32, Shader::IR::Inst*>;
+    using PtrUserList = boost::container::flat_map<u32,
+        boost::container::small_vector<Shader::IR::Inst*, 2>>;
 
     Optimization::SrtGvnTable gvn_table;
     // keys are GetUserData or ReadConst instructions that are used as pointers
@@ -181,18 +183,22 @@ static void VisitPointer(u32 off_dw, IR::Inst* subtree, PassInfo& pass_info,
     // flattened buffer.
     // TODO src and dst are contiguous. Optimize with wider loads/stores
     // TODO if this subtree is dynamically indexed, don't compact it (keep it sparse)
-    for (auto [src_off_dw, use] : *use_list) {
+    for (auto& [src_off_dw, uses] : *use_list) {
         c.mov(r10d, ptr[rdi + (src_off_dw << 2)]);
         c.mov(ptr[rsi + (pass_info.dst_off_dw << 2)], r10d);
 
-        use->SetFlags<u32>(pass_info.dst_off_dw);
+        for (auto* use : uses) {
+            use->SetFlags<u32>(pass_info.dst_off_dw);
+        }
         pass_info.dst_off_dw++;
     }
 
     // Then visit any children used as pointers
-    for (const auto [src_off_dw, use] : *use_list) {
-        if (pass_info.GetUsesAsPointer(use)) {
-            VisitPointer(src_off_dw, use, pass_info, c);
+    for (const auto& [src_off_dw, uses] : *use_list) {
+        for (auto* use : uses) {
+            if (pass_info.GetUsesAsPointer(use)) {
+                VisitPointer(src_off_dw, use, pass_info, c);
+            }
         }
     }
 
@@ -283,7 +289,7 @@ void FlattenExtendedUserdataPass(IR::Program& program) {
                     pass_info.pointer_uses.try_emplace(ptr_lo, PassInfo::PtrUserList{});
                 PassInfo::PtrUserList& user_list = ptr_uses_kv.first->second;
 
-                user_list[inst.Arg(1).U32()] = &inst;
+                user_list[inst.Arg(1).U32()].push_back(&inst);
 
                 if (ptr_lo->GetOpcode() == IR::Opcode::GetUserData) {
                     IR::ScalarReg ud_reg = ptr_lo->Arg(0).ScalarReg();

--- a/src/shader_recompiler/ir/passes/insert_ssbo_store_load_barrier.cpp
+++ b/src/shader_recompiler/ir/passes/insert_ssbo_store_load_barrier.cpp
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <iterator>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include "common/hack_features.h"
+#include "shader_recompiler/ir/ir_emitter.h"
+#include "shader_recompiler/ir/opcodes.h"
+#include "shader_recompiler/ir/program.h"
+#include "shader_recompiler/profile.h"
+
+namespace Shader::Optimization {
+
+namespace {
+
+bool IsStoreBuffer(const IR::Inst& inst) {
+    switch (inst.GetOpcode()) {
+    case IR::Opcode::StoreBufferU8:
+    case IR::Opcode::StoreBufferU16:
+    case IR::Opcode::StoreBufferU32:
+    case IR::Opcode::StoreBufferU32x2:
+    case IR::Opcode::StoreBufferU32x3:
+    case IR::Opcode::StoreBufferU32x4:
+    case IR::Opcode::StoreBufferU64:
+    case IR::Opcode::StoreBufferF32:
+    case IR::Opcode::StoreBufferF32x2:
+    case IR::Opcode::StoreBufferF32x3:
+    case IR::Opcode::StoreBufferF32x4:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool IsLoadBuffer(const IR::Inst& inst) {
+    switch (inst.GetOpcode()) {
+    case IR::Opcode::LoadBufferU8:
+    case IR::Opcode::LoadBufferU16:
+    case IR::Opcode::LoadBufferU32:
+    case IR::Opcode::LoadBufferU32x2:
+    case IR::Opcode::LoadBufferU32x3:
+    case IR::Opcode::LoadBufferU32x4:
+    case IR::Opcode::LoadBufferU64:
+    case IR::Opcode::LoadBufferF32:
+    case IR::Opcode::LoadBufferF32x2:
+    case IR::Opcode::LoadBufferF32x3:
+    case IR::Opcode::LoadBufferF32x4:
+        return true;
+    default:
+        return false;
+    }
+}
+
+} // namespace
+
+void InsertSsbsoStoreLoadBarrier(IR::Program& program, const Profile& profile) {
+    // GCN hardware forwards a same-address buffer store to a following buffer load within the same
+    // dispatch, so the original shader relies on that implicit forwarding. NVIDIA drivers do not
+    // guarantee it for non-coherent SSBO accesses, making the load observe stale data. Insert a
+    // device memory barrier after stores of any buffer that is both stored and loaded. Only needed
+    // on NVIDIA, and gated behind the 1886 hack feature for now.
+    if (!profile.needs_ssbo_store_load_barrier || !Common::HackFeatures::isTheOrder1886) {
+        return;
+    }
+
+    std::set<u32> stored_buffers;
+    std::set<u32> loaded_buffers;
+    for (IR::Block* block : program.blocks) {
+        for (IR::Inst& inst : block->Instructions()) {
+            if (IsStoreBuffer(inst)) {
+                stored_buffers.insert(inst.Arg(0).U32());
+            } else if (IsLoadBuffer(inst)) {
+                loaded_buffers.insert(inst.Arg(0).U32());
+            }
+        }
+    }
+
+    std::vector<std::pair<IR::Block*, IR::Block::iterator>> insert_at;
+    for (IR::Block* block : program.blocks) {
+        for (auto it = block->Instructions().begin(); it != block->Instructions().end(); ++it) {
+            IR::Inst& inst = *it;
+            if (!IsStoreBuffer(inst)) {
+                continue;
+            }
+            const u32 binding = inst.Arg(0).U32();
+            if (stored_buffers.count(binding) && loaded_buffers.count(binding)) {
+                insert_at.emplace_back(block, std::next(it));
+            }
+        }
+    }
+
+    for (auto [block, pos] : insert_at) {
+        IR::IREmitter ir{*block, pos};
+        ir.DeviceMemoryBarrier();
+    }
+}
+
+} // namespace Shader::Optimization

--- a/src/shader_recompiler/ir/passes/ir_passes.h
+++ b/src/shader_recompiler/ir/passes/ir_passes.h
@@ -20,6 +20,7 @@ void ConstantPropagationPass(IR::BlockList& program);
 void FlattenExtendedUserdataPass(IR::Program& program);
 void ReadLaneEliminationPass(IR::Program& program);
 void ResourceTrackingPass(IR::Program& program, const Profile& profile);
+void InsertSsbsoStoreLoadBarrier(IR::Program& program, const Profile& profile);
 void CollectShaderInfoPass(IR::Program& program, const Profile& profile);
 void LowerBufferFormatToRaw(IR::Program& program);
 void LowerFp64ToFp32(IR::Program& program);

--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -808,6 +808,28 @@ IR::U32 CalculateBufferAddress(IR::IREmitter& ir, const IR::Inst& inst, const In
     const u32 mask = (1 << shift) - 1;
     const IR::U32 soffset = IR::GetBufferSOffsetArg(&inst);
 
+    // addr64: VGPR pair provides a 64-bit byte offset from buffer base.
+    // Stride is ignored in this mode — the VGPR values are already byte offsets.
+    if (inst_info.addr64) {
+        const IR::U32 addr_lo = IR::GetBufferIndexArg(&inst);     // comp 0 = addr_lo
+        const IR::U32 addr_hi = IR::GetBufferVOffsetArg(&inst);   // comp 1 = addr_hi
+
+        // Fold soffset + inst_offset into 64-bit address via IAddCarry → SPIR-V OpIAddCarry
+        IR::U32 offset = ir.Imm32(inst_offset);
+        if (!soffset.IsImmediate() || soffset.U32() != 0) {
+            offset = ir.IAdd(offset, soffset);
+        }
+        IR::Value sum_carry = ir.IAddCarry(addr_lo, offset);
+        IR::U32 byte_lo = IR::U32{ir.CompositeExtract(sum_carry, 0)};
+        IR::U32 carry = IR::U32{ir.CompositeExtract(sum_carry, 1)};
+        IR::U32 byte_hi = ir.IAdd(addr_hi, carry);
+
+        // Byte offset → dword index: (byte_hi << (32-shift)) | (byte_lo >> shift)
+        IR::U32 dword_lo = ir.ShiftRightLogical(byte_lo, ir.Imm32(shift));
+        IR::U32 dword_hi = ir.ShiftLeftLogical(byte_hi, ir.Imm32(32 - shift));
+        return ir.BitwiseOr(dword_lo, dword_hi);
+    }
+
     // If address calculation is of the form "index * const_stride + offset" with offset constant
     // and both const_stride and offset are divisible with the element size, apply shift directly.
     if (inst_info.index_enable && !inst_info.voffset_enable && soffset.IsImmediate() &&

--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <queue>
 #include "shader_recompiler/frontend/control_flow_graph.h"
 #include "shader_recompiler/info.h"
 #include "shader_recompiler/ir/basic_block.h"
@@ -675,37 +676,39 @@ void PatchGlobalDataShareAccess(IR::Block& block, IR::Inst& inst, Info& info,
 
     IR::IREmitter ir{block, IR::Block::InstructionList::s_iterator_to(inst)};
 
-    // For data append/consume operations attempt to deduce the GDS address.
+    // For data append/consume operations, convert to GDS buffer atomic.
     if (inst.GetOpcode() == IR::Opcode::DataAppend || inst.GetOpcode() == IR::Opcode::DataConsume) {
-        const auto pred = [](const IR::Inst* inst) -> std::optional<const IR::Inst*> {
-            if (inst->GetOpcode() == IR::Opcode::GetUserData) {
-                return inst;
-            }
-            return std::nullopt;
-        };
-
-        u32 gds_addr = 0;
+        // gds_offset = GetM0() + inst_offset, already resolved by SsaRewrite.
+        // Compute index dynamically per dispatch so that the same SPIR-V module works
+        // across all GDS base addresses (fixes cross-slot reuse bug).
         const IR::Value& gds_offset = inst.Arg(0);
+        IR::U32 index;
         if (gds_offset.IsImmediate()) {
-            // Nothing to do, offset is known.
-            gds_addr = gds_offset.U32() & 0xFFFF;
+            // Fully static offset: fold at compile time.
+            index = ir.Imm32((gds_offset.U32() & 0xFFFF) >> 2);
         } else {
+            // Find the user data register that feeds M0, then emit a runtime chain:
+            //   index = ((GetUserData(reg) >> 16) + inst_offset) >> 2
+            const auto pred = [](const IR::Inst* i) -> std::optional<const IR::Inst*> {
+                return i->GetOpcode() == IR::Opcode::GetUserData ? std::optional{i} : std::nullopt;
+            };
             const auto result = IR::BreadthFirstSearch(&inst, pred);
-            ASSERT_MSG(result, "Unable to track M0 source");
+            ASSERT_MSG(result, "Unable to track M0 source for GDS");
 
-            // M0 must be set by some user data register.
-            const IR::Inst* prod = gds_offset.InstRecursive();
-            const u32 ud_reg = u32(result.value()->Arg(0).ScalarReg());
-            u32 m0_val = info.user_data[ud_reg] >> 16;
-            if (prod->GetOpcode() == IR::Opcode::IAdd32) {
-                m0_val += prod->Arg(1).U32();
-            }
-            gds_addr = m0_val & 0xFFFF;
+            const IR::ScalarReg ud_reg = result.value()->Arg(0).ScalarReg();
+            const IR::Inst* add = gds_offset.InstRecursive();
+            const u32 inst_offset = add->Arg(1).U32();
+
+            // Observed: GDS base lives in upper 16 bits of the user data register.
+            IR::U32 ud_val = ir.GetUserData(ud_reg);
+            IR::U32 gds_base = ir.ShiftRightLogical(ud_val, ir.Imm32(16));
+            IR::U32 gds_byte = ir.IAdd(gds_base, ir.Imm32(inst_offset));
+            IR::U32 clamped = ir.BitwiseAnd(gds_byte, ir.Imm32(0xFFFF));
+            index = ir.ShiftRightLogical(clamped, ir.Imm32(2));
         }
 
         // Patch instruction to GDS buffer atomic increment/decrement.
         const IR::U32 handle = ir.Imm32(binding);
-        const IR::U32 index = ir.Imm32(gds_addr >> 2);
         const bool is_append = inst.GetOpcode() == IR::Opcode::DataAppend;
         const IR::Value prev = is_append ? ir.BufferAtomicInc(handle, index, {})
                                          : ir.BufferAtomicDec(handle, index, {});

--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -511,9 +511,15 @@ void PatchBufferSharp(IR::Block& block, IR::Inst& inst, Info& info, Descriptors&
         raw[0] = handle->Arg(0).U32() | u64(handle->Arg(1).U32()) << 32;
         raw[1] = handle->Arg(2).U32() | u64(handle->Arg(3).U32()) << 32;
         const auto buffer = std::bit_cast<AmdGpu::Buffer>(raw);
+        auto used_types = BufferDataType(inst, profile, buffer.GetNumberFmt());
+        // When element_size==2, the buffer's guest address may only be 2-byte aligned,
+        // requiring U16 word-level access to apply non-dword-aligned offset correctly.
+        if (buffer.GetElementSize() == 2) {
+            used_types |= IR::Type::U16;
+        }
         buffer_binding = descriptors.Add(BufferResource{
             .sharp_idx = std::numeric_limits<u32>::max(),
-            .used_types = BufferDataType(inst, profile, buffer.GetNumberFmt()),
+            .used_types = used_types,
             .inline_cbuf = buffer,
             .buffer_type = BufferType::Guest,
         });
@@ -523,9 +529,15 @@ void PatchBufferSharp(IR::Block& block, IR::Inst& inst, Info& info, Descriptors&
         const auto inst_info = inst.Flags<IR::BufferInstInfo>();
         const auto sharp_idx = TrackSharp(buffer_handle, block, inst_info.pc);
         const auto buffer = info.ReadUdSharp<AmdGpu::Buffer>(sharp_idx);
+        auto used_types = BufferDataType(inst, profile, buffer.GetNumberFmt());
+        // When element_size==2, the buffer's guest address may only be 2-byte aligned,
+        // requiring U16 word-level access to apply non-dword-aligned offset correctly.
+        if (buffer.GetElementSize() == 2) {
+            used_types |= IR::Type::U16;
+        }
         buffer_binding = descriptors.Add(BufferResource{
             .sharp_idx = sharp_idx,
-            .used_types = BufferDataType(inst, profile, buffer.GetNumberFmt()),
+            .used_types = used_types,
             .buffer_type = BufferType::Guest,
             .is_written = IsBufferStore(inst),
             .is_formatted = inst.GetOpcode() == IR::Opcode::LoadBufferFormatF32 ||

--- a/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_tracking_pass.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <queue>
+#include "core/emulator_settings.h"
 #include "shader_recompiler/frontend/control_flow_graph.h"
 #include "shader_recompiler/info.h"
 #include "shader_recompiler/ir/basic_block.h"
@@ -796,6 +797,120 @@ void PatchGlobalDataShareAccess(IR::Block& block, IR::Inst& inst, Info& info,
     }
 }
 
+// Add {base_hi, base_lo} + addend (zero-extended from 32-bit) for 64-bit guest address.
+// Returns CompositeConstructU32x2(result_lo, result_hi).
+static IR::Value EmitAdd64(IR::IREmitter& ir, const IR::U32& base_lo, const IR::U32& base_hi,
+                           const IR::U32& addend) {
+    const IR::Value sum_carry = ir.IAddCarry(base_lo, addend);
+    const IR::U32 result_lo{ir.CompositeExtract(sum_carry, 0)};
+    const IR::U32 carry{ir.CompositeExtract(sum_carry, 1)};
+    const IR::U32 result_hi = ir.IAdd(base_hi, carry);
+    return ir.CompositeConstruct(result_lo, result_hi);
+}
+
+// Number of dwords loaded by a buffer load opcode; 0 = not a supported load.
+static u32 BufferLoadNumDwords(IR::Opcode op) {
+    switch (op) {
+    case IR::Opcode::LoadBufferU32:
+    case IR::Opcode::LoadBufferF32:
+        return 1;
+    case IR::Opcode::LoadBufferU32x2:
+    case IR::Opcode::LoadBufferF32x2:
+        return 2;
+    case IR::Opcode::LoadBufferU32x3:
+    case IR::Opcode::LoadBufferF32x3:
+        return 3;
+    case IR::Opcode::LoadBufferU32x4:
+    case IR::Opcode::LoadBufferF32x4:
+        return 4;
+    default:
+        return 0;
+    }
+}
+
+// Replace a buffer load that uses an inline V# (runtime s_mov_b32 constants) with
+// ReadConst instructions that resolve the guest address via BDA page table.
+// Returns true if the instruction was replaced, false if it fell through.
+static bool PatchInlineBuffer(IR::Block& block, IR::Inst& inst, Info& info,
+                              const BufferResource& buffer_res) {
+    const u32 num_dwords = BufferLoadNumDwords(inst.GetOpcode());
+    if (num_dwords == 0) {
+        return false;
+    }
+
+    if (!EmulatorSettings.IsDirectMemoryAccessEnabled()) {
+        LOG_ERROR(Render_Recompiler, "Inline V# buffer load at {:#x} requires DMA but DMA disabled",
+                  info.pgm_hash);
+        return false;
+    }
+
+    const auto buffer = buffer_res.GetSharp(info);
+    if (buffer.swizzle_enable || buffer.add_tid_enable) {
+        return false;
+    }
+
+    IR::IREmitter ir{block, IR::Block::InstructionList::s_iterator_to(inst)};
+    const auto inst_info = inst.Flags<IR::BufferInstInfo>();
+    const u32 inst_offset = inst_info.inst_offset.Value();
+
+    // Compute 64-bit guest address: U32x2{byte_lo, byte_hi}
+    IR::Value guest_addr;
+    if (inst_info.addr64) {
+        // addr64: address was CompositeConstruct(addr_lo, addr_hi, soffset).
+        // Guest address = {addr_hi, addr_lo} + soffset + inst_offset.
+        const IR::U32 addr_lo = IR::GetBufferIndexArg(&inst);
+        const IR::U32 addr_hi = IR::GetBufferVOffsetArg(&inst);
+        const IR::U32 soffset = IR::GetBufferSOffsetArg(&inst);
+
+        IR::U32 soffset_plus_offset = ir.Imm32(inst_offset);
+        if (!soffset.IsImmediate() || soffset.U32() != 0) {
+            soffset_plus_offset = ir.IAdd(soffset_plus_offset, soffset);
+        }
+        guest_addr = EmitAdd64(ir, addr_lo, addr_hi, soffset_plus_offset);
+    } else {
+        // Non-addr64: address was CompositeConstruct(index, voffset, soffset).
+        // Guest address = V#.base + index*stride + voffset + soffset + inst_offset.
+        const u64 vsharp_base = buffer.base_address;
+        const u32 base_lo = static_cast<u32>(vsharp_base);
+        const u32 base_hi = static_cast<u32>(vsharp_base >> 32);
+        const u32 stride = buffer.stride;
+
+        IR::U32 index = ir.Imm32(0);
+        if (inst_info.index_enable) {
+            index = IR::GetBufferIndexArg(&inst);
+        }
+        IR::U32 voffset = ir.Imm32(0);
+        if (inst_info.voffset_enable) {
+            voffset = IR::GetBufferVOffsetArg(&inst);
+        }
+        const IR::U32 soffset = IR::GetBufferSOffsetArg(&inst);
+
+        // buffer_offset32 = inst_offset + soffset + voffset + index * stride
+        IR::U32 offset32 = ir.Imm32(inst_offset);
+        offset32 = ir.IAdd(offset32, soffset);
+        offset32 = ir.IAdd(offset32, voffset);
+        if (stride != 0 && (!index.IsImmediate() || index.U32() != 0)) {
+            offset32 = ir.IAdd(offset32, ir.IMul(index, ir.Imm32(stride)));
+        }
+        guest_addr = EmitAdd64(ir, ir.Imm32(base_lo), ir.Imm32(base_hi), offset32);
+    }
+
+    // Replace buffer load with ReadConst (BDA path).
+    IR::Value result;
+    if (num_dwords == 1) {
+        result = ir.ReadConst(guest_addr, ir.Imm32(0));
+    } else {
+        boost::container::small_vector<IR::Value, 4> dwords;
+        for (u32 i = 0; i < num_dwords; ++i) {
+            dwords.push_back(ir.ReadConst(guest_addr, ir.Imm32(i)));
+        }
+        result = ir.CompositeConstruct(dwords);
+    }
+
+    inst.ReplaceUsesWith(result);
+    return true;
+}
+
 IR::U32 CalculateBufferAddress(IR::IREmitter& ir, const IR::Inst& inst, const Info& info,
                                const AmdGpu::Buffer& buffer, u32 stride) {
     const auto inst_info = inst.Flags<IR::BufferInstInfo>();
@@ -902,6 +1017,17 @@ void PatchBufferArgs(IR::Block& block, IR::Inst& inst, Info& info) {
     // Address of constant buffer reads can be calculated at IR emission time.
     if (inst.GetOpcode() == IR::Opcode::ReadConstBuffer) {
         return;
+    }
+
+    // Inline V# (runtime s_mov_b32 constants with no buffer-cache backing) must go through
+    // ReadConst / BDA page table rather than the normal buffer binding, because there is no
+    // buffer cache mapping for these guest addresses.
+    if (buffer_res.inline_cbuf) {
+        if (PatchInlineBuffer(block, inst, info, buffer_res)) {
+            return;
+        }
+        // Fall through to normal path if PatchInlineBuffer can't handle this instruction
+        // (store, atomic, swizzle, typed format, etc.).
     }
 
     IR::IREmitter ir{block, IR::Block::InstructionList::s_iterator_to(inst)};

--- a/src/shader_recompiler/ir/reg.h
+++ b/src/shader_recompiler/ir/reg.h
@@ -58,6 +58,7 @@ union BufferInstInfo {
     BitField<16, 1, u64> typed;
     BitField<17, 4, AmdGpu::DataFormat> inst_data_fmt;
     BitField<21, 3, AmdGpu::NumberFormat> inst_num_fmt;
+    BitField<24, 1, u64> addr64;
     BitField<32, 16, u64> pc;
 };
 

--- a/src/shader_recompiler/profile.h
+++ b/src/shader_recompiler/profile.h
@@ -50,6 +50,7 @@ struct Profile {
     bool needs_buffer_offsets{};
     bool needs_unorm_fixup{};
     bool needs_clip_distance_emulation{};
+    bool needs_ssbo_store_load_barrier{};
     bool supports_shader_stencil_export{};
 
     bool operator==(const Profile&) const = default;

--- a/src/shader_recompiler/recompiler.cpp
+++ b/src/shader_recompiler/recompiler.cpp
@@ -81,6 +81,7 @@ IR::Program TranslateProgram(const std::span<const u32>& code, Pools& pools, Inf
     Shader::Optimization::ReadLaneEliminationPass(program);
     Shader::Optimization::FlattenExtendedUserdataPass(program);
     Shader::Optimization::ResourceTrackingPass(program, profile);
+    Shader::Optimization::InsertSsbsoStoreLoadBarrier(program, profile);
     Shader::Optimization::LowerBufferFormatToRaw(program);
     Shader::Optimization::SharedMemorySimplifyPass(program, profile);
     Shader::Optimization::SharedMemoryToStoragePass(program, runtime_info, profile);

--- a/src/shader_recompiler/resource.h
+++ b/src/shader_recompiler/resource.h
@@ -56,7 +56,7 @@ struct BufferResource {
         AmdGpu::Buffer buffer{};
         if (inline_cbuf) {
             buffer = inline_cbuf;
-            if (inline_cbuf.base_address != 1) {
+            if (inline_cbuf.base_address > 1) {
                 buffer.base_address += info.pgm_base; // address fixup
             }
         } else {

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -197,6 +197,10 @@ struct FragmentRuntimeInfo {
     u8 mrtz_mask{};
     bool dual_source_blending{false};
     bool clip_distance_emulation{false};
+    // Whether the fragment shader is fed directly by the vertex shader (no tessellation or game
+    // geometry shader in between). Used to gate the per-vertex interpolation fallback.
+    bool is_vs_direct{false};
+    AmdGpu::PrimitiveType prim_type{AmdGpu::PrimitiveType::None};
 
     bool operator==(const FragmentRuntimeInfo& other) const noexcept {
         return std::ranges::equal(color_buffers, other.color_buffers) &&
@@ -204,6 +208,7 @@ struct FragmentRuntimeInfo {
                num_inputs == other.num_inputs && z_export_format == other.z_export_format &&
                mrtz_mask == other.mrtz_mask && dual_source_blending == other.dual_source_blending &&
                clip_distance_emulation == other.clip_distance_emulation &&
+               is_vs_direct == other.is_vs_direct && prim_type == other.prim_type &&
                std::ranges::equal(inputs.begin(), inputs.begin() + num_inputs, other.inputs.begin(),
                                   other.inputs.begin() + num_inputs);
     }

--- a/src/shader_recompiler/specialization.h
+++ b/src/shader_recompiler/specialization.h
@@ -91,6 +91,10 @@ struct StageSpecialization {
     boost::container::small_vector<FMaskSpecialization, 8> fmasks;
     boost::container::small_vector<SamplerSpecialization, 16> samplers;
     Backend::Bindings start{};
+    // Interface-format signature of the fragment shader's companion auxiliary geometry shader
+    // (per-vertex interpolation fallback). Computed at FS compile time (where fs_interpolation is
+    // fresh) and stored per-variant so preload can reload the aux GS by this signature. 0 = no aux GS.
+    u64 aux_gs_signature{};
 
     StageSpecialization() = default;
     StageSpecialization(const Info& info_, RuntimeInfo runtime_info_, const Profile& profile_,

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -218,6 +218,10 @@ Liverpool::Task Liverpool::ProcessCeUpdate(std::span<const u32> ccb) {
 Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<const u32> ccb) {
     FIBER_ENTER(dcb_task_name);
 
+    if (rasterizer) {
+        rasterizer->GetBufferCache().EnterBatchMode();
+    }
+
     cblock.Reset();
 
     // TODO: potentially, ASCs also can depend on CE and in this case the
@@ -898,12 +902,21 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
         ce_task.handle.destroy();
     }
 
+    if (rasterizer) {
+        rasterizer->GetBufferCache().LeaveBatchMode();
+    }
+
     FIBER_EXIT;
 }
 
 template <bool is_indirect>
 Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
     FIBER_ENTER(acb_task_name[vqid]);
+
+    if (rasterizer) {
+        rasterizer->GetBufferCache().EnterBatchMode();
+    }
+
     auto& queue = asc_queues[{vqid}];
     const bool host_markers_enabled = rasterizer && EmulatorSettings.IsVkHostMarkersEnabled();
 
@@ -1170,6 +1183,10 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
             *queue.read_addr += next_dw_off;
             *queue.read_addr %= queue.ring_size_dw;
         }
+    }
+
+    if (rasterizer) {
+        rasterizer->GetBufferCache().LeaveBatchMode();
     }
 
     FIBER_EXIT;

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -219,7 +219,7 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
     FIBER_ENTER(dcb_task_name);
 
     if (rasterizer) {
-        rasterizer->GetBufferCache().EnterBatchMode();
+        rasterizer->GetBufferCache().EnterBatchMode(VideoCore::BatchType::Graphics);
     }
 
     cblock.Reset();
@@ -903,7 +903,7 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
     }
 
     if (rasterizer) {
-        rasterizer->GetBufferCache().LeaveBatchMode();
+        rasterizer->GetBufferCache().LeaveBatchMode(VideoCore::BatchType::Graphics);
     }
 
     FIBER_EXIT;
@@ -914,7 +914,7 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
     FIBER_ENTER(acb_task_name[vqid]);
 
     if (rasterizer) {
-        rasterizer->GetBufferCache().EnterBatchMode();
+        rasterizer->GetBufferCache().EnterBatchMode(VideoCore::BatchType::Compute);
     }
 
     auto& queue = asc_queues[{vqid}];
@@ -1186,7 +1186,7 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
     }
 
     if (rasterizer) {
-        rasterizer->GetBufferCache().LeaveBatchMode();
+        rasterizer->GetBufferCache().LeaveBatchMode(VideoCore::BatchType::Compute);
     }
 
     FIBER_EXIT;

--- a/src/video_core/buffer_cache/buffer.h
+++ b/src/video_core/buffer_cache/buffer.h
@@ -155,7 +155,6 @@ public:
     bool is_picked{};
     bool is_coherent{};
     bool is_deleted{};
-    u64 sync_gen = 0; // Last batch gen when this buffer was synced
     int stream_score = 0;
     size_t size_bytes = 0;
     u64 lru_id = 0;

--- a/src/video_core/buffer_cache/buffer.h
+++ b/src/video_core/buffer_cache/buffer.h
@@ -155,6 +155,7 @@ public:
     bool is_picked{};
     bool is_coherent{};
     bool is_deleted{};
+    u64 sync_gen = 0; // Last batch gen when this buffer was synced
     int stream_score = 0;
     size_t size_bytes = 0;
     u64 lru_id = 0;

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -641,6 +641,13 @@ void BufferCache::ChangeRegister(BufferId buffer_id) {
 
 bool BufferCache::SynchronizeBuffer(Buffer& buffer, VAddr device_addr, u32 size, bool is_written,
                                     bool is_texel_buffer) {
+    // In batch mode, skip re-sync for read-only buffers already synced this batch.
+    // GPU-writable or texel buffers must sync every time (GPU may modify between draws).
+    if (!is_written && !is_texel_buffer && in_batch && buffer.sync_gen == batch_gen) {
+        return false;
+    }
+    buffer.sync_gen = batch_gen;
+
     boost::container::small_vector<vk::BufferCopy, 4> copies;
     size_t total_size_bytes = 0;
     VAddr buffer_start = buffer.CpuAddr();
@@ -780,6 +787,15 @@ void BufferCache::SynchronizeBuffersInRange(VAddr device_addr, u64 size) {
         u32 size = static_cast<u32>(end - start);
         SynchronizeBuffer(buffer, start, size, false, false);
     });
+}
+
+void BufferCache::EnterBatchMode() {
+    ++batch_gen;
+    in_batch = true;
+}
+
+void BufferCache::LeaveBatchMode() {
+    in_batch = false;
 }
 
 void BufferCache::WriteDataBuffer(Buffer& buffer, VAddr address, const void* value, u32 num_bytes) {

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -792,6 +792,7 @@ void BufferCache::SynchronizeBuffersInRange(VAddr device_addr, u64 size) {
 void BufferCache::EnterBatchMode() {
     ++batch_gen;
     in_batch = true;
+    ResetDmaSyncThisBatch();
 }
 
 void BufferCache::LeaveBatchMode() {

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -658,12 +658,15 @@ void BufferCache::ChangeRegister(BufferId buffer_id) {
 
 bool BufferCache::SynchronizeBuffer(Buffer& buffer, VAddr device_addr, u32 size, bool is_written,
                                     bool is_texel_buffer) {
-    // In batch mode, skip re-sync for read-only buffers already synced this batch.
+    // In batch mode, skip re-sync for read-only bindings already synced this batch.
     // GPU-writable or texel buffers must sync every time (GPU may modify between draws).
-    if (!is_written && !is_texel_buffer && in_batch && buffer.sync_gen == batch_gen) {
-        return false;
+    if (!is_written && !is_texel_buffer && batch_depth > 0) {
+        const auto key = std::pair<VAddr, u32>{device_addr, size};
+        if (synced_bindings.contains(key)) {
+            return false;
+        }
+        synced_bindings.insert(key);
     }
-    buffer.sync_gen = batch_gen;
 
     boost::container::small_vector<vk::BufferCopy, 4> copies;
     size_t total_size_bytes = 0;
@@ -806,14 +809,24 @@ void BufferCache::SynchronizeBuffersInRange(VAddr device_addr, u64 size) {
     });
 }
 
-void BufferCache::EnterBatchMode() {
-    ++batch_gen;
-    in_batch = true;
+void BufferCache::EnterBatchMode(BatchType /*type*/) {
+    // Each command-batch entry (a single ProcessGraphics/ProcessCompute invocation) is its
+    // own batch: indirect buffers and cross-queue yields interleave separate dcb/acb tasks,
+    // between which the CPU may modify buffers. So every entry resets the DMA flag and clears
+    // the sync set. batch_depth only keeps IsInBatch() true across nested entries.
+    synced_bindings.clear();
     ResetDmaSyncThisBatch();
+    ++batch_depth;
+    // LOG_INFO(Render_Vulkan, "EnterBatchMode: type={} depth={}", BatchTypeName(type), batch_depth);
 }
 
-void BufferCache::LeaveBatchMode() {
-    in_batch = false;
+void BufferCache::LeaveBatchMode(BatchType /*type*/) {
+    ASSERT(batch_depth > 0);
+    --batch_depth;
+    if (batch_depth == 0) {
+        synced_bindings.clear();
+    }
+    // LOG_INFO(Render_Vulkan, "LeaveBatchMode: type={} depth={}", BatchTypeName(type), batch_depth);
 }
 
 void BufferCache::WriteDataBuffer(Buffer& buffer, VAddr address, const void* value, u32 num_bytes) {

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -115,6 +115,23 @@ void BufferCache::DownloadBufferMemory(Buffer& buffer, VAddr device_addr, u64 si
     download_buffer.Commit();
     scheduler.EndRendering();
     const auto cmdbuf = scheduler.CommandBuffer();
+    // Synchronize prior GPU writes to this buffer (e.g. compute SSBO writes) before the transfer
+    // read. Without this barrier the copy can read stale L2 cache contents written before the
+    // dispatch, which surfaced as all-zero readbacks of the cascade AABB ring buffer.
+    const vk::BufferMemoryBarrier2 pre_barrier = {
+        .srcStageMask = vk::PipelineStageFlagBits2::eAllCommands,
+        .srcAccessMask = vk::AccessFlagBits2::eMemoryRead | vk::AccessFlagBits2::eMemoryWrite,
+        .dstStageMask = vk::PipelineStageFlagBits2::eTransfer,
+        .dstAccessMask = vk::AccessFlagBits2::eTransferRead,
+        .buffer = buffer.buffer,
+        .offset = 0,
+        .size = buffer.SizeBytes(),
+    };
+    cmdbuf.pipelineBarrier2(vk::DependencyInfo{
+        .dependencyFlags = vk::DependencyFlagBits::eByRegion,
+        .bufferMemoryBarrierCount = 1,
+        .pBufferMemoryBarriers = &pre_barrier,
+    });
     cmdbuf.copyBuffer(buffer.buffer, download_buffer.Handle(), copies);
     const auto write_data = [&]() {
         auto* memory = Core::Memory::Instance();

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -157,6 +157,25 @@ public:
     /// Leave batch command processing mode.
     void LeaveBatchMode();
 
+    /// Returns true if DMA buffer scan hasn't run yet this batch and marks it as done.
+    /// Guarantees at most one SynchronizeBuffersInRange per batch, avoiding the 32M
+    /// interval_map lookups on every intra-batch draw while never skipping when needed.
+    bool NeedDmaSyncThisBatch() {
+        if (dma_synced_this_batch) {
+            return false;
+        }
+        dma_synced_this_batch = true;
+        return true;
+    }
+
+    void ResetDmaSyncThisBatch() {
+        dma_synced_this_batch = false;
+    }
+
+    bool IsInBatch() {
+        return in_batch;
+    }
+
     /// Runs the garbage collector.
     void RunGarbageCollector();
 
@@ -228,6 +247,7 @@ private:
     PageTable page_table;
     u64 batch_gen = 0;   // Monotonic generation; incremented per batch
     bool in_batch = false; // True while processing a command batch
+    bool dma_synced_this_batch = false; // True after first DMA sync this batch
 };
 
 } // namespace VideoCore

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <set>
+
 #include <boost/container/small_vector.hpp>
 #include "common/lru_cache.h"
 #include "common/slot_vector.h"
@@ -27,6 +29,12 @@ class GraphicsPipeline;
 namespace VideoCore {
 
 using BufferId = Common::SlotId;
+
+/// Identifies which command processor entered the batch.
+enum class BatchType : u8 {
+    Graphics,
+    Compute,
+};
 
 class TextureCache;
 class MemoryTracker;
@@ -153,9 +161,9 @@ public:
     void SynchronizeDmaBuffers();
 
     /// Enter batch command processing mode: buffers synced once per batch are skipped on re-bind.
-    void EnterBatchMode();
+    void EnterBatchMode(BatchType type);
     /// Leave batch command processing mode.
-    void LeaveBatchMode();
+    void LeaveBatchMode(BatchType type);
 
     /// Returns true if DMA buffer scan hasn't run yet this batch and marks it as done.
     /// Guarantees at most one SynchronizeBuffersInRange per batch, avoiding the 32M
@@ -173,7 +181,7 @@ public:
     }
 
     bool IsInBatch() {
-        return in_batch;
+        return batch_depth > 0;
     }
 
     /// Runs the garbage collector.
@@ -245,8 +253,8 @@ private:
     RangeSet gpu_modified_ranges;
     SplitRangeMap<BufferId> buffer_ranges;
     PageTable page_table;
-    u64 batch_gen = 0;   // Monotonic generation; incremented per batch
-    bool in_batch = false; // True while processing a command batch
+    u32 batch_depth = 0; // Nesting depth of command batches (indirect buffers nest)
+    std::set<std::pair<VAddr, u32>> synced_bindings; // Read-only bindings synced this batch
     bool dma_synced_this_batch = false; // True after first DMA sync this batch
 };
 

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -152,6 +152,11 @@ public:
     /// Synchronizes all buffers neede for DMA.
     void SynchronizeDmaBuffers();
 
+    /// Enter batch command processing mode: buffers synced once per batch are skipped on re-bind.
+    void EnterBatchMode();
+    /// Leave batch command processing mode.
+    void LeaveBatchMode();
+
     /// Runs the garbage collector.
     void RunGarbageCollector();
 
@@ -221,6 +226,8 @@ private:
     RangeSet gpu_modified_ranges;
     SplitRangeMap<BufferId> buffer_ranges;
     PageTable page_table;
+    u64 batch_gen = 0;   // Monotonic generation; incremented per batch
+    bool in_batch = false; // True while processing a command batch
 };
 
 } // namespace VideoCore

--- a/src/video_core/buffer_cache/fault_manager.cpp
+++ b/src/video_core/buffer_cache/fault_manager.cpp
@@ -162,11 +162,14 @@ void FaultManager::ProcessFaultBuffer() {
             fault_ranges.Add(fault_buf[i], caching_pagesize);
             LOG_INFO(Render_Vulkan, "Accessed non-GPU cached memory at {:#x}", fault_buf[i]);
         }
-        fault_ranges.ForEach([&](VAddr start, VAddr end) {
-            ASSERT_MSG((end - start) <= std::numeric_limits<u32>::max(),
-                       "Buffer size is too large");
-            buffer_cache.FindBuffer(start, static_cast<u32>(end - start));
-        });
+        if (!fault_ranges.m_ranges_set.empty()) {
+            buffer_cache.ResetDmaSyncThisBatch();
+            fault_ranges.ForEach([&](VAddr start, VAddr end) {
+                ASSERT_MSG((end - start) <= std::numeric_limits<u32>::max(),
+                           "Buffer size is too large");
+                buffer_cache.FindBuffer(start, static_cast<u32>(end - start));
+            });
+        }
         fault_areas[area] = 0;
     });
 

--- a/src/video_core/buffer_cache/memory_tracker.h
+++ b/src/video_core/buffer_cache/memory_tracker.h
@@ -93,6 +93,13 @@ public:
                             auto&& on_upload) {
         IteratePages<true>(query_cpu_range, query_size,
                            [&func, is_written](RegionManager* manager, u64 offset, size_t size) {
+                               // Fast O(1) pre-check: skip the lock entirely if no dirty bits.
+                               // Safe because CPU only sets bits (never clears), and batches
+                               // are assumed to be CPU-write-free. A false negative (missed
+                               // dirty page) is at worst a one-frame glitch.
+                               if (manager->GetRegionBits<Type::CPU>().None()) {
+                                   return;
+                               }
                                manager->lock.lock();
                                manager->template ForEachModifiedRange<Type::CPU, true>(
                                    manager->GetCpuAddr() + offset, size, func);

--- a/src/video_core/buffer_cache/region_manager.h
+++ b/src/video_core/buffer_cache/region_manager.h
@@ -120,6 +120,14 @@ public:
         }
 
         RegionBits& bits = GetRegionBits<type>();
+
+        // Fast path: no bits set in the entire region (O(1) via summary word).
+        // Avoids 128-byte mask copy, UnsetRange, and UpdateProtection overhead
+        // when the region has already been synced and hasn't been touched since.
+        if (bits.None()) {
+            return;
+        }
+
         RegionBits mask(bits, start_page, end_page);
 
         if constexpr (clear) {

--- a/src/video_core/cache_storage.cpp
+++ b/src/video_core/cache_storage.cpp
@@ -82,6 +82,9 @@ constexpr std::string GetBlobFileExtension(BlobType type) {
     case BlobType::ShaderProfile: {
         return "bin";
     }
+    case BlobType::AuxiliaryShader: {
+        return "spv";
+    }
     default:
         UNREACHABLE();
     }

--- a/src/video_core/cache_storage.h
+++ b/src/video_core/cache_storage.h
@@ -18,6 +18,7 @@ enum class BlobType : u32 {
     ShaderBinary,
     PipelineKey,
     ShaderProfile,
+    AuxiliaryShader,
 };
 
 class DataBase {

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -183,6 +183,13 @@ GraphicsPipeline::GraphicsPipeline(
             .module = modules[stage],
             .pName = "main",
         });
+    } else if (modules[stage]) {
+        // Auxiliary geometry shader for the per-vertex interpolation expansion.
+        shader_stages.emplace_back(vk::PipelineShaderStageCreateInfo{
+            .stage = vk::ShaderStageFlagBits::eGeometry,
+            .module = modules[stage],
+            .pName = "main",
+        });
     }
     stage = u32(Shader::LogicalStage::TessellationControl);
     if (infos[stage]) {

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -55,6 +55,11 @@ struct GraphicsPipelineKey {
         AmdGpu::ProvokingVtxLast provoking_vtx_last : 1;
         u32 depth_clip_enable : 1;
     };
+    // Interface-format signature of the fragment shader's companion auxiliary geometry shader
+    // (per-vertex interpolation fallback). 0 means no aux GS; otherwise this pipeline inserts an
+    // aux GS looked up by this signature. Kept as a dedicated field (not overloaded onto
+    // stage_hashes[Geometry]) so that slot stays pure game-GS semantics.
+    size_t aux_gs_signature{};
 
     GraphicsPipelineKey() {
         std::memset(this, 0, sizeof(*this));

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -323,15 +323,25 @@ PipelineCache::~PipelineCache() = default;
 void PipelineCache::FillAuxGSModule() {
     // Fill the Geometry slot with the FS's companion auxiliary GS (per-vertex expansion)
     // when there is no game geometry shader. The module is compiled once (at FS compile time or
-    // preload) and cached, so this is just a lookup on the per-draw path.
+    // preload) and cached by interface-format signature, so this is just a lookup. A non-zero
+    // signature that misses the cache is a bug — the aux GS is always generated at FS compile time
+    // on the draw path, or loaded at preload (which returns false when the blob is absent) — so
+    // assert rather than silently leaving the FS's per-vertex inputs without a producer.
     if (infos[u32(Shader::LogicalStage::Geometry)]) {
         return;
     }
-    const u64 fs_perm_hash = graphics_key.stage_hashes[u32(Shader::LogicalStage::Fragment)];
-    const auto gs_it = aux_gs_cache.find(fs_perm_hash);
-    if (gs_it != aux_gs_cache.end()) {
-        modules[u32(Shader::LogicalStage::Geometry)] = gs_it->second;
+    if (graphics_key.aux_gs_signature == 0) {
+        return;
     }
+    // The signature excludes prim_type; assert the pipeline carrying a non-zero signature is always
+    // TriangleList, guarding the "uniform prim_type" assumption behind the shared key.
+    ASSERT_MSG(graphics_key.prim_type == AmdGpu::PrimitiveType::TriangleList,
+               "Per-vertex aux GS used for non-triangle primitive");
+    const auto gs_it = aux_gs_cache.find(graphics_key.aux_gs_signature);
+    ASSERT_MSG(gs_it != aux_gs_cache.end(),
+               "Per-vertex aux GS (signature {:#x}) missing from cache",
+               graphics_key.aux_gs_signature);
+    modules[u32(Shader::LogicalStage::Geometry)] = gs_it->second;
 }
 
 const GraphicsPipeline* PipelineCache::GetGraphicsPipeline() {
@@ -506,9 +516,19 @@ bool PipelineCache::RefreshGraphicsStages() {
 
         const auto params = AmdGpu::GetParams(*pgm);
         std::optional<Shader::Gcn::FetchShaderData> fetch_shader_;
+        u64 stage_aux_gs_signature{};
         std::tie(infos[stage_out_idx], modules[stage_out_idx], fetch_shader_,
-                 key.stage_hashes[stage_out_idx]) =
+                 key.stage_hashes[stage_out_idx], stage_aux_gs_signature) =
             GetProgram(stage_in, stage_out, params, binding);
+        if (stage_in == Shader::Stage::Fragment) {
+            // The signature excludes prim_type; assert a non-zero signature never belongs to a
+            // non-triangle primitive (CanPerVertexInterp already requires TriangleList at
+            // translation).
+            ASSERT_MSG(stage_aux_gs_signature == 0 ||
+                           regs.primitive_type == AmdGpu::PrimitiveType::TriangleList,
+                       "Per-vertex aux GS for non-triangle primitive");
+            key.aux_gs_signature = stage_aux_gs_signature;
+        }
         if (fetch_shader_) {
             fetch_shader = fetch_shader_;
         }
@@ -609,14 +629,16 @@ bool PipelineCache::RefreshComputeKey() {
     Shader::Backend::Bindings binding{};
     const auto& cs_pgm = liverpool->GetCsRegs();
     const auto cs_params = AmdGpu::GetParams(cs_pgm);
-    std::tie(infos[0], modules[0], fetch_shader, compute_key.value) =
+    std::tie(infos[0], modules[0], fetch_shader, compute_key.value, std::ignore) =
         GetProgram(Shader::Stage::Compute, LogicalStage::Compute, cs_params, binding);
     return true;
 }
 
 vk::ShaderModule PipelineCache::CompileModule(Shader::Info& info, Shader::RuntimeInfo& runtime_info,
                                               const std::span<const u32>& code, size_t perm_idx,
-                                              Shader::Backend::Bindings& binding) {
+                                              Shader::Backend::Bindings& binding,
+                                              u64& aux_gs_signature) {
+    aux_gs_signature = 0;
     LOG_INFO(Render_Vulkan, "Compiling {} shader {:#x} {}", info.stage, info.pgm_hash,
              perm_idx != 0 ? "(permutation)" : "");
     DumpShader(code, info.pgm_hash, info.stage, perm_idx, "bin");
@@ -627,20 +649,29 @@ vk::ShaderModule PipelineCache::CompileModule(Shader::Info& info, Shader::Runtim
 
     // Generate and compile the auxiliary geometry shader for the per-vertex interpolation
     // fallback. Done at FS compile time where fs_interpolation is still fresh. The compiled module
-    // is cached for reuse across draws; the SPIR-V is saved to disk for the next preload.
+    // and its SPIR-V are cached by interface-format signature so fragment shaders sharing the same
+    // input interface reuse one aux GS; the SPIR-V is saved to disk for the next preload.
     if (info.stage == Stage::Fragment &&
         Shader::Backend::SPIRV::NeedsPerVertexAuxGS(profile, info, runtime_info)) {
-        const u64 perm_hash = HashCombine(info.pgm_hash, perm_idx);
-        auto aux_gs_spv =
-            Shader::Backend::SPIRV::EmitPerVertexAuxGS(profile, info, runtime_info);
-        DumpShader(aux_gs_spv, info.pgm_hash, Stage::Geometry, perm_idx, "spv");
-        aux_gs_cache[perm_hash] = CompileSPV(aux_gs_spv, instance.GetDevice());
-        if (Storage::DataBase::Instance().IsOpened()) {
-            Storage::DataBase::Instance().Save(Storage::BlobType::AuxiliaryShader,
-                                               fmt::format("{:#018x}", perm_hash),
-                                               std::move(aux_gs_spv));
+        aux_gs_signature =
+            Shader::Backend::SPIRV::ComputePerVertexAuxGSSignature(info, runtime_info);
+        // The signature deliberately excludes prim_type (aux GS is only generated for TriangleList
+        // today). Assert the invariant that aux GS generation implies TriangleList, so a
+        // non-triangle primitive can never silently reuse a TriangleList-only aux GS.
+        ASSERT_MSG(runtime_info.fs_info.prim_type == AmdGpu::PrimitiveType::TriangleList,
+                   "Per-vertex aux GS generated for non-triangle primitive");
+        if (!aux_gs_cache.contains(aux_gs_signature)) {
+            auto aux_gs_spv =
+                Shader::Backend::SPIRV::EmitPerVertexAuxGS(profile, info, runtime_info);
+            DumpShader(aux_gs_spv, info.pgm_hash, Stage::Geometry, perm_idx, "spv");
+            aux_gs_cache[aux_gs_signature] = CompileSPV(aux_gs_spv, instance.GetDevice());
+            if (Storage::DataBase::Instance().IsOpened()) {
+                Storage::DataBase::Instance().Save(Storage::BlobType::AuxiliaryShader,
+                                                   fmt::format("{:#018x}_ag", aux_gs_signature),
+                                                   std::move(aux_gs_spv));
+            }
+            LOG_INFO(Render_Vulkan, "Generated per-vertex aux GS for FS {:#x}", info.pgm_hash);
         }
-        LOG_INFO(Render_Vulkan, "Generated per-vertex aux GS for FS {:#x}", info.pgm_hash);
     }
 
     vk::ShaderModule module;
@@ -674,14 +705,17 @@ PipelineCache::Result PipelineCache::GetProgram(Stage stage, LogicalStage l_stag
         it_pgm.value() = std::make_unique<Program>(stage, l_stage, params);
         auto& program = it_pgm.value();
         auto start = binding;
-        const auto module = CompileModule(program->info, runtime_info, params.code, 0, binding);
+        u64 aux_gs_signature{};
+        const auto module =
+            CompileModule(program->info, runtime_info, params.code, 0, binding, aux_gs_signature);
         auto spec = Shader::StageSpecialization(program->info, runtime_info, profile, start);
+        spec.aux_gs_signature = aux_gs_signature;
         const auto perm_hash = HashCombine(params.hash, 0);
 
         RegisterShaderMeta(program->info, spec.fetch_shader_data, spec, perm_hash, 0);
         program->AddPermut(module, std::move(spec));
         return std::make_tuple(&program->info, module, program->modules[0].spec.fetch_shader_data,
-                               perm_hash);
+                               perm_hash, aux_gs_signature);
     }
 
     auto& program = it_pgm.value();
@@ -699,18 +733,24 @@ PipelineCache::Result PipelineCache::GetProgram(Stage stage, LogicalStage l_stag
     const auto it = std::ranges::find(program->modules, spec, &Program::Module::spec);
     if (it == program->modules.end()) {
         auto new_info = Shader::Info(stage, l_stage, params);
-        module = CompileModule(new_info, runtime_info, params.code, perm_idx, binding);
+        u64 aux_gs_signature{};
+        module = CompileModule(new_info, runtime_info, params.code, perm_idx, binding,
+                               aux_gs_signature);
+        spec.aux_gs_signature = aux_gs_signature;
 
         RegisterShaderMeta(info, spec.fetch_shader_data, spec, perm_hash, perm_idx);
         program->AddPermut(module, std::move(spec));
-    } else {
-        info.AddBindings(binding);
-        module = it->module;
-        perm_idx = std::distance(program->modules.begin(), it);
-        perm_hash = HashCombine(params.hash, perm_idx);
+        return std::make_tuple(&program->info, module,
+                               program->modules[perm_idx].spec.fetch_shader_data, perm_hash,
+                               aux_gs_signature);
     }
+    info.AddBindings(binding);
+    module = it->module;
+    perm_idx = std::distance(program->modules.begin(), it);
+    perm_hash = HashCombine(params.hash, perm_idx);
     return std::make_tuple(&program->info, module,
-                           program->modules[perm_idx].spec.fetch_shader_data, perm_hash);
+                           program->modules[perm_idx].spec.fetch_shader_data, perm_hash,
+                           program->modules[perm_idx].spec.aux_gs_signature);
 }
 
 std::optional<vk::ShaderModule> PipelineCache::ReplaceShader(vk::ShaderModule module,

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -9,6 +9,7 @@
 #include "core/debug_state.h"
 #include "core/emulator_settings.h"
 #include "shader_recompiler/backend/spirv/emit_spirv.h"
+#include "shader_recompiler/backend/spirv/emit_spirv_per_vertex.h"
 #include "shader_recompiler/info.h"
 #include "shader_recompiler/recompiler.h"
 #include "shader_recompiler/runtime_info.h"
@@ -190,6 +191,9 @@ const Shader::RuntimeInfo& PipelineCache::BuildRuntimeInfo(Stage stage, LogicalS
         info.fs_info.en_flags = regs.ps_input_ena;
         info.fs_info.addr_flags = regs.ps_input_addr;
         info.fs_info.num_inputs = regs.num_interp;
+        info.fs_info.is_vs_direct =
+            regs.stage_enable.raw == AmdGpu::ShaderStageEnable::VgtStages::Vs;
+        info.fs_info.prim_type = graphics_key.prim_type;
         info.fs_info.z_export_format = regs.z_export_format;
         u8 stencil_ref_export_enable = regs.depth_shader_control.stencil_op_val_export_enable |
                                        regs.depth_shader_control.stencil_test_val_export_enable;
@@ -316,10 +320,25 @@ PipelineCache::PipelineCache(const Instance& instance_, Scheduler& scheduler_,
 
 PipelineCache::~PipelineCache() = default;
 
+void PipelineCache::FillAuxGSModule() {
+    // Fill the Geometry slot with the FS's companion auxiliary GS (per-vertex expansion)
+    // when there is no game geometry shader. The module is compiled once (at FS compile time or
+    // preload) and cached, so this is just a lookup on the per-draw path.
+    if (infos[u32(Shader::LogicalStage::Geometry)]) {
+        return;
+    }
+    const u64 fs_perm_hash = graphics_key.stage_hashes[u32(Shader::LogicalStage::Fragment)];
+    const auto gs_it = aux_gs_cache.find(fs_perm_hash);
+    if (gs_it != aux_gs_cache.end()) {
+        modules[u32(Shader::LogicalStage::Geometry)] = gs_it->second;
+    }
+}
+
 const GraphicsPipeline* PipelineCache::GetGraphicsPipeline() {
     if (!RefreshGraphicsKey()) {
         return nullptr;
     }
+    FillAuxGSModule();
     const auto [it, is_new] = graphics_pipelines.try_emplace(graphics_key);
     if (is_new) {
         const auto pipeline_hash = std::hash<GraphicsPipelineKey>{}(graphics_key);
@@ -605,6 +624,24 @@ vk::ShaderModule PipelineCache::CompileModule(Shader::Info& info, Shader::Runtim
     const auto ir_program = Shader::TranslateProgram(code, pools, info, runtime_info, profile);
     auto spv = Shader::Backend::SPIRV::EmitSPIRV(profile, runtime_info, ir_program, binding);
     DumpShader(spv, info.pgm_hash, info.stage, perm_idx, "spv");
+
+    // Generate and compile the auxiliary geometry shader for the per-vertex interpolation
+    // fallback. Done at FS compile time where fs_interpolation is still fresh. The compiled module
+    // is cached for reuse across draws; the SPIR-V is saved to disk for the next preload.
+    if (info.stage == Stage::Fragment &&
+        Shader::Backend::SPIRV::NeedsPerVertexAuxGS(profile, info, runtime_info)) {
+        const u64 perm_hash = HashCombine(info.pgm_hash, perm_idx);
+        auto aux_gs_spv =
+            Shader::Backend::SPIRV::EmitPerVertexAuxGS(profile, info, runtime_info);
+        DumpShader(aux_gs_spv, info.pgm_hash, Stage::Geometry, perm_idx, "spv");
+        aux_gs_cache[perm_hash] = CompileSPV(aux_gs_spv, instance.GetDevice());
+        if (Storage::DataBase::Instance().IsOpened()) {
+            Storage::DataBase::Instance().Save(Storage::BlobType::AuxiliaryShader,
+                                               fmt::format("{:#018x}", perm_hash),
+                                               std::move(aux_gs_spv));
+        }
+        LOG_INFO(Render_Vulkan, "Generated per-vertex aux GS for FS {:#x}", info.pgm_hash);
+    }
 
     vk::ShaderModule module;
 

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -308,6 +308,7 @@ PipelineCache::PipelineCache(const Instance& instance_, Scheduler& scheduler_,
         .needs_buffer_offsets = instance.StorageMinAlignment() > 4,
         .needs_unorm_fixup = instance.GetDriverID() == vk::DriverId::eMesaKosmickrisp,
         .needs_clip_distance_emulation = instance.GetDriverID() == vk::DriverId::eNvidiaProprietary,
+        .needs_ssbo_store_load_barrier = instance.GetDriverID() == vk::DriverId::eNvidiaProprietary,
         .supports_shader_stencil_export = instance_.IsShaderStencilExportSupported(),
     };
     WarmUp();

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.h
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.h
@@ -108,6 +108,7 @@ private:
                                    const std::span<const u32>& code, size_t perm_idx,
                                    Shader::Backend::Bindings& binding);
     const Shader::RuntimeInfo& BuildRuntimeInfo(Shader::Stage stage, Shader::LogicalStage l_stage);
+    void FillAuxGSModule();
 
     [[nodiscard]] bool IsPipelineCacheDirty() const {
         return num_new_pipelines > 0;
@@ -128,6 +129,10 @@ private:
     std::array<Shader::RuntimeInfo, MaxShaderStages> runtime_infos{};
     std::array<const Shader::Info*, MaxShaderStages> infos{};
     std::array<vk::ShaderModule, MaxShaderStages> modules{};
+    // Compiled companion auxiliary geometry shader modules (per-vertex expansion), keyed by
+    // the fragment shader's permutation hash. Populated once at FS compile time and on preload;
+    // like the main stage modules, they live for the session and are reclaimed at process exit.
+    tsl::robin_map<u64, vk::ShaderModule> aux_gs_cache;
     std::optional<Shader::Gcn::FetchShaderData> fetch_shader{};
     GraphicsPipelineKey graphics_key{};
     ComputePipelineKey compute_key{};

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.h
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.h
@@ -81,7 +81,7 @@ public:
     const ComputePipeline* GetComputePipeline();
 
     using Result = std::tuple<const Shader::Info*, vk::ShaderModule,
-                              std::optional<Shader::Gcn::FetchShaderData>, u64>;
+                              std::optional<Shader::Gcn::FetchShaderData>, u64, u64>;
     Result GetProgram(Shader::Stage stage, Shader::LogicalStage l_stage,
                       const Shader::ShaderParams& params, Shader::Backend::Bindings& binding);
 
@@ -106,7 +106,7 @@ private:
                                                    std::string_view ext);
     vk::ShaderModule CompileModule(Shader::Info& info, Shader::RuntimeInfo& runtime_info,
                                    const std::span<const u32>& code, size_t perm_idx,
-                                   Shader::Backend::Bindings& binding);
+                                   Shader::Backend::Bindings& binding, u64& aux_gs_signature);
     const Shader::RuntimeInfo& BuildRuntimeInfo(Shader::Stage stage, Shader::LogicalStage l_stage);
     void FillAuxGSModule();
 
@@ -130,8 +130,8 @@ private:
     std::array<const Shader::Info*, MaxShaderStages> infos{};
     std::array<vk::ShaderModule, MaxShaderStages> modules{};
     // Compiled companion auxiliary geometry shader modules (per-vertex expansion), keyed by
-    // the fragment shader's permutation hash. Populated once at FS compile time and on preload;
-    // like the main stage modules, they live for the session and are reclaimed at process exit.
+    // the FS input interface-format signature (aux_gs_signature). Populated once at FS compile
+    // time and on preload; shared across fragment shaders with the same input interface.
     tsl::robin_map<u64, vk::ShaderModule> aux_gs_cache;
     std::optional<Shader::Gcn::FetchShaderData> fetch_shader{};
     GraphicsPipelineKey graphics_key{};

--- a/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2025-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/hash.h"
 #include "common/serdes.h"
 #include "core/emulator_settings.h"
 #include "shader_recompiler/frontend/fetch_shader.h"
@@ -13,7 +14,7 @@
 namespace Serialization {
 /* You should increment versions below once corresponding serialization scheme is changed. */
 static constexpr u32 ShaderBinaryVersion = 2u;
-static constexpr u32 ShaderMetaVersion = 2u;
+static constexpr u32 ShaderMetaVersion = 3u;
 static constexpr u32 PipelineKeyVersion = 2u;
 } // namespace Serialization
 
@@ -237,6 +238,8 @@ bool PipelineCache::LoadGraphicsPipeline(Serialization::Archive& ar) {
     const auto [it, is_new] = graphics_pipelines.try_emplace(graphics_key);
     ASSERT(is_new);
 
+    FillAuxGSModule();
+
     it.value() = std::make_unique<GraphicsPipeline>(
         instance, scheduler, desc_heap, profile, graphics_key, *pipeline_cache, infos,
         runtime_infos, fetch_shader, modules, sdata, true);
@@ -263,6 +266,23 @@ bool PipelineCache::LoadPipelineStage(Serialization::Archive& ar, size_t stage) 
                                        spv);
     if (spv.empty()) {
         return false;
+    }
+
+    // Load and compile the companion auxiliary geometry shader for fragment shaders that need it.
+    // Multiple pipelines can share the same fragment permutation; guard against recompiling (and
+    // leaking the prior VkShaderModule) when that permutation's aux GS was already loaded.
+    if (stage == u32(Shader::LogicalStage::Fragment)) {
+        const u64 perm_hash = HashCombine(program->info.pgm_hash, perm_idx);
+        if (!aux_gs_cache.contains(perm_hash)) {
+            std::vector<u32> aux_gs_spv{};
+            Storage::DataBase::Instance().Load(Storage::BlobType::AuxiliaryShader,
+                                               fmt::format("{:#018x}", perm_hash), aux_gs_spv);
+            if (!aux_gs_spv.empty()) {
+                aux_gs_cache[perm_hash] = CompileSPV(aux_gs_spv, instance.GetDevice());
+                LOG_INFO(Render_Vulkan, "Loaded per-vertex aux GS for FS {:#x} from cache",
+                         program->info.pgm_hash);
+            }
+        }
     }
 
     // Permutation hash depends on shader variation index. To prevent collisions, we need insert it

--- a/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Copyright 2025-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "common/hash.h"
 #include "common/serdes.h"
 #include "core/emulator_settings.h"
 #include "shader_recompiler/frontend/fetch_shader.h"
@@ -215,6 +214,30 @@ bool PipelineCache::LoadGraphicsPipeline(Serialization::Archive& ar) {
     GraphicsPipeline::SerializationSupport sdata{};
     sdata.Deserialize(ar);
 
+    // Load the companion auxiliary geometry shader by its interface-format signature BEFORE the
+    // game stages. It is a dedicated AuxiliaryShader blob keyed by graphics_key.aux_gs_signature.
+    // A missing blob invalidates the whole pipeline (an FS restored to per-vertex would otherwise
+    // have no GS to supply its inputs). Doing this before the stage loop matters: on failure it
+    // returns false while no stage has entered program_cache yet, so the runtime draw re-translates
+    // the FS from the original code and re-generates the aux GS (self-heal). Loading it after the
+    // loop would leave the FS in program_cache, so the draw path would reuse the cached FS without
+    // ever re-generating the missing aux GS and FillAuxGSModule would assert.
+    if (graphics_key.aux_gs_signature != 0) {
+        if (!aux_gs_cache.contains(graphics_key.aux_gs_signature)) {
+            std::vector<u32> aux_gs_spv{};
+            Storage::DataBase::Instance().Load(
+                Storage::BlobType::AuxiliaryShader,
+                fmt::format("{:#018x}_ag", graphics_key.aux_gs_signature), aux_gs_spv);
+            if (aux_gs_spv.empty()) {
+                return false;
+            }
+            aux_gs_cache[graphics_key.aux_gs_signature] =
+                CompileSPV(aux_gs_spv, instance.GetDevice());
+            LOG_INFO(Render_Vulkan, "Loaded per-vertex aux GS (signature {:#x}) from cache",
+                     graphics_key.aux_gs_signature);
+        }
+    }
+
     for (int stage_idx = 0; stage_idx < MaxShaderStages; ++stage_idx) {
         const auto& hash = graphics_key.stage_hashes[stage_idx];
         if (!hash) {
@@ -266,23 +289,6 @@ bool PipelineCache::LoadPipelineStage(Serialization::Archive& ar, size_t stage) 
                                        spv);
     if (spv.empty()) {
         return false;
-    }
-
-    // Load and compile the companion auxiliary geometry shader for fragment shaders that need it.
-    // Multiple pipelines can share the same fragment permutation; guard against recompiling (and
-    // leaking the prior VkShaderModule) when that permutation's aux GS was already loaded.
-    if (stage == u32(Shader::LogicalStage::Fragment)) {
-        const u64 perm_hash = HashCombine(program->info.pgm_hash, perm_idx);
-        if (!aux_gs_cache.contains(perm_hash)) {
-            std::vector<u32> aux_gs_spv{};
-            Storage::DataBase::Instance().Load(Storage::BlobType::AuxiliaryShader,
-                                               fmt::format("{:#018x}", perm_hash), aux_gs_spv);
-            if (!aux_gs_spv.empty()) {
-                aux_gs_cache[perm_hash] = CompileSPV(aux_gs_spv, instance.GetDevice());
-                LOG_INFO(Render_Vulkan, "Loaded per-vertex aux GS for FS {:#x} from cache",
-                         program->info.pgm_hash);
-            }
-        }
     }
 
     // Permutation hash depends on shader variation index. To prevent collisions, we need insert it
@@ -478,6 +484,7 @@ void StageSpecialization::Serialize(Serialization::Archive& ar) const {
     spec.Write(images);
     spec.Write(fmasks);
     spec.Write(samplers);
+    spec.Write(aux_gs_signature);
 }
 
 bool StageSpecialization::Deserialize(Serialization::Archive& ar) {
@@ -504,6 +511,7 @@ bool StageSpecialization::Deserialize(Serialization::Archive& ar) {
     spec.Read(images);
     spec.Read(fmasks);
     spec.Read(samplers);
+    spec.Read(aux_gs_signature);
 
     return true;
 }

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "common/debug.h"
+#include "common/hack_features.h"
 #include "core/debug_state.h"
 #include "core/emulator_settings.h"
 #include "core/memory.h"
@@ -336,11 +337,11 @@ void Rasterizer::DispatchDirect() {
         return;
     }
 
-    // CUSA00100 VSM shadow hack: depthreduction never dispatches, so force
-    // clear shader to write a value with non-zero low-4-bit tile mask.
+    // The Order: 1886 VSM shadow hack: depth-reduction never dispatches,
+    // so force clear shader to write a value with non-zero low-4-bit tile mask.
     // push_data.ud_regs[1] = user_data[4] → stored as float to tile SSBO.
     // 0x7F80000F: +inf float with bitmask=0xF, safe from DenormFlushToZero.
-    if (cs.pgm_hash == 0x9846aaff) {
+    if (Common::HackFeatures::isTheOrder1886 && cs.pgm_hash == 0x9846aaff) {
         push_data.ud_regs[1] = 0x7F80000F;
     }
     scheduler.EndRendering();
@@ -699,10 +700,11 @@ void Rasterizer::BindTextures(const Shader::Info& stage, Shader::Backend::Bindin
     boost::container::small_vector<u32, 8> image_descriptor_array_sizes;
 
     for (const auto& image_desc : stage.images) {
-        // CUSA00100: CS shaders 0xa7b66f58/0xefaaab2b have garbage T# data
+        // The Order: 1886: CS shaders 0xa7b66f58/0xefaaab2b have garbage T# data
         // (mode always 1, textures never actually sampled). Bind empty descriptors
         // instead of letting texture cache parse invalid sharp data and crash the driver.
-        if (stage.pgm_hash == 0xa7b66f58 || stage.pgm_hash == 0xefaaab2b) {
+        if (Common::HackFeatures::isTheOrder1886 &&
+            (stage.pgm_hash == 0xa7b66f58 || stage.pgm_hash == 0xefaaab2b)) {
             image_bindings.emplace_back(std::piecewise_construct, std::tuple{}, std::tuple{});
             image_descriptor_array_sizes.push_back(1);
             continue;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -441,10 +441,13 @@ bool Rasterizer::BindResources(const Pipeline* pipeline) {
     }
 
     if (uses_dma) {
-        // We only use fault buffer for DMA right now.
-        Common::RecursiveSharedLock lock{mapped_ranges_mutex};
-        for (auto& range : mapped_ranges) {
-            buffer_cache.SynchronizeBuffersInRange(range.lower(), range.upper() - range.lower());
+        // DMA buffer sync only once per batch, unless a new buffer is created
+        // (e.g. by deferred fault processing) which resets the flag.
+        if (!buffer_cache.IsInBatch() || buffer_cache.NeedDmaSyncThisBatch()) {
+            Common::RecursiveSharedLock lock{mapped_ranges_mutex};
+            for (auto& range : mapped_ranges) {
+                buffer_cache.SynchronizeBuffersInRange(range.lower(), range.upper() - range.lower());
+            }
         }
         fault_process_pending = true;
     }

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -410,6 +410,8 @@ void Rasterizer::OnSubmit() {
 }
 
 bool Rasterizer::BindResources(const Pipeline* pipeline) {
+    RENDERER_TRACE;
+
     if (IsComputeImageCopy(pipeline) || IsComputeMetaClear(pipeline) ||
         IsComputeImageClear(pipeline)) {
         return false;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -336,6 +336,13 @@ void Rasterizer::DispatchDirect() {
         return;
     }
 
+    // CUSA00100 VSM shadow hack: depthreduction never dispatches, so force
+    // clear shader to write a value with non-zero low-4-bit tile mask.
+    // push_data.ud_regs[1] = user_data[4] → stored as float to tile SSBO.
+    // 0x7F80000F: +inf float with bitmask=0xF, safe from DenormFlushToZero.
+    if (cs.pgm_hash == 0x9846aaff) {
+        push_data.ud_regs[1] = 0x7F80000F;
+    }
     scheduler.EndRendering();
     pipeline->BindResources(set_writes, buffer_barriers, push_data);
 
@@ -692,6 +699,15 @@ void Rasterizer::BindTextures(const Shader::Info& stage, Shader::Backend::Bindin
     boost::container::small_vector<u32, 8> image_descriptor_array_sizes;
 
     for (const auto& image_desc : stage.images) {
+        // CUSA00100: CS shaders 0xa7b66f58/0xefaaab2b have garbage T# data
+        // (mode always 1, textures never actually sampled). Bind empty descriptors
+        // instead of letting texture cache parse invalid sharp data and crash the driver.
+        if (stage.pgm_hash == 0xa7b66f58 || stage.pgm_hash == 0xefaaab2b) {
+            image_bindings.emplace_back(std::piecewise_construct, std::tuple{}, std::tuple{});
+            image_descriptor_array_sizes.push_back(1);
+            continue;
+        }
+
         const auto tsharp = image_desc.GetSharp(stage);
         if (texture_cache.IsMeta(tsharp.Address())) {
             LOG_WARNING(Render_Vulkan, "Unexpected metadata read by a shader (texture)");

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -663,7 +663,7 @@ void Rasterizer::BindBuffers(const Shader::Info& stage, Shader::Backend::Binding
                 vsharp.base_address, size, desc.is_written, desc.is_formatted, buffer_id);
             const u32 offset_aligned = Common::AlignDown(offset, alignment);
             const u32 adjust = offset - offset_aligned;
-            ASSERT(adjust % 4 == 0);
+            ASSERT(adjust % 4 == 0 || (vsharp.GetElementSize() == 2 && adjust % 2 == 0));
             push_data.AddOffset(binding.buffer, adjust);
             buffer_infos.emplace_back(vk_buffer->Handle(), offset_aligned, size + adjust);
             if (auto barrier =

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -115,8 +115,13 @@ void TextureCache::DownloadImageMemory(ImageId image_id, bool sync) {
 
 void TextureCache::MarkAsMaybeDirty(ImageId image_id, Image& image) {
     if (image.hash == 0) {
-        // Initialize hash
+        // Initialize hash. Read via the read-only mirror to avoid triggering a readback, which
+        // would deadlock on the texture mutex held by the caller (see mirror-mapping-design.md).
+#ifdef _WIN32
+        const u8* addr = std::bit_cast<u8*>(image.info.guest_address + Core::MIRROR_OFFSET);
+#else
         const u8* addr = std::bit_cast<u8*>(image.info.guest_address);
+#endif
         image.hash = XXH3_64bits(addr, image.info.guest_size);
     }
     image.flags |= ImageFlagBits::MaybeCpuDirty;


### PR DESCRIPTION
## Overview

These are some issues observed while getting through the intro sequence.

Some issues were bypassed temporarily just to continue execution. This is not intended as a patch proposal; the main purpose is to document the observations and hopefully get feedback from people more familiar with the hardware behavior.

## 1. Invalid texture descriptors

Affected shaders:

* `cs_0x00000000a7b66f58_0`
* `cs_0x00000000efaaab2b`

These shaders contain a large number of invalid texture descriptors. Entering the game triggers an assertion failure.

I did not find a good way to handle these invalid bindings, so I temporarily skipped all texture bindings for these shaders to continue testing.

## 2. VSM shadow generation

Affected shader:

* `cs_0x000000008ea0ef5b_0`
* `cs_0x000000009846aaff_0`

This shader converts the depth buffer into VSM data.

It appears to rely on hardware HTILE data, but the bound HTILE buffer does not seem to contain the expected contents. The result is that shadows disappear, as if the generated data is based on far surfaces.

For testing purposes, I temporarily enabled another internal path that directly reads the depth buffer. This makes the result look correct, but I am not sure what the intended implementation should be.

A proper solution may require a better understanding of HTILE generation and usage.

## 3. TAA ghosting

Affected shader:

* `cs_0x0000000092311aca_0`

This TAA implementation uses 4x sampling, while the bound depth buffer appears to be 2x.

The mismatch produces incorrect results and severe ghosting.

It is not clear whether this is the actual cause or just a related symptom. The current change only makes this path compatible with 2x depth buffers.

## 4. Missing large bubbles in the pool

Several possible issues were observed:

### a. Dynamic GDS offset

Affected shader:

* `cs_0x00000000873b1ade_0`

The GDS offset is constant-folded during translation, but the runtime value can change.

### b. Indirect SSBO binding

Affected shader:

* `vs_0x00000000c75dd317_0`

This shader renders the large bubbles in the new game pool.

The particle data is stored in `ssbo10` and accessed through indirect `v#` addressing. The correct `v#` value is not known when creating the binding.

### c. addr64 support

The shader requires `addr64` support to read the correct offsets from push constants.

### d. Runtime constructed static v#

The shader constructs and accesses static `v#` values at runtime. They are currently not bound, so the correct data cannot be read.

This likely requires BDA support.

## Other observations

After passing the intro sequence, another assertion occurs due to buffers aligned to 2-byte boundaries.

## Notes

These are exploratory findings rather than confirmed root causes. Any feedback on the expected hardware behavior or correct implementation approach would be appreciated.

---

Claude Code / deepseek-v4-pro

<img width="1280" height="720" alt="Screenshot 2026-08-04 165209" src="https://github.com/user-attachments/assets/78891e74-d3c1-4832-b18d-c9da50e068cf" />

<img width="1280" height="720" alt="Screenshot 2026-08-04 165615" src="https://github.com/user-attachments/assets/c9ee3946-a772-4c18-819f-1d05e8f118a7" />

