### PR TITLE
Change default GetAuthorizationCode returns to be valid

### DIFF
--- a/src/core/libraries/np/np_auth.cpp
+++ b/src/core/libraries/np/np_auth.cpp
@@ -120,11 +120,10 @@ s32 GetAuthorizationCode(s32 req_id, const OrbisNpAuthGetAuthorizationCodeParame
 
     LOG_ERROR(Lib_NpAuth, "(STUBBED) called, req_id = {:#x}, async = {}", req_id, request.async);
 
-    // Not sure what values are expected here, so zeroing these for now.
     std::memset(auth_code, 0, sizeof(OrbisNpAuthorizationCode));
-    std::strncpy(auth_code->code, "AUTHCODE", 9);
+    std::strncpy(auth_code->code, "AUTHEN", 7);
     if (issuer_id != nullptr) {
-        *issuer_id = 100;
+        *issuer_id = 0x100;
     }
     return ORBIS_OK;
 }


### PR DESCRIPTION
Apparently authentication codes should be 6 characters long, and issuer_id should always be 0x100. These details come from verbose game logs.