### PR TITLE
Add an option to orient motion controls for a handheld

### DIFF
--- a/src/core/emulator_settings.h
+++ b/src/core/emulator_settings.h
@@ -324,7 +324,8 @@ struct InputSettings {
     Setting<int> usb_device_backend{UsbBackendType::Real}; // specific
     Setting<bool> use_special_pad{false};
     Setting<int> special_pad_class{1};
-    Setting<bool> motion_controls_enabled{true}; // specific
+    Setting<bool> motion_controls_enabled{true};   // specific
+    Setting<bool> motion_controls_vertical{false}; // specific
     Setting<bool> use_unified_input_config{true};
     Setting<std::string> default_controller_id{""};
     Setting<bool> background_controller_input{false}; // specific
@@ -342,6 +343,8 @@ struct InputSettings {
             make_override<InputSettings>("usb_device_backend", &InputSettings::usb_device_backend),
             make_override<InputSettings>("motion_controls_enabled",
                                          &InputSettings::motion_controls_enabled),
+            make_override<InputSettings>("motion_controls_vertical",
+                                         &InputSettings::motion_controls_vertical),
             make_override<InputSettings>("background_controller_input",
                                          &InputSettings::background_controller_input),
             make_override<InputSettings>("ime_accessibility_enabled",
@@ -355,10 +358,11 @@ struct InputSettings {
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(InputSettings, cursor_state, cursor_hide_timeout,
                                    usb_device_backend, use_special_pad, special_pad_class,
-                                   motion_controls_enabled, use_unified_input_config,
-                                   default_controller_id, background_controller_input,
-                                   ime_accessibility_enabled, ime_url_mail_short_panel, camera_id,
-                                   is_circle_enter, use_mice_as_mice)
+                                   motion_controls_enabled, motion_controls_vertical,
+                                   use_unified_input_config, default_controller_id,
+                                   background_controller_input, ime_accessibility_enabled,
+                                   ime_url_mail_short_panel, camera_id, is_circle_enter,
+                                   use_mice_as_mice)
 // -------------------------------
 // Audio settings
 // -------------------------------
@@ -764,6 +768,7 @@ public:
     SETTING_FORWARD(m_input, CursorHideTimeout, cursor_hide_timeout)
     SETTING_FORWARD(m_input, UsbDeviceBackend, usb_device_backend)
     SETTING_FORWARD_BOOL(m_input, MotionControlsEnabled, motion_controls_enabled)
+    SETTING_FORWARD_BOOL(m_input, MotionControlsVertical, motion_controls_vertical)
     SETTING_FORWARD_BOOL(m_input, BackgroundControllerInput, background_controller_input)
     SETTING_FORWARD_BOOL(m_input, ImeAccessibilityEnabled, ime_accessibility_enabled)
     SETTING_FORWARD_BOOL(m_input, ImeUrlMailShortPanel, ime_url_mail_short_panel)

--- a/src/imgui/big_picture/settings_dialog_imgui.cpp
+++ b/src/imgui/big_picture/settings_dialog_imgui.cpp
@@ -61,6 +61,7 @@ void SettingsWindow::LoadSettings(std::string profile) {
 
     /////////// Input Tab
     motionControlsSetting = EmulatorSettings.IsMotionControlsEnabled();
+    motionControlsVerticalSetting = EmulatorSettings.IsMotionControlsVertical();
     backgroundControllerSetting = EmulatorSettings.IsBackgroundControllerInput();
     cursorStateSetting = EmulatorSettings.GetCursorState();
     cursorTimeoutSetting = EmulatorSettings.GetCursorHideTimeout();
@@ -126,6 +127,7 @@ void SettingsWindow::SaveSettings(std::string profile) {
 
     /////////// Input Tab
     EmulatorSettings.SetMotionControlsEnabled(motionControlsSetting, isSpecific);
+    EmulatorSettings.SetMotionControlsVertical(motionControlsVerticalSetting, isSpecific);
     EmulatorSettings.SetBackgroundControllerInput(backgroundControllerSetting, isSpecific);
     EmulatorSettings.SetCursorState(cursorStateSetting, isSpecific);
     EmulatorSettings.SetCursorHideTimeout(cursorTimeoutSetting, isSpecific);
@@ -711,6 +713,9 @@ void SettingsWindow::DrawSettingsTable(SettingsCategory category) {
             ImGui::TableSetupColumn("Value");
 
             AddSettingCheckbox("Enable Motion Controls", motionControlsSetting);
+            if (motionControlsSetting) {
+                AddSettingCheckbox("Motion Controls Held Upright", motionControlsVerticalSetting);
+            }
             AddSettingCheckbox("Enable Background Controller Input", backgroundControllerSetting);
             AddSettingCombo("Hide Cursor", cursorStateSetting, hideCursorOptions);
 

--- a/src/imgui/big_picture/settings_dialog_imgui.h
+++ b/src/imgui/big_picture/settings_dialog_imgui.h
@@ -142,6 +142,7 @@ private:
 
     // Input tab
     bool motionControlsSetting;
+    bool motionControlsVerticalSetting;
     bool backgroundControllerSetting;
     int cursorStateSetting;
     int cursorTimeoutSetting;

--- a/src/input/controller.cpp
+++ b/src/input/controller.cpp
@@ -23,6 +23,24 @@ using Libraries::Pad::OrbisPadButtonDataOffset;
 
 namespace {
 
+/// SDL reports gamepad motion in the frame of a controller lying face up. A
+/// handheld is held upright instead, so its Y and Z are that frame's Z and -Y
+/// -- which is why yaw and roll feel swapped. Rotating -90 degrees about X puts
+/// them back where a game written for a DualShock expects them.
+///
+/// Off by default: nothing SDL reports says how the device is being held. Only
+/// applied to a physical sensor, never to emulated motion, which arrives in the
+/// frame a game already expects.
+void OrientMotion(const float in[3], float out[3], bool device_frame) {
+    if (device_frame && EmulatorSettings.IsMotionControlsVertical()) {
+        out[0] = in[0];
+        out[1] = -in[2];
+        out[2] = in[1];
+    } else {
+        std::memcpy(out, in, sizeof(float[3]));
+    }
+}
+
 void CalculateOrientation(const Libraries::Pad::OrbisFVector3& angular_velocity, float delta_time,
                           const Libraries::Pad::OrbisFQuaternion& last_orientation,
                           Libraries::Pad::OrbisFQuaternion& orientation) {
@@ -107,14 +125,14 @@ void GameController::Axis(Input::Axis axis, int value, bool smooth) {
     PushStateLocked(timestamp);
 }
 
-void GameController::UpdateGyro(const float gyro[3]) {
+void GameController::UpdateGyro(const float gyro[3], bool device_frame) {
     std::lock_guard lock{m_state_mutex};
-    std::memcpy(gyro_buf, gyro, sizeof(gyro_buf));
+    OrientMotion(gyro, gyro_buf, device_frame);
 }
 
-void GameController::UpdateAcceleration(const float acceleration[3]) {
+void GameController::UpdateAcceleration(const float acceleration[3], bool device_frame) {
     std::lock_guard lock{m_state_mutex};
-    std::memcpy(accel_buf, acceleration, sizeof(accel_buf));
+    OrientMotion(acceleration, accel_buf, device_frame);
 }
 
 void GameController::PollState() {

--- a/src/input/controller.h
+++ b/src/input/controller.h
@@ -95,8 +95,10 @@ public:
 
     void Button(Libraries::Pad::OrbisPadButtonDataOffset button, bool isPressed);
     void Axis(Input::Axis axis, int value, bool smooth = true);
-    void UpdateGyro(const float gyro[3]);
-    void UpdateAcceleration(const float acceleration[3]);
+    /// device_frame marks data straight from a physical sensor, which may need
+    /// reorienting; emulated motion is already in the frame a game expects.
+    void UpdateGyro(const float gyro[3], bool device_frame = false);
+    void UpdateAcceleration(const float acceleration[3], bool device_frame = false);
     void PollState();
     void ResetOrientation();
     void SetLightBarRGB(u8 const r, u8 const g, u8 const b);

--- a/src/sdl_window.cpp
+++ b/src/sdl_window.cpp
@@ -423,13 +423,13 @@ void WindowSDL::OnGamepadEvent(const SDL_Event* event) {
         case SDL_SENSOR_GYRO:
             gamepad = controllers.GetGamepadIndexFromJoystickId(event->gsensor.which);
             if (gamepad < 5) {
-                controllers[gamepad]->UpdateGyro(event->gsensor.data);
+                controllers[gamepad]->UpdateGyro(event->gsensor.data, true);
             }
             break;
         case SDL_SENSOR_ACCEL:
             gamepad = controllers.GetGamepadIndexFromJoystickId(event->gsensor.which);
             if (gamepad < 5) {
-                controllers[gamepad]->UpdateAcceleration(event->gsensor.data);
+                controllers[gamepad]->UpdateAcceleration(event->gsensor.data, true);
             }
             break;
         default:


### PR DESCRIPTION
Closes #3871.

SDL reports gamepad motion in the frame of a controller lying face up, which is how a DualShock is held — so passing `event->gsensor.data` straight through is correct for one. A handheld is held upright instead, and its frame is 90 degrees away about X. X is left-right in both, so pitch arrives correctly while yaw and roll land on each other: tilting the device moves the camera, turning it does nothing. On a Steam Deck a real 90 degree yaw arrives as -89.1 on `z` against +23.5 on `y`.

`Input.motion_controls_vertical` rotates motion -90 degrees about X — `(x, y, z)` to `(x, -z, y)` — before it reaches the emulated pad. Gyro and accelerometer both, since they share the frame. Per-game overrideable like the other input settings.

Off by default, and not auto-detected: nothing SDL reports says how a device is being held, and the rotation is wrong for a controller resting face up.

Built and run on a Steam Deck (OLED) in a retail game with motion controls. Off, behaviour is unchanged; on, a 90 degree yaw reads 92.0 about true vertical and the camera turns with the device.

No GUI checkbox here — config and per-game overrides only. Happy to add one to the Qt settings dialog if that is wanted.
