### PR TITLE
Nix remove abseil

### DIFF
--- a/documents/building-linux.md
+++ b/documents/building-linux.md
@@ -63,7 +63,7 @@ nix build .?submodules=1#debug
 nix build .?submodules=1#release
 ```
 ```bash
-nix build .?submodules=1#releaseWithDebugInfo
+nix build .?submodules=1#releaseWithDebInfo
 ```
 #### Other Linux distributions
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,29 +1,12 @@
 {
   "nodes": {
-    "abseilCppSource": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1750171688,
-        "narHash": "sha256-eB7OqTO9Vwts9nYQ/Mdq0Ds4T1KgmmpYdzU09VPWOhk=",
-        "owner": "abseil",
-        "repo": "abseil-cpp",
-        "rev": "76bb24329e8bf5f39704eb10d21b9a80befa7c81",
-        "type": "github"
-      },
-      "original": {
-        "owner": "abseil",
-        "ref": "20250512.1",
-        "repo": "abseil-cpp",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1787070829,
+        "narHash": "sha256-vXNVDVtvfiQuXthP0NHPFdNvvMTkGpx0UP8oddIWbNk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "0ae2bc1419c3f345984c2629e72e7a631820fa4d",
         "type": "github"
       },
       "original": {
@@ -35,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "abseilCppSource": "abseilCppSource",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -6,22 +6,16 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
-    
-    abseilCppSource = {
-      url = "github:abseil/abseil-cpp?ref=20250512.1";
-      flake = false;
-    };
   };
 
   outputs =
-    { self, nixpkgs, abseilCppSource }:
+    { self, nixpkgs }:
     let
       pkgsLinux = nixpkgs.legacyPackages.x86_64-linux;
 
     in
     {
       formatter.x86_64-linux = pkgsLinux.nixpkgs-fmt;
-
       devShells.x86_64-linux.default =
         let
           shell =
@@ -158,7 +152,6 @@
             , libuuid
             , systemdMinimal
             , libx11
-            , abseilCppSource
             , releaseMode ? "debug"
             , enableDiscordRpc ? false
             ,
@@ -212,7 +205,6 @@
                 (lib.cmakeBool "ENABLE_DISCORD_RPC" enableDiscordRpc)
                 (lib.cmakeBool "ENABLE_TESTS" false)
                 (lib.cmakeBool "ENABLE_SYSTEM_LIBRARIES" true)
-                "-DFETCHCONTENT_SOURCE_DIR_ABSL=${abseilCppSource}"
               ];
               dontStrip = (getBuildSettings releaseMode).symbols;
 
@@ -228,10 +220,10 @@
             });
         in
         {
-          debug = pkgsLinux.callPackage build { releaseMode = "debug"; inherit abseilCppSource; };
-          release = pkgsLinux.callPackage build { releaseMode = "release"; inherit abseilCppSource; };
-          releaseWithDebInfo = pkgsLinux.callPackage build { releaseMode = "relWithDebInfo"; inherit abseilCppSource; };
-          default = pkgsLinux.callPackage build { releaseMode = "relWithDebInfo"; inherit abseilCppSource; };
+          debug = pkgsLinux.callPackage build { releaseMode = "debug"; };
+          release = pkgsLinux.callPackage build { releaseMode = "release"; };
+          releaseWithDebInfo = pkgsLinux.callPackage build { releaseMode = "relWithDebInfo"; };
+          default = pkgsLinux.callPackage build { releaseMode = "relWithDebInfo"; };
         };
     };
 }


### PR DESCRIPTION
With the recent PR #4872 abseil-cpp  is provided as a git submodule and will no longer need to be fetched externally, therefore it has been removed. 

Updated the flake.lock to the most recent nixpkgs unstable and fixed a small typo in documentation. Which is not "releaseWithDebInfo". 