### PR TITLE
LLE system computer vision libraries except VrTracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ The following firmware modules are supported and must be placed in shadPS4's `sy
 | libSceFreeTypeOt.sprx          | libSceJpegDec.sprx             | libSceJpegEnc.sprx             | libSceJson.sprx                |
 | libSceJson2.sprx               | libSceLibcInternal.sprx        | libSceNgs2.sprx                | libScePngEnc.sprx              |
 | libScePsmKitSystem.sprx        | libSceRtc.sprx                 | libSceRudp.sprx                | libSceSystemGesture.sprx       |
-| libSceUlt.sprx                 | libSceWkFontConfig.sprx        | libSceXml.sprx                 |
+| libSceUlt.sprx                 | libSceWkFontConfig.sprx        | libSceXml.sprx                 | libSceDepth.sprx               |
+| libScePadTracker.sprx          | libSceMoveTracker.sprx         |
 </div>
 
 > [!Caution]

--- a/src/core/libraries/sysmodule/sysmodule_internal.cpp
+++ b/src/core/libraries/sysmodule/sysmodule_internal.cpp
@@ -243,6 +243,9 @@ s32 loadModuleInternal(s32 index, s32 argc, const void* argv, s32* res_out) {
              {"libSceRudp.sprx", &Libraries::Rudp::RegisterLib},
              {"libSceWkFontConfig.sprx", nullptr},
              {"libScePsmKitSystem.sprx", nullptr},
+             {"libSceDepth.sprx", nullptr},
+             {"libScePadTracker.sprx", nullptr},
+             {"libSceMoveTracker.sprx", nullptr},
              {"libSceSystemGesture.sprx", &Libraries::SystemGesture::RegisterLib},
              {"libSceXml.sprx", nullptr}});
 


### PR DESCRIPTION
This makes THE PLAYROOM boot into menus. You can't get ingame due to the camera output for some reason not working, and even if it did, I know from my own testing via homebrew that my HLE Camera library is incompatible with the LLE tracking libraries, so for now this is only done to prevent crashes for games that make use of these libraries.