### PR TITLE
shader recompiler multiple fixes, common, video core and buffer cashe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1030,6 +1030,7 @@ set(SHADER_RECOMPILER src/shader_recompiler/profile.h
                       src/shader_recompiler/ir/passes/lower_fp64_to_fp32.cpp
                       src/shader_recompiler/ir/passes/lower_user_clip_planes.cpp
                       src/shader_recompiler/ir/passes/phi_simplification_pass.cpp
+                      src/shader_recompiler/ir/passes/loop_wrap_guard_pass.cpp
                       src/shader_recompiler/ir/passes/readlane_elimination_pass.cpp
                       src/shader_recompiler/ir/passes/resource_discover_pass.cpp
                       src/shader_recompiler/ir/passes/resource_pass.h

--- a/src/common/object_pool.h
+++ b/src/common/object_pool.h
@@ -77,7 +77,9 @@ private:
         }
 
         void Release() {
-            std::destroy_n(storage.get(), used_objects);
+            for (size_t i = used_objects; i > 0; --i) {
+                std::destroy_at(std::addressof(storage[i - 1].object));
+            }
             used_objects = 0;
         }
 

--- a/src/shader_recompiler/backend/spirv/emit_spirv.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv.cpp
@@ -300,6 +300,9 @@ void SetupCapabilities(const Info& info, const Profile& profile, const RuntimeIn
     if (info.uses_group_quad) {
         ctx.AddCapability(spv::Capability::GroupNonUniformQuad);
     }
+    if (info.uses_group_shuffle) {
+        ctx.AddCapability(spv::Capability::GroupNonUniformShuffle);
+    }
     if (info.uses_group_ballot || info.loads.Get(IR::Attribute::SubgroupLtMask)) {
         ctx.AddCapability(spv::Capability::GroupNonUniformBallot);
     }

--- a/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
@@ -476,6 +476,7 @@ Id EmitCubeFaceIndex(EmitContext& ctx, IR::Inst* inst, Id cube_coords);
 Id EmitLaneId(EmitContext& ctx);
 Id EmitWarpId(EmitContext& ctx);
 Id EmitQuadShuffle(EmitContext& ctx, Id value, Id index);
+Id EmitShuffle(EmitContext& ctx, Id value, Id index);
 Id EmitReadFirstLane(EmitContext& ctx, Id value);
 Id EmitReadLane(EmitContext& ctx, Id value, Id lane);
 Id EmitWriteLane(EmitContext& ctx, Id value, Id write_value, u32 lane);

--- a/src/shader_recompiler/backend/spirv/emit_spirv_warp.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_warp.cpp
@@ -26,7 +26,14 @@ Id EmitReadFirstLane(EmitContext& ctx, Id value) {
     return ctx.OpGroupNonUniformBroadcastFirst(ctx.U32[1], SubgroupScope(ctx), value);
 }
 
+Id EmitShuffle(EmitContext& ctx, Id value, Id index) {
+    return ctx.OpGroupNonUniformShuffle(ctx.U32[1], SubgroupScope(ctx), value, index);
+}
+
 Id EmitReadLane(EmitContext& ctx, Id value, Id lane) {
+    if (ctx.profile.subgroup_size < 64) {
+        lane = ctx.OpBitwiseAnd(ctx.U32[1], lane, ctx.ConstU32(ctx.profile.subgroup_size - 1));
+    }
     return ctx.OpGroupNonUniformBroadcast(ctx.U32[1], SubgroupScope(ctx), value, lane);
 }
 

--- a/src/shader_recompiler/frontend/translate/data_share.cpp
+++ b/src/shader_recompiler/frontend/translate/data_share.cpp
@@ -276,8 +276,9 @@ void Translator::DS_SWIZZLE_B32(const GcnInst& inst) {
     if (offset1 & 0x80) {
         const IR::U32 id_in_group = ir.BitwiseAnd(lane_id, ir.Imm32(0b11));
         const IR::U32 base = ir.ShiftLeftLogical(id_in_group, ir.Imm32(1));
-        const IR::U32 index = ir.BitFieldExtract(ir.Imm32(offset0), base, ir.Imm32(2));
-        SetDst(inst.dst[0], ir.QuadShuffle(src, index));
+        const IR::U32 sel = ir.BitFieldExtract(ir.Imm32(offset0), base, ir.Imm32(2));
+        const IR::U32 quad_base = ir.BitwiseAnd(lane_id, ir.Imm32(~3u));
+        SetDst(inst.dst[0], ir.Shuffle(src, ir.BitwiseOr(quad_base, sel)));
     } else {
         const u8 and_mask = (offset0 & 0x1f) | (~u8{0} << 5);
         const u8 or_mask = (offset0 >> 5) | ((offset1 & 0x3) << 3);
@@ -285,7 +286,7 @@ void Translator::DS_SWIZZLE_B32(const GcnInst& inst) {
         const IR::U32 index = ir.BitwiseXor(
             ir.BitwiseOr(ir.BitwiseAnd(lane_id, ir.Imm32(and_mask)), ir.Imm32(or_mask)),
             ir.Imm32(xor_mask));
-        SetDst(inst.dst[0], ir.ReadLane(src, index));
+        SetDst(inst.dst[0], ir.Shuffle(src, index));
     }
 }
 

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -214,6 +214,7 @@ public:
     void V_CVT_F64_F32(const GcnInst& inst);
     void V_CVT_F32_UBYTE(u32 index, const GcnInst& inst);
     void V_FLOOR_F64(const GcnInst& inst);
+    void V_TRUNC_F64(const GcnInst& inst);
     void V_FRACT_F32(const GcnInst& inst);
     void V_TRUNC_F32(const GcnInst& inst);
     void V_CEIL_F32(const GcnInst& inst);
@@ -278,6 +279,7 @@ public:
     void V_ALIGNBYTE_B32(const GcnInst& inst);
     void V_MUL_F64(const GcnInst& inst);
     void V_MAX_F64(const GcnInst& inst);
+    void V_MIN_F64(const GcnInst& inst);
     void V_MUL_LO_U32(const GcnInst& inst);
     void V_MUL_HI_U32(bool is_signed, const GcnInst& inst);
     void V_MAD_U64_U32(const GcnInst& inst);

--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -159,6 +159,8 @@ void Translator::EmitVectorAlu(const GcnInst& inst) {
         return V_FRACT_F32(inst);
     case Opcode::V_TRUNC_F32:
         return V_TRUNC_F32(inst);
+    case Opcode::V_TRUNC_F64:
+        return V_TRUNC_F64(inst);
     case Opcode::V_CEIL_F32:
         return V_CEIL_F32(inst);
     case Opcode::V_RNDNE_F32:
@@ -371,15 +373,77 @@ void Translator::EmitVectorAlu(const GcnInst& inst) {
     case Opcode::V_CMPX_TRU_U32:
         return V_CMP_U32(ConditionOp::TRU, false, true, inst);
 
+        //     V_CMP_{OP8}_I64
+    case Opcode::V_CMP_F_I64:
+        return V_CMP_U64(ConditionOp::F, true, false, inst);
+    case Opcode::V_CMP_LT_I64:
+        return V_CMP_U64(ConditionOp::LT, true, false, inst);
+    case Opcode::V_CMP_EQ_I64:
+        return V_CMP_U64(ConditionOp::EQ, true, false, inst);
+    case Opcode::V_CMP_LE_I64:
+        return V_CMP_U64(ConditionOp::LE, true, false, inst);
+    case Opcode::V_CMP_GT_I64:
+        return V_CMP_U64(ConditionOp::GT, true, false, inst);
+    case Opcode::V_CMP_NE_I64:
+        return V_CMP_U64(ConditionOp::LG, true, false, inst);
+    case Opcode::V_CMP_GE_I64:
+        return V_CMP_U64(ConditionOp::GE, true, false, inst);
+    case Opcode::V_CMP_T_I64:
+        return V_CMP_U64(ConditionOp::TRU, true, false, inst);
+
+        //     V_CMPX_{OP8}_I64
+    case Opcode::V_CMPX_F_I64:
+        return V_CMP_U64(ConditionOp::F, true, true, inst);
+    case Opcode::V_CMPX_LT_I64:
+        return V_CMP_U64(ConditionOp::LT, true, true, inst);
+    case Opcode::V_CMPX_EQ_I64:
+        return V_CMP_U64(ConditionOp::EQ, true, true, inst);
+    case Opcode::V_CMPX_LE_I64:
+        return V_CMP_U64(ConditionOp::LE, true, true, inst);
+    case Opcode::V_CMPX_GT_I64:
+        return V_CMP_U64(ConditionOp::GT, true, true, inst);
+    case Opcode::V_CMPX_NE_I64:
+        return V_CMP_U64(ConditionOp::LG, true, true, inst);
+    case Opcode::V_CMPX_GE_I64:
+        return V_CMP_U64(ConditionOp::GE, true, true, inst);
+    case Opcode::V_CMPX_T_I64:
+        return V_CMP_U64(ConditionOp::TRU, true, true, inst);
+
         //     V_CMP_{OP8}_U64
-    case Opcode::V_CMP_EQ_U64:
-        return V_CMP_U64(ConditionOp::EQ, false, false, inst);
-    case Opcode::V_CMP_NE_U64:
-        return V_CMP_U64(ConditionOp::LG, false, false, inst);
-    case Opcode::V_CMP_GT_U64:
-        return V_CMP_U64(ConditionOp::GT, false, false, inst);
+    case Opcode::V_CMP_F_U64:
+        return V_CMP_U64(ConditionOp::F, false, false, inst);
     case Opcode::V_CMP_LT_U64:
         return V_CMP_U64(ConditionOp::LT, false, false, inst);
+    case Opcode::V_CMP_EQ_U64:
+        return V_CMP_U64(ConditionOp::EQ, false, false, inst);
+    case Opcode::V_CMP_LE_U64:
+        return V_CMP_U64(ConditionOp::LE, false, false, inst);
+    case Opcode::V_CMP_GT_U64:
+        return V_CMP_U64(ConditionOp::GT, false, false, inst);
+    case Opcode::V_CMP_NE_U64:
+        return V_CMP_U64(ConditionOp::LG, false, false, inst);
+    case Opcode::V_CMP_GE_U64:
+        return V_CMP_U64(ConditionOp::GE, false, false, inst);
+    case Opcode::V_CMP_T_U64:
+        return V_CMP_U64(ConditionOp::TRU, false, false, inst);
+
+        //     V_CMPX_{OP8}_U64
+    case Opcode::V_CMPX_F_U64:
+        return V_CMP_U64(ConditionOp::F, false, true, inst);
+    case Opcode::V_CMPX_LT_U64:
+        return V_CMP_U64(ConditionOp::LT, false, true, inst);
+    case Opcode::V_CMPX_EQ_U64:
+        return V_CMP_U64(ConditionOp::EQ, false, true, inst);
+    case Opcode::V_CMPX_LE_U64:
+        return V_CMP_U64(ConditionOp::LE, false, true, inst);
+    case Opcode::V_CMPX_GT_U64:
+        return V_CMP_U64(ConditionOp::GT, false, true, inst);
+    case Opcode::V_CMPX_NE_U64:
+        return V_CMP_U64(ConditionOp::LG, false, true, inst);
+    case Opcode::V_CMPX_GE_U64:
+        return V_CMP_U64(ConditionOp::GE, false, true, inst);
+    case Opcode::V_CMPX_T_U64:
+        return V_CMP_U64(ConditionOp::TRU, false, true, inst);
 
     case Opcode::V_CMP_CLASS_F32:
         return V_CMP_CLASS_F32(inst);
@@ -451,6 +515,8 @@ void Translator::EmitVectorAlu(const GcnInst& inst) {
         return V_MUL_F64(inst);
     case Opcode::V_MAX_F64:
         return V_MAX_F64(inst);
+    case Opcode::V_MIN_F64:
+        return V_MIN_F64(inst);
     case Opcode::V_MUL_LO_U32:
         return V_MUL_LO_U32(inst);
     case Opcode::V_MUL_HI_U32:
@@ -976,6 +1042,11 @@ void Translator::V_CVT_F32_UBYTE(u32 index, const GcnInst& inst) {
 void Translator::V_FLOOR_F64(const GcnInst& inst) {
     const IR::F64 src0{GetSrc64<IR::F64>(inst.src[0])};
     SetDst64(inst.dst[0], ir.FPFloor(src0));
+}
+
+void Translator::V_TRUNC_F64(const GcnInst& inst) {
+    const IR::F64 src0{GetSrc64<IR::F64>(inst.src[0])};
+    SetDst64(inst.dst[0], ir.FPTrunc(src0));
 }
 
 void Translator::V_FRACT_F32(const GcnInst& inst) {
@@ -1573,6 +1644,12 @@ void Translator::V_MAX_F64(const GcnInst& inst) {
     const IR::F64 src0{GetSrc64<IR::F64>(inst.src[0])};
     const IR::F64 src1{GetSrc64<IR::F64>(inst.src[1])};
     SetDst64(inst.dst[0], ir.FPMax(src0, src1));
+}
+
+void Translator::V_MIN_F64(const GcnInst& inst) {
+    const IR::F64 src0{GetSrc64<IR::F64>(inst.src[0])};
+    const IR::F64 src1{GetSrc64<IR::F64>(inst.src[1])};
+    SetDst64(inst.dst[0], ir.FPMin(src0, src1));
 }
 
 void Translator::V_MUL_LO_U32(const GcnInst& inst) {

--- a/src/shader_recompiler/info.h
+++ b/src/shader_recompiler/info.h
@@ -138,6 +138,7 @@ struct Info : InfoPersistent {
     bool uses_lane_id{};
     bool uses_shader_clock{};
     bool uses_group_quad{};
+    bool uses_group_shuffle{};
     bool uses_group_ballot{};
     IR::Type shared_types{};
     bool uses_fp16{};

--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -641,6 +641,10 @@ U32 IREmitter::QuadShuffle(const U32& value, const U32& index) {
     return Inst<U32>(Opcode::QuadShuffle, value, index);
 }
 
+U32 IREmitter::Shuffle(const U32& value, const U32& index) {
+    return Inst<U32>(Opcode::Shuffle, value, index);
+}
+
 U32 IREmitter::ReadFirstLane(const U32& value) {
     return Inst<U32>(Opcode::ReadFirstLane, value);
 }

--- a/src/shader_recompiler/ir/ir_emitter.h
+++ b/src/shader_recompiler/ir/ir_emitter.h
@@ -173,6 +173,7 @@ public:
     [[nodiscard]] U32 LaneId();
     [[nodiscard]] U32 WarpId();
     [[nodiscard]] U32 QuadShuffle(const U32& value, const U32& index);
+    [[nodiscard]] U32 Shuffle(const U32& value, const U32& index);
     [[nodiscard]] U32 ReadFirstLane(const U32& value);
     [[nodiscard]] U32 ReadLane(const U32& value, const U32& lane);
     [[nodiscard]] U32 WriteLane(const U32& value, const U32& write_value, const U32& lane);

--- a/src/shader_recompiler/ir/opcodes.inc
+++ b/src/shader_recompiler/ir/opcodes.inc
@@ -453,6 +453,7 @@ OPCODE(CubeFaceIndex,                                       F32,            F32x
 OPCODE(LaneId,                                              U32,                                                                                            )
 OPCODE(WarpId,                                              U32,                                                                                            )
 OPCODE(QuadShuffle,                                         U32,            U32,            U32                                                             )
+OPCODE(Shuffle,                                             U32,            U32,            U32                                                             )
 OPCODE(ReadFirstLane,                                       U32,            U32,                                                                            )
 OPCODE(ReadLane,                                            U32,            U32,            U32                                                             )
 OPCODE(WriteLane,                                           U32,            U32,            U32,            U32                                             )

--- a/src/shader_recompiler/ir/passes/ir_passes.h
+++ b/src/shader_recompiler/ir/passes/ir_passes.h
@@ -23,6 +23,7 @@ void DeadCodeEliminationPass(IR::Program& program);
 void ConstantPropagationPass(IR::BlockList& program);
 void FlattenExtendedUserdataPass(IR::Program& program);
 void ReadLaneEliminationPass(IR::Program& program);
+void LoopWrapGuardPass(IR::Program& program);
 ResourceDiscoveryList ResourceDiscoverPass(IR::Program& program, const Profile& profile);
 void ResourcePatchingPass(Shader::Info& info, const ResourceDiscoveryList& sharp_usages,
                           const Profile& profile);

--- a/src/shader_recompiler/ir/passes/loop_wrap_guard_pass.cpp
+++ b/src/shader_recompiler/ir/passes/loop_wrap_guard_pass.cpp
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: Copyright 2025 shadPS4 Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <algorithm>
+
+#include <boost/container/small_vector.hpp>
+
+#include "shader_recompiler/ir/ir_emitter.h"
+#include "shader_recompiler/ir/program.h"
+
+namespace Shader::Optimization {
+
+static bool IsStepOf(const IR::Value& incoming, const IR::Inst* phi, u32 step_imm) {
+    if (incoming.IsImmediate()) {
+        return false;
+    }
+    const IR::Inst* const producer = incoming.Inst();
+    if (producer->GetOpcode() == IR::Opcode::IAdd32) {
+        const IR::Value lhs = producer->Arg(0);
+        const IR::Value rhs = producer->Arg(1);
+        return !lhs.IsImmediate() && lhs.Inst() == phi && rhs.IsImmediate() &&
+               rhs.U32() == step_imm;
+    }
+    if (step_imm == 0xFFFFFFFFu && producer->GetOpcode() == IR::Opcode::ISub32) {
+        const IR::Value lhs = producer->Arg(0);
+        const IR::Value rhs = producer->Arg(1);
+        return !lhs.IsImmediate() && lhs.Inst() == phi && rhs.IsImmediate() && rhs.U32() == 1u;
+    }
+    return false;
+}
+
+static bool OnlyFeedsBranchConditions(IR::Inst& root) {
+    boost::container::small_vector<IR::Inst*, 8> worklist{&root};
+    boost::container::small_vector<const IR::Inst*, 16> visited;
+    while (!worklist.empty()) {
+        IR::Inst* const inst = worklist.back();
+        worklist.pop_back();
+        if (std::ranges::find(visited, inst) != visited.end()) {
+            continue;
+        }
+        visited.push_back(inst);
+        if (visited.size() > 64) {
+            return false;
+        }
+        if (!inst->HasUses()) {
+            return false;
+        }
+        for (const auto& [user, arg_index] : inst->Uses()) {
+            switch (user->GetOpcode()) {
+            case IR::Opcode::ConditionRef:
+                continue;
+            case IR::Opcode::LogicalNot:
+            case IR::Opcode::LogicalAnd:
+            case IR::Opcode::LogicalOr:
+            case IR::Opcode::Phi:
+                worklist.push_back(user);
+                continue;
+            default:
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+static const IR::Inst* AsSteppingPhi(const IR::Value& value, u32 step_imm) {
+    if (value.IsImmediate()) {
+        return nullptr;
+    }
+    const IR::Inst* const inst = value.Inst();
+    if (inst->GetOpcode() != IR::Opcode::Phi) {
+        return nullptr;
+    }
+    for (size_t i = 0; i < inst->NumArgs(); ++i) {
+        if (IsStepOf(inst->Arg(i), inst, step_imm)) {
+            return inst;
+        }
+    }
+    return nullptr;
+}
+
+void LoopWrapGuardPass(IR::Program& program) {
+    constexpr u32 bound_cap = 16384;
+    constexpr u32 MaxExitConst = 4;
+    for (IR::Block* const block : program.blocks) {
+        for (IR::Inst& inst : block->Instructions()) {
+            const IR::Opcode op = inst.GetOpcode();
+            const bool is_wrap_shape = op == IR::Opcode::INotEqual32;
+            const bool is_cap_shape =
+                bound_cap != 0 &&
+                (op == IR::Opcode::ULessThan32 || op == IR::Opcode::SLessThan32 ||
+                 op == IR::Opcode::UGreaterThan32 || op == IR::Opcode::SGreaterThan32);
+            if (!is_wrap_shape && !is_cap_shape) {
+                continue;
+            }
+            if (!OnlyFeedsBranchConditions(inst)) {
+                continue;
+            }
+            if (is_cap_shape) {
+                const bool phi_first =
+                    op == IR::Opcode::ULessThan32 || op == IR::Opcode::SLessThan32;
+                const IR::Value phi_side = inst.Arg(phi_first ? 0 : 1);
+                const u32 bound_idx = phi_first ? 1 : 0;
+                const IR::Value bound = inst.Arg(bound_idx);
+                if (bound.IsImmediate() || AsSteppingPhi(phi_side, 1u) == nullptr) {
+                    continue;
+                }
+                const bool is_signed =
+                    op == IR::Opcode::SLessThan32 || op == IR::Opcode::SGreaterThan32;
+                IR::IREmitter ir{*block, IR::Block::InstructionList::s_iterator_to(inst)};
+                const IR::U32 capped = ir.IMin(IR::U32{bound}, ir.Imm32(bound_cap), is_signed);
+                inst.SetArg(bound_idx, capped);
+                continue;
+            }
+            const IR::Value a = inst.Arg(0);
+            const IR::Value b = inst.Arg(1);
+            const IR::Inst* phi = nullptr;
+            u32 exit_const = 0;
+            if (b.IsImmediate() && (phi = AsSteppingPhi(a, 0xFFFFFFFFu)) != nullptr) {
+                exit_const = b.U32();
+            } else if (a.IsImmediate() && (phi = AsSteppingPhi(b, 0xFFFFFFFFu)) != nullptr) {
+                exit_const = a.U32();
+                inst.SetArg(0, b);
+                inst.SetArg(1, a);
+            } else {
+                phi = nullptr;
+            }
+            if (phi != nullptr && exit_const <= MaxExitConst) {
+                inst.ReplaceOpcode(IR::Opcode::UGreaterThan32);
+                continue;
+            }
+            bool rewrote_shape2 = false;
+            if ((phi = AsSteppingPhi(a, 1u)) != nullptr && (b.IsImmediate() || b.Inst() != phi)) {
+                inst.ReplaceOpcode(IR::Opcode::ULessThan32);
+                rewrote_shape2 = true;
+            } else if ((phi = AsSteppingPhi(b, 1u)) != nullptr &&
+                       (a.IsImmediate() || a.Inst() != phi)) {
+                inst.SetArg(0, b);
+                inst.SetArg(1, a);
+                inst.ReplaceOpcode(IR::Opcode::ULessThan32);
+                rewrote_shape2 = true;
+            }
+            if (rewrote_shape2 && bound_cap != 0 && !inst.Arg(1).IsImmediate()) {
+                IR::IREmitter ir{*block, IR::Block::InstructionList::s_iterator_to(inst)};
+                inst.SetArg(1, ir.IMin(IR::U32{inst.Arg(1)}, ir.Imm32(bound_cap), false));
+            }
+        }
+    }
+}
+
+} // namespace Shader::Optimization

--- a/src/shader_recompiler/ir/passes/shader_info_collection_pass.cpp
+++ b/src/shader_recompiler/ir/passes/shader_info_collection_pass.cpp
@@ -88,6 +88,9 @@ void Visit(Info& info, const IR::Inst& inst) {
     case IR::Opcode::QuadShuffle:
         info.uses_group_quad = true;
         break;
+    case IR::Opcode::Shuffle:
+        info.uses_group_shuffle = true;
+        break;
     case IR::Opcode::ReadLane:
     case IR::Opcode::ReadFirstLane:
     case IR::Opcode::WriteLane:

--- a/src/shader_recompiler/recompiler.cpp
+++ b/src/shader_recompiler/recompiler.cpp
@@ -139,6 +139,7 @@ IR::Program TranslateProgram(const std::span<const u32>& code, Pools& pools, Inf
     Shader::Optimization::SsaRewritePass(program);
     Shader::Optimization::ConstantPropagationPass(program.post_order_blocks);
     Shader::Optimization::DeadCodeEliminationPass(program);
+    Shader::Optimization::LoopWrapGuardPass(program);
     Shader::Optimization::SharedMemoryBarrierPass(program, runtime_info, profile);
     Shader::Optimization::CollectShaderInfoPass(program, profile);
     Shader::IR::DumpProgram(program, info);

--- a/src/video_core/amdgpu/liverpool.cpp
+++ b/src/video_core/amdgpu/liverpool.cpp
@@ -202,6 +202,7 @@ Liverpool::Task Liverpool::ProcessCeUpdate(std::span<const u32> ccb) {
                 YIELD_CE();
                 RESUME_CE(task);
             }
+            task.handle.destroy();
             break;
         }
         default:
@@ -837,6 +838,7 @@ Liverpool::Task Liverpool::ProcessGraphics(std::span<const u32> dcb, std::span<c
                     YIELD_GFX();
                     RESUME_GFX(task);
                 }
+                task.handle.destroy();
                 break;
             }
             case PM4ItOpcode::IncrementDeCounter: {
@@ -975,6 +977,7 @@ Liverpool::Task Liverpool::ProcessCompute(std::span<const u32> acb, u32 vqid) {
                 YIELD_ASC(vqid);
                 RESUME_ASC(task, vqid);
             }
+            task.handle.destroy();
             break;
         }
         case PM4ItOpcode::DmaData: {

--- a/src/video_core/buffer_cache/buffer.h
+++ b/src/video_core/buffer_cache/buffer.h
@@ -128,7 +128,11 @@ public:
     std::optional<vk::BufferMemoryBarrier2> GetBarrier(vk::AccessFlags2 dst_acess_mask,
                                                        vk::PipelineStageFlagBits2 dst_stage,
                                                        u32 offset = 0) {
-        if (dst_acess_mask == access_mask && stage == dst_stage) {
+        constexpr auto write_flags = vk::AccessFlagBits2::eShaderWrite |
+                                     vk::AccessFlagBits2::eTransferWrite |
+                                     vk::AccessFlagBits2::eMemoryWrite;
+        const bool was_write = static_cast<bool>(access_mask & write_flags);
+        if (dst_acess_mask == access_mask && stage == dst_stage && !was_write) {
             return {};
         }
 


### PR DESCRIPTION
common: Destroy pooled objects when a chunk is released. ObjectPool destroyed the storage union, never the objects, so every non-trivial member leaked 3,800 small blocks per shader, 15 million live allocations.

video_core: Free the coroutine frame of a finished indirect buffer.Three IndirectBuffer handlers drove the task to completion and dropped. final_suspend suspends and Task has no destructor, so one frame leaked per packet. Measured: host heap 3991 → 1283 MB.

buffer_cache: Barrier a buffer whose last access was a write. An identical access mask skipped the barrier even when the previous access had been a write.

shader_recompiler: Translate the remaining 64-bit compares and F64 ops. Only 4 of the 32 opcodes reached the function; the other 28 fell through to the unknown-opcode path.

shader_recompiler: Emit DS_SWIZZLE_B32 as a subgroup shuffle.Both swizzle modes compute the source lane from the lane id, but the code used Broadcast/QuadBroadcast, which require a dynamically uniform index undefined.

shader_recompiler: Guard loop exits that can wrap. while (i != end) with a zero or inverted count walks the counter through the whole 32-bit range. Also caps an exit bound loaded from memory.