### PR TITLE
Remove unused code from emulator-settings set of files.

### DIFF
--- a/src/core/emulator_settings.cpp
+++ b/src/core/emulator_settings.cpp
@@ -235,37 +235,6 @@ void EmulatorSettingsImpl::ClearGameSpecificOverrides() {
     ClearGroupOverrides(m_vulkan);
 }
 
-void EmulatorSettingsImpl::ResetGameSpecificValue(const std::string& key) {
-    // Walk every overrideable group until we find the matching key.
-    auto tryGroup = [&key](auto& group) {
-        for (auto& item : group.GetOverrideableFields()) {
-            if (key == item.key) {
-                item.reset_game_specific(&group);
-                return true;
-            }
-        }
-        return false;
-    };
-    if (tryGroup(m_general))
-        return;
-    if (tryGroup(m_log))
-        return;
-    if (tryGroup(m_debug))
-        return;
-    if (tryGroup(m_input))
-        return;
-    if (tryGroup(m_audio))
-        return;
-    // Windows static guest red-zone protection
-    if (tryGroup(m_windows_guest_red_zone_protection))
-        return;
-    if (tryGroup(m_gpu))
-        return;
-    if (tryGroup(m_vulkan))
-        return;
-    LOG_WARNING(Config, "ResetGameSpecificValue: key '{}' not found", key);
-}
-
 bool EmulatorSettingsImpl::Save(const std::string& serial) {
     try {
         if (!serial.empty()) {

--- a/src/core/emulator_settings.h
+++ b/src/core/emulator_settings.h
@@ -539,9 +539,6 @@ public:
     /// the emulator reverts to global settings.
     void ClearGameSpecificOverrides();
 
-    /// Reset a single field's game-specific override by its JSON ke
-    void ResetGameSpecificValue(const std::string& key);
-
     // general accessors
     bool AddGameInstallDir(const std::filesystem::path& dir, bool enabled = true);
     std::vector<std::filesystem::path> GetGameInstallDirs() const;

--- a/tests/test_emulator_settings.cpp
+++ b/tests/test_emulator_settings.cpp
@@ -557,40 +557,6 @@ TEST_F(EmulatorSettingsTest, ClearGameSpecificOverrides_NoopWhenNothingLoaded) {
     EXPECT_NO_THROW(temp_settings->ClearGameSpecificOverrides());
 }
 
-// ResetGameSpecificValue tests
-
-TEST_F(EmulatorSettingsTest, ResetGameSpecificValue_ClearsNamedKey) {
-    temp_settings->SetWindowWidth(1280);
-    json game;
-    game["GPU"]["window_width"] = 3840;
-    WriteJson(GameConfig("CUSA01234"), game);
-    temp_settings->Load("CUSA01234");
-
-    temp_settings->SetConfigMode(ConfigMode::Default);
-    ASSERT_EQ(temp_settings->GetWindowWidth(), 3840);
-
-    temp_settings->ResetGameSpecificValue("window_width");
-    EXPECT_EQ(temp_settings->GetWindowWidth(), 1280);
-}
-
-TEST_F(EmulatorSettingsTest, ResetGameSpecificValueOnlyAffectsTargetKey) {
-    json game;
-    game["GPU"]["window_width"] = 3840;
-    game["General"]["neo_mode"] = true;
-    WriteJson(GameConfig("CUSA01234"), game);
-    temp_settings->Load("CUSA01234");
-
-    temp_settings->ResetGameSpecificValue("window_width");
-    temp_settings->SetConfigMode(ConfigMode::Default);
-
-    EXPECT_EQ(temp_settings->GetWindowWidth(), 1280); // cleared
-    EXPECT_TRUE(temp_settings->IsNeo());              // still set
-}
-
-TEST_F(EmulatorSettingsTest, ResetGameSpecificValueUnknownKeyNoOp) {
-    EXPECT_NO_THROW(temp_settings->ResetGameSpecificValue("does_not_exist"));
-}
-
 // GameInstallDir tests
 
 TEST_F(EmulatorSettingsTest, AddGameInstallDirAddsEnabled) {


### PR DESCRIPTION
Inside of emulator_settings.cpp there is a function that is not referenced by any other code or called. Grepping through the codebase, I couldn't find anywhere that called this function.

```
rg -i "resetgamespecificvalue" src/core/emulator_settings.cpp
240:void EmulatorSettingsImpl::ResetGameSpecificValue(const std::string &key) {

src/core/emulator_settings.h
543:    void ResetGameSpecificValue(const std::string& key);
```

As it is seemingly at least unused. It may be worth deleting, unless there is a specific reason to keep it around. 

I have tested and the emulator still builds and runs on my end normally, wouldn't harm more thoroughly testing however if felt needed.