### PR TITLE
Re-anchor the fps counter when the display resizes

### DIFF
--- a/src/core/devtools/layer.cpp
+++ b/src/core/devtools/layer.cpp
@@ -30,6 +30,7 @@ using L = ::Core::Devtools::Layer;
 
 static bool show_simple_fps = false;
 static bool visibility_toggled = false;
+static float fps_anchor_width = FLT_MAX;
 static bool show_quit_window = false;
 
 static bool show_volume = false;
@@ -411,6 +412,11 @@ void L::Draw() {
         if (Begin("Video Info", nullptr,
                   ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoDecoration |
                       ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoDocking)) {
+            if (const float width = GetIO().DisplaySize.x; width != fps_anchor_width) {
+                visibility_toggled |= GetWindowPos().x + GetCurrentWindowRead()->SizeFull.x >=
+                                      fps_anchor_width - 1.0f;
+                fps_anchor_width = width;
+            }
             // Set window position to top left if it was toggled on
             if (visibility_toggled) {
                 SetWindowPos("Video Info", {999999.0f, 0.0f}, ImGuiCond_Always);


### PR DESCRIPTION
This PR fixes the fps counter not being realigned to the top right corner on window resize. Previously, the counter was only aligned to the corner when visibility is toggled. The fix is to introduce an anchoring mechanism for the counter when the display width resizes and wasn't manually moved by the user. 
Closes #5003 