### PR TITLE
Misc QoL stuff

### DIFF
--- a/src/common/thread.cpp
+++ b/src/common/thread.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <thread>
 
+#include "core/libraries/fiber/fiber.h"
 #include "core/libraries/kernel/threads/pthread.h"
 
 #include "common/error.h"
@@ -252,6 +253,10 @@ void AccurateTimer::End() {
 std::string GetCurrentThreadName() {
     using namespace Libraries::Kernel;
     if (g_curthread && !g_curthread->name.empty()) {
+        if (g_curthread->tcb->tcb_fiber) {
+            return fmt::format("{}@@{}", g_curthread->name,
+                               g_curthread->tcb->tcb_fiber->current_fiber->name);
+        }
         return g_curthread->name;
     }
 #ifdef _WIN32

--- a/src/core/libraries/kernel/threads/pthread.cpp
+++ b/src/core/libraries/kernel/threads/pthread.cpp
@@ -1255,6 +1255,7 @@ void RegisterThread(Core::Loader::SymbolsResolver* sym) {
     LIB_FUNCTION("P41kTWUS3EI", "libkernel", 1, "libkernel", ORBIS(posix_pthread_getschedparam));
     LIB_FUNCTION("oIRFTjoILbg", "libkernel", 1, "libkernel", ORBIS(posix_pthread_setschedparam));
     LIB_FUNCTION("How7B8Oet6k", "libkernel", 1, "libkernel", ORBIS(posix_pthread_getname_np));
+    LIB_FUNCTION("9HzfhdtESio", "libkernel", 1, "libkernel", posix_pthread_getname_np);
     LIB_FUNCTION("3kg7rT0NQIs", "libkernel", 1, "libkernel", posix_pthread_exit);
     LIB_FUNCTION("aI+OeCz8xrQ", "libkernel", 1, "libkernel", posix_pthread_self);
     LIB_FUNCTION("qBDmpCyGssE", "libkernel", 1, "libkernel", scePthreadCancel);

--- a/src/core/libraries/save_data/save_backup.cpp
+++ b/src/core/libraries/save_data/save_backup.cpp
@@ -181,15 +181,6 @@ void StartThread() {
     LOG_DEBUG(Lib_SaveData, "Starting backup thread");
     g_backup_status = WorkerStatus::Waiting;
     g_backup_thread = std::jthread{BackupThreadBody};
-    static std::once_flag flag;
-    std::call_once(flag, [] {
-        std::at_quick_exit([] {
-            StopThread();
-            while (GetWorkerStatus() != WorkerStatus::NotStarted) {
-                std::this_thread::sleep_for(std::chrono::milliseconds(100));
-            }
-        });
-    });
 }
 
 void StopThread() {
@@ -203,6 +194,9 @@ void StopThread() {
         g_backup_queue.emplace_back(BackupRequest{});
     }
     g_backup_thread_semaphore.release();
+    while (GetWorkerStatus() != WorkerStatus::NotStarted) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
 }
 
 bool NewRequest(Libraries::UserService::OrbisUserServiceUserId user_id, std::string_view title_id,

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -90,6 +90,9 @@ void Emulator::Shutdown() {
         return;
     }
     Common::Log::Flush();
+    Libraries::SaveData::Backup::StopThread();
+    Storage::DataBase::Instance().Close();
+    UpdatePlayTime(Common::Singleton<Common::ElfInfo>::Instance()->GameSerial());
     if (controllers) {
         controllers->ResetLightbarColors();
         // need to give SDL time to do this before the runtime exits
@@ -700,9 +703,6 @@ void Emulator::Run(std::filesystem::path file, std::vector<std::string> args,
         window->WaitEvent();
     }
 
-    UpdatePlayTime(id);
-    Storage::DataBase::Instance().Close();
-
     std::quick_exit(0);
 }
 
@@ -765,7 +765,6 @@ void Emulator::Restart(std::filesystem::path eboot_path,
         }
     }
 
-    Libraries::SaveData::Backup::StopThread();
     Relaunch(std::move(args));
 }
 
@@ -811,7 +810,7 @@ void Emulator::Restart(std::filesystem::path eboot_path,
 
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
-#elif defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
+#else
     std::vector<char*> argv;
 
     // Emulator executable
@@ -832,14 +831,12 @@ void Emulator::Restart(std::filesystem::path eboot_path,
         std::cerr << "Failed to restart game: fork failed" << std::endl;
         std::quick_exit(1);
     }
-#else
-#error "Unsupported platform"
 #endif
 
     std::quick_exit(0);
 }
 
-void Emulator::UpdatePlayTime(const std::string& serial) {
+void Emulator::UpdatePlayTime(const std::string_view serial) {
     const auto user_dir = Common::FS::GetUserPath(Common::FS::PathType::UserDir);
     const auto filePath = (user_dir / "play_time.txt").string();
 

--- a/src/emulator.h
+++ b/src/emulator.h
@@ -30,7 +30,7 @@ public:
              std::optional<std::filesystem::path> game_folder = {},
              std::vector<std::pair<std::filesystem::path, std::string>> mounts = {},
              std::vector<std::string> const& env_vars = {});
-    void UpdatePlayTime(const std::string& serial);
+    void UpdatePlayTime(const std::string_view serial);
     void Shutdown();
 
     /**


### PR DESCRIPTION
This PR moves more shutdown routines (save backup, updating the play time, and flushing shader cache) to Emulator::Shutdown, so now those also trigger on crashes, and not just on normal termination of the program.
It also adds Fiber names to logging, in the "thread_name@@fiber_name" format. Example from THE PLAYROOM:
```
[Lib.SystemService] <Info> (Game:Main@@Sequencer) systemservice.cpp:1805 sceSystemServiceHideSplashScreen: called
```
There's also a new libkernel-libkernel function export I encountered while doing OpenOrbis stuff.