### PR TITLE
presenter: Use present scheduler for blank frame prepare

### DIFF
--- a/src/core/libraries/videoout/driver.cpp
+++ b/src/core/libraries/videoout/driver.cpp
@@ -278,7 +278,7 @@ void VideoOutDriver::Flip(const Request& req) {
 }
 
 void VideoOutDriver::DrawBlankFrame() {
-    const auto empty_frame = presenter->PrepareBlankFrame(false);
+    const auto empty_frame = presenter->PrepareBlankFrame(true);
     presenter->Present(empty_frame);
 }
 


### PR DESCRIPTION
PrepareBlankFrame is called from present thread so using draw scheduler is a race condition