### PR TITLE
Core: Support for memory patches targeting a specific module

### DIFF
--- a/src/common/memory_patcher.cpp
+++ b/src/common/memory_patcher.cpp
@@ -4,8 +4,10 @@
 #include <algorithm>
 #include <codecvt>
 #include <fstream>
+#include <mutex>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <nlohmann/json.hpp>
 #include <pugixml.hpp>
 #include "common/elf_info.h"
@@ -23,6 +25,17 @@ std::string g_game_serial;
 std::string patch_file;
 bool patches_applied = false;
 std::vector<patchInfo> pending_patches;
+
+// A patch that names a module has to wait for it to be mapped. Modules load on guest threads
+// while patches can come in from the IPC thread, hence the mutex.
+struct LoadedModule {
+    uintptr_t base{};
+    uint64_t size{};
+};
+
+static std::mutex g_module_mutex;
+static std::unordered_map<std::string, LoadedModule> g_loaded_modules;
+static std::vector<patchInfo> g_pending_module_patches;
 
 std::string toHex(u64 value, size_t byteSize) {
     std::stringstream ss;
@@ -157,6 +170,7 @@ void ApplyPatchesFromXML(std::filesystem::path path) {
                         std::string address = patchLineIt->attribute("Address").value();
                         std::string patchValue = patchLineIt->attribute("Value").value();
                         std::string maskOffsetStr = patchLineIt->attribute("Offset").value();
+                        std::string moduleName = patchLineIt->attribute("Module").value();
                         std::string targetStr = "";
                         std::string sizeStr = "";
                         if (type == "mask_jump32") {
@@ -204,6 +218,7 @@ void ApplyPatchesFromXML(std::filesystem::path path) {
                             .littleEndian = littleEndian,
                             .patchMask = patchMask,
                             .maskOffset = maskOffsetValue,
+                            .moduleStr = moduleName,
                         };
                         MemoryPatcher::PatchMemory(patch);
                     }
@@ -247,6 +262,25 @@ void OnGameLoaded() {
     ApplyPendingPatches();
 }
 
+void OnModuleLoaded(const std::string& module_name, uintptr_t base_address, uint64_t image_size) {
+    std::vector<patchInfo> ready;
+    {
+        std::scoped_lock lock{g_module_mutex};
+        g_loaded_modules[module_name] = {base_address, image_size};
+        const auto it =
+            std::partition(g_pending_module_patches.begin(), g_pending_module_patches.end(),
+                           [&](const patchInfo& patch) { return patch.moduleStr != module_name; });
+        ready.assign(it, g_pending_module_patches.end());
+        g_pending_module_patches.erase(it, g_pending_module_patches.end());
+    }
+    for (const auto& patch : ready) {
+        if (patch.gameSerial != "*" && patch.gameSerial != g_game_serial) {
+            continue;
+        }
+        PatchMemory(patch);
+    }
+}
+
 void AddPatchToQueue(const patchInfo& patchToAdd) {
     if (patches_applied) {
         PatchMemory(patchToAdd);
@@ -273,18 +307,34 @@ void PatchMemory(const patchInfo& patch) {
     // Send a request to modify the process memory.
     void* cheatAddress = nullptr;
 
+    uintptr_t patch_base = g_eboot_address;
+    uint64_t patch_range = g_eboot_image_size;
+    if (!patch.moduleStr.empty()) {
+        // One lock for both, or a module loading in between would strand the patch.
+        std::scoped_lock lock{g_module_mutex};
+        const auto it = g_loaded_modules.find(patch.moduleStr);
+        if (it == g_loaded_modules.end()) {
+            // Not mapped yet, hold the patch until it is.
+            g_pending_module_patches.push_back(patch);
+            return;
+        }
+        patch_base = it->second.base;
+        patch_range = it->second.size;
+    }
+
     if (patch.patchMask == PatchMask::None) {
-        if (patch.isOffset) {
-            cheatAddress =
-                reinterpret_cast<void*>(g_eboot_address + std::stoi(patch.offsetStr, 0, 16));
+        if (!patch.moduleStr.empty() || patch.isOffset) {
+            // A PRX links at base 0, so its addresses are already module offsets.
+            cheatAddress = reinterpret_cast<void*>(patch_base + std::stoi(patch.offsetStr, 0, 16));
         } else {
-            cheatAddress = reinterpret_cast<void*>(g_eboot_address +
+            cheatAddress = reinterpret_cast<void*>(patch_base +
                                                    (std::stoi(patch.offsetStr, 0, 16) - 0x400000));
         }
     }
 
     if (patch.patchMask == PatchMask::Mask) {
-        cheatAddress = reinterpret_cast<void*>(PatternScan(patch.offsetStr) + patch.maskOffset);
+        cheatAddress = reinterpret_cast<void*>(
+            PatternScan(patch.offsetStr, patch_base, patch_range) + patch.maskOffset);
     }
 
     if (patch.patchMask == PatchMask::Mask_Jump32) {
@@ -301,7 +351,7 @@ void PatchMemory(const patchInfo& patch) {
         }
 
         // Find the base address using "Address"
-        uintptr_t baseAddress = PatternScan(patch.offsetStr);
+        uintptr_t baseAddress = PatternScan(patch.offsetStr, patch_base, patch_range);
         if (baseAddress == 0) {
             LOG_ERROR(Loader, "PatternScan failed for mask_jump32 with pattern: {}",
                       patch.offsetStr);
@@ -314,7 +364,7 @@ void PatchMemory(const patchInfo& patch) {
         std::memcpy(reinterpret_cast<void*>(patchAddress), nopBytes.data(), nopBytes.size());
 
         // Use "Target" to locate the start of the code cave
-        uintptr_t jump_target = PatternScan(patch.targetStr);
+        uintptr_t jump_target = PatternScan(patch.targetStr, patch_base, patch_range);
         if (jump_target == 0) {
             LOG_ERROR(Loader, "PatternScan failed to Target with pattern: {}", patch.targetStr);
             return;
@@ -408,15 +458,24 @@ static std::vector<int32_t> PatternToByte(const std::string& pattern) {
     return bytes;
 }
 
-uintptr_t PatternScan(const std::string& signature) {
+uintptr_t PatternScan(const std::string& signature, uintptr_t scan_base, uint64_t scan_size) {
+    if (scan_base == 0) {
+        scan_base = g_eboot_address;
+        scan_size = g_eboot_image_size;
+    }
     std::vector<int32_t> patternBytes = PatternToByte(signature);
-    const auto scanBytes = static_cast<uint8_t*>((void*)g_eboot_address);
+    const auto scanBytes = reinterpret_cast<uint8_t*>(scan_base);
 
     const int32_t* sigPtr = patternBytes.data();
     const size_t sigSize = patternBytes.size();
 
+    // A module can be smaller than the pattern, which would wrap the loop bound below.
+    if (sigSize > scan_size) {
+        return 0;
+    }
+
     uint32_t foundResults = 0;
-    for (uint32_t i = 0; i < g_eboot_image_size - sigSize; ++i) {
+    for (uint32_t i = 0; i < scan_size - sigSize; ++i) {
         bool found = true;
         for (uint32_t j = 0; j < sigSize; ++j) {
             if (scanBytes[i + j] != sigPtr[j] && sigPtr[j] != -1) {

--- a/src/common/memory_patcher.h
+++ b/src/common/memory_patcher.h
@@ -36,16 +36,20 @@ struct patchInfo {
     bool littleEndian;
     PatchMask patchMask;
     int maskOffset;
+    // Module this patch belongs to; empty means the address is an eboot one.
+    std::string moduleStr;
 };
 
 std::string convertValueToHex(const std::string type, const std::string valueStr);
 
 void OnGameLoaded();
+void OnModuleLoaded(const std::string& module_name, uintptr_t base_address, uint64_t image_size);
 void AddPatchToQueue(const patchInfo& patchToAdd);
 
 void PatchMemory(const patchInfo& patch);
 
 static std::vector<int32_t> PatternToByte(const std::string& pattern);
-uintptr_t PatternScan(const std::string& signature);
+uintptr_t PatternScan(const std::string& signature, uintptr_t scan_base = 0,
+                      uint64_t scan_size = 0);
 
 } // namespace MemoryPatcher

--- a/src/core/ipc/ipc.cpp
+++ b/src/core/ipc/ipc.cpp
@@ -48,6 +48,7 @@ extern std::unique_ptr<Vulkan::Presenter> presenter;
  * Command list:
  * - CAPABILITIES:
  *   - ENABLE_MEMORY_PATCH: enables PATCH_MEMORY command
+ *   - ENABLE_MEMORY_PATCH_MODULE: enables PATCH_MEMORY_MODULE command
  *   - ENABLE_EMU_CONTROL: enables PAUSE, RESUME, STOP, TOGGLE_FULLSCREEN commands
  * - INPUT CMD:
  *   - RUN: start the emulator execution
@@ -56,7 +57,11 @@ extern std::unique_ptr<Vulkan::Presenter> presenter;
  *       modName: str, offset: str, value: str,
  *       target: str, size: str, isOffset: number, littleEndian: number,
  *       patchMask: number, maskOffset: number
- *     ): add a memory patch, check @ref MemoryPatcher::PatchMemory for details
+ *     ): add a memory patch, check @ref MemoryPatcher::PatchMemory for details.
+ *        The address is always an eboot one.
+ *   - PATCH_MEMORY_MODULE(
+ *       ...same fields as PATCH_MEMORY..., module: str
+ *     ): same, but the address is an offset into that module ("" for the eboot)
  *   - PAUSE: pause the game execution
  *   - RESUME: resume the game execution
  *   - STOP: stop and quit the emulator
@@ -81,6 +86,7 @@ void IPC::Init() {
 
     std::cerr << ";#IPC_ENABLED\n";
     std::cerr << ";ENABLE_MEMORY_PATCH\n";
+    std::cerr << ";ENABLE_MEMORY_PATCH_MODULE\n";
     std::cerr << ";ENABLE_EMU_CONTROL\n";
     std::cerr << ";#IPC_END\n";
     std::cerr.flush();
@@ -123,7 +129,10 @@ void IPC::InputLoop() {
             run_semaphore.release();
         } else if (cmd == "START") {
             start_semaphore.release();
-        } else if (cmd == "PATCH_MEMORY") {
+        } else if (cmd == "PATCH_MEMORY" || cmd == "PATCH_MEMORY_MODULE") {
+            // PATCH_MEMORY_MODULE is the same message with the module appended. The fields are
+            // positional, so it has to be its own command rather than an extra field.
+            const bool has_module = cmd == "PATCH_MEMORY_MODULE";
             const MemoryPatcher::patchInfo entry = {
                 .gameSerial = "*",
                 .modNameStr = next_str(),
@@ -135,6 +144,7 @@ void IPC::InputLoop() {
                 .littleEndian = next_u64() != 0,
                 .patchMask = static_cast<MemoryPatcher::PatchMask>(next_u64()),
                 .maskOffset = static_cast<int>(next_u64()),
+                .moduleStr = has_module ? next_str() : std::string{},
             };
             MemoryPatcher::AddPatchToQueue(entry);
         } else if (cmd == "PAUSE") {

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -335,6 +335,8 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
             MemoryPatcher::OnGameLoaded();
         }
     }
+    // The module is mapped but has not run anything yet: apply the patches that name it.
+    MemoryPatcher::OnModuleLoaded(name, base_virtual_addr, base_size);
 }
 
 void Module::LoadDynamicInfo() {


### PR DESCRIPTION
At present, patches can only target the game's main executable: patch addresses are resolved via `g_eboot_address`, pattern scans are performed on the eboot image, and the changes are applied during `OnGameLoaded`. Therefore, it is not possible to write a patch for a bug in one of the PRX modules supplied with a game: when patches are applied, those modules have not yet been loaded and their base address is not that of the eboot. Furthermore, their address is not even the same from one run to the next, as it depends on what has been mapped before it.

This PR allows a patch line to specify the name of its target module:

```xml
<Line Type="bytes" Address="0x9908" Value="0F1F00" Module="spu.prx" />
```

Such patches read their own address as an offset within the module, resolve it (along with any mask patterns) based on the module's base address and size, and are applied when the module is actually mapped, just before its code is executed. If the module has not yet been loaded, the patch waits in a pending list that the module loader drains as each module loads; if the patch arrives later via IPC and the module is already known, it is applied immediately. Patches lacking this attribute behave exactly as before.

The second commit applies the changes necessary to integrate these patches with the IPC. PATCH_MEMORY has no field for the module, and its fields are positional: extending it would leave the parser one field out of sync with a sender that does not send that additional field. PATCH_MEMORY_MODULE is therefore defined as its own command, negotiated via the ENABLE_MEMORY_PATCH_MODULE capability, so as to keep the IPC backwards compatible.
A follow-up PR for the launcher will implement sending the new command; until then it is only advertised, and senders that do not know about it keep using PATCH_MEMORY.

~~The reason behind this PR stems from my need to fix a bug that freezes LittleBigPlanet 3 a few seconds after its main menu, the Pod, has loaded. The game includes a module called spu.prx, inherited from the PS3 version, which masks a memory address down to 32 bits before an atomic increment. On PS3 that was harmless, as guest memory sat below 4 GiB; but in shadPS4 the eboot maps beyond 4 GiB, so the increment lands on a low alias instead of the counter it is meant to update, and the queue that counter guards overflows. The fix involves 15 bytes at two points within that module, and without this change there is no way to express it.~~

Disclosure: analysis, debugging and development of this change were done with the help of Claude Code; I reviewed the reasoning and the final change myself before opening this PR.