### PR TITLE
shader_recompiler: Bind the masked value of a descriptor dword

### DIFF
--- a/src/shader_recompiler/ir/passes/resource_discover_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_discover_pass.cpp
@@ -246,6 +246,27 @@ IR::Inst* FindSharpSource(IR::Inst* handle) {
     return handle;
 }
 
+static void PeelDwordMasks(SharpReference& sharp) {
+    for (size_t i = 0; i < sharp.num_dwords; i++) {
+        IR::Inst* source = sharp.dwords[i].TryInst();
+        while (source && source->GetOpcode() == IR::Opcode::BitwiseAnd32) {
+            const IR::Value arg0 = source->Arg(0);
+            const IR::Value arg1 = source->Arg(1);
+            if (arg0.IsImmediate() == arg1.IsImmediate()) {
+                break;
+            }
+            const IR::Value operand = arg0.IsImmediate() ? arg1 : arg0;
+            IR::Inst* const next = operand.TryInst();
+            if (!next) {
+                break;
+            }
+            sharp.clear_masks[i] |= ~(arg0.IsImmediate() ? arg0.U32() : arg1.U32());
+            sharp.dwords[i] = operand;
+            source = next;
+        }
+    }
+}
+
 void MarkReadConstBufferSharpSources(const SharpReference& sharp) {
     // In cases of bindless sharp fetches mark all producer instructions
     // so the extended userdata flattening pass will include them.
@@ -285,6 +306,7 @@ void DiscoverBufferSharp(IR::Block& block, IR::Inst& inst, ResourceDiscoveryList
         vsharp.dwords[1] = dword1;
     }
 
+    PeelDwordMasks(vsharp);
     MarkReadConstBufferSharpSources(vsharp);
 }
 
@@ -313,6 +335,7 @@ void DiscoverImageSharp(IR::Block& block, IR::Inst& inst, ResourceDiscoveryList&
         tsharp.dwords[4] = tsharp_dw4;
     }
 
+    PeelDwordMasks(tsharp);
     MarkReadConstBufferSharpSources(tsharp);
 
     if (inst.GetOpcode() != IR::Opcode::ImageSampleRaw) {
@@ -343,6 +366,7 @@ void DiscoverImageSharp(IR::Block& block, IR::Inst& inst, ResourceDiscoveryList&
         ssharp.dwords[0] = ssharp_dw0;
     }
 
+    PeelDwordMasks(ssharp);
     MarkReadConstBufferSharpSources(ssharp);
 }
 

--- a/src/shader_recompiler/ir/passes/resource_pass.h
+++ b/src/shader_recompiler/ir/passes/resource_pass.h
@@ -21,6 +21,7 @@ union PostOpData {
 
 struct SharpReference {
     std::array<IR::Value, 8> dwords{};
+    std::array<u32, 8> clear_masks{};
     u32 num_dwords{};
     SharpFetchPostOp post_op{};
     PostOpData post_op_data;

--- a/src/shader_recompiler/ir/passes/resource_patching_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_patching_pass.cpp
@@ -180,6 +180,7 @@ SharpFetch<T> ConstructSharpFetch(const SharpReference& sharp) {
     SharpFetch<T> sharp_fetch{};
     for (u32 i = 0; i < sharp.num_dwords; i++) {
         auto dword = sharp.dwords[i];
+        sharp_fetch.clear_masks[i] = sharp.clear_masks[i];
         if (dword.IsImmediate()) {
             sharp_fetch.immediates[i] = dword.U32();
         } else {

--- a/src/shader_recompiler/resource.h
+++ b/src/shader_recompiler/resource.h
@@ -28,6 +28,7 @@ struct SharpFetch {
 
     std::array<u32, N> immediates;
     std::array<SharpLocation, N> offsets;
+    std::array<u32, N> clear_masks;
     u8 load_mask;
 
     bool operator==(const SharpFetch&) const = default;
@@ -43,7 +44,7 @@ struct SharpFetch {
         }
         std::array<u32, num_dwords> out_dw;
         for (u32 i = 0; i < num_dwords; i++) {
-            out_dw[i] = (mask & 1) ? flatbuf[offsets[i]] : immediates[i];
+            out_dw[i] = ((mask & 1) ? flatbuf[offsets[i]] : immediates[i]) & ~clear_masks[i];
             mask >>= 1;
         }
         std::memcpy(out, out_dw.data(), sizeof(out_dw));


### PR DESCRIPTION
Found this problem on god of war 2018. Logging the opcode the walk gave up on named BitwiseAnd32, 291 times across 273 shaders in a single frame, which was also the number of programs that ended up with no usable resource list. The mask, 0xc3ffffff, clears bits 26-29 the top of the stride field of V# word 1. PeelDwordMasks records the cleared bits per dword and continues the walk to the value underneath, which is a sharp source again; SharpFetch reapplies them when it assembles the descriptor.  this fix was developed with AI (Claude). I reviewed the change and wrote this description and checked the code. 




before <img width="1301" height="753" alt="Στιγμιότυπο οθόνης 2026-09-10 223226" src="https://github.com/user-attachments/assets/3e511c37-62c6-44f7-b4d3-87011531eb3d" />
after <img width="1282" height="737" alt="Στιγμιότυπο οθόνης 2026-09-10 224535" src="https://github.com/user-attachments/assets/9f90ac83-0823-4ece-b198-d388d0a8df3d" />
