### PR TITLE
Lib.Sysmodule: Enable more safe library LLEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,13 +154,13 @@ The following firmware modules are supported and must be placed in shadPS4's `sy
 | Modules                        | Modules                        | Modules                        | Modules                        |
 |--------------------------------|--------------------------------|--------------------------------|--------------------------------|
 | libSceAt9Enc.sprx              | libSceAudiodec.sprx            | libSceAudiodecCpu.sprx         | libSceAudiodecCpuDdp.sprx      |
-| libSceAudiodecCpuDtsHdLbr.sprx | libSceAudiodecCpuHevag.sprx    | libSceAudiodecCpuM4aac.sprx    | libSceBeisobmf.sprx            |
-| libSceBemp2sys.sprx            | libSceCesCs.sprx               | libSceFont.sprx                | libSceFontFt.sprx              |
-| libSceFreeTypeOl.sprx          | libSceFreeTypeOptOl.sprx       | libSceFreeTypeOt.sprx          | libSceJpegDec.sprx             |
-| libSceJpegEnc.sprx             | libSceJson.sprx                | libSceJson2.sprx               | libSceLibcInternal.sprx        |
-| libSceNgs2.sprx                | libScePngEnc.sprx              | libScePsmKitSystem.sprx        | libSceRtc.sprx                 |
-| libSceRudp.sprx                | libSceSystemGesture.sprx       | libSceUlt.sprx                 | libSceWkFontConfig.sprx        |
-| libSceXml.sprx                 |
+| libSceAudiodecCpuDtsHdLbr.sprx | libSceAudiodecCpuHevag.sprx    | libSceAudiodecCpuM4aac.sprx    | libSceAvPlayer.sprx            |
+| libSceAvPlayerStreaming.sprx   | libSceBeisobmf.sprx            | libSceBemp2sys.sprx            | libSceCesCs.sprx               |
+| libSceFont.sprx                | libSceFontFt.sprx              | libSceFreeTypeOl.sprx          | libSceFreeTypeOptOl.sprx       |
+| libSceFreeTypeOt.sprx          | libSceJpegDec.sprx             | libSceJpegEnc.sprx             | libSceJson.sprx                |
+| libSceJson2.sprx               | libSceLibcInternal.sprx        | libSceNgs2.sprx                | libScePngEnc.sprx              |
+| libScePsmKitSystem.sprx        | libSceRtc.sprx                 | libSceRudp.sprx                | libSceSystemGesture.sprx       |
+| libSceUlt.sprx                 | libSceWkFontConfig.sprx        | libSceXml.sprx                 |
 </div>
 
 > [!Caution]

--- a/README.md
+++ b/README.md
@@ -153,13 +153,13 @@ The following firmware modules are supported and must be placed in shadPS4's `sy
 
 | Modules                        | Modules                        | Modules                        | Modules                        |
 |--------------------------------|--------------------------------|--------------------------------|--------------------------------|
-| libSceAudiodec.sprx            | libSceAudiodecCpu.sprx         | libSceAudiodecCpuDdp.sprx      | libSceAudiodecCpuDtsHdLbr.sprx |
-| libSceAudiodecCpuHevag.sprx    | libSceAudiodecCpuM4aac.sprx    | libSceCesCs.sprx               | libSceFont.sprx                |
-| libSceFontFt.sprx              | libSceFreeTypeOl.sprx          | libSceFreeTypeOptOl.sprx       | libSceFreeTypeOt.sprx          |
-| libSceJpegDec.sprx             | libSceJpegEnc.sprx             | libSceJson.sprx                | libSceJson2.sprx               |
-| libSceLibcInternal.sprx        | libSceNgs2.sprx                | libScePngEnc.sprx              | libSceRtc.sprx                 |
-| libSceRudp.sprx                | libSceSystemGesture.sprx       | libSceUlt.sprx                 | libSceWkFontConfig.sprx        |
-| libSceXml.sprx                 | libSceAt9Enc.sprx              |
+| libSceAt9Enc.sprx              | libSceAudiodec.sprx            | libSceAudiodecCpu.sprx         | libSceAudiodecCpuDdp.sprx      |
+| libSceAudiodecCpuDtsHdLbr.sprx | libSceAudiodecCpuHevag.sprx    | libSceAudiodecCpuM4aac.sprx    | libSceCesCs.sprx               |
+| libSceFont.sprx                | libSceFontFt.sprx              | libSceFreeTypeOl.sprx          | libSceFreeTypeOptOl.sprx       |
+| libSceFreeTypeOt.sprx          | libSceJpegDec.sprx             | libSceJpegEnc.sprx             | libSceJson.sprx                |
+| libSceJson2.sprx               | libSceLibcInternal.sprx        | libSceNgs2.sprx                | libScePngEnc.sprx              |
+| libScePsmKitSystem.sprx        | libSceRtc.sprx                 | libSceRudp.sprx                | libSceSystemGesture.sprx       |
+| libSceUlt.sprx                 | libSceWkFontConfig.sprx        | libSceXml.sprx                 |
 </div>
 
 > [!Caution]

--- a/README.md
+++ b/README.md
@@ -154,12 +154,13 @@ The following firmware modules are supported and must be placed in shadPS4's `sy
 | Modules                        | Modules                        | Modules                        | Modules                        |
 |--------------------------------|--------------------------------|--------------------------------|--------------------------------|
 | libSceAt9Enc.sprx              | libSceAudiodec.sprx            | libSceAudiodecCpu.sprx         | libSceAudiodecCpuDdp.sprx      |
-| libSceAudiodecCpuDtsHdLbr.sprx | libSceAudiodecCpuHevag.sprx    | libSceAudiodecCpuM4aac.sprx    | libSceCesCs.sprx               |
-| libSceFont.sprx                | libSceFontFt.sprx              | libSceFreeTypeOl.sprx          | libSceFreeTypeOptOl.sprx       |
-| libSceFreeTypeOt.sprx          | libSceJpegDec.sprx             | libSceJpegEnc.sprx             | libSceJson.sprx                |
-| libSceJson2.sprx               | libSceLibcInternal.sprx        | libSceNgs2.sprx                | libScePngEnc.sprx              |
-| libScePsmKitSystem.sprx        | libSceRtc.sprx                 | libSceRudp.sprx                | libSceSystemGesture.sprx       |
-| libSceUlt.sprx                 | libSceWkFontConfig.sprx        | libSceXml.sprx                 |
+| libSceAudiodecCpuDtsHdLbr.sprx | libSceAudiodecCpuHevag.sprx    | libSceAudiodecCpuM4aac.sprx    | libSceBeisobmf.sprx            |
+| libSceBemp2sys.sprx            | libSceCesCs.sprx               | libSceFont.sprx                | libSceFontFt.sprx              |
+| libSceFreeTypeOl.sprx          | libSceFreeTypeOptOl.sprx       | libSceFreeTypeOt.sprx          | libSceJpegDec.sprx             |
+| libSceJpegEnc.sprx             | libSceJson.sprx                | libSceJson2.sprx               | libSceLibcInternal.sprx        |
+| libSceNgs2.sprx                | libScePngEnc.sprx              | libScePsmKitSystem.sprx        | libSceRtc.sprx                 |
+| libSceRudp.sprx                | libSceSystemGesture.sprx       | libSceUlt.sprx                 | libSceWkFontConfig.sprx        |
+| libSceXml.sprx                 |
 </div>
 
 > [!Caution]

--- a/src/core/libraries/sysmodule/sysmodule_internal.cpp
+++ b/src/core/libraries/sysmodule/sysmodule_internal.cpp
@@ -231,6 +231,8 @@ s32 loadModuleInternal(s32 index, s32 argc, const void* argv, s32* res_out) {
              {"libSceFreeTypeOt.sprx", nullptr},
              {"libSceFreeTypeOl.sprx", nullptr},
              {"libSceFreeTypeOptOl.sprx", nullptr},
+             {"libSceBeisobmf.sprx", nullptr},
+             {"libSceBemp2sys.sprx", nullptr},
              {"libSceRudp.sprx", &Libraries::Rudp::RegisterLib},
              {"libSceWkFontConfig.sprx", nullptr},
              {"libScePsmKitSystem.sprx", nullptr},

--- a/src/core/libraries/sysmodule/sysmodule_internal.cpp
+++ b/src/core/libraries/sysmodule/sysmodule_internal.cpp
@@ -233,6 +233,7 @@ s32 loadModuleInternal(s32 index, s32 argc, const void* argv, s32* res_out) {
              {"libSceFreeTypeOptOl.sprx", nullptr},
              {"libSceRudp.sprx", &Libraries::Rudp::RegisterLib},
              {"libSceWkFontConfig.sprx", nullptr},
+             {"libScePsmKitSystem.sprx", nullptr},
              {"libSceSystemGesture.sprx", &Libraries::SystemGesture::RegisterLib},
              {"libSceXml.sprx", nullptr}});
 


### PR DESCRIPTION
This PR enables loading libSceBeisobmf.sprx, libSceBemp2sys.sprx, and libScePsmKitSystem.sprx LLE. These three libraries are both used by Media Player, and their behavior is entirely self-contained (so they're safe to run LLE).

I believe I've seen libSceBeisobmf.sprx and libSceBemp2sys.sprx come up in some VR documentary in the past too, though I don't recall for certain. Properly reporting the lack of HMD connectivity made most of those VR-requiring titles hang on boot.