### PR TITLE
video_core: rebuild the pipeline cache instead of disabling it forever

### DIFF
--- a/src/video_core/cache_storage.cpp
+++ b/src/video_core/cache_storage.cpp
@@ -120,6 +120,20 @@ void DataBase::Open() {
     opened = true;
 }
 
+void DataBase::Reset() {
+    Close();
+
+    std::error_code ec{};
+    std::filesystem::remove_all(cache_path, ec);
+    if (ec) {
+        LOG_ERROR(Render, "Failed to discard the pipeline cache at {}: {}",
+                  cache_path.string().c_str(), ec.message());
+    }
+
+    ar_is_read_only = true;
+    Open();
+}
+
 void DataBase::Close() {
     if (!IsOpened()) {
         return;

--- a/src/video_core/cache_storage.h
+++ b/src/video_core/cache_storage.h
@@ -28,6 +28,8 @@ public:
 
     void Open();
     void Close();
+    /// Discards the stored cache and reopens it empty.
+    void Reset();
     [[nodiscard]] bool IsOpened() const {
         return opened;
     }

--- a/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
@@ -311,29 +311,37 @@ void PipelineCache::WarmUp() {
     // Check if cache is compatible
     std::vector<u8> profile_data{};
     Storage::DataBase::Instance().Load(Storage::BlobType::ShaderProfile, "profile", profile_data);
-    if (profile_data.empty()) {
+
+    bool cache_is_compatible = !profile_data.empty();
+    if (cache_is_compatible && profile_data.size() != sizeof(Shader::Profile)) {
+        LOG_WARNING(Render, "Pipeline cache profile has unexpected size ({} != {}). Discarding it",
+                    profile_data.size(), sizeof(Shader::Profile));
+        cache_is_compatible = false;
+    }
+    if (cache_is_compatible) {
+        Shader::Profile cached_profile{};
+        std::memcpy(&cached_profile, profile_data.data(), sizeof(cached_profile));
+        if (cached_profile != profile) {
+            LOG_WARNING(Render,
+                        "Pipeline cache isn't compatible with current system. Discarding it");
+            cache_is_compatible = false;
+        }
+    }
+
+    if (!cache_is_compatible) {
+        // The stored profile is written only when it is missing, so leaving an incompatible cache
+        // in place makes it incompatible on every later launch as well - shaders are recompiled
+        // from scratch every time until the user deletes the cache by hand. Start a fresh cache
+        // instead, which also drops pipelines built against the previous profile.
+        if (!profile_data.empty()) {
+            Storage::DataBase::Instance().Reset();
+        }
         Storage::DataBase::Instance().FinishPreload();
 
-        profile_data.resize(sizeof(profile));
-        std::memcpy(profile_data.data(), &profile, sizeof(profile));
+        std::vector<u8> fresh_profile_data(sizeof(profile));
+        std::memcpy(fresh_profile_data.data(), &profile, sizeof(profile));
         Storage::DataBase::Instance().Save(Storage::BlobType::ShaderProfile, "profile",
-                                           std::move(profile_data));
-        return;
-    }
-    if (profile_data.size() != sizeof(Shader::Profile)) {
-        LOG_WARNING(Render,
-                    "Pipeline cache profile has unexpected size ({} != {}). Ignoring the cache",
-                    profile_data.size(), sizeof(Shader::Profile));
-        Storage::DataBase::Instance().Close();
-        return;
-    }
-
-    Shader::Profile cached_profile{};
-    std::memcpy(&cached_profile, profile_data.data(), sizeof(cached_profile));
-    if (cached_profile != profile) {
-        LOG_WARNING(Render,
-                    "Pipeline cache isn't compatible with current system. Ignoring the cache");
-        Storage::DataBase::Instance().Close();
+                                           std::move(fresh_profile_data));
         return;
     }
 


### PR DESCRIPTION
**About AI, up front:** I work with an AI assistant. It helps me instrument the emulator, profile it and draft code. Everything below was measured on my own machine, and I can walk through every line of this change myself — ask me anything.

## The problem

Once the pipeline cache is found incompatible, it never recovers.

The profile blob is written in exactly one place — when it is missing. On a mismatch `WarmUp` closes the database and returns, and the stale blob stays on disk. The next launch loads that same stale profile, mismatches again, closes again. Shaders are recompiled from scratch on every single launch until the user deletes the cache folder by hand, which most people don't know exists.

This is what #4645 reported: *"shader cache stops compiling on consequent launches... this problem can be avoided by deleting profile.bin"*. #4704 fixed one cause of the mismatch (the padding one), but not the inability to recover from any other cause.

## It is happening right now

#4874 removed `max_ubo_size` from `Shader::Profile`. That changed `sizeof(Profile)` from 72 to 60, so every cache written before that commit fails the size check on every launch.

Same machine, same game, same cache folder (2712 files, 72-byte profile), only the build differs.

Current main (pre-release `54ec7d0`):

```
run 1  Pipeline cache profile has unexpected size (72 != 60). Ignoring the cache
       -> profile.bin still 72 bytes, 2712 files
run 2  Pipeline cache profile has unexpected size (72 != 60). Ignoring the cache
       -> profile.bin still 72 bytes, 2712 files
```

Nothing is ever preloaded, and nothing ever will be.

With this patch:

```
run 1  Pipeline cache profile has unexpected size (72 != 60). Discarding it
       -> cache reset, profile.bin 60 bytes
run 2  Preloaded 51 pipelines
```

## What the change does

Discard the incompatible cache and start a fresh one instead of leaving it in place. `DataBase::Reset()` closes the database, removes the cache directory (or archive) and reopens it empty; `WarmUp` then writes the current profile and continues exactly as it does on a first launch.

Dropping the stored pipelines is deliberate: they were built against the previous profile, so reusing them would not be safe. Only the profile blob is rewritten in the missing-blob path, so this is the only way the cache can come back.

I also folded the two compatibility checks into one path with a single exit. To me it reads better than three separate returns, but if you would rather keep the original shape, say so and I will restore it.

## Testing

- CI: Windows, Linux and macOS.
- By hand on Windows with Uncharted: The Nathan Drake Collection (CUSA02320), the runs shown above, against a real cache left over from an older build.
