### PR TITLE
chore: fix typo in flake.nix comment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,7 @@
                 libpulseaudio
               ];
 
-              # SDL3 requres extra libraries inside the devshell in order to pass CMake's configure.
+              # SDL3 requires extra libraries inside the devshell in order to pass CMake's configure.
               sdlConfigureDeps = [
                 jack1
                 fribidi


### PR DESCRIPTION
Fixes a typo in a `flake.nix` comment: "SDL3 requres extra libraries" -> "requires".

Comment only, no functional change.
