### PR TITLE
Kernel.Pthreads: Do not double destroy threads when free threads exceeds MaxCachedThreads

### DIFF
--- a/src/core/libraries/kernel/threads/thread_state.cpp
+++ b/src/core/libraries/kernel/threads/thread_state.cpp
@@ -126,7 +126,6 @@ void ThreadState::Free(Pthread* curthread, Pthread* thread) {
     }
     thread->tcb = nullptr;
     auto* sleepqueue = thread->sleepqueue;
-    std::destroy_at(thread);
     bool should_free;
     {
         std::scoped_lock lk{free_thread_lock};


### PR DESCRIPTION
pthreads should only be deleted in the should_free path, where thread_heap.Free() calls std::destroy_at for us. Right now, we are always deleting threads, and when thread_heap.Free() is called, this re-runs the pthread destructor on the already-destroyed pthread and triggers crashes.

I don't know why this wasn't causing issues on Windows before, but it's been blocking PAYDAY 2 on Linux for ages.