### PR TITLE
Harden GS copy shader parsing and fix GPU buffer synchronization

### DIFF
--- a/src/shader_recompiler/frontend/copy_shader.cpp
+++ b/src/shader_recompiler/frontend/copy_shader.cpp
@@ -1,36 +1,111 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <array>
+#include <optional>
+
 #include "shader_recompiler/frontend/copy_shader.h"
 #include "shader_recompiler/frontend/decode.h"
 #include "shader_recompiler/ir/attribute.h"
 
 namespace Shader {
 
+static bool IsDwordBufferLoad(const Gcn::GcnInst& inst) {
+    return inst.opcode == Gcn::Opcode::BUFFER_LOAD_DWORD ||
+           inst.opcode == Gcn::Opcode::BUFFER_LOAD_DWORDX2 ||
+           inst.opcode == Gcn::Opcode::BUFFER_LOAD_DWORDX3 ||
+           inst.opcode == Gcn::Opcode::BUFFER_LOAD_DWORDX4;
+}
+
+static u32 GetBufferLoadDwords(const Gcn::GcnInst& inst) {
+    switch (inst.opcode) {
+    case Gcn::Opcode::BUFFER_LOAD_DWORD:
+        return 1;
+    case Gcn::Opcode::BUFFER_LOAD_DWORDX2:
+        return 2;
+    case Gcn::Opcode::BUFFER_LOAD_DWORDX3:
+        return 3;
+    case Gcn::Opcode::BUFFER_LOAD_DWORDX4:
+        return 4;
+    default:
+        return 0;
+    }
+}
+
+static std::optional<s32> ReadConstant(const Gcn::InstOperand& operand,
+                                       const std::array<std::optional<s32>, 256>& sources) {
+    switch (operand.field) {
+    case Gcn::OperandField::ConstZero:
+        return 0;
+    case Gcn::OperandField::SignedConstIntPos:
+        return operand.code - Gcn::OperandFieldRange::SignedConstIntPosMin + 1;
+    case Gcn::OperandField::SignedConstIntNeg:
+        return static_cast<s32>(Gcn::OperandFieldRange::SignedConstIntNegMin) -
+               static_cast<s32>(operand.code) - 1;
+    case Gcn::OperandField::LiteralConst:
+        return static_cast<s32>(operand.code);
+    case Gcn::OperandField::ScalarGPR:
+        if (operand.code < sources.size()) {
+            return sources[operand.code];
+        }
+        return std::nullopt;
+    default:
+        return std::nullopt;
+    }
+}
+
 CopyShaderData ParseCopyShader(std::span<const u32> code) {
     Gcn::GcnCodeSlice code_slice{code.data(), code.data() + code.size()};
     Gcn::GcnDecodeContext decoder;
 
-    constexpr u32 token_mov_vcchi = 0xBEEB03FF;
-    ASSERT_MSG(code[0] == token_mov_vcchi, "First instruction is not s_mov_b32 vcc_hi, #imm");
-
     std::array<s32, 64> offsets{};
     offsets.fill(-1);
 
-    std::array<s32, 256> sources{};
-    sources.fill(-1);
+    std::array<std::optional<s32>, 256> sources{};
 
     CopyShaderData data{};
     auto last_attr{IR::Attribute::Position0};
     while (!code_slice.atEnd()) {
         auto inst = decoder.decodeInstruction(code_slice);
         switch (inst.opcode) {
+        case Gcn::Opcode::S_ADD_U32: {
+            const auto lhs = ReadConstant(inst.src[0], sources);
+            const auto rhs = ReadConstant(inst.src[1], sources);
+            if (lhs && rhs) {
+                sources[inst.dst[0].code] = *lhs + *rhs;
+            }
+            break;
+        }
+        case Gcn::Opcode::S_AND_B32: {
+            const auto lhs = ReadConstant(inst.src[0], sources);
+            const auto rhs = ReadConstant(inst.src[1], sources);
+            if (lhs && rhs) {
+                sources[inst.dst[0].code] = *lhs & *rhs;
+            }
+            break;
+        }
+        case Gcn::Opcode::S_OR_B32: {
+            const auto lhs = ReadConstant(inst.src[0], sources);
+            const auto rhs = ReadConstant(inst.src[1], sources);
+            if (lhs && rhs) {
+                sources[inst.dst[0].code] = *lhs | *rhs;
+            }
+            break;
+        }
         case Gcn::Opcode::S_LSHL_B32: {
-            ASSERT(inst.src[0].field == Gcn::OperandField::SignedConstIntPos &&
-                   inst.src[1].field == Gcn::OperandField::SignedConstIntPos);
-            sources[inst.dst[0].code] =
-                (inst.src[0].code - Gcn::OperandFieldRange::SignedConstIntPosMin + 1)
-                << (inst.src[1].code - Gcn::OperandFieldRange::SignedConstIntPosMin + 1);
+            const auto lhs = ReadConstant(inst.src[0], sources);
+            const auto rhs = ReadConstant(inst.src[1], sources);
+            if (lhs && rhs) {
+                sources[inst.dst[0].code] = *lhs << *rhs;
+            }
+            break;
+        }
+        case Gcn::Opcode::S_LSHR_B32: {
+            const auto lhs = ReadConstant(inst.src[0], sources);
+            const auto rhs = ReadConstant(inst.src[1], sources);
+            if (lhs && rhs) {
+                sources[inst.dst[0].code] = static_cast<s32>(static_cast<u32>(*lhs) >> *rhs);
+            }
             break;
         }
         case Gcn::Opcode::S_MOVK_I32: {
@@ -38,19 +113,21 @@ CopyShaderData ParseCopyShader(std::span<const u32> code) {
             break;
         }
         case Gcn::Opcode::S_MOV_B32: {
-            sources[inst.dst[0].code] = inst.src[0].code;
+            sources[inst.dst[0].code] = ReadConstant(inst.src[0], sources);
             break;
         }
         case Gcn::Opcode::S_ADDK_I32: {
-            sources[inst.dst[0].code] += inst.control.sopk.simm;
+            if (sources[inst.dst[0].code]) {
+                *sources[inst.dst[0].code] += inst.control.sopk.simm;
+            }
             break;
         }
         case Gcn::Opcode::S_BFM_B32: {
-            ASSERT(inst.src[0].field == Gcn::OperandField::SignedConstIntPos &&
-                   inst.src[1].field == Gcn::OperandField::SignedConstIntPos);
-            const auto src0 = inst.src[0].code - Gcn::OperandFieldRange::SignedConstIntPosMin + 1;
-            const auto src1 = inst.src[1].code - Gcn::OperandFieldRange::SignedConstIntPosMin + 1;
-            sources[inst.dst[0].code] = ((1 << src0) - 1) << src1;
+            const auto src0 = ReadConstant(inst.src[0], sources);
+            const auto src1 = ReadConstant(inst.src[1], sources);
+            if (src0 && src1) {
+                sources[inst.dst[0].code] = ((1 << *src0) - 1) << *src1;
+            }
             break;
         }
         case Gcn::Opcode::EXP: {
@@ -58,6 +135,9 @@ CopyShaderData ParseCopyShader(std::span<const u32> code) {
             const IR::Attribute semantic = static_cast<IR::Attribute>(exp.target);
             for (int i = 0; i < inst.src_count; ++i) {
                 if ((exp.en & (1 << i)) == 0) {
+                    continue;
+                }
+                if (inst.src[i].code >= offsets.size()) {
                     continue;
                 }
                 const auto ofs = offsets[inst.src[i].code];
@@ -70,24 +150,32 @@ CopyShaderData ParseCopyShader(std::span<const u32> code) {
             }
             break;
         }
-        case Gcn::Opcode::BUFFER_LOAD_DWORD: {
-            ASSERT_MSG(inst.src[1].code < offsets.size(),
-                       "offsets array for geometry shaders is too short");
-            offsets[inst.src[1].code] = inst.control.mubuf.offset;
-            if (inst.src[3].field != Gcn::OperandField::ConstZero) {
-                const u32 index = inst.src[3].code;
-                ASSERT(sources[index] != -1);
-                offsets[inst.src[1].code] += sources[index];
+        default: {
+            if (!IsDwordBufferLoad(inst)) {
+                break;
             }
-            data.num_comps++;
+            if (inst.src[1].code >= offsets.size()) {
+                break;
+            }
+            s32 offset = inst.control.mubuf.offset;
+            if (inst.src[3].field != Gcn::OperandField::ConstZero) {
+                const auto soffset = ReadConstant(inst.src[3], sources);
+                if (!soffset) {
+                    break;
+                }
+                offset += *soffset;
+            }
+            const u32 dwords = GetBufferLoadDwords(inst);
+            for (u32 i = 0; i < dwords && inst.src[1].code + i < offsets.size(); ++i) {
+                offsets[inst.src[1].code + i] = offset + static_cast<s32>(i * sizeof(u32));
+            }
+            data.num_comps += dwords;
             break;
         }
-        default:
-            break;
         }
     }
 
-    if (!IsPosition(last_attr)) {
+    if (!IsPosition(last_attr) && data.attr_map.size() >= 2) {
         data.num_attrs = static_cast<u32>(last_attr) - static_cast<u32>(IR::Attribute::Param0) + 1;
         const auto it = data.attr_map.begin();
         const u32 comp_stride = std::next(it)->first - it->first;

--- a/src/shader_recompiler/ir/passes/ring_access_elimination.cpp
+++ b/src/shader_recompiler/ir/passes/ring_access_elimination.cpp
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <algorithm>
+
 #include "common/assert.h"
+#include "common/logging/log.h"
 #include "shader_recompiler/ir/ir_emitter.h"
 #include "shader_recompiler/ir/opcodes.h"
 #include "shader_recompiler/ir/operand_helper.h"
@@ -12,6 +15,43 @@
 #include "shader_recompiler/runtime_info.h"
 
 namespace Shader::Optimization {
+
+static CopyShaderData BuildFallbackGsCopyData(u32 output_vertices, u32 dwords_per_vertex) {
+    CopyShaderData data{};
+    if (output_vertices == 0 || dwords_per_vertex == 0) {
+        return data;
+    }
+
+    data.output_vertices = output_vertices;
+    data.num_comps = dwords_per_vertex;
+    for (u32 dword = 0; dword < dwords_per_vertex; ++dword) {
+        const u32 offset = dword * output_vertices * 64;
+        if (dword < 4) {
+            data.attr_map[offset] = {IR::Attribute::Position0, dword};
+            continue;
+        }
+        const u32 param_index = (dword - 4) / 4;
+        if (param_index >= IR::NumParams) {
+            break;
+        }
+        data.attr_map[offset] = {IR::Attribute::Param0 + param_index, (dword - 4) % 4};
+        data.num_attrs = std::max(data.num_attrs, param_index + 1);
+    }
+    return data;
+}
+
+static void FillMissingGsCopyData(CopyShaderData& data, const CopyShaderData& fallback) {
+    if (data.output_vertices == 0) {
+        data.output_vertices = fallback.output_vertices;
+    }
+    if (data.num_comps == 0) {
+        data.num_comps = fallback.num_comps;
+    }
+    data.num_attrs = std::max(data.num_attrs, fallback.num_attrs);
+    for (const auto& [offset, attr] : fallback.attr_map) {
+        data.attr_map.try_emplace(offset, attr);
+    }
+}
 
 void RingAccessElimination(const IR::Program& program, const RuntimeInfo& runtime_info) {
     auto& info = program.info;
@@ -111,6 +151,15 @@ void RingAccessElimination(const IR::Program& program, const RuntimeInfo& runtim
                         dwords_per_vertex, info.gs_copy_data.num_comps);
             dwords_per_vertex = info.gs_copy_data.num_comps;
         }
+        const auto fallback_copy_data = BuildFallbackGsCopyData(output_vertices, dwords_per_vertex);
+        if (info.gs_copy_data.attr_map.empty()) {
+            LOG_WARNING(Render_Recompiler,
+                        "Failed to parse GS copy shader {:#x}; using sequential output mapping",
+                        gs_info.vs_copy_hash);
+            info.gs_copy_data = fallback_copy_data;
+        } else {
+            FillMissingGsCopyData(info.gs_copy_data, fallback_copy_data);
+        }
 
         ForEachInstruction([&](IR::IREmitter& ir, IR::Inst& inst) {
             const auto opcode = inst.GetOpcode();
@@ -150,7 +199,12 @@ void RingAccessElimination(const IR::Program& program, const RuntimeInfo& runtim
 
                 const auto vc_read_ofs = (((offset / comp_ofs) * comp_ofs) % output_size) * 16u;
                 const auto& it = info.gs_copy_data.attr_map.find(vc_read_ofs);
-                ASSERT(it != info.gs_copy_data.attr_map.cend());
+                if (it == info.gs_copy_data.attr_map.cend()) {
+                    LOG_WARNING(Render_Recompiler,
+                                "Missing GS copy mapping for offset {:#x} in copy shader {:#x}",
+                                vc_read_ofs, runtime_info.gs_info.vs_copy_hash);
+                    break;
+                }
                 const auto& [attr, comp] = it->second;
 
                 inst.Invalidate();

--- a/src/video_core/buffer_cache/buffer_cache.cpp
+++ b/src/video_core/buffer_cache/buffer_cache.cpp
@@ -201,12 +201,9 @@ void BufferCache::BindVertexBuffers(
         const auto [buffer, offset] = ObtainBuffer(range.base_address, size, false);
         range.vk_buffer = buffer->buffer;
         range.offset = offset;
-        if (IsRegionGpuModified(range.base_address, size)) {
-            if (auto barrier =
-                    buffer->GetBarrier(vk::AccessFlagBits2::eVertexAttributeRead,
-                                       vk::PipelineStageFlagBits2::eVertexAttributeInput)) {
-                barriers.emplace_back(*barrier);
-            }
+        if (auto barrier = buffer->GetBarrier(vk::AccessFlagBits2::eVertexAttributeRead,
+                                              vk::PipelineStageFlagBits2::eVertexAttributeInput)) {
+            barriers.emplace_back(*barrier);
         }
     }
 
@@ -258,11 +255,9 @@ void BufferCache::BindIndexBuffer(
     // Bind index buffer.
     const u32 index_buffer_size = regs.num_indices * index_size;
     const auto [vk_buffer, offset] = ObtainBuffer(index_address, index_buffer_size, false);
-    if (IsRegionGpuModified(index_address, index_buffer_size)) {
-        if (auto barrier = vk_buffer->GetBarrier(vk::AccessFlagBits2::eIndexRead,
-                                                 vk::PipelineStageFlagBits2::eIndexInput)) {
-            barriers.emplace_back(*barrier);
-        }
+    if (auto barrier = vk_buffer->GetBarrier(vk::AccessFlagBits2::eIndexRead,
+                                             vk::PipelineStageFlagBits2::eIndexInput)) {
+        barriers.emplace_back(*barrier);
     }
     const auto cmdbuf = scheduler.CommandBuffer();
     cmdbuf.bindIndexBuffer(vk_buffer->Handle(), offset, index_type);
@@ -379,10 +374,18 @@ void BufferCache::CopyBuffer(VAddr dst, VAddr src, u32 num_bytes, bool dst_gds, 
     });
 }
 
+static std::pair<VAddr, u64> CachePageRange(VAddr addr, u64 size) {
+    const VAddr begin = Common::AlignDown(addr, BufferCache::CACHING_PAGESIZE);
+    const VAddr end = Common::AlignUp(addr + size, BufferCache::CACHING_PAGESIZE);
+    return {begin, end - begin};
+}
+
 std::pair<Buffer*, u32> BufferCache::ObtainBuffer(VAddr device_addr, u32 size, bool is_written,
                                                   bool is_texel_buffer, BufferId buffer_id) {
     // For read-only buffers use device local stream buffer to reduce renderpass breaks.
-    if (!is_written && size <= CACHING_PAGESIZE && !IsRegionGpuModified(device_addr, size)) {
+    const auto [page_addr, page_size] = CachePageRange(device_addr, size);
+    if (!is_written && size <= CACHING_PAGESIZE && !IsRegionRegistered(device_addr, size) &&
+        !IsRegionGpuModified(page_addr, page_size)) {
         const u64 offset = stream_buffer.Copy(device_addr, size, instance.UniformMinAlignment());
         return {&stream_buffer, offset};
     }
@@ -392,7 +395,10 @@ std::pair<Buffer*, u32> BufferCache::ObtainBuffer(VAddr device_addr, u32 size, b
     Buffer& buffer = slot_buffers[buffer_id];
     SynchronizeBuffer(buffer, device_addr, size, is_written, is_texel_buffer);
     if (is_written) {
-        gpu_modified_ranges.Add(device_addr, size);
+        gpu_modified_ranges.Add(page_addr, page_size);
+        const auto [buffer_page_addr, buffer_page_size] =
+            CachePageRange(buffer.CpuAddr(), buffer.SizeBytes());
+        gpu_modified_ranges.Add(buffer_page_addr, buffer_page_size);
     }
     return {&buffer, buffer.Offset(device_addr)};
 }
@@ -427,7 +433,8 @@ bool BufferCache::IsRegionCpuModified(VAddr addr, size_t size) {
 }
 
 bool BufferCache::IsRegionGpuModified(VAddr addr, size_t size) {
-    return memory_tracker->IsRegionGpuModified(addr, size);
+    return memory_tracker->IsRegionGpuModified(addr, size) ||
+           gpu_modified_ranges.Intersects(addr, size);
 }
 
 BufferId BufferCache::FindBuffer(VAddr device_addr, u32 size) {

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -652,10 +652,12 @@ void Rasterizer::BindBuffers(const Shader::Info& stage, Shader::Backend::Binding
             ASSERT(adjust % 4 == 0);
             push_data.AddOffset(binding.buffer, adjust);
             buffer_infos.emplace_back(vk_buffer->Handle(), offset_aligned, size + adjust);
+            const vk::AccessFlags2 access_mask =
+                desc.is_written
+                    ? vk::AccessFlagBits2::eShaderRead | vk::AccessFlagBits2::eShaderWrite
+                    : vk::AccessFlagBits2::eShaderRead;
             if (auto barrier =
-                    vk_buffer->GetBarrier(desc.is_written ? vk::AccessFlagBits2::eShaderWrite
-                                                          : vk::AccessFlagBits2::eShaderRead,
-                                          vk::PipelineStageFlagBits2::eAllCommands)) {
+                    vk_buffer->GetBarrier(access_mask, vk::PipelineStageFlagBits2::eAllCommands)) {
                 buffer_barriers.emplace_back(*barrier);
             }
             if (desc.is_written && desc.is_formatted) {


### PR DESCRIPTION
Ok I'm submitting this PR again; I think it's in good enough shape now (?

In short, these changes fix the character facial vertex explosion issue in *The Idolmaster* and resolve crashes that occurred during story sequences and at the start of live performances.

For specific details, please refer to https://github.com/shadps4-emu/shadPS4/pull/4781

Additionally, a friend of mine, @RainKikyou, used these modifications to try and fix the vertex explosion issue in *GUNDAM VERSUS*, and the results look good.

However, during testing, we discovered that these changes prevent *Demon Slayer: Kimetsu no Yaiba* from launching; I haven't investigated this specific issue in depth.

These changes were generated with AI assistance and have been tested to ensure they work.