### PR TITLE
video_core: Validate texture subresource containment

### DIFF
--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -560,7 +560,7 @@ ImageId TextureCache::FindImage(ImageDesc& desc, bool exact_fmt) {
         if (exact_fmt && info.pixel_format != image_resolved.info.pixel_format) {
             // Cannot reuse this image as we need the exact requested format.
             image_id = {};
-        } else if (image_resolved.info.resources < info.resources) {
+        } else if (!image_resolved.info.resources.CanContain(info.resources)) {
             // The image was clearly picked up wrong.
             FreeImage(image_id);
             image_id = {};

--- a/src/video_core/texture_cache/types.h
+++ b/src/video_core/texture_cache/types.h
@@ -63,6 +63,10 @@ struct SubresourceExtent {
     u32 levels = 1;
     u32 layers = 1;
 
+    constexpr bool CanContain(const SubresourceExtent& requested) const {
+        return levels >= requested.levels && layers >= requested.layers;
+    }
+
     auto operator<=>(const SubresourceExtent&) const = default;
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,15 @@ set(TEST_TARGETS
     shadps4_gcn_test
 )
 
+add_executable(shadps4_texture_types_test
+    test_texture_types.cpp
+)
+target_link_libraries(shadps4_texture_types_test PRIVATE
+    GTest::gtest_main
+    spdlog::spdlog
+)
+list(APPEND TEST_TARGETS shadps4_texture_types_test)
+
 set(SETTINGS_TEST_SOURCES
     # Under test
     ${CMAKE_SOURCE_DIR}/src/core/emulator_settings.cpp

--- a/tests/test_texture_types.cpp
+++ b/tests/test_texture_types.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "video_core/texture_cache/types.h"
+
+namespace {
+
+using VideoCore::SubresourceExtent;
+
+TEST(SubresourceExtent, ContainsEqualExtent) {
+    constexpr SubresourceExtent available{.levels = 3, .layers = 6};
+
+    EXPECT_TRUE(available.CanContain(SubresourceExtent{.levels = 3, .layers = 6}));
+}
+
+TEST(SubresourceExtent, ContainsSmallerExtentInBothDimensions) {
+    constexpr SubresourceExtent available{.levels = 3, .layers = 6};
+
+    EXPECT_TRUE(available.CanContain(SubresourceExtent{.levels = 2, .layers = 5}));
+}
+
+TEST(SubresourceExtent, RejectsMoreMipLevelsDespiteFewerLayers) {
+    constexpr SubresourceExtent available{.levels = 1, .layers = 6};
+
+    EXPECT_FALSE(available.CanContain(SubresourceExtent{.levels = 3, .layers = 1}));
+}
+
+TEST(SubresourceExtent, RejectsMoreLayersDespiteFewerMipLevels) {
+    constexpr SubresourceExtent available{.levels = 3, .layers = 1};
+
+    EXPECT_FALSE(available.CanContain(SubresourceExtent{.levels = 1, .layers = 6}));
+}
+
+} // namespace


### PR DESCRIPTION
Layers were only checked when the mip count happened to be equal.

Tested with Uncharted Nathan Drake Collection.

Disclosure: AI assisted with GPT5.6