### PR TITLE
shader_recompiler: Improve ssa rewrite pass correctness and readability

### DIFF
--- a/src/shader_recompiler/ir/passes/ir_passes.h
+++ b/src/shader_recompiler/ir/passes/ir_passes.h
@@ -13,7 +13,7 @@ void InjectClipDistanceAttributes(IR::Program& program, RuntimeInfo& runtime_inf
 
 namespace Shader::Optimization {
 
-void SsaRewritePass(IR::BlockList& program);
+void SsaRewritePass(IR::Program& program);
 void IdentityRemovalPass(IR::BlockList& program);
 void DeadCodeEliminationPass(IR::Program& program);
 void ConstantPropagationPass(IR::BlockList& program);

--- a/src/shader_recompiler/ir/passes/ssa_rewrite_pass.cpp
+++ b/src/shader_recompiler/ir/passes/ssa_rewrite_pass.cpp
@@ -20,6 +20,7 @@
 
 #include "shader_recompiler/ir/basic_block.h"
 #include "shader_recompiler/ir/opcodes.h"
+#include "shader_recompiler/ir/program.h"
 #include "shader_recompiler/ir/reg.h"
 #include "shader_recompiler/ir/value.h"
 
@@ -161,144 +162,125 @@ struct DefTable {
     ValueMap m0_flag;
 };
 
-IR::Opcode UndefOpcode(IR::ScalarReg) noexcept {
+constexpr IR::Opcode UndefOpcode(IR::ScalarReg) noexcept {
     return IR::Opcode::UndefU32;
 }
 
-IR::Opcode UndefOpcode(IR::VectorReg) noexcept {
+constexpr IR::Opcode UndefOpcode(IR::VectorReg) noexcept {
     return IR::Opcode::UndefU32;
 }
 
-IR::Opcode UndefOpcode(const VccLoTag) noexcept {
+constexpr IR::Opcode UndefOpcode(const VccLoTag) noexcept {
     return IR::Opcode::UndefU32;
 }
 
-IR::Opcode UndefOpcode(const VccHiTag) noexcept {
+constexpr IR::Opcode UndefOpcode(const VccHiTag) noexcept {
     return IR::Opcode::UndefU32;
 }
 
-IR::Opcode UndefOpcode(const M0Tag) noexcept {
+constexpr IR::Opcode UndefOpcode(const M0Tag) noexcept {
     return IR::Opcode::UndefU32;
 }
 
-IR::Opcode UndefOpcode(const FlagTag) noexcept {
+constexpr IR::Opcode UndefOpcode(const FlagTag) noexcept {
     return IR::Opcode::UndefU1;
 }
 
-enum class Status {
-    Start,
-    SetValue,
-    PushPhiArgument,
-};
-
-template <typename Type>
-struct ReadState {
-    ReadState(IR::Block* block_) : block{block_} {}
-    ReadState() = default;
-
-    IR::Block* block{};
-    IR::Value result{};
-    IR::Inst* phi{};
-    IR::Block* const* pred_it{};
-    IR::Block* const* pred_end{};
-    Status pc{Status::Start};
-};
-
 class Pass {
 public:
+    explicit Pass(IR::Block* first_block_) : first_block{first_block_} {}
+
     template <typename Type>
     void WriteVariable(Type variable, IR::Block* block, const IR::Value& value) {
         current_def.SetDef(block, variable, value);
     }
 
     template <typename Type>
-    IR::Value ReadVariable(Type variable, IR::Block* root_block) {
-        boost::container::small_vector<ReadState<Type>, 64> stack{
-            ReadState<Type>(nullptr),
-            ReadState<Type>(root_block),
-        };
-        const auto prepare_phi_operand = [&] {
-            if (stack.back().pred_it == stack.back().pred_end) {
-                IR::Inst* const phi{stack.back().phi};
-                IR::Block* const block{stack.back().block};
-                const IR::Value result{TryRemoveTrivialPhi(*phi, block, UndefOpcode(variable))};
-                stack.pop_back();
-                stack.back().result = result;
-                WriteVariable(variable, block, result);
-            } else {
-                IR::Block* const imm_pred{*stack.back().pred_it};
-                stack.back().pc = Status::PushPhiArgument;
-                stack.emplace_back(imm_pred);
-            }
-        };
-        do {
-            IR::Block* const block{stack.back().block};
-            switch (stack.back().pc) {
-            case Status::Start: {
-                if (const IR::Value& def = current_def.Def(block, variable); !def.IsEmpty()) {
-                    stack.back().result = def;
-                } else if (!block->IsSsaSealed()) {
-                    // Incomplete CFG
-                    IR::Inst* phi{&*block->PrependNewInst(block->begin(), IR::Opcode::Phi)};
-                    phi->SetFlags(IR::TypeOf(UndefOpcode(variable)));
+    IR::Value ReadVariable(Type variable, IR::Block* block) {
+        // If variable has a definition in block, return it.
+        IR::Value def = current_def.Def(block, variable);
+        if (!def.IsEmpty()) {
+            return def;
+        }
 
-                    incomplete_phis[block].insert_or_assign(variable, phi);
-                    stack.back().result = IR::Value{&*phi};
-                } else if (const std::span imm_preds = block->ImmPredecessors();
-                           imm_preds.size() == 1) {
-                    // Optimize the common case of one predecessor: no phi needed
-                    stack.back().pc = Status::SetValue;
-                    stack.emplace_back(imm_preds.front());
-                    break;
-                } else {
-                    // Break potential cycles with operandless phi
-                    IR::Inst* const phi{&*block->PrependNewInst(block->begin(), IR::Opcode::Phi)};
-                    phi->SetFlags(IR::TypeOf(UndefOpcode(variable)));
+        // Otherwise, look up the value in block predecessors.
+        const std::span imm_preds = block->ImmPredecessors();
+        if (imm_preds.size() == 1) {
+            // Optimize the common case of one predecessor: no phi needed
+            def = ReadVariable(variable, imm_preds.front());
+        } else if (imm_preds.size() > 1) {
+            // This is a join block which may require a phi.
+            // That will act as the variables current definition to break potential cycles.
+            IR::Inst* const phi{&*block->PrependNewInst(block->begin(), IR::Opcode::Phi)};
+            phi->SetFlags(IR::TypeOf(UndefOpcode(variable)));
 
-                    WriteVariable(variable, block, IR::Value{phi});
+            // Set the value for this block to avoid an infinite recursion.
+            WriteVariable(variable, block, IR::Value{phi});
+            def = AddPhiOperands(variable, phi, block);
+        }
 
-                    stack.back().phi = phi;
-                    stack.back().pred_it = imm_preds.data();
-                    stack.back().pred_end = imm_preds.data() + imm_preds.size();
-                    prepare_phi_operand();
-                    break;
-                }
-            }
-                [[fallthrough]];
-            case Status::SetValue: {
-                const IR::Value result{stack.back().result};
-                WriteVariable(variable, block, result);
-                stack.pop_back();
-                stack.back().result = result;
-                break;
-            }
-            case Status::PushPhiArgument: {
-                IR::Inst* const phi{stack.back().phi};
-                phi->AddPhiOperand(*stack.back().pred_it, stack.back().result);
-                ++stack.back().pred_it;
-                prepare_phi_operand();
-                break;
-            }
-            }
-        } while (stack.size() > 1);
-        return stack.back().result;
+        // If we could not find a store for this variable, use undef.
+        if (def.IsEmpty()) {
+            def = IR::Value{GetUndefInst(UndefOpcode(variable))};
+        }
+
+        WriteVariable(variable, block, def);
+        return def;
     }
 
-    void SealBlock(IR::Block* block) {
-        const auto it{incomplete_phis.find(block)};
-        if (it != incomplete_phis.end()) {
+    template <typename Type>
+    IR::Value AddPhiOperands(Type variable, IR::Inst* phi, IR::Block* block) {
+        ASSERT_MSG(phi->NumArgs() == 0, "Phi candidate already has arguments");
+
+        bool found_empty_arg = false;
+        for (IR::Block* const pred : block->ImmPredecessors()) {
+            // If pred is not sealed, use empty value to indicate that phi
+            // needs to be completed after the whole CFG has been processed.
+            auto arg = pred->IsSsaSealed() ? ReadVariable(variable, pred) : IR::Value{};
+            phi->AddPhiOperand(pred, arg);
+            found_empty_arg |= arg.IsEmpty();
+        }
+        if (found_empty_arg) {
+            incomplete_phis[block].insert_or_assign(variable, phi);
+            return IR::Value{phi};
+        }
+        return TryRemoveTrivialPhi(*phi, block, UndefOpcode(variable));
+    }
+
+    void FinalizePhiCandidates() {
+        for (auto it = incomplete_phis.begin(); it != incomplete_phis.end(); ++it) {
             for (auto& [variant, phi] : it->second) {
-                std::visit([&](auto& variable) { AddPhiOperands(variable, *phi, block); }, variant);
+                std::visit([&](auto& variable) { FinalizePhiCandidate(variable, *phi, it->first); },
+                           variant);
             }
         }
-        block->SsaSeal();
     }
 
 private:
+    IR::Inst* GetUndefInst(IR::Opcode undef_opcode) {
+        auto [it, is_new] = undef_map.try_emplace(undef_opcode, nullptr);
+        if (is_new) {
+            IR::Inst* const undef{
+                &*first_block->PrependNewInst(first_block->begin(), undef_opcode)};
+            it->second = undef;
+        }
+        return it->second;
+    }
+
     template <typename Type>
-    IR::Value AddPhiOperands(Type variable, IR::Inst& phi, IR::Block* block) {
-        for (IR::Block* const imm_pred : block->ImmPredecessors()) {
-            phi.AddPhiOperand(imm_pred, ReadVariable(variable, imm_pred));
+    IR::Value FinalizePhiCandidate(Type variable, IR::Inst& phi, IR::Block* block) {
+        size_t arg_index{};
+        for (IR::Block* const pred : block->ImmPredecessors()) {
+            ASSERT(phi.PhiBlock(arg_index) == pred);
+            if (!phi.Arg(arg_index).IsEmpty()) {
+                arg_index++;
+                continue;
+            }
+            if (pred->IsSsaSealed()) {
+                phi.SetArg(arg_index++, ReadVariable(variable, pred));
+            } else {
+                phi.SetArg(arg_index++, IR::Value{GetUndefInst(UndefOpcode(variable))});
+            }
         }
         return TryRemoveTrivialPhi(phi, block, UndefOpcode(variable));
     }
@@ -318,24 +300,15 @@ private:
             }
             same = op;
         }
-        // Remove the phi node from the block, it will be reinserted
-        IR::Block::InstructionList& list{block->Instructions()};
-        list.erase(IR::Block::InstructionList::s_iterator_to(phi));
-
-        // Find the first non-phi instruction and use it as an insertion point
-        IR::Block::iterator reinsert_point{std::ranges::find_if_not(list, IR::IsPhi)};
         if (same.IsEmpty()) {
             // The phi is unreachable or in the start block
             // Insert an undefined instruction and make it the phi node replacement
-            // The "phi" node reinsertion point is specified after this instruction
-            reinsert_point = block->PrependNewInst(reinsert_point, undef_opcode);
-            same = IR::Value{&*reinsert_point};
-            ++reinsert_point;
+            same = IR::Value{GetUndefInst(undef_opcode)};
         }
-        // Reinsert the phi node and reroute all its uses to the "same" value
+        // Reroute all uses of the phi to the "same" value
         const auto users = phi.Uses();
-        list.insert(reinsert_point, phi);
         phi.ReplaceUsesWith(same);
+
         // Try to recursively remove all phi users, which might have become trivial
         for (const auto& [user, arg_index] : users) {
             if (user->GetOpcode() == IR::Opcode::Phi) {
@@ -345,6 +318,8 @@ private:
         return same;
     }
 
+    IR::Block* first_block;
+    std::unordered_map<IR::Opcode, IR::Inst*> undef_map;
     std::unordered_map<IR::Block*, std::map<Variant, IR::Inst*>> incomplete_phis;
     DefTable current_def;
 };
@@ -444,17 +419,18 @@ void VisitBlock(Pass& pass, IR::Block* block) {
     for (IR::Inst& inst : block->Instructions()) {
         VisitInst(pass, block, inst);
     }
-    pass.SealBlock(block);
+    block->SsaSeal();
 }
 
 } // Anonymous namespace
 
-void SsaRewritePass(IR::BlockList& program) {
-    Pass pass;
-    const auto end{program.rend()};
-    for (auto block = program.rbegin(); block != end; ++block) {
-        VisitBlock(pass, *block);
+void SsaRewritePass(IR::Program& program) {
+    Pass pass{program.blocks.front()};
+    const auto end = program.post_order_blocks.rend();
+    for (auto it = program.post_order_blocks.rbegin(); it != end; ++it) {
+        VisitBlock(pass, *it);
     }
+    pass.FinalizePhiCandidates();
 }
 
 } // namespace Shader::Optimization

--- a/src/shader_recompiler/recompiler.cpp
+++ b/src/shader_recompiler/recompiler.cpp
@@ -67,7 +67,7 @@ IR::Program TranslateProgram(const std::span<const u32>& code, Pools& pools, Inf
     if (!profile.support_float64) {
         Shader::Optimization::LowerFp64ToFp32(program);
     }
-    Shader::Optimization::SsaRewritePass(program.post_order_blocks);
+    Shader::Optimization::SsaRewritePass(program);
     Shader::Optimization::ConstantPropagationPass(program.post_order_blocks);
     Shader::Optimization::IdentityRemovalPass(program.blocks);
     if (info.l_stage == LogicalStage::TessellationControl) {

--- a/tests/gcn/test_predicate_reconstruction.cpp
+++ b/tests/gcn/test_predicate_reconstruction.cpp
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: Copyright 2026 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "common/object_pool.h"
+#include "shader_recompiler/ir/ir_emitter.h"
+#include "shader_recompiler/ir/passes/control_flow/mask_to_predicate_pass.h"
+#include "shader_recompiler/ir/passes/control_flow/predicate_interval_pass.h"
+
+namespace {
+
+struct IrFixture : testing::Test {
+    Common::ObjectPool<Shader::IR::Inst> inst_pool{64};
+    Shader::IR::Block block{inst_pool};
+    Shader::IR::IREmitter ir{block};
+};
+
+using Shader::IR::Opcode;
+using Shader::Optimization::ExtractMustFactors;
+
+TEST_F(IrFixture, BallotProjectionReturnsOriginalPredicate) {
+    const Shader::IR::U1 predicate = ir.GetScc();
+    const Shader::IR::U1 projected = ir.ProjectLane(ir.Ballot64(predicate));
+
+    Shader::Optimization::MaskToPredicatePass({&block});
+
+    EXPECT_EQ(projected.Resolve(), predicate.Resolve());
+}
+
+TEST_F(IrFixture, NestedMaskAndBecomesBooleanFactors) {
+    const Shader::IR::U1 outer = ir.GetScc();
+    const Shader::IR::U1 inner = ir.GetVcc();
+    const Shader::IR::U64 mask = ir.BitwiseAnd(ir.Ballot64(outer), ir.Ballot64(inner));
+    const Shader::IR::U1 projected = ir.ProjectLane(mask);
+
+    Shader::Optimization::MaskToPredicatePass({&block});
+
+    Shader::IR::Inst* const result = projected.Resolve().TryInstRecursive();
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(result->GetOpcode(), Opcode::LogicalAnd);
+    const auto factors = ExtractMustFactors(projected.Resolve());
+    ASSERT_EQ(factors.size(), 2);
+    EXPECT_NE(std::ranges::find(factors, outer.Resolve()), factors.end());
+    EXPECT_NE(std::ranges::find(factors, inner.Resolve()), factors.end());
+}
+
+TEST_F(IrFixture, UnknownExactMaskIsPreservedAsProjection) {
+    const Shader::IR::U64 exact_mask = ir.GetExecMask();
+    const Shader::IR::U1 nested = ir.GetScc();
+    const Shader::IR::U1 projected = ir.ProjectLane(ir.BitwiseAnd(exact_mask, ir.Ballot64(nested)));
+
+    Shader::Optimization::MaskToPredicatePass({&block});
+
+    Shader::IR::Inst* const result = projected.Resolve().TryInstRecursive();
+    ASSERT_NE(result, nullptr);
+    ASSERT_EQ(result->GetOpcode(), Opcode::LogicalAnd);
+    EXPECT_EQ(result->Arg(1).Resolve(), nested.Resolve());
+    EXPECT_EQ(result->Arg(0).Resolve().TryInstRecursive()->GetOpcode(), Opcode::INotEqual64);
+}
+
+TEST_F(IrFixture, CommonOuterPredicateFormsOneInterval) {
+    const Shader::IR::U1 outer = ir.GetScc();
+    const Shader::IR::U1 inner = ir.GetVcc();
+    const Shader::IR::U1 nested = ir.LogicalAnd(inner, outer);
+    const std::array fragments{
+        Shader::Optimization::PredicateFragment{.guard = outer, .instruction_count = 2},
+        Shader::Optimization::PredicateFragment{.guard = nested, .instruction_count = 3},
+        Shader::Optimization::PredicateFragment{.guard = outer, .instruction_count = 2},
+    };
+
+    const auto analysis = Shader::Optimization::AnalyzePredicateIntervals(fragments);
+    const auto common = std::ranges::find_if(analysis.intervals, [](const auto& interval) {
+        return interval.selected && interval.begin == 0 && interval.end == 2;
+    });
+    ASSERT_NE(common, analysis.intervals.end());
+    ASSERT_EQ(common->factors.size(), 1);
+    EXPECT_EQ(common->factors.front(), outer.Resolve());
+    const auto nested_interval =
+        std::ranges::find_if(analysis.intervals, [&](const auto& interval) {
+            return interval.selected && interval.begin == 1 && interval.end == 1 &&
+                   interval.factors.size() == 1 && interval.factors.front() == inner.Resolve();
+        });
+    EXPECT_NE(nested_interval, analysis.intervals.end());
+    EXPECT_TRUE(analysis.residual_factors[1].empty());
+}
+
+TEST_F(IrFixture, ScalarBarrierPreventsPredicateIntervalSpanning) {
+    const Shader::IR::U1 predicate = ir.GetScc();
+    const std::array fragments{
+        Shader::Optimization::PredicateFragment{.guard = predicate, .instruction_count = 2},
+        Shader::Optimization::PredicateFragment{
+            .guard = predicate, .instruction_count = 1, .barrier = true},
+        Shader::Optimization::PredicateFragment{.guard = predicate, .instruction_count = 2},
+    };
+
+    const auto analysis = Shader::Optimization::AnalyzePredicateIntervals(fragments);
+    EXPECT_TRUE(std::ranges::none_of(analysis.intervals, [](const auto& interval) {
+        return interval.begin == 0 && interval.end == 2;
+    }));
+}
+
+TEST_F(IrFixture, WaterfallExitPhiRetainsOnlyPredicateSharedByBothExits) {
+    Shader::IR::Block continue_path{inst_pool};
+    Shader::IR::Block early_exit_path{inst_pool};
+    const Shader::IR::U1 outer = ir.GetScc();
+    const Shader::IR::U1 continue_condition = ir.GetVcc();
+    const Shader::IR::U1 early_exit_condition = ir.LogicalNot(ir.GetVcc());
+    const Shader::IR::U1 continue_guard = ir.LogicalAnd(outer, continue_condition);
+    const Shader::IR::U1 early_exit_guard = ir.LogicalAnd(early_exit_condition, outer);
+
+    Shader::IR::Inst* const merge = &*block.PrependNewInst(block.begin(), Shader::IR::Opcode::Phi);
+    merge->SetFlags(Shader::IR::Type::U1);
+    merge->AddPhiOperand(&continue_path, continue_guard);
+    merge->AddPhiOperand(&early_exit_path, early_exit_guard);
+
+    const auto factors = ExtractMustFactors(Shader::IR::Value{merge});
+    ASSERT_EQ(factors.size(), 1);
+    EXPECT_EQ(factors.front(), outer.Resolve());
+}
+
+} // Anonymous namespace

--- a/tests/gcn/translator.cpp
+++ b/tests/gcn/translator.cpp
@@ -92,7 +92,7 @@ std::vector<u32> TranslateToSpirv(std::span<const u64> raw_gcn_insts) {
     }
     translator.TranslateInstruction(store_inst);
 
-    Shader::Optimization::SsaRewritePass(program.post_order_blocks);
+    Shader::Optimization::SsaRewritePass(program);
     Shader::Optimization::IdentityRemovalPass(program.blocks);
     Shader::Optimization::ResourceTrackingPassStub(program, profile);
     Shader::Optimization::ConstantPropagationPass(program.blocks);


### PR DESCRIPTION
The ssa rewrite pass is based on the spirv-opt pass of the same name:
https://github.com/KhronosGroup/SPIRV-Tools/blob/main/source/opt/ssa_rewrite_pass.cpp

This commit brings the pass closer to that reference implementation. Notably this fixes applying the pass to unstructured graphs which seems to be broken otherwise

Additionally the manual stack iteration of ReadVariable has been replaced with recusion which is much easier to reason about

Undef handling has also been changed, before each block would define its own Undef instruction, now the pass will keep track and reuse compatible instructions add insert them to the first block