### PR TITLE
Fix issues related to platinum trophies

### DIFF
--- a/src/core/libraries/np/np_trophy.cpp
+++ b/src/core/libraries/np/np_trophy.cpp
@@ -916,7 +916,7 @@ int PS4_SYSV_ABI sceNpTrophyUnlockTrophy(OrbisNpTrophyContext context, OrbisNpTr
     }
 
     pugi::xml_document doc;
-    pugi::xml_parse_result result = doc.load_file(trophy_file.native().c_str());
+    pugi::xml_parse_result result = doc.load_file(ctx.xml_save_file.native().c_str());
 
     if (!result) {
         LOG_ERROR(Lib_NpTrophy, "Failed to parse trophy xml : {}", result.description());

--- a/src/core/libraries/np/np_trophy.cpp
+++ b/src/core/libraries/np/np_trophy.cpp
@@ -925,8 +925,8 @@ int PS4_SYSV_ABI sceNpTrophyUnlockTrophy(OrbisNpTrophyContext context, OrbisNpTr
 
     *platinumId = ORBIS_NP_TROPHY_INVALID_TROPHY_ID;
 
-    int num_trophies = 0;
-    int num_trophies_unlocked = 0;
+    int num_base_trophies = 0;
+    int num_base_trophies_unlocked = 0;
     pugi::xml_node platinum_node;
 
     // Outputs filled during the scan.
@@ -952,10 +952,11 @@ int PS4_SYSV_ABI sceNpTrophyUnlockTrophy(OrbisNpTrophyContext context, OrbisNpTr
             }
         }
 
-        if (node.attribute("pid").as_int(-1) != ORBIS_NP_TROPHY_INVALID_TROPHY_ID) {
-            num_trophies++;
+        if (node.attribute("pid").as_int(-1) != ORBIS_NP_TROPHY_INVALID_TROPHY_ID &&
+            node.attribute("gid").as_int(0) > 0) {
+            num_base_trophies++;
             if (current_trophy_unlockstate) {
-                num_trophies_unlocked++;
+                num_base_trophies_unlocked++;
             }
         }
 
@@ -986,7 +987,7 @@ int PS4_SYSV_ABI sceNpTrophyUnlockTrophy(OrbisNpTrophyContext context, OrbisNpTr
     std::filesystem::path platinum_icon_path;
 
     if (!platinum_node.attribute("unlockstate").as_bool()) {
-        if ((num_trophies - 1) == num_trophies_unlocked) {
+        if ((num_base_trophies - 1) == num_base_trophies_unlocked) {
             unlock_platinum = true;
             platinum_id = platinum_node.attribute("id").as_int(ORBIS_NP_TROPHY_INVALID_TROPHY_ID);
             platinum_timestamp = trophy_timestamp; // same second is fine

--- a/src/core/libraries/np/np_trophy.cpp
+++ b/src/core/libraries/np/np_trophy.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2025-2026 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <thread>
 #include <unordered_map>
 #include <pugixml.hpp>
 

--- a/src/core/libraries/np/np_trophy.cpp
+++ b/src/core/libraries/np/np_trophy.cpp
@@ -1003,7 +1003,12 @@ int PS4_SYSV_ABI sceNpTrophyUnlockTrophy(OrbisNpTrophyContext context, OrbisNpTr
     // Queue UI notifications (only once, using the primary XML's strings).
     AddTrophyToQueue(trophy_icon_path, trophy_name, trophy_type);
     if (unlock_platinum) {
-        AddTrophyToQueue(platinum_icon_path, platinum_name, "P");
+        std::thread plat_popup_thread{[=]() {
+            std::this_thread::sleep_for(std::chrono::milliseconds(
+                (s32)EmulatorSettings.GetTrophyNotificationDuration() * 1000 + 250));
+            AddTrophyToQueue(platinum_icon_path, platinum_name, "P");
+        }};
+        plat_popup_thread.detach();
     }
 
     ApplyUnlockToXmlFile(ctx.xml_save_file, trophyId, trophy_timestamp, unlock_platinum,


### PR DESCRIPTION
This PR fixes a wrong file read bug that prevented platinum trophies from being unlocked at all, makes the check for its unlock take into account that DLC trophies don't count towards it, and delay its popup to only after the last trophy that triggered it has finished presenting its own popup, because otherwise, the platinum popup was just overwriting the previous one.