### PR TITLE
shader_recompiler: Add ssa destruction pass

### DIFF
--- a/src/shader_recompiler/ir/passes/ir_passes.h
+++ b/src/shader_recompiler/ir/passes/ir_passes.h
@@ -14,6 +14,7 @@ void InjectClipDistanceAttributes(IR::Program& program, RuntimeInfo& runtime_inf
 namespace Shader::Optimization {
 
 void SsaRewritePass(IR::Program& program);
+void SsaDestroyPass(IR::Program& program);
 void IdentityRemovalPass(IR::BlockList& program);
 void DeadCodeEliminationPass(IR::Program& program);
 void ConstantPropagationPass(IR::BlockList& program);

--- a/src/shader_recompiler/ir/passes/ssa_rewrite_pass.cpp
+++ b/src/shader_recompiler/ir/passes/ssa_rewrite_pass.cpp
@@ -458,4 +458,30 @@ void SsaRewritePass(IR::Program& program) {
     pass.FinalizePhiCandidates();
 }
 
+void SsaDestroyPass(IR::Program& program) {
+    // This implements the following mesa function with place_writes_in_imm_preds = true
+    // https://gitlab.freedesktop.org/mesa/mesa/-/blob/55f62fa8/src/compiler/nir/nir_from_ssa.c#L1075
+    u32 reg_index{};
+    const auto end = program.post_order_blocks.rend();
+    for (auto it1 = program.post_order_blocks.rbegin(); it1 != end; ++it1) {
+        IR::Block* block = *it1;
+        for (auto it = block->begin(); it != block->end(); ++it) {
+            IR::Inst& inst = *it;
+            if (inst.GetOpcode() != IR::Opcode::Phi) {
+                continue;
+            }
+            const IR::VirtualReg reg{reg_index++, inst.Flags<IR::Type>()};
+            for (size_t arg_index = 0; arg_index < inst.NumArgs(); arg_index++) {
+                IR::Value arg = inst.Arg(arg_index);
+                IR::Block* arg_block = inst.PhiBlock(arg_index);
+                arg_block->PrependNewInst(arg_block->end(), IR::Opcode::SetVirtualRegister,
+                                          {IR::Value{reg}, arg});
+            }
+            IR::Inst* const new_inst{
+                &*block->PrependNewInst(it, IR::Opcode::GetVirtualRegister, {IR::Value{reg}})};
+            inst.ReplaceUsesWith(IR::Value{new_inst});
+        }
+    }
+}
+
 } // namespace Shader::Optimization


### PR DESCRIPTION
Using the new virtual register infrastructure phi nodes can be destroyed back into register load/stores in a general way.
This can be used before any transformation that moves around or inserts new control flow blocks that could break SSA