### PR TITLE
shader_recompiler: Implement S_BITSET0_B64 and S_BITSET1_B64

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
@@ -344,7 +344,7 @@ Id EmitBitwiseOr32(EmitContext& ctx, IR::Inst* inst, Id a, Id b);
 Id EmitBitwiseOr64(EmitContext& ctx, IR::Inst* inst, Id a, Id b);
 Id EmitBitwiseXor32(EmitContext& ctx, IR::Inst* inst, Id a, Id b);
 Id EmitBitwiseXor64(EmitContext& ctx, IR::Inst* inst, Id a, Id b);
-Id EmitBitFieldInsert(EmitContext& ctx, Id base, Id insert, Id offset, Id count);
+Id EmitBitFieldInsert32(EmitContext& ctx, Id base, Id insert, Id offset, Id count);
 Id EmitBitFieldInsert64(EmitContext& ctx, Id base, Id insert, Id offset, Id count);
 Id EmitBitFieldSExtract(EmitContext& ctx, IR::Inst* inst, Id base, Id offset, Id count);
 Id EmitBitFieldUExtract(EmitContext& ctx, IR::Inst* inst, Id base, Id offset, Id count);

--- a/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_instructions.h
@@ -345,6 +345,7 @@ Id EmitBitwiseOr64(EmitContext& ctx, IR::Inst* inst, Id a, Id b);
 Id EmitBitwiseXor32(EmitContext& ctx, IR::Inst* inst, Id a, Id b);
 Id EmitBitwiseXor64(EmitContext& ctx, IR::Inst* inst, Id a, Id b);
 Id EmitBitFieldInsert(EmitContext& ctx, Id base, Id insert, Id offset, Id count);
+Id EmitBitFieldInsert64(EmitContext& ctx, Id base, Id insert, Id offset, Id count);
 Id EmitBitFieldSExtract(EmitContext& ctx, IR::Inst* inst, Id base, Id offset, Id count);
 Id EmitBitFieldUExtract(EmitContext& ctx, IR::Inst* inst, Id base, Id offset, Id count);
 Id EmitBitReverse32(EmitContext& ctx, Id value);

--- a/src/shader_recompiler/backend/spirv/emit_spirv_integer.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_integer.cpp
@@ -187,7 +187,7 @@ Id EmitBitwiseXor64(EmitContext& ctx, IR::Inst* inst, Id a, Id b) {
     return result;
 }
 
-Id EmitBitFieldInsert(EmitContext& ctx, Id base, Id insert, Id offset, Id count) {
+Id EmitBitFieldInsert32(EmitContext& ctx, Id base, Id insert, Id offset, Id count) {
     return ctx.OpBitFieldInsert(ctx.U32[1], base, insert, offset, count);
 }
 

--- a/src/shader_recompiler/backend/spirv/emit_spirv_integer.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_integer.cpp
@@ -191,6 +191,10 @@ Id EmitBitFieldInsert(EmitContext& ctx, Id base, Id insert, Id offset, Id count)
     return ctx.OpBitFieldInsert(ctx.U32[1], base, insert, offset, count);
 }
 
+Id EmitBitFieldInsert64(EmitContext& ctx, Id base, Id insert, Id offset, Id count) {
+    return ctx.OpBitFieldInsert(ctx.U64, base, insert, offset, count);
+}
+
 Id EmitBitFieldSExtract(EmitContext& ctx, IR::Inst* inst, Id base, Id offset, Id count) {
     const Id result{ctx.OpBitFieldSExtract(ctx.U32[1], base, offset, count)};
     SetZeroFlag(ctx, inst, result);

--- a/src/shader_recompiler/frontend/translate/scalar_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_alu.cpp
@@ -123,7 +123,7 @@ void Translator::EmitScalarAlu(const GcnInst& inst) {
         case Opcode::S_BITSET0_B64:
             return S_BITSET_B64(inst, 0);
         case Opcode::S_BITSET1_B64:
-            return S_BITSET_B64(inst, 1);    
+            return S_BITSET_B64(inst, 1);
         case Opcode::S_AND_SAVEEXEC_B64:
             return S_SAVEEXEC_B64(NegateMode::None, false, inst);
         case Opcode::S_ORN2_SAVEEXEC_B64:

--- a/src/shader_recompiler/frontend/translate/scalar_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_alu.cpp
@@ -579,13 +579,11 @@ void Translator::S_BITSET_B32(const GcnInst& inst, u32 bit_value) {
 }
 
 void Translator::S_BITSET_B64(const GcnInst& inst, u32 bit_value) {
-    // BitField{Insert,Extract} only operate on 32-bit values in the IR, so the
-    // 64-bit set/clear is expressed with plain bitwise ops instead.
     const IR::U64 old_value{GetSrc64(inst.dst[0])};
-    const IR::U32U64 offset{ir.BitwiseAnd(GetSrc64(inst.src[0]), ir.Imm64(u64(0x3F)))};
-    const IR::U64 mask{ir.ShiftLeftLogical(ir.Imm64(u64(1)), offset)};
-    const IR::U64 result{bit_value != 0 ? ir.BitwiseOr(old_value, mask)
-                                        : ir.BitwiseAnd(old_value, ir.BitwiseNot(mask))};
+    const IR::U64 masked_offset{ir.BitwiseAnd(GetSrc64(inst.src[0]), ir.Imm64(u64(0x3F)))};
+    const IR::U32 offset{ir.CompositeExtract(ir.UnpackUint2x32(masked_offset), 0)};
+    const IR::U64 result{
+        ir.BitFieldInsert(old_value, ir.Imm64(u64(bit_value)), offset, ir.Imm32(1U))};
     SetDst64(inst.dst[0], result);
 }
 

--- a/src/shader_recompiler/frontend/translate/scalar_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_alu.cpp
@@ -120,6 +120,10 @@ void Translator::EmitScalarAlu(const GcnInst& inst) {
             return S_BITSET_B32(inst, 0);
         case Opcode::S_BITSET1_B32:
             return S_BITSET_B32(inst, 1);
+        case Opcode::S_BITSET0_B64:
+            return S_BITSET_B64(inst, 0);
+        case Opcode::S_BITSET1_B64:
+            return S_BITSET_B64(inst, 1);    
         case Opcode::S_AND_SAVEEXEC_B64:
             return S_SAVEEXEC_B64(NegateMode::None, false, inst);
         case Opcode::S_ORN2_SAVEEXEC_B64:
@@ -572,6 +576,17 @@ void Translator::S_BITSET_B32(const GcnInst& inst, u32 bit_value) {
     const IR::U32 offset{ir.BitFieldExtract(GetSrc(inst.src[0]), ir.Imm32(0U), ir.Imm32(5U))};
     const IR::U32 result{ir.BitFieldInsert(old_value, ir.Imm32(bit_value), offset, ir.Imm32(1U))};
     SetDst(inst.dst[0], result);
+}
+
+void Translator::S_BITSET_B64(const GcnInst& inst, u32 bit_value) {
+    // BitField{Insert,Extract} only operate on 32-bit values in the IR, so the
+    // 64-bit set/clear is expressed with plain bitwise ops instead.
+    const IR::U64 old_value{GetSrc64(inst.dst[0])};
+    const IR::U32U64 offset{ir.BitwiseAnd(GetSrc64(inst.src[0]), ir.Imm64(u64(0x3F)))};
+    const IR::U64 mask{ir.ShiftLeftLogical(ir.Imm64(u64(1)), offset)};
+    const IR::U64 result{bit_value != 0 ? ir.BitwiseOr(old_value, mask)
+                                        : ir.BitwiseAnd(old_value, ir.BitwiseNot(mask))};
+    SetDst64(inst.dst[0], result);
 }
 
 void Translator::S_SAVEEXEC_B64(NegateMode negate, bool is_or, const GcnInst& inst) {

--- a/src/shader_recompiler/frontend/translate/scalar_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/scalar_alu.cpp
@@ -580,8 +580,7 @@ void Translator::S_BITSET_B32(const GcnInst& inst, u32 bit_value) {
 
 void Translator::S_BITSET_B64(const GcnInst& inst, u32 bit_value) {
     const IR::U64 old_value{GetSrc64(inst.dst[0])};
-    const IR::U64 masked_offset{ir.BitwiseAnd(GetSrc64(inst.src[0]), ir.Imm64(u64(0x3F)))};
-    const IR::U32 offset{ir.CompositeExtract(ir.UnpackUint2x32(masked_offset), 0)};
+    const IR::U32 offset{ir.BitwiseAnd(GetSrc(inst.src[0]), ir.Imm32(0x3F))};
     const IR::U64 result{
         ir.BitFieldInsert(old_value, ir.Imm64(u64(bit_value)), offset, ir.Imm32(1U))};
     SetDst64(inst.dst[0], result);

--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -131,6 +131,7 @@ public:
     void S_FLBIT_I32_B32(const GcnInst& inst);
     void S_FLBIT_I32_B64(const GcnInst& inst);
     void S_BITSET_B32(const GcnInst& inst, u32 bit_value);
+    void S_BITSET_B64(const GcnInst& inst, u32 bit_value);
     void S_GETPC_B64(const GcnInst& inst);
     void S_SAVEEXEC_B64(NegateMode negate, bool is_or, const GcnInst& inst);
     void S_ABS_I32(const GcnInst& inst);

--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -1590,14 +1590,19 @@ U32U64 IREmitter::BitwiseXor(const U32U64& a, const U32U64& b) {
     }
 }
 
-U32 IREmitter::BitFieldInsert(const U32& base, const U32& insert, const U32& offset,
-                              const U32& count) {
-    return Inst<U32>(Opcode::BitFieldInsert, base, insert, offset, count);
-}
-
-U64 IREmitter::BitFieldInsert(const U64& base, const U64& insert, const U32& offset,
-                              const U32& count) {
-    return Inst<U64>(Opcode::BitFieldInsert64, base, insert, offset, count);
+U32U64 IREmitter::BitFieldInsert(const U32U64& base, const U32U64& insert, const U32& offset,
+                                 const U32& count) {
+    if (base.Type() != insert.Type()) {
+        UNREACHABLE_MSG("Mismatching types {} and {}", base.Type(), insert.Type());
+    }
+    switch (base.Type()) {
+    case Type::U32:
+        return Inst<U32>(Opcode::BitFieldInsert32, base, insert, offset, count);
+    case Type::U64:
+        return Inst<U64>(Opcode::BitFieldInsert64, base, insert, offset, count);
+    default:
+        ThrowInvalidType(base.Type());
+    }
 }
 
 U32 IREmitter::BitFieldExtract(const U32& base, const U32& offset, const U32& count,

--- a/src/shader_recompiler/ir/ir_emitter.cpp
+++ b/src/shader_recompiler/ir/ir_emitter.cpp
@@ -1595,6 +1595,11 @@ U32 IREmitter::BitFieldInsert(const U32& base, const U32& insert, const U32& off
     return Inst<U32>(Opcode::BitFieldInsert, base, insert, offset, count);
 }
 
+U64 IREmitter::BitFieldInsert(const U64& base, const U64& insert, const U32& offset,
+                              const U32& count) {
+    return Inst<U64>(Opcode::BitFieldInsert64, base, insert, offset, count);
+}
+
 U32 IREmitter::BitFieldExtract(const U32& base, const U32& offset, const U32& count,
                                bool is_signed) {
     return Inst<U32>(is_signed ? Opcode::BitFieldSExtract : Opcode::BitFieldUExtract, base, offset,

--- a/src/shader_recompiler/ir/ir_emitter.h
+++ b/src/shader_recompiler/ir/ir_emitter.h
@@ -281,6 +281,8 @@ public:
     [[nodiscard]] U32U64 BitwiseXor(const U32U64& a, const U32U64& b);
     [[nodiscard]] U32 BitFieldInsert(const U32& base, const U32& insert, const U32& offset,
                                      const U32& count);
+    [[nodiscard]] U64 BitFieldInsert(const U64& base, const U64& insert, const U32& offset,
+                                     const U32& count);
     [[nodiscard]] U32 BitFieldExtract(const U32& base, const U32& offset, const U32& count,
                                       bool is_signed = false);
     [[nodiscard]] U32 BitReverse(const U32& value);

--- a/src/shader_recompiler/ir/ir_emitter.h
+++ b/src/shader_recompiler/ir/ir_emitter.h
@@ -279,10 +279,8 @@ public:
     [[nodiscard]] U32U64 BitwiseAnd(const U32U64& a, const U32U64& b);
     [[nodiscard]] U32U64 BitwiseOr(const U32U64& a, const U32U64& b);
     [[nodiscard]] U32U64 BitwiseXor(const U32U64& a, const U32U64& b);
-    [[nodiscard]] U32 BitFieldInsert(const U32& base, const U32& insert, const U32& offset,
-                                     const U32& count);
-    [[nodiscard]] U64 BitFieldInsert(const U64& base, const U64& insert, const U32& offset,
-                                     const U32& count);
+    [[nodiscard]] U32U64 BitFieldInsert(const U32U64& base, const U32U64& insert, const U32& offset,
+                                        const U32& count);
     [[nodiscard]] U32 BitFieldExtract(const U32& base, const U32& offset, const U32& count,
                                       bool is_signed = false);
     [[nodiscard]] U32 BitReverse(const U32& value);

--- a/src/shader_recompiler/ir/opcodes.inc
+++ b/src/shader_recompiler/ir/opcodes.inc
@@ -342,6 +342,7 @@ OPCODE(BitwiseOr64,                                         U64,            U64,
 OPCODE(BitwiseXor32,                                        U32,            U32,            U32,                                                            )
 OPCODE(BitwiseXor64,                                        U64,            U64,            U64,                                                            )
 OPCODE(BitFieldInsert,                                      U32,            U32,            U32,            U32,            U32,                            )
+OPCODE(BitFieldInsert64,                                    U64,            U64,            U64,            U32,            U32,                            )
 OPCODE(BitFieldSExtract,                                    U32,            U32,            U32,            U32,                                            )
 OPCODE(BitFieldUExtract,                                    U32,            U32,            U32,            U32,                                            )
 OPCODE(BitReverse32,                                        U32,            U32,                                                                            )

--- a/src/shader_recompiler/ir/opcodes.inc
+++ b/src/shader_recompiler/ir/opcodes.inc
@@ -341,7 +341,7 @@ OPCODE(BitwiseOr32,                                         U32,            U32,
 OPCODE(BitwiseOr64,                                         U64,            U64,            U64,                                                            )
 OPCODE(BitwiseXor32,                                        U32,            U32,            U32,                                                            )
 OPCODE(BitwiseXor64,                                        U64,            U64,            U64,                                                            )
-OPCODE(BitFieldInsert,                                      U32,            U32,            U32,            U32,            U32,                            )
+OPCODE(BitFieldInsert32,                                    U32,            U32,            U32,            U32,            U32,                            )
 OPCODE(BitFieldInsert64,                                    U64,            U64,            U64,            U32,            U32,                            )
 OPCODE(BitFieldSExtract,                                    U32,            U32,            U32,            U32,                                            )
 OPCODE(BitFieldUExtract,                                    U32,            U32,            U32,            U32,                                            )

--- a/src/shader_recompiler/ir/passes/constant_propagation_pass.cpp
+++ b/src/shader_recompiler/ir/passes/constant_propagation_pass.cpp
@@ -610,13 +610,22 @@ void ConstantPropagation(IR::Block& block, IR::Inst& inst) {
             return static_cast<u32>((base << left_shift) >> right_shift);
         });
         return;
-    case IR::Opcode::BitFieldInsert:
+    case IR::Opcode::BitFieldInsert32:
         FoldWhenAllImmediates(inst, [](u32 base, u32 insert, u32 offset, u32 bits) {
             if (bits >= 32 || offset >= 32) {
                 UNREACHABLE_MSG("Undefined result in {}({}, {}, {}, {})",
-                                IR::Opcode::BitFieldInsert, base, insert, offset, bits);
+                                IR::Opcode::BitFieldInsert32, base, insert, offset, bits);
             }
             return (base & ~(~(~0u << bits) << offset)) | (insert << offset);
+        });
+        return;
+    case IR::Opcode::BitFieldInsert64:
+        FoldWhenAllImmediates(inst, [](u64 base, u64 insert, u32 offset, u32 bits) {
+            if (bits >= 64 || offset >= 64) {
+                UNREACHABLE_MSG("Undefined result in {}({}, {}, {}, {})",
+                                IR::Opcode::BitFieldInsert64, base, insert, offset, bits);
+            }
+            return (base & ~(~(~u64{0} << bits) << offset)) | (insert << offset);
         });
         return;
     case IR::Opcode::CompositeExtractU32x2:


### PR DESCRIPTION
Implements the missing `S_BITSET0_B64` and `S_BITSET1_B64` scalar ALU
opcodes in the shader recompiler, part of the aggregate missing-opcode
tracker in #496.

Note: AI was used for code generation and investigation; all changes were validated against the AMD GCN3 ISA Reference Guide (rev 1.1).

This opcode is hit by The Last of Us Part II.




