### PR TITLE
shader: Handle ConstZero operand in V_CMP_U64

### DIFF
--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -1284,6 +1284,8 @@ void Translator::V_CMP_U64(ConditionOp op, bool is_signed, bool set_exec, const 
             return ir.GetThreadBitScalarReg(IR::ScalarReg(inst.src[0].code));
         case OperandField::VccLo:
             return ir.GetVcc();
+        case OperandField::ConstZero:
+            return ir.Imm1(false);
         default:
             UNREACHABLE_MSG("src0 = {}", u32(inst.src[0].field));
         }


### PR DESCRIPTION
Fixes unreachable code error in `V_CMP_U64` when `src0` operand is `ConstZero` (field code 128).

Error example:
```
[Debug] <Critical> (shadPS4:GpuCommandProcessor) vector_alu.cpp:1288 lambda: Unreachable code!
src0 = 128
```

Allows NHL games (tested on NHL 17 (CUSA04326), NHL 20 (CUSA15439), NHL 21 (CUSA18182)) to boot past the initial loading screen instead of crashing with the unreachable error.