### PR TITLE
video_core/gnmdriver: fix Naughty Dog titles stuck at black screen / 3 fps (Uncharted TNDC boots to main menu)

### DIFF
--- a/src/core/libraries/gnmdriver/gnmdriver.cpp
+++ b/src/core/libraries/gnmdriver/gnmdriver.cpp
@@ -2313,11 +2313,17 @@ s32 PS4_SYSV_ABI sceGnmSubmitCommandBuffers(u32 count, const u32* dcb_gpu_addrs[
 int PS4_SYSV_ABI sceGnmSubmitDone() {
     HLE_TRACE;
     LOG_DEBUG(Lib_GnmDriver, "called");
-    WaitGpuIdle();
-    if (!liverpool->IsGpuIdle()) {
-        submission_lock = true;
-    }
     liverpool->SubmitDone();
+    // Pace the guest by (bounded) draining of the gfx ring instead of the
+    // submission lock: the lock forces every submission after submitDone to
+    // wait until the WHOLE queue is idle, including async compute rings that
+    // engines like Naughty Dog's keep busy at all times - which serializes
+    // rendering to the interrupt cadence (~50-90 ms per frame observed in
+    // Uncharted TNDC). Draining just the gfx ring before returning keeps the
+    // engine's own frame pacing intact: all EOP fences of this frame are
+    // written before the guest's next FrameBegin. The wait is bounded because
+    // ring progress may depend on labels the guest writes after submitDone.
+    liverpool->WaitForGfxRingDrain();
     send_init_packet = true;
     ++frames_submitted;
     DebugState.IncGnmFrameNum();

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -123,7 +123,7 @@ u64 MemoryManager::ClampRangeSize(VAddr virtual_addr, u64 size) {
     clamped_size = std::min(clamped_size, size);
 
     if (size != clamped_size) {
-        LOG_WARNING(Kernel_Vmm, "Clamped requested buffer range addr={:#x}, size={:#x} to {:#x}",
+        LOG_DEBUG(Kernel_Vmm, "Clamped requested buffer range addr={:#x}, size={:#x} to {:#x}",
                     virtual_addr, size, clamped_size);
     }
     return clamped_size;

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -139,14 +139,14 @@ void Liverpool::Process(std::stop_token stoken) {
                     }
                     submit_cv.notify_all();
                 }
-                if (curr_qid == GfxQueueId) {
-                    while (pending_flip_signals) {
-                        --pending_flip_signals;
-                        if (rasterizer) {
-                            rasterizer->NotifyGuestFlip();
-                        }
-                        Platform::IrqC::Instance()->Signal(Platform::InterruptId::GfxFlip);
+                if (curr_qid == GfxQueueId && flip_signal_armed) {
+                    // Fallback for a flip NOP not followed by an executed tail
+                    // (should not happen in practice).
+                    flip_signal_armed = false;
+                    if (rasterizer) {
+                        rasterizer->NotifyGuestFlip();
                     }
+                    Platform::IrqC::Instance()->Signal(Platform::InterruptId::GfxFlip);
                 }
             }
         }
@@ -278,15 +278,19 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
 
                 switch (nop->data_block[0]) {
                 case PM4CmdNop::PayloadType::PatchedFlip: {
-                    // Defer the flip signal until the containing submit retires.
-                    // PatchFlipRequest appends the frame EOP fence AFTER this NOP,
-                    // so signaling here would let the present thread deliver the
-                    // flip event to the guest before the fence value is written
-                    // (observed as a guest-side assert of a zero EOP tick in
-                    // Naughty Dog titles once submission is pipelined). On real
-                    // hardware an eop-flip cannot precede the EOP of its own
-                    // submit either.
-                    ++pending_flip_signals;
+                    // Defer the flip signal until this DCB has fully executed.
+                    // PatchFlipRequest appends the frame fence (EventWriteEop or
+                    // label WriteData, depending on the PrepareFlip variant)
+                    // AFTER this NOP, so signaling here would let the present
+                    // thread deliver the flip event to the guest before the
+                    // fence value is visible - observed as a guest-side assert
+                    // of a zero EOP tick in Naughty Dog titles once submission
+                    // is pipelined. On real hardware an eop-flip cannot precede
+                    // the EOP of its own submit either. Waiting for the whole
+                    // submit to retire would be too coarse the other way: the
+                    // ring may legally stall on guest-written labels for many
+                    // seconds, serializing presentation.
+                    flip_signal_armed = true;
                     break;
                 }
                 case PM4CmdNop::PayloadType::DebugMarkerPush: {
@@ -910,6 +914,15 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
             dcb = NextPacket(dcb, header->type3.NumWords() + 1);
             break;
         }
+    }
+
+    if (flip_signal_armed) {
+        // Every packet after the flip NOP (fence writes included) has executed.
+        flip_signal_armed = false;
+        if (rasterizer) {
+            rasterizer->NotifyGuestFlip();
+        }
+        Platform::IrqC::Instance()->Signal(Platform::InterruptId::GfxFlip);
     }
 
     if (ce_task.handle) {

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -127,12 +127,27 @@ void Liverpool::Process(std::stop_token stoken) {
             if (task.done()) {
                 task.destroy();
 
-                std::scoped_lock lock{queue.m_access};
-                queue.submits.pop();
-
+                {
+                    std::scoped_lock lock{queue.m_access};
+                    queue.submits.pop();
+                }
                 --num_submits;
-                std::scoped_lock lock2{submit_mutex};
-                submit_cv.notify_all();
+                {
+                    std::scoped_lock lock2{submit_mutex};
+                    if (curr_qid == GfxQueueId) {
+                        --num_gfx_submits;
+                    }
+                    submit_cv.notify_all();
+                }
+                if (curr_qid == GfxQueueId) {
+                    while (pending_flip_signals) {
+                        --pending_flip_signals;
+                        if (rasterizer) {
+                            rasterizer->NotifyGuestFlip();
+                        }
+                        Platform::IrqC::Instance()->Signal(Platform::InterruptId::GfxFlip);
+                    }
+                }
             }
         }
 
@@ -263,9 +278,15 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
 
                 switch (nop->data_block[0]) {
                 case PM4CmdNop::PayloadType::PatchedFlip: {
-                    // There is no evidence that GPU CP drives flip events by parsing
-                    // special NOP packets. For convenience lets assume that it does.
-                    Platform::IrqC::Instance()->Signal(Platform::InterruptId::GfxFlip);
+                    // Defer the flip signal until the containing submit retires.
+                    // PatchFlipRequest appends the frame EOP fence AFTER this NOP,
+                    // so signaling here would let the present thread deliver the
+                    // flip event to the guest before the fence value is written
+                    // (observed as a guest-side assert of a zero EOP tick in
+                    // Naughty Dog titles once submission is pipelined). On real
+                    // hardware an eop-flip cannot precede the EOP of its own
+                    // submit either.
+                    ++pending_flip_signals;
                     break;
                 }
                 case PM4CmdNop::PayloadType::DebugMarkerPush: {
@@ -1223,6 +1244,7 @@ void Liverpool::SubmitGfx(std::span<const u32> dcb, std::span<const u32> ccb) {
 
     std::scoped_lock lk{submit_mutex};
     ++num_submits;
+    ++num_gfx_submits;
     submit_cv.notify_one();
 }
 

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -87,6 +87,17 @@ public:
         return num_submits == 0;
     }
 
+    // Waits (bounded) until the gfx ring has fully drained. Unlike the
+    // submission-lock approach this does not wait for async compute rings,
+    // which some engines (e.g. Naughty Dog titles) legitimately keep parked
+    // in WaitRegMem indefinitely. The timeout prevents deadlocks when ring
+    // progress depends on labels the guest writes only after submitDone.
+    void WaitForGfxRingDrain() {
+        using namespace std::chrono_literals;
+        std::unique_lock lk{submit_mutex};
+        submit_cv.wait_for(lk, 2000ms, [this] { return num_gfx_submits.load() == 0; });
+    }
+
     void SetVoPort(Libraries::VideoOut::VideoOutPort* port) {
         vo_port = port;
     }
@@ -224,6 +235,9 @@ private:
     Libraries::VideoOut::VideoOutPort* vo_port{};
     std::jthread process_thread{};
     std::atomic<u32> num_submits{};
+    std::atomic<u32> num_gfx_submits{};
+    // Flip signals deferred until the containing gfx submit retires (GPU thread only).
+    u32 pending_flip_signals{};
     std::atomic<u32> num_commands{};
     std::atomic<bool> submit_done{};
     std::mutex submit_mutex;

--- a/src/video_core/amdgpu/liverpool.h
+++ b/src/video_core/amdgpu/liverpool.h
@@ -236,8 +236,9 @@ private:
     std::jthread process_thread{};
     std::atomic<u32> num_submits{};
     std::atomic<u32> num_gfx_submits{};
-    // Flip signals deferred until the containing gfx submit retires (GPU thread only).
-    u32 pending_flip_signals{};
+    // Deferred flip signal: armed by the PatchedFlip NOP, delivered once the
+    // containing DCB has fully executed (GPU thread only).
+    bool flip_signal_armed{};
     std::atomic<u32> num_commands{};
     std::atomic<bool> submit_done{};
     std::mutex submit_mutex;

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -389,7 +389,8 @@ void BufferCache::CopyBuffer(VAddr dst, VAddr src, u32 num_bytes, bool dst_gds, 
 }
 
 std::pair<Buffer*, u32> BufferCache::ObtainBuffer(VAddr device_addr, u32 size, bool is_written,
-                                                  bool is_texel_buffer, BufferId buffer_id) {
+                                                  bool is_texel_buffer, BufferId buffer_id,
+                                                  u32 sync_limit) {
     // For read-only buffers use device local stream buffer to reduce renderpass breaks.
     if (!is_written && size <= CACHING_PAGESIZE && !IsRegionGpuModified(device_addr, size)) {
         const u64 offset = stream_buffer.Copy(device_addr, size, instance.UniformMinAlignment());
@@ -399,7 +400,21 @@ std::pair<Buffer*, u32> BufferCache::ObtainBuffer(VAddr device_addr, u32 size, b
         buffer_id = FindBuffer(device_addr, size);
     }
     Buffer& buffer = slot_buffers[buffer_id];
-    SynchronizeBuffer(buffer, device_addr, size, is_written, is_texel_buffer);
+    if (sync_limit != 0) {
+        // Unbounded descriptor: synchronize only a window near the base
+        // address, at most once per guest flip. Re-uploading everything the
+        // guest wrote anywhere into a multi-GiB range on every draw is
+        // prohibitively slow, and hundreds of draws per frame bind the same
+        // descriptor.
+        const u64 stamp = flip_stamp.load(std::memory_order_relaxed);
+        if (unbounded_sync_stamp != stamp) {
+            unbounded_sync_stamp = stamp;
+            SynchronizeBuffer(buffer, device_addr, std::min(size, sync_limit), is_written,
+                              is_texel_buffer);
+        }
+    } else {
+        SynchronizeBuffer(buffer, device_addr, size, is_written, is_texel_buffer);
+    }
     if (is_written) {
         gpu_modified_ranges.Add(device_addr, size);
     }

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -126,7 +126,13 @@ public:
     /// Obtains a buffer for the specified region.
     [[nodiscard]] std::pair<Buffer*, u32> ObtainBuffer(VAddr gpu_addr, u32 size, bool is_written,
                                                        bool is_texel_buffer = false,
-                                                       BufferId buffer_id = {});
+                                                       BufferId buffer_id = {},
+                                                       u32 sync_limit = 0);
+
+    /// Called by the GPU thread when a guest flip submit retires.
+    void NotifyGuestFlip() {
+        flip_stamp.fetch_add(1, std::memory_order_relaxed);
+    }
 
     /// Attempts to obtain a buffer without modifying the cache contents.
     [[nodiscard]] std::pair<Buffer*, u32> ObtainBufferForImage(VAddr gpu_addr, u32 size);
@@ -208,6 +214,8 @@ private:
     std::unique_ptr<MemoryTracker> memory_tracker;
     StreamBuffer staging_buffer;
     StreamBuffer stream_buffer;
+    std::atomic<u64> flip_stamp{};
+    u64 unbounded_sync_stamp = ~0ull;
     StreamBuffer download_buffer;
     StreamBuffer device_buffer;
     Buffer gds_buffer;

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -310,7 +310,7 @@ vk::SamplerAddressMode ClampMode(AmdGpu::ClampMode mode) {
         return vk::SamplerAddressMode::eClampToEdge;
     case AmdGpu::ClampMode::MirrorOnceHalfBorder:
     case AmdGpu::ClampMode::MirrorOnceBorder:
-        LOG_WARNING(Render_Vulkan, "Unimplemented clamp mode {}, using closest equivalent.",
+        LOG_DEBUG(Render_Vulkan, "Unimplemented clamp mode {}, using closest equivalent.",
                     static_cast<u32>(mode));
         [[fallthrough]];
     case AmdGpu::ClampMode::MirrorOnceLastTexel:

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -670,8 +670,19 @@ void Rasterizer::BindBuffers(const Shader::Info& stage, Shader::Backend::Binding
                 buffer_infos.emplace_back(VK_NULL_HANDLE, 0, VK_WHOLE_SIZE);
             }
         } else {
+            // V# with num_records=0xffffffff is a legal "pointer to all of
+            // memory" pattern (Naughty Dog). ClampRangeSize turns it into a
+            // multi-GiB range; treating that as a regular SSBO poisons the
+            // cache: marking gigabytes GPU-modified kills the stream-buffer
+            // fast path for every other buffer, and re-synchronizing the
+            // whole range on every draw costs tens of ms (12 s worst case
+            // observed). Keep reads coherent with a small window near the
+            // base address, synced at most once per flip.
+            const bool unbounded =
+                vsharp.num_records == 0xffffffffu && size >= 1_GB;
             const auto [vk_buffer, offset] = buffer_cache.ObtainBuffer(
-                vsharp.base_address, size, desc.is_written, desc.is_formatted, buffer_id);
+                vsharp.base_address, size, desc.is_written && !unbounded,
+                desc.is_formatted, buffer_id, unbounded ? 16_MB : 0);
             const u32 offset_aligned = Common::AlignDown(offset, alignment);
             const u32 adjust = offset - offset_aligned;
             ASSERT(adjust % 4 == 0);
@@ -683,7 +694,7 @@ void Rasterizer::BindBuffers(const Shader::Info& stage, Shader::Backend::Binding
                                           vk::PipelineStageFlagBits2::eAllCommands)) {
                 buffer_barriers.emplace_back(*barrier);
             }
-            if (desc.is_written && desc.is_formatted) {
+            if (desc.is_written && desc.is_formatted && !unbounded) {
                 texture_cache.InvalidateMemoryFromGPU(vsharp.base_address, size);
             }
         }

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -38,6 +38,10 @@ public:
         return buffer_cache;
     }
 
+    void NotifyGuestFlip() {
+        buffer_cache.NotifyGuestFlip();
+    }
+
     [[nodiscard]] VideoCore::TextureCache& GetTextureCache() noexcept {
         return texture_cache;
     }


### PR DESCRIPTION
Uncharted: The Nathan Drake Collection (CUSA02320) is listed as "Nothing" in the compatibility tracker: it boots to a black screen and crawls at 3-4 fps, never reaching the title screen in reasonable time. After instrumenting the emulator (Tracy + custom fence/event tracing) we found three independent problems. With all three fixed, the game reaches the full title screen and its main menu is rendered and navigable:

| Title screen | Main menu |
|---|---|
| ![title](https://raw.githubusercontent.com/sergek88/shadPS4/assets/title-screen.png) | ![menu](https://raw.githubusercontent.com/sergek88/shadPS4/assets/main-menu.png) |

### 1. Replace the submission lock with a bounded gfx-ring drain

`sceGnmSubmitDone` currently sets `submission_lock` whenever the GPU is not idle; every subsequent submission then blocks until the WHOLE queue drains (reset only by the GpuIdle IRQ). ND engines keep their async compute rings parked in `WaitRegMem` at all times, so "whole queue idle" effectively means "once per interrupt cadence": Tracy shows `WaitGpuIdle` costing a mean of 58 ms (max 30 s!) per call and `sceGnmSubmitDone` 86 ms — with actual GPU work being ~6 s out of a 90 s capture. The game is fully serialized by the emulator, not by its own pacing.

The replacement: `sceGnmSubmitDone` performs a *bounded* (2 s) wait for the *gfx ring only* to drain. This preserves the guarantee ND relies on — all EOP fences of the submitted frame are written before the guest's next `FrameBegin` (their `fg-draw-mgr.cpp:234` assert checks exactly that) — without waiting on compute rings, and the timeout prevents deadlocks when ring progress depends on labels the guest writes after `submitDone` returns (observed during loading phases).

### 2. Defer the flip signal until the flip submit retires

`PatchFlipRequest` appends the frame-tick `EventWriteEop` AFTER the `PatchedFlip` NOP in the DCB. Signaling `GfxFlip` while parsing the NOP lets the present thread deliver the flip event to the guest *before* the tick value is written — the guest wakes up, reads a zero EOP tick and asserts. The upstream submission lock was masking this race by keeping the guest too slow to observe it. On real hardware an eop-flip cannot precede the EOP of its own submit either, so the signal is now accumulated and fired when the containing gfx submit retires.

### 3. Tame "unbounded" V# descriptors (num_records = 0xffffffff)

ND shaders bind V# descriptors with `num_records = 0xffffffff`, `stride = 4` — a legal "pointer to all of memory" pattern. The u32 multiply overflows to 0xfffffffc and `ClampRangeSize` clamps it to the end of the contiguous mapping (~2.7 GiB). Treating that as a regular SSBO is catastrophic:

* `gpu_modified_ranges.Add()` marks the whole guest heap GPU-modified, killing the stream-buffer fast path for every other buffer;
* every draw re-synchronizes whatever the guest wrote anywhere in the range — we measured a single `ObtainBuffer` call taking **12.25 seconds** during the menu loading phase, and 24 ms average `Draw` cost (vs 34 µs in light scenes);
* re-protecting ~700k pages per draw plus region locks held across uploads burns ~5 CPU cores in page-fault storms.

The fix: for descriptors matching this pattern (num_records == 0xffffffff and clamped size >= 1 GiB) don't mark the range written, and synchronize only a 16 MiB window near the base address, at most once per guest flip. Reads stay coherent (ND uses the descriptor for data near its base); a proper long-term solution would route such descriptors through the existing BDA page-table path.

Also demotes the per-draw `ClampRangeSize`/`ClampMode` warnings to debug — with sync logging they alone cost milliseconds per frame.

### Results (RTX 5080, Windows 11, base 1.00 + update 1.02)

| | upstream main | this PR |
|---|---|---|
| intro logos | ~35 min | ~2 min |
| full title screen | not reached (bare text after ~50 min) | ~23 min, full art |
| main menu | never | rendered, navigable |
| guest EOP-tick assert | n/a (masked by lock) | not reproducible |

The remaining slowness (menu load phase) is the guest's own streaming loop paying HLE event-delivery latency per job wave; it is independent of these fixes and we plan to look into it next.

Happy to split this into three PRs if preferred, gate any part behind a config option, or adapt the descriptor heuristic.
