### PR TITLE
big_picture: Allow launching game in same process for testing

### DIFF
--- a/src/imgui/big_picture/big_picture.cpp
+++ b/src/imgui/big_picture/big_picture.cpp
@@ -187,7 +187,7 @@ void GetGameIconInfo(std::vector<IconInfo>& icons) {
     });
 }
 
-void Launch(char* executableName) {
+void Launch(char* executableName, bool sameProcess) {
     if (!SDL_Init(SDL_INIT_VIDEO)) {
         LOG_ERROR(ImGui, "SDL_INIT_VIDEO Error: {}", SDL_GetError());
         SDL_Quit();
@@ -387,7 +387,12 @@ void Launch(char* executableName) {
     if (runEbootPath != "") {
         auto* emulator = Common::Singleton<Core::Emulator>::Instance();
         emulator->executableName = executableName;
-        emulator->Relaunch({"--log-append", "--game", Common::FS::PathToUTF8String(runEbootPath)});
+        if (sameProcess) {
+            emulator->Run(runEbootPath);
+        } else {
+            emulator->Relaunch(
+                {"--log-append", "--game", Common::FS::PathToUTF8String(runEbootPath)});
+        }
     }
 }
 

--- a/src/imgui/big_picture/big_picture.h
+++ b/src/imgui/big_picture/big_picture.h
@@ -20,7 +20,7 @@ struct IconInfo {
     bool focusState;
 };
 
-void Launch(char* executableName);
+void Launch(char* executableName, bool sameProcess);
 void GetGameIconInfo(std::vector<IconInfo>& icons);
 SDL_Texture* LoadSdlTextureData(std::vector<u8> data);
 SDL_Texture* LoadSdlTextureDataFromFile(std::filesystem::path filePath);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,6 +62,7 @@ int main(int argc, char* argv[]) {
     bool configClean = false;
     bool configGlobal = false;
     bool bigPicture = false;
+    bool sameProcess = false;
 
     std::optional<std::filesystem::path> addGameFolder;
     std::optional<std::filesystem::path> setAddonFolder;
@@ -74,6 +75,8 @@ int main(int argc, char* argv[]) {
                  "Disable automatic loading of game patches");
 
     app.add_flag("-b,--big-picture", bigPicture, "Start in Big Picture Mode");
+    app.add_flag("--same-process", sameProcess,
+                 "Launch the game in the same process when using Big Picture Mode");
 
     // FULLSCREEN: behavior-identical
     app.add_option("-f,--fullscreen", fullscreenStr, "Fullscreen mode (true|false)");
@@ -143,7 +146,7 @@ int main(int argc, char* argv[]) {
     Common::Log::g_should_append |= EmulatorSettings.IsLogAppend();
 
     if (bigPicture) {
-        BigPictureMode::Launch(argv[0]);
+        BigPictureMode::Launch(argv[0], sameProcess);
         return 0;
     }
 


### PR DESCRIPTION
In my IDE launching the game in a separate process loses control and console output.