### PR TITLE
sdl_window: Skip camera initialization on macOS

### DIFF
--- a/src/sdl_window.cpp
+++ b/src/sdl_window.cpp
@@ -103,9 +103,13 @@ WindowSDL::WindowSDL(s32 width_, s32 height_, Input::GameControllers* controller
     if (!SDL_Init(SDL_INIT_VIDEO)) {
         UNREACHABLE_MSG("Failed to initialize SDL video subsystem: {}", SDL_GetError());
     }
+    // On macOS, the future Intel compatibility environment does not include camera frameworks.
+    // Just skip initializing it entirely, no point in splitting old vs new OS versions here.
+#ifndef __APPLE__
     if (!SDL_Init(SDL_INIT_CAMERA)) {
         LOG_ERROR(Input, "Failed to initialize SDL camera subsystem: {}", SDL_GetError());
     }
+#endif
     SDL_InitSubSystem(SDL_INIT_AUDIO);
 
     SDL_PropertiesID props = SDL_CreateProperties();


### PR DESCRIPTION
macOS 27 beta has the ability to test on the upcoming Intel game compatibility environment that will be around post-Rosetta. It does not include camera capture APIs, so skip initializing SDL cameras to avoid a crash.