### PR TITLE
ime: pass AddPolyline thickness and flags in the imgui 1.92.8 order

### DIFF
--- a/src/core/libraries/ime/ime_kb_layout.cpp
+++ b/src/core/libraries/ime/ime_kb_layout.cpp
@@ -1967,8 +1967,8 @@ void DrawImeKeyboardGrid(const ImeKbGridLayout& layout, const ImeKbDrawParams& p
             if (filled) {
                 draw->AddConvexPolyFilled(shape.data(), static_cast<int>(shape.size()), color);
             } else {
-                draw->AddPolyline(shape.data(), static_cast<int>(shape.size()), color, true,
-                                  thickness);
+                draw->AddPolyline(shape.data(), static_cast<int>(shape.size()), color, thickness,
+                                  ImDrawFlags_Closed);
             }
 
             if (caps_locked) {
@@ -2000,7 +2000,8 @@ void DrawImeKeyboardGrid(const ImeKbGridLayout& layout, const ImeKbDrawParams& p
                 ImVec2{left, bottom},
                 tip,
             };
-            draw->AddPolyline(frame.data(), static_cast<int>(frame.size()), color, true, thickness);
+            draw->AddPolyline(frame.data(), static_cast<int>(frame.size()), color, thickness,
+                              ImDrawFlags_Closed);
 
             const float cross_half = extent * 0.10f;
             const float cross_cx = left + body_w * 0.57f;


### PR DESCRIPTION
This PR fixes a regression from PR #4960 that causes a crash when opening the on screen keyboard
```
[Debug] <Critical> (shadPS4:PresentThread) assert.cpp:27 assert_fail_debug_msg: Assertion Failed!
((flags & ImDrawFlags_InvalidMask_) == 0) && "Incorrect parameter. Did you swap 'thickness' and 'flags'?" at D:\a\shadPS4\shadPS4\externals\imgui\imgui_draw.cpp:843
```
imgui 1.92.8 moved `ImDrawFlags_Closed `to bit 9, which means `true` is no longer correct here. The fix is to drop it for  `ImDrawFlags_Closed`. thickness and flags were also reordered as per the update. 