### PR TITLE
Fix more random UE crashes tied to readbackLinearImages

### DIFF
--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -119,7 +119,7 @@ void Scheduler::Wait(u64 tick) {
 }
 
 void Scheduler::PopPendingOperations() {
-    std::unique_lock lk(priority_pending_ops_mutex);
+    std::unique_lock lk(pending_ops_mutex);
     master_semaphore.Refresh();
     while (!pending_ops.empty() && master_semaphore.IsFree(pending_ops.front().gpu_tick)) {
         pending_ops.front().callback();

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -410,6 +410,7 @@ public:
     /// Defers an operation until the gpu has reached the current cpu tick.
     /// Will be run when submitting or calling PopPendingOperations.
     void DeferOperation(Common::UniqueFunction<void>&& func) {
+        std::unique_lock lk(pending_ops_mutex);
         pending_ops.emplace(std::move(func), CurrentTick());
     }
 
@@ -444,6 +445,7 @@ private:
         u64 gpu_tick;
     };
     std::queue<PendingOp> pending_ops;
+    std::mutex pending_ops_mutex;
     std::queue<PendingOp> priority_pending_ops;
     std::mutex priority_pending_ops_mutex;
     std::condition_variable_any priority_pending_ops_cv;


### PR DESCRIPTION
More proper solution to the issue I was dealing with in #4748. Having looked closer at the code, there isn't a race between PopPendingOperations and the priority op runners since they use different queues. The actual issue is that PopPendingOperations and DeferOperation can be run simultaneously, and since both functions modify the pending ops queue, this can trigger crashes.

#4748 probably helped as a coincidence because it meant the priority runners would now block the GPU command processor thread, but this should be more consistently working solution.

This helps with more random crashes in some UE titles, including Kingdom Hearts 3.