### PR TITLE
imgui: stop Triangle from opening context menus

### DIFF
--- a/src/imgui/renderer/imgui_core.cpp
+++ b/src/imgui/renderer/imgui_core.cpp
@@ -239,6 +239,7 @@ ImGuiID NewFrame(bool is_reusing_frame) {
 
     Sdl::NewFrame(is_reusing_frame);
     ImGui::NewFrame();
+    SetKeyOwner(ImGuiKey_GamepadFaceUp, ImHashStr("shadps4/pad"));
 
     ImGuiWindowFlags flags =
         ImGuiDockNodeFlags_PassthruCentralNode | ImGuiDockNodeFlags_AutoHideTabBar;


### PR DESCRIPTION
This PR fixes a regression caused by PR #4960 that created a binding for `ImGuiKey_NavGamepadContextMenu` to the triangle button, giving the button the ability to open context menus. The fix is to mark triangle as owned by the emulator to remove this ability since imgui nav's context menu request only accepts unowned keys