### PR TITLE
ngs2: propagate SystemSetup validation errors

### DIFF
--- a/src/core/libraries/ngs2/ngs2_impl.cpp
+++ b/src/core/libraries/ngs2/ngs2_impl.cpp
@@ -116,7 +116,7 @@ s32 SystemSetup(const OrbisNgs2SystemOption* option, OrbisNgs2ContextBufferInfo*
     SystemInternal setupResult;
     void* systemList = NULL;
     size_t requiredBufferSize = 0;
-    u32 result = ORBIS_NGS2_ERROR_INVALID_BUFFER_SIZE;
+    s32 result = ORBIS_NGS2_ERROR_INVALID_BUFFER_SIZE;
 
     if (option) {
         if (option->size != 64) {

--- a/tests/test_ngs2.cpp
+++ b/tests/test_ngs2.cpp
@@ -37,5 +37,52 @@ TEST(Ngs2Test, RackQueryBufferSizeRejectsInvalidArguments) {
     EXPECT_EQ(RackQueryBufferSize(&option, &info), ORBIS_NGS2_ERROR_INVALID_OPTION_SIZE);
 }
 
+TEST(Ngs2Test, SystemSetupRejectsUnsupportedSampleRate) {
+    OrbisNgs2SystemOption option{};
+    option.size = sizeof(option);
+    option.maxGrainSamples = 512;
+    option.numGrainSamples = 256;
+    option.sampleRate = 44000;
+
+    OrbisNgs2ContextBufferInfo info{};
+    EXPECT_EQ(SystemSetup(&option, &info, nullptr, nullptr), ORBIS_NGS2_ERROR_INVALID_SAMPLE_RATE);
+}
+
+TEST(Ngs2Test, SystemSetupRejectsMisalignedMaxGrainSamples) {
+    OrbisNgs2SystemOption option{};
+    option.size = sizeof(option);
+    option.maxGrainSamples = 500;
+    option.numGrainSamples = 256;
+    option.sampleRate = 48000;
+
+    OrbisNgs2ContextBufferInfo info{};
+    EXPECT_EQ(SystemSetup(&option, &info, nullptr, nullptr),
+              ORBIS_NGS2_ERROR_INVALID_MAX_GRAIN_SAMPLES);
+}
+
+TEST(Ngs2Test, SystemSetupDoesNotHandOutAHandleForAnInvalidOption) {
+    OrbisNgs2SystemOption option{};
+    option.size = sizeof(option);
+    option.maxGrainSamples = 512;
+    option.numGrainSamples = 256;
+    option.sampleRate = 44000;
+
+    u8 storage[256]{};
+    OrbisNgs2ContextBufferInfo info{};
+    info.hostBuffer = storage;
+    info.hostBufferSize = sizeof(storage);
+
+    OrbisNgs2Handle handle = 0;
+    EXPECT_EQ(SystemSetup(&option, &info, nullptr, &handle), ORBIS_NGS2_ERROR_INVALID_SAMPLE_RATE);
+    EXPECT_EQ(handle, 0);
+}
+
+TEST(Ngs2Test, SystemSetupQueriesBufferSizeWithDefaultOption) {
+    OrbisNgs2ContextBufferInfo info{};
+    EXPECT_EQ(SystemSetup(nullptr, &info, nullptr, nullptr), ORBIS_OK);
+    EXPECT_EQ(info.hostBuffer, nullptr);
+    EXPECT_GT(info.hostBufferSize, 0);
+}
+
 } // namespace
 } // namespace Libraries::Ngs2


### PR DESCRIPTION
In `SystemSetup`, in `src/core/libraries/ngs2/ngs2_impl.cpp`, the `result` variable is declared as `u32`, which directly contradicts the `ORBIS_NGS2_ERROR_*` constants returned by `SystemSetupCore`, all of which hold negative values. Because of that implicit conversion to an unsigned value, the two `if (result < 0)` guards at lines 133 and 163 can never mathematically be true, which turns those blocks into dead branches.

This logic flaw leads to a serious behaviour: `sceNgs2SystemQueryBufferSize` returns `ORBIS_OK` even for an invalid option, and fills `hostBufferInfo` anyway, while `sceNgs2SystemCreate` runs to completion and writes `*outHandle = 1` for a configuration it has just rejected internally.

The problem has stayed hidden until now because `sceNgs2SystemCreateWithAllocator` is the only execution path spared by the bug, simply because it re-evaluates the validation test on a local `s32` variable.

The fix is a one-line change, switching the variable from `u32` to `s32`. It has no public impact: `SystemSetup` is already declared as `s32` in the `ngs2_impl.h` header, and every caller already stores its return value in an `s32`.

Four new test cases were added to `tests/test_ngs2.cpp`, in the `shadps4_ngs2_test` target the CI already runs. Three of them fail on `main` and the fourth covers the healthy path, which confirms the fix holds.

Disclosure: Claude Opus 5 found the defect and wrote both the fix and the tests. I reviewed the change myself, checked the sign of the `ORBIS_NGS2_ERROR_*` constants and the callers in `ngs2.cpp`, and wrote this description.
