### PR TITLE
Core: Load guest modules below 4 GiB

### DIFF
--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -20,7 +20,9 @@ namespace Core {
 
 using EntryFunc = PS4_SYSV_ABI int (*)(size_t args, const void* argp, void* param);
 
-static constexpr u64 ModuleLoadBase = 0x800000000;
+// In the system managed area, and low enough that guest code truncating an address to 32 bits
+// still lands on the right module.
+static constexpr u64 ModuleLoadBase = 0x80000000;
 
 static u64 GetAlignedSize(const elf_program_header& phdr) {
     return (phdr.p_align != 0 ? (phdr.p_memsz + (phdr.p_align - 1)) & ~(phdr.p_align - 1)

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -20,6 +20,7 @@ namespace Core {
 
 using EntryFunc = PS4_SYSV_ABI int (*)(size_t args, const void* argp, void* param);
 
+static constexpr u64 ExecutableLoadBase = 0x400000;
 static constexpr u64 GameModuleLoadBase = 0x80000000;
 static constexpr u64 SystemModuleLoadBase = 0x800000000;
 
@@ -114,7 +115,11 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
     aligned_base_size = Common::AlignUp(base_size, BlockAlign);
 
     // Reserve memory area for module
-    const u64 load_base = IsSystemLib() ? SystemModuleLoadBase : GameModuleLoadBase;
+    const bool is_executable =
+        elf_header.e_type == ET_SCE_EXEC || elf_header.e_type == ET_SCE_DYNEXEC;
+    const u64 load_base = is_executable   ? ExecutableLoadBase
+                          : IsSystemLib() ? SystemModuleLoadBase
+                                          : GameModuleLoadBase;
     void** out_addr = reinterpret_cast<void**>(&base_virtual_addr);
     s32 result =
         memory->MapMemory(out_addr, load_base, aligned_base_size + TrampolineSize,

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -20,9 +20,9 @@ namespace Core {
 
 using EntryFunc = PS4_SYSV_ABI int (*)(size_t args, const void* argp, void* param);
 
-// In the system managed area, and low enough that guest code truncating an address to 32 bits
-// still lands on the right module.
-static constexpr u64 ModuleLoadBase = 0x80000000;
+static constexpr u64 ExecutableLoadBase = 0x400000;
+static constexpr u64 GameModuleLoadBase = 0x80000000;
+static constexpr u64 SystemModuleLoadBase = 0x800000000;
 
 static u64 GetAlignedSize(const elf_program_header& phdr) {
     return (phdr.p_align != 0 ? (phdr.p_memsz + (phdr.p_align - 1)) & ~(phdr.p_align - 1)
@@ -115,9 +115,14 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
     aligned_base_size = Common::AlignUp(base_size, BlockAlign);
 
     // Reserve memory area for module
+    const bool is_executable =
+        elf_header.e_type == ET_SCE_EXEC || elf_header.e_type == ET_SCE_DYNEXEC;
+    const u64 load_base = is_executable   ? ExecutableLoadBase
+                          : IsSystemLib() ? SystemModuleLoadBase
+                                          : GameModuleLoadBase;
     void** out_addr = reinterpret_cast<void**>(&base_virtual_addr);
     s32 result =
-        memory->MapMemory(out_addr, ModuleLoadBase, aligned_base_size + TrampolineSize,
+        memory->MapMemory(out_addr, load_base, aligned_base_size + TrampolineSize,
                           MemoryProt::NoAccess, MemoryMapFlags::NoFlags, VMAType::Reserved, name);
     ASSERT_MSG(result == ORBIS_OK, "Failed to reserve memory for module {}", name);
     LOG_INFO(Core_Linker, "Loading module {} to {}", name, fmt::ptr(*out_addr));

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -20,7 +20,6 @@ namespace Core {
 
 using EntryFunc = PS4_SYSV_ABI int (*)(size_t args, const void* argp, void* param);
 
-static constexpr u64 ExecutableLoadBase = 0x400000;
 static constexpr u64 GameModuleLoadBase = 0x80000000;
 static constexpr u64 SystemModuleLoadBase = 0x800000000;
 
@@ -115,11 +114,7 @@ void Module::LoadModuleToMemory(u32& max_tls_index) {
     aligned_base_size = Common::AlignUp(base_size, BlockAlign);
 
     // Reserve memory area for module
-    const bool is_executable =
-        elf_header.e_type == ET_SCE_EXEC || elf_header.e_type == ET_SCE_DYNEXEC;
-    const u64 load_base = is_executable   ? ExecutableLoadBase
-                          : IsSystemLib() ? SystemModuleLoadBase
-                                          : GameModuleLoadBase;
+    const u64 load_base = IsSystemLib() ? SystemModuleLoadBase : GameModuleLoadBase;
     void** out_addr = reinterpret_cast<void**>(&base_virtual_addr);
     s32 result =
         memory->MapMemory(out_addr, load_base, aligned_base_size + TrampolineSize,


### PR DESCRIPTION
At the moment, modules are mapped starting from 0x800000000. This address lies beyond the SYSTEM_MANAGED_MAX limit (0x7FFFFBFFF), so the modules end up outside the system-managed area to which they belong, and no pointer to them fits within 32 bits.

A title ported from PS3 may contain code that truncates an address to 32 bits, which is harmless on a real console because modules are mapped low, but causes addressing issues here.

Let's map them starting from 0x80000000 as recommended by @raphaelthegreat in #4847 