### PR TITLE
shader_recompiler: Implement V_ASHR_I64

### DIFF
--- a/src/shader_recompiler/frontend/translate/translate.h
+++ b/src/shader_recompiler/frontend/translate/translate.h
@@ -275,6 +275,7 @@ public:
     void V_CVT_PK_U8_F32(const GcnInst& inst);
     void V_LSHL_B64(const GcnInst& inst);
     void V_LSHR_B64(const GcnInst& inst);
+    void V_ASHR_I64(const GcnInst& inst);
     void V_ALIGNBIT_B32(const GcnInst& inst);
     void V_ALIGNBYTE_B32(const GcnInst& inst);
     void V_MUL_F64(const GcnInst& inst);

--- a/src/shader_recompiler/frontend/translate/vector_alu.cpp
+++ b/src/shader_recompiler/frontend/translate/vector_alu.cpp
@@ -447,6 +447,8 @@ void Translator::EmitVectorAlu(const GcnInst& inst) {
         return V_LSHL_B64(inst);
     case Opcode::V_LSHR_B64:
         return V_LSHR_B64(inst);
+    case Opcode::V_ASHR_I64:
+        return V_ASHR_I64(inst);
     case Opcode::V_ADD_F64:
         return V_ADD_F64(inst);
     case Opcode::V_ALIGNBIT_B32:
@@ -1552,6 +1554,12 @@ void Translator::V_LSHR_B64(const GcnInst& inst) {
     const IR::U64 src0{GetSrc64(inst.src[0])};
     const IR::U64 src1{GetSrc64(inst.src[1])};
     SetDst64(inst.dst[0], ir.ShiftRightLogical(src0, ir.BitwiseAnd(src1, ir.Imm64(u64(0x3F)))));
+}
+
+void Translator::V_ASHR_I64(const GcnInst& inst) {
+    const IR::U64 src0{GetSrc64(inst.src[0])};
+    const IR::U64 src1{GetSrc64(inst.src[1])};
+    SetDst64(inst.dst[0], ir.ShiftRightArithmetic(src0, ir.BitwiseAnd(src1, ir.Imm64(u64(0x3F)))));
 }
 
 void Translator::V_ALIGNBIT_B32(const GcnInst& inst) {


### PR DESCRIPTION

Implements the missing vector ALU opcode V_ASHR_I64, reported by @Kravickas in comments on PR #5009 and aggregate issue #496 (crash in Marvel's Avengers, CUSA14030).

Note: AI was used for code generation and investigation; changes were
validated against the existing merged 64-bit shift implementations
and the instruction metadata table in format.cpp. 

I also compiled the build locally (to save @raphaelthegreat from having to do extra work).


