### PR TITLE
renderer_vulkan: Handle QuadStrip as a triangle strip

### DIFF
--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -121,6 +121,8 @@ vk::PrimitiveTopology PrimitiveType(AmdGpu::PrimitiveType type) {
         return vk::PrimitiveTopology::eTriangleFan;
     case AmdGpu::PrimitiveType::TriangleStrip:
         return vk::PrimitiveTopology::eTriangleStrip;
+    case AmdGpu::PrimitiveType::QuadStrip:
+        return vk::PrimitiveTopology::eTriangleStrip;
     case AmdGpu::PrimitiveType::AdjLineList:
         return vk::PrimitiveTopology::eLineListWithAdjacency;
     case AmdGpu::PrimitiveType::AdjLineStrip:

--- a/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/liverpool_to_vk.cpp
@@ -122,6 +122,7 @@ vk::PrimitiveTopology PrimitiveType(AmdGpu::PrimitiveType type) {
     case AmdGpu::PrimitiveType::TriangleStrip:
         return vk::PrimitiveTopology::eTriangleStrip;
     case AmdGpu::PrimitiveType::QuadStrip:
+        LOG_WARNING(Render_Vulkan, "Unimplemented primitive type, using TriangleStrip.");
         return vk::PrimitiveTopology::eTriangleStrip;
     case AmdGpu::PrimitiveType::AdjLineList:
         return vk::PrimitiveTopology::eLineListWithAdjacency;


### PR DESCRIPTION
This PR fixes the following crash when attempting to aim a gun in The last of us Remastered and Uncharted 3 by adding the missing `QuadStrip` case to `PrimitiveType()`:
```
[Debug] <Critical> (shadPS4:GpuComm) liverpool_to_vk.cpp:138 PrimitiveType: Unreachable code!
Unimplemented primitive type: 20
```
 Since a triangle strip over the same vertices covers the same area at even vertex count, differing only in which diagonal each quad is split along, the existing topology can simply be reused directly.

<img width="1920" height="1080" alt="Uncharted" src="https://github.com/user-attachments/assets/2a87171b-6957-49d8-b2ad-6567b377ffa2" />
Guns can now be aimed and fired in Uncharted 3


Before
[Screencast_20260906_203304.webm](https://github.com/user-attachments/assets/601e0bcc-5040-49d3-8c68-f3f4ce4e72a8)

After
https://github.com/user-attachments/assets/7a28d4d7-76e2-4e43-ad8e-71b16a755950

