### PR TITLE
Big Picture: launch games in a clean process

### DIFF
--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2025-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <algorithm>
 #include <ctime>
 #include <filesystem>
 #include <fstream>
@@ -725,9 +726,6 @@ void Emulator::Restart(std::filesystem::path eboot_path,
         args.push_back(MemoryPatcher::patch_file);
     }
 
-    args.push_back("--wait-for-pid");
-    args.push_back(std::to_string(Debugger::GetCurrentPid()));
-
     if (waitForDebuggerBeforeRun) {
         args.push_back("--wait-for-debugger");
     }
@@ -739,8 +737,16 @@ void Emulator::Restart(std::filesystem::path eboot_path,
         }
     }
 
-    LOG_INFO(Common, "Restarting the emulator with args: {}", fmt::join(args, " "));
     Libraries::SaveData::Backup::StopThread();
+    Relaunch(std::move(args));
+}
+
+[[noreturn]] void Emulator::Relaunch(std::vector<std::string> args) {
+    const auto guest_args = std::find(args.begin(), args.end(), "--");
+    args.insert(guest_args,
+                {"--wait-for-pid", std::to_string(Debugger::GetCurrentPid())});
+
+    LOG_INFO(Common, "Relaunching the emulator with args: {}", fmt::join(args, " "));
     Common::Log::Shutdown();
 
     auto& ipc = IPC::Instance();
@@ -752,23 +758,24 @@ void Emulator::Restart(std::filesystem::path eboot_path,
         }
     }
 #if defined(_WIN32)
-    std::string cmdline;
+    std::wstring cmdline;
     // Emulator executable
-    cmdline += "\"";
-    cmdline += executableName;
-    cmdline += "\"";
+    const auto executable = Common::UTF8ToUTF16W(executableName);
+    cmdline += L"\"";
+    cmdline += executable;
+    cmdline += L"\"";
     for (const auto& arg : args) {
-        cmdline += " \"";
-        cmdline += arg;
-        cmdline += "\"";
+        cmdline += L" \"";
+        cmdline += Common::UTF8ToUTF16W(arg);
+        cmdline += L"\"";
     }
-    cmdline += "\0";
+    cmdline += L'\0';
 
-    STARTUPINFOA si{};
+    STARTUPINFOW si{};
     si.cb = sizeof(si);
     PROCESS_INFORMATION pi{};
-    bool success = CreateProcessA(nullptr, cmdline.data(), nullptr, nullptr, TRUE, 0, nullptr,
-                                  nullptr, &si, &pi);
+    bool success = CreateProcessW(executable.c_str(), cmdline.data(), nullptr, nullptr, TRUE, 0,
+                                  nullptr, nullptr, &si, &pi);
 
     if (!success) {
         std::cerr << "Failed to restart game: {}" << GetLastError() << std::endl;

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -743,8 +743,7 @@ void Emulator::Restart(std::filesystem::path eboot_path,
 
 [[noreturn]] void Emulator::Relaunch(std::vector<std::string> args) {
     const auto guest_args = std::find(args.begin(), args.end(), "--");
-    args.insert(guest_args,
-                {"--wait-for-pid", std::to_string(Debugger::GetCurrentPid())});
+    args.insert(guest_args, {"--wait-for-pid", std::to_string(Debugger::GetCurrentPid())});
 
     LOG_INFO(Common, "Relaunching the emulator with args: {}", fmt::join(args, " "));
     Common::Log::Shutdown();

--- a/src/emulator.h
+++ b/src/emulator.h
@@ -37,6 +37,12 @@ public:
      */
     void Restart(std::filesystem::path eboot_path, const std::vector<std::string>& guest_args = {});
 
+    /**
+     * Launches a new emulator process with the supplied CLI arguments, then terminates this
+     * process. The new process waits for this one to exit before initializing.
+     */
+    [[noreturn]] void Relaunch(std::vector<std::string> args);
+
     const char* executableName;
     bool waitForDebuggerBeforeRun{false};
 

--- a/src/imgui/big_picture/big_picture.cpp
+++ b/src/imgui/big_picture/big_picture.cpp
@@ -387,8 +387,7 @@ void Launch(char* executableName) {
     if (runEbootPath != "") {
         auto* emulator = Common::Singleton<Core::Emulator>::Instance();
         emulator->executableName = executableName;
-        emulator->Relaunch(
-            {"--log-append", "--game", Common::FS::PathToUTF8String(runEbootPath)});
+        emulator->Relaunch({"--log-append", "--game", Common::FS::PathToUTF8String(runEbootPath)});
     }
 }
 

--- a/src/imgui/big_picture/big_picture.cpp
+++ b/src/imgui/big_picture/big_picture.cpp
@@ -376,8 +376,9 @@ void Launch(char* executableName) {
     ImGui_ImplSDLRenderer3_Shutdown();
     ImGui_ImplSDL3_Shutdown();
     ImGui::DestroyContext();
-    SDL_DestroyWindow(window);
     SDL_DestroyRenderer(renderer);
+    renderer = nullptr;
+    SDL_DestroyWindow(window);
     SDL_Quit();
 
     EmulatorSettings.SetBigPictureScale(static_cast<int>(uiScale * 1000));
@@ -386,7 +387,8 @@ void Launch(char* executableName) {
     if (runEbootPath != "") {
         auto* emulator = Common::Singleton<Core::Emulator>::Instance();
         emulator->executableName = executableName;
-        emulator->Run(runEbootPath);
+        emulator->Relaunch(
+            {"--log-append", "--game", Common::FS::PathToUTF8String(runEbootPath)});
     }
 }
 


### PR DESCRIPTION
- prevent frontend renderer state from affecting game texture loading
- wait for Big Picture shutdown before initializing the game process
- reuse relaunch handling for IPC and native process creation
- preserve Unicode game paths on Windows
- correct SDL renderer and window destruction order