### PR TITLE
video_core: honor STENCILOPVAL for GCN ReplaceOp stencil writes

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -1316,7 +1316,23 @@ void Rasterizer::UpdateDepthStencilState() const {
         const auto front = regs.stencil_ref_front;
         const auto back =
             regs.depth_control.backface_enable ? regs.stencil_ref_back : regs.stencil_ref_front;
-        dynamic_state.SetStencilReferences(front.stencil_test_val, back.stencil_test_val);
+        // GCN REPLACE_OP writes DB_STENCILREFMASK.STENCILOPVAL, so a face whose stencil ops
+        // include ReplaceOp takes its Vulkan reference from op_val.
+        const auto& sc = regs.stencil_control;
+        const auto uses_op_val = [](AmdGpu::StencilFunc fail, AmdGpu::StencilFunc zpass,
+                                    AmdGpu::StencilFunc zfail) {
+            return fail == AmdGpu::StencilFunc::ReplaceOp ||
+                   zpass == AmdGpu::StencilFunc::ReplaceOp ||
+                   zfail == AmdGpu::StencilFunc::ReplaceOp;
+        };
+        const bool front_op =
+            uses_op_val(sc.stencil_fail_front, sc.stencil_zpass_front, sc.stencil_zfail_front);
+        const bool back_op =
+            regs.depth_control.backface_enable
+                ? uses_op_val(sc.stencil_fail_back, sc.stencil_zpass_back, sc.stencil_zfail_back)
+                : front_op;
+        dynamic_state.SetStencilReferences(front_op ? front.stencil_op_val : front.stencil_test_val,
+                                           back_op ? back.stencil_op_val : back.stencil_test_val);
         dynamic_state.SetStencilWriteMasks(!stencil_clear ? front.stencil_write_mask : 0U,
                                            !stencil_clear ? back.stencil_write_mask : 0U);
         dynamic_state.SetStencilCompareMasks(front.stencil_mask, back.stencil_mask);

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -1331,6 +1331,16 @@ void Rasterizer::UpdateDepthStencilState() const {
             regs.depth_control.backface_enable
                 ? uses_op_val(sc.stencil_fail_back, sc.stencil_zpass_back, sc.stencil_zfail_back)
                 : front_op;
+        const auto ref_conflict = [](AmdGpu::CompareFunc func, const AmdGpu::StencilRefMask& ref) {
+            return func != AmdGpu::CompareFunc::Always && func != AmdGpu::CompareFunc::Never &&
+                   ref.stencil_test_val != ref.stencil_op_val;
+        };
+        if ((front_op && ref_conflict(regs.depth_control.stencil_ref_func, front)) ||
+            (back_op && regs.depth_control.backface_enable &&
+             ref_conflict(regs.depth_control.stencil_bf_func, back))) {
+            LOG_WARNING(Render_Vulkan, "Stencil test requires test_val while ReplaceOp requires "
+                                       "op_val; the stencil test will use op_val");
+        }
         dynamic_state.SetStencilReferences(front_op ? front.stencil_op_val : front.stencil_test_val,
                                            back_op ? back.stencil_op_val : back.stencil_test_val);
         dynamic_state.SetStencilWriteMasks(!stencil_clear ? front.stencil_write_mask : 0U,


### PR DESCRIPTION
Fixes stale shadow maps, broken alpha blending, missing video output on in-game TVs in inFAMOUS Second Son and First Light and potentially in other games (I think God of War 3 had something similar to this? I don't have it to test though). 

So in Infamous, DB_STENCILREFMASK writes fields test_val and op_val but updatedepthstencilstate() converted it to vulkan dynamic state, which can only use one reference value per face, which always forced the test_val to be used for both compare and write. As such, both front.stencil_test_val and back.stencil_tes_val became the test_val of 0, causing replaceop to always write 0. This gates any pass that requires certain stencil values, which removes the rendering of Reggie, video output on TVs, breaks alpha blending on hair, and since the shadow mask repainted every frame, replaceop writing 0 forever made it so that this is never done per frame, causing the mask to be rasterized and then remain stale, causing this dirty camera lens effect. The fix is to gate which of the two fields get passed to dyanmic_state.SetStencilReferences() with the following rule: if any of the face's stencil ops is replaceop, pass op_val, otherwise, test_val.

before: test_val only ( no gating logic)
<img width="1188" height="687" alt="stale shadow mask 1" src="https://github.com/user-attachments/assets/d6dfa437-e66c-4f00-a5fd-e9c641d2cfaf" />

after: gating logic active
<img width="1187" height="683" alt="fixed shadow mask 1" src="https://github.com/user-attachments/assets/fb178627-70ee-4c06-8333-61579d829c55" />

before: test_val only ( no gating logic)
<img width="1195" height="681" alt="stale shadow mask 2" src="https://github.com/user-attachments/assets/2c741997-a259-424f-abe5-423ce96d35d6" />


after: gating logic active
<img width="1190" height="680" alt="stale shadow mask 3" src="https://github.com/user-attachments/assets/00859da8-6bd3-4ab1-a6c9-c7e302f29b4d" />
