### PR TITLE
Fixed DrawCenteredText with new imgui

### DIFF
--- a/src/imgui/imgui_std.h
+++ b/src/imgui/imgui_std.h
@@ -90,6 +90,7 @@ static void DrawCenteredText(const char* text, const char* text_end = nullptr,
     TextEx(text, text_end, ImGuiTextFlags_NoWidthForLargeClippedText);
     PopTextWrapPos();
     SetCursorPos(pos + content);
+    Dummy(ImVec2(0.0f, 0.0f));
 }
 
 // Limited-length InputTextEx wrapper (limits UTF-8 code points)


### PR DESCRIPTION
This should fix 

> [Debug] <Critical> (shadPS4:PresentThread) assert.cpp:29 assert_fail_debug_msg: Assertion Failed!
(0) && "Code uses SetCursorPos()/SetCursorScreenPos() to extend window/parent boundaries.\nPlease submit an item e.g. Dummy() afterwards in order to grow window/parent boundaries." at D:\a\shadPS4\shadPS4\externals\imgui\imgui.cpp:11729
[Kernel.Fs] <Info> (pxd::file_async(0)) file_system.cpp:288 close: Closing /app0/data/chara/adv/common.par

in save dialog found in yakuza 3 and 4 and 5