### PR TITLE
usbd: add a loopback listener for the emulated Dimensions Toypad

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -605,6 +605,8 @@ set(USBD_LIB src/core/libraries/usbd/usbd.cpp
              src/core/libraries/usbd/usb_backend.h
              src/core/libraries/usbd/emulated/dimensions.cpp
              src/core/libraries/usbd/emulated/dimensions.h
+             src/core/libraries/usbd/emulated/dimensions_listener.cpp
+             src/core/libraries/usbd/emulated/dimensions_listener.h
              src/core/libraries/usbd/emulated/infinity.cpp
              src/core/libraries/usbd/emulated/infinity.h
              src/core/libraries/usbd/emulated/skylander.cpp

--- a/src/core/emulator_settings.cpp
+++ b/src/core/emulator_settings.cpp
@@ -593,6 +593,7 @@ bool EmulatorSettingsImpl::TransferSettings() {
         setFromToml(s.ime_accessibility_enabled, input, "imeAccessibilityEnabled");
         setFromToml(s.ime_url_mail_short_panel, input, "imeUrlMailShortPanel");
         setFromToml(s.usb_device_backend, input, "usbDeviceBackend");
+        setFromToml(s.dimensions_listener_port, input, "dimensionsListenerPort");
     }
 
     if (og_data.contains("Audio")) {

--- a/src/core/emulator_settings.h
+++ b/src/core/emulator_settings.h
@@ -322,6 +322,10 @@ struct InputSettings {
     Setting<int> cursor_state{HideCursorState::Idle};      // specific
     Setting<int> cursor_hide_timeout{5};                   // specific
     Setting<int> usb_device_backend{UsbBackendType::Real}; // specific
+    // TCP port for the emulated Dimensions Toypad's loopback listener, which lets an
+    // external companion app place figures instead of the Dimensions Manager dialog.
+    // 0 disables it, which is the default - nothing binds unless it is asked for.
+    Setting<int> dimensions_listener_port{0}; // specific
     Setting<bool> use_special_pad{false};
     Setting<int> special_pad_class{1};
     Setting<bool> motion_controls_enabled{true}; // specific
@@ -340,6 +344,8 @@ struct InputSettings {
             make_override<InputSettings>("cursor_hide_timeout",
                                          &InputSettings::cursor_hide_timeout),
             make_override<InputSettings>("usb_device_backend", &InputSettings::usb_device_backend),
+            make_override<InputSettings>("dimensions_listener_port",
+                                         &InputSettings::dimensions_listener_port),
             make_override<InputSettings>("motion_controls_enabled",
                                          &InputSettings::motion_controls_enabled),
             make_override<InputSettings>("background_controller_input",
@@ -354,7 +360,8 @@ struct InputSettings {
     }
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(InputSettings, cursor_state, cursor_hide_timeout,
-                                   usb_device_backend, use_special_pad, special_pad_class,
+                                   usb_device_backend, dimensions_listener_port, use_special_pad,
+                                   special_pad_class,
                                    motion_controls_enabled, use_unified_input_config,
                                    default_controller_id, background_controller_input,
                                    ime_accessibility_enabled, ime_url_mail_short_panel, camera_id,
@@ -763,6 +770,7 @@ public:
     SETTING_FORWARD(m_input, CursorState, cursor_state)
     SETTING_FORWARD(m_input, CursorHideTimeout, cursor_hide_timeout)
     SETTING_FORWARD(m_input, UsbDeviceBackend, usb_device_backend)
+    SETTING_FORWARD(m_input, DimensionsListenerPort, dimensions_listener_port)
     SETTING_FORWARD_BOOL(m_input, MotionControlsEnabled, motion_controls_enabled)
     SETTING_FORWARD_BOOL(m_input, BackgroundControllerInput, background_controller_input)
     SETTING_FORWARD_BOOL(m_input, ImeAccessibilityEnabled, ime_accessibility_enabled)

--- a/src/core/libraries/usbd/emulated/dimensions.cpp
+++ b/src/core/libraries/usbd/emulated/dimensions.cpp
@@ -3,10 +3,12 @@
 
 #include "dimensions.h"
 
+#include "core/emulator_settings.h"
 #include "core/libraries/kernel/threads.h"
 #include "core/tls.h"
 
 #include <mutex>
+#include <string>
 #include <thread>
 
 namespace Libraries::Usbd {
@@ -492,6 +494,144 @@ std::optional<std::array<u8, 32>> DimensionsToypad::PopAddedRemovedResponse() {
     return response;
 }
 
+namespace {
+// Region index (center/left/right) for a wire pad value: 1=center, 2=left, 3=right.
+u8 LedPadIndex(u8 pad) {
+    switch (pad) {
+    case 1: return 0; // center
+    case 2: return 1; // left
+    case 3: return 2; // right
+    }
+    return 0;
+}
+// Wire pad value for a region index (the "All" commands enumerate center, left, right).
+u8 LedRegionPad(u8 region) {
+    static constexpr std::array<u8, 3> pads = {1, 2, 3};
+    return pads[region];
+}
+} // namespace
+
+std::array<DimensionsToypad::led_state, 3> DimensionsToypad::GetLedStates() {
+    std::lock_guard lock(m_led_mutex);
+    return m_led_state;
+}
+
+u8 DimensionsToypad::GetLedSerial() {
+    std::lock_guard lock(m_led_mutex);
+    return m_led_serial;
+}
+
+DimensionsToypad::led_state DimensionsToypad::GetLedState(u8 pad) {
+    std::lock_guard lock(m_led_mutex);
+    return m_led_state[LedPadIndex(pad)];
+}
+
+void DimensionsToypad::SetLedState(u8 pad, u8 mode, u8 r, u8 g, u8 b, u8 on_ms, u8 off_ms,
+                                   u8 count, u8 speed_ms) {
+    std::lock_guard lock(m_led_mutex);
+    auto apply = [&](u8 target_pad) {
+            led_state& state = m_led_state[LedPadIndex(target_pad)];
+        if (state.mode == mode && state.r == r && state.g == g && state.b == b &&
+            state.on_ms == on_ms && state.off_ms == off_ms && state.count == count &&
+            state.speed_ms == speed_ms) {
+            return; // unchanged - leave the serial alone so pollers can skip it
+        }
+        state.pad = target_pad;
+        state.mode = mode;
+        state.r = r;
+        state.g = g;
+        state.b = b;
+        state.on_ms = on_ms;
+        state.off_ms = off_ms;
+        state.count = count;
+        state.speed_ms = speed_ms;
+        ++m_led_serial;
+    };
+    if (pad == 0) { // all pads
+        apply(1);
+        apply(2);
+        apply(3);
+    } else {
+        apply(pad);
+    }
+}
+
+// Parses the game's HID LED commands (0xC0..0xC8) and mirrors the per-region
+// state. Same byte layout as the Cemu/RPCS3 forks (shared reverse-engineering):
+// header {0x55, len, command, messageId, ...}, args from buf[4]; "All" commands
+// enumerate center, left, right, each with a leading on/off byte.
+void DimensionsToypad::HandleLedCommand(const u8* buf, u32 buf_size) {
+    if (buf_size < 25) {
+        return;
+    }
+    const u8 command = buf[2];
+    switch (command) {
+    case 0xC0: // Color: pad, r, g, b
+        SetLedState(buf[4], 1, buf[5], buf[6], buf[7], 0, 0, 0, 0);
+        break;
+    case 0xC1: // Get Pad Color - query only, no state change
+        break;
+    case 0xC2: // Fade: pad, tickTime, tickCount, r, g, b
+        SetLedState(buf[4], 3, buf[7], buf[8], buf[9], 0, 0, buf[6], buf[5]);
+        break;
+    case 0xC3: // Flash: pad, on, off, count(0xFF=forever), r, g, b
+    {
+        const u8 count = (buf[7] == 0xFF) ? 0 : buf[7];
+        SetLedState(buf[4], 2, buf[8], buf[9], buf[10], buf[5], buf[6], count, 0);
+        break;
+    }
+    case 0xC4: // Fade Random: pad, tickTime, tickCount (colour left as-is)
+    {
+        const led_state existing = GetLedState(buf[4]);
+        SetLedState(buf[4], 3, existing.r, existing.g, existing.b, 0, 0, buf[6], buf[5]);
+        break;
+    }
+    case 0xC6: // Fade All: per-region on/off, tickTime, tickCount, r, g, b
+        for (u8 region = 0; region < 3; ++region) {
+            const u32 off = 4 + region * 6;
+            if (buf[off] == 0) {
+                SetLedState(LedRegionPad(region), 0, 0, 0, 0, 0, 0, 0, 0);
+                continue;
+            }
+            SetLedState(LedRegionPad(region), 3, buf[off + 3], buf[off + 4], buf[off + 5], 0, 0,
+                        buf[off + 2], buf[off + 1]);
+        }
+        break;
+    case 0xC7: // Flash All: per-region on/off, on, off, count, r, g, b
+        for (u8 region = 0; region < 3; ++region) {
+            const u32 off = 4 + region * 7;
+            if (buf[off] == 0) {
+                SetLedState(LedRegionPad(region), 0, 0, 0, 0, 0, 0, 0, 0);
+                continue;
+            }
+            const u8 count = (buf[off + 3] == 0xFF) ? 0 : buf[off + 3];
+            SetLedState(LedRegionPad(region), 2, buf[off + 4], buf[off + 5], buf[off + 6],
+                        buf[off + 1], buf[off + 2], count, 0);
+        }
+        break;
+    case 0xC8: // Color All: per-region on/off, r, g, b
+        for (u8 region = 0; region < 3; ++region) {
+            const u32 off = 4 + region * 4;
+            if (buf[off] == 0) {
+                SetLedState(LedRegionPad(region), 0, 0, 0, 0, 0, 0, 0, 0);
+                continue;
+            }
+            SetLedState(LedRegionPad(region), 1, buf[off + 1], buf[off + 2], buf[off + 3], 0, 0, 0,
+                        0);
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+DimensionsBackend::DimensionsBackend() {
+    m_listener = std::make_unique<DimensionsListener>(m_dimensions_toypad);
+    m_listener->Start(static_cast<u16>(EmulatorSettings.GetDimensionsListenerPort()));
+}
+
+DimensionsBackend::~DimensionsBackend() = default;
+
 libusb_endpoint_descriptor* DimensionsBackend::FillEndpointDescriptorPair() {
     return m_endpoint_descriptors.data();
 }
@@ -574,6 +714,9 @@ libusb_transfer_status DimensionsBackend::HandleAsyncTransfer(libusb_transfer* t
         case 0xC7: // Flash All
         case 0xC8: // Color All
         {
+            // Mirror the pad-region LED state out over the IPC channel so a
+            // companion app can render the pads glowing like a real toypad.
+            m_dimensions_toypad->HandleLedCommand(transfer->buffer, static_cast<u32>(transfer->length));
             // Send a blank response to acknowledge color has been sent to toypad
             m_dimensions_toypad->GetBlankResponse(0x01, sequence, q_result);
             break;

--- a/src/core/libraries/usbd/emulated/dimensions.h
+++ b/src/core/libraries/usbd/emulated/dimensions.h
@@ -11,6 +11,7 @@
 #include <queue>
 
 #include "common/io_file.h"
+#include "core/libraries/usbd/emulated/dimensions_listener.h"
 #include "core/libraries/usbd/usb_backend.h"
 
 namespace Libraries::Usbd {
@@ -50,6 +51,26 @@ public:
     void TempRemoveFigure(u8 index) override;
     void CancelRemoveFigure(u8 index) override;
 
+    // Per-region LED state the game is driving, so a companion app can render
+    // the pads glowing like the real toypad. mode: 0 off, 1 solid, 2 flash,
+    // 3 fade; pad: 1 = center, 2 = left, 3 = right. Durations are toypad ticks.
+    struct led_state {
+        u8 pad = 0;
+        u8 mode = 0;
+        u8 r = 0, g = 0, b = 0;
+        u8 on_ms = 0, off_ms = 0, count = 0, speed_ms = 0;
+    };
+
+    // Capture and mirror the game's LED commands (0xC0..0xC8). Called from the
+    // interrupt path for every command the toypad acknowledges.
+    void HandleLedCommand(const u8* buf, u32 buf_size);
+
+    // The current snapshot, plus a serial that only advances when a command
+    // actually changed a region - a poller can skip anything it already applied
+    // and so never restarts a flash mid-cycle.
+    std::array<led_state, 3> GetLedStates();
+    u8 GetLedSerial();
+
     u32 LoadDimensionsFigure(const std::array<u8, 0x2D * 0x04>& buf, Common::FS::IOFile file,
                              u8 pad, u8 index);
 
@@ -58,6 +79,14 @@ protected:
     std::array<DimensionsFigure, MAX_DIMENSIONS_FIGURES> m_figures{};
 
 private:
+    void SetLedState(u8 pad, u8 mode, u8 r, u8 g, u8 b, u8 on_ms, u8 off_ms, u8 count,
+                     u8 speed_ms);
+    led_state GetLedState(u8 pad);
+
+    std::mutex m_led_mutex;
+    std::array<led_state, 3> m_led_state{};
+    u8 m_led_serial = 0;
+
     static void RandomUID(u8* uid_buffer);
     static u8 GenerateChecksum(const std::array<u8, 32>& data, u32 num_of_bytes);
     static std::array<u8, 8> Decrypt(const u8* buf, std::optional<std::array<u8, 16>> key);
@@ -80,6 +109,10 @@ private:
 };
 
 class DimensionsBackend final : public UsbEmulatedBackend {
+public:
+    DimensionsBackend();
+    ~DimensionsBackend() override;
+
 protected:
     libusb_endpoint_descriptor* FillEndpointDescriptorPair() override;
     libusb_interface_descriptor* FillInterfaceDescriptor(
@@ -106,6 +139,7 @@ private:
     static void* PS4_SYSV_ABI WriteThread(void* arg);
 
     std::shared_ptr<DimensionsToypad> m_dimensions_toypad = std::make_shared<DimensionsToypad>();
+    std::unique_ptr<DimensionsListener> m_listener;
 
     std::array<u8, 9> m_endpoint_out_extra = {0x09, 0x21, 0x11, 0x01, 0x00, 0x01, 0x22, 0x1d, 0x00};
     std::vector<libusb_endpoint_descriptor> m_endpoint_descriptors = {

--- a/src/core/libraries/usbd/emulated/dimensions_listener.cpp
+++ b/src/core/libraries/usbd/emulated/dimensions_listener.cpp
@@ -1,0 +1,294 @@
+//  SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+//  SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "dimensions_listener.h"
+
+#include <array>
+#include <chrono>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
+#include "common/logging/log.h"
+#include "common/thread.h"
+#include "core/libraries/usbd/emulated/dimensions.h"
+
+namespace Libraries::Usbd {
+
+namespace {
+
+#ifdef _WIN32
+using socket_t = SOCKET;
+constexpr socket_t invalid_socket = INVALID_SOCKET;
+void CloseSocket(socket_t s) {
+    ::closesocket(s);
+}
+#else
+using socket_t = int;
+constexpr socket_t invalid_socket = -1;
+void CloseSocket(socket_t s) {
+    ::close(s);
+}
+#endif
+
+constexpr u8 kLoadCommand = 0x01;
+constexpr u8 kRemoveCommand = 0x02;
+constexpr u8 kMoveCommand = 0x03;
+constexpr u8 kGetLedCommand = 0x04;
+
+constexpr size_t kHeaderSize = 5;
+constexpr size_t kFigureDataSize = DIMENSIONS_FIGURE_SIZE;
+// { 'L', serial, 3, then 3 regions x 9 bytes }.
+constexpr size_t kLedResponseSize = 3 + 3 * 9;
+
+// A figure landing on a slot that still holds one has to be announced as two
+// separate events, and the game needs to see the removal before the arrival.
+// Issuing both back to back queues two 0x56 responses for the same slot in one
+// go, which the game reads as a single change and ignores - the swap silently
+// does nothing. Letting the removal be picked up first keeps them distinct.
+constexpr auto kRemoveThenLoadDelay = std::chrono::milliseconds(100);
+
+bool RecvAll(socket_t s, u8* data, size_t len) {
+    while (len != 0) {
+        const auto got = ::recv(s, reinterpret_cast<char*>(data), static_cast<int>(len), 0);
+        if (got <= 0) {
+            return false;
+        }
+        data += got;
+        len -= static_cast<size_t>(got);
+    }
+    return true;
+}
+
+bool SendAll(socket_t s, const u8* data, size_t len) {
+    while (len != 0) {
+        const auto sent = ::send(s, reinterpret_cast<const char*>(data), static_cast<int>(len), 0);
+        if (sent <= 0) {
+            return false;
+        }
+        data += sent;
+        len -= static_cast<size_t>(sent);
+    }
+    return true;
+}
+
+} // namespace
+
+DimensionsListener::DimensionsListener(std::shared_ptr<DimensionsToypad> toypad)
+    : m_toypad(std::move(toypad)) {}
+
+DimensionsListener::~DimensionsListener() {
+    Stop();
+}
+
+void DimensionsListener::Start(u16 port) {
+    if (port == 0 || m_running.exchange(true)) {
+        return;
+    }
+    m_thread = std::thread([this, port] { Run(port); });
+}
+
+void DimensionsListener::Stop() {
+    if (!m_running.exchange(false)) {
+        return;
+    }
+    // Closing the listening socket is what unblocks accept(); there is no
+    // portable way to interrupt it otherwise.
+    const auto listen_socket = m_listen_socket.exchange(~0ULL);
+    if (listen_socket != ~0ULL) {
+        CloseSocket(static_cast<socket_t>(listen_socket));
+    }
+    if (m_thread.joinable()) {
+        m_thread.join();
+    }
+}
+
+void DimensionsListener::Run(u16 port) {
+    Common::SetCurrentThreadName("shadPS4:DimensionsListener");
+
+#ifdef _WIN32
+    WSADATA wsa_data;
+    // Reference counted, so this cooperates with any other winsock user in the
+    // process rather than fighting over initialisation.
+    if (::WSAStartup(MAKEWORD(2, 2), &wsa_data) != 0) {
+        LOG_ERROR(Lib_Usbd, "Dimensions listener: WSAStartup failed");
+        m_running = false;
+        return;
+    }
+#endif
+
+    const socket_t server = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (server == invalid_socket) {
+        LOG_ERROR(Lib_Usbd, "Dimensions listener: could not create socket");
+#ifdef _WIN32
+        ::WSACleanup();
+#endif
+        m_running = false;
+        return;
+    }
+
+    int reuse = 1;
+    ::setsockopt(server, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char*>(&reuse),
+                 sizeof(reuse));
+
+    sockaddr_in address{};
+    address.sin_family = AF_INET;
+    address.sin_port = ::htons(port);
+    address.sin_addr.s_addr = ::htonl(INADDR_LOOPBACK);
+
+    if (::bind(server, reinterpret_cast<const sockaddr*>(&address), sizeof(address)) != 0 ||
+        ::listen(server, 1) != 0) {
+        LOG_ERROR(Lib_Usbd, "Dimensions listener: could not bind 127.0.0.1:{}", port);
+        CloseSocket(server);
+#ifdef _WIN32
+        ::WSACleanup();
+#endif
+        m_running = false;
+        return;
+    }
+
+    m_listen_socket = static_cast<u64>(server);
+    LOG_INFO(Lib_Usbd, "Dimensions listener active on 127.0.0.1:{}", port);
+
+    while (m_running) {
+        const socket_t client = ::accept(server, nullptr, nullptr);
+        if (client == invalid_socket) {
+            break; // Stop() closed the listening socket, or the socket died.
+        }
+        HandleClient(static_cast<u64>(client));
+        CloseSocket(client);
+    }
+
+    // Stop() may already have closed and cleared this; only close if it did not.
+    const auto remaining = m_listen_socket.exchange(~0ULL);
+    if (remaining != ~0ULL) {
+        CloseSocket(static_cast<socket_t>(remaining));
+    }
+#ifdef _WIN32
+    ::WSACleanup();
+#endif
+    LOG_INFO(Lib_Usbd, "Dimensions listener stopped");
+}
+
+void DimensionsListener::HandleClient(u64 client_handle) {
+    const auto client = static_cast<socket_t>(client_handle);
+
+    // A connection may carry several messages back to back; each command reads
+    // exactly the bytes it needs, so the next message boundary stays known.
+    while (m_running) {
+        std::array<u8, kHeaderSize> header{};
+        if (!RecvAll(client, header.data(), header.size())) {
+            return;
+        }
+
+        const u8 command = header[0];
+        const u8 pad = header[1];
+        const u8 index = header[2];
+
+        // GET_LED addresses no slot, so its zeroed pad/index must not be
+        // validated as one.
+        if (command != kGetLedCommand && (pad < 1 || pad > 3 || index >= MAX_DIMENSIONS_FIGURES)) {
+            LOG_ERROR(Lib_Usbd, "Dimensions listener: rejected cmd 0x{:02x} pad {} index {}",
+                      command, pad, index);
+            return;
+        }
+
+        switch (command) {
+        case kLoadCommand: {
+            std::array<u8, kFigureDataSize> tag{};
+            if (!RecvAll(client, tag.data(), tag.size())) {
+                return;
+            }
+
+            std::array<u8, 2> length_bytes{};
+            if (!RecvAll(client, length_bytes.data(), length_bytes.size())) {
+                return;
+            }
+            const u16 path_length = static_cast<u16>(length_bytes[0] | (length_bytes[1] << 8));
+
+            std::string path;
+            if (path_length != 0) {
+                std::vector<u8> path_bytes(path_length);
+                if (!RecvAll(client, path_bytes.data(), path_bytes.size())) {
+                    return;
+                }
+                path.assign(path_bytes.begin(), path_bytes.end());
+            }
+
+            // Loading onto an occupied slot replaces what is there, matching the
+            // contract the Cemu and RPCS3 listeners already established.
+            m_toypad->RemoveFigure(pad, index, true);
+            std::this_thread::sleep_for(kRemoveThenLoadDelay);
+
+            if (path.empty()) {
+                // No file behind this figure: the tag lives in memory for the
+                // session. An unopened IOFile makes DimensionsFigure::Save() a
+                // no-op, which is exactly the behaviour that wants.
+                m_toypad->LoadDimensionsFigure(tag, Common::FS::IOFile{}, pad, index);
+            } else {
+                m_toypad->LoadFigure(path, pad, index);
+            }
+            LOG_INFO(Lib_Usbd, "Dimensions listener: LOAD pad {} index {} ({})", pad, index,
+                     path.empty() ? "in-memory tag" : path);
+            break;
+        }
+        case kRemoveCommand: {
+            m_toypad->RemoveFigure(pad, index, true);
+            LOG_INFO(Lib_Usbd, "Dimensions listener: REMOVE pad {} index {}", pad, index);
+            break;
+        }
+        case kMoveCommand: {
+            const u8 source_pad = header[3];
+            const u8 source_index = header[4];
+            if (source_pad < 1 || source_pad > 3 || source_index >= MAX_DIMENSIONS_FIGURES) {
+                LOG_ERROR(Lib_Usbd, "Dimensions listener: rejected MOVE source pad {} index {}",
+                          source_pad, source_index);
+                return;
+            }
+            m_toypad->MoveFigure(pad, index, source_pad, source_index);
+            LOG_INFO(Lib_Usbd, "Dimensions listener: MOVE {}/{} -> {}/{}", source_pad, source_index,
+                     pad, index);
+            break;
+        }
+        case kGetLedCommand: {
+            const auto states = m_toypad->GetLedStates();
+            std::array<u8, kLedResponseSize> response{};
+            response[0] = 0x4C; // 'L' magic
+            response[1] = m_toypad->GetLedSerial();
+            response[2] = 0x03; // region count
+            for (size_t i = 0; i < states.size(); ++i) {
+                const size_t offset = 3 + i * 9;
+                response[offset + 0] = states[i].pad;
+                response[offset + 1] = states[i].mode;
+                response[offset + 2] = states[i].r;
+                response[offset + 3] = states[i].g;
+                response[offset + 4] = states[i].b;
+                response[offset + 5] = states[i].on_ms;
+                response[offset + 6] = states[i].off_ms;
+                response[offset + 7] = states[i].count;
+                response[offset + 8] = states[i].speed_ms;
+            }
+            if (!SendAll(client, response.data(), response.size())) {
+                return;
+            }
+            break;
+        }
+        default:
+            // The next message boundary is no longer knowable, so the connection
+            // cannot be reused after an unknown command.
+            LOG_ERROR(Lib_Usbd, "Dimensions listener: unknown command 0x{:02x}", command);
+            return;
+        }
+    }
+}
+
+} // namespace Libraries::Usbd

--- a/src/core/libraries/usbd/emulated/dimensions_listener.h
+++ b/src/core/libraries/usbd/emulated/dimensions_listener.h
@@ -1,0 +1,71 @@
+//  SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+//  SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <thread>
+
+#include "common/types.h"
+
+namespace Libraries::Usbd {
+
+class DimensionsToypad;
+
+// Loopback TCP listener for the emulated LEGO Dimensions Toypad.
+//
+// The Dimensions Manager dialog is the only way to place a figure, which means
+// reaching for a mouse every time a game asks for a different character. This
+// listener lets an external companion app do it instead: it accepts the same
+// small protocol the Cemu and RPCS3 Toypad forks already speak, so an app
+// written for either of those works here unchanged.
+//
+// It binds 127.0.0.1 only and is disabled unless a port is set in the
+// configuration (dimensionsListenerPort, 0 = off). There is no authentication
+// and no encryption - loopback-only is the security model.
+//
+// Wire protocol - every message starts with a 5-byte header:
+//
+//   [0] command   0x01 LOAD, 0x02 REMOVE, 0x03 MOVE, 0x04 GET_LED
+//   [1] pad       1-3 (destination for MOVE)
+//   [2] slot      0-6 (destination for MOVE)
+//   [3] src pad   MOVE only, otherwise 0
+//   [4] src slot  MOVE only, otherwise 0
+//
+// LOAD then carries 180 raw tag bytes, a u16 little-endian path length and that
+// many UTF-8 path bytes. With a path the file is opened read/write so the game's
+// writes persist back into the .bin, exactly as a dialog-loaded figure does;
+// with a zero-length path the figure lives in memory for the session only.
+//
+// LOAD, REMOVE and MOVE are fire-and-forget. GET_LED is the only command that
+// replies: a 30-byte snapshot of what the game currently has the three LED
+// regions doing - see DimensionsToypad's LED mirror.
+class DimensionsListener {
+public:
+    explicit DimensionsListener(std::shared_ptr<DimensionsToypad> toypad);
+    ~DimensionsListener();
+
+    DimensionsListener(const DimensionsListener&) = delete;
+    DimensionsListener& operator=(const DimensionsListener&) = delete;
+
+    // Binds and starts accepting. A port of 0 means "disabled" and does nothing,
+    // so the listener costs exactly one branch when it is not configured.
+    void Start(u16 port);
+
+    // Closes the listening socket, which drops the accept loop out of its blocking
+    // call, then joins the thread. Safe to call when never started.
+    void Stop();
+
+private:
+    void Run(u16 port);
+    void HandleClient(u64 client);
+
+    std::shared_ptr<DimensionsToypad> m_toypad;
+    std::atomic<bool> m_running{false};
+    std::thread m_thread;
+    // Held as u64 so the header does not have to drag in winsock / sys/socket.
+    std::atomic<u64> m_listen_socket{~0ULL};
+};
+
+} // namespace Libraries::Usbd


### PR DESCRIPTION
Placing a figure is only possible through the Dimensions Manager dialog, which means reaching for a mouse every time a game asks for a different character. This adds an opt-in loopback TCP listener so an external companion app can do it from a controller instead.

The protocol is the one the Cemu and RPCS3 Toypad forks already speak (LOAD / REMOVE / MOVE, plus GET_LED), so an app written for either of those works here unchanged. It binds 127.0.0.1 only and does nothing at all unless dimensionsListenerPort is set - the default of 0 leaves it disabled, so nothing binds for users who do not ask for it.

GET_LED returns a snapshot of the LED state the game is driving. The toypad now parses the 0xC0..0xC8 LED commands as they pass through the interrupt path and keeps a per-region mirror of mode, colour and timings, with a serial that only advances when a command actually changed something, so a poller can skip what it has already applied and never restarts a flash mid-cycle.

The Dimensions Manager dialog and the existing USB_*_FIGURE IPC commands are untouched; this is an additional interface, not a replacement.