### PR TITLE
Add asserts for some common corrupt dump indicators

### DIFF
--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -242,10 +242,9 @@ s32 Linker::LoadModule(const std::filesystem::path& elf_name, bool is_dynamic) {
     s32 mod_id = m_modules.size();
     auto module =
         std::make_unique<Module>(memory, elf_name, std::move(handle), max_tls_index, mod_id);
-    if (!module->IsValid()) {
-        LOG_ERROR(Core_Linker, "Provided file {} is not valid ELF file", elf_name.string());
-        return -1;
-    }
+    ASSERT_MSG(module->IsValid(),
+               "Provided file {} is not valid ELF file. This usually indicated a corrupted dump.",
+               elf_name.string());
 
     num_static_modules += !is_dynamic;
     m_modules.emplace_back(std::move(module));

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -446,6 +446,13 @@ bool Linker::Resolve(const std::string& name, Loader::SymbolType sym_type, Modul
     if (library->name != "libc" && library->name != "libSceFios2") {
         LOG_WARNING(Core_Linker, "Linker: Stub resolved {} as {} (lib: {}, mod: {})", sr.name,
                     return_info->name, library->name, module->name);
+    } else {
+        ASSERT_MSG(library->name != "libc" || return_info->name != "Need_sceLibc",
+                   "libc.prx is missing, but the guest attempted to use it. "
+                   "This usually indicates a corrupted dump.");
+        ASSERT_MSG(library->name != "libSceFios2" || return_info->name != "sceFiosInitialize",
+                   "libSceFios2.prx is missing, but the guest attempted to use it. "
+                   "This usually indicates a corrupted dump.");
     }
     return false;
 }

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -465,10 +465,8 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
 
     game_info.game_folder = game_folder;
 
-    if (!mnt->Exists(guest_eboot_path)) {
-        LOG_CRITICAL(Loader, "eboot.bin does not exist: {}", guest_eboot_path);
-        std::quick_exit(0);
-    }
+    ASSERT_MSG(mnt->Exists(guest_eboot_path), "Guest app's main executable {} does not exist",
+               guest_eboot_path);
 
     LOG_INFO(Loader, "Starting shadps4 emulator v{} ", Common::g_version);
     LOG_INFO(Loader, "Revision {}", Common::g_scm_rev);


### PR DESCRIPTION
This adds an assert for missing libc/fios2 when games link against them (so homebrew eboots still work because they don't link them unless explicitly needed), and another for loading invalid ELF files (which was just skipped with an error log previously).