### PR TITLE
BugFix: LOG_GENERIC evaluated arguments before checking level

### DIFF
--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -53,7 +53,8 @@ static constexpr std::array level_string_views{"Trace", "Debug",    "Info", "War
 // Define the fmt lib macros
 #define LOG_GENERIC(log_class, log_level, format, ...)                                             \
     do {                                                                                           \
-        if (auto logger = Common::Log::ALL_LOGGERS[log_class]) {                                   \
+        if (auto logger = Common::Log::ALL_LOGGERS[log_class];                                     \
+            logger && logger->should_log(log_level)) {                                             \
             logger->log(log_level, "[{}] <{}> ({}) {}:{} {}: " format, log_class,                  \
                         Common::Log::to_string_view(log_level), Common::GetCurrentThreadName(),    \
                         spdlog::source_loc::basename(__FILE__), __LINE__,                          \


### PR DESCRIPTION
Was doing some debugging with:
`strace -f -c -p $shadps4_pid`

And saw nearly 450000 calls to `prctl`. Went a step further, and found that when tracing specifically for `prctl`, it's all to `PR_GET_NAME` which felt insane, because why are we checking for who we are so often? Going through the codebase I found that pthread_getname was in GetCurrentThreadName, which led me to the LOG_GENERIC call. 

Adding this check here significantly reduced the prctl spam.