### PR TITLE
Implement sceSysmoduleLoadModuleByNameInternal

### DIFF
--- a/src/core/emulator_settings.h
+++ b/src/core/emulator_settings.h
@@ -195,6 +195,7 @@ struct GeneralSettings {
     Setting<std::filesystem::path> home_dir;
     Setting<std::filesystem::path> sys_modules_dir;
     Setting<std::filesystem::path> font_dir;
+    Setting<std::filesystem::path> fw_root_dir;
 
     Setting<int> volume_slider{100};
     Setting<bool> neo_mode{false};
@@ -233,7 +234,6 @@ struct GeneralSettings {
                                            &GeneralSettings::trophy_notification_side),
             make_override<GeneralSettings>("connected_to_network",
                                            &GeneralSettings::connected_to_network),
-            make_override<GeneralSettings>("console_language", &GeneralSettings::console_language),
             make_override<GeneralSettings>("shadnet_server", &GeneralSettings::shadnet_server),
             make_override<GeneralSettings>("shadnet_webapi_server",
                                            &GeneralSettings::shadnet_webapi_server),
@@ -249,7 +249,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(GeneralSettings, install_dirs, addon_install_
                                    trophy_notification_side, connected_to_network,
                                    discord_rpc_enabled, show_fps_counter, console_language,
                                    big_picture_scale, shadnet_server, shadnet_webapi_server,
-                                   signaling_info, enable_upnp)
+                                   signaling_info, enable_upnp, fw_root_dir)
 
 // -------------------------------
 // Log settings
@@ -685,6 +685,7 @@ public:
     SETTING_FORWARD(m_general, ShadNetWebApiServer, shadnet_webapi_server)
     SETTING_FORWARD(m_general, SignalingInfo, signaling_info)
     SETTING_FORWARD_BOOL(m_general, UPnPEnabled, enable_upnp)
+    SETTING_FORWARD(m_general, FwRootDir, fw_root_dir)
 
     // Log settings
     SETTING_FORWARD_BOOL(m_log, LogAppend, append)

--- a/src/core/emulator_settings.h
+++ b/src/core/emulator_settings.h
@@ -195,7 +195,6 @@ struct GeneralSettings {
     Setting<std::filesystem::path> home_dir;
     Setting<std::filesystem::path> sys_modules_dir;
     Setting<std::filesystem::path> font_dir;
-    Setting<std::filesystem::path> fw_root_dir;
 
     Setting<int> volume_slider{100};
     Setting<bool> neo_mode{false};
@@ -234,6 +233,7 @@ struct GeneralSettings {
                                            &GeneralSettings::trophy_notification_side),
             make_override<GeneralSettings>("connected_to_network",
                                            &GeneralSettings::connected_to_network),
+            make_override<GeneralSettings>("console_language", &GeneralSettings::console_language),
             make_override<GeneralSettings>("shadnet_server", &GeneralSettings::shadnet_server),
             make_override<GeneralSettings>("shadnet_webapi_server",
                                            &GeneralSettings::shadnet_webapi_server),
@@ -249,7 +249,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(GeneralSettings, install_dirs, addon_install_
                                    trophy_notification_side, connected_to_network,
                                    discord_rpc_enabled, show_fps_counter, console_language,
                                    big_picture_scale, shadnet_server, shadnet_webapi_server,
-                                   signaling_info, enable_upnp, fw_root_dir)
+                                   signaling_info, enable_upnp)
 
 // -------------------------------
 // Log settings
@@ -685,7 +685,6 @@ public:
     SETTING_FORWARD(m_general, ShadNetWebApiServer, shadnet_webapi_server)
     SETTING_FORWARD(m_general, SignalingInfo, signaling_info)
     SETTING_FORWARD_BOOL(m_general, UPnPEnabled, enable_upnp)
-    SETTING_FORWARD(m_general, FwRootDir, fw_root_dir)
 
     // Log settings
     SETTING_FORWARD_BOOL(m_log, LogAppend, append)

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -1583,6 +1583,8 @@ void RegisterFileSystem(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("c7ZnT7V1B98", "libScePosix", 1, "libkernel", posix_rmdir);
     LIB_FUNCTION("c7ZnT7V1B98", "libkernel", 1, "libkernel", posix_rmdir);
     LIB_FUNCTION("naInUjYt3so", "libkernel", 1, "libkernel", sceKernelRmdir);
+    LIB_FUNCTION("8vE6Z6VEYyk", "libkernel_psmkit", 1, "libkernel", posix_access);
+    LIB_FUNCTION("8vE6Z6VEYyk", "libkernel", 1, "libkernel", posix_access);
     LIB_FUNCTION("E6ao34wPw+U", "libScePosix", 1, "libkernel", posix_stat);
     LIB_FUNCTION("E6ao34wPw+U", "libkernel", 1, "libkernel", posix_stat);
     LIB_FUNCTION("eV9wAD2riIA", "libkernel", 1, "libkernel", sceKernelStat);

--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -659,6 +659,27 @@ s32 PS4_SYSV_ABI sceKernelRmdir(const char* path) {
     return result;
 }
 
+s32 PS4_SYSV_ABI posix_access(const char* path, s32 mode) {
+    LOG_INFO(Kernel_Fs, "(PARTIAL) path = {}, mode = {}", path, mode);
+    if (strlen(path) > 255) {
+        *__Error() = POSIX_ENAMETOOLONG;
+        return -1;
+    }
+
+    auto* mnt = Common::Singleton<Core::FileSys::MntPoints>::Instance();
+    const bool is_dir = mnt->IsDirectory(path);
+    const bool is_file = !is_dir && mnt->Exists(path);
+    const bool is_root = strncmp(path, "/", 2) == 0;
+    if (!is_dir && !is_file && !is_root) {
+        *__Error() = POSIX_ENOENT;
+        return -1;
+    }
+    if (is_root) {
+        LOG_WARNING(Kernel_Fs, "Checking accessibility of filesystem root");
+    }
+    return ORBIS_OK;
+}
+
 s32 PS4_SYSV_ABI posix_stat(const char* path, OrbisKernelStat* sb) {
     LOG_DEBUG(Kernel_Fs, "(PARTIAL) path = {}", path);
     if (strlen(path) > 255) {

--- a/src/core/libraries/kernel/file_system.h
+++ b/src/core/libraries/kernel/file_system.h
@@ -68,6 +68,7 @@ constexpr int ORBIS_KERNEL_O_DIRECTORY = 0x00020000;
 s32 PS4_SYSV_ABI posix_open(const char* path, s32 flags, u16 mode);
 s32 PS4_SYSV_ABI posix_close(s32 fd);
 s64 PS4_SYSV_ABI posix_lseek(s32 fd, s64 offset, s32 whence);
+s32 PS4_SYSV_ABI posix_access(const char* path, s32 mode);
 s64 PS4_SYSV_ABI sceKernelWrite(s32 fd, const void* buf, u64 nbytes);
 s64 PS4_SYSV_ABI sceKernelRead(s32 fd, void* buf, u64 nbytes);
 s64 PS4_SYSV_ABI sceKernelPread(s32 fd, void* buf, u64 nbytes, s64 offset);

--- a/src/core/libraries/kernel/process.cpp
+++ b/src/core/libraries/kernel/process.cpp
@@ -74,7 +74,9 @@ void* PS4_SYSV_ABI sceKernelGetProcParam() {
 s32 PS4_SYSV_ABI sceKernelLoadStartModule(const char* moduleFileName, u64 args, const void* argp,
                                           u32 flags, const void* pOpt, s32* pRes) {
     LOG_INFO(Lib_Kernel, "called filename = {}, args = {}", moduleFileName, args);
-    ASSERT(flags == 0);
+    if (flags != 0) {
+        LOG_ERROR(Lib_Kernel, "unhandled flags: {:#x}", flags);
+    }
 
     auto* linker = Common::Singleton<Core::Linker>::Instance();
 

--- a/src/core/libraries/kernel/process.cpp
+++ b/src/core/libraries/kernel/process.cpp
@@ -295,6 +295,8 @@ void RegisterProcess(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("g0VTBxfJyu0", "libkernel", 1, "libkernel", sceKernelGetCurrentCpu);
     LIB_FUNCTION("959qrazPIrg", "libkernel", 1, "libkernel", sceKernelGetProcParam);
     LIB_FUNCTION("wzvqT4UqKX8", "libkernel", 1, "libkernel", sceKernelLoadStartModule);
+    LIB_FUNCTION("Y1nEpkCieOY", "libkernel", 1, "libkernel",
+                 sceKernelLoadStartModule); // sceKernelLoadStartModuleInternalForMono
     LIB_FUNCTION("LwG8g3niqwA", "libkernel", 1, "libkernel", sceKernelDlsym);
     LIB_FUNCTION("RpQJJVKTiFM", "libkernel", 1, "libkernel", sceKernelGetModuleInfoForUnwind);
     LIB_FUNCTION("f7KBOafysXo", "libkernel", 1, "libkernel", sceKernelGetModuleInfoFromAddr);

--- a/src/core/libraries/kernel/process.h
+++ b/src/core/libraries/kernel/process.h
@@ -30,6 +30,9 @@ s32 PS4_SYSV_ABI sceKernelGetCompiledSdkVersion(s32* ver);
 s32 PS4_SYSV_ABI sceKernelGetModuleInfoForUnwind(VAddr addr, s32 flags,
                                                  OrbisModuleInfoForUnwind* info);
 
+s32 PS4_SYSV_ABI sceKernelLoadStartModule(const char* moduleFileName, u64 args, const void* argp,
+                                          u32 flags, const void* pOpt, s32* pRes);
+
 void RegisterProcess(Core::Loader::SymbolsResolver* sym);
 
 } // namespace Libraries::Kernel

--- a/src/core/libraries/sysmodule/sysmodule.cpp
+++ b/src/core/libraries/sysmodule/sysmodule.cpp
@@ -6,6 +6,7 @@
 #include "common/elf_info.h"
 #include "common/logging/log.h"
 #include "core/libraries/error_codes.h"
+#include "core/libraries/kernel/file_system.h"
 #include "core/libraries/kernel/orbis_error.h"
 #include "core/libraries/kernel/process.h"
 #include "core/libraries/libs.h"
@@ -98,9 +99,20 @@ s32 PS4_SYSV_ABI sceSysmoduleLoadModule(OrbisSysModule id) {
     return result;
 }
 
-s32 PS4_SYSV_ABI sceSysmoduleLoadModuleByNameInternal() {
-    LOG_ERROR(Lib_SysModule, "(STUBBED) called");
-    return ORBIS_OK;
+s32 PS4_SYSV_ABI sceSysmoduleLoadModuleByNameInternal(char const* name, u64 args, void const* argp,
+                                                      void const* popt, s32* res) {
+    LOG_ERROR(Lib_SysModule, "(DUMMY) called, name: {}", name);
+    std::string filename = std::string(name) + ".sprx";
+    s32 exists;
+    exists = Libraries::Kernel::posix_access(("/sys/common/lib/" + filename).c_str(), 0);
+    if (exists == 0)
+        return Libraries::Kernel::sceKernelLoadStartModule(("/sys/common/lib/" + filename).c_str(),
+                                                           args, argp, 0, popt, res);
+    exists = Libraries::Kernel::posix_access(("/sys/priv/lib/" + filename).c_str(), 0);
+    if (exists == 0)
+        return Libraries::Kernel::sceKernelLoadStartModule(("/sys/priv/lib/" + filename).c_str(),
+                                                           args, argp, 0, popt, res);
+    return ORBIS_KERNEL_ERROR_EINVAL;
 }
 
 s32 PS4_SYSV_ABI sceSysmoduleLoadModuleInternal(OrbisSysModuleInternal id) {

--- a/src/core/libraries/sysmodule/sysmodule.cpp
+++ b/src/core/libraries/sysmodule/sysmodule.cpp
@@ -7,6 +7,7 @@
 #include "common/logging/log.h"
 #include "core/libraries/error_codes.h"
 #include "core/libraries/kernel/file_system.h"
+#include "core/libraries/kernel/kernel.h"
 #include "core/libraries/kernel/orbis_error.h"
 #include "core/libraries/kernel/process.h"
 #include "core/libraries/libs.h"
@@ -104,14 +105,16 @@ s32 PS4_SYSV_ABI sceSysmoduleLoadModuleByNameInternal(char const* name, u64 args
     LOG_ERROR(Lib_SysModule, "(DUMMY) called, name: {}", name);
     std::string filename = std::string(name) + ".sprx";
     s32 exists;
-    exists = Libraries::Kernel::posix_access(("/sys/common/lib/" + filename).c_str(), 0);
+    using namespace Kernel;
+    std::string system_base = std::string("/") + sceKernelGetFsSandboxRandomWord();
+    exists = posix_access((system_base + "/common/lib/" + filename).c_str(), 0);
     if (exists == 0)
-        return Libraries::Kernel::sceKernelLoadStartModule(("/sys/common/lib/" + filename).c_str(),
-                                                           args, argp, 0, popt, res);
-    exists = Libraries::Kernel::posix_access(("/sys/priv/lib/" + filename).c_str(), 0);
+        return sceKernelLoadStartModule((system_base + "/common/lib/" + filename).c_str(), args,
+                                        argp, 0, popt, res);
+    exists = posix_access((system_base + "/priv/lib/" + filename).c_str(), 0);
     if (exists == 0)
-        return Libraries::Kernel::sceKernelLoadStartModule(("/sys/priv/lib/" + filename).c_str(),
-                                                           args, argp, 0, popt, res);
+        return sceKernelLoadStartModule((system_base + "/priv/lib/" + filename).c_str(), args, argp,
+                                        0, popt, res);
     return ORBIS_KERNEL_ERROR_EINVAL;
 }
 

--- a/src/core/libraries/sysmodule/sysmodule.h
+++ b/src/core/libraries/sysmodule/sysmodule.h
@@ -23,7 +23,8 @@ s32 PS4_SYSV_ABI sceSysmoduleIsCameraPreloaded();
 s32 PS4_SYSV_ABI sceSysmoduleIsLoaded(OrbisSysModule id);
 s32 PS4_SYSV_ABI sceSysmoduleIsLoadedInternal(OrbisSysModuleInternal id);
 s32 PS4_SYSV_ABI sceSysmoduleLoadModule(OrbisSysModule id);
-s32 PS4_SYSV_ABI sceSysmoduleLoadModuleByNameInternal();
+s32 PS4_SYSV_ABI sceSysmoduleLoadModuleByNameInternal(char const* name, u64 args, void const* argp,
+                                                      void const* popt, s32* res);
 s32 PS4_SYSV_ABI sceSysmoduleLoadModuleInternal(OrbisSysModuleInternal id);
 s32 PS4_SYSV_ABI sceSysmoduleLoadModuleInternalWithArg(OrbisSysModuleInternal id, s32 argc,
                                                        const void* argv, u64 unk, s32* res_out);

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -642,6 +642,16 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
     }
     mnt->Mount(host_font2_dir, guest_font_dir);
 
+    if (!id.empty() && std::filesystem::exists(EmulatorSettings.GetSysModulesDir() / id)) {
+        mnt->Mount(EmulatorSettings.GetSysModulesDir() / id,
+                   std::string("/") + sandbox_root + "/common/lib/");
+        mnt->Mount(EmulatorSettings.GetSysModulesDir() / id,
+                   std::string("/") + sandbox_root + "/priv/lib/");
+        // should be empty but whatever
+        mnt->Mount(EmulatorSettings.GetSysModulesDir() / id,
+                   std::string("/") + sandbox_root + "/common_ex/lib/");
+    }
+
     if (std::filesystem::is_empty(host_font_dir) || std::filesystem::is_empty(host_font2_dir)) {
         LOG_WARNING(Loader, "No dumped system fonts, expect missing text or instability");
     }


### PR DESCRIPTION
Force-LLEing stuff from sys_modules/title_id/ is already a thing, and this PR makes that possible for apps that use the internal function sceSysmoduleLoadModuleByNameInternal to load modules instead of the standard API for games, such as VSH. This by itself is not enough to satisfy module loading logic for that though, at least not in a clean way, as some modules ideally should be skipped without reporting an error, so it can both proceed, while at the same time we don't have to deal with having to emulate even more stuff for misc libraries.

I only tagged Stephen in one commit, but his contributions were more encompassing than just that one addition.