### PR TITLE
Nix: Provide relevant runtime llibraries required for running shadPS4 entirely though the devshell.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,8 @@
             , clang-tools
             , cmake
             , pkg-config
+            , vulkan-loader
+            , mesa
             , renderdoc
             , gef
             , strace
@@ -50,47 +52,53 @@
             , libxrandr
             , libxrender
             , libxtst
+            , libX11
+            , libxcb
             , libxscrnsaver
             , enableDebugTooling ? true
             ,
             }:
+            let
+              runtimeDeps = [
+                libGL
+                libxext
+                libdrm
+                libgbm
+                libpulseaudio
+              ];
+
+              # SDL3 requres extra libraries inside the devshell in order to pass CMake's configure.
+              sdlConfigureDeps = [
+                jack1
+                fribidi
+                libthai
+                sndio
+                libusb1
+                libxkbcommon
+                libxcursor
+                libxfixes
+                libxi
+                libxinerama
+                libxrandr
+                libxrender
+                libxtst
+                libxscrnsaver
+              ] ++ runtimeDeps;
+            in
 
             mkShell.override { stdenv = clangStdenv; } {
               inputsFrom = [ self.packages.x86_64-linux.default ];
 
-              packages =
-                let
-                  # SDL3 requres extra libraries inside the devshell in order to pass CMake's configure.
-                  sdlConfigureDeps = [
-                    libGL
-                    jack1
-                    fribidi
-                    libthai
-                    libpulseaudio
-                    sndio
-                    libdrm
-                    libgbm
-                    libusb1
-                    libxkbcommon
-                    libxcursor
-                    libxext
-                    libxfixes
-                    libxi
-                    libxinerama
-                    libxrandr
-                    libxrender
-                    libxtst
-                    libxscrnsaver
-                  ];
-                in
-                [
-                  clang-tools
-                  cmake
-                  pkg-config
-                ] ++ sdlConfigureDeps ++ lib.optionals enableDebugTooling [ renderdoc gef strace perf vulkan-tools ];
+              packages = [
+                clang-tools
+                cmake
+                pkg-config
+                libxcb.dev
+              ] ++ sdlConfigureDeps ++ lib.optionals enableDebugTooling [ renderdoc gef strace perf vulkan-tools ];
 
               shellHook = ''
                 echo "Entering shadPS4 development shell!"
+                export LD_LIBRARY_PATH="${lib.makeLibraryPath (lib.flatten runtimeDeps ++ [ vulkan-loader libX11 ])}:$LD_LIBRARY_PATH"
               '';
 
               CMAKE_C_COMPILER = "clang";


### PR DESCRIPTION
Allows shadPS4 to now be built and run entirely through the shell as well as  a separate build. Was missing some libraries at runtime in order to do this. Making iterative  compiling and testing much easier. 