### PR TITLE
Fix regressions from #4844

### DIFF
--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -445,7 +445,7 @@ private:
         u64 gpu_tick;
     };
     std::queue<PendingOp> pending_ops;
-    std::mutex pending_ops_mutex;
+    std::recursive_mutex pending_ops_mutex;
     std::queue<PendingOp> priority_pending_ops;
     std::mutex priority_pending_ops_mutex;
     std::condition_variable_any priority_pending_ops_cv;


### PR DESCRIPTION
DMA needs buffer cache stuff, and the buffer cache likes to defer ops. Use a recursive mutex here instead of a normal mutex so these operations don't fire exceptions.