### PR TITLE
Fix incorrect error return on attempting to create a file in a nonexistent folder in a writable mount

### DIFF
--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -237,7 +237,9 @@ s32 PS4_SYSV_ABI open(const char* raw_path, s32 flags, u16 mode) {
         file->handle = mnt->Open(file->m_guest_name, access_mode);
         if (!file->handle || !file->handle->IsOpen()) {
             h->DeleteHandle(handle);
-            *__Error() = (write || rdwr || truncate) ? POSIX_EROFS : POSIX_EIO;
+            *__Error() = (write || rdwr || truncate) && mnt->GetMount(raw_path)->read_only
+                             ? POSIX_EROFS
+                             : POSIX_EIO;
             LOG_ERROR(Kernel_Fs, "Opening {} failed, backend did not serve the file", raw_path);
             return -1;
         }


### PR DESCRIPTION
Tearaway Unfolded creates files in its savedata by first trying to create the file, and if that fails to get created due to the parent folder(s) not existing, it creates the folder(s) and tries again. After the Abstract Filesystem PR, this case was failed to be considered and `open` incorrectly returned EROFS in errno instead of EIO, causing the game to think the savedata isn't writable and abort. This PR fixes the errno return value in this case, which fixes savedata handling in the aforementioned game.