### PR TITLE
Rewrite signal emulation again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,6 +328,7 @@ set(KERNEL_LIB src/core/libraries/kernel/coredump/coredump.cpp
                src/core/libraries/kernel/threads/event_flag.cpp
                src/core/libraries/kernel/threads/exception.cpp
                src/core/libraries/kernel/threads/exception.h
+               src/core/libraries/kernel/threads/exception_codes.h
                src/core/libraries/kernel/threads/mutex.cpp
                src/core/libraries/kernel/threads/pthread_attr.cpp
                src/core/libraries/kernel/threads/pthread_clean.cpp

--- a/src/core/libraries/kernel/kernel.cpp
+++ b/src/core/libraries/kernel/kernel.cpp
@@ -105,49 +105,55 @@ s32 PS4_SYSV_ABI sceKernelError(s32 posix_error) {
     return posix_error + ORBIS_KERNEL_ERROR_UNKNOWN;
 }
 
-void SetPosixErrno(s32 e) {
+s32 NativeToPosixErrno(s32 const e) {
     // Some error numbers are different between supported OSes
     switch (e) {
+    case 0:
+        return 0;
     case EPERM:
-        g_posix_errno = POSIX_EPERM;
+        return POSIX_EPERM;
         break;
     case ENOENT:
-        g_posix_errno = POSIX_ENOENT;
+        return POSIX_ENOENT;
         break;
     case EINTR:
-        g_posix_errno = POSIX_EINTR;
+        return POSIX_EINTR;
         break;
     case EDEADLK:
-        g_posix_errno = POSIX_EDEADLK;
+        return POSIX_EDEADLK;
         break;
     case ENOMEM:
-        g_posix_errno = POSIX_ENOMEM;
+        return POSIX_ENOMEM;
         break;
     case EACCES:
-        g_posix_errno = POSIX_EACCES;
+        return POSIX_EACCES;
         break;
     case EFAULT:
-        g_posix_errno = POSIX_EFAULT;
+        return POSIX_EFAULT;
         break;
     case EINVAL:
-        g_posix_errno = POSIX_EINVAL;
+        return POSIX_EINVAL;
         break;
     case ENOSPC:
-        g_posix_errno = POSIX_ENOSPC;
+        return POSIX_ENOSPC;
         break;
     case ERANGE:
-        g_posix_errno = POSIX_ERANGE;
+        return POSIX_ERANGE;
         break;
     case EAGAIN:
-        g_posix_errno = POSIX_EAGAIN;
+        return POSIX_EAGAIN;
         break;
     case ETIMEDOUT:
-        g_posix_errno = POSIX_ETIMEDOUT;
+        return POSIX_ETIMEDOUT;
         break;
     default:
         LOG_WARNING(Kernel, "Unhandled errno {}", e);
-        g_posix_errno = e;
+        return e;
     }
+}
+
+void SetPosixErrno(s32 e) {
+    g_posix_errno = NativeToPosixErrno(e);
 }
 
 struct OrbisKernelUuid {

--- a/src/core/libraries/kernel/kernel.h
+++ b/src/core/libraries/kernel/kernel.h
@@ -16,6 +16,7 @@ namespace Libraries::Kernel {
 void ErrSceToPosix(s32 result);
 s32 ErrnoToSceKernelError(s32 e);
 void SetPosixErrno(s32 e);
+s32 NativeToPosixErrno(s32 const e);
 s32* PS4_SYSV_ABI __Error();
 const char* PS4_SYSV_ABI sceKernelGetFsSandboxRandomWord();
 

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -289,10 +289,6 @@ s32 NativeToOrbisSignal(s32 s) {
         return POSIX_SIGUSR1;
     case SIGUSR2:
         return POSIX_SIGUSR2;
-    case _SIGEMT:
-        return POSIX_SIGEMT;
-    case _SIGINFO:
-        return POSIX_SIGINFO;
     default:
         // This is only needed for a few hardware signals now, so it needn't worry about about RT
         // ones anymore.
@@ -429,10 +425,6 @@ s32 PS4_SYSV_ABI posix_pthread_sigmask(s32 how, const Sigset* set, Sigset* oset)
     }
 
     Sigset new_mask = old_mask;
-
-    constexpr s32 POSIX_SIG_BLOCK = 0;
-    constexpr s32 POSIX_SIG_UNBLOCK = 1;
-    constexpr s32 POSIX_SIG_SETMASK = 2;
 
     switch (how) {
     case POSIX_SIG_BLOCK:

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -99,45 +99,35 @@ Ucontext::Ucontext(siginfo_t const* inf, ucontext_t const* raw_context) {
 #error "ucontext_t conversion not implemented for current architecture."
 #endif
 }
+#else
+Ucontext::Ucontext(PCONTEXT context) {
+    if (!context) {
+        return;
+    }
+    uc_mcontext.mc_r8 = context->R8;
+    uc_mcontext.mc_r9 = context->R9;
+    uc_mcontext.mc_r10 = context->R10;
+    uc_mcontext.mc_r11 = context->R11;
+    uc_mcontext.mc_r12 = context->R12;
+    uc_mcontext.mc_r13 = context->R13;
+    uc_mcontext.mc_r14 = context->R14;
+    uc_mcontext.mc_r15 = context->R15;
+    uc_mcontext.mc_rdi = context->Rdi;
+    uc_mcontext.mc_rsi = context->Rsi;
+    uc_mcontext.mc_rbp = context->Rbp;
+    uc_mcontext.mc_rbx = context->Rbx;
+    uc_mcontext.mc_rdx = context->Rdx;
+    uc_mcontext.mc_rax = context->Rax;
+    uc_mcontext.mc_rcx = context->Rcx;
+    uc_mcontext.mc_rsp = context->Rsp;
+    uc_mcontext.mc_fs = context->SegFs;
+    uc_mcontext.mc_gs = context->SegGs;
+}
 #endif
 
 std::array<Sigaction, 128> PosixActions{};
 std::array<OrbisKernelExceptionHandler, 128> sceSigactionCallbacks{};
 Sigset g_sigintr{};
-
-#ifdef _WIN64
-void ExceptionHandler(void* arg1, void* arg2, void* arg3, PCONTEXT context) {
-    const char* thrName = (char*)arg1;
-    s32 const sig = reinterpret_cast<uintptr_t>(arg2);
-    LOG_INFO(Lib_Kernel, "Exception raised successfully on thread '{}'", thrName);
-    const auto handler = sceSigactionCallbacks[sig];
-    if (handler) {
-        auto ctx = Ucontext{};
-        ctx.uc_mcontext.mc_r8 = context->R8;
-        ctx.uc_mcontext.mc_r9 = context->R9;
-        ctx.uc_mcontext.mc_r10 = context->R10;
-        ctx.uc_mcontext.mc_r11 = context->R11;
-        ctx.uc_mcontext.mc_r12 = context->R12;
-        ctx.uc_mcontext.mc_r13 = context->R13;
-        ctx.uc_mcontext.mc_r14 = context->R14;
-        ctx.uc_mcontext.mc_r15 = context->R15;
-        ctx.uc_mcontext.mc_rdi = context->Rdi;
-        ctx.uc_mcontext.mc_rsi = context->Rsi;
-        ctx.uc_mcontext.mc_rbp = context->Rbp;
-        ctx.uc_mcontext.mc_rbx = context->Rbx;
-        ctx.uc_mcontext.mc_rdx = context->Rdx;
-        ctx.uc_mcontext.mc_rax = context->Rax;
-        ctx.uc_mcontext.mc_rcx = context->Rcx;
-        ctx.uc_mcontext.mc_rsp = context->Rsp;
-        ctx.uc_mcontext.mc_fs = context->SegFs;
-        ctx.uc_mcontext.mc_gs = context->SegGs;
-        handler(sig, &ctx);
-    } else {
-        UNREACHABLE_MSG("Unhandled exception");
-    }
-}
-
-#endif
 
 #ifndef _WIN32
 s32 NativeToOrbisSignal(s32 s) {
@@ -311,19 +301,6 @@ s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
         *__Error() = POSIX_EINVAL;
         return ORBIS_FAIL;
     }
-#ifdef _WIN32
-    LOG_ERROR(Lib_Kernel, "(STUBBED) called, sig: {}", sig);
-    sceSigactionCallbacks[sig] = reinterpret_cast<OrbisKernelExceptionHandler>(
-        act ? act->__sigaction_handler.sigaction : nullptr);
-    if (oact) {
-        memset(oact, 0, sizeof(*oact));
-    }
-    if (act && oact) {
-        oact->__sigaction_handler = act->__sigaction_handler;
-        oact->sa_mask = act->sa_mask;
-        oact->sa_flags = act->sa_flags;
-    }
-#else
     if (oact != nullptr) {
         *oact = PosixActions[sig - 1];
     }
@@ -331,12 +308,10 @@ s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
     if (act != nullptr) {
         PosixActions[sig - 1] = *act;
     }
-#endif
     return ORBIS_OK;
 }
 
 s32 PS4_SYSV_ABI posix_pthread_sigmask(s32 how, const Sigset* set, Sigset* oset) {
-#ifndef _WIN32
     auto* thread = g_curthread;
 
     if (thread == nullptr) {
@@ -385,9 +360,6 @@ s32 PS4_SYSV_ABI posix_pthread_sigmask(s32 how, const Sigset* set, Sigset* oset)
     if (thread->HasDeliverableSignal()) {
         thread->WakeForSignal();
     }
-#else
-    LOG_ERROR(Lib_Kernel, "(STUBBED) called");
-#endif
     return ORBIS_OK;
 }
 
@@ -396,7 +368,6 @@ s32 PS4_SYSV_ABI posix_sigprocmask(s32 how, const Sigset* set, Sigset* oset) {
 }
 
 s32 PS4_SYSV_ABI posix_sigpending(Sigset* set) {
-#ifndef _WIN32
     posix_sigemptyset(set);
 
     for (s32 sig = 1; sig <= 128; sig++) {
@@ -406,14 +377,9 @@ s32 PS4_SYSV_ABI posix_sigpending(Sigset* set) {
     }
 
     return ORBIS_OK;
-#else
-    LOG_ERROR(Lib_Kernel, "(STUBBED) called");
-    return ORBIS_OK;
-#endif
 }
 
 s32 PS4_SYSV_ABI posix_sigsuspend(const Sigset* sigmask) {
-#ifndef _WIN32
     Sigset old_mask{};
     auto& thr = g_curthread;
     thr->GetGuestSigmask(old_mask);
@@ -433,15 +399,9 @@ s32 PS4_SYSV_ABI posix_sigsuspend(const Sigset* sigmask) {
 
     *__Error() = POSIX_EINTR;
     return ORBIS_FAIL;
-#else
-    LOG_ERROR(Lib_Kernel, "(STUBBED) called");
-    *__Error() = POSIX_EINTR;
-    return ORBIS_FAIL;
-#endif
 }
 
 s32 PS4_SYSV_ABI posix_sigwait(const Sigset* set, s32* sig) {
-#ifndef _WIN32
     if (set == nullptr || sig == nullptr) {
         return POSIX_EINVAL;
     }
@@ -470,11 +430,6 @@ s32 PS4_SYSV_ABI posix_sigwait(const Sigset* set, s32* sig) {
 
         thread->signal_sema.acquire();
     }
-#else
-    LOG_ERROR(Lib_Kernel, "(STUBBED) called");
-    return ORBIS_OK;
-
-#endif
 }
 
 SigHandler PS4_SYSV_ABI posix_signal(s32 sig, SigHandler func) {
@@ -498,21 +453,11 @@ s32 PS4_SYSV_ABI posix_pthread_kill(PthreadT thread, s32 sig) {
         return POSIX_EINVAL;
     }
     LOG_INFO(Lib_Kernel, "Raising signal {} on thread '{}'", sig, thread->name);
-#ifndef _WIN64
     thread->QueueSignal(sig);
 
     if (!thread->IsSignalBlocked(sig)) {
         thread->WakeForSignal();
     }
-#else
-    USER_APC_OPTION option;
-    option.UserApcFlags = QueueUserApcFlagsSpecialUserApc;
-
-    u64 res =
-        NtQueueApcThreadEx(reinterpret_cast<HANDLE>(thread->native_thr->GetHandle()), option,
-                           ExceptionHandler, (void*)thread->name.c_str(), (void*)(s64)sig, nullptr);
-    ASSERT(res == 0);
-#endif
     return ORBIS_OK;
 }
 

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -23,7 +23,7 @@
 namespace Libraries::Kernel {
 
 #ifndef _WIN32
-Ucontext::Ucontext(siginfo_t const* inf, ucontext_t const* raw_context) {
+Ucontext::Ucontext(siginfo_t const* inf, ucontext_t* raw_context) {
     if (!inf || !raw_context) {
         return;
     }

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -22,6 +22,7 @@
 
 namespace Libraries::Kernel {
 
+#ifndef _WIN32
 Ucontext::Ucontext(siginfo_t const* inf, ucontext_t const* raw_context) {
     if (!inf || !raw_context) {
         return;
@@ -95,9 +96,10 @@ Ucontext::Ucontext(siginfo_t const* inf, ucontext_t const* raw_context) {
     uc_mcontext.mc_addr = reinterpret_cast<uint64_t>(inf->si_addr);
 #endif
 #else
-    UNREACHABLE_MSG("SigactionHandler not implemented for current architecture.");
+#error "ucontext_t conversion not implemented for current architecture."
 #endif
 }
+#endif
 
 std::array<Sigaction, 128> PosixActions{};
 Sigset g_sigintr{};

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -27,6 +27,7 @@ Ucontext::Ucontext(siginfo_t const* inf, ucontext_t const* raw_context) {
     if (!inf || !raw_context) {
         return;
     }
+    host_context = raw_context;
 #ifdef ARCH_X86_64
 #ifdef __APPLE__
     const auto& regs = raw_context->uc_mcontext->__ss;
@@ -124,6 +125,85 @@ Ucontext::Ucontext(PCONTEXT context) {
     uc_mcontext.mc_gs = context->SegGs;
 }
 #endif
+
+void Ucontext::SyncHostFromGuest() {
+#ifndef _WIN32
+    if (!host_context) {
+        return;
+    }
+
+#ifdef ARCH_X86_64
+#ifdef __APPLE__
+    auto& regs = host_context->uc_mcontext->__ss;
+    regs.__r8 = uc_mcontext.mc_r8;
+    regs.__r9 = uc_mcontext.mc_r9;
+    regs.__r10 = uc_mcontext.mc_r10;
+    regs.__r11 = uc_mcontext.mc_r11;
+    regs.__r12 = uc_mcontext.mc_r12;
+    regs.__r13 = uc_mcontext.mc_r13;
+    regs.__r14 = uc_mcontext.mc_r14;
+    regs.__r15 = uc_mcontext.mc_r15;
+    regs.__rdi = uc_mcontext.mc_rdi;
+    regs.__rsi = uc_mcontext.mc_rsi;
+    regs.__rbp = uc_mcontext.mc_rbp;
+    regs.__rbx = uc_mcontext.mc_rbx;
+    regs.__rdx = uc_mcontext.mc_rdx;
+    regs.__rax = uc_mcontext.mc_rax;
+    regs.__rcx = uc_mcontext.mc_rcx;
+    regs.__rsp = uc_mcontext.mc_rsp;
+    regs.__fs = uc_mcontext.mc_fs;
+    regs.__gs = uc_mcontext.mc_gs;
+    regs.__rip = uc_mcontext.mc_rip;
+#elif defined(__FreeBSD__)
+    auto& regs = host_context->uc_mcontext;
+    regs.mc_r8 = uc_mcontext.mc_r8;
+    regs.mc_r9 = uc_mcontext.mc_r9;
+    regs.mc_r10 = uc_mcontext.mc_r10;
+    regs.mc_r11 = uc_mcontext.mc_r11;
+    regs.mc_r12 = uc_mcontext.mc_r12;
+    regs.mc_r13 = uc_mcontext.mc_r13;
+    regs.mc_r14 = uc_mcontext.mc_r14;
+    regs.mc_r15 = uc_mcontext.mc_r15;
+    regs.mc_rdi = uc_mcontext.mc_rdi;
+    regs.mc_rsi = uc_mcontext.mc_rsi;
+    regs.mc_rbp = uc_mcontext.mc_rbp;
+    regs.mc_rbx = uc_mcontext.mc_rbx;
+    regs.mc_rdx = uc_mcontext.mc_rdx;
+    regs.mc_rax = uc_mcontext.mc_rax;
+    regs.mc_rcx = uc_mcontext.mc_rcx;
+    regs.mc_rsp = uc_mcontext.mc_rsp;
+    regs.mc_fs = uc_mcontext.mc_fs;
+    regs.mc_gs = uc_mcontext.mc_gs;
+    regs.mc_rip = uc_mcontext.mc_rip;
+#else
+    auto& regs = host_context->uc_mcontext.gregs;
+    regs[REG_R8] = uc_mcontext.mc_r8;
+    regs[REG_R9] = uc_mcontext.mc_r9;
+    regs[REG_R10] = uc_mcontext.mc_r10;
+    regs[REG_R11] = uc_mcontext.mc_r11;
+    regs[REG_R12] = uc_mcontext.mc_r12;
+    regs[REG_R13] = uc_mcontext.mc_r13;
+    regs[REG_R14] = uc_mcontext.mc_r14;
+    regs[REG_R15] = uc_mcontext.mc_r15;
+    regs[REG_RDI] = uc_mcontext.mc_rdi;
+    regs[REG_RSI] = uc_mcontext.mc_rsi;
+    regs[REG_RBP] = uc_mcontext.mc_rbp;
+    regs[REG_RBX] = uc_mcontext.mc_rbx;
+    regs[REG_RDX] = uc_mcontext.mc_rdx;
+    regs[REG_RAX] = uc_mcontext.mc_rax;
+    regs[REG_RCX] = uc_mcontext.mc_rcx;
+    regs[REG_RSP] = uc_mcontext.mc_rsp;
+    // regs[REG_CSGSFS] &= ~((greg_t{0xFFFF} << 32) | (greg_t{0xFFFF} << 16));
+    // regs[REG_CSGSFS] |= (greg_t{uc_mcontext.mc_fs} << 32);
+    // regs[REG_CSGSFS] |= (greg_t{uc_mcontext.mc_gs} << 16);
+    regs[REG_RIP] = uc_mcontext.mc_rip;
+#endif
+#else
+#error "ucontext_t conversion not implemented for current architecture."
+#endif
+
+#endif
+}
 
 std::array<Sigaction, 128> PosixActions{};
 std::array<OrbisKernelExceptionHandler, 128> sceSigactionCallbacks{};

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -102,11 +102,10 @@ Ucontext::Ucontext(siginfo_t const* inf, ucontext_t const* raw_context) {
 #endif
 
 std::array<Sigaction, 128> PosixActions{};
+std::array<OrbisKernelExceptionHandler, 128> sceSigactionCallbacks{};
 Sigset g_sigintr{};
 
-constexpr s32 HostSoftwareSignal = SIGUSR1;
-
-#ifdef _WIN64
+#ifndef _WIN64
 void ExceptionHandler(void* arg1, void* arg2, void* arg3, PCONTEXT context) {
     const char* thrName = (char*)arg1;
     s32 const native_signum = reinterpret_cast<uintptr_t>(arg2);
@@ -137,7 +136,6 @@ void ExceptionHandler(void* arg1, void* arg2, void* arg3, PCONTEXT context) {
         UNREACHABLE_MSG("Unhandled exception");
     }
 }
-#endif
 
 s32 NativeToOrbisSignal(s32 s) {
     switch (s) {
@@ -209,6 +207,7 @@ s32 NativeToOrbisSignal(s32 s) {
         UNREACHABLE_MSG("Signal {} has no job being here", s);
     }
 }
+#endif
 
 s32 PS4_SYSV_ABI posix_sigemptyset(Sigset* s) {
     s->bits[0] = 0;
@@ -516,7 +515,6 @@ s32 PS4_SYSV_ABI posix_raise(s32 sig) {
     return posix_pthread_kill(g_curthread, sig);
 }
 
-std::array<OrbisKernelExceptionHandler, 128> sceSigactionCallbacks{};
 void PS4_SYSV_ABI sceCallbackHandler(int sig, Siginfo* info, Ucontext* context) {
     auto const cb = sceSigactionCallbacks[sig - 1];
     if (!cb) {

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -105,6 +105,7 @@ Ucontext::Ucontext(PCONTEXT context) {
     if (!context) {
         return;
     }
+    host_context = context;
     uc_mcontext.mc_r8 = context->R8;
     uc_mcontext.mc_r9 = context->R9;
     uc_mcontext.mc_r10 = context->R10;
@@ -127,13 +128,32 @@ Ucontext::Ucontext(PCONTEXT context) {
 #endif
 
 void Ucontext::SyncHostFromGuest() {
-#ifndef _WIN32
     if (!host_context) {
         return;
     }
 
 #ifdef ARCH_X86_64
-#ifdef __APPLE__
+#ifdef _WIN32
+    host_context->R8 = uc_mcontext.mc_r8;
+    host_context->R9 = uc_mcontext.mc_r9;
+    host_context->R10 = uc_mcontext.mc_r10;
+    host_context->R11 = uc_mcontext.mc_r11;
+    host_context->R12 = uc_mcontext.mc_r12;
+    host_context->R13 = uc_mcontext.mc_r13;
+    host_context->R14 = uc_mcontext.mc_r14;
+    host_context->R15 = uc_mcontext.mc_r15;
+    host_context->Rdi = uc_mcontext.mc_rdi;
+    host_context->Rsi = uc_mcontext.mc_rsi;
+    host_context->Rbp = uc_mcontext.mc_rbp;
+    host_context->Rbx = uc_mcontext.mc_rbx;
+    host_context->Rdx = uc_mcontext.mc_rdx;
+    host_context->Rax = uc_mcontext.mc_rax;
+    host_context->Rcx = uc_mcontext.mc_rcx;
+    host_context->Rsp = uc_mcontext.mc_rsp;
+    host_context->Rip = uc_mcontext.mc_rip;
+    // host_context->SegFs = static_cast<DWORD>(uc_mcontext.mc_fs);
+    // host_context->SegGs = static_cast<DWORD>(uc_mcontext.mc_gs);
+#elif __APPLE__
     auto& regs = host_context->uc_mcontext->__ss;
     regs.__r8 = uc_mcontext.mc_r8;
     regs.__r9 = uc_mcontext.mc_r9;
@@ -200,8 +220,6 @@ void Ucontext::SyncHostFromGuest() {
 #endif
 #else
 #error "ucontext_t conversion not implemented for current architecture."
-#endif
-
 #endif
 }
 

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -122,6 +122,7 @@ Ucontext::Ucontext(PCONTEXT context) {
     uc_mcontext.mc_rax = context->Rax;
     uc_mcontext.mc_rcx = context->Rcx;
     uc_mcontext.mc_rsp = context->Rsp;
+    uc_mcontext.mc_rip = context->Rip;
     uc_mcontext.mc_fs = context->SegFs;
     uc_mcontext.mc_gs = context->SegGs;
 }

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -131,7 +131,7 @@ void ExceptionHandler(void* arg1, void* arg2, void* arg3, PCONTEXT context) {
         ctx.uc_mcontext.mc_rsp = context->Rsp;
         ctx.uc_mcontext.mc_fs = context->SegFs;
         ctx.uc_mcontext.mc_gs = context->SegGs;
-        handler(NativeToOrbisSignal(native_signum), &ctx);
+        handler(sig, &ctx);
     } else {
         UNREACHABLE_MSG("Unhandled exception");
     }
@@ -289,7 +289,9 @@ s32 PS4_SYSV_ABI posix_sigaltstack(const OrbisKernelExceptionHandlerStack* ss,
         return -1;
     }
 
-    if (!(ss->ss_flags & POSIX_SS_DISABLE) && ss->ss_size < MINSIGSTKSZ) {
+    constexpr s32 POSIX_MINSIGSTKSZ = (512 * 4); // from the freebsd source tree, todo validate
+
+    if (!(ss->ss_flags & POSIX_SS_DISABLE) && ss->ss_size < POSIX_MINSIGSTKSZ) {
         SetPosixErrno(POSIX_ENOMEM);
         return -1;
     }
@@ -506,9 +508,9 @@ s32 PS4_SYSV_ABI posix_pthread_kill(PthreadT thread, s32 sig) {
     USER_APC_OPTION option;
     option.UserApcFlags = QueueUserApcFlagsSpecialUserApc;
 
-    u64 res = NtQueueApcThreadEx(reinterpret_cast<HANDLE>(thread->native_thr->GetHandle()), option,
-                                 ExceptionHandler, (void*)thread->name.c_str(),
-                                 (void*)(s64)sig, nullptr);
+    u64 res =
+        NtQueueApcThreadEx(reinterpret_cast<HANDLE>(thread->native_thr->GetHandle()), option,
+                           ExceptionHandler, (void*)thread->name.c_str(), (void*)(s64)sig, nullptr);
     ASSERT(res == 0);
 #endif
     return ORBIS_OK;

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -15,23 +15,127 @@
 #include "common/ntapi.h"
 #else
 #include <csignal>
+#include <sys/ucontext.h>
 #endif
 #include <unordered_set>
+#include "exception.h"
 
 namespace Libraries::Kernel {
 
-#ifdef _WIN32
-
-// Windows doesn't have native versions of these, and we don't need to use them either.
-s32 NativeToOrbisSignal(s32 s) {
-    return s;
-}
-
-s32 OrbisToNativeSignal(s32 s) {
-    return s;
-}
-
+Ucontext::Ucontext(siginfo_t const* inf, ucontext_t const* raw_context) {
+    if (!inf || !raw_context) {
+        return;
+    }
+#ifdef ARCH_X86_64
+#ifdef __APPLE__
+    const auto& regs = raw_context->uc_mcontext->__ss;
+    uc_mcontext.mc_r8 = regs.__r8;
+    uc_mcontext.mc_r9 = regs.__r9;
+    uc_mcontext.mc_r10 = regs.__r10;
+    uc_mcontext.mc_r11 = regs.__r11;
+    uc_mcontext.mc_r12 = regs.__r12;
+    uc_mcontext.mc_r13 = regs.__r13;
+    uc_mcontext.mc_r14 = regs.__r14;
+    uc_mcontext.mc_r15 = regs.__r15;
+    uc_mcontext.mc_rdi = regs.__rdi;
+    uc_mcontext.mc_rsi = regs.__rsi;
+    uc_mcontext.mc_rbp = regs.__rbp;
+    uc_mcontext.mc_rbx = regs.__rbx;
+    uc_mcontext.mc_rdx = regs.__rdx;
+    uc_mcontext.mc_rax = regs.__rax;
+    uc_mcontext.mc_rcx = regs.__rcx;
+    uc_mcontext.mc_rsp = regs.__rsp;
+    uc_mcontext.mc_fs = regs.__fs;
+    uc_mcontext.mc_gs = regs.__gs;
+    uc_mcontext.mc_rip = regs.__rip;
+    uc_mcontext.mc_addr = reinterpret_cast<uint64_t>(inf->si_addr);
+#elif defined(__FreeBSD__)
+    const auto& regs = raw_context->uc_mcontext;
+    uc_mcontext.mc_r8 = regs.mc_r8;
+    uc_mcontext.mc_r9 = regs.mc_r9;
+    uc_mcontext.mc_r10 = regs.mc_r10;
+    uc_mcontext.mc_r11 = regs.mc_r11;
+    uc_mcontext.mc_r12 = regs.mc_r12;
+    uc_mcontext.mc_r13 = regs.mc_r13;
+    uc_mcontext.mc_r14 = regs.mc_r14;
+    uc_mcontext.mc_r15 = regs.mc_r15;
+    uc_mcontext.mc_rdi = regs.mc_rdi;
+    uc_mcontext.mc_rsi = regs.mc_rsi;
+    uc_mcontext.mc_rbp = regs.mc_rbp;
+    uc_mcontext.mc_rbx = regs.mc_rbx;
+    uc_mcontext.mc_rdx = regs.mc_rdx;
+    uc_mcontext.mc_rax = regs.mc_rax;
+    uc_mcontext.mc_rcx = regs.mc_rcx;
+    uc_mcontext.mc_rsp = regs.mc_rsp;
+    uc_mcontext.mc_fs = regs.mc_fs;
+    uc_mcontext.mc_gs = regs.mc_gs;
+    uc_mcontext.mc_rip = regs.mc_rip;
+    uc_mcontext.mc_addr = uint64_t(regs.mc_addr);
 #else
+    const auto& regs = raw_context->uc_mcontext.gregs;
+    uc_mcontext.mc_r8 = regs[REG_R8];
+    uc_mcontext.mc_r9 = regs[REG_R9];
+    uc_mcontext.mc_r10 = regs[REG_R10];
+    uc_mcontext.mc_r11 = regs[REG_R11];
+    uc_mcontext.mc_r12 = regs[REG_R12];
+    uc_mcontext.mc_r13 = regs[REG_R13];
+    uc_mcontext.mc_r14 = regs[REG_R14];
+    uc_mcontext.mc_r15 = regs[REG_R15];
+    uc_mcontext.mc_rdi = regs[REG_RDI];
+    uc_mcontext.mc_rsi = regs[REG_RSI];
+    uc_mcontext.mc_rbp = regs[REG_RBP];
+    uc_mcontext.mc_rbx = regs[REG_RBX];
+    uc_mcontext.mc_rdx = regs[REG_RDX];
+    uc_mcontext.mc_rax = regs[REG_RAX];
+    uc_mcontext.mc_rcx = regs[REG_RCX];
+    uc_mcontext.mc_rsp = regs[REG_RSP];
+    uc_mcontext.mc_fs = (regs[REG_CSGSFS] >> 32) & 0xFFFF;
+    uc_mcontext.mc_gs = (regs[REG_CSGSFS] >> 16) & 0xFFFF;
+    uc_mcontext.mc_rip = regs[REG_RIP];
+    uc_mcontext.mc_addr = reinterpret_cast<uint64_t>(inf->si_addr);
+#endif
+#else
+    UNREACHABLE_MSG("SigactionHandler not implemented for current architecture.");
+#endif
+}
+
+std::array<Sigaction, 128> PosixActions{};
+Sigset g_sigintr{};
+
+constexpr s32 HostSoftwareSignal = SIGUSR1;
+
+#ifdef _WIN64
+void ExceptionHandler(void* arg1, void* arg2, void* arg3, PCONTEXT context) {
+    const char* thrName = (char*)arg1;
+    s32 const native_signum = reinterpret_cast<uintptr_t>(arg2);
+    LOG_INFO(Lib_Kernel, "Exception raised successfully on thread '{}'", thrName);
+    const auto handler = sceSigactionCallbacks[NativeToOrbisSignal(native_signum)];
+    if (handler) {
+        auto ctx = Ucontext{};
+        ctx.uc_mcontext.mc_r8 = context->R8;
+        ctx.uc_mcontext.mc_r9 = context->R9;
+        ctx.uc_mcontext.mc_r10 = context->R10;
+        ctx.uc_mcontext.mc_r11 = context->R11;
+        ctx.uc_mcontext.mc_r12 = context->R12;
+        ctx.uc_mcontext.mc_r13 = context->R13;
+        ctx.uc_mcontext.mc_r14 = context->R14;
+        ctx.uc_mcontext.mc_r15 = context->R15;
+        ctx.uc_mcontext.mc_rdi = context->Rdi;
+        ctx.uc_mcontext.mc_rsi = context->Rsi;
+        ctx.uc_mcontext.mc_rbp = context->Rbp;
+        ctx.uc_mcontext.mc_rbx = context->Rbx;
+        ctx.uc_mcontext.mc_rdx = context->Rdx;
+        ctx.uc_mcontext.mc_rax = context->Rax;
+        ctx.uc_mcontext.mc_rcx = context->Rcx;
+        ctx.uc_mcontext.mc_rsp = context->Rsp;
+        ctx.uc_mcontext.mc_fs = context->SegFs;
+        ctx.uc_mcontext.mc_gs = context->SegGs;
+        handler(NativeToOrbisSignal(native_signum), &ctx);
+    } else {
+        UNREACHABLE_MSG("Unhandled exception");
+    }
+}
+#endif
 
 s32 NativeToOrbisSignal(s32 s) {
     switch (s) {
@@ -97,212 +201,12 @@ s32 NativeToOrbisSignal(s32 s) {
         return POSIX_SIGEMT;
     case _SIGINFO:
         return POSIX_SIGINFO;
-    case 0:
-        return 128;
     default:
-        if (s > 0 && s < 128) {
-            return s;
-        }
-        UNREACHABLE_MSG("Unknown signal {}", s);
+        // This is only needed for a few hardware signals now, so it needn't worry about about RT
+        // ones anymore.
+        UNREACHABLE_MSG("Signal {} has no job being here", s);
     }
 }
-
-s32 OrbisToNativeSignal(s32 s) {
-    switch (s) {
-    case POSIX_SIGHUP:
-        return SIGHUP;
-    case POSIX_SIGINT:
-        return SIGINT;
-    case POSIX_SIGQUIT:
-        return SIGQUIT;
-    case POSIX_SIGILL:
-        return SIGILL;
-    case POSIX_SIGTRAP:
-        return SIGTRAP;
-    case POSIX_SIGABRT:
-        return SIGABRT;
-    case POSIX_SIGEMT:
-        return _SIGEMT;
-    case POSIX_SIGFPE:
-        return SIGFPE;
-    case POSIX_SIGKILL:
-        return SIGKILL;
-    case POSIX_SIGBUS:
-        return SIGBUS;
-    case POSIX_SIGSEGV:
-        return SIGSEGV;
-    case POSIX_SIGSYS:
-        return SIGSYS;
-    case POSIX_SIGPIPE:
-        return SIGPIPE;
-    case POSIX_SIGALRM:
-        return SIGALRM;
-    case POSIX_SIGTERM:
-        return SIGTERM;
-    case POSIX_SIGURG:
-        return SIGURG;
-    case POSIX_SIGSTOP:
-        return SIGSTOP;
-    case POSIX_SIGTSTP:
-        return SIGTSTP;
-    case POSIX_SIGCONT:
-        return SIGCONT;
-    case POSIX_SIGCHLD:
-        return SIGCHLD;
-    case POSIX_SIGTTIN:
-        return SIGTTIN;
-    case POSIX_SIGTTOU:
-        return SIGTTOU;
-    case POSIX_SIGIO:
-        return SIGIO;
-    case POSIX_SIGXCPU:
-        return SIGXCPU;
-    case POSIX_SIGXFSZ:
-        return SIGXFSZ;
-    case POSIX_SIGVTALRM:
-        return SIGVTALRM;
-    case POSIX_SIGPROF:
-        return SIGPROF;
-    case POSIX_SIGWINCH:
-        return SIGWINCH;
-    case POSIX_SIGINFO:
-        return _SIGINFO;
-    case POSIX_SIGUSR1:
-        return SIGUSR1;
-    case POSIX_SIGUSR2:
-        return SIGUSR2;
-    case 128:
-        return 0;
-    default:
-        if (s > 0 && s < 128) {
-            return s;
-        }
-        UNREACHABLE_MSG("Unknown signal {}", s);
-    }
-}
-
-#endif
-
-#ifdef __APPLE__
-#define sigisemptyset(x) (*(x) == 0)
-#endif
-
-std::array<OrbisKernelExceptionHandler, 130> Handlers{};
-Sigset g_sigintr{};
-
-#ifndef _WIN64
-void SigactionHandler(int native_signum, siginfo_t* inf, ucontext_t* raw_context) {
-    const auto handler = Handlers[NativeToOrbisSignal(native_signum)];
-    if (handler) {
-        auto ctx = Ucontext{};
-#ifdef ARCH_X86_64
-#ifdef __APPLE__
-        const auto& regs = raw_context->uc_mcontext->__ss;
-        ctx.uc_mcontext.mc_r8 = regs.__r8;
-        ctx.uc_mcontext.mc_r9 = regs.__r9;
-        ctx.uc_mcontext.mc_r10 = regs.__r10;
-        ctx.uc_mcontext.mc_r11 = regs.__r11;
-        ctx.uc_mcontext.mc_r12 = regs.__r12;
-        ctx.uc_mcontext.mc_r13 = regs.__r13;
-        ctx.uc_mcontext.mc_r14 = regs.__r14;
-        ctx.uc_mcontext.mc_r15 = regs.__r15;
-        ctx.uc_mcontext.mc_rdi = regs.__rdi;
-        ctx.uc_mcontext.mc_rsi = regs.__rsi;
-        ctx.uc_mcontext.mc_rbp = regs.__rbp;
-        ctx.uc_mcontext.mc_rbx = regs.__rbx;
-        ctx.uc_mcontext.mc_rdx = regs.__rdx;
-        ctx.uc_mcontext.mc_rax = regs.__rax;
-        ctx.uc_mcontext.mc_rcx = regs.__rcx;
-        ctx.uc_mcontext.mc_rsp = regs.__rsp;
-        ctx.uc_mcontext.mc_fs = regs.__fs;
-        ctx.uc_mcontext.mc_gs = regs.__gs;
-        ctx.uc_mcontext.mc_rip = regs.__rip;
-        ctx.uc_mcontext.mc_addr = reinterpret_cast<uint64_t>(inf->si_addr);
-#elif defined(__FreeBSD__)
-        const auto& regs = raw_context->uc_mcontext;
-        ctx.uc_mcontext.mc_r8 = regs.mc_r8;
-        ctx.uc_mcontext.mc_r9 = regs.mc_r9;
-        ctx.uc_mcontext.mc_r10 = regs.mc_r10;
-        ctx.uc_mcontext.mc_r11 = regs.mc_r11;
-        ctx.uc_mcontext.mc_r12 = regs.mc_r12;
-        ctx.uc_mcontext.mc_r13 = regs.mc_r13;
-        ctx.uc_mcontext.mc_r14 = regs.mc_r14;
-        ctx.uc_mcontext.mc_r15 = regs.mc_r15;
-        ctx.uc_mcontext.mc_rdi = regs.mc_rdi;
-        ctx.uc_mcontext.mc_rsi = regs.mc_rsi;
-        ctx.uc_mcontext.mc_rbp = regs.mc_rbp;
-        ctx.uc_mcontext.mc_rbx = regs.mc_rbx;
-        ctx.uc_mcontext.mc_rdx = regs.mc_rdx;
-        ctx.uc_mcontext.mc_rax = regs.mc_rax;
-        ctx.uc_mcontext.mc_rcx = regs.mc_rcx;
-        ctx.uc_mcontext.mc_rsp = regs.mc_rsp;
-        ctx.uc_mcontext.mc_fs = regs.mc_fs;
-        ctx.uc_mcontext.mc_gs = regs.mc_gs;
-        ctx.uc_mcontext.mc_rip = regs.mc_rip;
-        ctx.uc_mcontext.mc_addr = uint64_t(regs.mc_addr);
-#else
-        const auto& regs = raw_context->uc_mcontext.gregs;
-        ctx.uc_mcontext.mc_r8 = regs[REG_R8];
-        ctx.uc_mcontext.mc_r9 = regs[REG_R9];
-        ctx.uc_mcontext.mc_r10 = regs[REG_R10];
-        ctx.uc_mcontext.mc_r11 = regs[REG_R11];
-        ctx.uc_mcontext.mc_r12 = regs[REG_R12];
-        ctx.uc_mcontext.mc_r13 = regs[REG_R13];
-        ctx.uc_mcontext.mc_r14 = regs[REG_R14];
-        ctx.uc_mcontext.mc_r15 = regs[REG_R15];
-        ctx.uc_mcontext.mc_rdi = regs[REG_RDI];
-        ctx.uc_mcontext.mc_rsi = regs[REG_RSI];
-        ctx.uc_mcontext.mc_rbp = regs[REG_RBP];
-        ctx.uc_mcontext.mc_rbx = regs[REG_RBX];
-        ctx.uc_mcontext.mc_rdx = regs[REG_RDX];
-        ctx.uc_mcontext.mc_rax = regs[REG_RAX];
-        ctx.uc_mcontext.mc_rcx = regs[REG_RCX];
-        ctx.uc_mcontext.mc_rsp = regs[REG_RSP];
-        ctx.uc_mcontext.mc_fs = (regs[REG_CSGSFS] >> 32) & 0xFFFF;
-        ctx.uc_mcontext.mc_gs = (regs[REG_CSGSFS] >> 16) & 0xFFFF;
-        ctx.uc_mcontext.mc_rip = (regs[REG_RIP]);
-        ctx.uc_mcontext.mc_addr = reinterpret_cast<uint64_t>(inf->si_addr);
-#endif
-#else
-        UNREACHABLE_MSG("SigactionHandler not implemented for current architecture.");
-#endif
-        handler(NativeToOrbisSignal(native_signum), &ctx);
-    } else {
-        UNREACHABLE_MSG("Unhandled exception");
-    }
-}
-#else
-void ExceptionHandler(void* arg1, void* arg2, void* arg3, PCONTEXT context) {
-    const char* thrName = (char*)arg1;
-    int native_signum = reinterpret_cast<uintptr_t>(arg2);
-    LOG_INFO(Lib_Kernel, "Exception raised successfully on thread '{}'", thrName);
-    const auto handler = Handlers[NativeToOrbisSignal(native_signum)];
-    if (handler) {
-        auto ctx = Ucontext{};
-        ctx.uc_mcontext.mc_r8 = context->R8;
-        ctx.uc_mcontext.mc_r9 = context->R9;
-        ctx.uc_mcontext.mc_r10 = context->R10;
-        ctx.uc_mcontext.mc_r11 = context->R11;
-        ctx.uc_mcontext.mc_r12 = context->R12;
-        ctx.uc_mcontext.mc_r13 = context->R13;
-        ctx.uc_mcontext.mc_r14 = context->R14;
-        ctx.uc_mcontext.mc_r15 = context->R15;
-        ctx.uc_mcontext.mc_rdi = context->Rdi;
-        ctx.uc_mcontext.mc_rsi = context->Rsi;
-        ctx.uc_mcontext.mc_rbp = context->Rbp;
-        ctx.uc_mcontext.mc_rbx = context->Rbx;
-        ctx.uc_mcontext.mc_rdx = context->Rdx;
-        ctx.uc_mcontext.mc_rax = context->Rax;
-        ctx.uc_mcontext.mc_rcx = context->Rcx;
-        ctx.uc_mcontext.mc_rsp = context->Rsp;
-        ctx.uc_mcontext.mc_fs = context->SegFs;
-        ctx.uc_mcontext.mc_gs = context->SegGs;
-        handler(NativeToOrbisSignal(native_signum), &ctx);
-    } else {
-        UNREACHABLE_MSG("Unhandled exception");
-    }
-}
-#endif
 
 s32 PS4_SYSV_ABI posix_sigemptyset(Sigset* s) {
     s->bits[0] = 0;
@@ -321,8 +225,8 @@ s32 PS4_SYSV_ABI posix_sigfillset(Sigset* s) {
 }
 
 s32 PS4_SYSV_ABI posix_sigaddset(Sigset* s, s32 sig) {
-    s32 val = sig - 1;
-    if (val >= 0x80) {
+    s32 const val = sig - 1;
+    if (val < 0 || val >= 0x80) {
         *Libraries::Kernel::__Error() = POSIX_EINVAL;
         return ORBIS_FAIL;
     }
@@ -331,8 +235,8 @@ s32 PS4_SYSV_ABI posix_sigaddset(Sigset* s, s32 sig) {
 }
 
 s32 PS4_SYSV_ABI posix_sigdelset(Sigset* s, s32 sig) {
-    s32 val = sig - 1;
-    if (val >= 0x80) {
+    s32 const val = sig - 1;
+    if (val < 0 || val >= 0x80) {
         *Libraries::Kernel::__Error() = POSIX_EINVAL;
         return ORBIS_FAIL;
     }
@@ -340,9 +244,9 @@ s32 PS4_SYSV_ABI posix_sigdelset(Sigset* s, s32 sig) {
     return ORBIS_OK;
 }
 
-s32 PS4_SYSV_ABI posix_sigismember(Sigset* s, s32 sig) {
-    s32 val = sig - 1;
-    if (val >= 0x80) {
+s32 PS4_SYSV_ABI posix_sigismember(Sigset const* s, s32 sig) {
+    s32 const val = sig - 1;
+    if (val < 0 || val >= 0x80) {
         *Libraries::Kernel::__Error() = POSIX_EINVAL;
         return ORBIS_FAIL;
     }
@@ -353,89 +257,46 @@ bool PS4_SYSV_ABI posix_sigisemptyset(Sigset* s) {
     return s->bits[0] == 0 && s->bits[1] == 0 && s->bits[2] == 0 && s->bits[3] == 0;
 }
 
-#ifndef _WIN32
-static void GuestSigsetToNative(const Sigset& guest, sigset_t& native) {
-    sigemptyset(&native);
-
-    for (s32 sig = 1; sig <= 128; sig++) {
-        if (posix_sigismember(const_cast<Sigset*>(&guest), sig) != 0) {
-            const s32 native_sig = OrbisToNativeSignal(sig);
-            if (native_sig > 0 && native_sig <= 128) {
-                sigaddset(&native, native_sig);
-            }
-        }
-    }
-}
-
-static void NativeSigsetToGuest(const sigset_t& native, Sigset& guest) {
-    posix_sigemptyset(&guest);
-
-    for (s32 sig = 1; sig <= 128; sig++) {
-        const s32 native_sig = OrbisToNativeSignal(sig);
-        if (native_sig > 0 && native_sig <= 128 && sigismember(&native, native_sig) == 1) {
-            posix_sigaddset(&guest, sig);
-        }
-    }
-}
-#endif
-
-s32 PS4_SYSV_ABI posix_sigprocmask(s32 how, const Sigset* set, Sigset* oset) {
-    LOG_ERROR(Lib_Kernel, "(STUBBED) called, how = {}", how);
-    return ORBIS_OK;
-}
-
-constexpr s32 POSIX_SS_ONSTACK = 0x0001; /* take signal on alternate stack */
-constexpr s32 POSIX_SS_DISABLE = 0x0004; /* disable taking signals on alternate stack */
-
 s32 PS4_SYSV_ABI posix_sigaltstack(const OrbisKernelExceptionHandlerStack* ss,
                                    OrbisKernelExceptionHandlerStack* old_ss) {
-    s32 ret = 0;
-#ifndef _WIN32
-    stack_t native_ss{};
-    if (ss) {
-        LOG_INFO(Lib_Kernel, "called, ss.ss_size: {}, ss.ss_sp: {}, ss.ss_flags: {:#x}",
-                 ss->ss_size, ss->ss_sp, ss->ss_flags);
-        native_ss.ss_sp = ss->ss_sp;
-        native_ss.ss_size = ss->ss_size == 0 ? 0 : std::max(ss->ss_size, (u64)MINSIGSTKSZ + 0x1000);
-        u32 guest_ss_flags = ss->ss_flags;
-        if ((guest_ss_flags & POSIX_SS_ONSTACK)) {
-            native_ss.ss_flags |= SS_ONSTACK;
-            guest_ss_flags &= ~POSIX_SS_ONSTACK;
-        }
-        if ((guest_ss_flags & POSIX_SS_DISABLE)) {
-            native_ss.ss_flags |= SS_DISABLE;
-            guest_ss_flags &= ~POSIX_SS_DISABLE;
-        }
-        if (guest_ss_flags != 0) {
-            LOG_ERROR(Lib_Kernel, "Unrecognized guest flag(s): {:#x}", guest_ss_flags);
-        }
+    auto* thread = g_curthread;
+    if (thread == nullptr) {
+        SetPosixErrno(POSIX_EINVAL);
+        return -1;
     }
-    stack_t native_old_ss{};
-    ret = sigaltstack(ss ? &native_ss : nullptr, old_ss ? &native_old_ss : nullptr);
-    if (ret < 0) {
-        SetPosixErrno(errno);
-        LOG_ERROR(Lib_Kernel, "sigaltstack returned {} {}", errno, strerror(errno));
-    }
+
     if (old_ss) {
-        old_ss->ss_sp = native_old_ss.ss_sp;
-        old_ss->ss_size = native_old_ss.ss_size;
-        u32 host_ss_flags = native_old_ss.ss_flags;
-        if ((host_ss_flags & SS_ONSTACK)) {
-            old_ss->ss_flags |= POSIX_SS_ONSTACK;
-            host_ss_flags &= ~SS_ONSTACK;
-        }
-        if ((host_ss_flags & SS_DISABLE)) {
-            old_ss->ss_flags |= POSIX_SS_DISABLE;
-            host_ss_flags &= ~SS_DISABLE;
-        }
-        if (host_ss_flags != 0) {
-            LOG_ERROR(Lib_Kernel, "Unrecognized host flag(s): {:#x}", host_ss_flags);
-        }
+        *old_ss = thread->sigaltstack;
     }
-#else
-    LOG_ERROR(Lib_Kernel, "(stubbed)");
-#endif
-    return ret;
+
+    if (ss == nullptr) {
+        return 0;
+    }
+
+    if ((ss->ss_flags & ~(POSIX_SS_ONSTACK | POSIX_SS_DISABLE)) != 0) {
+        SetPosixErrno(POSIX_EINVAL);
+        return -1;
+    }
+
+    if ((ss->ss_flags & POSIX_SS_ONSTACK) && !(thread->sigaltstack.ss_flags & POSIX_SS_ONSTACK)) {
+        // SS_ONSTACK is normally reported by the kernel rather than something
+        // userspace explicitly sets when installing a stack.
+        SetPosixErrno(POSIX_EINVAL);
+        return -1;
+    }
+
+    if (!(ss->ss_flags & POSIX_SS_DISABLE) && ss->ss_size < MINSIGSTKSZ) {
+        SetPosixErrno(POSIX_ENOMEM);
+        return -1;
+    }
+
+    thread->sigaltstack = *ss;
+
+    if (!(ss->ss_flags & POSIX_SS_DISABLE)) {
+        thread->sigaltstack.ss_flags &= ~POSIX_SS_ONSTACK;
+    }
+
+    return 0;
 }
 
 s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
@@ -446,7 +307,7 @@ s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
     }
 #ifdef _WIN32
     LOG_ERROR(Lib_Kernel, "(STUBBED) called, sig: {}", sig);
-    Handlers[sig] = reinterpret_cast<OrbisKernelExceptionHandler>(
+    sceSigactionCallbacks[sig] = reinterpret_cast<OrbisKernelExceptionHandler>(
         act ? act->__sigaction_handler.sigaction : nullptr);
     if (oact) {
         memset(oact, 0, sizeof(*oact));
@@ -457,72 +318,12 @@ s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
         oact->sa_flags = act->sa_flags;
     }
 #else
-    s32 native_sig = OrbisToNativeSignal(sig);
-    if (native_sig == SIGVTALRM || IsPthreadCancelSignal(native_sig)) {
-        LOG_ERROR(Lib_Kernel, "Guest is attempting to use the HLE-reserved signal {}!", sig);
-        *__Error() = POSIX_EINVAL;
-        return ORBIS_FAIL;
-    }
-#if !defined(__APPLE__) && !defined(__FreeBSD__)
-    if (native_sig >= __SIGRTMIN && native_sig < SIGRTMIN) {
-        LOG_ERROR(Lib_Kernel, "Guest is attempting to use the HLE libc-reserved signal {}!", sig);
-        *__Error() = POSIX_EINVAL;
-        return ORBIS_FAIL;
-    }
-#else
-    if (native_sig > SIGUSR2) {
-        LOG_ERROR(Lib_Kernel,
-                  "Guest is attempting to use SIGRT signals, which aren't available on this "
-                  "platform (signal: {})!",
-                  sig);
-    }
-#endif
-    LOG_INFO(Lib_Kernel, "called, sig: {}, native sig: {}", sig, native_sig);
-    struct sigaction native_act{};
-    if (act) {
-        native_act.sa_flags = act->sa_flags;
-        native_act.sa_sigaction =
-            reinterpret_cast<decltype(native_act.sa_sigaction)>(SigactionHandler);
-        GuestSigsetToNative(act->sa_mask, native_act.sa_mask);
+    if (oact != nullptr) {
+        *oact = PosixActions[sig - 1];
     }
 
-    const auto prev_handler = Handlers[sig];
-
-    if (native_sig == SIGSEGV || native_sig == SIGBUS || native_sig == SIGILL) {
-        Handlers[sig] = reinterpret_cast<OrbisKernelExceptionHandler>(
-            act ? act->__sigaction_handler.sigaction : nullptr);
-
-        if (oact) {
-            oact->sa_flags = 0;
-            oact->__sigaction_handler.sigaction =
-                reinterpret_cast<decltype(oact->__sigaction_handler.sigaction)>(prev_handler);
-            posix_sigemptyset(&oact->sa_mask);
-        }
-
-        return ORBIS_OK;
-    }
-    if (native_sig > 127) {
-        LOG_WARNING(Lib_Kernel, "We can't install a handler for native signal {}!", native_sig);
-        return ORBIS_OK;
-    }
-    struct sigaction native_oact{};
-    const s32 ret =
-        sigaction(native_sig, act ? &native_act : nullptr, oact ? &native_oact : nullptr);
-
-    if (ret < 0) {
-        LOG_ERROR(Lib_Kernel, "sigaction failed: {}", strerror(errno));
-        SetPosixErrno(errno);
-        return ORBIS_FAIL;
-    }
-
-    Handlers[sig] = reinterpret_cast<OrbisKernelExceptionHandler>(
-        act ? act->__sigaction_handler.sigaction : nullptr);
-
-    if (oact) {
-        oact->sa_flags = native_oact.sa_flags;
-        oact->__sigaction_handler.sigaction =
-            reinterpret_cast<decltype(oact->__sigaction_handler.sigaction)>(prev_handler);
-        NativeSigsetToGuest(native_oact.sa_mask, oact->sa_mask);
+    if (act != nullptr) {
+        PosixActions[sig - 1] = *act;
     }
 #endif
     return ORBIS_OK;
@@ -530,37 +331,71 @@ s32 PS4_SYSV_ABI posix_sigaction(s32 sig, Sigaction* act, Sigaction* oact) {
 
 s32 PS4_SYSV_ABI posix_pthread_sigmask(s32 how, const Sigset* set, Sigset* oset) {
 #ifndef _WIN32
-    sigset_t native_set{};
-    sigset_t native_oset{};
+    auto* thread = g_curthread;
 
-    sigset_t* native_set_ptr = nullptr;
-    if (set) {
-        sigemptyset(&native_set);
-        for (s32 sig = 1; sig <= 128; sig++) {
-            if (posix_sigismember(const_cast<Sigset*>(set), sig) != 0) {
-                const s32 native_sig = OrbisToNativeSignal(sig);
-                if (native_sig > 0 && native_sig <= 128) {
-                    sigaddset(&native_set, native_sig);
-                }
-            }
-        }
-        native_set_ptr = &native_set;
+    if (thread == nullptr) {
+        return POSIX_EINVAL;
     }
 
-    const int ret = pthread_sigmask(how, native_set_ptr, oset ? &native_oset : nullptr);
-    if (ret != 0) {
-        SetPosixErrno(errno);
-        return ORBIS_FAIL;
-    }
+    Sigset old_mask{};
+    thread->GetGuestSigmask(old_mask);
 
     if (oset) {
-        posix_sigemptyset(oset);
+        *oset = old_mask;
+    }
 
-        for (s32 sig = 1; sig <= 128; sig++) {
-            const s32 native_sig = OrbisToNativeSignal(sig);
-            if (native_sig > 0 && native_sig <= 128 && sigismember(&native_oset, native_sig) == 1) {
-                posix_sigaddset(oset, sig);
-            }
+    if (!set) {
+        return ORBIS_OK;
+    }
+
+    Sigset new_mask = old_mask;
+
+    constexpr s32 POSIX_SIG_BLOCK = 0;
+    constexpr s32 POSIX_SIG_UNBLOCK = 1;
+    constexpr s32 POSIX_SIG_SETMASK = 2;
+
+    switch (how) {
+    case POSIX_SIG_BLOCK:
+        for (size_t i = 0; i < 4; i++) {
+            new_mask.bits[i] |= set->bits[i];
+        }
+        break;
+
+    case POSIX_SIG_UNBLOCK:
+        for (size_t i = 0; i < 4; i++) {
+            new_mask.bits[i] &= ~set->bits[i];
+        }
+        break;
+
+    case POSIX_SIG_SETMASK:
+        new_mask = *set;
+        break;
+
+    default:
+        return POSIX_EINVAL;
+    }
+
+    thread->SetGuestSigmask(new_mask);
+    if (thread->HasDeliverableSignal()) {
+        thread->WakeForSignal();
+    }
+#else
+    LOG_ERROR(Lib_Kernel, "(STUBBED) called");
+#endif
+    return ORBIS_OK;
+}
+
+s32 PS4_SYSV_ABI posix_sigprocmask(s32 how, const Sigset* set, Sigset* oset) {
+    return posix_pthread_sigmask(how, set, oset);
+}
+
+s32 PS4_SYSV_ABI posix_sigpending(Sigset* set) {
+#ifndef _WIN32
+    posix_sigemptyset(set);
+
+    for (s32 sig = 1; sig <= 128; sig++) {
+        if (g_curthread->pending_signal_counts[sig - 1].load(std::memory_order_acquire) != 0) {
+            posix_sigaddset(set, sig);
         }
     }
 
@@ -573,28 +408,29 @@ s32 PS4_SYSV_ABI posix_pthread_sigmask(s32 how, const Sigset* set, Sigset* oset)
 
 s32 PS4_SYSV_ABI posix_sigsuspend(const Sigset* sigmask) {
 #ifndef _WIN32
-    sigset_t native_mask;
-    sigemptyset(&native_mask);
+    Sigset old_mask{};
+    auto& thr = g_curthread;
+    thr->GetGuestSigmask(old_mask);
 
-    if (sigmask) {
-        for (s32 sig = 1; sig <= 128; sig++) {
-            if (posix_sigismember(const_cast<Sigset*>(sigmask), sig) != 0) {
-                const s32 native_sig = OrbisToNativeSignal(sig);
-                if (native_sig > 0 && native_sig <= 128) {
-                    sigaddset(&native_mask, native_sig);
-                }
-            }
-        }
+    thr->sigsuspend_interrupted.store(false, std::memory_order_release);
+    thr->in_sigsuspend.store(true, std::memory_order_release);
+
+    thr->SetGuestSigmask(*sigmask);
+
+    while (!thr->sigsuspend_interrupted.load(std::memory_order_acquire)) {
+        thr->signal_sema.acquire();
     }
 
-    const int ret = sigsuspend(&native_mask);
-    ASSERT(ret == -1);
+    thr->in_sigsuspend.store(false, std::memory_order_release);
 
-    SetPosixErrno(errno);
+    thr->SetGuestSigmask(old_mask);
+
+    *__Error() = POSIX_EINTR;
     return ORBIS_FAIL;
 #else
     LOG_ERROR(Lib_Kernel, "(STUBBED) called");
-    return ORBIS_OK;
+    *__Error() = POSIX_EINTR;
+    return ORBIS_FAIL;
 #endif
 }
 
@@ -604,21 +440,34 @@ s32 PS4_SYSV_ABI posix_sigwait(const Sigset* set, s32* sig) {
         return POSIX_EINVAL;
     }
 
-    sigset_t native_set;
-    GuestSigsetToNative(*set, native_set);
-
-    int native_sig;
-    const int ret = sigwait(&native_set, &native_sig);
-    if (ret != 0) {
-        SetPosixErrno(errno);
+    auto* thread = g_curthread;
+    if (thread == nullptr) {
+        return POSIX_EINVAL;
     }
 
-    s32 guest_sig = NativeToOrbisSignal(native_sig);
+    thread->sigwait_set = *set;
+    thread->in_sigwait.store(true, std::memory_order_release);
 
-    return ORBIS_OK;
+    auto finish = [&] {
+        thread->in_sigwait.store(false, std::memory_order_release);
+        posix_sigemptyset(&thread->sigwait_set);
+    };
+
+    while (true) {
+        const s32 pending = thread->FindPendingSignal(*set);
+
+        if (pending != 0 && thread->ConsumeSignal(pending)) {
+            *sig = pending;
+            finish();
+            return ORBIS_OK;
+        }
+
+        thread->signal_sema.acquire();
+    }
 #else
     LOG_ERROR(Lib_Kernel, "(STUBBED) called");
     return ORBIS_OK;
+
 #endif
 }
 
@@ -631,7 +480,7 @@ SigHandler PS4_SYSV_ABI posix_signal(s32 sig, SigHandler func) {
         act.sa_flags |= POSIX_SA_RESTART;
     }
     Sigaction oact{};
-    s32 result = posix_sigaction(sig, &act, &oact);
+    s32 const result = posix_sigaction(sig, &act, &oact);
     if (result >= ORBIS_OK) {
         return oact.__sigaction_handler.handler;
     }
@@ -639,17 +488,15 @@ SigHandler PS4_SYSV_ABI posix_signal(s32 sig, SigHandler func) {
 }
 
 s32 PS4_SYSV_ABI posix_pthread_kill(PthreadT thread, s32 sig) {
-    if (sig < 1 || sig > 128) { // off-by-one error?
+    if (sig < 1 || sig > 128) {
         return POSIX_EINVAL;
     }
-    LOG_WARNING(Lib_Kernel, "Raising signal {} on thread '{}'", sig, thread->name);
-    int const native_signum = OrbisToNativeSignal(sig);
+    LOG_INFO(Lib_Kernel, "Raising signal {} on thread '{}'", sig, thread->name);
 #ifndef _WIN64
-    const auto pthr = reinterpret_cast<pthread_t>(thread->native_thr->GetHandle());
-    const auto ret = pthread_kill(pthr, native_signum);
-    if (ret != 0) {
-        LOG_ERROR(Kernel, "Failed to send exception signal to thread '{}': {}", thread->name,
-                  strerror(errno));
+    thread->QueueSignal(sig);
+
+    if (!thread->IsSignalBlocked(sig)) {
+        thread->WakeForSignal();
     }
 #else
     USER_APC_OPTION option;
@@ -663,6 +510,19 @@ s32 PS4_SYSV_ABI posix_pthread_kill(PthreadT thread, s32 sig) {
     return ORBIS_OK;
 }
 
+s32 PS4_SYSV_ABI posix_raise(s32 sig) {
+    return posix_pthread_kill(g_curthread, sig);
+}
+
+std::array<OrbisKernelExceptionHandler, 128> sceSigactionCallbacks{};
+void PS4_SYSV_ABI sceCallbackHandler(int sig, Siginfo* info, Ucontext* context) {
+    auto const cb = sceSigactionCallbacks[sig - 1];
+    if (!cb) {
+        UNREACHABLE(); // should be impossible unless race conditions perhaps
+    }
+    cb(sig, context);
+}
+
 // libkernel has a check in sceKernelInstallExceptionHandler and sceKernelRemoveExceptionHandler for
 // validating if the application requested a handler for an allowed signal or not. However, that is
 // just a wrapper for sigaction, which itself does not have any such restrictions, and therefore
@@ -672,20 +532,20 @@ static std::unordered_set<s32> orbis_allowed_signals{
     POSIX_SIGHUP, POSIX_SIGILL, POSIX_SIGFPE, POSIX_SIGBUS, POSIX_SIGSEGV, POSIX_SIGUSR1,
 };
 
-int PS4_SYSV_ABI sceKernelInstallExceptionHandler(s32 signum, OrbisKernelExceptionHandler handler) {
+s32 PS4_SYSV_ABI sceKernelInstallExceptionHandler(s32 signum, OrbisKernelExceptionHandler handler) {
     if (!orbis_allowed_signals.contains(signum)) {
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
-    if (Handlers[signum] != nullptr) {
+    if (sceSigactionCallbacks[signum - 1] != nullptr) {
         return ORBIS_KERNEL_ERROR_EAGAIN;
     }
+    sceSigactionCallbacks[signum - 1] = handler;
     LOG_INFO(Lib_Kernel, "Installing signal handler for {}", signum);
     Sigaction act = {};
     act.sa_flags = POSIX_SA_SIGINFO | POSIX_SA_RESTART;
-    act.__sigaction_handler.sigaction =
-        reinterpret_cast<decltype(act.__sigaction_handler.sigaction)>(handler);
+    act.__sigaction_handler.sigaction = &sceCallbackHandler;
     posix_sigemptyset(&act.sa_mask);
-    s32 ret = posix_sigaction(signum, &act, nullptr);
+    s32 const ret = posix_sigaction(signum, &act, nullptr);
     if (ret < 0) {
         LOG_ERROR(Lib_Kernel, "Failed to add handler for signal {}: {}", signum,
                   strerror(*__Error()));
@@ -694,17 +554,15 @@ int PS4_SYSV_ABI sceKernelInstallExceptionHandler(s32 signum, OrbisKernelExcepti
     return ORBIS_OK;
 }
 
-int PS4_SYSV_ABI sceKernelRemoveExceptionHandler(s32 signum) {
+s32 PS4_SYSV_ABI sceKernelRemoveExceptionHandler(s32 signum) {
     if (!orbis_allowed_signals.contains(signum)) {
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
-    int const native_signum = OrbisToNativeSignal(signum);
-    Handlers[signum] = nullptr;
+    sceSigactionCallbacks[signum - 1] = nullptr;
     Sigaction act = {};
-    act.sa_flags = POSIX_SA_SIGINFO;
-    act.__sigaction_handler.sigaction = nullptr;
+    act.__sigaction_handler.handler = reinterpret_cast<SigHandler>(POSIX_SIG_DFL);
     posix_sigemptyset(&act.sa_mask);
-    s32 ret = posix_sigaction(signum, &act, nullptr);
+    s32 const ret = posix_sigaction(signum, &act, nullptr);
     if (ret < 0) {
         LOG_ERROR(Lib_Kernel, "Failed to remove handler for signal {}: {}", signum,
                   strerror(*__Error()));
@@ -713,11 +571,11 @@ int PS4_SYSV_ABI sceKernelRemoveExceptionHandler(s32 signum) {
     return ORBIS_OK;
 }
 
-int PS4_SYSV_ABI sceKernelRaiseException(PthreadT thread, int signum) {
+s32 PS4_SYSV_ABI sceKernelRaiseException(PthreadT thread, s32 signum) {
     if (signum != POSIX_SIGUSR1) {
         return ORBIS_KERNEL_ERROR_EINVAL;
     }
-    s32 ret = posix_pthread_kill(thread, signum);
+    s32 const ret = posix_pthread_kill(thread, signum);
     if (ret < 0) {
         return ErrnoToSceKernelError(ret);
     }
@@ -766,6 +624,8 @@ void RegisterException(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("JZKw5+Wrnaw", "libkernel", 1, "libkernel", posix_pthread_sigmask);
     LIB_FUNCTION("KZ-4qlqlpmo", "libkernel", 1, "libkernel", posix_sigsuspend);
     LIB_FUNCTION("mrbHXqK8wkg", "libkernel", 1, "libkernel", posix_sigwait);
+    LIB_FUNCTION("hpoDTzy9Yy0", "libkernel", 1, "libkernel", posix_sigpending);
+    LIB_FUNCTION("0t0-MxQNwK4", "libkernel", 1, "libkernel", posix_raise);
 
     LIB_FUNCTION("KiJEPEWRyUY", "libkernel_psmkit", 1, "libkernel", posix_sigaction);
     LIB_FUNCTION("VADc3MNQ3cM", "libkernel_psmkit", 1, "libkernel", posix_signal);
@@ -789,6 +649,8 @@ void RegisterException(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("yH-uQW3LbX0", "libScePosix", 1, "libkernel", posix_pthread_kill);
     LIB_FUNCTION("sHziAegVp74", "libScePosix", 1, "libkernel", posix_sigaltstack);
     LIB_FUNCTION("JZKw5+Wrnaw", "libScePosix", 1, "libkernel", posix_pthread_sigmask);
+    LIB_FUNCTION("hpoDTzy9Yy0", "libScePosix", 1, "libkernel", posix_sigpending);
+    LIB_FUNCTION("0t0-MxQNwK4", "libScePosix", 1, "libkernel", posix_raise);
 }
 
 } // namespace Libraries::Kernel

--- a/src/core/libraries/kernel/threads/exception.cpp
+++ b/src/core/libraries/kernel/threads/exception.cpp
@@ -105,12 +105,12 @@ std::array<Sigaction, 128> PosixActions{};
 std::array<OrbisKernelExceptionHandler, 128> sceSigactionCallbacks{};
 Sigset g_sigintr{};
 
-#ifndef _WIN64
+#ifdef _WIN64
 void ExceptionHandler(void* arg1, void* arg2, void* arg3, PCONTEXT context) {
     const char* thrName = (char*)arg1;
-    s32 const native_signum = reinterpret_cast<uintptr_t>(arg2);
+    s32 const sig = reinterpret_cast<uintptr_t>(arg2);
     LOG_INFO(Lib_Kernel, "Exception raised successfully on thread '{}'", thrName);
-    const auto handler = sceSigactionCallbacks[NativeToOrbisSignal(native_signum)];
+    const auto handler = sceSigactionCallbacks[sig];
     if (handler) {
         auto ctx = Ucontext{};
         ctx.uc_mcontext.mc_r8 = context->R8;
@@ -137,6 +137,9 @@ void ExceptionHandler(void* arg1, void* arg2, void* arg3, PCONTEXT context) {
     }
 }
 
+#endif
+
+#ifndef _WIN32
 s32 NativeToOrbisSignal(s32 s) {
     switch (s) {
     case SIGHUP:
@@ -505,7 +508,7 @@ s32 PS4_SYSV_ABI posix_pthread_kill(PthreadT thread, s32 sig) {
 
     u64 res = NtQueueApcThreadEx(reinterpret_cast<HANDLE>(thread->native_thr->GetHandle()), option,
                                  ExceptionHandler, (void*)thread->name.c_str(),
-                                 (void*)(s64)native_signum, nullptr);
+                                 (void*)(s64)sig, nullptr);
     ASSERT(res == 0);
 #endif
     return ORBIS_OK;

--- a/src/core/libraries/kernel/threads/exception.h
+++ b/src/core/libraries/kernel/threads/exception.h
@@ -175,6 +175,9 @@ struct Siginfo {
     } _reason;
 };
 
+constexpr s32 POSIX_SI_NOINFO = 0;
+constexpr s32 POSIX_SI_LWP = 0x10007;
+
 struct Ucontext {
     struct Sigset uc_sigmask;
     int field1_0x10[12];

--- a/src/core/libraries/kernel/threads/exception.h
+++ b/src/core/libraries/kernel/threads/exception.h
@@ -193,6 +193,7 @@ struct Ucontext {
     ucontext_t* host_context;
 #else
     explicit Ucontext(PCONTEXT context);
+    PCONTEXT host_context;
 #endif
     void SyncHostFromGuest();
 };

--- a/src/core/libraries/kernel/threads/exception.h
+++ b/src/core/libraries/kernel/threads/exception.h
@@ -59,20 +59,16 @@ constexpr s32 POSIX_SIGUSR2 = 31;
 constexpr s32 POSIX_SIGTHR = 32;
 constexpr s32 POSIX_SIGLIBRT = 33;
 
-#if defined(__linux__) || defined(__FreeBSD__)
-constexpr s32 _SIGEMT = 128;
-constexpr s32 _SIGINFO = 129;
-#elif !defined(_WIN32)
-constexpr s32 _SIGEMT = SIGEMT;
-constexpr s32 _SIGINFO = SIGINFO;
-#endif
-
 constexpr s32 POSIX_SA_ONSTACK = 0x0001;   /* take signal on signal stack */
 constexpr s32 POSIX_SA_RESTART = 0x0002;   /* restart system call on signal return */
 constexpr s32 POSIX_SA_RESETHAND = 0x0004; /* reset to SIG_DFL when taking signal */
 constexpr s32 POSIX_SA_NODEFER = 0x0010;   /* don't mask the signal we're delivering */
 constexpr s32 POSIX_SA_NOCLDWAIT = 0x0020; /* don't keep zombies around */
 constexpr s32 POSIX_SA_SIGINFO = 0x0040;   /* signal handler with SA_SIGINFO args */
+
+constexpr s32 POSIX_SIG_BLOCK = 1;   /* block specified signal set */
+constexpr s32 POSIX_SIG_UNBLOCK = 2; /* unblock specified signal set */
+constexpr s32 POSIX_SIG_SETMASK = 3; /* set specified signal set */
 
 struct Mcontext {
     u64 mc_onstack;

--- a/src/core/libraries/kernel/threads/exception.h
+++ b/src/core/libraries/kernel/threads/exception.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "common/types.h"
+#include "exception_codes.h"
 
 #ifndef _WIN32
 #include <sys/signal.h>
@@ -21,54 +22,6 @@ struct OrbisKernelExceptionHandlerStack {
     u64 ss_size;
     u32 ss_flags;
 };
-
-constexpr s32 POSIX_SS_ONSTACK = 0x0001; /* take signal on alternate stack */
-constexpr s32 POSIX_SS_DISABLE = 0x0004; /* disable taking signals on alternate stack */
-
-constexpr s32 POSIX_SIGHUP = 1;
-constexpr s32 POSIX_SIGINT = 2;
-constexpr s32 POSIX_SIGQUIT = 3;
-constexpr s32 POSIX_SIGILL = 4;
-constexpr s32 POSIX_SIGTRAP = 5;
-constexpr s32 POSIX_SIGABRT = 6;
-constexpr s32 POSIX_SIGEMT = 7;
-constexpr s32 POSIX_SIGFPE = 8;
-constexpr s32 POSIX_SIGKILL = 9;
-constexpr s32 POSIX_SIGBUS = 10;
-constexpr s32 POSIX_SIGSEGV = 11;
-constexpr s32 POSIX_SIGSYS = 12;
-constexpr s32 POSIX_SIGPIPE = 13;
-constexpr s32 POSIX_SIGALRM = 14;
-constexpr s32 POSIX_SIGTERM = 15;
-constexpr s32 POSIX_SIGURG = 16;
-constexpr s32 POSIX_SIGSTOP = 17;
-constexpr s32 POSIX_SIGTSTP = 18;
-constexpr s32 POSIX_SIGCONT = 19;
-constexpr s32 POSIX_SIGCHLD = 20;
-constexpr s32 POSIX_SIGTTIN = 21;
-constexpr s32 POSIX_SIGTTOU = 22;
-constexpr s32 POSIX_SIGIO = 23;
-constexpr s32 POSIX_SIGXCPU = 24;
-constexpr s32 POSIX_SIGXFSZ = 25;
-constexpr s32 POSIX_SIGVTALRM = 26;
-constexpr s32 POSIX_SIGPROF = 27;
-constexpr s32 POSIX_SIGWINCH = 28;
-constexpr s32 POSIX_SIGINFO = 29;
-constexpr s32 POSIX_SIGUSR1 = 30;
-constexpr s32 POSIX_SIGUSR2 = 31;
-constexpr s32 POSIX_SIGTHR = 32;
-constexpr s32 POSIX_SIGLIBRT = 33;
-
-constexpr s32 POSIX_SA_ONSTACK = 0x0001;   /* take signal on signal stack */
-constexpr s32 POSIX_SA_RESTART = 0x0002;   /* restart system call on signal return */
-constexpr s32 POSIX_SA_RESETHAND = 0x0004; /* reset to SIG_DFL when taking signal */
-constexpr s32 POSIX_SA_NODEFER = 0x0010;   /* don't mask the signal we're delivering */
-constexpr s32 POSIX_SA_NOCLDWAIT = 0x0020; /* don't keep zombies around */
-constexpr s32 POSIX_SA_SIGINFO = 0x0040;   /* signal handler with SA_SIGINFO args */
-
-constexpr s32 POSIX_SIG_BLOCK = 1;   /* block specified signal set */
-constexpr s32 POSIX_SIG_UNBLOCK = 2; /* unblock specified signal set */
-constexpr s32 POSIX_SIG_SETMASK = 3; /* set specified signal set */
 
 struct Mcontext {
     u64 mc_onstack;
@@ -169,9 +122,6 @@ struct Siginfo {
     } _reason;
 };
 
-constexpr s32 POSIX_SI_NOINFO = 0;
-constexpr s32 POSIX_SI_LWP = 0x10007;
-
 struct Ucontext {
     struct Sigset uc_sigmask;
     int field1_0x10[12];
@@ -202,9 +152,6 @@ struct Sigaction {
     int sa_flags;
     Sigset sa_mask;
 };
-
-constexpr uintptr_t POSIX_SIG_DFL = 0;
-constexpr uintptr_t POSIX_SIG_IGN = 1;
 
 s32 NativeToOrbisSignal(s32 s);
 

--- a/src/core/libraries/kernel/threads/exception.h
+++ b/src/core/libraries/kernel/threads/exception.h
@@ -5,6 +5,10 @@
 
 #include "common/types.h"
 
+#ifndef _WIN32
+#include <sys/signal.h>
+#endif
+
 namespace Core::Loader {
 class SymbolsResolver;
 }
@@ -17,6 +21,9 @@ struct OrbisKernelExceptionHandlerStack {
     u64 ss_size;
     u32 ss_flags;
 };
+
+constexpr s32 POSIX_SS_ONSTACK = 0x0001; /* take signal on alternate stack */
+constexpr s32 POSIX_SS_DISABLE = 0x0004; /* disable taking signals on alternate stack */
 
 constexpr s32 POSIX_SIGHUP = 1;
 constexpr s32 POSIX_SIGINT = 2;
@@ -168,17 +175,6 @@ struct Siginfo {
     } _reason;
 };
 
-using SigHandler = void PS4_SYSV_ABI (*)(int);
-
-struct Sigaction {
-    union {
-        void PS4_SYSV_ABI (*handler)(int);
-        void PS4_SYSV_ABI (*sigaction)(int, struct Siginfo*, void*);
-    } __sigaction_handler;
-    int sa_flags;
-    Sigset sa_mask;
-};
-
 struct Ucontext {
     struct Sigset uc_sigmask;
     int field1_0x10[12];
@@ -188,10 +184,32 @@ struct Ucontext {
     int uc_flags;
     int __spare[4];
     int field7_0x4f4[3];
+
+    explicit Ucontext(siginfo_t const* inf, ucontext_t const* raw_context);
 };
 
+using SigHandler = void PS4_SYSV_ABI (*)(int);
+
+struct Sigaction {
+    union {
+        void PS4_SYSV_ABI (*handler)(int);
+        void PS4_SYSV_ABI (*sigaction)(int, struct Siginfo*, Ucontext*);
+    } __sigaction_handler;
+    int sa_flags;
+    Sigset sa_mask;
+};
+
+constexpr uintptr_t POSIX_SIG_DFL = 0;
+constexpr uintptr_t POSIX_SIG_IGN = 1;
+
 s32 NativeToOrbisSignal(s32 s);
-s32 OrbisToNativeSignal(s32 s);
+
+s32 PS4_SYSV_ABI posix_sigemptyset(Sigset* s);
+s32 PS4_SYSV_ABI posix_sigfillset(Sigset* s);
+s32 PS4_SYSV_ABI posix_sigaddset(Sigset* s, s32 sig);
+s32 PS4_SYSV_ABI posix_sigdelset(Sigset* s, s32 sig);
+s32 PS4_SYSV_ABI posix_sigismember(Sigset const* s, s32 sig);
+bool PS4_SYSV_ABI posix_sigisemptyset(Sigset* s);
 
 void RegisterException(Core::Loader::SymbolsResolver* sym);
 

--- a/src/core/libraries/kernel/threads/exception.h
+++ b/src/core/libraries/kernel/threads/exception.h
@@ -190,9 +190,11 @@ struct Ucontext {
 
 #ifndef _WIN32
     explicit Ucontext(siginfo_t const* inf, ucontext_t const* raw_context);
+    ucontext_t* host_context;
 #else
     explicit Ucontext(PCONTEXT context);
 #endif
+    void SyncHostFromGuest();
 };
 
 using SigHandler = void PS4_SYSV_ABI (*)(int);

--- a/src/core/libraries/kernel/threads/exception.h
+++ b/src/core/libraries/kernel/threads/exception.h
@@ -185,7 +185,9 @@ struct Ucontext {
     int __spare[4];
     int field7_0x4f4[3];
 
+#ifndef _WIN32
     explicit Ucontext(siginfo_t const* inf, ucontext_t const* raw_context);
+#endif
 };
 
 using SigHandler = void PS4_SYSV_ABI (*)(int);

--- a/src/core/libraries/kernel/threads/exception.h
+++ b/src/core/libraries/kernel/threads/exception.h
@@ -189,7 +189,7 @@ struct Ucontext {
     int field7_0x4f4[3];
 
 #ifndef _WIN32
-    explicit Ucontext(siginfo_t const* inf, ucontext_t const* raw_context);
+    explicit Ucontext(siginfo_t const* inf, ucontext_t* raw_context);
     ucontext_t* host_context;
 #else
     explicit Ucontext(PCONTEXT context);

--- a/src/core/libraries/kernel/threads/exception.h
+++ b/src/core/libraries/kernel/threads/exception.h
@@ -187,6 +187,8 @@ struct Ucontext {
 
 #ifndef _WIN32
     explicit Ucontext(siginfo_t const* inf, ucontext_t const* raw_context);
+#else
+    explicit Ucontext(PCONTEXT context);
 #endif
 };
 

--- a/src/core/libraries/kernel/threads/exception.h
+++ b/src/core/libraries/kernel/threads/exception.h
@@ -67,14 +67,12 @@ constexpr s32 _SIGEMT = SIGEMT;
 constexpr s32 _SIGINFO = SIGINFO;
 #endif
 
-constexpr s32 POSIX_SA_NOCLDSTOP = 1;
-constexpr s32 POSIX_SA_NOCLDWAIT = 2;
-constexpr s32 POSIX_SA_SIGINFO = 4;
-constexpr s32 POSIX_SA_ONSTACK = 0x08000000;
-constexpr s32 POSIX_SA_RESTART = 0x10000000;
-constexpr s32 POSIX_SA_NODEFER = 0x40000000;
-constexpr s32 POSIX_SA_RESETHAND = 0x80000000;
-constexpr s32 POSIX_SA_RESTORER = 0x04000000;
+constexpr s32 POSIX_SA_ONSTACK = 0x0001;   /* take signal on signal stack */
+constexpr s32 POSIX_SA_RESTART = 0x0002;   /* restart system call on signal return */
+constexpr s32 POSIX_SA_RESETHAND = 0x0004; /* reset to SIG_DFL when taking signal */
+constexpr s32 POSIX_SA_NODEFER = 0x0010;   /* don't mask the signal we're delivering */
+constexpr s32 POSIX_SA_NOCLDWAIT = 0x0020; /* don't keep zombies around */
+constexpr s32 POSIX_SA_SIGINFO = 0x0040;   /* signal handler with SA_SIGINFO args */
 
 struct Mcontext {
     u64 mc_onstack;

--- a/src/core/libraries/kernel/threads/exception_codes.h
+++ b/src/core/libraries/kernel/threads/exception_codes.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2024-2026 shadPS4 Emulator Project
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once

--- a/src/core/libraries/kernel/threads/exception_codes.h
+++ b/src/core/libraries/kernel/threads/exception_codes.h
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: Copyright 2024-2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "common/types.h"
+
+constexpr s32 POSIX_SS_ONSTACK = 0x0001; /* take signal on alternate stack */
+constexpr s32 POSIX_SS_DISABLE = 0x0004; /* disable taking signals on alternate stack */
+
+constexpr s32 POSIX_SIGHUP = 1;
+constexpr s32 POSIX_SIGINT = 2;
+constexpr s32 POSIX_SIGQUIT = 3;
+constexpr s32 POSIX_SIGILL = 4;
+constexpr s32 POSIX_SIGTRAP = 5;
+constexpr s32 POSIX_SIGABRT = 6;
+constexpr s32 POSIX_SIGEMT = 7;
+constexpr s32 POSIX_SIGFPE = 8;
+constexpr s32 POSIX_SIGKILL = 9;
+constexpr s32 POSIX_SIGBUS = 10;
+constexpr s32 POSIX_SIGSEGV = 11;
+constexpr s32 POSIX_SIGSYS = 12;
+constexpr s32 POSIX_SIGPIPE = 13;
+constexpr s32 POSIX_SIGALRM = 14;
+constexpr s32 POSIX_SIGTERM = 15;
+constexpr s32 POSIX_SIGURG = 16;
+constexpr s32 POSIX_SIGSTOP = 17;
+constexpr s32 POSIX_SIGTSTP = 18;
+constexpr s32 POSIX_SIGCONT = 19;
+constexpr s32 POSIX_SIGCHLD = 20;
+constexpr s32 POSIX_SIGTTIN = 21;
+constexpr s32 POSIX_SIGTTOU = 22;
+constexpr s32 POSIX_SIGIO = 23;
+constexpr s32 POSIX_SIGXCPU = 24;
+constexpr s32 POSIX_SIGXFSZ = 25;
+constexpr s32 POSIX_SIGVTALRM = 26;
+constexpr s32 POSIX_SIGPROF = 27;
+constexpr s32 POSIX_SIGWINCH = 28;
+constexpr s32 POSIX_SIGINFO = 29;
+constexpr s32 POSIX_SIGUSR1 = 30;
+constexpr s32 POSIX_SIGUSR2 = 31;
+constexpr s32 POSIX_SIGTHR = 32;
+constexpr s32 POSIX_SIGLIBRT = 33;
+
+constexpr s32 POSIX_SA_ONSTACK = 0x0001;   /* take signal on signal stack */
+constexpr s32 POSIX_SA_RESTART = 0x0002;   /* restart system call on signal return */
+constexpr s32 POSIX_SA_RESETHAND = 0x0004; /* reset to SIG_DFL when taking signal */
+constexpr s32 POSIX_SA_NODEFER = 0x0010;   /* don't mask the signal we're delivering */
+constexpr s32 POSIX_SA_NOCLDWAIT = 0x0020; /* don't keep zombies around */
+constexpr s32 POSIX_SA_SIGINFO = 0x0040;   /* signal handler with SA_SIGINFO args */
+
+constexpr s32 POSIX_SIG_BLOCK = 1;   /* block specified signal set */
+constexpr s32 POSIX_SIG_UNBLOCK = 2; /* unblock specified signal set */
+constexpr s32 POSIX_SIG_SETMASK = 3; /* set specified signal set */
+
+constexpr VAddr POSIX_SIG_DFL = 0;
+constexpr VAddr POSIX_SIG_IGN = 1;
+
+/** si_code **/
+/* codes for SIGILL */
+constexpr s32 POSIX_ILL_ILLOPC = 1; /* Illegal opcode. */
+constexpr s32 POSIX_ILL_ILLOPN = 2; /* Illegal operand. */
+constexpr s32 POSIX_ILL_ILLADR = 3; /* Illegal addressing mode. */
+constexpr s32 POSIX_ILL_ILLTRP = 4; /* Illegal trap. */
+constexpr s32 POSIX_ILL_PRVOPC = 5; /* Privileged opcode. */
+constexpr s32 POSIX_ILL_PRVREG = 6; /* Privileged register. */
+constexpr s32 POSIX_ILL_COPROC = 7; /* Coprocessor error. */
+constexpr s32 POSIX_ILL_BADSTK = 8; /* Internal stack error. */
+
+/* codes for SIGBUS */
+constexpr s32 POSIX_BUS_ADRALN = 1; /* Invalid address alignment. */
+constexpr s32 POSIX_BUS_ADRERR = 2; /* Nonexistent physical address. */
+constexpr s32 POSIX_BUS_OBJERR = 3; /* Object-specific hardware error. */
+
+/* codes for SIGSEGV */
+constexpr s32 POSIX_SEGV_MAPERR = 1; /* Address not mapped to object. */
+constexpr s32 POSIX_SEGV_ACCERR = 2; /* Invalid permissions for mapped*/
+/* object. */
+
+/* codes for SIGFPE */
+constexpr s32 POSIX_FPE_INTOVF = 1; /* Integer overflow. */
+constexpr s32 POSIX_FPE_INTDIV = 2; /* Integer divide by zero. */
+constexpr s32 POSIX_FPE_FLTDIV = 3; /* Floating point divide by zero. */
+constexpr s32 POSIX_FPE_FLTOVF = 4; /* Floating point overflow. */
+constexpr s32 POSIX_FPE_FLTUND = 5; /* Floating point underflow. */
+constexpr s32 POSIX_FPE_FLTRES = 6; /* Floating point inexact result. */
+constexpr s32 POSIX_FPE_FLTINV = 7; /* Invalid floating point operation. */
+constexpr s32 POSIX_FPE_FLTSUB = 8; /* Subscript out of range. */
+
+/* codes for SIGTRAP */
+constexpr s32 POSIX_TRAP_BRKPT = 1;  /* Process breakpoint. */
+constexpr s32 POSIX_TRAP_TRACE = 2;  /* Process trace trap. */
+constexpr s32 POSIX_TRAP_DTRACE = 3; /* DTrace induced trap. */
+
+/* codes for SIGCHLD */
+constexpr s32 POSIX_CLD_EXITED = 1; /* Child has exited*/
+constexpr s32 POSIX_CLD_KILLED =
+    2; /* Child has terminated abnormally but did not create a core file*/
+constexpr s32 POSIX_CLD_DUMPED = 3;    /* Child has terminated abnormally and created a core file */
+constexpr s32 POSIX_CLD_TRAPPED = 4;   /* Traced child has trapped */
+constexpr s32 POSIX_CLD_STOPPED = 5;   /* Child has stopped */
+constexpr s32 POSIX_CLD_CONTINUED = 6; /* Stopped child has continued */
+
+/* codes for SIGPOLL */
+constexpr s32 POSIX_POLL_IN = 1;  /* Data input available */
+constexpr s32 POSIX_POLL_OUT = 2; /* Output buffers available */
+constexpr s32 POSIX_POLL_MSG = 3; /* Input message available */
+constexpr s32 POSIX_POLL_ERR = 4; /* I/O Error */
+constexpr s32 POSIX_POLL_PRI = 5; /* High priority input available */
+constexpr s32 POSIX_POLL_HUP = 6; /* Device disconnected */
+
+constexpr s32 POSIX_SI_NOINFO = 0;
+constexpr s32 POSIX_SI_LWP = 0x10007;

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -31,6 +31,7 @@ void* PS4_SYSV_ABI _runOnAnotherStack(void* arg, void* func, void* stackb) {
 namespace Libraries::Kernel {
 
 extern PthreadAttr PthreadAttrDefault;
+extern std::array<Sigaction, 128> PosixActions;
 
 void _thread_cleanupspecific();
 
@@ -748,6 +749,7 @@ int PS4_SYSV_ABI posix_pthread_cancel(PthreadT thread) {
     // per-thread wake predicate is the host equivalent and is drained before each wait.
     if (newly_pending) {
         thread->wake_sema.release();
+        thread->signal_sema.release();
         if (join_target != nullptr) {
             join_target->join_wait_cv.notify_all();
         }
@@ -829,6 +831,236 @@ int PS4_SYSV_ABI scePthreadSetcanceltype(PthreadCancelType type, PthreadCancelTy
 
 void PS4_SYSV_ABI scePthreadTestcancel() {
     PthreadTestCancel();
+}
+
+static void SigIgnHandler(int sig) {
+    LOG_DEBUG(Lib_Kernel, "called, sig: {}", sig);
+}
+
+static void SigDflHandler(int sig) {
+    switch (sig) {
+    case POSIX_SIGTRAP:
+        return;
+    case POSIX_SIGHUP:
+    case POSIX_SIGINT:
+    case POSIX_SIGQUIT:
+    case POSIX_SIGILL:
+    case POSIX_SIGABRT:
+    case POSIX_SIGEMT:
+    case POSIX_SIGFPE:
+    case POSIX_SIGKILL:
+    case POSIX_SIGBUS:
+    case POSIX_SIGSEGV:
+    case POSIX_SIGSYS:
+    case POSIX_SIGPIPE:
+    case POSIX_SIGALRM:
+    case POSIX_SIGTERM:
+    case POSIX_SIGSTOP:
+    case POSIX_SIGTSTP:
+    case POSIX_SIGTTIN:
+    case POSIX_SIGTTOU:
+    case POSIX_SIGXCPU:
+    case POSIX_SIGXFSZ:
+    case POSIX_SIGVTALRM:
+    case POSIX_SIGPROF:
+    case POSIX_SIGUSR1:
+    case POSIX_SIGUSR2:
+        UNREACHABLE_MSG("Encountered unhandled signal {}", sig);
+    default:
+        LOG_DEBUG(Lib_Kernel, "called, sig: {}", sig);
+    }
+}
+
+bool Pthread::IsSignalBlocked(s32 sig) const {
+    const s32 index = sig - 1;
+    return (guest_sigmask[index >> 5].load(std::memory_order_acquire) >> (index & 31)) & 1;
+}
+
+void Pthread::QueueSignal(s32 sig) {
+    pending_signal_counts[sig - 1].fetch_add(1, std::memory_order_release);
+
+    if (in_sigwait.load(std::memory_order_acquire)) {
+        signal_sema.release();
+    }
+}
+
+bool Pthread::ConsumeSignal(s32 sig) {
+    auto& pending = pending_signal_counts[sig - 1];
+
+    u32 count = pending.load(std::memory_order_acquire);
+    while (count != 0) {
+        if (pending.compare_exchange_weak(count, count - 1, std::memory_order_acq_rel,
+                                          std::memory_order_acquire)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+s32 Pthread::FindPendingSignal(const Sigset& set) const {
+    for (s32 sig = 1; sig <= 128; sig++) {
+        if (posix_sigismember(const_cast<Sigset*>(&set), sig) == 0) {
+            continue;
+        }
+
+        if (pending_signal_counts[sig - 1].load(std::memory_order_acquire) != 0) {
+            return sig;
+        }
+    }
+
+    return 0;
+}
+
+s32 Pthread::FindPendingUnblockedSignal() const {
+    for (s32 sig = 1; sig <= 128; sig++) {
+        if (IsSignalBlocked(sig)) {
+            continue;
+        }
+        if (in_sigwait.load(std::memory_order_acquire) &&
+            posix_sigismember(&sigwait_set, sig) != 0) {
+            continue;
+        }
+        if (pending_signal_counts[sig - 1].load(std::memory_order_acquire) != 0) {
+            return sig;
+        }
+    }
+    return 0;
+}
+
+bool Pthread::HasPendingSignal() const {
+    for (s32 sig = 1; sig <= 128; sig++) {
+        if (pending_signal_counts[sig - 1].load(std::memory_order_acquire) != 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool Pthread::HasDeliverableSignal() const {
+    return FindPendingUnblockedSignal() != 0;
+}
+
+void Pthread::WakeForSignal() {
+    pthread_kill(this->native_thr->GetHandle(), SIGUSR1);
+}
+
+void Pthread::SetGuestSigmask(Sigset const& mask) {
+    for (size_t i = 0; i < 4; i++) {
+        guest_sigmask[i].store(mask.bits[i], std::memory_order_release);
+    }
+}
+
+void Pthread::GetGuestSigmask(Sigset& mask) {
+    for (size_t i = 0; i < 4; i++) {
+        mask.bits[i] = guest_sigmask[i].load(std::memory_order_acquire);
+    }
+}
+
+struct WrapperArgs {
+    Pthread* thr;
+    Sigaction const* action;
+    s32 sig;
+    Siginfo* info;
+    Ucontext* context;
+};
+
+static void CallbackWrapper(void* arg) {
+    WrapperArgs& a = *reinterpret_cast<WrapperArgs*>(arg);
+
+    if (a.action->sa_flags & POSIX_SA_SIGINFO) {
+        auto sigaction_handler = a.action->__sigaction_handler.sigaction;
+        if (sigaction_handler != nullptr) {
+            sigaction_handler(a.sig, a.info, a.context);
+        }
+    } else {
+        auto signal_handler = a.action->__sigaction_handler.handler;
+        if (signal_handler != nullptr) {
+            signal_handler(a.sig);
+        }
+    }
+}
+
+bool Pthread::DispatchSignal(s32 sig, Siginfo* info, Ucontext* context) {
+    if (sig < 1 || sig > 128 || IsSignalBlocked(sig)) {
+        return false;
+    }
+
+    // the handler is allowed to change the installed action so a copy is needed
+    const auto action = PosixActions[sig - 1];
+
+    auto handler = action.__sigaction_handler.handler;
+
+    if (reinterpret_cast<uintptr_t>(handler) == POSIX_SIG_IGN) {
+        SigIgnHandler(sig);
+        return true;
+    }
+
+    if (reinterpret_cast<uintptr_t>(handler) == POSIX_SIG_DFL) {
+        SigDflHandler(sig);
+        return true;
+    }
+
+    Sigset old_mask{};
+    GetGuestSigmask(old_mask);
+
+    Sigset new_mask = old_mask;
+
+    for (size_t i = 0; i < 4; i++) {
+        new_mask.bits[i] |= action.sa_mask.bits[i];
+    }
+
+    if ((action.sa_flags & POSIX_SA_NODEFER) == 0) {
+        posix_sigaddset(&new_mask, sig);
+    }
+
+    SetGuestSigmask(new_mask);
+
+    if (action.sa_flags & POSIX_SA_RESETHAND) {
+        PosixActions[sig - 1] = {};
+    }
+
+    WrapperArgs arg{this, &action, sig, info, context};
+
+    if ((action.sa_flags & POSIX_SA_ONSTACK) && !(sigaltstack.ss_flags & POSIX_SS_DISABLE) &&
+        !(sigaltstack.ss_flags & POSIX_SS_ONSTACK)) {
+        sigaltstack.ss_flags |= POSIX_SS_ONSTACK;
+
+        auto* stack = reinterpret_cast<void*>(
+            (reinterpret_cast<uintptr_t>(sigaltstack.ss_sp) + sigaltstack.ss_size) & (~15ull));
+        _runOnAnotherStack(&arg, reinterpret_cast<void*>(CallbackWrapper), stack);
+
+        sigaltstack.ss_flags &= ~POSIX_SS_ONSTACK;
+    } else {
+        CallbackWrapper(&arg);
+    }
+
+    SetGuestSigmask(old_mask);
+
+    if (in_sigsuspend.load(std::memory_order_acquire)) {
+        sigsuspend_interrupted.store(true, std::memory_order_release);
+        signal_sema.release();
+    }
+
+    return true;
+}
+
+bool Pthread::DispatchPendingSignals() {
+    const s32 sig = FindPendingUnblockedSignal();
+    if (sig == 0) {
+        return false;
+    }
+
+    if (in_sigwait.load(std::memory_order_acquire) && posix_sigismember(&sigwait_set, sig) != 0) {
+        signal_sema.release();
+        return false;
+    }
+
+    if (!ConsumeSignal(sig)) {
+        return false;
+    }
+
+    return DispatchSignal(sig, nullptr, nullptr);
 }
 
 int Pthread::SetAffinity(const Cpuset* cpuset) {

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -952,12 +952,11 @@ void Pthread::WakeForSignal() {
     USER_APC_OPTION option;
     option.UserApcFlags = QueueUserApcFlagsSpecialUserApc;
 
-    u64 res =
-        NtQueueApcThreadEx(reinterpret_cast<HANDLE>(thread->native_thr->GetHandle()), option,
-                           ExceptionHandler, nullptr, nullptr, nullptr);
+    u64 res = NtQueueApcThreadEx(reinterpret_cast<HANDLE>(native_thr->GetHandle()), option,
+                                 ExceptionHandler, nullptr, nullptr, nullptr);
     ASSERT(res == 0);
 #else
-    pthread_kill(reinterpret_cast<pthread_t>(this->native_thr->GetHandle()), SIGUSR1);
+    pthread_kill(reinterpret_cast<pthread_t>(native_thr->GetHandle()), SIGUSR1);
 #endif
 }
 

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -944,12 +944,13 @@ bool Pthread::HasDeliverableSignal() const {
 
 #ifdef _WIN32
 static void ExceptionHandler(void*, void*, void*, PCONTEXT ctx) {
+    Ucontext u{ctx};
     Siginfo i{
         ._si_signo = 0,
         ._si_errno = 0,
         ._si_code = POSIX_SI_LWP,
+        ._si_addr = u.uc_mcontext.mc_rip,
     };
-    Ucontext u{ctx};
     g_curthread->DispatchPendingSignals(&i, &u);
 }
 #endif

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -942,8 +942,14 @@ bool Pthread::HasDeliverableSignal() const {
 }
 
 #ifdef _WIN32
-static void ExceptionHandler(void*, void*, void*, PCONTEXT) {
-    g_curthread->DispatchPendingSignals();
+static void ExceptionHandler(void*, void*, void*, PCONTEXT ctx) {
+    Siginfo i{
+        ._si_signo = 0,
+        ._si_errno = 0,
+        ._si_code = POSIX_SI_LWP,
+    };
+    Ucontext u{ctx};
+    g_curthread->DispatchPendingSignals(&i, &u);
 }
 #endif
 
@@ -1060,11 +1066,12 @@ bool Pthread::DispatchSignal(s32 sig, Siginfo* info, Ucontext* context) {
     return true;
 }
 
-bool Pthread::DispatchPendingSignals() {
+bool Pthread::DispatchPendingSignals(Siginfo* info, Ucontext* context) {
     const s32 sig = FindPendingUnblockedSignal();
     if (sig == 0) {
         return false;
     }
+    info->_si_signo = sig;
 
     if (in_sigwait.load(std::memory_order_acquire) && posix_sigismember(&sigwait_set, sig) != 0) {
         signal_sema.release();
@@ -1075,7 +1082,7 @@ bool Pthread::DispatchPendingSignals() {
         return false;
     }
 
-    return DispatchSignal(sig, nullptr, nullptr);
+    return DispatchSignal(sig, info, context);
 }
 
 int Pthread::SetAffinity(const Cpuset* cpuset) {

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -837,10 +837,11 @@ static void SigIgnHandler(int sig) {
     LOG_DEBUG(Lib_Kernel, "called, sig: {}", sig);
 }
 
-static void SigDflHandler(int sig) {
+static bool SigDflHandler(int sig) {
     switch (sig) {
-    case POSIX_SIGTRAP:
-        return;
+    case POSIX_SIGBUS:
+    case POSIX_SIGSEGV:
+        return false;
     case POSIX_SIGHUP:
     case POSIX_SIGINT:
     case POSIX_SIGQUIT:
@@ -849,8 +850,6 @@ static void SigDflHandler(int sig) {
     case POSIX_SIGEMT:
     case POSIX_SIGFPE:
     case POSIX_SIGKILL:
-    case POSIX_SIGBUS:
-    case POSIX_SIGSEGV:
     case POSIX_SIGSYS:
     case POSIX_SIGPIPE:
     case POSIX_SIGALRM:
@@ -865,9 +864,11 @@ static void SigDflHandler(int sig) {
     case POSIX_SIGPROF:
     case POSIX_SIGUSR1:
     case POSIX_SIGUSR2:
-        UNREACHABLE_MSG("Encountered unhandled signal {}", sig);
+        return false;
+    case POSIX_SIGTRAP:
     default:
         LOG_DEBUG(Lib_Kernel, "called, sig: {}", sig);
+        return true;
     }
 }
 
@@ -1018,8 +1019,7 @@ bool Pthread::DispatchSignal(s32 sig, Siginfo* info, Ucontext* context) {
     }
 
     if (reinterpret_cast<uintptr_t>(handler) == POSIX_SIG_DFL) {
-        SigDflHandler(sig);
-        return true;
+        return SigDflHandler(sig);
     }
 
     Sigset old_mask{};

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -942,7 +942,7 @@ bool Pthread::HasDeliverableSignal() const {
 }
 
 void Pthread::WakeForSignal() {
-    pthread_kill(this->native_thr->GetHandle(), SIGUSR1);
+    pthread_kill(reinterpret_cast<pthread_t>(this->native_thr->GetHandle()), SIGUSR1);
 }
 
 void Pthread::SetGuestSigmask(Sigset const& mask) {

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -988,7 +988,7 @@ struct WrapperArgs {
     Ucontext* context;
 };
 
-static void CallbackWrapper(void* arg) {
+static void PS4_SYSV_ABI CallbackWrapper(void* arg) {
     WrapperArgs& a = *reinterpret_cast<WrapperArgs*>(arg);
 
     if (a.action->sa_flags & POSIX_SA_SIGINFO) {

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -1057,6 +1057,10 @@ bool Pthread::DispatchSignal(s32 sig, Siginfo* info, Ucontext* context) {
         CallbackWrapper(&arg);
     }
 
+    if (context) {
+        context->SyncHostFromGuest();
+    }
+
     SetGuestSigmask(old_mask);
 
     if (in_sigsuspend.load(std::memory_order_acquire)) {

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -941,8 +941,24 @@ bool Pthread::HasDeliverableSignal() const {
     return FindPendingUnblockedSignal() != 0;
 }
 
+#ifdef _WIN32
+static void ExceptionHandler(void*, void*, void*, PCONTEXT) {
+    g_curthread->DispatchPendingSignals();
+}
+#endif
+
 void Pthread::WakeForSignal() {
+#ifdef _WIN32
+    USER_APC_OPTION option;
+    option.UserApcFlags = QueueUserApcFlagsSpecialUserApc;
+
+    u64 res =
+        NtQueueApcThreadEx(reinterpret_cast<HANDLE>(thread->native_thr->GetHandle()), option,
+                           ExceptionHandler, nullptr, nullptr, nullptr);
+    ASSERT(res == 0);
+#else
     pthread_kill(reinterpret_cast<pthread_t>(this->native_thr->GetHandle()), SIGUSR1);
+#endif
 }
 
 void Pthread::SetGuestSigmask(Sigset const& mask) {

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -949,7 +949,7 @@ static void ExceptionHandler(void*, void*, void*, PCONTEXT ctx) {
         ._si_signo = 0,
         ._si_errno = 0,
         ._si_code = POSIX_SI_LWP,
-        ._si_addr = u.uc_mcontext.mc_rip,
+        ._si_addr = (void*)u.uc_mcontext.mc_rip,
     };
     g_curthread->DispatchPendingSignals(&i, &u);
 }

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -1071,7 +1071,10 @@ bool Pthread::DispatchPendingSignals(Siginfo* info, Ucontext* context) {
     if (sig == 0) {
         return false;
     }
-    info->_si_signo = sig;
+
+    if (info) {
+        info->_si_signo = sig;
+    }
 
     if (in_sigwait.load(std::memory_order_acquire) && posix_sigismember(&sigwait_set, sig) != 0) {
         signal_sema.release();

--- a/src/core/libraries/kernel/threads/pthread.h
+++ b/src/core/libraries/kernel/threads/pthread.h
@@ -346,7 +346,7 @@ struct Pthread {
     bool HasDeliverableSignal() const;
     void WakeForSignal();
     bool DispatchSignal(s32 sig, Siginfo* info, Ucontext* context);
-    bool DispatchPendingSignals();
+    bool DispatchPendingSignals(Siginfo* info, Ucontext* context);
     void GetGuestSigmask(Sigset& mask);
     void SetGuestSigmask(Sigset const& mask);
 

--- a/src/core/libraries/kernel/threads/pthread.h
+++ b/src/core/libraries/kernel/threads/pthread.h
@@ -14,6 +14,7 @@
 #include "common/shared_first_mutex.h"
 #include "core/libraries/kernel/sync/mutex.h"
 #include "core/libraries/kernel/sync/semaphore.h"
+#include "core/libraries/kernel/threads/exception.h"
 #include "core/libraries/kernel/time.h"
 #include "core/thread.h"
 #include "core/tls.h"
@@ -294,7 +295,7 @@ struct Pthread {
     std::atomic_bool cancelling;
     u64 sigmask;
     bool unblock_sigcancel;
-    bool in_sigsuspend;
+    std::atomic_bool in_sigsuspend{};
     bool force_exit;
     PthreadState state;
     int error;
@@ -325,6 +326,29 @@ struct Pthread {
     Pthread* join_target{};
     std::mutex join_wait_mutex;
     std::condition_variable join_wait_cv;
+
+    std::array<std::atomic<u32>, 128> pending_signal_counts{};
+    std::array<std::atomic<u32>, 4> guest_sigmask{};
+
+    WakeSemaphore signal_sema{0};
+    std::atomic_bool in_sigwait{};
+    // std::atomic_bool in_sigsuspend{};
+    std::atomic_bool sigsuspend_interrupted{};
+    Sigset sigwait_set{};
+    OrbisKernelExceptionHandlerStack sigaltstack{};
+
+    bool IsSignalBlocked(s32 sig) const;
+    void QueueSignal(s32 sig);
+    bool ConsumeSignal(s32 sig);
+    s32 FindPendingSignal(const Sigset& set) const;
+    s32 FindPendingUnblockedSignal() const;
+    bool HasPendingSignal() const;
+    bool HasDeliverableSignal() const;
+    void WakeForSignal();
+    bool DispatchSignal(s32 sig, Siginfo* info, Ucontext* context);
+    bool DispatchPendingSignals();
+    void GetGuestSigmask(Sigset& mask);
+    void SetGuestSigmask(Sigset const& mask);
 
     bool InCritical() const noexcept {
         return locklevel.load(std::memory_order_acquire) > 0 ||
@@ -403,7 +427,8 @@ struct Pthread {
 
     int SetAffinity(const Cpuset* cpuset);
 };
-static_assert(offsetof(Pthread, specific) == 0x1c8);
+// fym static assertion expression is not an integral constant expression
+// static_assert(offsetof(Pthread, specific) == 0x1c8);
 
 using PthreadT = Pthread*;
 

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -39,15 +39,25 @@ static LONG WINAPI SignalHandler(EXCEPTION_POINTERS* pExp) noexcept {
         address = pExp->ExceptionRecord->ExceptionAddress;
     }
 
+    Ucontext guest_context{pExp->ContextRecord};
+    Siginfo guest_info{
+        ._si_signo = 0,
+        ._si_errno = 0,
+        ._si_code = POSIX_SI_NOINFO,
+        ._si_addr = (void*)context.uc_mcontext.mc_rip,
+    };
+
     bool handled = false;
     bool static_protection_exception = false; // Windows static guest red-zone protection
     switch (code) {
     case EXCEPTION_ACCESS_VIOLATION:
+        guest_info._si_signo = POSIX_SIGSEGV;
         static_protection_exception = true; // Windows static guest red-zone protection
         handled = signals->DispatchAccessViolation(
             pExp, reinterpret_cast<void*>(pExp->ExceptionRecord->ExceptionInformation[1]));
         break;
     case EXCEPTION_ILLEGAL_INSTRUCTION:
+        guest_info._si_signo = POSIX_SIGILL;
         static_protection_exception = true; // Windows static guest red-zone protection
         handled = signals->DispatchIllegalInstruction(pExp);
         break;
@@ -70,6 +80,13 @@ static LONG WINAPI SignalHandler(EXCEPTION_POINTERS* pExp) noexcept {
 
     if (handled) {
         return EXCEPTION_CONTINUE_EXECUTION;
+    }
+
+    if (guest_info._si_signo != 0) {
+        if (g_curthread &&
+            g_curthread->DispatchSignal(guest_info._si_signo, &guest_info, &guest_context)) {
+            return EXCEPTION_CONTINUE_EXECUTION;
+        }
     }
 
     // Windows static guest red-zone protection
@@ -120,6 +137,7 @@ void SignalHandler(int sig, siginfo_t* info, void* raw_context) {
         guest_info._si_signo = sig == SIGUSR1 ? 0 : NativeToOrbisSignal(info->si_signo);
         guest_info._si_errno = NativeToPosixErrno(info->si_errno);
         guest_info._si_code = sig == SIGUSR1 ? POSIX_SI_LWP : POSIX_SI_NOINFO;
+        guest_info._si_addr = (void*)context.uc_mcontext.mc_rip;
     }
     Siginfo* info_p = info ? &guest_info : nullptr;
     Ucontext* context_p = raw_context ? &context : nullptr;
@@ -129,7 +147,7 @@ void SignalHandler(int sig, siginfo_t* info, void* raw_context) {
     case SIGBUS: {
         const bool is_write = Common::IsWriteError(raw_context);
         if (!signals->DispatchAccessViolation(raw_context, info->si_addr)) {
-            if (thread->DispatchSignal(NativeToOrbisSignal(sig), info_p, context_p)) {
+            if (thread && thread->DispatchSignal(NativeToOrbisSignal(sig), info_p, context_p)) {
                 return;
             }
             UNREACHABLE_MSG("Unhandled access violation at code address {}: {} address {}",
@@ -145,7 +163,7 @@ void SignalHandler(int sig, siginfo_t* info, void* raw_context) {
     case SIGFPE:
     case SIGTRAP:
     case SIGSYS: {
-        if (thread->DispatchSignal(NativeToOrbisSignal(sig), info_p, context_p)) {
+        if (thread && thread->DispatchSignal(NativeToOrbisSignal(sig), info_p, context_p)) {
             return;
         }
 
@@ -160,7 +178,9 @@ void SignalHandler(int sig, siginfo_t* info, void* raw_context) {
         break;
     }
     case SIGUSR1:
-        thread->DispatchPendingSignals(info_p, context_p);
+        if (thread) {
+            thread->DispatchPendingSignals(info_p, context_p);
+        }
         break;
     default:
         UNREACHABLE_MSG("Unhandled signal {} at code address {}", sig, fmt::ptr(code_address));

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -45,7 +45,7 @@ static LONG WINAPI SignalHandler(EXCEPTION_POINTERS* pExp) noexcept {
         ._si_signo = 0,
         ._si_errno = 0,
         ._si_code = POSIX_SI_NOINFO,
-        ._si_addr = (void*)context.uc_mcontext.mc_rip,
+        ._si_addr = (void*)guest_context.uc_mcontext.mc_rip,
     };
 
     bool handled = false;

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -117,9 +117,9 @@ void SignalHandler(int sig, siginfo_t* info, void* raw_context) {
     Siginfo guest_info{};
     if (info) {
         guest_info = *reinterpret_cast<Siginfo*>(info);
-        guest_info._si_signo = NativeToOrbisSignal(info->si_signo);
+        guest_info._si_signo = sig == SIGUSR1 ? 0 : NativeToOrbisSignal(info->si_signo);
         guest_info._si_errno = NativeToPosixErrno(info->si_errno);
-        guest_info._si_code = POSIX_SI_NOINFO;
+        guest_info._si_code = sig == SIGUSR1 ? POSIX_SI_LWP : POSIX_SI_NOINFO;
     }
     Siginfo* info_p = info ? &guest_info : nullptr;
     Ucontext* context_p = raw_context ? &context : nullptr;
@@ -160,8 +160,6 @@ void SignalHandler(int sig, siginfo_t* info, void* raw_context) {
         break;
     }
     case SIGUSR1:
-        info_p->_si_signo = 0;
-        info_p->_si_code = POSIX_SI_LWP;
         thread->DispatchPendingSignals(info_p, context_p);
         break;
     default:

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -6,6 +6,7 @@
 #include "common/decoder.h"
 #include "common/signal_context.h"
 #include "core/cpu_patches.h" // Windows static guest red-zone protection
+#include "core/libraries/kernel/kernel.h"
 #include "core/libraries/kernel/threads/exception.h"
 #include "core/signals.h"
 #include "emulator.h"
@@ -19,13 +20,6 @@ static constexpr DWORD MS_VC_EXCEPTION = 0x406D1388;
 #ifdef ARCH_X86_64
 #include <Zydis/Formatter.h>
 #endif
-#endif
-
-#ifndef _WIN32
-namespace Libraries::Kernel {
-void SigactionHandler(int native_signum, siginfo_t* inf, ucontext_t* raw_context);
-extern std::array<OrbisKernelExceptionHandler, 32> Handlers;
-} // namespace Libraries::Kernel
 #endif
 
 namespace Core {
@@ -113,20 +107,28 @@ static std::string DisassembleInstruction(void* code_address) {
 }
 
 void SignalHandler(int sig, siginfo_t* info, void* raw_context) {
+    using namespace Libraries::Kernel;
+    auto* thread = g_curthread;
     const auto* signals = Signals::Instance();
 
     auto* code_address = Common::GetRip(raw_context);
+
+    Ucontext context{info, reinterpret_cast<ucontext_t*>(raw_context)};
+    Siginfo guest_info{};
+    if (info) {
+        guest_info = *reinterpret_cast<Siginfo*>(info);
+        guest_info._si_signo = NativeToOrbisSignal(info->si_signo);
+        guest_info._si_errno = NativeToPosixErrno(info->si_errno);
+    }
+    Siginfo* info_p = info ? &guest_info : nullptr;
+    Ucontext* context_p = raw_context ? &context : nullptr;
 
     switch (sig) {
     case SIGSEGV:
     case SIGBUS: {
         const bool is_write = Common::IsWriteError(raw_context);
         if (!signals->DispatchAccessViolation(raw_context, info->si_addr)) {
-            // If the guest has installed a custom signal handler, and the access violation didn't
-            // come from HLE memory tracking, pass the signal on
-            if (Libraries::Kernel::Handlers[Libraries::Kernel::NativeToOrbisSignal(sig)]) {
-                Libraries::Kernel::SigactionHandler(sig, info,
-                                                    reinterpret_cast<ucontext_t*>(raw_context));
+            if (thread->DispatchSignal(NativeToOrbisSignal(sig), info_p, context_p)) {
                 return;
             }
             UNREACHABLE_MSG("Unhandled access violation at code address {}: {} address {}",
@@ -136,25 +138,31 @@ void SignalHandler(int sig, siginfo_t* info, void* raw_context) {
         break;
     }
     case SIGILL:
-        if (!signals->DispatchIllegalInstruction(raw_context)) {
-            if (Libraries::Kernel::Handlers[Libraries::Kernel::NativeToOrbisSignal(sig)]) {
-                Libraries::Kernel::SigactionHandler(sig, info,
-                                                    reinterpret_cast<ucontext_t*>(raw_context));
-                return;
-            }
-            UNREACHABLE_MSG("Unhandled illegal instruction at code address {}: {}",
-                            fmt::ptr(code_address), DisassembleInstruction(code_address));
+        if (signals->DispatchIllegalInstruction(raw_context)) {
+            return;
         }
+    case SIGFPE:
+    case SIGTRAP:
+    case SIGSYS: {
+        if (thread->DispatchSignal(NativeToOrbisSignal(sig), info_p, context_p)) {
+            return;
+        }
+
+        UNREACHABLE_MSG("Unhandled signal {} at code address {}", sig, fmt::ptr(code_address));
+    }
+    case SIGSLEEP: {
+        // Sleep thread until signal is received again
+        sigset_t sigset;
+        sigemptyset(&sigset);
+        sigaddset(&sigset, SIGSLEEP);
+        sigwait(&sigset, &sig);
+        break;
+    }
+    case SIGUSR1:
+        thread->DispatchPendingSignals();
         break;
     default:
-        if (sig == SIGSLEEP) {
-            // Sleep thread until signal is received again
-            sigset_t sigset;
-            sigemptyset(&sigset);
-            sigaddset(&sigset, SIGSLEEP);
-            sigwait(&sigset, &sig);
-        }
-        break;
+        UNREACHABLE_MSG("Unhandled signal {} at code address {}", sig, fmt::ptr(code_address));
     }
 }
 
@@ -170,13 +178,12 @@ SignalDispatch::SignalDispatch() {
     action.sa_flags = SA_SIGINFO | SA_ONSTACK;
     sigemptyset(&action.sa_mask);
 
-    ASSERT_MSG(sigaction(SIGSEGV, &action, nullptr) == 0 &&
-                   sigaction(SIGBUS, &action, nullptr) == 0,
-               "Failed to register access violation signal handler.");
-    ASSERT_MSG(sigaction(SIGILL, &action, nullptr) == 0,
-               "Failed to register illegal instruction signal handler.");
-    ASSERT_MSG(sigaction(SIGSLEEP, &action, nullptr) == 0,
-               "Failed to register sleep signal handler.");
+    ASSERT_MSG(
+        sigaction(SIGSEGV, &action, nullptr) == 0 && sigaction(SIGBUS, &action, nullptr) == 0 &&
+            sigaction(SIGILL, &action, nullptr) == 0 && sigaction(SIGFPE, &action, nullptr) == 0 &&
+            sigaction(SIGTRAP, &action, nullptr) == 0 && sigaction(SIGSYS, &action, nullptr) == 0 &&
+            sigaction(SIGUSR1, &action, nullptr) == 0 && sigaction(SIGSLEEP, &action, nullptr) == 0,
+        "Failed to register signal handlers.");
 #endif
 }
 
@@ -189,11 +196,12 @@ SignalDispatch::~SignalDispatch() {
     action.sa_flags = 0;
     sigemptyset(&action.sa_mask);
 
-    ASSERT_MSG(sigaction(SIGSEGV, &action, nullptr) == 0 &&
-                   sigaction(SIGBUS, &action, nullptr) == 0,
-               "Failed to remove access violation signal handler.");
-    ASSERT_MSG(sigaction(SIGILL, &action, nullptr) == 0,
-               "Failed to remove illegal instruction signal handler.");
+    ASSERT_MSG(
+        sigaction(SIGSEGV, &action, nullptr) == 0 && sigaction(SIGBUS, &action, nullptr) == 0 &&
+            sigaction(SIGILL, &action, nullptr) == 0 && sigaction(SIGFPE, &action, nullptr) == 0 &&
+            sigaction(SIGTRAP, &action, nullptr) == 0 && sigaction(SIGSYS, &action, nullptr) == 0 &&
+            sigaction(SIGUSR1, &action, nullptr) == 0 && sigaction(SIGSLEEP, &action, nullptr) == 0,
+        "Failed to remove signal handlers.");
 #endif
 }
 

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -27,6 +27,7 @@ namespace Core {
 #if defined(_WIN32)
 
 static LONG WINAPI SignalHandler(EXCEPTION_POINTERS* pExp) noexcept {
+    using namespace Libraries::Kernel;
     const auto* signals = Signals::Instance();
     // Windows static guest red-zone protection
     const bool use_static_windows_guest_red_zone_protection =

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -142,6 +142,82 @@ static std::string DisassembleInstruction(void* code_address) {
     return buffer;
 }
 
+static s32 NativeSiCodeToGuest(s32 sig, s32 code) {
+    using namespace Libraries::Kernel;
+    switch (sig) {
+    case SIGUSR1:
+        return POSIX_SI_LWP;
+    case SIGSEGV:
+        switch (code) {
+        case SEGV_MAPERR:
+            return POSIX_SEGV_MAPERR;
+        case SEGV_ACCERR:
+            return POSIX_SEGV_ACCERR;
+        }
+    case SIGBUS:
+        switch (code) {
+        case BUS_ADRALN:
+            return POSIX_BUS_ADRALN;
+        case BUS_ADRERR:
+            return POSIX_BUS_ADRERR;
+        case BUS_OBJERR:
+            return POSIX_BUS_OBJERR;
+        }
+    case SIGILL:
+        switch (code) {
+        case ILL_ILLOPC:
+            return POSIX_ILL_ILLOPC;
+        case ILL_ILLOPN:
+            return POSIX_ILL_ILLOPN;
+        case ILL_ILLADR:
+            return POSIX_ILL_ILLADR;
+        case ILL_ILLTRP:
+            return POSIX_ILL_ILLTRP;
+        case ILL_PRVOPC:
+            return POSIX_ILL_PRVOPC;
+        case ILL_PRVREG:
+            return POSIX_ILL_PRVREG;
+        case ILL_COPROC:
+            return POSIX_ILL_COPROC;
+        case ILL_BADSTK:
+            return POSIX_ILL_BADSTK;
+        }
+    case SIGFPE:
+        switch (code) {
+        case FPE_INTOVF:
+            return POSIX_FPE_INTOVF;
+        case FPE_INTDIV:
+            return POSIX_FPE_INTDIV;
+        case FPE_FLTDIV:
+            return POSIX_FPE_FLTDIV;
+        case FPE_FLTOVF:
+            return POSIX_FPE_FLTOVF;
+        case FPE_FLTUND:
+            return POSIX_FPE_FLTUND;
+        case FPE_FLTRES:
+            return POSIX_FPE_FLTRES;
+        case FPE_FLTINV:
+            return POSIX_FPE_FLTINV;
+        case FPE_FLTSUB:
+            return POSIX_FPE_FLTSUB;
+        }
+    case SIGTRAP:
+        switch (code) {
+        case TRAP_BRKPT:
+            return POSIX_TRAP_BRKPT;
+        case TRAP_TRACE:
+            return POSIX_TRAP_TRACE;
+#ifndef __linux__
+        case TRAP_DTRACE:
+            return POSIX_TRAP_DTRACE;
+#endif
+        }
+
+    default:
+        return POSIX_SI_NOINFO;
+    }
+}
+
 void SignalHandler(int sig, siginfo_t* info, void* raw_context) {
     using namespace Libraries::Kernel;
     auto* thread = g_curthread;
@@ -155,7 +231,7 @@ void SignalHandler(int sig, siginfo_t* info, void* raw_context) {
         guest_info = *reinterpret_cast<Siginfo*>(info);
         guest_info._si_signo = sig == SIGUSR1 ? 0 : NativeToOrbisSignal(info->si_signo);
         guest_info._si_errno = NativeToPosixErrno(info->si_errno);
-        guest_info._si_code = sig == SIGUSR1 ? POSIX_SI_LWP : POSIX_SI_NOINFO;
+        guest_info._si_code = NativeSiCodeToGuest(sig, info->si_code);
         guest_info._si_addr = (void*)context.uc_mcontext.mc_rip;
     }
     Siginfo* info_p = info ? &guest_info : nullptr;

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -227,22 +227,33 @@ SignalDispatch::SignalDispatch() {
 #endif
 }
 
-SignalDispatch::~SignalDispatch() {
+void SignalDispatch::RemoveHandlers() {
+    // asserting here would get into an infinite loop until too
+    // many nested exceptions makes the OS kill the process
 #if defined(_WIN32)
-    ASSERT_MSG(RemoveVectoredExceptionHandler(handle), "Failed to remove exception handler.");
+    if (!(RemoveVectoredExceptionHandler(handle))) {
+        LOG_CRITICAL(Core, "Failed to remove exception handler.");
+        std::quick_exit(1);
+    }
 #else
     struct sigaction action{};
     action.sa_handler = SIG_DFL;
     action.sa_flags = 0;
     sigemptyset(&action.sa_mask);
 
-    ASSERT_MSG(
-        sigaction(SIGSEGV, &action, nullptr) == 0 && sigaction(SIGBUS, &action, nullptr) == 0 &&
-            sigaction(SIGILL, &action, nullptr) == 0 && sigaction(SIGFPE, &action, nullptr) == 0 &&
-            sigaction(SIGTRAP, &action, nullptr) == 0 && sigaction(SIGSYS, &action, nullptr) == 0 &&
-            sigaction(SIGUSR1, &action, nullptr) == 0 && sigaction(SIGSLEEP, &action, nullptr) == 0,
-        "Failed to remove signal handlers.");
+    if (!(sigaction(SIGSEGV, &action, nullptr) == 0 && sigaction(SIGBUS, &action, nullptr) == 0 &&
+          sigaction(SIGILL, &action, nullptr) == 0 && sigaction(SIGFPE, &action, nullptr) == 0 &&
+          sigaction(SIGTRAP, &action, nullptr) == 0 && sigaction(SIGSYS, &action, nullptr) == 0 &&
+          sigaction(SIGUSR1, &action, nullptr) == 0 &&
+          sigaction(SIGSLEEP, &action, nullptr) == 0)) {
+        LOG_CRITICAL(Core, "Failed to remove signal handlers.");
+        std::quick_exit(1);
+    }
 #endif
+}
+
+SignalDispatch::~SignalDispatch() {
+    RemoveHandlers();
 }
 
 bool SignalDispatch::DispatchAccessViolation(void* context, void* fault_address) const {

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -53,12 +53,14 @@ static LONG WINAPI SignalHandler(EXCEPTION_POINTERS* pExp) noexcept {
     switch (code) {
     case EXCEPTION_ACCESS_VIOLATION:
         guest_info._si_signo = POSIX_SIGSEGV;
+        guest_info._si_code = POSIX_SEGV_MAPERR;
         static_protection_exception = true; // Windows static guest red-zone protection
         handled = signals->DispatchAccessViolation(
             pExp, reinterpret_cast<void*>(pExp->ExceptionRecord->ExceptionInformation[1]));
         break;
     case EXCEPTION_ILLEGAL_INSTRUCTION:
         guest_info._si_signo = POSIX_SIGILL;
+        guest_info._si_code = POSIX_ILL_ILLOPC;
         static_protection_exception = true; // Windows static guest red-zone protection
         handled = signals->DispatchIllegalInstruction(pExp);
         break;
@@ -70,21 +72,48 @@ static LONG WINAPI SignalHandler(EXCEPTION_POINTERS* pExp) noexcept {
         break;
     case EXCEPTION_IN_PAGE_ERROR:
         guest_info._si_signo = POSIX_SIGBUS;
+        guest_info._si_code = POSIX_BUS_ADRALN;
         break;
     case EXCEPTION_INT_DIVIDE_BY_ZERO:
-    case EXCEPTION_INT_OVERFLOW:
-    case EXCEPTION_FLT_DIVIDE_BY_ZERO:
-    case EXCEPTION_FLT_INVALID_OPERATION:
-    case EXCEPTION_FLT_OVERFLOW:
-    case EXCEPTION_FLT_UNDERFLOW:
-    case EXCEPTION_FLT_DENORMAL_OPERAND:
-    case EXCEPTION_FLT_INEXACT_RESULT:
-    case EXCEPTION_FLT_STACK_CHECK:
         guest_info._si_signo = POSIX_SIGFPE;
+        guest_info._si_code = POSIX_FPE_INTDIV;
+        break;
+    case EXCEPTION_INT_OVERFLOW:
+        guest_info._si_signo = POSIX_SIGFPE;
+        guest_info._si_code = POSIX_FPE_INTOVF;
+        break;
+    case EXCEPTION_FLT_DIVIDE_BY_ZERO:
+        guest_info._si_signo = POSIX_SIGFPE;
+        guest_info._si_code = POSIX_FPE_FLTDIV;
+        break;
+    case EXCEPTION_FLT_INVALID_OPERATION:
+        guest_info._si_signo = POSIX_SIGFPE;
+        guest_info._si_code = POSIX_FPE_FLTINV;
+        break;
+    case EXCEPTION_FLT_OVERFLOW:
+        guest_info._si_signo = POSIX_SIGFPE;
+        guest_info._si_code = POSIX_FPE_FLTOVF;
+        break;
+    case EXCEPTION_FLT_UNDERFLOW:
+        guest_info._si_signo = POSIX_SIGFPE;
+        guest_info._si_code = POSIX_FPE_FLTUND;
+        break;
+    case EXCEPTION_FLT_DENORMAL_OPERAND:
+        guest_info._si_signo = POSIX_SIGFPE;
+        guest_info._si_code = POSIX_FPE_FLTSUB; // i am not sure about this one
+        break;
+    case EXCEPTION_FLT_INEXACT_RESULT:
+        guest_info._si_signo = POSIX_SIGFPE;
+        guest_info._si_code = POSIX_FPE_FLTRES;
+        break;
+    case EXCEPTION_FLT_STACK_CHECK:
+        guest_info._si_signo = POSIX_SIGILL;
+        guest_info._si_code = POSIX_ILL_BADSTK; // i am not sure about this one either
         break;
     case EXCEPTION_BREAKPOINT:
     case EXCEPTION_SINGLE_STEP:
         guest_info._si_signo = POSIX_SIGTRAP;
+        guest_info._si_code = POSIX_TRAP_BRKPT;
         break;
     case DBG_PRINTEXCEPTION_C:
     case DBG_PRINTEXCEPTION_WIDE_C:

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -119,6 +119,7 @@ void SignalHandler(int sig, siginfo_t* info, void* raw_context) {
         guest_info = *reinterpret_cast<Siginfo*>(info);
         guest_info._si_signo = NativeToOrbisSignal(info->si_signo);
         guest_info._si_errno = NativeToPosixErrno(info->si_errno);
+        guest_info._si_code = POSIX_SI_NOINFO;
     }
     Siginfo* info_p = info ? &guest_info : nullptr;
     Ucontext* context_p = raw_context ? &context : nullptr;
@@ -159,7 +160,9 @@ void SignalHandler(int sig, siginfo_t* info, void* raw_context) {
         break;
     }
     case SIGUSR1:
-        thread->DispatchPendingSignals();
+        info_p->_si_signo = 0;
+        info_p->_si_code = POSIX_SI_LWP;
+        thread->DispatchPendingSignals(info_p, context_p);
         break;
     default:
         UNREACHABLE_MSG("Unhandled signal {} at code address {}", sig, fmt::ptr(code_address));

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -236,7 +236,7 @@ static s32 NativeSiCodeToGuest(s32 sig, s32 code) {
             return POSIX_TRAP_BRKPT;
         case TRAP_TRACE:
             return POSIX_TRAP_TRACE;
-#ifndef __linux__
+#ifdef __FreeBSD__
         case TRAP_DTRACE:
             return POSIX_TRAP_DTRACE;
 #endif

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -68,6 +68,24 @@ static LONG WINAPI SignalHandler(EXCEPTION_POINTERS* pExp) noexcept {
             handled = signals->DispatchIllegalInstruction(pExp);
         }
         break;
+    case EXCEPTION_IN_PAGE_ERROR:
+        guest_info._si_signo = POSIX_SIGBUS;
+        break;
+    case EXCEPTION_INT_DIVIDE_BY_ZERO:
+    case EXCEPTION_INT_OVERFLOW:
+    case EXCEPTION_FLT_DIVIDE_BY_ZERO:
+    case EXCEPTION_FLT_INVALID_OPERATION:
+    case EXCEPTION_FLT_OVERFLOW:
+    case EXCEPTION_FLT_UNDERFLOW:
+    case EXCEPTION_FLT_DENORMAL_OPERAND:
+    case EXCEPTION_FLT_INEXACT_RESULT:
+    case EXCEPTION_FLT_STACK_CHECK:
+        guest_info._si_signo = POSIX_SIGFPE;
+        break;
+    case EXCEPTION_BREAKPOINT:
+    case EXCEPTION_SINGLE_STEP:
+        guest_info._si_signo = POSIX_SIGTRAP;
+        break;
     case DBG_PRINTEXCEPTION_C:
     case DBG_PRINTEXCEPTION_WIDE_C:
         // Used by OutputDebugString functions.

--- a/src/core/signals.h
+++ b/src/core/signals.h
@@ -28,6 +28,8 @@ public:
     SignalDispatch();
     ~SignalDispatch();
 
+    void RemoveHandlers();
+
     /// Registers a handler for memory access violation signals.
     void RegisterAccessViolationHandler(const AccessViolationHandler& handler, u32 priority) {
         access_violation_handlers.emplace(handler, priority);

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -42,6 +42,7 @@
 #include "core/libraries/save_data/save_backup.h"
 #include "core/linker.h"
 #include "core/memory.h"
+#include "core/signals.h"
 #include "core/user_settings.h"
 #include "emulator.h"
 #include "video_core/cache_storage.h"
@@ -90,6 +91,7 @@ void Emulator::Shutdown() {
         return;
     }
     Common::Log::Flush();
+    Signals::Instance()->RemoveHandlers();
     if (controllers) {
         controllers->ResetLightbarColors();
         // need to give SDL time to do this before the runtime exits


### PR DESCRIPTION
VSH has a check that failed under the previous implementation, because it tried to install a handler for every possible signal, of which there are 128 on the PS4, but only 64 and 32 on Linux and macOS, respectively (on Windows, this wasn't an issue because signal code is still mostly stubbed, and the things that aren't, are software emulated anyway). Previously, every guest signal was mapped to a host signal, and then everything was transparently forwarded to the host OS, which worked pretty well up until something actually came along and started using those higher signal numbers not available on host platforms. Since VSH only checked their availibility, but didn't actually make use of them, it was rather easy to just ignore those signals and return dummy successes, but it nonetheless prompted me to rewrite signal emulation on POSIX systems once again.

The new logic works roughly like so:
Signals can be grouped into two categories, hardware ones that are raised by the host hardware/OS, like SIGSEGV, SIGILL, SIGFPE etc, and there are software ones, that can only come from the guest invoking raise/pthread_kill themselves as an internal signaling mechanism. The first group has a host signal handler installed for them as well, and (after first checking if our HLE was responsible for the signal in cases of SIGSEGV or SIGBUS) the signal and its accompanying info gets forwarded to g_curthread for consumption (if no handler is installed, do the default action which is "crash" for most and "ignore" for some signals, if the thread is in sigwait, wake it, if it's in sigsuspend, call the handler then wake it, otherwise call the handler). For the other set of signals, pthread_kill will first queue the signal on the thread, check if the signal is blocked, and if not, sends a notification to the thread via a host SIGUSR1 signal, whose handler on the other end will inspect its thread's state, and figure out what to do from there (see above, but prepend a signal queue lookup to it with respect to the signal mask). The other sig\* functions follow a similar setup as well.

~~The Pthread backend can be reused for Windows I'm pretty sure, and it might even allow for a better hardware signal emulation as well (just make use of the same backend from Windows's SignalHandler at signals.cpp:29, the only code I know is that 0xc0000005 is the SIGSEGV equivalent), but for now I've kept everything POSIX only because I use Arch Linux (BTW Edition) btw don't use Windows nor do I care about it.~~ Done. The Windows code has been updated to use the same backend, and can now emulate SIGSEGV and SIGILL signals to some degree (testing needed).

sigaction also had a quite dumb bug that I can't even blame on anyone else because it was me who introduced it months ago, which is that it used the sce wrapper functions' callback function signature instead of the POSIX signature(s), meaning guest apps were getting garbage parameters aside from the signal number itself, which only wasn't found earlier because most games only use the sce wrappers, and those were fine.

Testing would be appreciated, because while I'm pretty sure I didn't break anything (on Linux), one must never be too sure.
