### PR TITLE
Add experimental Windows static red-zone protection

### DIFF
--- a/src/core/cpu_patches.cpp
+++ b/src/core/cpu_patches.cpp
@@ -1,10 +1,17 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <array>
+#include <atomic>
+#include <bitset>
+#include <climits>
+#include <cstring>
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <set>
+#include <unordered_set>
 #include <vector>
 #include <Zydis/Zydis.h>
 #include <xbyak/xbyak.h>
@@ -539,6 +546,8 @@ struct PatchInfo {
     bool trampoline;
 };
 
+constexpr size_t NearJumpSize = 5;
+
 #if defined(_WIN32)
 static const bool need_tcb_trampoline = true;
 #else
@@ -588,6 +597,9 @@ struct PatchModule {
     /// Code generator for writing trampoline patches.
     Xbyak::CodeGenerator trampoline_gen;
 
+    /// Prevents repeated generation attempts after the fixed trampoline area is exhausted.
+    bool trampoline_exhausted{};
+
     PatchModule(u8* module_ptr, const u64 module_size, u8* trampoline_ptr,
                 const u64 trampoline_size)
         : start(module_ptr), end(module_ptr + module_size), patch_gen(module_size, module_ptr),
@@ -595,12 +607,31 @@ struct PatchModule {
 };
 static std::map<u64, PatchModule> modules;
 
+static bool HandleTrampolineError(PatchModule* module, const Xbyak::Error& error) {
+    if (static_cast<int>(error) != Xbyak::ERR_CODE_IS_TOO_BIG) {
+        return false;
+    }
+    if (!module->trampoline_exhausted) {
+        LOG_WARNING(Core, "Patch trampoline space exhausted for module at {}",
+                    fmt::ptr(module->start));
+        module->trampoline_exhausted = true;
+    }
+    return true;
+}
+
 static PatchModule* GetModule(const void* ptr) {
     auto upper_bound = modules.upper_bound(reinterpret_cast<u64>(ptr));
     if (upper_bound == modules.begin()) {
         return nullptr;
     }
     return &(std::prev(upper_bound)->second);
+}
+
+// Windows static guest red-zone protection
+static PatchModule* GetContainingModule(const void* ptr) {
+    auto* module = GetModule(ptr);
+    const auto* address = static_cast<const u8*>(ptr);
+    return module != nullptr && address < module->end ? module : nullptr;
 }
 
 /// Returns a boolean indicating whether the instruction was patched, and the offset to advance past
@@ -621,10 +652,14 @@ static std::pair<bool, u64> TryPatch(u8* code, PatchModule* module) {
             if (patch_info.filter(operands)) {
                 auto& patch_gen = module->patch_gen;
 
-                if (needs_trampoline && instruction.length < 5) {
+                if (needs_trampoline && instruction.length < NearJumpSize) {
                     // Trampoline is needed but instruction is too short to patch.
                     // Return false and length to signal to AOT compilation that this instruction
                     // should be skipped and handled at runtime.
+                    return std::make_pair(false, instruction.length);
+                }
+
+                if (needs_trampoline && module->trampoline_exhausted) {
                     return std::make_pair(false, instruction.length);
                 }
 
@@ -634,12 +669,20 @@ static std::pair<bool, u64> TryPatch(u8* code, PatchModule* module) {
 
                 if (needs_trampoline) {
                     auto& trampoline_gen = module->trampoline_gen;
+                    const size_t trampoline_offset = trampoline_gen.getSize();
                     const auto trampoline_ptr = trampoline_gen.getCurr();
+                    try {
+                        patch_info.generator(code, operands, trampoline_gen);
 
-                    patch_info.generator(code, operands, trampoline_gen);
-
-                    // Return to the following instruction at the end of the trampoline.
-                    trampoline_gen.jmp(code + instruction.length);
+                        // Return to the following instruction at the end of the trampoline.
+                        trampoline_gen.jmp(code + instruction.length);
+                    } catch (const Xbyak::Error& error) {
+                        trampoline_gen.setSize(trampoline_offset);
+                        if (HandleTrampolineError(module, error)) {
+                            return std::make_pair(false, instruction.length);
+                        }
+                        throw;
+                    }
 
                     // Replace instruction with near jump to the trampoline.
                     patch_gen.jmp(trampoline_ptr, Xbyak::CodeGenerator::LabelType::T_NEAR);
@@ -901,13 +944,1232 @@ static void TryPatchAot(void* code_address, u64 code_size) {
     }
 }
 
+// ============================================================================
+// Windows static guest red-zone protection
+// ============================================================================
+
+namespace WindowsGuestRedZoneProtection {
+namespace {
+
+std::atomic active_mode{WindowsGuestRedZoneProtectionMode::Disabled};
+
+} // namespace
+
+void SetActiveMode(WindowsGuestRedZoneProtectionMode mode) noexcept {
+    active_mode.store(mode, std::memory_order_release);
+}
+
+WindowsGuestRedZoneProtectionMode GetActiveMode() noexcept {
+    return active_mode.load(std::memory_order_acquire);
+}
+
+bool IsStaticPatchingEnabled() noexcept {
+    return GetActiveMode() == WindowsGuestRedZoneProtectionMode::StaticPatching;
+}
+
+} // namespace WindowsGuestRedZoneProtection
+
+#if defined(_WIN32)
+
+namespace {
+
+constexpr size_t GuestRedZoneSize = 128;
+constexpr size_t ShortJumpSize = 2;
+using RedZoneMask = std::bitset<GuestRedZoneSize>;
+
+struct DecodedCodeInstruction {
+    uintptr_t address{};
+    ZydisDecodedInstruction instruction{};
+    std::array<ZydisDecodedOperand, ZYDIS_MAX_OPERAND_COUNT> operands{};
+    RedZoneMask red_zone_use{};
+    RedZoneMask red_zone_def{};
+    RedZoneMask red_zone_live{};
+    bool accesses_memory{};
+    bool uses_stack_pointer{};
+    bool has_red_zone_operand{};
+    bool has_unmodeled_red_zone_operand{};
+    bool changes_stack_pointer{};
+    bool replaces_stack_pointer{};
+    std::optional<s64> stack_pointer_delta;
+};
+
+struct DecodedFunction {
+    std::map<uintptr_t, DecodedCodeInstruction> instructions;
+    std::set<uintptr_t> branch_targets;
+    bool uses_red_zone{};
+    bool has_indirect_branch{};
+    bool requires_conservative_red_zone_tracking{};
+};
+
+struct InstructionRewrite {
+    const PatchInfo* cpu_patch{};
+    bool protect_red_zone{};
+    bool protected_indirect_call{};
+};
+
+bool IsStackPointerRegister(ZydisRegister reg) {
+    return reg != ZYDIS_REGISTER_NONE &&
+           ZydisRegisterGetLargestEnclosing(ZYDIS_MACHINE_MODE_LONG_64, reg) == ZYDIS_REGISTER_RSP;
+}
+
+bool IsControlFlowTerminator(const ZydisDecodedInstruction& instruction) {
+    return instruction.meta.category == ZYDIS_CATEGORY_UNCOND_BR ||
+           instruction.meta.category == ZYDIS_CATEGORY_RET ||
+           instruction.meta.category == ZYDIS_CATEGORY_INTERRUPT ||
+           instruction.meta.category == ZYDIS_CATEGORY_SYSRET ||
+           instruction.mnemonic == ZYDIS_MNEMONIC_UD2;
+}
+
+uintptr_t GetRelativeTarget(const DecodedCodeInstruction& decoded) {
+    for (u8 index = 0; index < decoded.instruction.operand_count_visible; ++index) {
+        const auto& operand = decoded.operands[index];
+        if (operand.type != ZYDIS_OPERAND_TYPE_IMMEDIATE || !operand.imm.is_relative) {
+            continue;
+        }
+
+        ZyanU64 target{};
+        if (ZYAN_SUCCESS(ZydisCalcAbsoluteAddress(&decoded.instruction, &operand, decoded.address,
+                                                  &target))) {
+            return target;
+        }
+    }
+    return 0;
+}
+
+DecodedCodeInstruction DecodeCodeInstruction(uintptr_t address, uintptr_t end) {
+    DecodedCodeInstruction decoded{.address = address};
+    const auto status = Common::Decoder::Instance()->decodeInstruction(
+        decoded.instruction, decoded.operands.data(), reinterpret_cast<void*>(address),
+        end - address);
+    if (!ZYAN_SUCCESS(status)) {
+        decoded.instruction.length = 0;
+        return decoded;
+    }
+
+    for (u8 index = 0; index < decoded.instruction.operand_count; ++index) {
+        const auto& operand = decoded.operands[index];
+        if (operand.type == ZYDIS_OPERAND_TYPE_REGISTER) {
+            decoded.uses_stack_pointer |= IsStackPointerRegister(operand.reg.value);
+            if (IsStackPointerRegister(operand.reg.value) &&
+                (operand.actions & ZYDIS_OPERAND_ACTION_MASK_WRITE) != 0 &&
+                decoded.instruction.meta.category != ZYDIS_CATEGORY_CALL &&
+                decoded.instruction.meta.category != ZYDIS_CATEGORY_RET) {
+                decoded.changes_stack_pointer = true;
+            }
+            continue;
+        }
+        if (operand.type != ZYDIS_OPERAND_TYPE_MEMORY) {
+            continue;
+        }
+
+        const bool stack_relative =
+            IsStackPointerRegister(operand.mem.base) || IsStackPointerRegister(operand.mem.index);
+        decoded.uses_stack_pointer |= stack_relative;
+        constexpr ZydisOperandActions MemoryAccessMask =
+            ZYDIS_OPERAND_ACTION_MASK_READ | ZYDIS_OPERAND_ACTION_MASK_WRITE;
+        if (decoded.instruction.mnemonic != ZYDIS_MNEMONIC_LEA &&
+            decoded.instruction.mnemonic != ZYDIS_MNEMONIC_NOP && !stack_relative &&
+            (operand.actions & MemoryAccessMask) != 0) {
+            decoded.accesses_memory = true;
+        }
+    }
+
+    if (decoded.changes_stack_pointer) {
+        const auto& operands = decoded.operands;
+        if (decoded.instruction.mnemonic == ZYDIS_MNEMONIC_MOV &&
+            operands[0].type == ZYDIS_OPERAND_TYPE_REGISTER &&
+            IsStackPointerRegister(operands[0].reg.value) &&
+            operands[1].type == ZYDIS_OPERAND_TYPE_MEMORY) {
+            decoded.replaces_stack_pointer = true;
+        } else if ((decoded.instruction.mnemonic == ZYDIS_MNEMONIC_ADD ||
+                    decoded.instruction.mnemonic == ZYDIS_MNEMONIC_SUB) &&
+                   operands[0].type == ZYDIS_OPERAND_TYPE_REGISTER &&
+                   IsStackPointerRegister(operands[0].reg.value) &&
+                   operands[1].type == ZYDIS_OPERAND_TYPE_IMMEDIATE) {
+            const s64 immediate = operands[1].imm.is_signed
+                                      ? operands[1].imm.value.s
+                                      : static_cast<s64>(operands[1].imm.value.u);
+            decoded.stack_pointer_delta =
+                decoded.instruction.mnemonic == ZYDIS_MNEMONIC_ADD ? immediate : -immediate;
+        } else if (decoded.instruction.mnemonic == ZYDIS_MNEMONIC_LEA &&
+                   operands[0].type == ZYDIS_OPERAND_TYPE_REGISTER &&
+                   IsStackPointerRegister(operands[0].reg.value) &&
+                   operands[1].type == ZYDIS_OPERAND_TYPE_MEMORY &&
+                   IsStackPointerRegister(operands[1].mem.base) &&
+                   operands[1].mem.index == ZYDIS_REGISTER_NONE) {
+            decoded.stack_pointer_delta = operands[1].mem.disp.value;
+        } else if (decoded.instruction.mnemonic == ZYDIS_MNEMONIC_PUSH ||
+                   decoded.instruction.mnemonic == ZYDIS_MNEMONIC_PUSHF ||
+                   decoded.instruction.mnemonic == ZYDIS_MNEMONIC_PUSHFD ||
+                   decoded.instruction.mnemonic == ZYDIS_MNEMONIC_PUSHFQ) {
+            decoded.stack_pointer_delta = -static_cast<s64>(sizeof(u64));
+        } else if (decoded.instruction.mnemonic == ZYDIS_MNEMONIC_POP ||
+                   decoded.instruction.mnemonic == ZYDIS_MNEMONIC_POPF ||
+                   decoded.instruction.mnemonic == ZYDIS_MNEMONIC_POPFD ||
+                   decoded.instruction.mnemonic == ZYDIS_MNEMONIC_POPFQ) {
+            decoded.stack_pointer_delta = sizeof(u64);
+        }
+    }
+
+    for (u8 index = 0; index < decoded.instruction.operand_count_visible; ++index) {
+        const auto& operand = decoded.operands[index];
+        if (operand.type != ZYDIS_OPERAND_TYPE_MEMORY ||
+            !IsStackPointerRegister(operand.mem.base) || operand.mem.disp.size == 0 ||
+            operand.mem.disp.value >= 0) {
+            continue;
+        }
+
+        decoded.has_red_zone_operand = true;
+        if (decoded.instruction.mnemonic == ZYDIS_MNEMONIC_LEA) {
+            if (decoded.stack_pointer_delta.has_value()) {
+                decoded.has_red_zone_operand = false;
+                continue;
+            }
+            decoded.has_unmodeled_red_zone_operand = true;
+            continue;
+        }
+
+        const s64 access_start = operand.mem.disp.value;
+        const s64 access_size = std::max<s64>(operand.size / 8, 1);
+        const s64 range_start = std::max(access_start, -static_cast<s64>(GuestRedZoneSize));
+        const s64 range_end = std::min(access_start + access_size, 0LL);
+        for (s64 offset = range_start; offset < range_end; ++offset) {
+            const size_t bit = static_cast<size_t>(offset + static_cast<s64>(GuestRedZoneSize));
+            if ((operand.actions & ZYDIS_OPERAND_ACTION_MASK_READ) != 0) {
+                decoded.red_zone_use.set(bit);
+            }
+            if ((operand.actions & ZYDIS_OPERAND_ACTION_WRITE) != 0) {
+                decoded.red_zone_def.set(bit);
+            }
+        }
+    }
+    return decoded;
+}
+
+bool IsSameRegister(ZydisRegister lhs, ZydisRegister rhs) {
+    return lhs != ZYDIS_REGISTER_NONE && rhs != ZYDIS_REGISTER_NONE &&
+           ZydisRegisterGetLargestEnclosing(ZYDIS_MACHINE_MODE_LONG_64, lhs) ==
+               ZydisRegisterGetLargestEnclosing(ZYDIS_MACHINE_MODE_LONG_64, rhs);
+}
+
+bool WritesRegister(const DecodedCodeInstruction& decoded, ZydisRegister reg) {
+    return std::ranges::any_of(std::span{decoded.operands}.first(decoded.instruction.operand_count),
+                               [reg](const ZydisDecodedOperand& operand) {
+                                   return operand.type == ZYDIS_OPERAND_TYPE_REGISTER &&
+                                          (operand.actions & ZYDIS_OPERAND_ACTION_MASK_WRITE) !=
+                                              0 &&
+                                          IsSameRegister(operand.reg.value, reg);
+                               });
+}
+
+std::optional<std::vector<uintptr_t>> ResolveBoundedJumpTable(
+    const DecodedFunction& function, uintptr_t branch_address, uintptr_t function_start,
+    uintptr_t function_end, uintptr_t segment_start, uintptr_t segment_end) {
+    const auto branch = function.instructions.find(branch_address);
+    if (branch == function.instructions.end() ||
+        branch->second.instruction.mnemonic != ZYDIS_MNEMONIC_JMP ||
+        branch->second.operands[0].type != ZYDIS_OPERAND_TYPE_REGISTER) {
+        return std::nullopt;
+    }
+    const ZydisRegister target_reg = branch->second.operands[0].reg.value;
+
+    const auto previous_contiguous = [&function](auto instruction) {
+        if (instruction == function.instructions.begin()) {
+            return function.instructions.end();
+        }
+        const auto previous = std::prev(instruction);
+        return previous->first + previous->second.instruction.length == instruction->first
+                   ? previous
+                   : function.instructions.end();
+    };
+
+    constexpr size_t MaxInterveningInstructions = 4;
+    auto add = function.instructions.end();
+    auto pattern_cursor = branch;
+    for (size_t count = 0; count <= MaxInterveningInstructions; ++count) {
+        const auto candidate = previous_contiguous(pattern_cursor);
+        if (candidate == function.instructions.end()) {
+            break;
+        }
+        const auto& decoded = candidate->second;
+        if (decoded.instruction.mnemonic == ZYDIS_MNEMONIC_ADD &&
+            decoded.operands[0].type == ZYDIS_OPERAND_TYPE_REGISTER &&
+            IsSameRegister(decoded.operands[0].reg.value, target_reg) &&
+            decoded.operands[1].type == ZYDIS_OPERAND_TYPE_REGISTER) {
+            add = candidate;
+            break;
+        }
+        if (WritesRegister(decoded, target_reg) || IsControlFlowTerminator(decoded.instruction)) {
+            return std::nullopt;
+        }
+        pattern_cursor = candidate;
+    }
+    if (add == function.instructions.end()) {
+        return std::nullopt;
+    }
+    const ZydisRegister table_reg = add->second.operands[1].reg.value;
+
+    const auto load = previous_contiguous(add);
+    if (load == function.instructions.end() ||
+        load->second.instruction.mnemonic != ZYDIS_MNEMONIC_MOVSXD ||
+        load->second.operands[0].type != ZYDIS_OPERAND_TYPE_REGISTER ||
+        !IsSameRegister(load->second.operands[0].reg.value, target_reg) ||
+        load->second.operands[1].type != ZYDIS_OPERAND_TYPE_MEMORY ||
+        !IsSameRegister(load->second.operands[1].mem.base, table_reg) ||
+        load->second.operands[1].mem.index == ZYDIS_REGISTER_NONE ||
+        load->second.operands[1].mem.scale != sizeof(s32)) {
+        return std::nullopt;
+    }
+    const ZydisRegister index_reg = load->second.operands[1].mem.index;
+
+    constexpr size_t MaxPatternInstructions = 64;
+    std::optional<size_t> table_size;
+    std::optional<uintptr_t> guarded_path_start;
+    auto cursor = load;
+    for (size_t count = 0; count < MaxPatternInstructions; ++count) {
+        cursor = previous_contiguous(cursor);
+        if (cursor == function.instructions.end()) {
+            break;
+        }
+        const auto& decoded = cursor->second;
+        if (decoded.instruction.mnemonic == ZYDIS_MNEMONIC_CMP &&
+            decoded.operands[0].type == ZYDIS_OPERAND_TYPE_REGISTER &&
+            IsSameRegister(decoded.operands[0].reg.value, index_reg) &&
+            decoded.operands[1].type == ZYDIS_OPERAND_TYPE_IMMEDIATE) {
+            const uintptr_t next_address = decoded.address + decoded.instruction.length;
+            const auto bounds_branch = function.instructions.find(next_address);
+            if (bounds_branch == function.instructions.end()) {
+                return std::nullopt;
+            }
+            const s64 bound = decoded.operands[1].imm.is_signed
+                                  ? decoded.operands[1].imm.value.s
+                                  : static_cast<s64>(decoded.operands[1].imm.value.u);
+            if (bound < 0) {
+                return std::nullopt;
+            }
+            if (bounds_branch->second.instruction.mnemonic == ZYDIS_MNEMONIC_JNBE) {
+                table_size = static_cast<size_t>(bound) + 1;
+            } else if (bounds_branch->second.instruction.mnemonic == ZYDIS_MNEMONIC_JNB) {
+                table_size = static_cast<size_t>(bound);
+            } else {
+                return std::nullopt;
+            }
+            guarded_path_start = next_address + bounds_branch->second.instruction.length;
+            break;
+        }
+        if (WritesRegister(decoded, index_reg)) {
+            return std::nullopt;
+        }
+    }
+    if (!table_size) {
+        return std::nullopt;
+    }
+    if (std::ranges::any_of(function.branch_targets, [&](uintptr_t target) {
+            return target >= *guarded_path_start && target <= branch_address;
+        })) {
+        return std::nullopt;
+    }
+
+    const auto decode_table_address =
+        [table_reg](const DecodedCodeInstruction& decoded) -> std::optional<uintptr_t> {
+        if (decoded.instruction.mnemonic != ZYDIS_MNEMONIC_LEA ||
+            decoded.operands[0].type != ZYDIS_OPERAND_TYPE_REGISTER ||
+            !IsSameRegister(decoded.operands[0].reg.value, table_reg) ||
+            decoded.operands[1].type != ZYDIS_OPERAND_TYPE_MEMORY) {
+            return std::nullopt;
+        }
+        ZyanU64 absolute_address{};
+        if (!ZYAN_SUCCESS(ZydisCalcAbsoluteAddress(&decoded.instruction, &decoded.operands[1],
+                                                   decoded.address, &absolute_address))) {
+            return std::nullopt;
+        }
+        return absolute_address;
+    };
+
+    std::set<uintptr_t> table_candidates;
+    cursor = load;
+    for (size_t count = 0; count < MaxPatternInstructions; ++count) {
+        cursor = previous_contiguous(cursor);
+        if (cursor == function.instructions.end()) {
+            break;
+        }
+        if (!WritesRegister(cursor->second, table_reg)) {
+            continue;
+        }
+        if (const auto address = decode_table_address(cursor->second)) {
+            table_candidates.insert(*address);
+        }
+        break;
+    }
+    if (table_candidates.empty()) {
+        for (const auto& [address, decoded] : function.instructions) {
+            if (address >= branch_address) {
+                break;
+            }
+            if (const auto table_address = decode_table_address(decoded)) {
+                table_candidates.insert(*table_address);
+            }
+        }
+    }
+    constexpr size_t MaxJumpTableEntries = 4096;
+    if (*table_size == 0 || *table_size > MaxJumpTableEntries) {
+        return std::nullopt;
+    }
+
+    std::optional<std::vector<uintptr_t>> resolved_targets;
+    for (const uintptr_t table_address : table_candidates) {
+        if (table_address < segment_start || table_address > segment_end ||
+            *table_size > (segment_end - table_address) / sizeof(s32)) {
+            continue;
+        }
+
+        std::vector<uintptr_t> targets;
+        targets.reserve(*table_size);
+        bool valid = true;
+        for (size_t index = 0; index < *table_size; ++index) {
+            s32 offset;
+            std::memcpy(&offset,
+                        reinterpret_cast<const void*>(table_address + index * sizeof(offset)),
+                        sizeof(offset));
+            const s64 target = static_cast<s64>(table_address) + offset;
+            if (target < static_cast<s64>(function_start) ||
+                target >= static_cast<s64>(function_end)) {
+                valid = false;
+                break;
+            }
+            targets.push_back(static_cast<uintptr_t>(target));
+        }
+        if (!valid) {
+            continue;
+        }
+        std::ranges::sort(targets);
+        targets.erase(std::ranges::unique(targets).begin(), targets.end());
+        if (resolved_targets) {
+            return std::nullopt;
+        }
+        resolved_targets = std::move(targets);
+    }
+    return resolved_targets;
+}
+
+DecodedFunction DecodeFunction(uintptr_t function_start, uintptr_t function_end,
+                               uintptr_t segment_start, uintptr_t segment_end) {
+    DecodedFunction function;
+    std::vector<uintptr_t> blocks{function_start};
+    std::unordered_set<uintptr_t> visited;
+    std::set<uintptr_t> indirect_branches;
+    std::set<uintptr_t> resolved_indirect_branches;
+
+    while (true) {
+        while (!blocks.empty()) {
+            uintptr_t address = blocks.back();
+            blocks.pop_back();
+
+            while (address >= function_start && address < function_end &&
+                   !visited.contains(address)) {
+                visited.insert(address);
+                auto decoded = DecodeCodeInstruction(address, function_end);
+                if (decoded.instruction.length == 0) {
+                    break;
+                }
+
+                function.uses_red_zone |= decoded.has_red_zone_operand;
+                function.requires_conservative_red_zone_tracking |=
+                    decoded.has_unmodeled_red_zone_operand ||
+                    (decoded.changes_stack_pointer && !decoded.stack_pointer_delta.has_value());
+
+                const uintptr_t next_address = address + decoded.instruction.length;
+                const uintptr_t branch_target = GetRelativeTarget(decoded);
+                if (branch_target >= function_start && branch_target < function_end) {
+                    function.branch_targets.insert(branch_target);
+                }
+                function.instructions.emplace(address, decoded);
+
+                if (decoded.instruction.meta.category == ZYDIS_CATEGORY_COND_BR) {
+                    if (branch_target >= function_start && branch_target < function_end) {
+                        blocks.push_back(branch_target);
+                    }
+                } else if (IsControlFlowTerminator(decoded.instruction)) {
+                    if (decoded.instruction.meta.category == ZYDIS_CATEGORY_UNCOND_BR &&
+                        branch_target >= function_start && branch_target < function_end) {
+                        blocks.push_back(branch_target);
+                    } else if (decoded.instruction.meta.category == ZYDIS_CATEGORY_UNCOND_BR &&
+                               branch_target == 0) {
+                        indirect_branches.insert(address);
+                    }
+                    break;
+                }
+                address = next_address;
+            }
+        }
+
+        bool discovered_block = false;
+        for (const uintptr_t branch_address : indirect_branches) {
+            if (resolved_indirect_branches.contains(branch_address)) {
+                continue;
+            }
+            const auto targets = ResolveBoundedJumpTable(function, branch_address, function_start,
+                                                         function_end, segment_start, segment_end);
+            if (!targets) {
+                continue;
+            }
+            resolved_indirect_branches.insert(branch_address);
+            for (const uintptr_t target : *targets) {
+                function.branch_targets.insert(target);
+                if (!visited.contains(target)) {
+                    blocks.push_back(target);
+                    discovered_block = true;
+                }
+            }
+        }
+        if (!discovered_block) {
+            break;
+        }
+    }
+    function.has_indirect_branch = indirect_branches.size() != resolved_indirect_branches.size();
+    return function;
+}
+
+RedZoneMask TranslateRedZoneMask(const RedZoneMask& mask, s64 stack_pointer_delta) {
+    RedZoneMask translated;
+    for (size_t bit = 0; bit < GuestRedZoneSize; ++bit) {
+        if (!mask.test(bit)) {
+            continue;
+        }
+        const s64 after_offset = static_cast<s64>(bit) - static_cast<s64>(GuestRedZoneSize);
+        const s64 before_offset = after_offset + stack_pointer_delta;
+        if (before_offset >= -static_cast<s64>(GuestRedZoneSize) && before_offset < 0) {
+            translated.set(static_cast<size_t>(before_offset + static_cast<s64>(GuestRedZoneSize)));
+        }
+    }
+    return translated;
+}
+
+void AnalyzeRedZoneLiveness(DecodedFunction& function) {
+    if (!function.uses_red_zone) {
+        return;
+    }
+
+    if (function.has_indirect_branch || function.requires_conservative_red_zone_tracking ||
+        std::ranges::any_of(function.branch_targets, [&function](uintptr_t target) {
+            return !function.instructions.contains(target);
+        })) {
+        for (auto& [_, decoded] : function.instructions) {
+            decoded.red_zone_live.set();
+        }
+        return;
+    }
+
+    std::vector<DecodedCodeInstruction*> instructions;
+    instructions.reserve(function.instructions.size());
+    std::map<uintptr_t, size_t> indices;
+    for (auto& [address, decoded] : function.instructions) {
+        indices.emplace(address, instructions.size());
+        instructions.push_back(&decoded);
+    }
+
+    std::vector<RedZoneMask> live_in(instructions.size());
+    bool changed;
+    do {
+        changed = false;
+        for (size_t reverse_index = instructions.size(); reverse_index-- > 0;) {
+            const auto& decoded = *instructions[reverse_index];
+            RedZoneMask live_out;
+
+            const auto add_successor = [&](uintptr_t address) {
+                if (const auto successor = indices.find(address); successor != indices.end()) {
+                    live_out |= live_in[successor->second];
+                }
+            };
+
+            const uintptr_t next_address = decoded.address + decoded.instruction.length;
+            const uintptr_t branch_target = GetRelativeTarget(decoded);
+            if (decoded.instruction.meta.category == ZYDIS_CATEGORY_COND_BR) {
+                add_successor(next_address);
+                add_successor(branch_target);
+            } else if (decoded.instruction.meta.category == ZYDIS_CATEGORY_UNCOND_BR) {
+                add_successor(branch_target);
+            } else if (!IsControlFlowTerminator(decoded.instruction)) {
+                add_successor(next_address);
+            }
+
+            const RedZoneMask translated_live_out =
+                decoded.stack_pointer_delta.has_value()
+                    ? TranslateRedZoneMask(live_out, *decoded.stack_pointer_delta)
+                    : live_out;
+            const RedZoneMask new_live_in =
+                decoded.red_zone_use | (translated_live_out & ~decoded.red_zone_def);
+            if (new_live_in != live_in[reverse_index]) {
+                live_in[reverse_index] = new_live_in;
+                changed = true;
+            }
+        }
+    } while (changed);
+
+    for (size_t index = 0; index < instructions.size(); ++index) {
+        instructions[index]->red_zone_live = live_in[index];
+    }
+}
+
+bool EncodeRelocatedInstruction(const DecodedCodeInstruction& decoded,
+                                Xbyak::CodeGenerator& generator) {
+    ZydisEncoderRequest request;
+    if (!ZYAN_SUCCESS(ZydisEncoderDecodedInstructionToEncoderRequest(
+            &decoded.instruction, decoded.operands.data(),
+            decoded.instruction.operand_count_visible, &request))) {
+        return false;
+    }
+
+    for (u8 index = 0; index < decoded.instruction.operand_count_visible; ++index) {
+        const auto& operand = decoded.operands[index];
+        if (operand.type == ZYDIS_OPERAND_TYPE_IMMEDIATE && operand.imm.is_relative) {
+            ZyanU64 absolute_address{};
+            if (!ZYAN_SUCCESS(ZydisCalcAbsoluteAddress(&decoded.instruction, &operand,
+                                                       decoded.address, &absolute_address))) {
+                return false;
+            }
+            request.operands[index].imm.u = absolute_address;
+        } else if (operand.type == ZYDIS_OPERAND_TYPE_MEMORY &&
+                   (operand.mem.base == ZYDIS_REGISTER_RIP ||
+                    operand.mem.base == ZYDIS_REGISTER_EIP)) {
+            ZyanU64 absolute_address{};
+            if (!ZYAN_SUCCESS(ZydisCalcAbsoluteAddress(&decoded.instruction, &operand,
+                                                       decoded.address, &absolute_address))) {
+                return false;
+            }
+            request.operands[index].mem.displacement = static_cast<ZyanI64>(absolute_address);
+        }
+    }
+
+    std::array<u8, ZYDIS_MAX_INSTRUCTION_LENGTH> encoded{};
+    ZyanUSize encoded_size = encoded.size();
+    if (!ZYAN_SUCCESS(ZydisEncoderEncodeInstructionAbsolute(
+            &request, encoded.data(), &encoded_size,
+            reinterpret_cast<ZyanU64>(generator.getCurr())))) {
+        return false;
+    }
+    generator.db(encoded.data(), encoded_size);
+    return true;
+}
+
+bool GenerateProtectedIndirectCall(const DecodedCodeInstruction& decoded,
+                                   Xbyak::CodeGenerator& generator) {
+    ASSERT(decoded.instruction.meta.category == ZYDIS_CATEGORY_CALL);
+    const auto& target = decoded.operands[0];
+    ASSERT(target.type == ZYDIS_OPERAND_TYPE_MEMORY && target.size == sizeof(uintptr_t) * CHAR_BIT);
+
+    ZydisEncoderRequest request{};
+    request.machine_mode = ZYDIS_MACHINE_MODE_LONG_64;
+    request.mnemonic = ZYDIS_MNEMONIC_MOV;
+    request.operand_count = 2;
+    request.operands[0].type = ZYDIS_OPERAND_TYPE_REGISTER;
+    request.operands[0].reg.value = ZYDIS_REGISTER_R11;
+
+    ZydisEncoderRequest original_request{};
+    if (!ZYAN_SUCCESS(ZydisEncoderDecodedInstructionToEncoderRequest(
+            &decoded.instruction, decoded.operands.data(),
+            decoded.instruction.operand_count_visible, &original_request))) {
+        return false;
+    }
+    request.prefixes = original_request.prefixes & ZYDIS_ATTRIB_HAS_SEGMENT;
+    request.address_size_hint = original_request.address_size_hint;
+    request.operands[1] = original_request.operands[0];
+    request.operands[1].mem.size = sizeof(uintptr_t);
+
+    if (target.mem.base == ZYDIS_REGISTER_RIP || target.mem.base == ZYDIS_REGISTER_EIP) {
+        ZyanU64 absolute_address{};
+        if (!ZYAN_SUCCESS(ZydisCalcAbsoluteAddress(&decoded.instruction, &target, decoded.address,
+                                                   &absolute_address))) {
+            return false;
+        }
+        request.operands[1].mem.displacement = static_cast<ZyanI64>(absolute_address);
+    }
+
+    generator.lea(rsp, ptr[rsp - GuestRedZoneSize]);
+    generator.push(r11);
+
+    std::array<u8, ZYDIS_MAX_INSTRUCTION_LENGTH> encoded{};
+    ZyanUSize encoded_size = encoded.size();
+    if (!ZYAN_SUCCESS(ZydisEncoderEncodeInstructionAbsolute(
+            &request, encoded.data(), &encoded_size,
+            reinterpret_cast<ZyanU64>(generator.getCurr())))) {
+        return false;
+    }
+    generator.db(encoded.data(), encoded_size);
+
+    generator.xchg(r11, ptr[rsp]);
+    generator.lea(rsp, ptr[rsp + GuestRedZoneSize + sizeof(uintptr_t)]);
+    generator.call(ptr[rsp - GuestRedZoneSize - sizeof(uintptr_t)]);
+    return true;
+}
+
+bool IsInPlaceMemoryPatch(ZydisMnemonic mnemonic) {
+    return mnemonic == ZYDIS_MNEMONIC_MOVNTSS || mnemonic == ZYDIS_MNEMONIC_MOVNTSD;
+}
+
+const PatchInfo* FindMatchingPatch(const DecodedCodeInstruction& decoded) {
+    const auto patches = Patches.find(decoded.instruction.mnemonic);
+    if (patches == Patches.end()) {
+        return nullptr;
+    }
+    const auto patch =
+        std::ranges::find_if(patches->second, [&decoded](const PatchInfo& candidate) {
+            return candidate.filter(decoded.operands.data());
+        });
+    return patch != patches->second.end() ? &*patch : nullptr;
+}
+
+} // namespace
+
+RedZonePatchResult PatchRedZoneMemoryInstructions(u64 segment_addr, u64 segment_size,
+                                                  std::span<const uintptr_t> function_starts) {
+    RedZonePatchResult result{};
+    auto* module = GetContainingModule(reinterpret_cast<void*>(segment_addr));
+    if (module == nullptr || function_starts.empty()) {
+        return result;
+    }
+
+    const uintptr_t segment_end = segment_addr + segment_size;
+    std::vector<uintptr_t> starts;
+    starts.reserve(function_starts.size());
+    for (const uintptr_t start : function_starts) {
+        if (start >= segment_addr && start < segment_end) {
+            starts.push_back(start);
+        }
+    }
+    std::ranges::sort(starts);
+    const auto unique_end = std::ranges::unique(starts).begin();
+    starts.erase(unique_end, starts.end());
+
+    std::unique_lock lock{module->mutex};
+    for (size_t function_index = 0; function_index < starts.size(); ++function_index) {
+        const uintptr_t function_start = starts[function_index];
+        const uintptr_t function_end =
+            function_index + 1 < starts.size() ? starts[function_index + 1] : segment_end;
+        if (function_end <= function_start) {
+            continue;
+        }
+
+        ++result.function_count;
+        auto function = DecodeFunction(function_start, function_end, segment_addr, segment_end);
+        AnalyzeRedZoneLiveness(function);
+        result.instruction_count += function.instructions.size();
+
+        std::map<uintptr_t, InstructionRewrite> rewrite_sites;
+
+        // Apply existing instruction substitutions ahead of time now that only verified
+        // instruction boundaries are being visited. Short trampoline patches are combined with
+        // the relocation pass below.
+        for (auto& [address, decoded] : function.instructions) {
+            const PatchInfo* matching_patch = FindMatchingPatch(decoded);
+            const auto [patched, _] = TryPatch(reinterpret_cast<u8*>(address), module);
+            if (IsInPlaceMemoryPatch(decoded.instruction.mnemonic)) {
+                const RedZoneMask red_zone_live = decoded.red_zone_live;
+                decoded = DecodeCodeInstruction(address, function_end);
+                decoded.red_zone_live = red_zone_live;
+            } else if (patched) {
+                decoded = DecodeCodeInstruction(address, function_end);
+                decoded.accesses_memory = false;
+            } else if (matching_patch != nullptr && matching_patch->trampoline) {
+                rewrite_sites.emplace(address, InstructionRewrite{.cpu_patch = matching_patch});
+                ++result.cpu_patch_instruction_count;
+            }
+        }
+
+        if (function.uses_red_zone) {
+            ++result.red_zone_function_count;
+            result.indirect_red_zone_function_count += function.has_indirect_branch;
+            for (const auto& [address, decoded] : function.instructions) {
+                if (!decoded.accesses_memory || !decoded.red_zone_live.any() ||
+                    rewrite_sites.contains(address)) {
+                    continue;
+                }
+                ++result.memory_instruction_count;
+                if (decoded.instruction.length < NearJumpSize) {
+                    ++result.short_memory_instruction_count;
+                }
+                if (decoded.instruction.meta.category == ZYDIS_CATEGORY_CALL &&
+                    decoded.operands[0].type == ZYDIS_OPERAND_TYPE_MEMORY &&
+                    decoded.operands[0].size == sizeof(uintptr_t) * CHAR_BIT &&
+                    !IsStackPointerRegister(decoded.operands[0].mem.base) &&
+                    !IsStackPointerRegister(decoded.operands[0].mem.index)) {
+                    rewrite_sites[address] = {
+                        .protect_red_zone = true,
+                        .protected_indirect_call = true,
+                    };
+                    continue;
+                }
+                if (decoded.uses_stack_pointer && !decoded.replaces_stack_pointer) {
+                    ++result.stack_dependent_memory_instruction_count;
+                    continue;
+                }
+                if (decoded.instruction.meta.category == ZYDIS_CATEGORY_CALL ||
+                    IsControlFlowTerminator(decoded.instruction)) {
+                    ++result.control_flow_memory_instruction_count;
+                    continue;
+                }
+                rewrite_sites[address].protect_red_zone = true;
+            }
+        }
+        if (rewrite_sites.empty()) {
+            continue;
+        }
+
+        struct RelocationSpan {
+            std::vector<const DecodedCodeInstruction*> instructions;
+            uintptr_t patch_start{};
+            uintptr_t continuation{};
+            size_t patch_size{};
+        };
+
+        const auto emit_span = [&](const RelocationSpan& span) -> std::optional<size_t> {
+            const size_t trampoline_offset = module->trampoline_gen.getSize();
+            if (module->trampoline_exhausted) {
+                return std::nullopt;
+            }
+            try {
+                for (const auto* decoded : span.instructions) {
+                    const auto rewrite = rewrite_sites.find(decoded->address);
+                    const bool protected_indirect_call =
+                        rewrite != rewrite_sites.end() && rewrite->second.protected_indirect_call;
+                    const bool protect_red_zone = rewrite != rewrite_sites.end() &&
+                                                  rewrite->second.protect_red_zone &&
+                                                  !protected_indirect_call;
+                    if (protect_red_zone) {
+                        module->trampoline_gen.lea(rsp, ptr[rsp - GuestRedZoneSize]);
+                    }
+                    if (protected_indirect_call) {
+                        if (!GenerateProtectedIndirectCall(*decoded, module->trampoline_gen)) {
+                            module->trampoline_gen.setSize(trampoline_offset);
+                            return std::nullopt;
+                        }
+                    } else if (rewrite != rewrite_sites.end() &&
+                               rewrite->second.cpu_patch != nullptr) {
+                        rewrite->second.cpu_patch->generator(
+                            reinterpret_cast<void*>(decoded->address), decoded->operands.data(),
+                            module->trampoline_gen);
+                    } else if (!EncodeRelocatedInstruction(*decoded, module->trampoline_gen)) {
+                        module->trampoline_gen.setSize(trampoline_offset);
+                        return std::nullopt;
+                    }
+                    if (protect_red_zone && !decoded->replaces_stack_pointer) {
+                        module->trampoline_gen.lea(rsp, ptr[rsp + GuestRedZoneSize]);
+                    }
+                }
+                module->trampoline_gen.jmp(reinterpret_cast<void*>(span.continuation));
+            } catch (const Xbyak::Error& error) {
+                module->trampoline_gen.setSize(trampoline_offset);
+                if (HandleTrampolineError(module, error)) {
+                    return std::nullopt;
+                }
+                throw;
+            }
+            return trampoline_offset;
+        };
+
+        const auto record_rewrites = [&](const RelocationSpan& span) {
+            for (const auto* decoded : span.instructions) {
+                const auto rewrite = rewrite_sites.find(decoded->address);
+                if (rewrite == rewrite_sites.end()) {
+                    continue;
+                }
+                if (rewrite->second.protect_red_zone) {
+                    ++result.patched_memory_instruction_count;
+                }
+                if (rewrite->second.cpu_patch != nullptr) {
+                    ++result.patched_cpu_patch_instruction_count;
+                }
+                module->patched.insert(reinterpret_cast<u8*>(decoded->address));
+            }
+        };
+
+        std::vector<std::pair<uintptr_t, uintptr_t>> patched_spans;
+        std::vector<uintptr_t> relay_slots;
+        std::vector<uintptr_t> short_relay_slots;
+        std::vector<uintptr_t> unresolved_sites;
+        uintptr_t covered_until{};
+        for (auto site_it = rewrite_sites.begin(); site_it != rewrite_sites.end(); ++site_it) {
+            const uintptr_t site = site_it->first;
+            if (site < covered_until) {
+                continue;
+            }
+
+            const auto collect_forward_span = [&]() -> std::optional<RelocationSpan> {
+                RelocationSpan span{.patch_start = site, .continuation = site};
+                while (span.patch_size < NearJumpSize) {
+                    const auto decoded_it = function.instructions.find(span.continuation);
+                    if (decoded_it == function.instructions.end() ||
+                        (span.continuation != site &&
+                         function.branch_targets.contains(span.continuation))) {
+                        return std::nullopt;
+                    }
+
+                    const auto& decoded = decoded_it->second;
+                    span.instructions.push_back(&decoded);
+                    span.patch_size += decoded.instruction.length;
+                    span.continuation += decoded.instruction.length;
+                    if (span.patch_size < NearJumpSize &&
+                        IsControlFlowTerminator(decoded.instruction)) {
+                        return std::nullopt;
+                    }
+                }
+                return span;
+            };
+
+            const auto collect_backward_span = [&]() -> std::optional<RelocationSpan> {
+                const auto site_instruction = function.instructions.find(site);
+                ASSERT(site_instruction != function.instructions.end());
+                RelocationSpan span{
+                    .instructions = {&site_instruction->second},
+                    .patch_start = site,
+                    .continuation = site + site_instruction->second.instruction.length,
+                    .patch_size = site_instruction->second.instruction.length,
+                };
+
+                while (span.patch_size < NearJumpSize) {
+                    const auto previous_end = function.instructions.lower_bound(span.patch_start);
+                    if (previous_end == function.instructions.begin() ||
+                        function.branch_targets.contains(span.patch_start)) {
+                        return std::nullopt;
+                    }
+
+                    const auto previous = std::prev(previous_end);
+                    const auto& decoded = previous->second;
+                    if (previous->first + decoded.instruction.length != span.patch_start ||
+                        previous->first < covered_until ||
+                        IsControlFlowTerminator(decoded.instruction)) {
+                        return std::nullopt;
+                    }
+
+                    span.instructions.insert(span.instructions.begin(), &decoded);
+                    span.patch_start = previous->first;
+                    span.patch_size += decoded.instruction.length;
+                }
+                return span;
+            };
+
+            std::optional<RelocationSpan> selected_span;
+            std::optional<size_t> trampoline_offset;
+            const auto& site_instruction = function.instructions.at(site);
+            const bool can_relocate_neighbors = !function.has_indirect_branch;
+            if (can_relocate_neighbors || site_instruction.instruction.length >= NearJumpSize) {
+                auto forward_span = collect_forward_span();
+                if (forward_span) {
+                    trampoline_offset = emit_span(*forward_span);
+                    if (trampoline_offset) {
+                        selected_span = std::move(forward_span);
+                    }
+                }
+            }
+            if (!selected_span && can_relocate_neighbors) {
+                if (auto backward_span = collect_backward_span()) {
+                    trampoline_offset = emit_span(*backward_span);
+                    if (trampoline_offset) {
+                        selected_span = std::move(backward_span);
+                    }
+                }
+            }
+            if (!selected_span) {
+                unresolved_sites.push_back(site);
+                continue;
+            }
+
+            const auto& span = *selected_span;
+            const auto* trampoline = module->trampoline_gen.getCode() + *trampoline_offset;
+
+            auto& patch_gen = module->patch_gen;
+            patch_gen.reset();
+            patch_gen.setSize(span.patch_start - reinterpret_cast<uintptr_t>(patch_gen.getCode()));
+            patch_gen.jmp(trampoline, Xbyak::CodeGenerator::LabelType::T_NEAR);
+            patch_gen.nop(span.patch_size - NearJumpSize);
+
+            record_rewrites(span);
+            patched_spans.emplace_back(span.patch_start, span.continuation);
+            if (span.patch_size >= NearJumpSize * 2) {
+                relay_slots.push_back(span.patch_start + NearJumpSize);
+            }
+            if (span.patch_size >= NearJumpSize + ShortJumpSize) {
+                short_relay_slots.push_back(span.patch_start + NearJumpSize);
+            }
+            covered_until = span.continuation;
+        }
+
+        const auto record_unsupported = [&](uintptr_t site) {
+            const auto& rewrite = rewrite_sites.at(site);
+            if (rewrite.cpu_patch != nullptr) {
+                ++result.unsupported_cpu_patch_instruction_count;
+            }
+            if (rewrite.protect_red_zone) {
+                ++result.unrelocatable_memory_instruction_count;
+            }
+        };
+        const auto overlaps_patched_span = [&patched_spans](uintptr_t start, uintptr_t end) {
+            return std::ranges::any_of(patched_spans, [start, end](const auto& patched) {
+                return start < patched.second && patched.first < end;
+            });
+        };
+
+        for (const uintptr_t site : unresolved_sites) {
+            if (module->patched.contains(reinterpret_cast<u8*>(site))) {
+                continue;
+            }
+
+            const auto site_instruction = function.instructions.find(site);
+            ASSERT(site_instruction != function.instructions.end());
+            if (function.has_indirect_branch ||
+                site_instruction->second.instruction.length < ShortJumpSize) {
+                record_unsupported(site);
+                continue;
+            }
+
+            const RelocationSpan site_span{
+                .instructions = {&site_instruction->second},
+                .patch_start = site,
+                .continuation = site + site_instruction->second.instruction.length,
+                .patch_size = site_instruction->second.instruction.length,
+            };
+            const size_t trampoline_start = module->trampoline_gen.getSize();
+            const auto site_trampoline_offset = emit_span(site_span);
+            if (!site_trampoline_offset) {
+                record_unsupported(site);
+                continue;
+            }
+
+            constexpr s64 ShortJumpMin = std::numeric_limits<s8>::min();
+            constexpr s64 ShortJumpMax = std::numeric_limits<s8>::max();
+            const auto relay_slot = std::ranges::find_if(relay_slots, [site](uintptr_t address) {
+                const s64 displacement =
+                    static_cast<s64>(address) - static_cast<s64>(site + ShortJumpSize);
+                return displacement >= ShortJumpMin && displacement <= ShortJumpMax;
+            });
+            if (relay_slot != relay_slots.end()) {
+                const auto* site_trampoline =
+                    module->trampoline_gen.getCode() + *site_trampoline_offset;
+
+                auto& patch_gen = module->patch_gen;
+                patch_gen.reset();
+                patch_gen.setSize(*relay_slot - reinterpret_cast<uintptr_t>(patch_gen.getCode()));
+                patch_gen.jmp(site_trampoline, Xbyak::CodeGenerator::LabelType::T_NEAR);
+
+                patch_gen.reset();
+                patch_gen.setSize(site - reinterpret_cast<uintptr_t>(patch_gen.getCode()));
+                patch_gen.jmp(reinterpret_cast<void*>(*relay_slot),
+                              Xbyak::CodeGenerator::LabelType::T_SHORT);
+                patch_gen.nop(site_span.patch_size - ShortJumpSize);
+
+                record_rewrites(site_span);
+                patched_spans.emplace_back(site_span.patch_start, site_span.continuation);
+                std::erase(short_relay_slots, *relay_slot);
+                relay_slots.erase(relay_slot);
+                continue;
+            }
+
+            const auto find_host = [&](uintptr_t short_jump_address) {
+                std::pair<std::optional<RelocationSpan>, std::optional<size_t>> result;
+                const s64 minimum_host = static_cast<s64>(short_jump_address) +
+                                         static_cast<s64>(ShortJumpSize) -
+                                         static_cast<s64>(NearJumpSize) + ShortJumpMin;
+                const s64 maximum_host = static_cast<s64>(short_jump_address) +
+                                         static_cast<s64>(ShortJumpSize) -
+                                         static_cast<s64>(NearJumpSize) + ShortJumpMax;
+
+                auto candidate = function.instructions.lower_bound(
+                    static_cast<uintptr_t>(std::max<s64>(minimum_host, 0)));
+                for (; candidate != function.instructions.end() &&
+                       static_cast<s64>(candidate->first) <= maximum_host;
+                     ++candidate) {
+                    RelocationSpan span{.patch_start = candidate->first,
+                                        .continuation = candidate->first};
+                    while (span.patch_size < NearJumpSize * 2) {
+                        const auto instruction = function.instructions.find(span.continuation);
+                        if (instruction == function.instructions.end() ||
+                            (span.continuation != span.patch_start &&
+                             function.branch_targets.contains(span.continuation))) {
+                            span.instructions.clear();
+                            break;
+                        }
+                        span.instructions.push_back(&instruction->second);
+                        span.patch_size += instruction->second.instruction.length;
+                        span.continuation += instruction->second.instruction.length;
+                        if (span.patch_size < NearJumpSize * 2 &&
+                            IsControlFlowTerminator(instruction->second.instruction)) {
+                            span.instructions.clear();
+                            break;
+                        }
+                    }
+                    if (span.instructions.empty() ||
+                        !(span.continuation <= site ||
+                          span.patch_start >= site_span.continuation) ||
+                        overlaps_patched_span(span.patch_start, span.continuation)) {
+                        continue;
+                    }
+
+                    const uintptr_t relay_address = span.patch_start + NearJumpSize;
+                    const s64 displacement = static_cast<s64>(relay_address) -
+                                             static_cast<s64>(short_jump_address + ShortJumpSize);
+                    if (displacement < ShortJumpMin || displacement > ShortJumpMax) {
+                        continue;
+                    }
+
+                    const auto offset = emit_span(span);
+                    if (!offset) {
+                        continue;
+                    }
+                    result.first = std::move(span);
+                    result.second = offset;
+                    break;
+                }
+                return result;
+            };
+
+            auto [host_span, host_trampoline_offset] = find_host(site);
+            std::optional<uintptr_t> final_relay_slot;
+            uintptr_t final_short_jump = site;
+            std::map<uintptr_t, uintptr_t> relay_parent{{site, site}};
+            std::vector<uintptr_t> relay_queue{site};
+            for (size_t queue_index = 0;
+                 !host_span && !final_relay_slot && queue_index < relay_queue.size();
+                 ++queue_index) {
+                const uintptr_t current = relay_queue[queue_index];
+                if (current != site) {
+                    if (std::ranges::find(relay_slots, current) != relay_slots.end()) {
+                        final_relay_slot = current;
+                        final_short_jump = relay_parent.at(current);
+                        break;
+                    }
+                    const auto near_slot =
+                        std::ranges::find_if(relay_slots, [current](uintptr_t address) {
+                            const s64 displacement = static_cast<s64>(address) -
+                                                     static_cast<s64>(current + ShortJumpSize);
+                            return address != current && displacement >= ShortJumpMin &&
+                                   displacement <= ShortJumpMax;
+                        });
+                    if (near_slot != relay_slots.end()) {
+                        final_relay_slot = *near_slot;
+                        final_short_jump = current;
+                        break;
+                    }
+
+                    auto bridge_host = find_host(current);
+                    if (bridge_host.first) {
+                        host_span = std::move(bridge_host.first);
+                        host_trampoline_offset = bridge_host.second;
+                        final_short_jump = current;
+                        break;
+                    }
+                }
+
+                for (const uintptr_t slot : short_relay_slots) {
+                    if (relay_parent.contains(slot)) {
+                        continue;
+                    }
+                    const s64 displacement =
+                        static_cast<s64>(slot) - static_cast<s64>(current + ShortJumpSize);
+                    if (displacement < ShortJumpMin || displacement > ShortJumpMax) {
+                        continue;
+                    }
+                    relay_parent.emplace(slot, current);
+                    relay_queue.push_back(slot);
+                }
+            }
+
+            if (!host_span && !final_relay_slot) {
+                module->trampoline_gen.setSize(trampoline_start);
+                record_unsupported(site);
+                continue;
+            }
+
+            const auto* site_trampoline =
+                module->trampoline_gen.getCode() + *site_trampoline_offset;
+            auto& patch_gen = module->patch_gen;
+            uintptr_t relay_address{};
+            if (final_relay_slot) {
+                relay_address = *final_relay_slot;
+                patch_gen.reset();
+                patch_gen.setSize(relay_address - reinterpret_cast<uintptr_t>(patch_gen.getCode()));
+                patch_gen.jmp(site_trampoline, Xbyak::CodeGenerator::LabelType::T_NEAR);
+                std::erase(relay_slots, relay_address);
+                std::erase(short_relay_slots, relay_address);
+            } else {
+                ASSERT(host_span && host_trampoline_offset);
+                const auto* host_trampoline =
+                    module->trampoline_gen.getCode() + *host_trampoline_offset;
+                relay_address = host_span->patch_start + NearJumpSize;
+
+                patch_gen.reset();
+                patch_gen.setSize(host_span->patch_start -
+                                  reinterpret_cast<uintptr_t>(patch_gen.getCode()));
+                patch_gen.jmp(host_trampoline, Xbyak::CodeGenerator::LabelType::T_NEAR);
+                patch_gen.jmp(site_trampoline, Xbyak::CodeGenerator::LabelType::T_NEAR);
+                patch_gen.nop(host_span->patch_size - NearJumpSize * 2);
+            }
+
+            uintptr_t jump_target = relay_address;
+            while (final_short_jump != site) {
+                patch_gen.reset();
+                patch_gen.setSize(final_short_jump -
+                                  reinterpret_cast<uintptr_t>(patch_gen.getCode()));
+                patch_gen.jmp(reinterpret_cast<void*>(jump_target),
+                              Xbyak::CodeGenerator::LabelType::T_SHORT);
+                jump_target = final_short_jump;
+                const auto parent = relay_parent.find(final_short_jump);
+                ASSERT(parent != relay_parent.end());
+                final_short_jump = parent->second;
+                std::erase(relay_slots, jump_target);
+                std::erase(short_relay_slots, jump_target);
+            }
+
+            patch_gen.reset();
+            patch_gen.setSize(site - reinterpret_cast<uintptr_t>(patch_gen.getCode()));
+            patch_gen.jmp(reinterpret_cast<void*>(jump_target),
+                          Xbyak::CodeGenerator::LabelType::T_SHORT);
+            patch_gen.nop(site_span.patch_size - ShortJumpSize);
+
+            if (host_span) {
+                record_rewrites(*host_span);
+                patched_spans.emplace_back(host_span->patch_start, host_span->continuation);
+                if (host_span->patch_size >= NearJumpSize * 3) {
+                    relay_slots.push_back(host_span->patch_start + NearJumpSize * 2);
+                }
+                if (host_span->patch_size >= NearJumpSize * 2 + ShortJumpSize) {
+                    short_relay_slots.push_back(host_span->patch_start + NearJumpSize * 2);
+                }
+            }
+            record_rewrites(site_span);
+            patched_spans.emplace_back(site_span.patch_start, site_span.continuation);
+        }
+    }
+    return result;
+}
+
+#else
+
+RedZonePatchResult PatchRedZoneMemoryInstructions(u64, u64, std::span<const uintptr_t>) {
+    return {};
+}
+
+#endif
+
+// ============================================================================
+// End Windows static guest red-zone protection
+// ============================================================================
+
 static bool PatchesAccessViolationHandler(void* context, void* /* fault_address */) {
     return TryPatchJit(Common::GetRip(context));
 }
 
 static bool PatchesIllegalInstructionHandler(void* context) {
     void* code_address = Common::GetRip(context);
-    if (Is4ByteExtrqOrInsertq(code_address)) {
+#if defined(_WIN32)
+    // Windows static guest red-zone protection
+    const bool inspect_short_cpu_patch =
+        !WindowsGuestRedZoneProtection::IsStaticPatchingEnabled() ||
+        GetContainingModule(code_address) != nullptr;
+#else
+    constexpr bool inspect_short_cpu_patch = true;
+#endif
+    if (inspect_short_cpu_patch && // Windows static guest red-zone protection
+        Is4ByteExtrqOrInsertq(code_address)) {
         // The instruction is not big enough for a relative jump, don't try to patch it and pass it
         // to our illegal instruction interpreter directly
         return TryExecuteIllegalInstruction(context, code_address);

--- a/src/core/cpu_patches.h
+++ b/src/core/cpu_patches.h
@@ -3,9 +3,49 @@
 
 #pragma once
 
+#include <span>
+
 #include "common/types.h"
 
+// ============================================================================
+// Windows static guest red-zone protection
+// ============================================================================
+
+enum class WindowsGuestRedZoneProtectionMode : u32 {
+    Disabled,
+    StaticPatching,
+};
+
+namespace Core::WindowsGuestRedZoneProtection {
+
+void SetActiveMode(WindowsGuestRedZoneProtectionMode mode) noexcept;
+WindowsGuestRedZoneProtectionMode GetActiveMode() noexcept;
+bool IsStaticPatchingEnabled() noexcept;
+
+} // namespace Core::WindowsGuestRedZoneProtection
+
+// ============================================================================
+// End Windows static guest red-zone protection
+// ============================================================================
+
 namespace Core {
+
+// Windows static guest red-zone protection
+struct RedZonePatchResult {
+    u64 function_count{};
+    u64 instruction_count{};
+    u64 red_zone_function_count{};
+    u64 memory_instruction_count{};
+    u64 short_memory_instruction_count{};
+    u64 patched_memory_instruction_count{};
+    u64 stack_dependent_memory_instruction_count{};
+    u64 control_flow_memory_instruction_count{};
+    u64 unrelocatable_memory_instruction_count{};
+    u64 indirect_red_zone_function_count{};
+    u64 cpu_patch_instruction_count{};
+    u64 patched_cpu_patch_instruction_count{};
+    u64 unsupported_cpu_patch_instruction_count{};
+};
 
 /// Registers a module for patching, providing an area to generate trampoline code.
 void RegisterPatchModule(void* module_ptr, u64 module_size, void* trampoline_area_ptr,
@@ -13,5 +53,10 @@ void RegisterPatchModule(void* module_ptr, u64 module_size, void* trampoline_are
 
 /// Applies CPU patches that need to be done before beginning executions.
 void PrePatchInstructions(u64 segment_addr, u64 segment_size);
+
+// Windows static guest red-zone protection
+/// Keeps Windows exception dispatch outside live guest red zones at faultable memory accesses.
+RedZonePatchResult PatchRedZoneMemoryInstructions(u64 segment_addr, u64 segment_size,
+                                                  std::span<const uintptr_t> function_starts);
 
 } // namespace Core

--- a/src/core/emulator_settings.cpp
+++ b/src/core/emulator_settings.cpp
@@ -229,6 +229,8 @@ void EmulatorSettingsImpl::ClearGameSpecificOverrides() {
     ClearGroupOverrides(m_debug);
     ClearGroupOverrides(m_input);
     ClearGroupOverrides(m_audio);
+    // Windows static guest red-zone protection
+    ClearGroupOverrides(m_windows_guest_red_zone_protection);
     ClearGroupOverrides(m_gpu);
     ClearGroupOverrides(m_vulkan);
 }
@@ -253,6 +255,9 @@ void EmulatorSettingsImpl::ResetGameSpecificValue(const std::string& key) {
     if (tryGroup(m_input))
         return;
     if (tryGroup(m_audio))
+        return;
+    // Windows static guest red-zone protection
+    if (tryGroup(m_windows_guest_red_zone_protection))
         return;
     if (tryGroup(m_gpu))
         return;
@@ -289,6 +294,12 @@ bool EmulatorSettingsImpl::Save(const std::string& serial) {
             json audioObj = json::object();
             SaveGroupGameSpecific(m_audio, audioObj);
             j["Audio"] = audioObj;
+
+            // Windows static guest red-zone protection
+            json windowsGuestRedZoneProtectionObj = json::object();
+            SaveGroupGameSpecific(m_windows_guest_red_zone_protection,
+                                  windowsGuestRedZoneProtectionObj);
+            j["WindowsGuestRedZoneProtection"] = windowsGuestRedZoneProtectionObj;
 
             json gpuObj = json::object();
             SaveGroupGameSpecific(m_gpu, gpuObj);
@@ -357,6 +368,9 @@ bool EmulatorSettingsImpl::Save(const std::string& serial) {
 // ── Load ──────────────────────────────────────────────────────────────
 
 bool EmulatorSettingsImpl::Load(const std::string& serial) {
+    // A newly loaded profile replaces, rather than extends, the previous profile.
+    ClearGameSpecificOverrides(); // Windows static guest red-zone protection
+
     try {
         if (serial.empty()) {
             // ── Global config ──────────────────────────────────────────
@@ -459,6 +473,10 @@ bool EmulatorSettingsImpl::Load(const std::string& serial) {
                 ApplyGroupOverrides(m_input, gj.at("Input"), changed);
             if (gj.contains("Audio"))
                 ApplyGroupOverrides(m_audio, gj.at("Audio"), changed);
+            // Windows static guest red-zone protection
+            if (gj.contains("WindowsGuestRedZoneProtection"))
+                ApplyGroupOverrides(m_windows_guest_red_zone_protection,
+                                    gj.at("WindowsGuestRedZoneProtection"), changed);
             if (gj.contains("GPU"))
                 ApplyGroupOverrides(m_gpu, gj.at("GPU"), changed);
             if (gj.contains("Vulkan"))
@@ -480,6 +498,8 @@ void EmulatorSettingsImpl::SetDefaultValues() {
     m_debug = DebugSettings{};
     m_input = InputSettings{};
     m_audio = AudioSettings{};
+    // Windows static guest red-zone protection
+    m_windows_guest_red_zone_protection = WindowsGuestRedZoneProtectionSettings{};
     m_gpu = GPUSettings{};
     m_vulkan = VulkanSettings{};
 }
@@ -738,6 +758,8 @@ std::vector<std::string> EmulatorSettingsImpl::GetAllOverrideableKeys() const {
     addGroup(m_debug.GetOverrideableFields());
     addGroup(m_input.GetOverrideableFields());
     addGroup(m_audio.GetOverrideableFields());
+    // Windows static guest red-zone protection
+    addGroup(m_windows_guest_red_zone_protection.GetOverrideableFields());
     addGroup(m_gpu.GetOverrideableFields());
     addGroup(m_vulkan.GetOverrideableFields());
     return keys;

--- a/src/core/emulator_settings.h
+++ b/src/core/emulator_settings.h
@@ -8,12 +8,14 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <ostream> // Windows static guest red-zone protection
 #include <sstream>
 #include <string>
 #include <vector>
 #include <nlohmann/json.hpp>
 #include "common/logging/log.h"
 #include "common/types.h"
+#include "core/cpu_patches.h" // Windows static guest red-zone protection
 
 #define EmulatorSettings (*EmulatorSettingsImpl::GetInstance())
 
@@ -35,6 +37,16 @@ enum GpuReadbacksMode : int {
     Relaxed,
     Precise,
 };
+
+// Windows static guest red-zone protection
+NLOHMANN_JSON_SERIALIZE_ENUM(WindowsGuestRedZoneProtectionMode,
+                             {{WindowsGuestRedZoneProtectionMode::Disabled, "Disabled"},
+                              {WindowsGuestRedZoneProtectionMode::StaticPatching,
+                               "StaticPatching"}})
+
+inline std::ostream& operator<<(std::ostream& output, WindowsGuestRedZoneProtectionMode mode) {
+    return output << nlohmann::json(mode).get<std::string>();
+}
 
 enum class ConfigMode {
     Default,
@@ -380,6 +392,21 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(AudioSettings, audio_backend, sdl_mic_device,
                                    openal_mic_device, openal_main_output_device,
                                    openal_padSpk_output_device, openal_hrtf, openal_output_mode)
 
+// Windows static guest red-zone protection
+struct WindowsGuestRedZoneProtectionSettings {
+    Setting<WindowsGuestRedZoneProtectionMode> windows_guest_red_zone_protection_mode{
+        WindowsGuestRedZoneProtectionMode::Disabled};
+
+    std::vector<OverrideItem> GetOverrideableFields() const {
+        return std::vector<OverrideItem>{make_override<WindowsGuestRedZoneProtectionSettings>(
+            "windows_guest_red_zone_protection_mode",
+            &WindowsGuestRedZoneProtectionSettings::windows_guest_red_zone_protection_mode)};
+    }
+};
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(WindowsGuestRedZoneProtectionSettings,
+                                   windows_guest_red_zone_protection_mode)
+
 // -------------------------------
 // GPU settings
 // -------------------------------
@@ -536,6 +563,8 @@ private:
     DebugSettings m_debug{};
     InputSettings m_input{};
     AudioSettings m_audio{};
+    // Windows static guest red-zone protection
+    WindowsGuestRedZoneProtectionSettings m_windows_guest_red_zone_protection{};
     GPUSettings m_gpu{};
     VulkanSettings m_vulkan{};
     ConfigMode m_configMode{ConfigMode::Default};
@@ -589,6 +618,10 @@ public:
     }
     std::vector<OverrideItem> GetAudioOverrideableFields() const {
         return m_audio.GetOverrideableFields();
+    }
+    // Windows static guest red-zone protection
+    std::vector<OverrideItem> GetWindowsGuestRedZoneProtectionOverrideableFields() const {
+        return m_windows_guest_red_zone_protection.GetOverrideableFields();
     }
     std::vector<OverrideItem> GetGPUOverrideableFields() const {
         return m_gpu.GetOverrideableFields();
@@ -676,6 +709,10 @@ public:
     SETTING_FORWARD(m_audio, OpenALPadSpkOutputDevice, openal_padSpk_output_device)
     SETTING_FORWARD(m_audio, OpenALHrtf, openal_hrtf)
     SETTING_FORWARD(m_audio, OpenALOutputMode, openal_output_mode)
+
+    // Windows static guest red-zone protection
+    SETTING_FORWARD(m_windows_guest_red_zone_protection, WindowsGuestRedZoneProtectionMode,
+                    windows_guest_red_zone_protection_mode)
 
     // Debug settings
     SETTING_FORWARD_BOOL(m_debug, DebugDump, debug_dump)

--- a/src/core/loader/dwarf.cpp
+++ b/src/core/loader/dwarf.cpp
@@ -14,13 +14,32 @@ T get(uintptr_t addr) {
     return val;
 }
 
+// Windows static guest red-zone protection
+static size_t GetEncodedSize(u8 encoding) {
+    switch (encoding & DW_EH_PE_format_mask) {
+    case DW_EH_PE_ptr:
+        return sizeof(uintptr_t);
+    case DW_EH_PE_udata2:
+    case DW_EH_PE_sdata2:
+        return sizeof(u16);
+    case DW_EH_PE_udata4:
+    case DW_EH_PE_sdata4:
+        return sizeof(u32);
+    case DW_EH_PE_udata8:
+    case DW_EH_PE_sdata8:
+        return sizeof(u64);
+    default:
+        return 0;
+    }
+}
+
 static uintptr_t getEncodedP(uintptr_t& addr, uintptr_t end, u8 encoding, uintptr_t datarelBase) {
     const uintptr_t startAddr = addr;
     const u8* p = (u8*)addr;
     uintptr_t result;
 
     // First get value
-    switch (encoding & 0x0F) {
+    switch (encoding & DW_EH_PE_format_mask) { // Windows static guest red-zone protection
     case DW_EH_PE_ptr:
         result = get<uintptr_t>(addr);
         p += sizeof(uintptr_t);
@@ -63,7 +82,7 @@ static uintptr_t getEncodedP(uintptr_t& addr, uintptr_t end, u8 encoding, uintpt
     }
 
     // Then add relative offset
-    switch (encoding & 0x70) {
+    switch (encoding & DW_EH_PE_application_mask) { // Windows static guest red-zone protection
     case DW_EH_PE_absptr:
         // do nothing
         break;
@@ -130,7 +149,37 @@ bool DecodeEHHdr(uintptr_t ehHdrStart, uintptr_t ehHdrEnd, EHHeaderInfo& ehHdrIn
     ehHdrInfo.fde_count =
         fde_count_enc == DW_EH_PE_omit ? 0 : getEncodedP(p, ehHdrEnd, fde_count_enc, ehHdrStart);
     ehHdrInfo.table = p;
+    ehHdrInfo.datarel_base = ehHdrStart; // Windows static guest red-zone protection
 
+    return true;
+}
+
+// Windows static guest red-zone protection
+bool DecodeEHHdrTable(const EHHeaderInfo& ehHdrInfo, uintptr_t ehHdrEnd,
+                      std::vector<uintptr_t>& functionStarts) {
+    functionStarts.clear();
+    if (ehHdrInfo.fde_count == 0 || ehHdrInfo.table_enc == DW_EH_PE_omit) {
+        return true;
+    }
+
+    const size_t encoded_size = GetEncodedSize(ehHdrInfo.table_enc);
+    if (encoded_size == 0 || ehHdrInfo.table > ehHdrEnd) {
+        return false;
+    }
+
+    const size_t entry_size = encoded_size * 2;
+    const size_t remaining_size = ehHdrEnd - ehHdrInfo.table;
+    if (ehHdrInfo.fde_count > remaining_size / entry_size) {
+        return false;
+    }
+
+    functionStarts.reserve(ehHdrInfo.fde_count);
+    uintptr_t cursor = ehHdrInfo.table;
+    for (size_t index = 0; index < ehHdrInfo.fde_count; ++index) {
+        functionStarts.push_back(
+            getEncodedP(cursor, ehHdrEnd, ehHdrInfo.table_enc, ehHdrInfo.datarel_base));
+        getEncodedP(cursor, ehHdrEnd, ehHdrInfo.table_enc, ehHdrInfo.datarel_base);
+    }
     return true;
 }
 

--- a/src/core/loader/dwarf.h
+++ b/src/core/loader/dwarf.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <vector> // Windows static guest red-zone protection
+
 #include "common/types.h"
 
 namespace Dwarf {
@@ -25,17 +27,24 @@ enum {
     DW_EH_PE_funcrel = 0x40,
     DW_EH_PE_aligned = 0x50,
     DW_EH_PE_indirect = 0x80,
-    DW_EH_PE_omit = 0xFF
+    DW_EH_PE_omit = 0xFF,
+    // Windows static guest red-zone protection
+    DW_EH_PE_format_mask = 0x0F,
+    DW_EH_PE_application_mask = 0x70,
 };
 
 /// Information encoded in the EH frame header.
 struct EHHeaderInfo {
-    uintptr_t eh_frame_ptr;
-    size_t fde_count;
-    uintptr_t table;
-    u8 table_enc;
+    uintptr_t eh_frame_ptr{};    // Windows static guest red-zone protection
+    size_t fde_count{};          // Windows static guest red-zone protection
+    uintptr_t table{};           // Windows static guest red-zone protection
+    uintptr_t datarel_base{};    // Windows static guest red-zone protection
+    u8 table_enc{DW_EH_PE_omit}; // Windows static guest red-zone protection
 };
 
 bool DecodeEHHdr(uintptr_t ehHdrStart, uintptr_t ehHdrEnd, EHHeaderInfo& ehHdrInfo);
+// Windows static guest red-zone protection
+bool DecodeEHHdrTable(const EHHeaderInfo& ehHdrInfo, uintptr_t ehHdrEnd,
+                      std::vector<uintptr_t>& functionStarts);
 
 } // namespace Dwarf

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -181,6 +181,13 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
         }
     };
 
+#if defined(ARCH_X86_64) && defined(_WIN32)
+    // Windows static guest red-zone protection
+    const bool use_static_windows_guest_red_zone_protection =
+        WindowsGuestRedZoneProtection::IsStaticPatchingEnabled();
+    std::vector<std::pair<VAddr, u64>> executable_segments;
+    std::vector<uintptr_t> function_starts;
+#endif
     for (u16 i = 0; i < elf_header.e_phnum; i++) {
         const auto header_type = elf.ElfPheaderTypeStr(elf_pheader[i].p_type);
         switch (elf_pheader[i].p_type) {
@@ -205,6 +212,12 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
 #ifdef ARCH_X86_64
             if (elf_pheader[i].p_flags & PF_EXEC) {
                 PrePatchInstructions(segment_addr, segment_file_size);
+#ifdef _WIN32
+                // Windows static guest red-zone protection
+                if (use_static_windows_guest_red_zone_protection) {
+                    executable_segments.emplace_back(segment_addr, segment_file_size);
+                }
+#endif
             }
 #endif
             break;
@@ -247,6 +260,13 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
             const VAddr eh_hdr_end = eh_hdr_start + eh_frame_hdr_size;
             Dwarf::EHHeaderInfo hdr_info;
             if (Dwarf::DecodeEHHdr(eh_hdr_start, eh_hdr_end, hdr_info)) {
+#if defined(ARCH_X86_64) && defined(_WIN32)
+                // Windows static guest red-zone protection
+                if (use_static_windows_guest_red_zone_protection &&
+                    !Dwarf::DecodeEHHdrTable(hdr_info, eh_hdr_end, function_starts)) {
+                    LOG_ERROR(Core_Linker, "Failed to decode EH frame search table for {}", name);
+                }
+#endif
                 eh_frame_addr = hdr_info.eh_frame_ptr - base_virtual_addr;
                 if (eh_frame_hdr_addr > eh_frame_addr) {
                     eh_frame_size = (eh_frame_hdr_addr - eh_frame_addr);
@@ -260,6 +280,60 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
             LOG_ERROR(Core_Linker, "Unimplemented type {}", header_type);
         }
     }
+
+#if defined(ARCH_X86_64) && defined(_WIN32)
+    // Windows static guest red-zone protection
+    if (use_static_windows_guest_red_zone_protection) {
+        u64 analyzed_function_count{};
+        u64 stack_dependent_instruction_count{};
+        u64 control_flow_instruction_count{};
+        u64 unrelocatable_instruction_count{};
+        u64 unsupported_cpu_patch_instruction_count{};
+        for (const auto& [segment_addr, segment_size] : executable_segments) {
+            // Windows static guest red-zone protection
+            const auto result =
+                PatchRedZoneMemoryInstructions(segment_addr, segment_size, function_starts);
+            analyzed_function_count += result.function_count;
+            stack_dependent_instruction_count += result.stack_dependent_memory_instruction_count;
+            control_flow_instruction_count += result.control_flow_memory_instruction_count;
+            unrelocatable_instruction_count += result.unrelocatable_memory_instruction_count;
+            unsupported_cpu_patch_instruction_count +=
+                result.unsupported_cpu_patch_instruction_count;
+            LOG_DEBUG(
+                Core_Linker,
+                "Windows guest red-zone static patching for {}: {} functions, {} instructions, "
+                "{} red-zone functions, {}/{} memory instructions patched "
+                "({} short, {} stack-dependent, {} control-flow, {} unrelocatable), "
+                "{}/{} short CPU patches applied ({} unsupported), {} indirect red-zone "
+                "functions",
+                name, result.function_count, result.instruction_count,
+                result.red_zone_function_count, result.patched_memory_instruction_count,
+                result.memory_instruction_count, result.short_memory_instruction_count,
+                result.stack_dependent_memory_instruction_count,
+                result.control_flow_memory_instruction_count,
+                result.unrelocatable_memory_instruction_count,
+                result.patched_cpu_patch_instruction_count, result.cpu_patch_instruction_count,
+                result.unsupported_cpu_patch_instruction_count,
+                result.indirect_red_zone_function_count);
+        }
+        if (!executable_segments.empty() && analyzed_function_count == 0) {
+            LOG_WARNING(Core_Linker,
+                        "Windows guest red-zone static patching could not find function "
+                        "boundaries for {}; protection was not applied",
+                        name);
+        } else if (stack_dependent_instruction_count != 0 || control_flow_instruction_count != 0 ||
+                   unrelocatable_instruction_count != 0 ||
+                   unsupported_cpu_patch_instruction_count != 0) {
+            LOG_WARNING(
+                Core_Linker,
+                "Windows guest red-zone static patching for {} is partial: {} stack-dependent, "
+                "{} control-flow, and {} unrelocatable memory instructions were not protected; "
+                "{} CPU patch instructions were unsupported",
+                name, stack_dependent_instruction_count, control_flow_instruction_count,
+                unrelocatable_instruction_count, unsupported_cpu_patch_instruction_count);
+        }
+    }
+#endif
 
     const VAddr entry_addr = base_virtual_addr + elf.GetElfEntry();
     LOG_INFO(Core_Linker, "program entry addr ..........: {:#018x}", entry_addr);

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -5,6 +5,7 @@
 #include "common/assert.h"
 #include "common/decoder.h"
 #include "common/signal_context.h"
+#include "core/cpu_patches.h" // Windows static guest red-zone protection
 #include "core/libraries/kernel/threads/exception.h"
 #include "core/signals.h"
 #include "emulator.h"
@@ -33,6 +34,9 @@ namespace Core {
 
 static LONG WINAPI SignalHandler(EXCEPTION_POINTERS* pExp) noexcept {
     const auto* signals = Signals::Instance();
+    // Windows static guest red-zone protection
+    const bool use_static_windows_guest_red_zone_protection =
+        WindowsGuestRedZoneProtection::IsStaticPatchingEnabled();
     DWORD code = 0;
     PVOID address = nullptr;
 
@@ -42,13 +46,22 @@ static LONG WINAPI SignalHandler(EXCEPTION_POINTERS* pExp) noexcept {
     }
 
     bool handled = false;
+    bool static_protection_exception = false; // Windows static guest red-zone protection
     switch (code) {
     case EXCEPTION_ACCESS_VIOLATION:
+        static_protection_exception = true; // Windows static guest red-zone protection
         handled = signals->DispatchAccessViolation(
             pExp, reinterpret_cast<void*>(pExp->ExceptionRecord->ExceptionInformation[1]));
         break;
     case EXCEPTION_ILLEGAL_INSTRUCTION:
+        static_protection_exception = true; // Windows static guest red-zone protection
         handled = signals->DispatchIllegalInstruction(pExp);
+        break;
+    case EXCEPTION_PRIV_INSTRUCTION: // Windows static guest red-zone protection
+        if (use_static_windows_guest_red_zone_protection) {
+            static_protection_exception = true;
+            handled = signals->DispatchIllegalInstruction(pExp);
+        }
         break;
     case DBG_PRINTEXCEPTION_C:
     case DBG_PRINTEXCEPTION_WIDE_C:
@@ -65,8 +78,11 @@ static LONG WINAPI SignalHandler(EXCEPTION_POINTERS* pExp) noexcept {
         return EXCEPTION_CONTINUE_EXECUTION;
     }
 
-    // Breakpoints almost certainly come from our asserts/unreachables, no need to log it again.
-    if (code != EXCEPTION_BREAKPOINT) {
+    // Windows static guest red-zone protection
+    const bool report_unhandled = use_static_windows_guest_red_zone_protection
+                                      ? static_protection_exception
+                                      : code != EXCEPTION_BREAKPOINT;
+    if (report_unhandled) { // Windows static guest red-zone protection
         LOG_CRITICAL(Debug, "Unhandled Exception code {:#x} at {}", code, address);
         Common::Singleton<Core::Emulator>::Instance()->Shutdown();
     }

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -26,6 +26,7 @@
 #include "common/polyfill_thread.h"
 #include "common/scm_rev.h"
 #include "common/singleton.h"
+#include "core/cpu_patches.h" // Windows static guest red-zone protection
 #include "core/debugger.h"
 #include "core/devtools/widget/module_list.h"
 #include "core/emulator_settings.h"
@@ -421,9 +422,20 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
     }
 
     EmulatorSettings.Load(id);
+    // Windows static guest red-zone protection
+    WindowsGuestRedZoneProtection::SetActiveMode(
+        EmulatorSettings.GetWindowsGuestRedZoneProtectionMode());
     // Switch to configured log
     Common::Log::Switch((!id.empty() && EmulatorSettings.IsLogSeparate()) ? id + ".log"
                                                                           : "shad_log.txt");
+#ifdef _WIN32
+    // Windows static guest red-zone protection
+    if (WindowsGuestRedZoneProtection::IsStaticPatchingEnabled()) {
+        LOG_INFO(Core,
+                 "Windows guest red-zone static protection uses module EH metadata and cannot "
+                 "cover code without function entries");
+    }
+#endif
 
     auto guest_eboot_path = "/app0/" + eboot_name.generic_string();
 

--- a/src/imgui/big_picture/settings_dialog_imgui.cpp
+++ b/src/imgui/big_picture/settings_dialog_imgui.cpp
@@ -81,6 +81,15 @@ void SettingsWindow::LoadSettings(std::string profile) {
         readbacksModeSetting = EmulatorSettings.GetReadbacksMode();
         readbackLinearImagesSetting = EmulatorSettings.IsReadbackLinearImagesEnabled();
         directMemoryAccessSetting = EmulatorSettings.IsDirectMemoryAccessEnabled();
+        // Windows static guest red-zone protection
+        windowsGuestRedZoneProtectionModeSetting =
+            static_cast<int>(EmulatorSettings.GetWindowsGuestRedZoneProtectionMode());
+        if (windowsGuestRedZoneProtectionModeSetting < 0 ||
+            windowsGuestRedZoneProtectionModeSetting >=
+                static_cast<int>(windowsGuestRedZoneProtectionModeOptions.size())) {
+            windowsGuestRedZoneProtectionModeSetting =
+                static_cast<int>(WindowsGuestRedZoneProtectionMode::Disabled);
+        }
         devkitConsoleSetting = EmulatorSettings.IsDevKit();
         neoModeSetting = EmulatorSettings.IsNeo();
         shadnetEnabledSetting = EmulatorSettings.IsShadNetEnabledSetting();
@@ -136,6 +145,11 @@ void SettingsWindow::SaveSettings(std::string profile) {
         EmulatorSettings.SetReadbacksMode(readbacksModeSetting, true);
         EmulatorSettings.SetReadbackLinearImagesEnabled(readbackLinearImagesSetting, true);
         EmulatorSettings.SetDirectMemoryAccessEnabled(directMemoryAccessSetting, true);
+        // Windows static guest red-zone protection
+        EmulatorSettings.SetWindowsGuestRedZoneProtectionMode(
+            static_cast<WindowsGuestRedZoneProtectionMode>(
+                windowsGuestRedZoneProtectionModeSetting),
+            true);
         EmulatorSettings.SetDevKit(devkitConsoleSetting, true);
         EmulatorSettings.SetNeo(neoModeSetting, true);
         EmulatorSettings.SetShadNetEnabled(shadnetEnabledSetting, true);
@@ -744,6 +758,12 @@ void SettingsWindow::DrawSettingsTable(SettingsCategory category) {
             AddSettingCombo("Readbacks Mode", readbacksModeSetting, readbacksModeOptions);
             AddSettingCheckbox("Enable Readback Linear Images", readbackLinearImagesSetting);
             AddSettingCheckbox("Enable Direct Memory Access", directMemoryAccessSetting);
+#ifdef _WIN32
+            // Windows static guest red-zone protection
+            AddSettingCombo("Windows Guest Red Zone Protection (Requires Restart)",
+                            windowsGuestRedZoneProtectionModeSetting,
+                            windowsGuestRedZoneProtectionModeOptions);
+#endif
             AddSettingCheckbox("Enable Devkit Console Mode", devkitConsoleSetting);
             AddSettingCheckbox("Enable PS4 Neo Mode", neoModeSetting);
             AddSettingCheckbox("Enable ShadNet", shadnetEnabledSetting);

--- a/src/imgui/big_picture/settings_dialog_imgui.h
+++ b/src/imgui/big_picture/settings_dialog_imgui.h
@@ -117,6 +117,9 @@ private:
     const std::vector<std::string> hideCursorOptions = {"Never", "Idle", "Always"};
     const std::vector<std::string> trophySideOptions = {"left", "right", "top", "bottom"};
     const std::vector<std::string> readbacksModeOptions = {"Disabled", "Relaxed", "Precise"};
+    // Windows static guest red-zone protection
+    const std::vector<std::string> windowsGuestRedZoneProtectionModeOptions = {"Disabled",
+                                                                               "Static Patching"};
 
     //////////////// Setting Variables
     //////////////// Note:: Use int for all comboboxes as needed by ImGui
@@ -157,6 +160,8 @@ private:
     int readbacksModeSetting;
     bool readbackLinearImagesSetting;
     bool directMemoryAccessSetting;
+    // Windows static guest red-zone protection
+    int windowsGuestRedZoneProtectionModeSetting;
     bool devkitConsoleSetting;
     bool neoModeSetting;
     bool shadnetEnabledSetting;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,8 @@ set(SETTINGS_TEST_SOURCES
 
     # Tests
     test_emulator_settings.cpp
+    # Windows static guest red-zone protection
+    test_windows_guest_red_zone_protection_settings.cpp
 )
 
 set(NGS2_TEST_SOURCES

--- a/tests/test_windows_guest_red_zone_protection_settings.cpp
+++ b/tests/test_windows_guest_red_zone_protection_settings.cpp
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// Windows static guest red-zone protection
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include "common/path_util.h"
+#include "core/emulator_settings.h"
+#include "core/emulator_state.h"
+
+namespace fs = std::filesystem;
+using json = nlohmann::json;
+
+class WindowsGuestRedZoneProtectionProfileTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        const auto suffix = std::chrono::steady_clock::now().time_since_epoch().count();
+        root = fs::temp_directory_path() /
+               ("shadps4_red_zone_settings_test_" + std::to_string(suffix));
+        custom_configs = root / "custom_configs";
+        fs::create_directories(custom_configs);
+
+        Common::FS::SetUserPath(Common::FS::PathType::UserDir, root);
+        Common::FS::SetUserPath(Common::FS::PathType::CustomConfigs, custom_configs);
+
+        state = std::make_shared<EmulatorState>();
+        EmulatorState::SetInstance(state);
+        settings = std::make_shared<EmulatorSettingsImpl>();
+        EmulatorSettingsImpl::SetInstance(settings);
+    }
+
+    void TearDown() override {
+        EmulatorSettingsImpl::SetInstance(nullptr);
+        EmulatorState::SetInstance(nullptr);
+        settings.reset();
+        state.reset();
+
+        std::error_code error;
+        fs::remove_all(root, error);
+    }
+
+    void WriteGameConfig(const std::string& serial, const json& config) const {
+        std::ofstream output(custom_configs / (serial + ".json"));
+        ASSERT_TRUE(output.is_open());
+        output << config;
+    }
+
+    fs::path root;
+    fs::path custom_configs;
+    std::shared_ptr<EmulatorState> state;
+    std::shared_ptr<EmulatorSettingsImpl> settings;
+};
+
+TEST(WindowsGuestRedZoneProtectionSettingsTest, DisabledIsTheDefault) {
+    EmulatorSettingsImpl settings;
+
+    EXPECT_EQ(settings.GetWindowsGuestRedZoneProtectionMode(),
+              WindowsGuestRedZoneProtectionMode::Disabled);
+}
+
+TEST(WindowsGuestRedZoneProtectionSettingsTest, GameOverrideDoesNotChangeGlobalMode) {
+    EmulatorSettingsImpl settings;
+    settings.SetWindowsGuestRedZoneProtectionMode(WindowsGuestRedZoneProtectionMode::StaticPatching,
+                                                  true);
+
+    EXPECT_EQ(settings.GetWindowsGuestRedZoneProtectionMode(),
+              WindowsGuestRedZoneProtectionMode::StaticPatching);
+
+    settings.SetConfigMode(ConfigMode::Global);
+    EXPECT_EQ(settings.GetWindowsGuestRedZoneProtectionMode(),
+              WindowsGuestRedZoneProtectionMode::Disabled);
+}
+
+TEST(WindowsGuestRedZoneProtectionSettingsTest, JsonUsesTheExistingPerGameKey) {
+    WindowsGuestRedZoneProtectionSettings source;
+    source.windows_guest_red_zone_protection_mode.value =
+        WindowsGuestRedZoneProtectionMode::StaticPatching;
+
+    const nlohmann::json encoded = source;
+    ASSERT_TRUE(encoded.contains("windows_guest_red_zone_protection_mode"));
+
+    const auto decoded = encoded.get<WindowsGuestRedZoneProtectionSettings>();
+    EXPECT_EQ(decoded.windows_guest_red_zone_protection_mode.value,
+              WindowsGuestRedZoneProtectionMode::StaticPatching);
+}
+
+TEST_F(WindowsGuestRedZoneProtectionProfileTest, MissingProfileClearsExperimentalOverrides) {
+    settings->SetWindowsGuestRedZoneProtectionMode(
+        WindowsGuestRedZoneProtectionMode::StaticPatching, true);
+    settings->SetReadbacksMode(GpuReadbacksMode::Precise, true);
+
+    EXPECT_FALSE(settings->Load("CUSA00001"));
+    EXPECT_EQ(settings->GetWindowsGuestRedZoneProtectionMode(),
+              WindowsGuestRedZoneProtectionMode::Disabled);
+    EXPECT_EQ(settings->GetReadbacksMode(), GpuReadbacksMode::Disabled);
+}
+
+TEST_F(WindowsGuestRedZoneProtectionProfileTest, NewProfileReplacesExperimentalOverrides) {
+    json enabled;
+    enabled["WindowsGuestRedZoneProtection"]["windows_guest_red_zone_protection_mode"] =
+        "StaticPatching";
+    enabled["GPU"]["readbacks_mode"] = GpuReadbacksMode::Precise;
+    WriteGameConfig("CUSA00001", enabled);
+    WriteGameConfig("CUSA00002", json::object());
+
+    ASSERT_TRUE(settings->Load("CUSA00001"));
+    EXPECT_EQ(settings->GetWindowsGuestRedZoneProtectionMode(),
+              WindowsGuestRedZoneProtectionMode::StaticPatching);
+    EXPECT_EQ(settings->GetReadbacksMode(), GpuReadbacksMode::Precise);
+
+    ASSERT_TRUE(settings->Load("CUSA00002"));
+    EXPECT_EQ(settings->GetWindowsGuestRedZoneProtectionMode(),
+              WindowsGuestRedZoneProtectionMode::Disabled);
+    EXPECT_EQ(settings->GetReadbacksMode(), GpuReadbacksMode::Disabled);
+}
+
+TEST_F(WindowsGuestRedZoneProtectionProfileTest, GlobalConfigCannotEnableProtection) {
+    json global;
+    global["WindowsGuestRedZoneProtection"]["windows_guest_red_zone_protection_mode"] =
+        "StaticPatching";
+    std::ofstream output(root / "config.json");
+    ASSERT_TRUE(output.is_open());
+    output << global;
+    output.close();
+
+    ASSERT_TRUE(settings->Load());
+    EXPECT_EQ(settings->GetWindowsGuestRedZoneProtectionMode(),
+              WindowsGuestRedZoneProtectionMode::Disabled);
+}


### PR DESCRIPTION
- Analyze EH function boundaries and relocate faultable guest instructions through red-zone-safe trampolines.
- Integrate Windows exception handling and existing CPU patches without an external debugger.
- Add a Windows-only per-game setting, coverage diagnostics, and configuration tests.

# Windows Guest Red Zone Protection

Enable the feature using either Big Picture mode or manual configuration.

## Method 1: Big Picture mode

1. Launch shadPS4 in Big Picture mode.
2. Select **Settings** in the bottom-right corner.
3. Open **Profiles** and select the game.
4. Create a game-specific configuration if one does not already exist.
5. Open **Experimental**.
6. Set **Windows Guest Red Zone Protection** to **Static Patching**.
7. Select **Apply** or **Save**, then restart the game.

## Method 2: Manual configuration

1. Close the game.
2. Open:

   `%APPDATA%\shadPS4\custom_configs\`

3. Open or create `<GAME_SERIAL>.json`, for example `CUSA01073.json`.
4. Add this top-level group:

   ```json
   {
     "WindowsGuestRedZoneProtection": {
       "windows_guest_red_zone_protection_mode": "StaticPatching"
     }
   }
   ```

   If other groups already exist, add the required comma.
5. Save the file and restart the game.

## Disable

Change the value to:

```json
"windows_guest_red_zone_protection_mode": "Disabled"
```

Alternatively, remove the entire `WindowsGuestRedZoneProtection` group.

> This setting is available only on Windows and works only in a game-specific configuration. Adding it to the global configuration will not enable it.
