### PR TITLE
Core: Call sceLibcInternalMemoryMutexEnable LLE on startup

### DIFF
--- a/src/core/libraries/kernel/kernel.cpp
+++ b/src/core/libraries/kernel/kernel.cpp
@@ -150,23 +150,6 @@ void SetPosixErrno(s32 e) {
     }
 }
 
-static u64 g_mspace_atomic_id_mask = 0;
-static u64 g_mstate_table[64] = {0};
-
-struct HeapInfoInfo {
-    u64 size = sizeof(HeapInfoInfo);
-    u32 flag;
-    u32 getSegmentInfo;
-    u64* mspace_atomic_id_mask;
-    u64* mstate_table;
-};
-
-void PS4_SYSV_ABI sceLibcHeapGetTraceInfo(HeapInfoInfo* info) {
-    info->mspace_atomic_id_mask = &g_mspace_atomic_id_mask;
-    info->mstate_table = g_mstate_table;
-    info->getSegmentInfo = 0;
-}
-
 struct OrbisKernelUuid {
     u32 timeLow;
     u16 timeMid;
@@ -493,9 +476,6 @@ void RegisterLib(Core::Loader::SymbolsResolver* sym) {
 
     LIB_FUNCTION("mkawd0NA9ts", "libkernel", 1, "libkernel", posix_sysconf);
     LIB_FUNCTION("mkawd0NA9ts", "libScePosix", 1, "libkernel", posix_sysconf);
-
-    LIB_FUNCTION("NWtTN10cJzE", "libSceLibcInternalExt", 1, "libSceLibcInternal",
-                 sceLibcHeapGetTraceInfo);
 
     // network
     LIB_FUNCTION("XVL8So3QJUk", "libkernel", 1, "libkernel", Libraries::Net::sys_connect);

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -92,23 +92,20 @@ void Linker::Execute(const std::vector<std::string>& args) {
     // Relocate all modules
     RelocateAllImports();
 
-    // If we're running LLE libSceLibcInternal,
-    // we need to find the _malloc_init function and run it manually.
-    // This is something libkernel runs during initialization.
+    // libkernel entry is responsible for initializing malloc-related elements of libSceLibcInternal
+    // this is done through calling _malloc_init, and sceLibcInternalMemoryMutexEnable.
     static PS4_SYSV_ABI s32 (*malloc_init)() = nullptr;
+    static PS4_SYSV_ABI void (*sceLibcInternalMemoryMutexEnable)() = nullptr;
 
     if (has_libcinternal) {
         for (const auto& m : m_modules) {
             const auto& mod = m.get();
             if (mod->name.contains("libSceLibcInternal.sprx")) {
-                // Found libSceLibcInternal, now search through function exports.
-                // Looking for _malloc_init to init libSceLibcInternal properly
-                // and for all the memory allocating functions, so we can initialize our heap API
-                for (const auto& sym : mod->export_sym.GetSymbols()) {
-                    if (sym.nid_name.compare("_malloc_init") == 0) {
-                        malloc_init = reinterpret_cast<PS4_SYSV_ABI s32 (*)()>(sym.virtual_address);
-                    }
-                }
+                malloc_init =
+                    reinterpret_cast<PS4_SYSV_ABI s32 (*)()>(mod->FindByName("_malloc_init"));
+                sceLibcInternalMemoryMutexEnable = reinterpret_cast<PS4_SYSV_ABI void (*)()>(
+                    mod->FindByName("sceLibcInternalMemoryMutexEnable"));
+                break;
             }
         }
     }
@@ -165,10 +162,11 @@ void Linker::Execute(const std::vector<std::string>& args) {
         if (has_libcinternal) {
             LoadLibcInternal();
 
-            if (malloc_init != nullptr) {
+            if (malloc_init && sceLibcInternalMemoryMutexEnable) {
                 // Call _malloc_init
                 s32 ret = malloc_init();
                 ASSERT_MSG(ret == 0, "malloc_init failed");
+                sceLibcInternalMemoryMutexEnable();
             }
         }
 


### PR DESCRIPTION
Also use mod->FindByName instead of doing the manual lookup.

This fixes our issues with libSceLibcInternal heap corruption errors when attempting to run games with LLE libSceAvPlayer.