### PR TITLE
video_core: delete an incompatible pipeline cache instead of ignoring it

### DIFF
--- a/src/video_core/cache_storage.cpp
+++ b/src/video_core/cache_storage.cpp
@@ -120,6 +120,18 @@ void DataBase::Open() {
     opened = true;
 }
 
+void DataBase::Reset() {
+    Close();
+    std::error_code ec{};
+    std::filesystem::remove_all(cache_path, ec);
+    if (ec) {
+        LOG_ERROR(Render, "Failed to delete the cache at {}: {}", cache_path.string().c_str(),
+                  ec.message());
+    }
+    ar_is_read_only = true;
+    Open();
+}
+
 void DataBase::Close() {
     if (!IsOpened()) {
         return;

--- a/src/video_core/cache_storage.h
+++ b/src/video_core/cache_storage.h
@@ -28,6 +28,8 @@ public:
 
     void Open();
     void Close();
+    /// Deletes the stored cache and opens an empty one.
+    void Reset();
     [[nodiscard]] bool IsOpened() const {
         return opened;
     }

--- a/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
@@ -308,23 +308,29 @@ void PipelineCache::WarmUp() {
 
     Storage::DataBase::Instance().Open();
 
+    // The profile is only saved when it is missing, so an incompatible cache stays incompatible on
+    // every later launch as well. Delete it and start over instead.
+    const auto start_fresh_cache = [this] {
+        Storage::DataBase::Instance().FinishPreload();
+        std::vector<u8> data(sizeof(profile));
+        std::memcpy(data.data(), &profile, sizeof(profile));
+        Storage::DataBase::Instance().Save(Storage::BlobType::ShaderProfile, "profile",
+                                           std::move(data));
+    };
+
     // Check if cache is compatible
     std::vector<u8> profile_data{};
     Storage::DataBase::Instance().Load(Storage::BlobType::ShaderProfile, "profile", profile_data);
     if (profile_data.empty()) {
-        Storage::DataBase::Instance().FinishPreload();
-
-        profile_data.resize(sizeof(profile));
-        std::memcpy(profile_data.data(), &profile, sizeof(profile));
-        Storage::DataBase::Instance().Save(Storage::BlobType::ShaderProfile, "profile",
-                                           std::move(profile_data));
+        start_fresh_cache();
         return;
     }
     if (profile_data.size() != sizeof(Shader::Profile)) {
         LOG_WARNING(Render,
                     "Pipeline cache profile has unexpected size ({} != {}). Ignoring the cache",
                     profile_data.size(), sizeof(Shader::Profile));
-        Storage::DataBase::Instance().Close();
+        Storage::DataBase::Instance().Reset();
+        start_fresh_cache();
         return;
     }
 
@@ -333,7 +339,8 @@ void PipelineCache::WarmUp() {
     if (cached_profile != profile) {
         LOG_WARNING(Render,
                     "Pipeline cache isn't compatible with current system. Ignoring the cache");
-        Storage::DataBase::Instance().Close();
+        Storage::DataBase::Instance().Reset();
+        start_fresh_cache();
         return;
     }
 


### PR DESCRIPTION
Second week working on Uncharted with the help of AI, already got pretty far. For now I am sending a small patch here, and I keep working on improvements.

The bug. The profile file is only written when it is missing. If it does not match, WarmUp closes the database and returns, and the old file stays on disk. Next launch reads the same old file, does not match again, closes again. Shaders are compiled from scratch every launch until you delete the cache folder by hand.

Already reported in #4645 - "can be avoided by deleting profile.bin". #4704 fixed one reason for the mismatch, but not the fact that the cache never comes back.

It is broken right now. #4874 removed max_ubo_size from Shader::Profile, sizeof went from 72 to 60, so every cache written before that fails the size check on every launch.

My machine, same game, same cache folder (2712 files, 72-byte profile):

current main (pre-release 54ec7d0):

    run 1: unexpected size (72 != 60). Ignoring the cache -> profile.bin still 72 bytes
    run 2: unexpected size (72 != 60). Ignoring the cache -> profile.bin still 72 bytes

with this patch:

    run 1: unexpected size (72 != 60) -> cache deleted, profile.bin 60 bytes
    run 2: Preloaded 51 pipelines

The patch deletes the cache and starts a new one. Stored pipelines go away with it because they were built for the old profile.

Built by CI on Windows, Linux and macOS. Tested by hand on Windows with CUSA02320.
