### PR TITLE
Fix regressions from #4952

### DIFF
--- a/src/core/libraries/kernel/file_system.cpp
+++ b/src/core/libraries/kernel/file_system.cpp
@@ -237,9 +237,10 @@ s32 PS4_SYSV_ABI open(const char* raw_path, s32 flags, u16 mode) {
         file->handle = mnt->Open(file->m_guest_name, access_mode);
         if (!file->handle || !file->handle->IsOpen()) {
             h->DeleteHandle(handle);
-            *__Error() = (write || rdwr || truncate) && mnt->GetMount(raw_path)->read_only
-                             ? POSIX_EROFS
-                             : POSIX_EIO;
+            auto mount = mnt->GetMount(raw_path);
+            *__Error() =
+                mount ? (write || rdwr || truncate) && mount->read_only ? POSIX_EROFS : POSIX_EIO
+                      : POSIX_EINVAL;
             LOG_ERROR(Kernel_Fs, "Opening {} failed, backend did not serve the file", raw_path);
             return -1;
         }


### PR DESCRIPTION
Files outside of mount points for some reason get far into opening that they hit the error path I modified, instead of just erroring out much sooner, so here's a fix for all those games that try opening debug files in the current directory, which is not allowed on the PS4, but we need to handle the errors coming from that regardless.