### PR TITLE
Support 8 and 16 byte copies in SRT Pointer Visitation

### DIFF
--- a/src/shader_recompiler/ir/passes/flatten_extended_userdata_pass.cpp
+++ b/src/shader_recompiler/ir/passes/flatten_extended_userdata_pass.cpp
@@ -82,7 +82,9 @@ static bool SrtWalkerSignalHandler(void* context, void* fault_address) {
     ZyanStatus status = Common::Decoder::Instance()->decodeInstruction(instruction, operands,
                                                                        const_cast<void*>(code), 15);
 
-    ASSERT(ZYAN_SUCCESS(status) && instruction.mnemonic == ZYDIS_MNEMONIC_MOV &&
+    ASSERT(ZYAN_SUCCESS(status) &&
+           (instruction.mnemonic == ZYDIS_MNEMONIC_MOV ||
+            instruction.mnemonic == ZYDIS_MNEMONIC_MOVUPS) &&
            operands[0].type == ZYDIS_OPERAND_TYPE_REGISTER &&
            operands[1].type == ZYDIS_OPERAND_TYPE_MEMORY);
 
@@ -90,7 +92,12 @@ static bool SrtWalkerSignalHandler(void* context, void* fault_address) {
     const size_t patch_size = 3;
     u8* code_patch = const_cast<u8*>(reinterpret_cast<const u8*>(code));
 
-    // We can only encounter rdi or r10d as the first operand in a
+    // We can encounter:
+    // - rdi
+    // - r10d
+    // - r10
+    // - xmm0
+    // as the first operand in a
     // fault memory access for SRT walker.
     switch (operands[0].reg.value) {
     case ZYDIS_REGISTER_RDI:
@@ -104,6 +111,18 @@ static bool SrtWalkerSignalHandler(void* context, void* fault_address) {
         code_patch[0] = 0x45;
         code_patch[1] = 0x31;
         code_patch[2] = 0xD2;
+        break;
+    case ZYDIS_REGISTER_R10:
+        // mov r10, [rdi + off_dw << 2] -> xor r10, r10
+        code_patch[0] = 0x4D;
+        code_patch[1] = 0x31;
+        code_patch[2] = 0xD2;
+        break;
+    case ZYDIS_REGISTER_XMM0:
+        // movups xmm0, [rdi + off_dw << 2] -> xorps xmm0, xmm0
+        code_patch[0] = 0x0F;
+        code_patch[1] = 0x57;
+        code_patch[2] = 0xC0;
         break;
     default:
         UNREACHABLE_MSG("Unsupported register for SRT walker patch");
@@ -179,14 +198,37 @@ static void VisitPointer(u32 off_dw, IR::Inst* subtree, PassInfo& pass_info,
     // First copy all the src data from this tree level
     // That way, all data that was contiguous in the guest SRT is also contiguous in the
     // flattened buffer.
-    // TODO src and dst are contiguous. Optimize with wider loads/stores
     // TODO if this subtree is dynamically indexed, don't compact it (keep it sparse)
-    for (auto [src_off_dw, use] : *use_list) {
-        c.mov(r10d, ptr[rdi + (src_off_dw << 2)]);
-        c.mov(ptr[rsi + (pass_info.dst_off_dw << 2)], r10d);
+    for (auto it = use_list->begin(); it != use_list->end();) {
+        // Keys are sorted and unique, so it[1].first + 2 == it[3].first
+        // implies it[2].first.
+        const auto contiguous = [&](std::ptrdiff_t idx) {
+            return use_list->end() - it > idx && it[idx].first == it->first + idx;
+        };
+        const u32 dwords = contiguous(1) ? (contiguous(3) ? 4 : 2) : 1;
 
-        use->SetFlags<u32>(pass_info.dst_off_dw);
-        pass_info.dst_off_dw++;
+        const u32 src = it->first << 2;
+        const u32 dst = pass_info.dst_off_dw << 2;
+
+        // Note: do not switch to rep movsd (measured expensive, messy fault case)
+        switch (dwords) {
+        case 4:
+            c.movups(xmm0, ptr[rdi + src]);
+            c.movups(ptr[rsi + dst], xmm0);
+            break;
+        case 2:
+            c.mov(r10, ptr[rdi + src]);
+            c.mov(ptr[rsi + dst], r10);
+            break;
+        case 1:
+            c.mov(r10d, ptr[rdi + src]);
+            c.mov(ptr[rsi + dst], r10d);
+            break;
+        }
+
+        for (u32 k = 0; k < dwords; ++k, ++it) {
+            it->second->SetFlags<u32>(pass_info.dst_off_dw++);
+        }
     }
 
     // Then visit any children used as pointers

--- a/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_serialization.cpp
@@ -12,7 +12,7 @@
 
 namespace Serialization {
 /* You should increment versions below once corresponding serialization scheme is changed. */
-static constexpr u32 ShaderBinaryVersion = 3u;
+static constexpr u32 ShaderBinaryVersion = 4u;
 static constexpr u32 ShaderMetaVersion = 3u;
 static constexpr u32 PipelineKeyVersion = 3u;
 } // namespace Serialization


### PR DESCRIPTION
Was looking at addressing the subtree indexing, but thought this was a good first step here. Used movups to allow the 4 dword copy/r10 for the 2-dword + SignalHandler fault cases handled and a new mnemonic in the ASSERT. Also bumped the ShaderBinaryVersion to handle any cached walker/handler version mismatch.

Proof is in the pudding:
```
 57                            | push   rdi
 48 8b 7f 08                   | mov    rdi,QWORD PTR [rdi+0x8]      ; PushPtr
 49 ba ff ff ff ff ff ff 00 00 | movabs r10,0xffffffffffff
 4c 21 d7                      | and    rdi,r10
-44 8b 17                      | mov    r10d,DWORD PTR [rdi]         ; previously 6 dword copies
-44 89 56 40                   | mov    DWORD PTR [rsi+0x40],r10d
-44 8b 57 04                   | mov    r10d,DWORD PTR [rdi+0x4]
-44 89 56 44                   | mov    DWORD PTR [rsi+0x44],r10d
-44 8b 57 08                   | mov    r10d,DWORD PTR [rdi+0x8]
-44 89 56 48                   | mov    DWORD PTR [rsi+0x48],r10d
-44 8b 57 0c                   | mov    r10d,DWORD PTR [rdi+0xc]
-44 89 56 4c                   | mov    DWORD PTR [rsi+0x4c],r10d
-44 8b 57 18                   | mov    r10d,DWORD PTR [rdi+0x18]
-44 89 56 50                   | mov    DWORD PTR [rsi+0x50],r10d
-44 8b 57 1c                   | mov    r10d,DWORD PTR [rdi+0x1c]
-44 89 56 54                   | mov    DWORD PTR [rsi+0x54],r10d
+0f 10 07                      | movups xmm0,XMMWORD PTR [rdi]       ; new 16B copy
+0f 11 46 40                   | movups XMMWORD PTR [rsi+0x40],xmm0
+4c 8b 57 18                   | mov    r10,QWORD PTR [rdi+0x18]     ; new 8B copy
+4c 89 56 50                   | mov    QWORD PTR [rsi+0x50],r10
 44 8b 57 28                   | mov    r10d,DWORD PTR [rdi+0x28]
 44 89 56 58                   | mov    DWORD PTR [rsi+0x58],r10d
-44 8b 57 40                   | mov    r10d,DWORD PTR [rdi+0x40]    ; previously 2 dword copies
-44 89 56 5c                   | mov    DWORD PTR [rsi+0x5c],r10d
-44 8b 57 44                   | mov    r10d,DWORD PTR [rdi+0x44]
-44 89 56 60                   | mov    DWORD PTR [rsi+0x60],r10d
+4c 8b 57 40                   | mov    r10,QWORD PTR [rdi+0x40]     ; new 8B copy
+4c 89 56 5c                   | mov    QWORD PTR [rsi+0x5c],r10
 57                            | push   rdi
 48 8b 7f 40                   | mov    rdi,QWORD PTR [rdi+0x40]
 49 ba ff ff ff ff ff ff 00 00 | movabs r10,0xffffffffffff
 4c 21 d7                      | and    rdi,r10
-44 8b 17                      | mov    r10d,DWORD PTR [rdi]         ; perviously 4 dword copies
-44 89 56 64                   | mov    DWORD PTR [rsi+0x64],r10d
-44 8b 57 04                   | mov    r10d,DWORD PTR [rdi+0x4]
-44 89 56 68                   | mov    DWORD PTR [rsi+0x68],r10d
-44 8b 57 08                   | mov    r10d,DWORD PTR [rdi+0x8]
-44 89 56 6c                   | mov    DWORD PTR [rsi+0x6c],r10d
-44 8b 57 0c                   | mov    r10d,DWORD PTR [rdi+0xc]
-44 89 56 70                   | mov    DWORD PTR [rsi+0x70],r10d
+0f 10 07                      | movups xmm0,XMMWORD PTR [rdi]       ; new 16B copy
+0f 11 46 64                   | movups XMMWORD PTR [rsi+0x64],xmm0
 5f                            | pop    rdi
 5f                            | pop    rdi
 c3                            | ret
```