### PR TITLE
video_core: Only enable sampler comparison for comparison fetches

### DIFF
--- a/src/shader_recompiler/ir/passes/resource_patching_pass.cpp
+++ b/src/shader_recompiler/ir/passes/resource_patching_pass.cpp
@@ -125,7 +125,8 @@ public:
     u32 Add(const SamplerResource& desc) {
         const u32 index{Add(sampler_resources, desc, [this, &desc](const auto& existing) {
             return desc.sharp_fetch == existing.sharp_fetch && desc.post_op == existing.post_op &&
-                   desc.post_op_tsharp_dw3_off == existing.post_op_tsharp_dw3_off;
+                   desc.post_op_tsharp_dw3_off == existing.post_op_tsharp_dw3_off &&
+                   desc.is_depth == existing.is_depth;
         })};
         return index;
     }
@@ -311,6 +312,7 @@ void PatchImageSharp(const ResourceDiscovery& resource, Info& info, Descriptors&
             .post_op = resource.sharps[1].post_op,
             .post_op_tsharp_dw3_off =
                 lod_prod.IsEmpty() ? UNKNOWN_LOCATION : SharpLocationFromSource(lod_prod.Inst()),
+            .is_depth = bool(inst_info.is_depth), // true for the _C (compare) opcodes
         });
         inst.SetArg(0, ir.Imm32(image_binding | sampler_binding << 16));
     } else {

--- a/src/shader_recompiler/resource.h
+++ b/src/shader_recompiler/resource.h
@@ -170,6 +170,7 @@ struct SamplerResource {
     SharpFetch<AmdGpu::Sampler> sharp_fetch{};
     SharpFetchPostOp post_op{};
     SharpLocation post_op_tsharp_dw3_off{};
+    bool is_depth{};
 
     constexpr AmdGpu::Sampler GetSharp(const auto& info) const noexcept {
         AmdGpu::Sampler sampler{};

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -850,7 +850,8 @@ void Rasterizer::BindTextures(const Shader::Info& stage, Shader::Backend::Bindin
 
     for (const auto& sampler : stage.samplers) {
         auto ssharp = sampler.GetSharp(stage);
-        const auto vk_sampler = texture_cache.GetSampler(ssharp, liverpool->regs.ta_bc_base);
+        const auto vk_sampler =
+            texture_cache.GetSampler(ssharp, liverpool->regs.ta_bc_base, sampler.is_depth);
         image_infos.emplace_back(vk_sampler, VK_NULL_HANDLE, vk::ImageLayout::eGeneral);
         auto& set_write = set_writes[set_write_index++];
         set_write.dstSet = VK_NULL_HANDLE;

--- a/src/video_core/texture_cache/sampler.cpp
+++ b/src/video_core/texture_cache/sampler.cpp
@@ -9,7 +9,7 @@
 namespace VideoCore {
 
 Sampler::Sampler(const Vulkan::Instance& instance, const AmdGpu::Sampler& sampler,
-                 const AmdGpu::BorderColorBuffer border_color_base) {
+                 const AmdGpu::BorderColorBuffer border_color_base, const bool is_depth) {
     using namespace Vulkan;
     const bool anisotropy_enable = instance.IsAnisotropicFilteringSupported() &&
                                    (AmdGpu::IsAnisoFilter(sampler.xy_mag_filter) ||
@@ -54,7 +54,8 @@ Sampler::Sampler(const Vulkan::Instance& instance, const AmdGpu::Sampler& sample
         .mipLodBias = std::min(sampler.LodBias(), instance.MaxSamplerLodBias()),
         .anisotropyEnable = anisotropy_enable,
         .maxAnisotropy = max_anisotropy,
-        .compareEnable = sampler.depth_compare_func != AmdGpu::DepthCompare::Never,
+        // GCN compares per instruction; a plain read of a compare sampler is undefined in Vulkan.
+        .compareEnable = is_depth,
         .compareOp = LiverpoolToVK::DepthCompare(sampler.depth_compare_func),
         .minLod = sampler.MinLod(),
         .maxLod = sampler.MaxLod(),

--- a/src/video_core/texture_cache/sampler.h
+++ b/src/video_core/texture_cache/sampler.h
@@ -16,7 +16,7 @@ namespace VideoCore {
 class Sampler {
 public:
     explicit Sampler(const Vulkan::Instance& instance, const AmdGpu::Sampler& sampler,
-                     const AmdGpu::BorderColorBuffer border_color_base);
+                     const AmdGpu::BorderColorBuffer border_color_base, bool is_depth);
     ~Sampler();
 
     Sampler(const Sampler&) = delete;

--- a/src/video_core/texture_cache/texture_cache.cpp
+++ b/src/video_core/texture_cache/texture_cache.cpp
@@ -804,11 +804,15 @@ void TextureCache::RefreshImage(Image& image) {
 }
 
 vk::Sampler TextureCache::GetSampler(const AmdGpu::Sampler& sampler,
-                                     AmdGpu::BorderColorBuffer border_color_base) {
-    const u64 hash = XXH3_64bits(&sampler, sizeof(sampler));
+                                     AmdGpu::BorderColorBuffer border_color_base,
+                                     const bool is_depth) {
+    // Compare and plain uses of one S# need separate samplers.
+    const u64 hash =
+        XXH3_64bits(&sampler, sizeof(sampler)) ^ (is_depth ? 0x9E3779B97F4A7C15ULL : 0);
 
     std::scoped_lock lock{samplers_mutex};
-    const auto [it, new_sampler] = samplers.try_emplace(hash, instance, sampler, border_color_base);
+    const auto [it, new_sampler] =
+        samplers.try_emplace(hash, instance, sampler, border_color_base, is_depth);
     if (new_sampler) {
         samplers.at(hash).lru_id = sampler_lru_cache.Insert(hash, gc_tick);
     } else {

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -138,7 +138,8 @@ public:
 
     /// Retrieves the sampler that matches the provided S# descriptor.
     [[nodiscard]] vk::Sampler GetSampler(const AmdGpu::Sampler& sampler,
-                                         AmdGpu::BorderColorBuffer border_color_base);
+                                         AmdGpu::BorderColorBuffer border_color_base,
+                                         bool is_depth);
 
     /// Retrieves the image with the specified id.
     [[nodiscard]] Image& GetImage(ImageId id) {


### PR DESCRIPTION
This PR fixes the corrupt bloom in GR2 for Pascal and older Nvidia gpus by disabling vulkan depth comparison operations 
for plain (non _C) GCN instructions. GR2's bloom blur fragment shader `fs_0x0000000058bfbd5f_0` has no `IMAGE_SAMPLE_C`
GCN instructions, only `IMAGE_SAMPLE`. Therefore, there should be no sampler comparison at all. The S#'s `depth_compare_func`,
which in this case is Always, only decides which compareop is used. Whether the comparison should happen is decided by 
the opcode. 
Currently,` .compareEnable = sampler.depth_compare_func != AmdGpu::DepthCompare::Never`, so vulkan depth comparison
is enabled solely based on depth_compare_func, and textures get read by non-_C instructions through a comparison sampler.
The shader creates 48 samples per pixel for two textures, a 480×270` R11G11B10_FLOAT` (32 samples) and a 16×16 `R32_FLOAT` LUT (16 samples), through the same sampler. The 16x16 LUT holds the blur weights.
The behavioral difference between newer Nvidia gpu architectures like Turing and older ones like pascal is that for newer
gpus, the 16 LUT fetches return the correct value  0 to ~0.15 (the sampled weight) with no vulkan comparison being made.
On Pascal, these fetches return 1.0 (the Always comparison result), which results in saturated white squares instead of 
proper bloom.
The fix is to derive the _C bit for each instruction from the existing 64bit MIMG instruction decode as `IR::TextureInstInfo::is_depth` and save the `is_depth` result to a bool variable,` SamplerResource::is_depth`. The vulkan depth comparison is refactored to `.compareEnable=is_depth` so that only sampler bindings used by _C instructions will have vulkan depth comparison enabled. A dedup predicate was added so that the shader has slots for two samplers when the same S# is used for both plain and compare reads, which allows a separate sampler object to be used for each case. A sampler hash change in the texture cache was added so that when two sampler objects are requested, a separate sampler object is created for each case. 

<img width="1920" height="1080" alt="CUSA04943_20260910_200050_728_game_000000" src="https://github.com/user-attachments/assets/34069107-b0fd-4c59-8f5a-b66af777d12b" />

Before (Pascal GPU)

<img width="1920" height="1080" alt="CUSA04943_20260911_083227_707_game_000000" src="https://github.com/user-attachments/assets/639fd656-c75d-4bcb-9ec1-305ed23108e5" />

After (Pascal GPU)
