### PR TITLE
Fix cut off logging in log files after the signals rewrite

### DIFF
--- a/src/common/assert.cpp
+++ b/src/common/assert.cpp
@@ -4,6 +4,7 @@
 #include "common/arch.h"
 #include "common/assert.h"
 #include "core/signals.h"
+#include "emulator.h"
 
 #if defined(ARCH_X86_64)
 #define Crash() __asm__ __volatile__("int $3")
@@ -15,6 +16,7 @@
 
 void assert_fail_impl() {
     Core::Signals::Instance()->RemoveHandlers();
+    Common::Singleton<Core::Emulator>::Instance()->Shutdown();
     Crash();
 }
 

--- a/src/common/logging/log.cpp
+++ b/src/common/logging/log.cpp
@@ -17,14 +17,6 @@
 #include "common/types.h"
 #include "core/emulator_settings.h"
 
-// return codes above 'standard'
-// https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes
-enum class ShadPs4ReturnCode : u32 {
-    TERMINATE_WITHOUT_EXCEPTION = 20'000,
-    TERMINATE_WITH_EXCEPTION = 20'001,
-    TERMINATE_WITH_UNKNOWN_EXCEPTION = 20'002,
-};
-
 namespace Common::Log {
 bool g_should_append = false;
 
@@ -183,7 +175,6 @@ void Setup(std::string_view shadps4_filename) {
     std::call_once(already_registered, []() {
         std::atexit(Shutdown);
         std::at_quick_exit(Flush);
-        std::set_terminate(Terminate);
     });
 
     for (auto& [name, logger] : ALL_LOGGERS) {
@@ -242,26 +233,6 @@ void Flush() {
 
     if (g_console_sink != nullptr) {
         g_console_sink->flush();
-    }
-}
-
-void Terminate() {
-    try {
-        if (std::exception_ptr eptr{std::current_exception()}) {
-            std::rethrow_exception(eptr);
-        }
-
-        LOG_CRITICAL(Debug, "Exiting without exception");
-
-        std::quick_exit(std::to_underlying(ShadPs4ReturnCode::TERMINATE_WITHOUT_EXCEPTION));
-    } catch (const std::exception& exception) {
-        LOG_CRITICAL(Debug, "Exception: {}", exception);
-
-        std::quick_exit(std::to_underlying(ShadPs4ReturnCode::TERMINATE_WITH_EXCEPTION));
-    } catch (...) {
-        LOG_CRITICAL(Debug, "Unknown exception caught");
-
-        std::quick_exit(std::to_underlying(ShadPs4ReturnCode::TERMINATE_WITH_UNKNOWN_EXCEPTION));
     }
 }
 

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -266,10 +266,6 @@ static void* RunThread(void* arg) {
     UnblockPthreadCancelSignal();
 #endif
 
-#ifdef WIN32
-    std::set_terminate(Common::Log::Terminate);
-#endif
-
     /* Run the current thread's start routine with argument: */
     auto* const stack =
         (void*)(((size_t)curthread->attr.stackaddr_attr + curthread->attr.stacksize_attr) & (~15));

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -861,8 +861,8 @@ static bool SigDflHandler(int sig) {
     case POSIX_SIGPROF:
     case POSIX_SIGUSR1:
     case POSIX_SIGUSR2:
-        return false;
     case POSIX_SIGTRAP:
+        return false;
     default:
         LOG_DEBUG(Lib_Kernel, "called, sig: {}", sig);
         return true;

--- a/src/core/linker.cpp
+++ b/src/core/linker.cpp
@@ -148,7 +148,6 @@ void Linker::Execute(const std::vector<std::string>& args) {
 
     main_thread.Run([this, module, &args, has_libcinternal](std::stop_token) {
         Common::SetCurrentThreadName("Game:Main");
-        std::set_terminate(Common::Log::Terminate);
 
 #ifndef _WIN32 // Clear any existing signal mask for game threads.
         sigset_t emptyset;

--- a/src/core/signals.cpp
+++ b/src/core/signals.cpp
@@ -29,7 +29,7 @@ namespace Core {
 static LONG WINAPI SignalHandler(EXCEPTION_POINTERS* pExp) noexcept {
     using namespace Libraries::Kernel;
     const auto* signals = Signals::Instance();
-    // Windows static guest red-zone protection
+
     const bool use_static_windows_guest_red_zone_protection =
         WindowsGuestRedZoneProtection::IsStaticPatchingEnabled();
     DWORD code = 0;
@@ -137,11 +137,9 @@ static LONG WINAPI SignalHandler(EXCEPTION_POINTERS* pExp) noexcept {
         }
     }
 
-    // Windows static guest red-zone protection
-    const bool report_unhandled = use_static_windows_guest_red_zone_protection
-                                      ? static_protection_exception
-                                      : code != EXCEPTION_BREAKPOINT;
-    if (report_unhandled) { // Windows static guest red-zone protection
+    const bool report_unhandled =
+        use_static_windows_guest_red_zone_protection ? static_protection_exception : true;
+    if (report_unhandled) {
         LOG_CRITICAL(Debug, "Unhandled Exception code {:#x} at {}", code, address);
         Common::Singleton<Core::Emulator>::Instance()->Shutdown();
     }


### PR DESCRIPTION
This also fixes a small and inconsequential bug about guest breakpoint handling and cleans up some dead code.