### PR TITLE
Appends last time played for each game in play_time.txt

### DIFF
--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright 2025-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <chrono>
+#include <ctime>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -850,13 +852,16 @@ void Emulator::UpdatePlayTime(const std::string& serial) {
 
     std::string playTimeSaved = fmt::format("{:d}:{:02d}:{:02d}", hours, minutes, seconds);
 
+	std::time_t last_time_played; 
+	std::time(&last_time_played);
+
     std::ofstream outfile(filePath, std::ios::trunc);
     bool lineUpdated = false;
     for (const auto& l : lines) {
         std::istringstream iss(l);
-        std::string s;
+			std::string s;
         if (iss >> s && s == serial) {
-            outfile << fmt::format("{} {}\n", serial, playTimeSaved);
+            outfile << fmt::format("{} {} {}\n", serial, playTimeSaved, last_time_played);
             lineUpdated = true;
         } else {
             outfile << l << "\n";
@@ -864,10 +869,10 @@ void Emulator::UpdatePlayTime(const std::string& serial) {
     }
 
     if (!lineUpdated) {
-        outfile << fmt::format("{} {}\n", serial, playTimeSaved);
+        outfile << fmt::format("{} {} {}\n", serial, playTimeSaved, last_time_played);
     }
 
-    LOG_INFO(Loader, "Playing time for {}: {}", serial, playTimeSaved);
+    LOG_INFO(Loader, "Playing time for {}: {} {}", serial, playTimeSaved, last_time_played);
 }
 
 } // namespace Core

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -1,11 +1,10 @@
 // SPDX-FileCopyrightText: Copyright 2025-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include <chrono>
-#include <ctime>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <ctime>
 #include <set>
 #include <sstream>
 #include <fmt/core.h>
@@ -852,14 +851,13 @@ void Emulator::UpdatePlayTime(const std::string& serial) {
 
     std::string playTimeSaved = fmt::format("{:d}:{:02d}:{:02d}", hours, minutes, seconds);
 
-	std::time_t last_time_played; 
-	std::time(&last_time_played);
+	const std::time_t last_time_played = std::time(nullptr);
 
     std::ofstream outfile(filePath, std::ios::trunc);
     bool lineUpdated = false;
     for (const auto& l : lines) {
         std::istringstream iss(l);
-			std::string s;
+		std::string s;
         if (iss >> s && s == serial) {
             outfile << fmt::format("{} {} {}\n", serial, playTimeSaved, last_time_played);
             lineUpdated = true;

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright 2025-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <ctime>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
-#include <ctime>
 #include <set>
 #include <sstream>
 #include <fmt/core.h>
@@ -851,13 +851,13 @@ void Emulator::UpdatePlayTime(const std::string& serial) {
 
     std::string playTimeSaved = fmt::format("{:d}:{:02d}:{:02d}", hours, minutes, seconds);
 
-	const std::time_t last_time_played = std::time(nullptr);
+    const std::time_t last_time_played = std::time(nullptr);
 
     std::ofstream outfile(filePath, std::ios::trunc);
     bool lineUpdated = false;
     for (const auto& l : lines) {
         std::istringstream iss(l);
-		std::string s;
+        std::string s;
         if (iss >> s && s == serial) {
             outfile << fmt::format("{} {} {}\n", serial, playTimeSaved, last_time_played);
             lineUpdated = true;


### PR DESCRIPTION
A really small change which just appends the Unix epoch time for games when playtime is updated in the UpdatePlayTime function.

I have tested, this does not affect the QT launcher in any way, it currently ignores this new meta data.