### PR TITLE
shader_recompiler: decorate written storage buffers as Coherent

### DIFF
--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -782,6 +782,11 @@ EmitContext::BufferSpv EmitContext::DefineBuffer(bool is_written, u32 elem_shift
     Decorate(id, spv::Decoration::DescriptorSet, 0U);
     if (!is_written) {
         Decorate(id, spv::Decoration::NonWritable);
+    } else {
+        // Guest shaders may use buffer stores with s_barrier for handoff
+        // between invocations of a workgroup. Mark written buffers coherent
+        // so accesses are not cached in registers across the barrier.
+        Decorate(id, spv::Decoration::Coherent);
     }
     switch (buffer_type) {
     case BufferType::GdsBuffer:

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -759,7 +759,7 @@ void EmitContext::DefinePushDataBlock() {
     interfaces.push_back(push_data_block);
 }
 
-EmitContext::BufferSpv EmitContext::DefineBuffer(bool is_written, u32 elem_shift,
+EmitContext::BufferSpv EmitContext::DefineBuffer(bool is_written, bool is_coherent, u32 elem_shift,
                                                  BufferType buffer_type, Id data_type) {
     // Define array type.
     const Id record_array_type{TypeRuntimeArray(data_type)};
@@ -782,6 +782,10 @@ EmitContext::BufferSpv EmitContext::DefineBuffer(bool is_written, u32 elem_shift
     Decorate(id, spv::Decoration::DescriptorSet, 0U);
     if (!is_written) {
         Decorate(id, spv::Decoration::NonWritable);
+    } else if (is_coherent) {
+        // The guest V# MTYPE marks this buffer as shared between invocations;
+        // Coherent forbids caching its accesses in registers across barriers.
+        Decorate(id, spv::Decoration::Coherent);
     }
     switch (buffer_type) {
     case BufferType::GdsBuffer:
@@ -813,6 +817,10 @@ EmitContext::BufferSpv EmitContext::DefineBuffer(bool is_written, u32 elem_shift
 void EmitContext::DefineBuffers() {
     for (const auto& desc : info.buffers) {
         const auto buf_sharp = desc.GetSharp(info);
+        // MTYPE class 3 marks guest buffers shared between invocations; shared
+        // memory lowered to a storage buffer needs the same guarantee.
+        const bool is_coherent =
+            desc.buffer_type == BufferType::SharedMemory || buf_sharp.mtype == 3;
 
         // Set indexes for special buffers.
         if (desc.buffer_type == BufferType::Flatbuf) {
@@ -827,23 +835,23 @@ void EmitContext::DefineBuffers() {
         auto& spv_buffer = buffers.emplace_back(binding.buffer++, desc.buffer_type);
         if (True(desc.used_types & IR::Type::U64)) {
             spv_buffer.Alias(PointerType::U64) =
-                DefineBuffer(desc.is_written, 3, desc.buffer_type, U64);
+                DefineBuffer(desc.is_written, is_coherent, 3, desc.buffer_type, U64);
         }
         if (True(desc.used_types & IR::Type::U32)) {
             spv_buffer.Alias(PointerType::U32) =
-                DefineBuffer(desc.is_written, 2, desc.buffer_type, U32[1]);
+                DefineBuffer(desc.is_written, is_coherent, 2, desc.buffer_type, U32[1]);
         }
         if (True(desc.used_types & IR::Type::F32)) {
             spv_buffer.Alias(PointerType::F32) =
-                DefineBuffer(desc.is_written, 2, desc.buffer_type, F32[1]);
+                DefineBuffer(desc.is_written, is_coherent, 2, desc.buffer_type, F32[1]);
         }
         if (True(desc.used_types & IR::Type::U16)) {
             spv_buffer.Alias(PointerType::U16) =
-                DefineBuffer(desc.is_written, 1, desc.buffer_type, U16);
+                DefineBuffer(desc.is_written, is_coherent, 1, desc.buffer_type, U16);
         }
         if (True(desc.used_types & IR::Type::U8)) {
             spv_buffer.Alias(PointerType::U8) =
-                DefineBuffer(desc.is_written, 0, desc.buffer_type, U8);
+                DefineBuffer(desc.is_written, is_coherent, 0, desc.buffer_type, U8);
         }
         ++binding.unified;
     }

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -782,11 +782,6 @@ EmitContext::BufferSpv EmitContext::DefineBuffer(bool is_written, u32 elem_shift
     Decorate(id, spv::Decoration::DescriptorSet, 0U);
     if (!is_written) {
         Decorate(id, spv::Decoration::NonWritable);
-    } else {
-        // Guest shaders may use buffer stores with s_barrier for handoff
-        // between invocations of a workgroup. Mark written buffers coherent
-        // so accesses are not cached in registers across the barrier.
-        Decorate(id, spv::Decoration::Coherent);
     }
     switch (buffer_type) {
     case BufferType::GdsBuffer:

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -401,7 +401,8 @@ private:
     SpirvAttribute GetAttributeInfo(AmdGpu::NumberFormat fmt, Id id, u32 num_components,
                                     bool output, bool loaded = false, bool array = false);
 
-    BufferSpv DefineBuffer(bool is_written, u32 elem_shift, BufferType buffer_type, Id data_type);
+    BufferSpv DefineBuffer(bool is_written, bool is_coherent, u32 elem_shift,
+                           BufferType buffer_type, Id data_type);
 
     Id DefineFloat32ToUfloatM5(u32 mantissa_bits, std::string_view name);
     Id DefineUfloatM5ToFloat32(u32 mantissa_bits, std::string_view name);

--- a/src/video_core/amdgpu/resource.h
+++ b/src/video_core/amdgpu/resource.h
@@ -28,7 +28,8 @@ struct Buffer {
     u32 element_size : 2;
     u32 index_stride : 2;
     u32 add_tid_enable : 1;
-    u32 _padding1 : 6;
+    u32 _padding1 : 3;
+    u32 mtype : 3;
     u32 type : 2; // overlaps with T# type, so should be 0 for buffer
 
     static constexpr Buffer Null() {


### PR DESCRIPTION
This PR fixes uncontrollably stretching hair on movement for NVIDIA gpus in TLOU Remastered by decorating written storage buffers as `Coherent`. 
According to OpenGL Shading Language 4.60 specification, section 4.10 "Memory Qualifiers":
https://registry.khronos.org/OpenGL/specs/gl/GLSLangSpec.4.60.html

"_When accessing memory using variables not declared as coherent, the memory accessed by a shader may be cached by the implementation to service future accesses to the same address. Memory stores may be cached in such a way that the values written may not be visible to other shader invocations accessing the same memory. **The implementation may cache the values fetched by memory reads and return the same values to any shader invocation accessing the same memory, even if the underlying memory has been modified since the first memory read**. While variables not declared as coherent may not be useful for communicating between shader invocations, using non-coherent accesses may result in higher performance._"

Hair threads exchange positional data through buffers and without `Coherent`, NVIDIA can legally reuse stale, cached copies. The fix is to decorate written storage buffers as `Coherent`.

Before (stale):
<img width="1273" height="725" alt="TLOU-before" src="https://github.com/user-attachments/assets/9f5a28eb-588a-47bb-9346-61979ff9ad20" />

After: (Coherent)
<img width="1283" height="725" alt="TLOU-after" src="https://github.com/user-attachments/assets/5b45a2e9-29ae-41e0-b870-09d0235940b8" />
