### PR TITLE
video_core: Decode sRGB for A2R10G10B10Srgb display buffers

### DIFF
--- a/src/video_core/host_shaders/post_process.frag
+++ b/src/video_core/host_shaders/post_process.frag
@@ -11,6 +11,7 @@ layout (binding = 0) uniform sampler2D texSampler;
 layout (push_constant) uniform settings {
     float gamma;
     bool hdr;
+    bool srgb_input;
 } pp;
 
 const float cutoff = 0.0031308, a = 1.055, b = 0.055, d = 12.92;
@@ -22,11 +23,22 @@ vec3 gamma(vec3 rgb) {
     );
 }
 
+// Exact inverse of gamma() at unit gamma, for buffers that are sRGB encoded but must be sampled
+// through a UNORM view because Vulkan has no sRGB variant of the 10-bit format.
+vec3 degamma(vec3 rgb) {
+    return mix(
+        pow(max(rgb + b, 0.0) / a, vec3(2.4)),
+        rgb / d,
+        lessThan(rgb, vec3(d * cutoff))
+    );
+}
+
 void main() {
     vec4 color_linear = texture(texSampler, uv);
     if (pp.hdr) {
         color = color_linear;
     } else {
+        if (pp.srgb_input) color_linear.rgb = degamma(color_linear.rgb);
         color = vec4(gamma(color_linear.rgb), color_linear.a);
     }
 }

--- a/src/video_core/renderer_vulkan/host_passes/pp_pass.h
+++ b/src/video_core/renderer_vulkan/host_passes/pp_pass.h
@@ -17,6 +17,7 @@ public:
     struct Settings {
         float gamma = 1.0f;
         u32 hdr = 0;
+        u32 srgb_input = 0;
     };
 
     void Create(vk::Device device, vk::Format surface_format);

--- a/src/video_core/renderer_vulkan/vk_presenter.cpp
+++ b/src/video_core/renderer_vulkan/vk_presenter.cpp
@@ -738,6 +738,11 @@ Frame* Presenter::PrepareFrame(const Libraries::VideoOut::BufferAttributeGroup& 
 
     image_view = fsr_pass.Render(cmdbuf, image_view, image_size, {frame->width, frame->height},
                                  fsr_settings, frame->is_hdr);
+
+    // Vulkan has no sRGB variant of the 10-bit format, so an A2R10G10B10Srgb buffer reaches
+    // the post process pass still sRGB encoded and has to be decoded there instead.
+    pp_settings.srgb_input =
+        attribute.attrib.pixel_format == Libraries::VideoOut::PixelFormat::A2R10G10B10Srgb;
     pp_pass.Render(cmdbuf, image_view, image_size, *frame, pp_settings);
 
     DebugState.game_resolution = {image_size.width, image_size.height};


### PR DESCRIPTION
This PR fixes the doubled gamma in TLOU Remastered v1.11. The issue was that when updating from v1.00 to v1.11, TLOU went from 8 bit sRGB (`A8B8G8R8Srgb`) to 10 bit sRGB (`A2R10G10B10Srgb`) display color format in v1.11, the latter of which is not expressible by vulkan. As such, the hardware decoding was skipped for `A2R10G10B10Srgb` and was encoded by the shader. This effectively led to double encoding, which doubled the gamma output in the game. The fix is to implement shader decoding for `A2R10G10B10Srgb` display buffers.

before (decoding skipped, encoding active)

<img width="1278" height="716" alt="TLOU-before1" src="https://github.com/user-attachments/assets/9456a722-4356-4c9d-a0d6-39e4c6729fcf" />

after (decoding active, encoding active)

<img width="1276" height="717" alt="TLOU-after1" src="https://github.com/user-attachments/assets/1c62cd97-59eb-43d4-9666-75327bb01fe2" />
