### PR TITLE
app_content: don't abort when the dump has no TITLE_ID

### DIFF
--- a/src/core/libraries/app_content/app_content.cpp
+++ b/src/core/libraries/app_content/app_content.cpp
@@ -296,7 +296,11 @@ int PS4_SYSV_ABI sceAppContentInitialize(const OrbisAppContentInitParam* initPar
     if (const auto value = param_sfo->GetString("TITLE_ID"); value.has_value()) {
         title_id = *value;
     } else {
-        UNREACHABLE_MSG("Failed to get TITLE_ID");
+        // A dump with a missing or unreadable param.sfo has no title id to key addons on.
+        // That only means there are no addons to mount, which the path below already
+        // treats as success - it is not a reason to bring the emulator down.
+        LOG_ERROR(Lib_AppContent, "Failed to get TITLE_ID, addons will be unavailable");
+        return ORBIS_OK;
     }
     const auto addon_path = addons_dir / title_id;
     if (!std::filesystem::exists(addon_path)) {


### PR DESCRIPTION
`sceAppContentInitialize` read `TITLE_ID` from `param.sfo` and hit `UNREACHABLE_MSG`
when it was absent, taking the emulator down with "Failed to get TITLE_ID".

A dump with a missing or unreadable `param.sfo` is not an emulator invariant violation —
it just means there is no title id to key addon lookups on, and so no addons to mount.
The very next branch already treats "no addon directory" as success, so the missing id
now logs an error and returns `ORBIS_OK` the same way.

The title boots and plays with this change; only addon content stays unavailable, which
is the correct consequence of not knowing the title id.
