### PR TITLE
shader_recompiler: Fix front-face attribute encoding

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -149,6 +149,16 @@ Id EmitGetAttribute(EmitContext& ctx, IR::Attribute attr, u32 comp, u32 index) {
     }
 }
 
+Id EmitGetAttributeU1(EmitContext& ctx, IR::Attribute attr, u32 comp) {
+    ASSERT(comp == 0);
+    switch (attr) {
+    case IR::Attribute::IsFrontFace:
+        return ctx.OpLoad(ctx.U1[1], ctx.front_facing);
+    default:
+        UNREACHABLE_MSG("Unsupported U1 attribute {}", attr);
+    }
+}
+
 Id EmitGetAttributeU32(EmitContext& ctx, IR::Attribute attr, u32 comp) {
     switch (attr) {
     case IR::Attribute::VertexId:

--- a/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
@@ -113,6 +113,7 @@ Id EmitBufferAtomicCmpSwap32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id ad
 Id EmitBufferAtomicFCmpSwap32(EmitContext& ctx, IR::Inst* inst, u32 handle, Id address, Id value,
                               Id cmp_value);
 Id EmitGetAttribute(EmitContext& ctx, IR::Attribute attr, u32 comp, u32 index);
+Id EmitGetAttributeU1(EmitContext& ctx, IR::Attribute attr, u32 comp);
 Id EmitGetAttributeU32(EmitContext& ctx, IR::Attribute attr, u32 comp);
 void EmitSetAttribute(EmitContext& ctx, IR::Attribute attr, Id value, u32 comp);
 Id EmitGetTessGenericAttribute(EmitContext& ctx, Id vertex_index, Id attr_index, Id comp_index);

--- a/src/shader_recompiler/frontend/translate/translate.cpp
+++ b/src/shader_recompiler/frontend/translate/translate.cpp
@@ -166,7 +166,13 @@ void Translator::EmitPrologue(IR::Block* first_block) {
         }
         if (runtime_info.fs_info.addr_flags.front_face_ena) {
             if (runtime_info.fs_info.en_flags.front_face_ena) {
-                ir.SetVectorReg(dst_vreg++, ir.GetAttributeU32(IR::Attribute::IsFrontFace));
+                const IR::U1 front_face = ir.GetAttributeU1(IR::Attribute::IsFrontFace);
+                if (runtime_info.fs_info.front_face_all_bits) {
+                    ir.SetVectorReg(dst_vreg++, ir.BitCast<IR::U32>(front_face));
+                } else {
+                    ir.SetVectorReg(dst_vreg++, IR::F32{ir.Select(front_face, ir.Imm32(1.0f),
+                                                                  ir.Imm32(-1.0f))});
+                }
             } else {
                 ir.SetVectorReg(dst_vreg++, ir.Imm32(0));
             }

--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -266,6 +266,10 @@ F32 IREmitter::GetAttribute(IR::Attribute attribute, u32 comp, u32 index) {
     return Inst<F32>(Opcode::GetAttribute, attribute, Imm32(comp), Imm32(index));
 }
 
+U1 IREmitter::GetAttributeU1(IR::Attribute attribute, u32 comp) {
+    return Inst<U1>(Opcode::GetAttributeU1, attribute, Imm32(comp));
+}
+
 U32 IREmitter::GetAttributeU32(IR::Attribute attribute, u32 comp) {
     return Inst<U32>(Opcode::GetAttributeU32, attribute, Imm32(comp));
 }

--- a/src/shader_recompiler/ir/ir_emitter.h
+++ b/src/shader_recompiler/ir/ir_emitter.h
@@ -85,6 +85,7 @@ public:
     [[nodiscard]] U1 Condition(IR::Condition cond);
 
     [[nodiscard]] F32 GetAttribute(Attribute attribute, u32 comp = 0, u32 index = 0);
+    [[nodiscard]] U1 GetAttributeU1(Attribute attribute, u32 comp = 0);
     [[nodiscard]] U32 GetAttributeU32(Attribute attribute, u32 comp = 0);
     void SetAttribute(Attribute attribute, const F32& value, u32 comp = 0);
 

--- a/src/shader_recompiler/ir/opcodes.inc
+++ b/src/shader_recompiler/ir/opcodes.inc
@@ -74,6 +74,7 @@ OPCODE(SetGotoVariable,                                     Void,           U32,
 OPCODE(GetMaskLaneVariable,                                 U1,             VectorReg,      U32,                                                            )
 OPCODE(SetMaskLaneVariable,                                 Void,           VectorReg,      U32,            U1,                                             )
 OPCODE(GetAttribute,                                        F32,            Attribute,      U32,            U32,                                            )
+OPCODE(GetAttributeU1,                                      U1,             Attribute,      U32,                                                            )
 OPCODE(GetAttributeU32,                                     U32,            Attribute,      U32,                                                            )
 OPCODE(SetAttribute,                                        Void,           Attribute,      F32,            U32,                                            )
 OPCODE(GetPatch,                                            F32,            Patch,                                                                          )

--- a/src/shader_recompiler/ir/passes/shader_info_collection_pass.cpp
+++ b/src/shader_recompiler/ir/passes/shader_info_collection_pass.cpp
@@ -11,6 +11,7 @@ namespace Shader::Optimization {
 void Visit(Info& info, const IR::Inst& inst) {
     switch (inst.GetOpcode()) {
     case IR::Opcode::GetAttribute:
+    case IR::Opcode::GetAttributeU1:
     case IR::Opcode::GetAttributeU32:
         info.loads.Set(inst.Arg(0).Attribute(), inst.Arg(1).U32());
         break;

--- a/src/shader_recompiler/runtime_info.h
+++ b/src/shader_recompiler/runtime_info.h
@@ -197,6 +197,7 @@ struct FragmentRuntimeInfo {
     std::array<PsColorBuffer, MaxColorBuffers> color_buffers;
     AmdGpu::ShaderExportFormat z_export_format;
     u8 mrtz_mask{};
+    bool front_face_all_bits{false};
     bool dual_source_blending{false};
     bool clip_distance_emulation{false};
 
@@ -204,7 +205,8 @@ struct FragmentRuntimeInfo {
         return std::ranges::equal(color_buffers, other.color_buffers) &&
                en_flags == other.en_flags && addr_flags == other.addr_flags &&
                num_inputs == other.num_inputs && z_export_format == other.z_export_format &&
-               mrtz_mask == other.mrtz_mask && dual_source_blending == other.dual_source_blending &&
+               mrtz_mask == other.mrtz_mask && front_face_all_bits == other.front_face_all_bits &&
+               dual_source_blending == other.dual_source_blending &&
                clip_distance_emulation == other.clip_distance_emulation &&
                std::ranges::equal(inputs.begin(), inputs.begin() + num_inputs, other.inputs.begin(),
                                   other.inputs.begin() + num_inputs);

--- a/src/video_core/amdgpu/regs.h
+++ b/src/video_core/amdgpu/regs.h
@@ -86,7 +86,9 @@ union Regs {
         PsInput ps_input_addr;
         INSERT_PADDING_WORDS(1);
         u32 num_interp : 6;
-        INSERT_PADDING_WORDS(12);
+        INSERT_PADDING_WORDS(1);
+        BarycentricControl barycentric_control;
+        INSERT_PADDING_WORDS(10);
         ShaderPosFormat shader_pos_format;
         ShaderExportFormat z_export_format;
         ColorExportFormat color_export_format;

--- a/src/video_core/amdgpu/regs_shader.h
+++ b/src/video_core/amdgpu/regs_shader.h
@@ -123,6 +123,12 @@ struct PsInput {
     bool operator==(const PsInput&) const = default;
 };
 
+struct BarycentricControl {
+    u32 : 24;
+    u32 front_face_all_bits : 1;
+};
+static_assert(sizeof(BarycentricControl) == sizeof(u32));
+
 enum class ShaderExportComp : u32 {
     None = 0,
     OneComp = 1,

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -191,6 +191,7 @@ const Shader::RuntimeInfo& PipelineCache::BuildRuntimeInfo(Stage stage, LogicalS
         info.fs_info.en_flags = regs.ps_input_ena;
         info.fs_info.addr_flags = regs.ps_input_addr;
         info.fs_info.num_inputs = regs.num_interp;
+        info.fs_info.front_face_all_bits = regs.barycentric_control.front_face_all_bits;
         info.fs_info.z_export_format = regs.z_export_format;
         u8 stencil_ref_export_enable = regs.depth_shader_control.stencil_op_val_export_enable |
                                        regs.depth_shader_control.stencil_test_val_export_enable;

--- a/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
@@ -12,8 +12,8 @@
 
 namespace Serialization {
 /* You should increment versions below once corresponding serialization scheme is changed. */
-static constexpr u32 ShaderBinaryVersion = 3u;
-static constexpr u32 ShaderMetaVersion = 3u;
+static constexpr u32 ShaderBinaryVersion = 4u;
+static constexpr u32 ShaderMetaVersion = 4u;
 static constexpr u32 PipelineKeyVersion = 3u;
 } // namespace Serialization
 

--- a/tests/gcn/test_gcn_instructions.cpp
+++ b/tests/gcn/test_gcn_instructions.cpp
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <cmath>
+#include <unordered_map>
 
 #include <gtest/gtest.h>
 #include <half.hpp>
+#include <spirv/unified1/spirv.hpp11>
 
 #include "gcn_test_runner.hpp"
 #include "instructions.hpp"
@@ -25,6 +27,72 @@ struct F32x2 {
     float a;
     float b;
 };
+
+struct FrontFaceSpirvInfo {
+    bool has_front_facing{};
+    u32 select_count{};
+    u32 true_value{};
+    u32 false_value{};
+};
+
+FrontFaceSpirvInfo InspectFrontFaceSpirv(const std::vector<u32>& spirv) {
+    FrontFaceSpirvInfo info{};
+    if (spirv.size() < 5U) {
+        ADD_FAILURE() << "SPIR-V header is truncated";
+        return info;
+    }
+
+    std::unordered_map<u32, u32> constants;
+    u32 true_value_id{};
+    u32 false_value_id{};
+    for (size_t offset = 5; offset < spirv.size();) {
+        const u32 instruction = spirv[offset];
+        const u32 word_count = instruction >> 16;
+        const auto opcode = static_cast<spv::Op>(instruction & 0xffffU);
+        if (word_count == 0U || offset + word_count > spirv.size()) {
+            ADD_FAILURE() << "Malformed SPIR-V instruction at word " << offset;
+            return info;
+        }
+
+        if (opcode == spv::Op::OpDecorate && word_count >= 4U &&
+            spirv[offset + 2] == static_cast<u32>(spv::Decoration::BuiltIn) &&
+            spirv[offset + 3] == static_cast<u32>(spv::BuiltIn::FrontFacing)) {
+            info.has_front_facing = true;
+        } else if (opcode == spv::Op::OpConstant && word_count == 4U) {
+            constants.emplace(spirv[offset + 2], spirv[offset + 3]);
+        } else if (opcode == spv::Op::OpSelect && word_count == 6U) {
+            ++info.select_count;
+            true_value_id = spirv[offset + 4];
+            false_value_id = spirv[offset + 5];
+        }
+        offset += word_count;
+    }
+
+    if (info.select_count == 1U && constants.contains(true_value_id) &&
+        constants.contains(false_value_id)) {
+        info.true_value = constants.at(true_value_id);
+        info.false_value = constants.at(false_value_id);
+    }
+    return info;
+}
+
+TEST_F(GcnTest, fragment_front_face_uses_float_sign_bits) {
+    const auto info = InspectFrontFaceSpirv(TranslateFragmentFrontFaceToSpirv(false));
+
+    EXPECT_TRUE(info.has_front_facing);
+    EXPECT_EQ(info.select_count, 1U);
+    EXPECT_EQ(info.true_value, 0x3f800000U);
+    EXPECT_EQ(info.false_value, 0xbf800000U);
+}
+
+TEST_F(GcnTest, fragment_front_face_uses_all_bits) {
+    const auto info = InspectFrontFaceSpirv(TranslateFragmentFrontFaceToSpirv(true));
+
+    EXPECT_TRUE(info.has_front_facing);
+    EXPECT_EQ(info.select_count, 1U);
+    EXPECT_EQ(info.true_value, 1U);
+    EXPECT_EQ(info.false_value, 0U);
+}
 
 // Example
 // TEST_F(GcnTest, test_name) {

--- a/tests/gcn/translator.cpp
+++ b/tests/gcn/translator.cpp
@@ -16,6 +16,7 @@
 #include "shader_recompiler/ir/program.h"
 #include "shader_recompiler/profile.h"
 #include "shader_recompiler/recompiler.h"
+#include "video_core/amdgpu/pixel_format.h"
 
 using namespace Shader;
 
@@ -104,4 +105,46 @@ std::vector<u32> TranslateToSpirv(std::span<const u64> raw_gcn_insts) {
     const auto spirv = Backend::SPIRV::EmitSPIRV(profile, runtime_info, program, bindings);
 
     return spirv;
+}
+
+std::vector<u32> TranslateFragmentFrontFaceToSpirv(bool front_face_all_bits) {
+    Shader::Info info{};
+    info.stage = Stage::Fragment;
+    info.l_stage = LogicalStage::Fragment;
+
+    IR::Program program{info};
+    Pools pools{};
+    IR::Block* block = pools.block_pool.Create(pools.inst_pool);
+    program.blocks.push_back(block);
+    program.syntax_list.emplace_back();
+    program.syntax_list.back().type = IR::AbstractSyntaxNode::Type::Block;
+    program.syntax_list.back().data.block = block;
+    program.syntax_list.emplace_back();
+    program.syntax_list.back().type = IR::AbstractSyntaxNode::Type::Return;
+    program.post_order_blocks = IR::PostOrder(program.syntax_list.front());
+
+    Profile profile{};
+    profile.supported_spirv = 0x00010600;
+    RuntimeInfo runtime_info{};
+    runtime_info.Initialize(Stage::Fragment);
+    runtime_info.fs_info.en_flags.front_face_ena = 1;
+    runtime_info.fs_info.addr_flags.front_face_ena = 1;
+    runtime_info.fs_info.front_face_all_bits = front_face_all_bits;
+    runtime_info.fs_info.color_buffers[0].num_format = AmdGpu::NumberFormat::Float;
+
+    Gcn::Translator translator(program.info, runtime_info, profile);
+    translator.EmitPrologue(block);
+
+    IR::IREmitter ir{*block};
+    const IR::U32 front_face = ir.GetVectorReg<IR::U32>(IR::VectorReg::V0);
+    ir.SetAttribute(IR::Attribute::RenderTarget0, ir.BitCast<IR::F32>(front_face));
+    ir.Epilogue();
+
+    Optimization::SsaRewritePass(program.post_order_blocks);
+    Optimization::IdentityRemovalPass(program.blocks);
+    Optimization::ConstantPropagationPass(program.blocks);
+    Optimization::DeadCodeEliminationPass(program);
+    Optimization::CollectShaderInfoPass(program, profile);
+    Backend::Bindings bindings{};
+    return Backend::SPIRV::EmitSPIRV(profile, runtime_info, program, bindings);
 }

--- a/tests/gcn/translator.hpp
+++ b/tests/gcn/translator.hpp
@@ -10,3 +10,4 @@
 
 std::vector<u32> TranslateToSpirv(u64 raw_gcn_inst);
 std::vector<u32> TranslateToSpirv(std::span<const u64> raw_gcn_insts);
+std::vector<u32> TranslateFragmentFrontFaceToSpirv(bool front_face_all_bits);


### PR DESCRIPTION
- Encode front-facing primitives as +1.0f
- Encode back-facing primitives as -1.0f
- Preserve the raw float bits expected in pixel shader VGPRs