### PR TITLE
imgui: raise the font atlas cap from the backend's max texture size

### DIFF
--- a/src/imgui/big_picture/big_picture.cpp
+++ b/src/imgui/big_picture/big_picture.cpp
@@ -1,6 +1,8 @@
 //  SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
 //  SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <algorithm>
+#include <bit>
 #include <fstream>
 #include <stb_image.h>
 
@@ -259,6 +261,12 @@ void Launch(char* executableName, bool sameProcess) {
     io.FontDefault = ImGui::FontStack::AddPrimaryUiFont(
         io.Fonts, 64.0f, EmulatorSettings.GetConsoleLanguage(), cfgBase, true);
     io.FontGlobalScale = 0.5f;
+    // size the big picture font atlas cap from the renderer limit
+    const auto max_dim = SDL_GetNumberProperty(SDL_GetRendererProperties(renderer),
+                                               SDL_PROP_RENDERER_MAX_TEXTURE_SIZE_NUMBER, 8192);
+    const int atlas_max = static_cast<int>(std::bit_floor(std::max<u64>(max_dim, 512)));
+    io.Fonts->TexMaxWidth = atlas_max;
+    io.Fonts->TexMaxHeight = atlas_max;
     io.Fonts->Build();
 
     ImGui_ImplSDL3_InitForSDLRenderer(window, renderer);

--- a/src/imgui/renderer/imgui_core.cpp
+++ b/src/imgui/renderer/imgui_core.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <bit>
 #include <cstdint>
 #include <SDL3/SDL_events.h>
 #include <imgui.h>
@@ -102,6 +103,13 @@ void Initialize(const ::Vulkan::Instance& instance, const Frontend::WindowSDL& w
     // Big Picture
     FontStack::AddPrimaryUiFont(ImGui::GetIO().Fonts, 64.0f, EmulatorSettings.GetConsoleLanguage(),
                                 font_cfg, true);
+
+    // Let the atlas size grow to the largest image the device can create,
+    // floored to the power of two the packer requires.
+    const u32 max_dim = instance.GetPhysicalDevice().getProperties().limits.maxImageDimension2D;
+    const int atlas_max = static_cast<int>(std::bit_floor(std::max<u32>(max_dim, 512u)));
+    io.Fonts->TexMaxWidth = atlas_max;
+    io.Fonts->TexMaxHeight = atlas_max;
 
     io.Fonts->Build();
 


### PR DESCRIPTION
This PR fixes a regression by PR #4960, which caused the following error when attempting to boot any game with Korean or Traditional Chinese as the Console Language:
```
[Debug] <Critical> (shadPS4:Main) assert.cpp:27 assert_fail_debug_msg: Assertion Failed!
pack_id != ImFontAtlasRectId_Invalid && "Out of texture memory." at D:\a\shadPS4\shadPS4\externals\imgui\imgui_draw.cpp:4835
```
The font atlas size was capped to `TexMaxWidth = 8192` and `TexMaxHeight = 8192`, which is not big enough to support these languages. The fix is to just set the maximum size to the device's `maxImageDimension2D` floored to a power of 2