### PR TITLE
net: implement sceNetGetSockInfo, AP callbacks and POSIX socket options

### DIFF
--- a/src/core/libraries/network/net.cpp
+++ b/src/core/libraries/network/net.cpp
@@ -1033,9 +1033,32 @@ int PS4_SYSV_ABI sceNetGetRouteInfo() {
     return ORBIS_OK;
 }
 
-int PS4_SYSV_ABI sceNetGetSockInfo() {
-    LOG_ERROR(Lib_Net, "(STUBBED) called");
-    return ORBIS_OK;
+int PS4_SYSV_ABI sceNetGetSockInfo(OrbisNetId s, OrbisNetSockInfo* info, int n, int flags) {
+    if (info == nullptr || n <= 0) {
+        *Libraries::Kernel::__Error() = ORBIS_NET_EINVAL;
+        return -1;
+    }
+    auto file = FDTable::Instance()->GetSocket(s);
+    if (!file) {
+        *Libraries::Kernel::__Error() = ORBIS_NET_EBADF;
+        LOG_ERROR(Lib_Net, "socket id is invalid = {}", s);
+        return -1;
+    }
+
+    std::memset(info, 0, sizeof(OrbisNetSockInfo));
+    info->socket_type = file->socket->socket_type;
+    if (auto native = file->socket->Native(); native.has_value()) {
+        unsigned long available = 0;
+#ifdef _WIN32
+        if (ioctlsocket(*native, FIONREAD, &available) == 0) {
+#else
+        if (ioctl(*native, FIONREAD, &available) == 0) {
+#endif
+            info->recv_queue_len = static_cast<s32>(available);
+        }
+    }
+    // The return value is the number of entries written; callers reject anything <= 0.
+    return 1;
 }
 
 int PS4_SYSV_ABI sceNetGetSockInfo6() {

--- a/src/core/libraries/network/net.h
+++ b/src/core/libraries/network/net.h
@@ -63,7 +63,7 @@ constexpr std::string_view NameOf(OrbisNetProtocol p) {
     case ORBIS_NET_SOL_SOCKET:
         return "ORBIS_NET_SOL_SOCKET";
     default:
-        UNREACHABLE_MSG("{}", (u32)p);
+        return "unknown";
     }
 }
 
@@ -97,6 +97,12 @@ enum OrbisNetSocketSoOption : u32 {
     ORBIS_NET_SO_USESIGNATURE = 0x00040000,
     ORBIS_NET_SO_SNDBUF = 0x1001,
     ORBIS_NET_SO_RCVBUF = 0x1002,
+    // libScePosix passes the FreeBSD-numbered options straight through, so socket code
+    // coming in over the POSIX entry points uses these rather than the 0x11xx sceNet ones.
+    ORBIS_NET_SO_SNDLOWAT = 0x1003,
+    ORBIS_NET_SO_RCVLOWAT = 0x1004,
+    ORBIS_NET_SO_POSIX_SNDTIMEO = 0x1005,
+    ORBIS_NET_SO_POSIX_RCVTIMEO = 0x1006,
     ORBIS_NET_SO_ERROR = 0x1007,
     ORBIS_NET_SO_TYPE = 0x1008,
     ORBIS_NET_SO_SNDTIMEO = 0x1105,
@@ -163,8 +169,16 @@ constexpr std::string_view NameOf(OrbisNetSocketSoOption o) {
         return "ORBIS_NET_SO_NAME";
     case ORBIS_NET_SO_PRIORITY:
         return "ORBIS_NET_SO_PRIORITY";
+    case ORBIS_NET_SO_SNDLOWAT:
+        return "ORBIS_NET_SO_SNDLOWAT";
+    case ORBIS_NET_SO_RCVLOWAT:
+        return "ORBIS_NET_SO_RCVLOWAT";
+    case ORBIS_NET_SO_POSIX_SNDTIMEO:
+        return "ORBIS_NET_SO_POSIX_SNDTIMEO";
+    case ORBIS_NET_SO_POSIX_RCVTIMEO:
+        return "ORBIS_NET_SO_POSIX_RCVTIMEO";
     default:
-        UNREACHABLE_MSG("{}", (u32)o);
+        return "unknown";
     }
 }
 
@@ -262,6 +276,19 @@ struct OrbisNetResolverInfo {
     u32 recordsv4;
     u32 pad[14];
 };
+
+// Layout recovered from how callers use the buffer rather than from documentation:
+// they reserve 0xA0 bytes per entry, read a readable-byte count at +0x2C and the socket
+// type at +0x44, and treat a return value of zero or less as failure. Fields whose
+// meaning has not been established are left zeroed.
+struct OrbisNetSockInfo {
+    u8 unknown_00[0x2C];
+    s32 recv_queue_len;
+    u8 unknown_30[0x14];
+    s32 socket_type;
+    u8 unknown_48[0x58];
+};
+static_assert(sizeof(OrbisNetSockInfo) == 0xA0);
 
 int PS4_SYSV_ABI in6addr_any();
 int PS4_SYSV_ABI in6addr_loopback();
@@ -395,7 +422,7 @@ int PS4_SYSV_ABI sceNetGetNameToIndex();
 int PS4_SYSV_ABI sceNetGetpeername(OrbisNetId s, OrbisNetSockaddr* addr, u32* paddrlen);
 int PS4_SYSV_ABI sceNetGetRandom();
 int PS4_SYSV_ABI sceNetGetRouteInfo();
-int PS4_SYSV_ABI sceNetGetSockInfo();
+int PS4_SYSV_ABI sceNetGetSockInfo(OrbisNetId s, OrbisNetSockInfo* info, int n, int flags);
 int PS4_SYSV_ABI sceNetGetSockInfo6();
 int PS4_SYSV_ABI sceNetGetsockname(OrbisNetId s, OrbisNetSockaddr* addr, u32* paddrlen);
 int PS4_SYSV_ABI sceNetGetsockopt(OrbisNetId s, int level, int optname, void* optval, u32* optlen);

--- a/src/core/libraries/network/net_ctl_obj.cpp
+++ b/src/core/libraries/network/net_ctl_obj.cpp
@@ -44,6 +44,39 @@ s32 NetCtlInternal::RegisterNpToolkitCallback(OrbisNetCtlCallbackForNpToolkit fu
     return next_id;
 }
 
+s32 NetCtlInternal::RegisterApCallback(OrbisNetCtlCallback func, void* arg) {
+    std::scoped_lock lock{m_mutex};
+
+    // Find the next available slot
+    const auto it = std::ranges::find(ap_callbacks, nullptr, &NetCtlCallback::func);
+    if (it == ap_callbacks.end()) {
+        return ORBIS_NET_CTL_ERROR_CALLBACK_MAX;
+    }
+
+    const int next_id = std::distance(ap_callbacks.begin(), it);
+    ap_callbacks[next_id].func = func;
+    ap_callbacks[next_id].arg = arg;
+    return next_id;
+}
+
+void NetCtlInternal::CheckApCallback() {
+    std::scoped_lock lock{m_mutex};
+    const auto event = EmulatorSettings.IsConnectedToNetwork()
+                           ? ORBIS_NET_CTL_EVENT_TYPE_IPOBTAINED
+                           : ORBIS_NET_CTL_EVENT_TYPE_DISCONNECTED;
+    // Games poll this once per frame; delivering the same event every time would mean
+    // thousands of duplicate notifications per session, so only report real changes.
+    if (ap_last_event == event) {
+        return;
+    }
+    ap_last_event = event;
+    for (const auto [func, arg] : ap_callbacks) {
+        if (func != nullptr) {
+            func(event, arg);
+        }
+    }
+}
+
 void NetCtlInternal::CheckCallback() {
     std::scoped_lock lock{m_mutex};
     const auto event = EmulatorSettings.IsConnectedToNetwork()

--- a/src/core/libraries/network/net_ctl_obj.h
+++ b/src/core/libraries/network/net_ctl_obj.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <mutex>
+#include <optional>
 #include "common/types.h"
 
 namespace Libraries::NetCtl {
@@ -28,12 +29,17 @@ public:
 
     s32 RegisterCallback(OrbisNetCtlCallback func, void* arg);
     s32 RegisterNpToolkitCallback(OrbisNetCtlCallbackForNpToolkit func, void* arg);
+    s32 RegisterApCallback(OrbisNetCtlCallback func, void* arg);
     void CheckCallback();
     void CheckNpToolkitCallback();
+    void CheckApCallback();
 
 public:
     std::array<NetCtlCallbackForNpToolkit, 8> nptool_callbacks{};
     std::array<NetCtlCallback, 8> callbacks{};
+    std::array<NetCtlCallback, 8> ap_callbacks{};
+    // Last event handed to the AP callbacks, so a poll that changes nothing stays silent.
+    std::optional<int> ap_last_event;
     std::mutex m_mutex;
 };
 } // namespace Libraries::NetCtl

--- a/src/core/libraries/network/netctl.cpp
+++ b/src/core/libraries/network/netctl.cpp
@@ -486,7 +486,7 @@ int PS4_SYSV_ABI sceNetCtlUnregisterCallbackForNpToolkit() {
 }
 
 int PS4_SYSV_ABI sceNetCtlApCheckCallback() {
-    LOG_ERROR(Lib_NetCtl, "(STUBBED) called");
+    netctl.CheckApCallback();
     return ORBIS_OK;
 }
 
@@ -520,8 +520,15 @@ int PS4_SYSV_ABI sceNetCtlApInit() {
     return ORBIS_OK;
 }
 
-int PS4_SYSV_ABI sceNetCtlApRegisterCallback() {
-    LOG_ERROR(Lib_NetCtl, "(STUBBED) called");
+int PS4_SYSV_ABI sceNetCtlApRegisterCallback(OrbisNetCtlCallback func, void* arg, int* cid) {
+    if (!func || !cid) {
+        return ORBIS_NET_CTL_ERROR_INVALID_ADDR;
+    }
+    s32 result = netctl.RegisterApCallback(func, arg);
+    if (result < 0) {
+        return result;
+    }
+    *cid = result;
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/network/netctl.h
+++ b/src/core/libraries/network/netctl.h
@@ -152,7 +152,7 @@ int PS4_SYSV_ABI sceNetCtlApGetInfo();
 int PS4_SYSV_ABI sceNetCtlApGetResult();
 int PS4_SYSV_ABI sceNetCtlApGetState();
 int PS4_SYSV_ABI sceNetCtlApInit();
-int PS4_SYSV_ABI sceNetCtlApRegisterCallback();
+int PS4_SYSV_ABI sceNetCtlApRegisterCallback(OrbisNetCtlCallback func, void* arg, int* cid);
 int PS4_SYSV_ABI sceNetCtlApStop();
 int PS4_SYSV_ABI sceNetCtlApTerm();
 int PS4_SYSV_ABI sceNetCtlApUnregisterCallback();

--- a/src/core/libraries/network/posix_sockets.cpp
+++ b/src/core/libraries/network/posix_sockets.cpp
@@ -489,23 +489,33 @@ int PosixSocket::SetSocketOptions(int level, int optname, const void* optval, u3
             CASE_SETSOCKOPT_VALUE(ORBIS_NET_SO_USECRYPTO, &sockopt_so_usecrypto);
             CASE_SETSOCKOPT_VALUE(ORBIS_NET_SO_USESIGNATURE, &sockopt_so_usesignature);
         case ORBIS_NET_SO_SNDTIMEO:
-        case ORBIS_NET_SO_RCVTIMEO: {
-            if (optlen != sizeof(int)) {
+        case ORBIS_NET_SO_RCVTIMEO:
+        case ORBIS_NET_SO_POSIX_SNDTIMEO:
+        case ORBIS_NET_SO_POSIX_RCVTIMEO: {
+            // sceNet passes the timeout as a microsecond count in an int, while the POSIX
+            // entry points pass a FreeBSD timeval, so accept whichever shape arrived.
+            s64 timeout_us;
+            if (optlen == sizeof(s32)) {
+                timeout_us = *(const s32*)optval;
+            } else if (optlen == 2 * sizeof(s64)) {
+                const s64* tv = (const s64*)optval;
+                timeout_us = tv[0] * 1000000 + tv[1];
+            } else {
+                LOG_ERROR(Lib_Net, "unexpected timeout optlen = {}", optlen);
                 *Libraries::Kernel::__Error() = ORBIS_NET_ERROR_EFAULT;
                 return -1;
             }
-            std::vector<char> val;
-            const auto optname_nat = (optname == ORBIS_NET_SO_SNDTIMEO) ? SO_SNDTIMEO : SO_RCVTIMEO;
-            int timeout_us = *(const int*)optval;
+            const bool is_send =
+                optname == ORBIS_NET_SO_SNDTIMEO || optname == ORBIS_NET_SO_POSIX_SNDTIMEO;
+            const auto optname_nat = is_send ? SO_SNDTIMEO : SO_RCVTIMEO;
 #ifdef _WIN32
-            DWORD timeout = timeout_us / 1000;
+            DWORD timeout = static_cast<DWORD>(timeout_us / 1000);
 #else
-            timeval timeout{.tv_sec = timeout_us / 1000000, .tv_usec = timeout_us % 1000000};
+            timeval timeout{.tv_sec = static_cast<time_t>(timeout_us / 1000000),
+                            .tv_usec = static_cast<suseconds_t>(timeout_us % 1000000)};
 #endif
-            val.insert(val.end(), (char*)&timeout, (char*)&timeout + sizeof(timeout));
-            optlen = sizeof(timeout);
-            return ConvertReturnErrorCode(
-                setsockopt(sock, native_level, optname_nat, val.data(), optlen));
+            return ConvertReturnErrorCode(setsockopt(sock, native_level, optname_nat,
+                                                     (const char*)&timeout, sizeof(timeout)));
         }
         case ORBIS_NET_SO_ONESBCAST: {
 
@@ -593,8 +603,9 @@ int PosixSocket::SetSocketOptions(int level, int optname, const void* optval, u3
         }
     }
 
-    UNREACHABLE_MSG("Unknown level ={} optname ={}", level, optname);
-    return 0;
+    LOG_ERROR(Lib_Net, "unsupported level = {}, optname = {}", level, optname);
+    *Libraries::Kernel::__Error() = ORBIS_NET_ENOPROTOOPT;
+    return -1;
 }
 
 #define CASE_GETSOCKOPT(opt)                                                                       \
@@ -672,8 +683,9 @@ int PosixSocket::GetSocketOptions(int level, int optname, void* optval, u32* opt
             CASE_GETSOCKOPT_VALUE(ORBIS_NET_TCP_MSS_TO_ADVERTISE, sockopt_tcp_mss_to_advertise);
         }
     }
-    UNREACHABLE_MSG("Unknown level ={} optname ={}", level, optname);
-    return 0;
+    LOG_ERROR(Lib_Net, "unsupported level = {}, optname = {}", level, optname);
+    *Libraries::Kernel::__Error() = ORBIS_NET_ENOPROTOOPT;
+    return -1;
 }
 
 int PosixSocket::GetPeerName(OrbisNetSockaddr* name, u32* namelen) {


### PR DESCRIPTION
Unity/Mono titles using PlayLink cannot get past network start-up. Three separate
problems, found while bringing up Knowledge is Power (CUSA12435).

### `sceNetGetSockInfo` was a parameterless stub returning `ORBIS_OK`

Callers treat a return value <= 0 as failure, so the game destroyed and recreated its
UDP socket forever — **16,015 `sys_socketex` calls with zero `sys_socketclose`** in a
single run, and no socket ever stayed open long enough to receive anything.

The struct layout is recovered from how the game and its `PS4NativeSockets` plugin use
the buffer: they reserve `0xA0` bytes per entry, read a readable-byte count at `+0x2C`
and the socket type at `+0x44` (compared against `SOCK_DGRAM` and `SOCK_DGRAM_P2P`).
Fields whose meaning is not established are left zeroed rather than guessed at — happy
to adjust if someone has the real layout.

### `NameOf(OrbisNetSocketSoOption)` aborted on unknown options

It is called to build a log string and the lambda is evaluated eagerly, so an unknown
option killed the emulator through `UNREACHABLE_MSG` even with debug logging off. It
now returns `"unknown"`, and `Set`/`GetSocketOptions` report `ENOPROTOOPT` instead of
aborting.

### POSIX socket options were missing

The POSIX entry points pass FreeBSD-numbered options (`0x1003`-`0x1006`), which were
absent from the enum, and carry the timeout as a `timeval` rather than the microsecond
`int` the sceNet-numbered options use. Both shapes are now accepted.

### `sceNetCtlApCheckCallback` never dispatched

It now delivers to callbacks registered through `sceNetCtlApRegisterCallback`, and only
on an actual state change — games poll it every frame, so unconditional delivery meant
2,099 duplicate events in one 55-minute run.

### Result

The title reaches a stable listening state on UDP 9066-9071, `sys_socketex` drops from
16,015 to 7, and two phones complete the PlayLink handshake.

### Open question for maintainers

The non-AP `sceNetCtlCheckCallback` is also a stub even though
`NetCtlInternal::CheckCallback()` is fully implemented. I left it alone — it would
affect other titles and I could not tell whether the current behaviour is deliberate.

Tested on Windows, clang-cl, NVIDIA RTX 2080.
